### PR TITLE
MSD Emails: Add Titan Premium/Ultra product slugs and tier-aware product detection

### DIFF
--- a/client/dashboard/emails/types.ts
+++ b/client/dashboard/emails/types.ts
@@ -36,3 +36,9 @@ export enum MailboxProvider {
 	Google = EmailProvider.Google,
 	Titan = EmailProvider.Titan,
 }
+
+export enum TitanPlanTier {
+	Pro = 'pro',
+	Premium = 'premium',
+	Ultra = 'ultra',
+}

--- a/client/dashboard/emails/utils/get-product-provider.ts
+++ b/client/dashboard/emails/utils/get-product-provider.ts
@@ -2,10 +2,9 @@ import { TitanMailSlugs } from '@automattic/api-core';
 import { MailboxProvider } from '../types';
 
 export function getProductProvider( emailProduct: { product_slug: string } ): MailboxProvider {
-	if (
-		emailProduct.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		emailProduct.product_slug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
-	) {
+	const titanSlugs = Object.values( TitanMailSlugs ) as readonly string[];
+
+	if ( titanSlugs.includes( emailProduct.product_slug ) ) {
 		return MailboxProvider.Titan;
 	}
 

--- a/client/dashboard/emails/utils/is-monthly-email-product.ts
+++ b/client/dashboard/emails/utils/is-monthly-email-product.ts
@@ -1,8 +1,12 @@
 import { TitanMailSlugs, GoogleWorkspaceSlugs } from '@automattic/api-core';
 
+const MONTHLY_EMAIL_PRODUCT_SLUGS: readonly string[] = [
+	TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
+	TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG,
+	TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG,
+	GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
+];
+
 export function isMonthlyEmailProduct( emailProduct: { product_slug: string } ): boolean {
-	return (
-		emailProduct.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		emailProduct.product_slug === GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
-	);
+	return MONTHLY_EMAIL_PRODUCT_SLUGS.includes( emailProduct.product_slug );
 }

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -1,0 +1,33 @@
+import { TitanMailSlugs } from '@automattic/api-core';
+import { IntervalLength, TitanPlanTier } from '../types';
+
+export const TITAN_TIER_SLUGS: Record< TitanPlanTier, Record< IntervalLength, string > > = {
+	[ TitanPlanTier.Pro ]: {
+		[ IntervalLength.Monthly ]: TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
+		[ IntervalLength.Annually ]: TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG,
+	},
+	[ TitanPlanTier.Premium ]: {
+		[ IntervalLength.Monthly ]: TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG,
+		[ IntervalLength.Annually ]: TitanMailSlugs.TITAN_MAIL_PREMIUM_YEARLY_SLUG,
+	},
+	[ TitanPlanTier.Ultra ]: {
+		[ IntervalLength.Monthly ]: TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG,
+		[ IntervalLength.Annually ]: TitanMailSlugs.TITAN_MAIL_ULTRA_YEARLY_SLUG,
+	},
+};
+
+export function isTitanPlanTier( value: unknown ): value is TitanPlanTier {
+	return Object.values( TitanPlanTier ).includes( value as TitanPlanTier );
+}
+
+export function getTitanTierFromSlug( productSlug?: string ): TitanPlanTier | undefined {
+	if ( ! productSlug ) {
+		return undefined;
+	}
+
+	const tiers = Object.keys( TITAN_TIER_SLUGS ) as TitanPlanTier[];
+
+	return tiers.find( ( tier ) =>
+		Object.values( TITAN_TIER_SLUGS[ tier ] ).includes( productSlug )
+	);
+}

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -25,9 +25,7 @@ export function getTitanTierFromSlug( productSlug?: string ): TitanPlanTier | un
 		return undefined;
 	}
 
-	const tiers = Object.keys( TITAN_TIER_SLUGS ) as TitanPlanTier[];
-
-	return tiers.find( ( tier ) =>
+	return Object.values( TitanPlanTier ).find( ( tier ) =>
 		Object.values( TITAN_TIER_SLUGS[ tier ] ).includes( productSlug )
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -42,10 +42,7 @@ export type ProductCategory =
 	| 'other';
 
 function isTitanMailSlug( productSlug: string ): boolean {
-	return (
-		productSlug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		productSlug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
-	);
+	return ( Object.values( TitanMailSlugs ) as readonly string[] ).includes( productSlug );
 }
 
 function isAkismetProductSlug( productSlug: string ): boolean {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -463,9 +463,11 @@ export function isJetpackCrmProduct( keyOrSlug: string ): boolean {
 type ObjectWithProductSlug = { product_slug?: string };
 
 export function isTitanMail( purchase: Purchase | ObjectWithProductSlug ): boolean {
-	return ( Object.values( TitanMailSlugs ) as readonly ( string | undefined )[] ).includes(
-		purchase.product_slug
-	);
+	if ( ! purchase.product_slug ) {
+		return false;
+	}
+
+	return ( Object.values( TitanMailSlugs ) as readonly string[] ).includes( purchase.product_slug );
 }
 
 export function isGoogleWorkspace( purchase: Purchase | ObjectWithProductSlug ): boolean {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -463,9 +463,8 @@ export function isJetpackCrmProduct( keyOrSlug: string ): boolean {
 type ObjectWithProductSlug = { product_slug?: string };
 
 export function isTitanMail( purchase: Purchase | ObjectWithProductSlug ): boolean {
-	return (
-		purchase.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
-		purchase.product_slug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
+	return ( Object.values( TitanMailSlugs ) as readonly ( string | undefined )[] ).includes(
+		purchase.product_slug
 	);
 }
 

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -282,6 +282,10 @@ export const DomainProductSlugs = {
 export const TitanMailSlugs = {
 	TITAN_MAIL_MONTHLY_SLUG: 'wp_titan_mail_monthly',
 	TITAN_MAIL_YEARLY_SLUG: 'wp_titan_mail_yearly',
+	TITAN_MAIL_PREMIUM_MONTHLY_SLUG: 'wp_titan_mail_premium_monthly',
+	TITAN_MAIL_PREMIUM_YEARLY_SLUG: 'wp_titan_mail_premium_yearly',
+	TITAN_MAIL_ULTRA_MONTHLY_SLUG: 'wp_titan_mail_ultra_monthly',
+	TITAN_MAIL_ULTRA_YEARLY_SLUG: 'wp_titan_mail_ultra_yearly',
 } as const;
 
 export const GoogleWorkspaceSlugs = {


### PR DESCRIPTION
Part of DOTEMP-111

## Proposed Changes

* Add the new Titan tier product slugs to `TitanMailSlugs` in `@automattic/api-core`: `wp_titan_mail_premium_monthly/yearly` and `wp_titan_mail_ultra_monthly/yearly`, matching the products registered on the backend (Premium: store IDs 402/403, Ultra: store IDs 404/405).
* Introduce a `TitanPlanTier` enum (`pro` | `premium` | `ultra`) and a tier-to-slug matrix with helpers (`getTitanTierFromSlug`, `isTitanPlanTier`) in `client/dashboard/emails/utils/titan-tiers.ts`.
* Convert exact slug-equality checks to set membership so all Titan products are detected, not just the original Pro pair:
  * `client/dashboard/emails/utils/is-monthly-email-product.ts`
  * `client/dashboard/emails/utils/get-product-provider.ts`
  * `isTitanMail()` in `client/dashboard/utils/purchase.ts`
  * `isTitanMailSlug()` in `client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts`

## Why are these changes being made?

The backend now supports three Titan plan tiers (Pro, Premium, Ultra). This PR lays the client-side groundwork so the new products are classified correctly in the emails flow, the purchases list, and cancellation copy before any UI sells them. Split out of #111530 to keep PRs small; the tier-aware purchase flow and the plan selection UI follow in stacked PRs.

There is no behavior change today: the membership checks return identical results to the old equality checks for every product that currently exists, and the new helpers are not referenced yet.

## Testing Instructions

1. No user-facing changes.
2. `yarn typecheck-client` passes.
3. Verify existing email purchase flows are unaffected: provider/interval detection for `wp_titan_mail_monthly/yearly` and Google Workspace products behaves as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
