### PR TITLE
Domains: fix bundle tracking tests broken by the live fetcher merge

### DIFF
--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1,4 +1,4 @@
-import { DomainAvailabilityStatus } from '@automattic/api-core';
+import { DomainAvailabilityStatus, type BundleSuggestion } from '@automattic/api-core';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { buildAvailability } from '../../test-helpers/factories/availability';
@@ -6,11 +6,30 @@ import { buildCart, buildCartItem } from '../../test-helpers/factories/cart';
 import { buildFreeSuggestion, buildSuggestion } from '../../test-helpers/factories/suggestions';
 import { mockGetAvailabilityQuery } from '../../test-helpers/queries/availability';
 import {
+	mockGetBundleSuggestionQuery,
 	mockGetFreeSuggestionQuery,
 	mockGetSuggestionsQuery,
 } from '../../test-helpers/queries/suggestions';
 import { TestDomainSearch } from '../../test-helpers/renderer';
 import { ResultsPage } from '../results';
+
+// Mirrors the retired mock fetcher's fixture shape (mock-<sld>-group ids) so
+// assertions written against it keep reading naturally.
+const buildBundleSuggestion = ( sld: string ): BundleSuggestion => ( {
+	sld,
+	domains: [
+		{ domain: `${ sld }.com`, cost: '$22.00', raw_price: 22, product_slug: 'domain_reg' },
+		{ domain: `${ sld }.net`, cost: '$18.00', raw_price: 18, product_slug: 'domain_reg' },
+		{ domain: `${ sld }.org`, cost: '$20.00', raw_price: 20, product_slug: 'domain_reg' },
+	],
+	bundle_price: 48,
+	original_price: 60,
+	discount_percent: 20,
+	category: 'business',
+	bundle_id: `mock-${ sld }`,
+	bundle_group_id: `mock-${ sld }-group`,
+	catalogue_version: 'mock',
+} );
 
 describe( 'ResultsPage', () => {
 	it( 'renders the search bar, filters and cart', () => {
@@ -934,6 +953,10 @@ describe( 'ResultsPage', () => {
 				params: { query: 'bundle-shown' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-shown.com' } ) ],
 			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-shown' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-shown' ),
+			} );
 
 			render(
 				<TestDomainSearch
@@ -984,6 +1007,10 @@ describe( 'ResultsPage', () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'bundle-accept' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-accept.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-accept' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-accept' ),
 			} );
 
 			render(


### PR DESCRIPTION
Related to #DOMAINS-2179

## Proposed Changes

Fixes two bundle tracking tests that are currently failing on trunk: `ResultsPage › tracking › fires the onBundleShown event once when a bundle suggestion renders` and `fires the onBundleAddToCart event when the bundle CTA is clicked`.

These tests landed in #111470 written against the retired mock bundle fetcher. #111449 (the live `with_bundles=1` fetcher) merged 18 minutes earlier without a rebase between the two, so on trunk the bundle request goes unmocked, the suggestion never resolves, the card never renders, and both tests fail. Any branch rebased onto current trunk inherits the failure (this is what's failing CI on #111450).

The fix mocks the `with_bundles=1` request with `mockGetBundleSuggestionQuery` (already in the test helpers from #111449) and a fixture that keeps the old `mock-<sld>-group` id scheme, so the existing assertions read unchanged.

## Testing Instructions

```
yarn test-packages packages/domain-search/src/page/test/results.tsx
```

39/39 pass (was 37/39 on trunk).
