### PR TITLE
Subscribers: source total counts from the list response (NL-274)

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -316,12 +316,18 @@ export default function SubscriberDataViews( {
 		is_owner_subscribed: isOwnerSubscribed,
 		pages,
 		total,
+		total_unfiltered: totalUnfiltered,
 	} = subscribersQueryResult || {
 		subscribers: [],
 		is_owner_subscribed: false,
 		pages: 0,
 		total: 0,
+		total_unfiltered: undefined,
 	};
+	// Prefer the list endpoint's unfiltered population over /counts so the
+	// "X out of Y total" denominator can't lag behind the filtered numerator.
+	// See NL-274 / 222712-ghe-Automattic/wpcom.
+	const denominator = totalUnfiltered ?? grandTotal;
 
 	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : JetpackEmptyListView;
 	const shouldShowLaunchpad =
@@ -687,15 +693,19 @@ export default function SubscriberDataViews( {
 	}, [ currentView.search, currentView.filters ] );
 
 	// Memoize the data and pagination info.
+	// totalItems is the count of rows being paged through: the filtered total
+	// from the list response, which always matches `pages`. Using the /counts
+	// grand total here would mismatch the data when a filter is active (and
+	// could drift from the list count even without filters — see NL-274).
 	const { data, paginationInfo } = useMemo( () => {
 		return {
 			data: subscribers,
 			paginationInfo: {
-				totalItems: grandTotal,
+				totalItems: total,
 				totalPages: pages,
 			},
 		};
-	}, [ subscribers, grandTotal, pages ] );
+	}, [ subscribers, total, pages ] );
 
 	return (
 		<div
@@ -777,7 +787,7 @@ export default function SubscriberDataViews( {
 					) : (
 						<>
 							<SubscriberTotals
-								totalSubscribers={ grandTotal }
+								totalSubscribers={ denominator }
 								filteredCount={ total }
 								filters={ filters }
 								searchTerm={ searchTerm }

--- a/client/my-sites/subscribers/components/subscriber-totals/test/subscriber-totals.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/test/subscriber-totals.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { SubscribersFilterBy } from '../../../constants';
+import SubscriberTotals from '../index';
+
+describe( 'SubscriberTotals', () => {
+	it( 'renders only the grand total when no filter or search is active', () => {
+		render(
+			<SubscriberTotals
+				totalSubscribers={ 100 }
+				filteredCount={ 100 }
+				filters={ [ SubscribersFilterBy.All ] }
+				searchTerm=""
+				isLoading={ false }
+			/>
+		);
+
+		expect( screen.getByText( '100 total subscribers' ) ).toBeVisible();
+		expect( screen.queryByText( /out of/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders "<filtered> out of <total>" when a filter is active', () => {
+		render(
+			<SubscriberTotals
+				totalSubscribers={ 200 }
+				filteredCount={ 50 }
+				filters={ [ SubscribersFilterBy.Paid ] }
+				searchTerm=""
+				isLoading={ false }
+			/>
+		);
+
+		expect( screen.getByText( '50 paid subscribers' ) ).toBeVisible();
+		expect( screen.getByText( 'out of 200 total subscribers' ) ).toBeVisible();
+	} );
+
+	it( 'renders the denominator the parent passes, keeping numerator ≤ denominator', () => {
+		// Regression for NL-274: when every subscriber matches the active
+		// filter (here, all 500 happen to be free), the filtered numerator
+		// can equal — but must never exceed — the unfiltered denominator.
+		const totalUnfiltered = 500;
+		const filteredFree = 500;
+
+		render(
+			<SubscriberTotals
+				totalSubscribers={ totalUnfiltered }
+				filteredCount={ filteredFree }
+				filters={ [ SubscribersFilterBy.Free ] }
+				searchTerm=""
+				isLoading={ false }
+			/>
+		);
+
+		expect( screen.getByText( '500 free subscribers' ) ).toBeVisible();
+		expect( screen.getByText( 'out of 500 total subscribers' ) ).toBeVisible();
+		expect( filteredFree ).toBeLessThanOrEqual( totalUnfiltered );
+	} );
+
+	it( 'renders matching-results copy when searching', () => {
+		render(
+			<SubscriberTotals
+				totalSubscribers={ 1000 }
+				filteredCount={ 3 }
+				filters={ [ SubscribersFilterBy.All ] }
+				searchTerm="alice"
+				isLoading={ false }
+			/>
+		);
+
+		expect( screen.getByText( '3 matching results' ) ).toBeVisible();
+		expect( screen.getByText( 'out of 1,000 total subscribers' ) ).toBeVisible();
+	} );
+
+	it( 'renders unconfirmed-only copy without a denominator', () => {
+		render(
+			<SubscriberTotals
+				totalSubscribers={ 200 }
+				filteredCount={ 7 }
+				filters={ [ SubscribersFilterBy.UnconfirmedSubscriber ] }
+				searchTerm=""
+				isLoading={ false }
+			/>
+		);
+
+		expect( screen.getByText( '7 unconfirmed subscribers' ) ).toBeVisible();
+		expect( screen.queryByText( /out of/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a loading spinner while data is in flight', () => {
+		const { container } = render(
+			<SubscriberTotals
+				totalSubscribers={ 0 }
+				filteredCount={ 0 }
+				filters={ [ SubscribersFilterBy.All ] }
+				searchTerm=""
+				isLoading
+			/>
+		);
+
+		expect( container.querySelector( '.subscriber-totals.is-loading' ) ).toBeVisible();
+	} );
+} );

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -3,6 +3,7 @@ import { SubscribersFilterBy, SubscribersSortBy } from '../constants';
 export type SubscriberEndpointResponse = {
 	per_page: number;
 	total: number;
+	total_unfiltered?: number;
 	page: number;
 	pages: number;
 	subscribers: Subscriber[];


### PR DESCRIPTION
Part of NL-274. Backend: 222712-ghe-Automattic/wpcom (must ship first).

## Proposed Changes

* Add an optional `total_unfiltered` field to `SubscriberEndpointResponse` to match the new field returned by the `/subscribers/list` endpoint.
* In `SubscriberDataViews`, use `total_unfiltered` (with a fallback to the existing `/counts` `total_subscribers`) as the "X out of Y total subscribers" denominator.
* Point the DataViews paginator's `totalItems` at the list response's filtered `total`, so the "N items" footer always matches the rows being paged.
* Add unit tests for `SubscriberTotals` covering the unfiltered/filtered/search/unconfirmed/loading branches, plus a regression case where the filtered count equals the unfiltered population (numerator ≤ denominator).

Before | After
--- | ----
<img width="448" height="227" alt="Screenshot 2026-06-10 at 4 37 04 PM" src="https://github.com/user-attachments/assets/697535b0-03ef-4ef9-ac69-eb153b3a9028" /> | <img width="444" height="231" alt="Screenshot 2026-06-10 at 4 36 24 PM" src="https://github.com/user-attachments/assets/01449625-c4a8-4a9e-91fe-40f83232a313" />


## Why are these changes being made?

The Subscribers page rendered "X filtered subscribers out of Y total" with numerator and denominator from **different endpoints**: the numerator came from `GET /sites/<id>/subscribers/list` (the live, deduped list), the denominator from `GET /sites/<id>/subscribers/counts` (a precomputed aggregate that misses email subscribers with `user_id > 0` and no reader-follow row). The aggregate can lag the list, so filtering by "free" or "paid" can produce the impossible-looking state of the filtered count exceeding the total. The DataViews paginator footer was sourced from the same stale aggregate, so its "N items" disagreed with the filtered list it was paging through.

222712-ghe-Automattic/wpcom adds `total_unfiltered` to the list response so the denominator can come from the same query as the numerator. Numerator ≤ denominator now holds by construction. The frontend keeps the `/counts` fallback so this PR is safe to merge before the wpcom field is deployed.

This is a frontend-display fix only; the aggregate still undercounts on other surfaces (Stats, etc.) and that's a separate backend follow-up (NL-274 phase 2), out of scope here.

## Testing Instructions

Requires an API sandbox pointing at a wpcom checkout with 222712-ghe-Automattic/wpcom applied, plus a site exhibiting count drift.

1. Visit `/subscribers/<site>`.
2. With no filter active, confirm "Y total subscribers" in the header. With `total_unfiltered` present, this reflects the list endpoint's full population.
3. Apply the **Free** (or **Paid**) filter. Confirm "X free subscribers out of Y total subscribers" renders, and that **X ≤ Y** even on a drift-affected site where the pre-fix behavior would have shown X > Y.
4. Confirm the DataViews paginator footer at the bottom of the table shows a count that matches the filtered list, not the `/counts` aggregate.
5. Fallback path: with a build pointed at production (no `total_unfiltered` in the response), confirm the page still renders correctly using the existing `/counts` denominator.
6. Unit tests: `yarn test-client client/my-sites/subscribers`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

### Deploy ordering

222712-ghe-Automattic/wpcom (backend) **must reach production before this PR is merged**. The fallback to `/counts` keeps the page working if this lands first, but the bug only resolves once the new field is being served.