### PR TITLE
Agent Studio: Make the refine dock an inset panel and pin the actions bar

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -205,51 +206,57 @@ function OnePagerOutputDetail( { output }: Props ) {
 	const canAnnotate = pages.length > 1;
 
 	return (
-		<VStack spacing={ 4 } className="a4a-agent-studio-output-detail__content">
-			{ ( selectedVariant?.pdf_download_url || canAnnotate ) && (
-				<HStack
-					className="a4a-agent-studio-output-detail__actions"
-					justify="flex-end"
-					spacing={ 2 }
-				>
-					{ canAnnotate && (
-						<Button variant="secondary" onClick={ startAnnotating } disabled={ isAnnotating }>
-							{ __( 'Annotate' ) }
-						</Button>
-					) }
-					{ selectedVariant?.pdf_download_url && (
-						<Button
-							variant="primary"
-							href={ selectedVariant.pdf_download_url }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{ __( 'Download PDF' ) }
-						</Button>
-					) }
-				</HStack>
-			) }
-			{ ! coverSrcDoc && ( selectedVariantHtml.isLoading || baseVariantHtml.isLoading ) ? (
-				<StateMessage spinner>
-					<Text>{ __( 'Loading preview…' ) }</Text>
-				</StateMessage>
-			) : (
-				<AnnotationViewer
-					pages={ pages }
-					coverNavigation={
-						variants.length > 1
-							? {
-									count: variants.length,
-									activeIndex: safeIndex,
-									onSelect: setActiveIndex,
-							  }
-							: undefined
-					}
-					isAnnotating={ isAnnotating }
-					onExit={ exitAnnotating }
-					onSubmit={ handleAnnotationsSubmit }
-				/>
-			) }
+		<div
+			className={ clsx( 'a4a-agent-studio-output-detail__content', {
+				'is-refine-open': isRefineOpen && !! postId,
+			} ) }
+		>
+			<VStack spacing={ 4 } className="a4a-agent-studio-output-detail__main">
+				{ ( selectedVariant?.pdf_download_url || canAnnotate ) && (
+					<HStack
+						className="a4a-agent-studio-output-detail__actions"
+						justify="flex-end"
+						spacing={ 2 }
+					>
+						{ canAnnotate && (
+							<Button variant="secondary" onClick={ startAnnotating } disabled={ isAnnotating }>
+								{ __( 'Annotate' ) }
+							</Button>
+						) }
+						{ selectedVariant?.pdf_download_url && (
+							<Button
+								variant="primary"
+								href={ selectedVariant.pdf_download_url }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __( 'Download PDF' ) }
+							</Button>
+						) }
+					</HStack>
+				) }
+				{ ! coverSrcDoc && ( selectedVariantHtml.isLoading || baseVariantHtml.isLoading ) ? (
+					<StateMessage spinner>
+						<Text>{ __( 'Loading preview…' ) }</Text>
+					</StateMessage>
+				) : (
+					<AnnotationViewer
+						pages={ pages }
+						coverNavigation={
+							variants.length > 1
+								? {
+										count: variants.length,
+										activeIndex: safeIndex,
+										onSelect: setActiveIndex,
+								  }
+								: undefined
+						}
+						isAnnotating={ isAnnotating }
+						onExit={ exitAnnotating }
+						onSubmit={ handleAnnotationsSubmit }
+					/>
+				) }
+			</VStack>
 			{ isRefineOpen && postId && (
 				<RefineWithAiDock
 					collateralPostId={ postId }
@@ -259,7 +266,7 @@ function OnePagerOutputDetail( { output }: Props ) {
 					onClose={ () => setIsRefineOpen( false ) }
 				/>
 			) }
-		</VStack>
+		</div>
 	);
 }
 

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
@@ -1,17 +1,31 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .a4a-refine-with-ai-dock {
 	// Calypso doesn't set border-box globally here; without it the padded
 	// header overflows and pushes the close button off the edge.
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	position: fixed;
-	inset-block: 0;
-	inset-inline-end: 0;
-	width: min(400px, 100vw);
-	z-index: 100;
-	background: var(--color-surface);
-	border-inline-start: 1px solid var(--color-border-subtle);
-	box-shadow: -2px 0 12px rgba(0, 0, 0, 0.08);
+	width: 100%;
+	// On mobile the dock stacks below the preview; cap its height so the
+	// transcript scrolls internally and the input stays pinned.
+	height: min( 480px, 70vh );
+	background: var( --color-surface );
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 8px;
+	overflow: hidden;
+
+	// Desktop: the dock is inset beside the preview as a fixed-width column
+	// (reflowing the content, not overlaying it) and sticks within the
+	// scrolling layout body so it stays in view as the preview scrolls.
+	@include break-medium {
+		flex: 0 0 auto;
+		width: min( 380px, 100% );
+		position: sticky;
+		inset-block-start: 16px;
+		height: calc( 100vh - 130px );
+	}
 }
 
 .a4a-refine-with-ai-dock__header {
@@ -19,7 +33,7 @@
 	flex-shrink: 0;
 	padding-block: 12px;
 	padding-inline: 16px;
-	border-block-end: 1px solid var(--color-border-subtle);
+	border-block-end: 1px solid var( --color-border-subtle );
 }
 
 .a4a-refine-with-ai-dock__header strong {
@@ -45,4 +59,3 @@
 		padding-block-end: 16px;
 	}
 }
