### PR TITLE
MSD Emails: Add emails/titan-tiers feature flag

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -32,6 +32,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -32,6 +32,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": false,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -29,6 +29,7 @@
 		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": false,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -29,6 +29,7 @@
 		"dashboard/wp-beta-program": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": false,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,

--- a/config/development.json
+++ b/config/development.json
@@ -85,6 +85,7 @@
 		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
+		"emails/titan-tiers": true,
 		"entrepreneur/skip-trial-for-migration": true,
 		"google-drive": true,
 		"google-my-business": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,6 +36,7 @@
 		"design-picker/use-assembler-styles": true,
 		"domain-bundling": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": false,
 		"google-my-business": false,
 		"help": true,
 		"help-center/logged-out-fab": true,

--- a/config/production.json
+++ b/config/production.json
@@ -47,6 +47,7 @@
 		"dolly/telegram": true,
 		"domain-bundling": false,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": false,
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out-fab": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -46,6 +46,7 @@
 		"dev/store-sandbox-helper": true,
 		"dolly/telegram": true,
 		"domain-transfer-redesign": true,
+		"emails/titan-tiers": false,
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,6 +36,7 @@
 		"current-site/notice": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-banners": false,
+		"emails/titan-tiers": false,
 		"google-my-business": false,
 		"help": true,
 		"hosting-server-settings-enhancements": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,6 +51,7 @@
 		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
+		"emails/titan-tiers": false,
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,


### PR DESCRIPTION
Part of DOTEMP-111

## Proposed Changes

* Add a new `emails/titan-tiers` feature flag: enabled in `config/development.json` and `config/dashboard-development.json`, explicitly declared `false` in production, stage, horizon, wpcalypso, test, and the corresponding dashboard variant configs.

## Why are these changes being made?

The backend now supports three Titan plan tiers (Pro, Premium, Ultra). This flag will gate the tier plan selection UI in the Multi-site Dashboard Emails flow while pricing, copy, and design are finalized. Split out of #111530 to keep PRs small; the UI that consumes the flag follows in that PR.

## Testing Instructions

1. No user-facing changes; the flag is not referenced by any code yet.
2. Verify `emails/titan-tiers` is `true` only in the development configs and `false` in all other variants.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
