### PR TITLE
MSD Emails: Add Titan plan selection grid (Pro, Premium, Ultra) behind feature flag

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -6,6 +6,7 @@ import {
 	queryClient,
 	rawUserPreferencesQuery,
 	siteByIdQuery,
+	siteProductsQuery,
 	userMailboxesQuery,
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, Outlet } from '@tanstack/react-router';
@@ -160,15 +161,20 @@ export const addMailboxRoute = createRoute( {
 		}
 	},
 	loader: async ( { params: { domain: domainName } } ) => {
-		const products = queryClient.ensureQueryData( productsQuery() );
-
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+
+		// useEmailProduct reads site-specific products when the domain has a
+		// blog_id and only falls back to the global products list otherwise, so
+		// warm the same query the component will read to avoid a cold-load crash.
+		const products = domain.blog_id
+			? queryClient.ensureQueryData( siteProductsQuery( domain.blog_id ) )
+			: queryClient.ensureQueryData( productsQuery() );
 		const site = queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
-		const mailboxAccounts = await queryClient.ensureQueryData(
+		const mailboxAccounts = queryClient.ensureQueryData(
 			mailboxAccountsQuery( domain.blog_id, domainName )
 		);
 
-		await Promise.all( [ products, site, domain, mailboxAccounts ] );
+		await Promise.all( [ products, site, mailboxAccounts ] );
 	},
 } ).lazy( () =>
 	import( '../../emails/add-mailbox' ).then( ( d ) =>

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -10,7 +10,8 @@ import {
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, Outlet } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
-import { IntervalLength, MailboxProvider } from '../../emails/types';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../emails/types';
+import { isTitanPlanTier } from '../../emails/utils/titan-tiers';
 import { accountHasWarningWithSlug } from '../../utils/email-utils';
 import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
@@ -138,6 +139,11 @@ export const addMailboxRoute = createRoute( {
 	} ),
 	getParentRoute: () => emailsRoute,
 	path: 'add-mailbox/$domain/$provider/$interval',
+	validateSearch: ( search ): { tier?: TitanPlanTier } => {
+		return {
+			tier: isTitanPlanTier( search.tier ) ? search.tier : undefined,
+		};
+	},
 	beforeLoad: async ( { params: { domain: domainName, provider, interval } } ) => {
 		await redirectIfInvalidDomain( domainName );
 

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -1,7 +1,7 @@
 import { createTitanMailboxMutation, mailboxAccountsQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { useMatch, useParams } from '@tanstack/react-router';
+import { useMatch, useParams, useSearch } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, Notice } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -41,10 +41,11 @@ const AddProfessionalEmail = () => {
 	const isAddMailboxRoute = match.routeId === addMailboxRoute.id;
 
 	const { provider, interval } = useParams( { shouldThrow: false, strict: false } );
+	const { tier } = useSearch( { strict: false } );
 
 	const { domain, domainName } = useDomainFromUrlParam();
 	const userCanAddEmail = domain?.current_user_can_add_email;
-	const { product } = useEmailProduct( provider, interval, domain );
+	const { product } = useEmailProduct( provider, interval, domain, tier );
 	const { data: existingMailboxes } = useSuspenseQuery(
 		mailboxAccountsQuery( domain.blog_id, domainName )
 	);
@@ -112,12 +113,14 @@ const AddProfessionalEmail = () => {
 			return;
 		}
 
-		isAddMailboxRoute
-			? addToCart( { mailboxOperations, onFinally: () => setIsSubmitting( false ) } )
-			: setUpMailbox( {
-					mailboxOperations,
-					onFinally: () => setIsSubmitting( false ),
-			  } );
+		if ( isAddMailboxRoute ) {
+			addToCart( { mailboxOperations, onFinally: () => setIsSubmitting( false ) } );
+		} else {
+			setUpMailbox( {
+				mailboxOperations,
+				onFinally: () => setIsSubmitting( false ),
+			} );
+		}
 	};
 
 	const removeForm = ( index: number ) => {

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -145,7 +145,7 @@ const AddProfessionalEmail = () => {
 	let mailboxCost;
 	const totalItems = mailboxEntities.length;
 	let totalPrice = '0';
-	if ( isAddMailboxRoute ) {
+	if ( isAddMailboxRoute && product ) {
 		mailboxCost = getMailboxCost( {
 			domain,
 			product,

--- a/client/dashboard/emails/choose-email-solution/components/google-workspace-card.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/google-workspace-card.tsx
@@ -1,0 +1,116 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { chevronDown, chevronUp } from '@wordpress/icons';
+import { useState } from 'react';
+import { Card, CardBody } from '../../../components/card';
+import { Text } from '../../../components/text';
+import GoogleLogo from '../../../images/google-logo.svg';
+import { IntervalLength } from '../../types';
+import type { Product } from '@automattic/api-core';
+
+// Placeholder feature list, final copy pending (DOTEMP-111).
+const GOOGLE_WORKSPACE_FEATURES = [
+	'Send and receive from your custom domain',
+	'30 GB storage',
+	'Email, calendar, and contacts',
+	'Video calls, docs, spreadsheets, and more',
+	'Real-time collaboration',
+	'Store and share files in the cloud',
+	'24/7 support via email',
+];
+
+export function GoogleWorkspaceCard( {
+	product,
+	interval,
+	available,
+	hasFreeTrial,
+	onSelect,
+}: {
+	product?: Product;
+	interval: IntervalLength;
+	available: boolean;
+	hasFreeTrial: boolean;
+	onSelect: () => void;
+} ) {
+	const [ showFeatures, setShowFeatures ] = useState( false );
+	const featuresId = useInstanceId( GoogleWorkspaceCard, 'google-workspace-features' );
+
+	const name = product?.product_name ?? __( 'Google Workspace' );
+	const price = formatCurrency( product?.cost ?? 0, product?.currency_code ?? 'USD', {
+		stripZeros: true,
+	} );
+
+	return (
+		<Card>
+			<CardBody>
+				<HStack alignment="topLeft" justify="flex-start" spacing={ 4 } style={ { minWidth: 0 } }>
+					<img src={ GoogleLogo } alt="" width={ 30 } height={ 30 } />
+					<VStack spacing={ 2 } justify="flex-start" style={ { minWidth: 0, flex: 1 } }>
+						<Text as="h2" size={ 16 } weight={ 600 }>
+							{ name }
+						</Text>
+						<HStack alignment="center" justify="space-between" spacing={ 4 }>
+							<HStack
+								justify="flex-start"
+								spacing={ 1 }
+								expanded={ false }
+								style={ { minWidth: 0 } }
+							>
+								<Text>
+									{ __(
+										'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
+									) }
+								</Text>
+								<Button
+									size="small"
+									label={ showFeatures ? __( 'Hide features' ) : __( 'Show features' ) }
+									icon={ showFeatures ? chevronUp : chevronDown }
+									aria-expanded={ showFeatures }
+									aria-controls={ featuresId }
+									onClick={ () => setShowFeatures( ! showFeatures ) }
+								/>
+							</HStack>
+							<Button
+								__next40pxDefaultSize
+								className="google-workspace-card-action"
+								variant="secondary"
+								disabled={ ! available }
+								onClick={ onSelect }
+								style={ { flexShrink: 0 } }
+							>
+								{ __( 'Get Google Workspace' ) }
+							</Button>
+						</HStack>
+						{ showFeatures && (
+							<ul id={ featuresId } className="email-provider-features">
+								{ GOOGLE_WORKSPACE_FEATURES.map( ( feature, featureIndex ) => (
+									<li key={ `feature-google-${ featureIndex }` }>{ feature }</li>
+								) ) }
+							</ul>
+						) }
+						<HStack justify="flex-start" spacing={ 1 } expanded={ false }>
+							<Text size={ 16 } weight={ 600 }>
+								{ price }
+							</Text>
+							<Text variant="muted">
+								{ interval === IntervalLength.Annually ? __( '/year' ) : __( '/month' ) }
+							</Text>
+						</HStack>
+						{ ! available && (
+							<Text variant="muted">{ __( 'Not available for this domain name.' ) }</Text>
+						) }
+						{ available && hasFreeTrial && (
+							<div className="email-provider-trial">{ __( '3 month free trial' ) }</div>
+						) }
+					</VStack>
+				</HStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -1,0 +1,248 @@
+import { useNavigate } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { addMailboxRoute } from '../../../app/router/emails';
+import { PriceDisplay } from '../../../components/price-display';
+import { Text } from '../../../components/text';
+import { useEmailProduct } from '../../hooks/use-email-product';
+import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
+import type { Domain, Product } from '@automattic/api-core';
+
+// Placeholder descriptions and feature lists, final copy pending (DOTEMP-111).
+const TIER_DETAILS: Record< TitanPlanTier, { description: string; features: string[] } > = {
+	[ TitanPlanTier.Pro ]: {
+		description: 'Everything you need to get started with professional, secure email.',
+		features: [
+			'30 GB storage',
+			'Rich email',
+			'Native mobile apps',
+			'Integrated calendar',
+			'Integrated contacts',
+			'Guaranteed email delivery',
+			'Advanced anti-spam',
+			'Advanced anti-virus',
+		],
+	},
+	[ TitanPlanTier.Premium ]: {
+		description: 'Smarter tools to help your growing business stay organized and productive.',
+		features: [
+			'50 GB storage',
+			'Unlimited read receipts',
+			'Unlimited email templates',
+			'Unlimited contact groups',
+			'Follow up reminders',
+			'Send later',
+			'Grammar & spell check',
+			'Priority inbox',
+		],
+	},
+	[ TitanPlanTier.Ultra ]: {
+		description: 'AI-powered email to scale your business and boost marketing impact.',
+		features: [
+			'100 GB storage',
+			'AI email writer',
+			'Appointment booking',
+			'Email campaigns',
+			'Attachment and link tracking',
+			'Email designer',
+			'Signature designer',
+		],
+	},
+};
+
+interface TitanPlan {
+	tier: TitanPlanTier;
+	product?: Product;
+	hasFreeTrial: boolean;
+	isPopular: boolean;
+	everythingInName?: string;
+}
+
+const getTierName = ( tier: TitanPlanTier ): string => {
+	switch ( tier ) {
+		case TitanPlanTier.Pro:
+			return __( 'Pro' );
+		case TitanPlanTier.Premium:
+			return __( 'Premium' );
+		case TitanPlanTier.Ultra:
+			return __( 'Ultra' );
+	}
+};
+
+export function TitanPlanGrid( {
+	domain,
+	domainName,
+	interval,
+	available,
+	hasProFreeTrial,
+	proTrialMonths,
+}: {
+	domain?: Domain;
+	domainName: string;
+	interval: IntervalLength;
+	available: boolean;
+	hasProFreeTrial: boolean;
+	proTrialMonths: number;
+} ) {
+	const navigate = useNavigate();
+
+	const { product: proProduct } = useEmailProduct(
+		MailboxProvider.Titan,
+		interval,
+		domain,
+		TitanPlanTier.Pro
+	);
+	const { product: premiumProduct } = useEmailProduct(
+		MailboxProvider.Titan,
+		interval,
+		domain,
+		TitanPlanTier.Premium
+	);
+	const { product: ultraProduct } = useEmailProduct(
+		MailboxProvider.Titan,
+		interval,
+		domain,
+		TitanPlanTier.Ultra
+	);
+
+	const plans: TitanPlan[] = [
+		{
+			tier: TitanPlanTier.Pro,
+			product: proProduct,
+			hasFreeTrial: hasProFreeTrial,
+			isPopular: false,
+		},
+		{
+			tier: TitanPlanTier.Premium,
+			product: premiumProduct,
+			hasFreeTrial: false,
+			isPopular: true,
+			everythingInName: getTierName( TitanPlanTier.Pro ),
+		},
+		{
+			tier: TitanPlanTier.Ultra,
+			product: ultraProduct,
+			hasFreeTrial: false,
+			isPopular: false,
+			everythingInName: getTierName( TitanPlanTier.Premium ),
+		},
+	];
+
+	const getMonthlyPrice = ( product?: Product ) => {
+		if ( ! product?.cost ) {
+			return 0;
+		}
+
+		return interval === IntervalLength.Annually ? product.cost / 12 : product.cost;
+	};
+
+	return (
+		<div className="email-providers">
+			{ plans.map( ( plan ) => {
+				const planName = getTierName( plan.tier );
+				const details = TIER_DETAILS[ plan.tier ];
+
+				return (
+					<VStack
+						className="email-provider email-titan-plan"
+						key={ `titan-plan-${ plan.tier }` }
+						spacing={ 4 }
+					>
+						<Text
+							as="h2"
+							size={ 28 }
+							lineHeight="36px"
+							className="email-provider-name email-titan-plan-name"
+						>
+							{ planName }
+						</Text>
+						<Text className="email-titan-plan-description">{ details.description }</Text>
+						<VStack spacing={ 2 } justify="flex-start" className="email-titan-plan-price">
+							<HStack alignment="bottomLeft">
+								<PriceDisplay
+									price={ plan.hasFreeTrial ? 0 : getMonthlyPrice( plan.product ) }
+									currency={ plan.product?.currency_code ?? 'USD' }
+								/>
+								{ plan.hasFreeTrial && (
+									<PriceDisplay
+										price={ getMonthlyPrice( plan.product ) }
+										currency={ plan.product?.currency_code ?? 'USD' }
+										discounted
+									/>
+								) }
+							</HStack>
+							<Text variant="muted">
+								{ interval === IntervalLength.Annually
+									? __( 'per month, per mailbox, billed every 12 months.' )
+									: __( 'per month, per mailbox, billed monthly.' ) }
+							</Text>
+							{ plan.hasFreeTrial && (
+								<div className="email-provider-trial">
+									{ sprintf(
+										/* translators: %d is the number of free trial months. */
+										__( '%d month free trial' ),
+										proTrialMonths
+									) }
+								</div>
+							) }
+							{ ! available && (
+								<Text variant="muted">{ __( 'Not available for this domain name.' ) }</Text>
+							) }
+						</VStack>
+						<Button
+							__next40pxDefaultSize
+							className="email-provider-action"
+							variant={ plan.isPopular ? 'primary' : 'secondary' }
+							disabled={ ! available }
+							onClick={ () =>
+								navigate( {
+									to: addMailboxRoute.to,
+									params: {
+										domain: domainName,
+										provider: MailboxProvider.Titan,
+										interval,
+									},
+									search: { tier: plan.tier },
+								} )
+							}
+						>
+							{ plan.hasFreeTrial
+								? __( 'Start trial' )
+								: sprintf(
+										/* translators: %s is the email plan name. */
+										__( 'Get %s' ),
+										planName
+								  ) }
+						</Button>
+						<VStack spacing={ 1 }>
+							{ plan.everythingInName && (
+								<Text weight={ 600 }>
+									{ sprintf(
+										/* translators: %s is the name of the previous, cheaper email plan. */
+										__( 'Everything in %s' ),
+										plan.everythingInName
+									) }
+								</Text>
+							) }
+							<ul className="email-provider-features">
+								{ details.features.map( ( feature, featureIndex ) => (
+									<li key={ `feature-${ plan.tier }-${ featureIndex }` }>{ feature }</li>
+								) ) }
+							</ul>
+						</VStack>
+						<img
+							className="email-provider-powered-by"
+							src={ poweredByTitanLogo }
+							alt={ __( 'Powered by Titan' ) }
+						/>
+					</VStack>
+				);
+			} ) }
+		</div>
+	);
+}

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -30,9 +30,10 @@ import { useAnnualSavings } from '../hooks/use-annual-savings';
 import { useDomainFromUrlParam } from '../hooks/use-domain-from-url-param';
 import { useEmailProduct } from '../hooks/use-email-product';
 import poweredByTitanLogo from '../resources/powered-by-titan-caps.svg';
-import { IntervalLength, MailboxProvider } from '../types';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../types';
 import { isEligibleForIntroductoryOffer } from '../utils/is-eligible-for-introductory-offer';
 import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
+import { getTitanTierFromSlug } from '../utils/titan-tiers';
 import { ExistingForwardsNotice } from './components/existing-forwards-notice';
 
 import './style.scss';
@@ -87,6 +88,7 @@ export default function ChooseEmailSolution() {
 	const navigate = useNavigate();
 	let redirectTo = null;
 	if ( hasTitanMailWithUs( domain ) && isTitanAvailable ) {
+		const subscriptionTier = getTitanTierFromSlug( titanEmailSubscription?.product_slug );
 		redirectTo = {
 			to: addMailboxRoute.to,
 			params: {
@@ -95,6 +97,10 @@ export default function ChooseEmailSolution() {
 				interval: isMonthlyEmailProduct( titanEmailSubscription )
 					? IntervalLength.Monthly
 					: IntervalLength.Annually,
+			},
+			search: {
+				// Omit the default tier so existing Pro URLs stay unchanged.
+				tier: subscriptionTier === TitanPlanTier.Pro ? undefined : subscriptionTier,
 			},
 		};
 	} else if ( hasGSuiteWithUs( domain ) && isGoogleAvailable ) {

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -1,4 +1,5 @@
 import { EmailSubscription, Product } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
@@ -35,6 +36,8 @@ import { isEligibleForIntroductoryOffer } from '../utils/is-eligible-for-introdu
 import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
 import { getTitanTierFromSlug } from '../utils/titan-tiers';
 import { ExistingForwardsNotice } from './components/existing-forwards-notice';
+import { GoogleWorkspaceCard } from './components/google-workspace-card';
+import { TitanPlanGrid } from './components/titan-plan-grid';
 
 import './style.scss';
 
@@ -43,6 +46,8 @@ const getTrialMonths = ( product?: Product ) =>
 
 export default function ChooseEmailSolution() {
 	const { domain, domainName } = useDomainFromUrlParam();
+
+	const isTitanPlanSelectionEnabled = config.isEnabled( 'emails/titan-tiers' );
 
 	const [ billingInterval, setBillingInterval ] = useState< IntervalLength >(
 		IntervalLength.Annually
@@ -176,128 +181,184 @@ export default function ChooseEmailSolution() {
 		},
 	};
 
+	const pageHeader = (
+		<PageHeader
+			prefix={ <Breadcrumbs length={ 2 } /> }
+			description={ __(
+				'Choose between Professional Email and Google Workspace for your domain.'
+			) }
+		/>
+	);
+
+	const pageNotices = (
+		<>
+			{ ! canAddEmail && <EmailNonDomainOwnerNotice domain={ domain } /> }
+			{ hasEmailForwards( domain ) && <ExistingForwardsNotice /> }
+		</>
+	);
+
+	const intervalSelector = (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			isBlock
+			label={ __( 'Billing interval' ) }
+			hideLabelFromVision
+			value={ billingInterval }
+			onChange={ ( newBillingInterval ) =>
+				setBillingInterval( newBillingInterval as IntervalLength )
+			}
+		>
+			<ToggleGroupControlOption label={ __( 'Monthly' ) } value={ IntervalLength.Monthly } />
+			<ToggleGroupControlOption
+				/* translators: %d is the annual savings percentage. */
+				label={ sprintf( __( 'Annually (save up to %d%%)' ), bestAnnualSavings ) }
+				value={ IntervalLength.Annually }
+			/>
+		</ToggleGroupControl>
+	);
+
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					description={ __(
-						'Choose between Professional Email and Google Workspace for your domain.'
-					) }
-				/>
+				// Same narrow-header/wide-content pattern as client/dashboard/sites/site-plans.
+				isTitanPlanSelectionEnabled ? (
+					<div className="choose-email-solution-narrow">{ pageHeader }</div>
+				) : (
+					pageHeader
+				)
 			}
-			size="small"
+			size={ isTitanPlanSelectionEnabled ? 'large' : 'small' }
 			notices={
-				<>
-					{ ! canAddEmail && <EmailNonDomainOwnerNotice domain={ domain } /> }
-					{ hasEmailForwards( domain ) && <ExistingForwardsNotice /> }
-				</>
+				isTitanPlanSelectionEnabled ? (
+					<div className="choose-email-solution-narrow">{ pageNotices }</div>
+				) : (
+					pageNotices
+				)
 			}
 		>
 			{ /* Billing interval selector */ }
-			<ToggleGroupControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				isBlock
-				label={ __( 'Billing interval' ) }
-				hideLabelFromVision
-				value={ billingInterval }
-				onChange={ ( newBillingInterval ) =>
-					setBillingInterval( newBillingInterval as IntervalLength )
-				}
-			>
-				<ToggleGroupControlOption label={ __( 'Monthly' ) } value={ IntervalLength.Monthly } />
-				<ToggleGroupControlOption
-					/* translators: %d is the annual savings percentage. */
-					label={ sprintf( __( 'Annually (save up to %d%%)' ), bestAnnualSavings ) }
-					value={ IntervalLength.Annually }
-				/>
-			</ToggleGroupControl>
+			{ isTitanPlanSelectionEnabled ? (
+				<div className="choose-email-solution-narrow">{ intervalSelector }</div>
+			) : (
+				intervalSelector
+			) }
+
+			{ isTitanPlanSelectionEnabled && (
+				<VStack className="choose-email-solution-wide" spacing={ 6 }>
+					<TitanPlanGrid
+						domain={ domain }
+						domainName={ domainName }
+						interval={ billingInterval }
+						available={ isTitanAvailable }
+						hasProFreeTrial={ hasTitanFreeTrial }
+						proTrialMonths={ getTrialMonths( titanProduct ) }
+					/>
+					<GoogleWorkspaceCard
+						product={ googleProduct }
+						interval={ billingInterval }
+						available={ isGoogleAvailable }
+						hasFreeTrial={ hasGoogleFreeTrial }
+						onSelect={ () =>
+							navigate( {
+								to: addMailboxRoute.to,
+								params: {
+									domain: domainName,
+									provider: MailboxProvider.Google,
+									interval: billingInterval,
+								},
+							} )
+						}
+					/>
+				</VStack>
+			) }
 
 			{ /* Split card for providers */ }
-			<div className="email-providers">
-				{ Object.entries( providers ).map( ( [ providerId, provider ] ) => (
-					<VStack className="email-provider" key={ `provider-${ providerId }` } spacing={ 4 }>
-						<Icon icon={ provider.logo } size={ 30 } className="email-provider-logo" />
-						<Text as="h2" size={ 28 } lineHeight="40px" className="email-provider-name">
-							{ provider.name }
-						</Text>
-						<Text>{ provider.description }</Text>
-						<VStack
-							spacing={ 2 }
-							justify="flex-start"
-							style={ { minHeight: hasFreeTrial ? '96px' : '76px' } }
-						>
-							{ provider.available ? (
-								<>
-									<HStack alignment="bottomLeft">
-										<PriceDisplay
-											price={ provider.hasFreeTrial ? 0 : provider.product?.cost ?? 0 }
-											currency={ provider.product?.currency_code ?? 'USD' }
-										/>
-										{ provider.hasFreeTrial && (
+			{ ! isTitanPlanSelectionEnabled && (
+				<div className="email-providers">
+					{ Object.entries( providers ).map( ( [ providerId, provider ] ) => (
+						<VStack className="email-provider" key={ `provider-${ providerId }` } spacing={ 4 }>
+							<Icon icon={ provider.logo } size={ 30 } className="email-provider-logo" />
+							<Text as="h2" size={ 28 } lineHeight="40px" className="email-provider-name">
+								{ provider.name }
+							</Text>
+							<Text>{ provider.description }</Text>
+							<VStack
+								spacing={ 2 }
+								justify="flex-start"
+								style={ { minHeight: hasFreeTrial ? '96px' : '76px' } }
+							>
+								{ provider.available ? (
+									<>
+										<HStack alignment="bottomLeft">
 											<PriceDisplay
-												price={ provider.product?.cost ?? 0 }
+												price={ provider.hasFreeTrial ? 0 : provider.product?.cost ?? 0 }
 												currency={ provider.product?.currency_code ?? 'USD' }
-												discounted
 											/>
+											{ provider.hasFreeTrial && (
+												<PriceDisplay
+													price={ provider.product?.cost ?? 0 }
+													currency={ provider.product?.currency_code ?? 'USD' }
+													discounted
+												/>
+											) }
+										</HStack>
+										<Text variant="muted">
+											{ billingInterval === 'annually'
+												? __( 'per year, per mailbox, excl. taxes.' )
+												: __( 'per month, per mailbox, excl. taxes.' ) }
+										</Text>
+										{ provider.hasFreeTrial && (
+											<div className="email-provider-trial">
+												{ provider.trialMonths === 12
+													? sprintf(
+															/* translators: %d is the number of free trial months. */
+															__( '%d month free trial' ),
+															provider.trialMonths
+													  )
+													: __( '3 month free trial' ) }
+											</div>
 										) }
-									</HStack>
-									<Text variant="muted">
-										{ billingInterval === 'annually'
-											? __( 'per year, per mailbox, excl. taxes.' )
-											: __( 'per month, per mailbox, excl. taxes.' ) }
+									</>
+								) : (
+									<Text size={ 20 } weight={ 500 }>
+										{ __( 'Not available for this domain name' ) }
 									</Text>
-									{ provider.hasFreeTrial && (
-										<div className="email-provider-trial">
-											{ provider.trialMonths === 12
-												? sprintf(
-														/* translators: %d is the number of free trial months. */
-														__( '%d month free trial' ),
-														provider.trialMonths
-												  )
-												: __( '3 month free trial' ) }
-										</div>
-									) }
-								</>
-							) : (
-								<Text size={ 20 } weight={ 500 }>
-									{ __( 'Not available for this domain name' ) }
-								</Text>
+								) }
+							</VStack>
+							<Button
+								className="email-provider-action"
+								variant="primary"
+								disabled={ ! provider.available }
+								onClick={ () =>
+									navigate( {
+										to: addMailboxRoute.to,
+										params: {
+											domainName: domainName,
+											provider: providerId,
+											interval: billingInterval,
+										},
+									} )
+								}
+							>
+								{ provider.action }
+							</Button>
+							<ul className="email-provider-features">
+								{ provider.features.map( ( feature, featureIndex ) => (
+									<li key={ `feature-${ providerId }-${ featureIndex }` }>{ feature }</li>
+								) ) }
+							</ul>
+							{ provider.poweredBy && (
+								<img
+									className="email-provider-powered-by"
+									src={ provider.poweredBy.logo }
+									alt={ provider.poweredBy.text }
+								/>
 							) }
 						</VStack>
-						<Button
-							className="email-provider-action"
-							variant="primary"
-							disabled={ ! provider.available }
-							onClick={ () =>
-								navigate( {
-									to: addMailboxRoute.to,
-									params: {
-										domainName: domainName,
-										provider: providerId,
-										interval: billingInterval,
-									},
-								} )
-							}
-						>
-							{ provider.action }
-						</Button>
-						<ul className="email-provider-features">
-							{ provider.features.map( ( feature, featureIndex ) => (
-								<li key={ `feature-${ providerId }-${ featureIndex }` }>{ feature }</li>
-							) ) }
-						</ul>
-						{ provider.poweredBy && (
-							<img
-								className="email-provider-powered-by"
-								src={ provider.poweredBy.logo }
-								alt={ provider.poweredBy.text }
-							/>
-						) }
-					</VStack>
-				) ) }
-			</div>
+					) ) }
+				</div>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/emails/choose-email-solution/style.scss
+++ b/client/dashboard/emails/choose-email-solution/style.scss
@@ -19,7 +19,7 @@
 	padding: 20px;
 	justify-content: flex-start;
 
-	&:not(:first-child) {
+	&:not( :first-child ) {
 		border-top: 1px solid var( --dashboard-surface__border-color, #{$gray-200} );
 
 		@include break-small {
@@ -52,6 +52,34 @@
 	justify-content: center;
 }
 
+// Narrow header column centered above the wide plan grid, mirroring
+// the pattern in client/dashboard/sites/site-plans.
+.choose-email-solution-narrow {
+	width: 100%;
+	max-width: 660px;
+	margin-inline: auto;
+}
+
+.choose-email-solution-wide {
+	width: 100%;
+	max-width: 1032px;
+	margin-inline: auto;
+}
+
+// Equal-width columns so the price blocks and CTAs align across tiers.
+.email-titan-plan {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+.email-titan-plan-description {
+	min-height: 72px;
+}
+
+.email-titan-plan-price {
+	min-height: 120px;
+}
+
 .email-provider-features {
 	padding: 0;
 	line-height: 28px;
@@ -60,4 +88,17 @@
 
 .email-provider-powered-by {
 	width: 145px;
+}
+
+// Keep the description row at text height: the 40px CTA overlaps the
+// 20px line symmetrically instead of inflating the row and the gaps
+// around it.
+.google-workspace-card-action {
+	margin-block: -10px;
+}
+
+// Pin the logo to the card bottom so it aligns across tiers with
+// different feature list lengths.
+.email-titan-plan .email-provider-powered-by {
+	margin-block-start: auto;
 }

--- a/client/dashboard/emails/hooks/use-add-to-cart.ts
+++ b/client/dashboard/emails/hooks/use-add-to-cart.ts
@@ -1,4 +1,4 @@
-import { useParams, useRouter } from '@tanstack/react-router';
+import { useParams, useRouter, useSearch } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -17,9 +17,10 @@ export const useAddToCart = () => {
 	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { provider, interval } = useParams( { strict: false } );
+	const { tier } = useSearch( { strict: false } );
 	const { domain, domainName, site } = useDomainFromUrlParam();
 
-	const emailProduct = useEmailProduct( provider, interval, domain );
+	const emailProduct = useEmailProduct( provider, interval, domain, tier );
 	const router = useRouter();
 
 	const addToCart = async ( {

--- a/client/dashboard/emails/hooks/use-email-product.ts
+++ b/client/dashboard/emails/hooks/use-email-product.ts
@@ -1,23 +1,19 @@
-import { Domain, GoogleWorkspaceSlugs, Product, TitanMailSlugs } from '@automattic/api-core';
+import { Domain, GoogleWorkspaceSlugs, Product } from '@automattic/api-core';
 import { productsQuery, siteProductsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { MailboxProvider, IntervalLength } from '../types';
+import { MailboxProvider, IntervalLength, TitanPlanTier } from '../types';
+import { TITAN_TIER_SLUGS } from '../utils/titan-tiers';
 
-const EMAIL_PRODUCTS = {
-	[ MailboxProvider.Titan ]: {
-		monthly: TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
-		annually: TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG,
-	},
-	[ MailboxProvider.Google ]: {
-		monthly: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
-		annually: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-	},
+const GOOGLE_PRODUCTS = {
+	monthly: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
+	annually: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 };
 
 export const useEmailProduct = (
 	provider: MailboxProvider,
 	interval: IntervalLength,
-	domain?: Domain
+	domain?: Domain,
+	tier: TitanPlanTier = TitanPlanTier.Pro
 ) => {
 	const siteId = domain?.blog_id;
 	const { data: siteProducts } = useQuery( {
@@ -29,7 +25,10 @@ export const useEmailProduct = (
 		enabled: ! siteId,
 	} );
 
-	const productSlug = EMAIL_PRODUCTS[ provider ]?.[ interval ];
+	const productSlug =
+		provider === MailboxProvider.Titan
+			? TITAN_TIER_SLUGS[ tier ]?.[ interval ]
+			: GOOGLE_PRODUCTS[ interval ];
 	const product = ( siteId ? siteProducts : products )?.[ productSlug ] as Product;
 
 	return {

--- a/client/dashboard/emails/types.ts
+++ b/client/dashboard/emails/types.ts
@@ -36,3 +36,9 @@ export enum MailboxProvider {
 	Google = EmailProvider.Google,
 	Titan = EmailProvider.Titan,
 }
+
+export enum TitanPlanTier {
+	Pro = 'pro',
+	Premium = 'premium',
+	Ultra = 'ultra',
+}

--- a/client/dashboard/emails/utils/get-cart-items.ts
+++ b/client/dashboard/emails/utils/get-cart-items.ts
@@ -1,8 +1,6 @@
-import { TitanMailSlugs } from '@automattic/api-core';
 import { MailboxForm, GSuiteProductUser } from '../entities/mailbox-form';
 import { MailboxProvider } from '../types';
 import { EmailProperties } from './get-email-product-properties';
-import { isMonthlyEmailProduct } from './is-monthly-email-product';
 import type { MinimalRequestCartProduct, RequestCartProductExtra } from '@automattic/shopping-cart';
 
 export interface TitanProductProps {
@@ -56,37 +54,23 @@ function titanMailProduct(
 	};
 }
 
-/**
- * Creates a new shopping cart item for Titan Mail Yearly.
- */
-export function titanMailYearly( properties: TitanProductProps ): MinimalRequestCartProduct {
-	return titanMailProduct( properties, TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG );
-}
-
-/**
- * Creates a new shopping cart item for Titan Mail Monthly.
- */
-export function titanMailMonthly( properties: TitanProductProps ): MinimalRequestCartProduct {
-	return titanMailProduct( properties, TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG );
-}
-
 const getTitanCartItems = (
 	mailboxes: MailboxForm< MailboxProvider >[],
 	mailProperties: EmailProperties
 ) => {
 	const { emailProduct, newQuantity, quantity } = mailProperties;
 	const email_users = mailboxes.map( ( mailbox ) => mailbox.getAsCartItem() );
-	const cartItemFunction = isMonthlyEmailProduct( emailProduct )
-		? titanMailMonthly
-		: titanMailYearly;
-	return cartItemFunction( {
-		domain: mailboxes[ 0 ].formFields.domain.value,
-		quantity,
-		extra: {
-			email_users,
-			new_quantity: newQuantity,
+	return titanMailProduct(
+		{
+			domain: mailboxes[ 0 ].formFields.domain.value,
+			quantity,
+			extra: {
+				email_users,
+				new_quantity: newQuantity,
+			},
 		},
-	} );
+		emailProduct.product_slug
+	);
 };
 
 const getGSuiteCartItems = (

--- a/client/dashboard/emails/utils/get-product-provider.ts
+++ b/client/dashboard/emails/utils/get-product-provider.ts
@@ -2,10 +2,9 @@ import { TitanMailSlugs } from '@automattic/api-core';
 import { MailboxProvider } from '../types';
 
 export function getProductProvider( emailProduct: { product_slug: string } ): MailboxProvider {
-	if (
-		emailProduct.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		emailProduct.product_slug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
-	) {
+	const titanSlugs = Object.values( TitanMailSlugs ) as readonly string[];
+
+	if ( titanSlugs.includes( emailProduct.product_slug ) ) {
 		return MailboxProvider.Titan;
 	}
 

--- a/client/dashboard/emails/utils/is-monthly-email-product.ts
+++ b/client/dashboard/emails/utils/is-monthly-email-product.ts
@@ -1,8 +1,12 @@
 import { TitanMailSlugs, GoogleWorkspaceSlugs } from '@automattic/api-core';
 
+const MONTHLY_EMAIL_PRODUCT_SLUGS: readonly string[] = [
+	TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
+	TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG,
+	TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG,
+	GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
+];
+
 export function isMonthlyEmailProduct( emailProduct: { product_slug: string } ): boolean {
-	return (
-		emailProduct.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		emailProduct.product_slug === GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
-	);
+	return MONTHLY_EMAIL_PRODUCT_SLUGS.includes( emailProduct.product_slug );
 }

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -1,0 +1,33 @@
+import { TitanMailSlugs } from '@automattic/api-core';
+import { IntervalLength, TitanPlanTier } from '../types';
+
+export const TITAN_TIER_SLUGS: Record< TitanPlanTier, Record< IntervalLength, string > > = {
+	[ TitanPlanTier.Pro ]: {
+		[ IntervalLength.Monthly ]: TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
+		[ IntervalLength.Annually ]: TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG,
+	},
+	[ TitanPlanTier.Premium ]: {
+		[ IntervalLength.Monthly ]: TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG,
+		[ IntervalLength.Annually ]: TitanMailSlugs.TITAN_MAIL_PREMIUM_YEARLY_SLUG,
+	},
+	[ TitanPlanTier.Ultra ]: {
+		[ IntervalLength.Monthly ]: TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG,
+		[ IntervalLength.Annually ]: TitanMailSlugs.TITAN_MAIL_ULTRA_YEARLY_SLUG,
+	},
+};
+
+export function isTitanPlanTier( value: unknown ): value is TitanPlanTier {
+	return Object.values( TitanPlanTier ).includes( value as TitanPlanTier );
+}
+
+export function getTitanTierFromSlug( productSlug?: string ): TitanPlanTier | undefined {
+	if ( ! productSlug ) {
+		return undefined;
+	}
+
+	const tiers = Object.keys( TITAN_TIER_SLUGS ) as TitanPlanTier[];
+
+	return tiers.find( ( tier ) =>
+		Object.values( TITAN_TIER_SLUGS[ tier ] ).includes( productSlug )
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -42,10 +42,7 @@ export type ProductCategory =
 	| 'other';
 
 function isTitanMailSlug( productSlug: string ): boolean {
-	return (
-		productSlug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		productSlug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
-	);
+	return ( Object.values( TitanMailSlugs ) as readonly string[] ).includes( productSlug );
 }
 
 function isAkismetProductSlug( productSlug: string ): boolean {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -463,9 +463,8 @@ export function isJetpackCrmProduct( keyOrSlug: string ): boolean {
 type ObjectWithProductSlug = { product_slug?: string };
 
 export function isTitanMail( purchase: Purchase | ObjectWithProductSlug ): boolean {
-	return (
-		purchase.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		purchase.product_slug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
+	return ( Object.values( TitanMailSlugs ) as readonly ( string | undefined )[] ).includes(
+		purchase.product_slug
 	);
 }
 

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -32,6 +32,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,

--- a/config/development.json
+++ b/config/development.json
@@ -85,6 +85,7 @@
 		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
+		"emails/titan-tiers": true,
 		"entrepreneur/skip-trial-for-migration": true,
 		"google-drive": true,
 		"google-my-business": true,

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -282,6 +282,10 @@ export const DomainProductSlugs = {
 export const TitanMailSlugs = {
 	TITAN_MAIL_MONTHLY_SLUG: 'wp_titan_mail_monthly',
 	TITAN_MAIL_YEARLY_SLUG: 'wp_titan_mail_yearly',
+	TITAN_MAIL_PREMIUM_MONTHLY_SLUG: 'wp_titan_mail_premium_monthly',
+	TITAN_MAIL_PREMIUM_YEARLY_SLUG: 'wp_titan_mail_premium_yearly',
+	TITAN_MAIL_ULTRA_MONTHLY_SLUG: 'wp_titan_mail_ultra_monthly',
+	TITAN_MAIL_ULTRA_YEARLY_SLUG: 'wp_titan_mail_ultra_yearly',
 } as const;
 
 export const GoogleWorkspaceSlugs = {


### PR DESCRIPTION
Part of DOTEMP-111

Depends on the stacked PRs below; after they merge, this branch will be rebased and shrink to just the plan selection UI.

* #111535 - introduces the `emails/titan-tiers` feature flag
* #111536 - Titan Premium/Ultra slugs and tier-aware product detection
* #111537 - threads the tier through the mailbox purchase flow

## Proposed Changes

* Add the new Titan tier product slugs to `TitanMailSlugs` in `@automattic/api-core`: `wp_titan_mail_premium_monthly/yearly` and `wp_titan_mail_ultra_monthly/yearly` (registered on the backend as Premium, store IDs 402/403, and Ultra, store IDs 404/405).
* Introduce a `TitanPlanTier` enum (`pro` | `premium` | `ultra`) and a tier-to-slug matrix with helpers (`getTitanTierFromSlug`, `isTitanPlanTier`) in `client/dashboard/emails/utils/titan-tiers.ts`.
* Render a three-tier Titan plan grid (Pro, Premium, Ultra) on the MSD choose-email-solution screen behind a new `emails/titan-tiers` feature flag (enabled in development configs only). Plan descriptions and feature lists are placeholders pending final copy. Google Workspace moves to a compact card below the grid with an inline features disclosure.
* Follow the narrow-header/wide-grid layout pattern established by `client/dashboard/sites/site-plans`: the page header, notices, and billing interval toggle stay in a centered 660px column while the grid breaks out to 1032px.
* Carry the selected tier through the purchase flow: `addMailboxRoute` accepts an optional `tier` search param (defaults to Pro, existing URLs unchanged), `useEmailProduct()` resolves the product for a given tier, and the cart item uses the resolved product slug directly instead of the hardcoded monthly/yearly pair.
* Derive the tier from the existing subscription's `product_slug` when redirecting domains that already have Titan, so adding seats to a Premium/Ultra subscription adds seats of the same tier.
* Make slug checks tier-aware by switching exact-equality comparisons to set membership in `is-monthly-email-product.ts`, `get-product-provider.ts`, `utils/purchase.ts` (`isTitanMail`), and `cancel-purchase/get-confirmation-copy.ts` (`isTitanMailSlug`).
* Only the Pro tier shows trial pricing/CTA; Premium and Ultra are intentionally excluded from introductory offers for now.

With the flag disabled, the screen renders the existing two-provider comparison unchanged.

## Why are these changes being made?

The backend now supports three Titan plan tiers (Pro, Premium, Ultra) with tier-aware provisioning, renewal, and unsuspension. This PR adds the corresponding plan selection UI to the MSD Emails flow so users can choose a tier when purchasing Professional Email, per the Titan Additional Email Product SKUs project. The work is gated behind a feature flag while pricing, copy, and design are finalized.

## Testing Instructions

1. Run `yarn start-dashboard` (the `emails/titan-tiers` flag is enabled in development configs).
2. Log in with an account that owns a custom domain without an email subscription.
3. Go to `http://my.localhost:3000/emails`, choose "Add mailbox", and pick the domain.
4. On "Choose an email solution", verify:
   * Three Titan cards (Pro, Premium, Ultra) render with per-month pricing ("billed every 12 months" when the annual toggle is selected), placeholder feature lists, "Everything in Pro/Premium" headers, and a "Powered by Titan" logo on each card.
   * The Pro card shows the free trial badge and "Start trial" CTA when the domain is eligible for the introductory offer; Premium and Ultra never show trial UI.
   * Google Workspace renders as a compact collapsible card below the grid; the chevron expands its feature list.
   * The grid is wider than the page header, mirroring the site-plans layout.
5. Select a tier and verify the add-mailbox page URL carries `?tier=premium`/`?tier=ultra` and checkout receives the matching product slug (`wp_titan_mail_premium_yearly`, etc.).
6. For a domain that already has a Titan subscription, verify the redirect to add-mailbox preserves the subscription's tier.
7. Disable the flag (or use a stage/production config) and verify the screen renders the existing two-provider comparison unchanged.

Note: Premium/Ultra products must exist in the store the API serves; on sandboxes without them the cards render with empty prices.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