-

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/style.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/style.scss
@@ -1,9 +1,50 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .a4a-agent-studio-output-detail__content {
 	width: 100%;
 }
 
+.a4a-agent-studio-output-detail__main {
+	width: 100%;
+}
+
+// With the refine dock open, the content and dock sit side by side: the dock
+// is inset within the page layout and the preview reflows to make room for it,
+// rather than the dock floating over the layout as an overlay.
+.a4a-agent-studio-output-detail__content.is-refine-open {
+	@include break-medium {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		gap: 24px;
+	}
+
+	.a4a-agent-studio-output-detail__main {
+		min-width: 0;
+
+		@include break-medium {
+			flex: 1 1 auto;
+		}
+	}
+}
+
+// Keep the actions bar (Annotate / Download PDF) pinned to the top of the
+// scrolling layout body so it stays reachable as the user scrolls the preview.
+// The layout body has a 16px block-start padding; offsetting the sticky stop by
+// that amount pins the bar flush to the body's edge so the preview can't peek
+// through above it, and the matching block-start padding keeps the buttons in
+// place.
 .a4a-agent-studio-output-detail__actions {
 	width: 100%;
+	position: sticky;
+	inset-block-start: -16px;
+	z-index: 2;
+	padding-block: 16px 12px;
+	background: var( --color-surface );
+	// Lift the bar with a soft shadow so the preview reads as scrolling beneath
+	// a floating toolbar rather than being clipped by a hard line.
+	box-shadow: 0 6px 8px -6px rgba( 0, 0, 0, 0.16 );
 }
 
 .a4a-agent-studio-output-detail__state {


### PR DESCRIPTION
Part of A4AD-136

## Proposed Changes

* Dock the Agent Studio "Refine with AI" panel inline beside the deliverable preview as an inset, sticky column instead of a viewport overlay. When the dock is open, the preview reflows to make room for it (two-column row at `break-medium` and up; stacked below the preview on narrow screens).
* Pin the deliverable actions bar (Annotate / Download PDF) to the top of the scrolling layout body so it stays reachable as the preview grows, with a soft shadow so the preview reads as scrolling beneath a floating toolbar.

## Why are these changes being made?

The output-detail screen renders a one-pager preview plus a "Refine with AI" chat dock. The dock was a `position: fixed` drawer pinned to the viewport edge (`z-index: 100`), so it floated over the entire layout — including the sidebar navigation and header — rather than sitting within the page content. The agentic UI library (`@automattic/agenttic-ui`) has no "inset" vs "overlay" mode of its own (only a `floating`/`embedded` variant, and we already use `embedded`), so this was purely a question of how the dock was positioned on the page.

A4AD-136 asks for the inset presentation: the dock should be docked within the layout and reflow the content beside it, not overlay it.

Separately, the actions bar (Annotate / Download PDF) lived at the top of the content column and scrolled out of view as the user scrolled down a multi-page preview, so those actions became unreachable without scrolling back up.

## Testing Instructions

Prerequisites: a local A4A dev instance (`yarn start-a8c-for-agencies`) and an Agent Studio one-pager deliverable that has finished generating.

1. Open Agent Studio and click into a completed one-pager deliverable.
2. Scroll the preview down. Verify the **Annotate** and **Download PDF** actions stay pinned to the top of the scrolling area and remain clickable, with a soft shadow separating them from the preview pages (no preview content peeks above the bar).
3. Click **Annotate**, add a note, and send it to AI (or otherwise open the refine dock). Verify the "Refine with AI" dock appears as a column to the right of the preview and the preview shrinks to make room — it should not float over the sidebar navigation.
4. Scroll the preview while the dock is open. Verify the dock stays in view (sticky) and the transcript scrolls within the dock with the input pinned at the bottom.
5. Narrow the browser below the medium breakpoint. Verify the dock stacks below the preview at full width with its own internal scroll.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
