### PR TITLE
Remove redundant Gutenberg E2E schedules

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -41,6 +41,8 @@ object WPComTests : Project({
 		}
 	}
 
+	// Legacy per-leg Gutenberg build types stay addressable for Gutenbot/manual REST triggers.
+	// Do not schedule them here; the GutenbergPlaywrightTests matrix owns daily coverage.
 	// Gutenberg Simple
 	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c", atomic=false, edge=false));
 	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada", atomic=false, edge=false));
@@ -166,18 +168,6 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 		},
 		buildFeatures = {
 			notifyAllFailuresAndFirstSuccess("#gutenberg-e2e")
-		},
-		buildTriggers = {
-			schedule {
-				schedulingPolicy = daily {
-					hour = 4
-				}
-				branchFilter = """
-					+:trunk
-				""".trimIndent()
-				triggerBuild = always()
-				withPendingChangesOnly = false
-			}
 		}
 	)
 }


### PR DESCRIPTION
Part of TESTOPS-49

## Proposed Changes

* Remove the daily TeamCity schedule from the legacy per-leg Gutenberg E2E build factory.
* Keep the legacy build IDs and UUIDs addressable for Gutenbot/manual REST triggers.
* Keep the daily schedule on the consolidated `GutenbergPlaywrightTests` matrix build.

## Why are these changes being made?

The legacy per-leg Gutenberg builds are externally triggered by Gutenbot for release/nightly flows. They do not need their own daily TeamCity schedule now that the `GutenbergPlaywrightTests` matrix owns daily Gutenberg E2E coverage.

This keeps external callers working while reducing duplicate scheduled Gutenberg runs and related Slack noise.

## Testing Instructions

* Verified the diff only removes the legacy per-leg schedule block and leaves the matrix schedule intact.
* Ran `git diff --check HEAD~1..HEAD`.
* Tried TeamCity DSL generation with Maven, but local `mvn` is not installed.
* Tried TeamCity DSL generation with Docker Maven; dependency resolution failed while fetching the TeamCity DSL parent POM from TeamCity due a TLS handshake error.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?