### PR TITLE
MSD Emails: Thread Titan plan tier through the mailbox purchase flow

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -11,7 +11,8 @@ import {
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, Outlet } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
-import { IntervalLength, MailboxProvider } from '../../emails/types';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../emails/types';
+import { isTitanPlanTier } from '../../emails/utils/titan-tiers';
 import { accountHasWarningWithSlug } from '../../utils/email-utils';
 import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
@@ -144,6 +145,11 @@ export const addMailboxRoute = createRoute( {
 	} ),
 	getParentRoute: () => emailsRoute,
 	path: 'add-mailbox/$domain/$provider/$interval',
+	validateSearch: ( search ): { tier?: TitanPlanTier } => {
+		return {
+			tier: isTitanPlanTier( search.tier ) ? search.tier : undefined,
+		};
+	},
 	beforeLoad: async ( { params: { domain: domainName, provider, interval } } ) => {
 		await redirectIfInvalidDomain( domainName );
 

--- a/client/dashboard/emails/add-mailbox/components/cart.tsx
+++ b/client/dashboard/emails/add-mailbox/components/cart.tsx
@@ -30,11 +30,11 @@ const animation = {
 export const Cart = ( {
 	totalItems,
 	totalPrice,
-	isCartBusy,
+	disabled,
 }: {
 	totalItems: number;
 	totalPrice: string;
-	isCartBusy: boolean;
+	disabled?: boolean;
 } ) => {
 	const { recordTracksEvent } = useAnalytics();
 	const { domainName } = useDomainFromUrlParam();
@@ -68,7 +68,7 @@ export const Cart = ( {
 							<Button
 								variant="primary"
 								__next40pxDefaultSize
-								disabled={ isCartBusy }
+								disabled={ disabled }
 								type="submit"
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_emails_add_mailbox_add_to_cart_click', {

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -1,7 +1,7 @@
 import { createTitanMailboxMutation, mailboxAccountsQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { useMatch, useParams } from '@tanstack/react-router';
+import { useMatch, useParams, useSearch } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, Notice } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -41,10 +41,11 @@ const AddProfessionalEmail = () => {
 	const isAddMailboxRoute = match.routeId === addMailboxRoute.id;
 
 	const { provider, interval } = useParams( { shouldThrow: false, strict: false } );
+	const { tier } = useSearch( { strict: false } );
 
 	const { domain, domainName } = useDomainFromUrlParam();
 	const userCanAddEmail = domain?.current_user_can_add_email;
-	const { product } = useEmailProduct( provider, interval, domain );
+	const { product } = useEmailProduct( provider, interval, domain, tier );
 	const { data: existingMailboxes } = useSuspenseQuery(
 		mailboxAccountsQuery( domain.blog_id, domainName )
 	);

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -139,7 +139,7 @@ const AddProfessionalEmail = () => {
 
 	const showEmailPurchaseDisabledMessage = ! userCanAddEmail && ! isDomainInCart;
 	const disabled = isAddMailboxRoute
-		? isSubmitting || showEmailPurchaseDisabledMessage
+		? isSubmitting || showEmailPurchaseDisabledMessage || ! product
 		: isSubmitting || isPending;
 
 	let mailboxCost;
@@ -262,7 +262,7 @@ const AddProfessionalEmail = () => {
 					</ButtonStack>
 
 					{ isAddMailboxRoute && (
-						<Cart totalItems={ totalItems } totalPrice={ totalPrice } isCartBusy={ isSubmitting } />
+						<Cart totalItems={ totalItems } totalPrice={ totalPrice } disabled={ disabled } />
 					) }
 				</VStack>
 			</form>

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -30,9 +30,10 @@ import { useAnnualSavings } from '../hooks/use-annual-savings';
 import { useDomainFromUrlParam } from '../hooks/use-domain-from-url-param';
 import { useEmailProduct } from '../hooks/use-email-product';
 import poweredByTitanLogo from '../resources/powered-by-titan-caps.svg';
-import { IntervalLength, MailboxProvider } from '../types';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../types';
 import { isEligibleForIntroductoryOffer } from '../utils/is-eligible-for-introductory-offer';
 import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
+import { getTitanTierFromSlug } from '../utils/titan-tiers';
 import { ExistingForwardsNotice } from './components/existing-forwards-notice';
 
 import './style.scss';
@@ -87,6 +88,7 @@ export default function ChooseEmailSolution() {
 	const navigate = useNavigate();
 	let redirectTo = null;
 	if ( hasTitanMailWithUs( domain ) && isTitanAvailable ) {
+		const subscriptionTier = getTitanTierFromSlug( titanEmailSubscription?.product_slug );
 		redirectTo = {
 			to: addMailboxRoute.to,
 			params: {
@@ -95,6 +97,10 @@ export default function ChooseEmailSolution() {
 				interval: isMonthlyEmailProduct( titanEmailSubscription )
 					? IntervalLength.Monthly
 					: IntervalLength.Annually,
+			},
+			search: {
+				// Omit the default tier so existing Pro URLs stay unchanged.
+				tier: subscriptionTier === TitanPlanTier.Pro ? undefined : subscriptionTier,
 			},
 		};
 	} else if ( hasGSuiteWithUs( domain ) && isGoogleAvailable ) {

--- a/client/dashboard/emails/hooks/use-add-to-cart.ts
+++ b/client/dashboard/emails/hooks/use-add-to-cart.ts
@@ -1,4 +1,4 @@
-import { useParams, useRouter } from '@tanstack/react-router';
+import { useParams, useRouter, useSearch } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -17,9 +17,10 @@ export const useAddToCart = () => {
 	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { provider, interval } = useParams( { strict: false } );
+	const { tier } = useSearch( { strict: false } );
 	const { domain, domainName, site } = useDomainFromUrlParam();
 
-	const emailProduct = useEmailProduct( provider, interval, domain );
+	const emailProduct = useEmailProduct( provider, interval, domain, tier );
 	const router = useRouter();
 
 	const addToCart = async ( {

--- a/client/dashboard/emails/hooks/use-add-to-cart.ts
+++ b/client/dashboard/emails/hooks/use-add-to-cart.ts
@@ -30,6 +30,14 @@ export const useAddToCart = () => {
 		mailboxOperations: MailboxOperations;
 		onFinally: () => void;
 	} ) => {
+		// The cart item reads product_slug off the product, so bail if it hasn't
+		// resolved (e.g. a tier whose product isn't available).
+		const product = emailProduct.product;
+		if ( ! product ) {
+			onFinally();
+			return;
+		}
+
 		const { shoppingCartManagerClient } = await import(
 			/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
 		);
@@ -39,7 +47,7 @@ export const useAddToCart = () => {
 		const emailProperties = getEmailProductProperties(
 			provider,
 			domain,
-			emailProduct.product,
+			product,
 			numberOfMailboxes
 		);
 

--- a/client/dashboard/emails/hooks/use-email-product.ts
+++ b/client/dashboard/emails/hooks/use-email-product.ts
@@ -1,23 +1,19 @@
-import { Domain, GoogleWorkspaceSlugs, Product, TitanMailSlugs } from '@automattic/api-core';
+import { Domain, GoogleWorkspaceSlugs, Product } from '@automattic/api-core';
 import { productsQuery, siteProductsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { MailboxProvider, IntervalLength } from '../types';
+import { MailboxProvider, IntervalLength, TitanPlanTier } from '../types';
+import { TITAN_TIER_SLUGS } from '../utils/titan-tiers';
 
-const EMAIL_PRODUCTS = {
-	[ MailboxProvider.Titan ]: {
-		monthly: TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
-		annually: TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG,
-	},
-	[ MailboxProvider.Google ]: {
-		monthly: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
-		annually: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-	},
+const GOOGLE_PRODUCTS = {
+	monthly: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
+	annually: GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 };
 
 export const useEmailProduct = (
 	provider: MailboxProvider,
 	interval: IntervalLength,
-	domain?: Domain
+	domain?: Domain,
+	tier: TitanPlanTier = TitanPlanTier.Pro
 ) => {
 	const siteId = domain?.blog_id;
 	const { data: siteProducts } = useQuery( {
@@ -29,7 +25,10 @@ export const useEmailProduct = (
 		enabled: ! siteId,
 	} );
 
-	const productSlug = EMAIL_PRODUCTS[ provider ]?.[ interval ];
+	const productSlug =
+		provider === MailboxProvider.Titan
+			? TITAN_TIER_SLUGS[ tier ]?.[ interval ]
+			: GOOGLE_PRODUCTS[ interval ];
 	const product = ( siteId ? siteProducts : products )?.[ productSlug ] as Product;
 
 	return {

--- a/client/dashboard/emails/hooks/use-email-product.ts
+++ b/client/dashboard/emails/hooks/use-email-product.ts
@@ -29,7 +29,7 @@ export const useEmailProduct = (
 		provider === MailboxProvider.Titan
 			? TITAN_TIER_SLUGS[ tier ]?.[ interval ]
 			: GOOGLE_PRODUCTS[ interval ];
-	const product = ( siteId ? siteProducts : products )?.[ productSlug ] as Product;
+	const product = ( siteId ? siteProducts : products )?.[ productSlug ] as Product | undefined;
 
 	return {
 		product,

--- a/client/dashboard/emails/utils/get-cart-items.ts
+++ b/client/dashboard/emails/utils/get-cart-items.ts
@@ -1,8 +1,6 @@
-import { TitanMailSlugs } from '@automattic/api-core';
 import { MailboxForm, GSuiteProductUser } from '../entities/mailbox-form';
 import { MailboxProvider } from '../types';
 import { EmailProperties } from './get-email-product-properties';
-import { isMonthlyEmailProduct } from './is-monthly-email-product';
 import type { MinimalRequestCartProduct, RequestCartProductExtra } from '@automattic/shopping-cart';
 
 export interface TitanProductProps {
@@ -56,37 +54,23 @@ function titanMailProduct(
 	};
 }
 
-/**
- * Creates a new shopping cart item for Titan Mail Yearly.
- */
-export function titanMailYearly( properties: TitanProductProps ): MinimalRequestCartProduct {
-	return titanMailProduct( properties, TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG );
-}
-
-/**
- * Creates a new shopping cart item for Titan Mail Monthly.
- */
-export function titanMailMonthly( properties: TitanProductProps ): MinimalRequestCartProduct {
-	return titanMailProduct( properties, TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG );
-}
-
 const getTitanCartItems = (
 	mailboxes: MailboxForm< MailboxProvider >[],
 	mailProperties: EmailProperties
 ) => {
 	const { emailProduct, newQuantity, quantity } = mailProperties;
 	const email_users = mailboxes.map( ( mailbox ) => mailbox.getAsCartItem() );
-	const cartItemFunction = isMonthlyEmailProduct( emailProduct )
-		? titanMailMonthly
-		: titanMailYearly;
-	return cartItemFunction( {
-		domain: mailboxes[ 0 ].formFields.domain.value,
-		quantity,
-		extra: {
-			email_users,
-			new_quantity: newQuantity,
+	return titanMailProduct(
+		{
+			domain: mailboxes[ 0 ].formFields.domain.value,
+			quantity,
+			extra: {
+				email_users,
+				new_quantity: newQuantity,
+			},
 		},
-	} );
+		emailProduct.product_slug
+	);
 };
 
 const getGSuiteCartItems = (


### PR DESCRIPTION
Part of DOTEMP-111

## What is this PR for?

Titan email has three plan tiers: **Pro, Premium, and Ultra**. Right now the "add mailbox" purchase flow always buys Pro. This PR teaches that flow to carry a chosen tier all the way from the entry point to checkout, so the upcoming plan-picker UI (#111530) can buy the right one.

**Nothing changes for users today.** Every path still defaults to Pro and buys the exact same product as before. This is plumbing for the next PR.

## What changed

* The purchase flow can now carry an optional tier (defaulting to Pro) and resolves it to the correct product for checkout.
* The selected tier can be passed through the add-mailbox URL; unrecognized values fall back to the default.
* When a domain already has a Titan subscription, the flow reuses that subscription's tier, so adding seats stays on the same plan. URLs for the existing (Pro) case are unchanged.

## Testing Instructions

1. Run the dashboard and go through: Emails > Add mailbox > pick a domain > Get Professional Email > add a mailbox > Purchase.
2. Confirm the checkout cart contains `wp_titan_mail_yearly` (or `_monthly`), exactly as before.
3. Confirm a domain with an existing Titan subscription still redirects into add-mailbox with no `tier` in the URL.
4. Add `?tier=garbage` to an add-mailbox URL and confirm it's ignored. `?tier=premium` is accepted (the resolved product stays empty until the Premium product exists in the store, which is expected for now).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
