### PR TITLE
Improve Tracks events

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -106,6 +106,10 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( '../../utils/tracks', () => ( {
+	recordBigSkyTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
+} ) );
 jest.mock( '../../stores', () => ( {
 	AGENTS_MANAGER_STORE: 'automattic/agents-manager',
 } ) );

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -11,6 +11,8 @@ const mockSetIsOpen = jest.fn();
 const mockSetIsDocked = jest.fn();
 const mockUseAgentLayoutManager = jest.fn();
 const mockResumeActiveChat = jest.fn();
+const mockCloseSidebar = jest.fn();
+let mockLayoutIsDocked = false;
 let mockContext: Partial< AgentsManagerContextType > = {};
 let mockAgentsManagerState: {
 	isOpen?: boolean;
@@ -49,6 +51,10 @@ jest.mock( '@wordpress/icons', () => ( {
 jest.mock( '../../contexts', () => ( {
 	useAgentsManagerContext: () => mockContext,
 } ) );
+jest.mock( '../../utils/tracks', () => ( {
+	recordBigSkyTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
+} ) );
 jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
 	__esModule: true,
 	default: () => mockHasAdminBar,
@@ -56,12 +62,12 @@ jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
 jest.mock( '../../hooks/use-agent-layout-manager', () => ( options: unknown ) => {
 	mockUseAgentLayoutManager( options );
 	return {
-		isDocked: false,
-		canDock: false,
+		isDocked: mockLayoutIsDocked,
+		canDock: mockLayoutIsDocked,
 		dock: jest.fn(),
 		undock: jest.fn(),
 		openSidebar: jest.fn(),
-		closeSidebar: jest.fn(),
+		closeSidebar: mockCloseSidebar,
 		createAgentPortal: ( children: React.ReactNode ) => children,
 	};
 } );
@@ -82,14 +88,17 @@ jest.mock( '../orchestrator-chat', () => ( {
 		chatHeaderOptions,
 		isOpen,
 		onExpand,
+		onClose,
 	}: {
 		chatHeaderOptions: { title: string }[];
 		isOpen: boolean;
 		onExpand: () => void;
+		onClose: () => void;
 	} ) => (
 		<div data-testid="orchestrator-chat" data-chat-open={ String( isOpen ) }>
 			{ chatHeaderOptions.map( ( option ) => option.title ).join( '|' ) }
 			<button onClick={ onExpand }>Expand chat</button>
+			<button onClick={ onClose }>Close chat</button>
 		</div>
 	),
 } ) );
@@ -126,6 +135,9 @@ jest.mock( '../support-guides', () => ( {
 } ) );
 
 import AgentDock from '../agent-dock';
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
+
+const mockRecordBigSkyTracksEvent = recordBigSkyTracksEvent as jest.Mock;
 
 function LocationProbe() {
 	const { pathname } = useLocation();
@@ -159,6 +171,7 @@ describe( 'AgentDock', () => {
 		jest.clearAllMocks();
 		mockHasAdminBar = false;
 		mockShouldUseUnifiedAgent = false;
+		mockLayoutIsDocked = false;
 		mockAgentsManagerState = { isOpen: true, isDocked: false };
 		mockContext = {
 			siteKey: 'site-1',
@@ -305,6 +318,33 @@ describe( 'AgentDock', () => {
 		expect( mockUseAgentLayoutManager ).toHaveBeenCalledWith(
 			expect.objectContaining( { defaultDocked: false } )
 		);
+	} );
+
+	it( 'fires only dock_back_button_click when closing while undocked', () => {
+		useWpAdminAgent();
+		mockLayoutIsDocked = false;
+
+		renderAgentDock();
+		fireEvent.click( screen.getByText( 'Close chat' ) );
+
+		// Undocked close collapses the floating panel and tracks the back button.
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'dock_back_button_click' );
+		expect( mockRecordBigSkyTracksEvent ).not.toHaveBeenCalledWith( 'sidebar_close_click' );
+		expect( mockCloseSidebar ).not.toHaveBeenCalled();
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( false, true );
+	} );
+
+	it( 'collapses the sidebar without dock_back_button_click when closing while docked', () => {
+		useWpAdminAgent();
+		mockLayoutIsDocked = true;
+
+		renderAgentDock();
+		fireEvent.click( screen.getByText( 'Close chat' ) );
+
+		// Docked close goes through closeSidebar, which fires sidebar_close_click
+		// via onCloseSidebar — so dock_back_button_click must not fire here.
+		expect( mockCloseSidebar ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordBigSkyTracksEvent ).not.toHaveBeenCalledWith( 'dock_back_button_click' );
 	} );
 
 	it( 'opens regular agents and saves shared Agents Manager state', () => {

--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -39,6 +39,10 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { setIsMinimized: mockSetIsMinimized } ),
 } ) );
 jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
+jest.mock( '../../utils/tracks', () => ( {
+	recordBigSkyTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
+} ) );
 jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
 	hasAiChatEntryButton: () =>
 		!! globalThis.document.getElementById( 'wp-admin-bar-agents-manager-ai-chat' ) ||

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -35,6 +35,10 @@ jest.mock( '../../contexts', () => ( {
 jest.mock( '../../hooks/custom-actions', () => ( {
 	useRegisterCustomActions: () => {},
 } ) );
+jest.mock( '../../utils/tracks', () => ( {
+	recordBigSkyTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
+} ) );
 jest.mock( '../../hooks/use-conversation', () => () => ( { isLoading: false } ) );
 jest.mock( '../../hooks/use-save-new-chat-route', () => () => {} );
 jest.mock( '../../hooks/use-checkpoint-action', () => () => {} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 /* eslint-disable import/order -- jest.mock calls must precede imports */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { Suggestion } from '@automattic/agenttic-ui';
 
 const mockUseAgentChat = jest.fn();
@@ -70,8 +70,10 @@ jest.mock( '../agent-chat', () => ( {
 	__esModule: true,
 	default: ( {
 		onSuggestionClick,
+		onSubmit,
 	}: {
 		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
+		onSubmit: ( message: string ) => void;
 	} ) => (
 		<>
 			<button
@@ -88,14 +90,17 @@ jest.mock( '../agent-chat', () => ( {
 			<button onClick={ () => onSuggestionClick( 'Check the grammar and spelling of this text' ) }>
 				Click string suggestion
 			</button>
+			<button onClick={ () => onSubmit( 'Describe these images' ) }>Submit with images</button>
 		</>
 	),
 } ) );
 
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import OrchestratorChat from '../orchestrator-chat';
 
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
 		mockUseAgentChat.mockReturnValue( {
 			addMessage: jest.fn(),
 			messages: [],
@@ -212,5 +217,45 @@ describe( 'OrchestratorChat', () => {
 		);
 
 		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
+	} );
+
+	it( 'fires file_upload_success after images upload on send, with the uploaded media count', async () => {
+		const uploadImagesToWordPress = jest.fn().mockResolvedValue( [
+			{ id: 1, url: 'a' },
+			{ id: 2, url: 'b' },
+		] );
+		const useImageUpload = () => ( {
+			pendingImages: [ { id: 'p1' }, { id: 'p2' } ],
+			uploadingImages: [],
+			isUploadingImages: false,
+			handleFilesSelected: jest.fn(),
+			handleRemoveImage: jest.fn(),
+			uploadImagesToWordPress,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useImageUpload={ useImageUpload as never }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Submit with images' ) );
+
+		await waitFor( () => {
+			expect( uploadImagesToWordPress ).toHaveBeenCalled();
+			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'file_upload_success', {
+				count: 2,
+			} );
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -9,15 +9,17 @@ import {
 	type MarkdownExtensions,
 	type Suggestion,
 	type ChatState,
+	type UploadedImage,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useMemo, useRef } from '@wordpress/element';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isPluginCompassHost } from '../../utils/is-plugin-compass-agent';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ChatMessageSkeleton from '../chat-message-skeleton';
 import ContextCards from '../context-cards';
@@ -222,6 +224,64 @@ export default function AgentChat( {
 		floatingChatState = 'compact';
 	}
 
+	// Image-upload tracking mirrors Big Sky's `file_upload_*` events. The
+	// uploader only renders on the editor surface (a provider supplies
+	// `useImageUpload`); reader-chat has no provider, but gate defensively so
+	// `jetpack_big_sky_*` never fires from that surface.
+	const trackImageUpload = ! isReaderChatHost() && !! imageUpload;
+	const handleFilesSelected = useCallback(
+		async ( files: File[] ) => {
+			if ( trackImageUpload ) {
+				recordBigSkyTracksEvent( 'file_upload_success', {
+					count: files.length,
+				} );
+			}
+			await imageUpload?.handleFilesSelected( files );
+		},
+		[ imageUpload, trackImageUpload ]
+	);
+	const handleBrowse = useCallback(
+		( files: File[] ) => {
+			if ( trackImageUpload ) {
+				recordBigSkyTracksEvent( 'file_upload_click', {
+					count: files.length,
+				} );
+			}
+		},
+		[ trackImageUpload ]
+	);
+	const handleDrop = useCallback(
+		( files: File[] ) => {
+			if ( trackImageUpload ) {
+				recordBigSkyTracksEvent( 'file_upload_drop', {
+					count: files.length,
+				} );
+			}
+		},
+		[ trackImageUpload ]
+	);
+	const handleRemoveImage = useCallback(
+		( image: UploadedImage ) => {
+			if ( trackImageUpload ) {
+				recordBigSkyTracksEvent( 'file_upload_remove', {
+					image_id: image.id,
+				} );
+			}
+			imageUpload?.handleRemoveImage( image );
+		},
+		[ imageUpload, trackImageUpload ]
+	);
+	const handleImageDragStart = useCallback( () => {
+		if ( trackImageUpload ) {
+			recordBigSkyTracksEvent( 'file_upload_drag_start' );
+		}
+	}, [ trackImageUpload ] );
+	const handleUploadError = useCallback( () => {
+		if ( trackImageUpload ) {
+			recordBigSkyTracksEvent( 'file_upload_invalid' );
+		}
+	}, [ trackImageUpload ] );
+
 	return (
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
@@ -280,8 +340,12 @@ export default function AgentChat( {
 								ref={ imageUploaderRef }
 								images={ imageUpload.pendingImages }
 								uploadingImages={ imageUpload.uploadingImages }
-								onFilesSelected={ imageUpload.handleFilesSelected }
-								onRemoveImage={ imageUpload.handleRemoveImage }
+								onFilesSelected={ handleFilesSelected }
+								onBrowse={ handleBrowse }
+								onDrop={ handleDrop }
+								onRemoveImage={ handleRemoveImage }
+								onImageDragStart={ handleImageDragStart }
+								onError={ handleUploadError }
 								acceptedFileTypes={ acceptedImageFileTypes }
 								showFileMetadata
 								allowDragToInsert={ false }

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -229,17 +229,14 @@ export default function AgentChat( {
 	// `useImageUpload`); reader-chat has no provider, but gate defensively so
 	// `jetpack_big_sky_*` never fires from that surface.
 	const trackImageUpload = ! isReaderChatHost() && !! imageUpload;
+
 	const handleFilesSelected = useCallback(
 		async ( files: File[] ) => {
-			if ( trackImageUpload ) {
-				recordBigSkyTracksEvent( 'file_upload_success', {
-					count: files.length,
-				} );
-			}
 			await imageUpload?.handleFilesSelected( files );
 		},
-		[ imageUpload, trackImageUpload ]
+		[ imageUpload ]
 	);
+
 	const handleBrowse = useCallback(
 		( files: File[] ) => {
 			if ( trackImageUpload ) {
@@ -250,6 +247,7 @@ export default function AgentChat( {
 		},
 		[ trackImageUpload ]
 	);
+
 	const handleDrop = useCallback(
 		( files: File[] ) => {
 			if ( trackImageUpload ) {
@@ -260,6 +258,7 @@ export default function AgentChat( {
 		},
 		[ trackImageUpload ]
 	);
+
 	const handleRemoveImage = useCallback(
 		( image: UploadedImage ) => {
 			if ( trackImageUpload ) {
@@ -271,11 +270,13 @@ export default function AgentChat( {
 		},
 		[ imageUpload, trackImageUpload ]
 	);
+
 	const handleImageDragStart = useCallback( () => {
 		if ( trackImageUpload ) {
 			recordBigSkyTracksEvent( 'file_upload_drag_start' );
 		}
 	}, [ trackImageUpload ] );
+
 	const handleUploadError = useCallback( () => {
 		if ( trackImageUpload ) {
 			recordBigSkyTracksEvent( 'file_upload_invalid' );

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -19,6 +19,7 @@ import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { persistLastActivity } from '../../utils/persist-last-activity';
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import OrchestratorChat from '../orchestrator-chat';
@@ -123,12 +124,33 @@ export default function AgentDock( {
 			desktopMediaQuery,
 			// Only open the sidebar; keep the current route. Admin-bar items
 			// set their own route (e.g. history) before opening it.
-			onOpenSidebar: () => setOpenState( true ),
-			onCloseSidebar: () => setOpenState( false ),
+			onOpenSidebar: () => {
+				recordBigSkyTracksEvent( 'sidebar_open_click' );
+				setOpenState( true );
+			},
+			onCloseSidebar: () => {
+				recordBigSkyTracksEvent( 'sidebar_close_click' );
+				setOpenState( false );
+			},
+			onDock: () => {
+				recordBigSkyTracksEvent( 'ai_chat_docked' );
+			},
+			onUndock: () => {
+				recordBigSkyTracksEvent( 'ai_chat_undocked' );
+			},
 			isSplitScreen,
 		} );
 
-	const handleClose = isDocked ? closeSidebar : () => setOpenState( false );
+	// Docked close fires `sidebar_close_click` (via `onCloseSidebar`); undocked
+	// close fires `dock_back_button_click`. Matches Big Sky.
+	const handleClose = () => {
+		if ( isDocked ) {
+			closeSidebar();
+		} else {
+			recordBigSkyTracksEvent( 'dock_back_button_click' );
+			setOpenState( false );
+		}
+	};
 
 	// WP admin bar integration. Returns whether the AI chat entry button is present.
 	const hasAiChatEntry = useAdminBarIntegration( {
@@ -191,6 +213,7 @@ export default function AgentDock( {
 	);
 
 	const handleExpand = () => {
+		recordBigSkyTracksEvent( 'dock_assistant_icon_click' );
 		if ( isMinimized ) {
 			setIsMinimized( false );
 		}
@@ -222,7 +245,12 @@ export default function AgentDock( {
 				icon: comment,
 				title: __( 'New chat', '__i18n_text_domain__' ),
 				isDisabled: pathname === '/chat' && isOrchestratorChatEmpty,
-				onClick: () => navigate( '/' ),
+				onClick: () => {
+					recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+						type: 'reset_chat',
+					} );
+					navigate( '/' );
+				},
 			},
 			// Sidebar docking only makes sense in wp-admin where a block-editor
 			// sidebar slot exists. On public reader-chat frontends there's no
@@ -232,6 +260,9 @@ export default function AgentDock( {
 					icon: login,
 					title: __( 'Pop out sidebar', '__i18n_text_domain__' ),
 					onClick: () => {
+						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+							type: 'undock',
+						} );
 						undock();
 						setIsDocked( false );
 					},
@@ -242,6 +273,9 @@ export default function AgentDock( {
 					icon: drawerRight,
 					title: __( 'Move to sidebar', '__i18n_text_domain__' ),
 					onClick: () => {
+						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+							type: 'dock',
+						} );
 						dock();
 						setIsDocked( true );
 					},

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
+import { recordAgentsManagerTracksEvent } from '../../utils/tracks';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
@@ -68,7 +69,10 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 					<Button
 						className="agents-manager-chat-header__history-btn"
 						icon={ backup }
-						onClick={ () => navigate( '/history' ) }
+						onClick={ () => {
+							recordAgentsManagerTracksEvent( 'chat_history_open' );
+							navigate( '/history' );
+						} }
 						label={ __( 'View history', '__i18n_text_domain__' ) }
 						size="small"
 					/>
@@ -77,7 +81,10 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 					<Button
 						className="agents-manager-chat-header__minimize-btn"
 						icon={ lineSolid }
-						onClick={ () => setIsMinimized( true ) }
+						onClick={ () => {
+							recordAgentsManagerTracksEvent( 'chat_minimize' );
+							setIsMinimized( true );
+						} }
 						label={ __( 'Minimize', '__i18n_text_domain__' ) }
 						size="small"
 					/>

--- a/packages/agents-manager/src/components/custom-a-link/index.tsx
+++ b/packages/agents-manager/src/components/custom-a-link/index.tsx
@@ -1,8 +1,8 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isThisASupportArticleLink } from '@automattic/urls';
 import { useMemo } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { recordAgentsManagerTracksEvent } from '../../utils/tracks';
 import { uriTransformer } from '../../utils/uri-transformer';
 
 export default function CustomALink( {
@@ -38,7 +38,7 @@ export default function CustomALink( {
 					} );
 				}
 
-				recordTracksEvent( 'calypso_agents_manager_link_click', {
+				recordAgentsManagerTracksEvent( 'link_click', {
 					href: transformedHref,
 					type: isSupportArticle ? 'support_article' : 'external',
 					source: isFromOrchestrator ? 'orchestrator' : 'zendesk',

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -245,6 +245,10 @@ export default function OrchestratorChat( {
 					// Upload files to WordPress media library
 					const mediaObjects = await uploadImagesToWordPress();
 
+					recordBigSkyTracksEvent( 'file_upload_success', {
+						count: mediaObjects.length,
+					} );
+
 					// Create image data objects with full metadata including attachment ID
 					const imageData = mediaObjects.map( ( media ) => ( {
 						url: media.url,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -33,6 +33,7 @@ import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import type { BigSkyMessage } from '../../types';
@@ -45,6 +46,14 @@ import type {
 	ImageUploadHook,
 	UseCheckpointHook,
 } from '../../utils/load-external-providers';
+
+/**
+ * Pipe-delimited list of suggestion ids (e.g. `|id1|id2|`), matching Big Sky's
+ * `suggestions` / `available_suggestions` tracks-prop format.
+ */
+function formatSuggestionIds( suggestions: Suggestion[] ): string {
+	return '|' + suggestions.map( ( s ) => s.id ).join( '|' ) + '|';
+}
 
 interface Props {
 	/** Suggestions displayed when the chat is empty. */
@@ -182,6 +191,19 @@ export default function OrchestratorChat( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ dynamicSuggestionsKey, registerSuggestions, clearSuggestions ] );
 
+	// Track when a new set of suggestions is rendered. Keyed on the rendered
+	// ids so re-renders that don't change the set don't re-fire.
+	const renderedSuggestionsKey = suggestions.map( ( s ) => s.id ).join( '|' );
+	useEffect( () => {
+		if ( suggestions.length > 0 ) {
+			recordBigSkyTracksEvent( 'chat_suggestions_rendered', {
+				suggestions: formatSuggestionIds( suggestions ),
+			} );
+		}
+		// `suggestions` identity is unstable; key on its rendered ids instead.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ renderedSuggestionsKey ] );
+
 	// Persist the chat route so the conversation can be resumed later.
 	useSaveNewChatRoute( hasUserSentMessage );
 
@@ -212,6 +234,11 @@ export default function OrchestratorChat( {
 		async ( message: string ) => {
 			setHasUserSentMessage( true );
 			persistLastActivity( siteKey );
+
+			recordBigSkyTracksEvent( 'chat_input_send_message', {
+				message_length: message?.length || 0,
+				has_images: pendingImages.length > 0,
+			} );
 
 			if ( pendingImages.length > 0 && uploadImagesToWordPress ) {
 				try {
@@ -363,13 +390,25 @@ export default function OrchestratorChat( {
 		};
 	}, [] );
 
-	const handleSuggestionClick = useCallback( ( suggestion: Suggestion | string ) => {
-		const value =
-			typeof suggestion === 'string' ? suggestion : suggestion.prompt ?? suggestion.label;
-		window.dispatchEvent(
-			new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value } } )
-		);
-	}, [] );
+	const handleSuggestionClick = useCallback(
+		( suggestion: Suggestion | string, availableSuggestions?: Suggestion[] ) => {
+			const value =
+				typeof suggestion === 'string' ? suggestion : suggestion.prompt ?? suggestion.label;
+
+			if ( typeof suggestion !== 'string' ) {
+				recordBigSkyTracksEvent( 'chat_suggestion_click', {
+					suggestion_text: suggestion.prompt || '',
+					suggestion_id: suggestion.id || '',
+					available_suggestions: formatSuggestionIds( availableSuggestions ?? [] ),
+				} );
+			}
+
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value } } )
+			);
+		},
+		[]
+	);
 
 	// Invoke abilities setup hook to register hook-based abilities that utilize React context.
 	// Provides custom action handlers for agent and chat interaction within Big Sky's AI store.

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FoldableCard } from '@automattic/components';
 import { isThisASupportArticleLink } from '@automattic/urls';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -7,6 +6,7 @@ import { Icon, chevronRight, page } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { recordAgentsManagerTracksEvent } from '../../utils/tracks';
 import './style.scss';
 
 interface Source {
@@ -44,7 +44,7 @@ export default function SourcesDisplay( { sources }: Props ) {
 			} );
 		}
 
-		recordTracksEvent( 'calypso_agents_manager_link_click', {
+		recordAgentsManagerTracksEvent( 'link_click', {
 			href: url,
 			type: isSupportArticle ? 'support_article' : 'external',
 			source: isFromOrchestrator ? 'orchestrator' : 'zendesk',

--- a/packages/agents-manager/src/contexts/AgentsManagerContext.tsx
+++ b/packages/agents-manager/src/contexts/AgentsManagerContext.tsx
@@ -84,7 +84,10 @@ export const AgentsManagerContextProvider: React.FC< AgentsManagerContextProvide
 		navigate( '/chat', { state: { sessionId: getActiveSessionId() } } );
 	}, [ navigate, getActiveSessionId ] );
 
-	// Publish the resolved agent id for non-React callers
+	// Publish the resolved agent id for non-React callers. Written in render (not a
+	// useEffect) so it lands in the same render that sets `agentConfig`, before the
+	// chat tree mounts and reads it from event handlers; a useEffect runs post-commit
+	// and could lag a synchronous child interaction. The write is idempotent, so safe in render.
 	setResolvedAgentId( agentConfig?.agentId );
 
 	return (

--- a/packages/agents-manager/src/contexts/AgentsManagerContext.tsx
+++ b/packages/agents-manager/src/contexts/AgentsManagerContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useState } from '@wordpress/element';
 import { useNavigate } from 'react-router-dom';
 import { getSessionId } from '../utils/agent-session';
+import { setResolvedAgentId } from '../utils/resolved-agent-id';
 import type { UseAgentChatConfig } from '@automattic/agenttic-client';
 import type { AgentsManagerSite, CurrentUser } from '@automattic/data-stores';
 
@@ -82,6 +83,9 @@ export const AgentsManagerContextProvider: React.FC< AgentsManagerContextProvide
 	const resumeActiveChat = useCallback( () => {
 		navigate( '/chat', { state: { sessionId: getActiveSessionId() } } );
 	}, [ navigate, getActiveSessionId ] );
+
+	// Publish the resolved agent id for non-React callers
+	setResolvedAgentId( agentConfig?.agentId );
 
 	return (
 		<AgentsManagerContext.Provider

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -128,8 +128,8 @@ interface Window {
 	/** Big Sky injects this on editor surfaces. Narrowed to the fields AM consumes. */
 	bigSkyInitialState?: {
 		bigSkyVersion?: string;
-		isFreeTrial?: boolean;
-		isDevMode?: boolean;
+		isFreeTrial?: string;
+		isDevMode?: string;
 		currentScreen?: { screen?: string };
 	};
 }

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -15,6 +15,8 @@ declare const agentsManagerData:
 			useUnifiedExperience?: boolean;
 			agentId?: string;
 			helpCenterUrl?: string;
+			/** Dev/internal context (localhost, jurassic, proxied a11ns, internal Atomic). Drives `is_test`. */
+			isDevMode?: boolean;
 	  }
 	| undefined;
 
@@ -123,4 +125,11 @@ interface AgentsManagerActions {
  */
 interface Window {
 	__agentsManagerActions?: AgentsManagerActions;
+	/** Big Sky injects this on editor surfaces. Narrowed to the fields AM consumes. */
+	bigSkyInitialState?: {
+		bigSkyVersion?: string;
+		isFreeTrial?: boolean;
+		isDevMode?: boolean;
+		currentScreen?: { screen?: string };
+	};
 }

--- a/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { renderHook, act } from '@testing-library/react';
 import { useAgentsManagerContext } from '../../contexts';
+import { recordAgentsManagerTracksEvent, recordBigSkyTracksEvent } from '../../utils/tracks';
 import useFeedbackAction from '../use-feedback-action';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
 
@@ -28,9 +28,10 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
-jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ), {
-	virtual: true,
-} );
+jest.mock( '../../utils/tracks', () => ( {
+	recordBigSkyTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
+} ) );
 jest.mock( '../../contexts', () => ( {
 	useAgentsManagerContext: jest.fn(),
 } ) );
@@ -43,7 +44,12 @@ const mockFetch = jest.fn().mockResolvedValue( { ok: true } );
 globalThis.fetch = mockFetch;
 
 const mockRegisterMessageActions = jest.fn();
-const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
+const mockRecordBigSkyTracksEvent = recordBigSkyTracksEvent as jest.MockedFunction<
+	typeof recordBigSkyTracksEvent
+>;
+const mockRecordAgentsManagerTracksEvent = recordAgentsManagerTracksEvent as jest.MockedFunction<
+	typeof recordAgentsManagerTracksEvent
+>;
 const mockGetActiveSessionId = jest.fn();
 
 const mockAuthProvider = jest.fn().mockResolvedValue( { Authorization: 'Bearer test-token' } );
@@ -174,14 +180,13 @@ describe( 'useFeedbackAction', () => {
 			);
 		} );
 
-		it( 'records tracks event', async () => {
+		it( 'records the verbatim Big Sky thumbs-up event', async () => {
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 			await triggerFeedback( 'msg-1', 'up' );
 
-			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-				'calypso_agents_manager_response_feedback_action',
-				{ type: 'thumb_up', message_id: 'msg-1' }
-			);
+			expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'response_action_thumbs_up', {
+				message_id: 'msg-1',
+			} );
 		} );
 
 		it( 'does not show feedback input', async () => {
@@ -212,14 +217,13 @@ describe( 'useFeedbackAction', () => {
 			);
 		} );
 
-		it( 'records tracks event', async () => {
+		it( 'records the verbatim Big Sky thumbs-down event', async () => {
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 			await triggerFeedback( 'msg-1', 'down' );
 
-			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-				'calypso_agents_manager_response_feedback_action',
-				{ type: 'thumb_down', message_id: 'msg-1' }
-			);
+			expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'response_action_thumbs_down', {
+				message_id: 'msg-1',
+			} );
 		} );
 
 		it( 'shows feedback input', async () => {
@@ -296,9 +300,11 @@ describe( 'useFeedbackAction', () => {
 				await result.current.submitFeedbackText( 'Helpful feedback' );
 			} );
 
-			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-				'calypso_agents_manager_response_feedback_submitted',
-				{ message_id: 'msg-1' }
+			expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
+				'response_feedback_submitted',
+				{
+					message_id: 'msg-1',
+				}
 			);
 		} );
 

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -1,6 +1,7 @@
 import { createElement, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { undo, Icon } from '@wordpress/icons';
+import { recordBigSkyTracksEvent } from '../utils/tracks';
 import type { UseCheckpointReturn } from '../utils/load-external-providers';
 import type { UseAgentChatReturn, UIMessage } from '@automattic/agenttic-client';
 
@@ -65,6 +66,9 @@ export default function useCheckpointAction(
 							className: 'agents-manager-message-action-icon',
 						} ),
 						onClick: async () => {
+							recordBigSkyTracksEvent( 'restore_checkpoint_action', {
+								id: checkpointId,
+							} );
 							try {
 								await checkpointRef.current?.restoreCheckpoint( checkpointId );
 							} catch ( error ) {

--- a/packages/agents-manager/src/hooks/use-feedback-action.ts
+++ b/packages/agents-manager/src/hooks/use-feedback-action.ts
@@ -1,8 +1,8 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { createElement, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
+import { recordAgentsManagerTracksEvent, recordBigSkyTracksEvent } from '../utils/tracks';
 import type { AuthProvider, UseAgentChatReturn } from '@automattic/agenttic-client';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
 
@@ -182,10 +182,10 @@ export default function useFeedbackAction( {
 				return;
 			}
 
-			recordTracksEvent( 'calypso_agents_manager_response_feedback_action', {
-				type: feedback === 'up' ? 'thumb_up' : 'thumb_down',
-				message_id: messageId,
-			} );
+			recordBigSkyTracksEvent(
+				feedback === 'up' ? 'response_action_thumbs_up' : 'response_action_thumbs_down',
+				{ message_id: messageId }
+			);
 
 			const message = messagesRef.current.find( ( m ) => m.id === messageId );
 			const messageText = message ? getMessageText( message ) : undefined;
@@ -280,7 +280,7 @@ export default function useFeedbackAction( {
 				previousMessages
 			);
 
-			recordTracksEvent( 'calypso_agents_manager_response_feedback_submitted', {
+			recordAgentsManagerTracksEvent( 'response_feedback_submitted', {
 				message_id: currentMessageId,
 			} );
 		},

--- a/packages/agents-manager/src/hooks/use-help-search-query.ts
+++ b/packages/agents-manager/src/hooks/use-help-search-query.ts
@@ -1,10 +1,10 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { buildQueryString } from '@wordpress/url';
 import { getLocaleSlug } from 'i18n-calypso';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useAgentsManagerContext } from '../contexts';
+import { recordAgentsManagerTracksEvent } from '../utils/tracks';
 
 interface HelpSearchRailcar {
 	railcar?: string;
@@ -52,7 +52,7 @@ const fetchArticlesAPI = async (
 	results.forEach( ( result, index ) => {
 		if ( result.railcar ) {
 			queueMicrotask( () => {
-				recordTracksEvent( 'calypso_agents_manager_search_traintracks_render', {
+				recordAgentsManagerTracksEvent( 'search_traintracks_render', {
 					...result.railcar,
 					ui_algo: 'default',
 					ui_position: index,

--- a/packages/agents-manager/src/utils/__tests__/resolved-agent-id.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/resolved-agent-id.test.ts
@@ -1,0 +1,28 @@
+import { getResolvedAgentId, setResolvedAgentId } from '../resolved-agent-id';
+
+describe( 'resolved-agent-id bridge', () => {
+	afterEach( () => {
+		setResolvedAgentId( undefined );
+	} );
+
+	it( 'returns undefined before any value is published', () => {
+		expect( getResolvedAgentId() ).toBeUndefined();
+	} );
+
+	it( 'returns the published id after set', () => {
+		setResolvedAgentId( 'reader-chat' );
+		expect( getResolvedAgentId() ).toBe( 'reader-chat' );
+	} );
+
+	it( 'overwrites a previously published id', () => {
+		setResolvedAgentId( 'big-sky' );
+		setResolvedAgentId( 'orchestrator' );
+		expect( getResolvedAgentId() ).toBe( 'orchestrator' );
+	} );
+
+	it( 'can be cleared back to undefined', () => {
+		setResolvedAgentId( 'reader-chat' );
+		setResolvedAgentId( undefined );
+		expect( getResolvedAgentId() ).toBeUndefined();
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -14,6 +14,7 @@ jest.mock( '../is-reader-chat-agent', () => {
 	return { ...actual, isReaderChatHost: jest.fn( () => false ) };
 } );
 
+import { select } from '@wordpress/data';
 import { isReaderChatHost } from '../is-reader-chat-agent';
 import { setResolvedAgentId } from '../resolved-agent-id';
 import {
@@ -24,6 +25,7 @@ import {
 
 const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
 const mockIsReaderChatHost = isReaderChatHost as jest.MockedFunction< typeof isReaderChatHost >;
+const mockSelect = select as jest.MockedFunction< typeof select >;
 
 function lastEventProps(): Record< string, unknown > {
 	const call = mockRecordTracksEvent.mock.calls.at( -1 );
@@ -135,6 +137,41 @@ describe( 'tracks wrappers', () => {
 			setResolvedAgentId( 'reader-chat' );
 			recordAgentsManagerTracksEvent( 'chat_minimize' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'is_test (getIsTest)', () => {
+		it( 'is true when agentsManagerData asserts dev mode', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = { isDevMode: true };
+			recordAgentsManagerTracksEvent( 'x' );
+			expect( lastEventProps().is_test ).toBe( true );
+		} );
+
+		it( 'falls through to bigSkyInitialState when agentsManagerData omits isDevMode', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {};
+			( window as Window ).bigSkyInitialState = { isDevMode: '1' };
+			recordAgentsManagerTracksEvent( 'x' );
+			expect( lastEventProps().is_test ).toBe( true );
+		} );
+
+		it( 'is false when neither source asserts dev mode', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {};
+			recordAgentsManagerTracksEvent( 'x' );
+			expect( lastEventProps().is_test ).toBe( false );
+		} );
+	} );
+
+	describe( 'getBigSkyPageProps resilience', () => {
+		it( 'does not throw and emits neutral page props when select throws', () => {
+			mockSelect.mockImplementation( () => {
+				throw new Error( 'store not registered' );
+			} );
+
+			expect( () => recordBigSkyTracksEvent( 'chat_input_send_message' ) ).not.toThrow();
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+			expect( lastEventProps() ).toMatchObject( { post_type: '', is_home_page: false } );
+
+			mockSelect.mockImplementation( () => ( {} ) as ReturnType< typeof select > );
 		} );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ), {
+	virtual: true,
+} );
+jest.mock( '@wordpress/data', () => ( { select: jest.fn( () => ( {} ) ) } ) );
+jest.mock( '../agent-session', () => ( { getSessionId: jest.fn( () => 'session-xyz' ) } ) );
+jest.mock( '../is-reader-chat-agent', () => {
+	const actual = jest.requireActual( '../is-reader-chat-agent' );
+	return { ...actual, isReaderChatHost: jest.fn( () => false ) };
+} );
+
+import { isReaderChatHost } from '../is-reader-chat-agent';
+import { setResolvedAgentId } from '../resolved-agent-id';
+import {
+	getBigSkyTracksData,
+	recordAgentsManagerTracksEvent,
+	recordBigSkyTracksEvent,
+} from '../tracks';
+
+const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
+const mockIsReaderChatHost = isReaderChatHost as jest.MockedFunction< typeof isReaderChatHost >;
+
+function lastEventProps(): Record< string, unknown > {
+	const call = mockRecordTracksEvent.mock.calls.at( -1 );
+	return ( call?.[ 1 ] ?? {} ) as Record< string, unknown >;
+}
+
+describe( 'tracks wrappers', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockIsReaderChatHost.mockReturnValue( false );
+		setResolvedAgentId( undefined );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = { isDevMode: true };
+	} );
+
+	afterEach( () => {
+		setResolvedAgentId( undefined );
+		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( window as Window ).bigSkyInitialState;
+	} );
+
+	describe( 'recordBigSkyTracksEvent', () => {
+		it( 'falls back to honest defaults when bigSkyInitialState is absent', () => {
+			recordBigSkyTracksEvent( 'chat_input_send_message', {
+				message_length: 5,
+			} );
+
+			const [ eventName ] = mockRecordTracksEvent.mock.calls[ 0 ];
+			expect( eventName ).toBe( 'jetpack_big_sky_chat_input_send_message' );
+
+			const props = lastEventProps();
+			expect( props ).toMatchObject( {
+				message_length: 5,
+				is_test: true,
+				sessionid: 'session-xyz',
+				session_type: 'unknown',
+				phase: 'editor',
+				big_sky_version: '0',
+				screen: 'site-editor',
+				post_type: '',
+				is_home_page: false,
+			} );
+		} );
+
+		it( 'sources session_type, screen, and big_sky_version from bigSkyInitialState', () => {
+			( window as Window ).bigSkyInitialState = {
+				bigSkyVersion: '7',
+				isFreeTrial: false,
+				currentScreen: { screen: 'dashboard' },
+			};
+
+			recordBigSkyTracksEvent( 'chat_input_send_message' );
+
+			expect( lastEventProps() ).toMatchObject( {
+				session_type: 'paid-user-session',
+				screen: 'dashboard',
+				big_sky_version: '7',
+			} );
+		} );
+
+		it( 'lets caller props win on collision', () => {
+			recordBigSkyTracksEvent( 'x', { sessionid: 'override' } );
+			expect( lastEventProps().sessionid ).toBe( 'override' );
+		} );
+
+		it( 'no-ops when the resolved agent id is a reader-chat agent', () => {
+			setResolvedAgentId( 'reader-chat' );
+			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			expect( mockRecordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'fires when the resolved agent id is a non-reader agent', () => {
+			setResolvedAgentId( 'big-sky' );
+			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'fires when the resolved agent id is unset', () => {
+			setResolvedAgentId( undefined );
+			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'recordAgentsManagerTracksEvent', () => {
+		it( 'injects the unified base-prop set', () => {
+			recordAgentsManagerTracksEvent( 'chat_minimize' );
+
+			const [ eventName ] = mockRecordTracksEvent.mock.calls[ 0 ];
+			expect( eventName ).toBe( 'calypso_agents_manager_chat_minimize' );
+
+			const props = lastEventProps();
+			expect( props ).toMatchObject( {
+				ai_session_id: 'session-xyz',
+				agent_name: 'dolly',
+				surface: 'editor',
+				is_test: true,
+			} );
+			// `is_a11n` is an unresolved seam — present but undefined for now.
+			expect( props ).toHaveProperty( 'is_a11n', undefined );
+		} );
+
+		it( 'uses the reader-chat surface token off the editor', () => {
+			mockIsReaderChatHost.mockReturnValue( true );
+			recordAgentsManagerTracksEvent( 'x' );
+			expect( lastEventProps().surface ).toBe( 'reader-chat' );
+		} );
+
+		it( 'fires even when the resolved agent id is a reader-chat agent', () => {
+			setResolvedAgentId( 'reader-chat' );
+			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );
+
+describe( 'getBigSkyTracksData', () => {
+	function setState( state: Window[ 'bigSkyInitialState' ] ): void {
+		( window as Window ).bigSkyInitialState = state;
+	}
+
+	afterEach( () => {
+		delete ( window as Window ).bigSkyInitialState;
+	} );
+
+	it( 'returns all fallbacks when the blob is absent', () => {
+		expect( getBigSkyTracksData() ).toEqual( {
+			bigSkyVersion: '0',
+			sessionType: 'unknown',
+			screen: 'site-editor',
+			isDevMode: false,
+		} );
+	} );
+
+	it( 'maps the present blob to resolved values', () => {
+		setState( {
+			bigSkyVersion: '7',
+			isFreeTrial: true,
+			isDevMode: true,
+			currentScreen: { screen: 'dashboard' },
+		} );
+
+		expect( getBigSkyTracksData() ).toEqual( {
+			bigSkyVersion: '7',
+			sessionType: 'free-trial-session',
+			screen: 'dashboard',
+			isDevMode: true,
+		} );
+	} );
+
+	it( 'reports a paid session when isFreeTrial is false', () => {
+		setState( { isFreeTrial: false } );
+		expect( getBigSkyTracksData().sessionType ).toBe( 'paid-user-session' );
+	} );
+
+	it( 'reports unknown when isFreeTrial is missing', () => {
+		setState( { bigSkyVersion: '7' } );
+		expect( getBigSkyTracksData().sessionType ).toBe( 'unknown' );
+	} );
+
+	it( 'reports unknown when isFreeTrial is non-boolean', () => {
+		setState( { isFreeTrial: 'yes' as unknown as boolean } );
+		expect( getBigSkyTracksData().sessionType ).toBe( 'unknown' );
+	} );
+
+	it( 'falls back to per-field defaults for a partial blob', () => {
+		setState( { isFreeTrial: true } );
+		expect( getBigSkyTracksData() ).toEqual( {
+			bigSkyVersion: '0',
+			sessionType: 'free-trial-session',
+			screen: 'site-editor',
+			isDevMode: false,
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -70,7 +70,7 @@ describe( 'tracks wrappers', () => {
 		it( 'sources session_type, screen, and big_sky_version from bigSkyInitialState', () => {
 			( window as Window ).bigSkyInitialState = {
 				bigSkyVersion: '7',
-				isFreeTrial: false,
+				isFreeTrial: '',
 				currentScreen: { screen: 'dashboard' },
 			};
 
@@ -160,8 +160,8 @@ describe( 'getBigSkyTracksData', () => {
 	it( 'maps the present blob to resolved values', () => {
 		setState( {
 			bigSkyVersion: '7',
-			isFreeTrial: true,
-			isDevMode: true,
+			isFreeTrial: '1',
+			isDevMode: '1',
 			currentScreen: { screen: 'dashboard' },
 		} );
 
@@ -173,23 +173,18 @@ describe( 'getBigSkyTracksData', () => {
 		} );
 	} );
 
-	it( 'reports a paid session when isFreeTrial is false', () => {
-		setState( { isFreeTrial: false } );
+	it( 'reports a paid session when isFreeTrial is the empty string', () => {
+		setState( { isFreeTrial: '' } );
 		expect( getBigSkyTracksData().sessionType ).toBe( 'paid-user-session' );
 	} );
 
-	it( 'reports unknown when isFreeTrial is missing', () => {
+	it( 'reports a paid session when isFreeTrial is missing from a present blob', () => {
 		setState( { bigSkyVersion: '7' } );
-		expect( getBigSkyTracksData().sessionType ).toBe( 'unknown' );
-	} );
-
-	it( 'reports unknown when isFreeTrial is non-boolean', () => {
-		setState( { isFreeTrial: 'yes' as unknown as boolean } );
-		expect( getBigSkyTracksData().sessionType ).toBe( 'unknown' );
+		expect( getBigSkyTracksData().sessionType ).toBe( 'paid-user-session' );
 	} );
 
 	it( 'falls back to per-field defaults for a partial blob', () => {
-		setState( { isFreeTrial: true } );
+		setState( { isFreeTrial: '1' } );
 		expect( getBigSkyTracksData() ).toEqual( {
 			bigSkyVersion: '0',
 			sessionType: 'free-trial-session',

--- a/packages/agents-manager/src/utils/resolved-agent-id.ts
+++ b/packages/agents-manager/src/utils/resolved-agent-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Module bridge for the resolved agent id.
+ *
+ * The Provider publishes the resolved `agentConfig.agentId` here so non-React
+ * callers — the parity Tracks wrapper, fired from event handlers — can read the
+ * same answer components see. No `window` access, so SSR-safe by construction.
+ */
+
+let resolvedAgentId: string | undefined;
+
+export function setResolvedAgentId( id: string | undefined ): void {
+	resolvedAgentId = id;
+}
+
+export function getResolvedAgentId(): string | undefined {
+	return resolvedAgentId;
+}

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -59,28 +59,30 @@ export function getBigSkyTracksData(): BigSkyTracksData {
 }
 
 function getIsTest(): boolean {
-	if ( typeof agentsManagerData !== 'undefined' && agentsManagerData ) {
-		return !! agentsManagerData.isDevMode;
-	}
-	return getBigSkyTracksData().isDevMode;
+	const amDevMode = typeof agentsManagerData !== 'undefined' && !! agentsManagerData?.isDevMode;
+	return amDevMode || getBigSkyTracksData().isDevMode;
 }
 
 /**
  * Editor-surface page props, mirroring Big Sky's `getCurrentPageProperties`.
  */
 function getBigSkyPageProps(): TracksProps {
-	const editor = select( 'core/editor' ) as EditorSelectStore;
-	const core = select( 'core' ) as CoreSelectStore;
+	try {
+		const editor = select( 'core/editor' ) as EditorSelectStore;
+		const core = select( 'core' ) as CoreSelectStore;
 
-	const postId = editor?.getCurrentPostId?.();
-	const siteRecord = core?.getEntityRecord?.( 'root', 'site' ) as
-		| { page_on_front?: number }
-		| undefined;
+		const postId = editor?.getCurrentPostId?.();
+		const siteRecord = core?.getEntityRecord?.( 'root', 'site' ) as
+			| { page_on_front?: number }
+			| undefined;
 
-	return {
-		post_type: editor?.getCurrentPostType?.() ?? '',
-		is_home_page: postId !== undefined && postId === siteRecord?.page_on_front,
-	};
+		return {
+			post_type: editor?.getCurrentPostType?.() ?? '',
+			is_home_page: postId !== undefined && postId === siteRecord?.page_on_front,
+		};
+	} catch {
+		return { post_type: '', is_home_page: false };
+	}
 }
 
 /**

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -50,15 +50,9 @@ export function getBigSkyTracksData(): BigSkyTracksData {
 		return { bigSkyVersion: '0', sessionType: 'unknown', screen: 'site-editor', isDevMode: false };
 	}
 
-	// `isFreeTrial` missing/non-boolean → `unknown`
-	let sessionType = 'unknown';
-	if ( typeof state.isFreeTrial === 'boolean' ) {
-		sessionType = state.isFreeTrial ? 'free-trial-session' : 'paid-user-session';
-	}
-
 	return {
 		bigSkyVersion: state.bigSkyVersion ?? '0',
-		sessionType,
+		sessionType: state.isFreeTrial ? 'free-trial-session' : 'paid-user-session',
 		screen: state.currentScreen?.screen ?? 'site-editor',
 		isDevMode: !! state.isDevMode,
 	};

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -1,0 +1,130 @@
+/**
+ * Central Tracks wrappers for the Agents Manager.
+ *
+ * Two record functions because each injects a different base-prop set:
+ * - `recordBigSkyTracksEvent` keeps Big Sky's exact event names and props so its
+ *   live Looker dashboard keeps working. Removable once that parity is dropped.
+ * - `recordAgentsManagerTracksEvent` uses the unified property schema shared across the new
+ *   AI products.
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { select } from '@wordpress/data';
+import { getSessionId } from './agent-session';
+import { isReaderChatAgent, isReaderChatHost } from './is-reader-chat-agent';
+import { getResolvedAgentId } from './resolved-agent-id';
+
+type TracksProps = Record< string, unknown >;
+
+type EditorSelectStore =
+	| {
+			getCurrentPostType?: () => string | undefined;
+			getCurrentPostId?: () => number | undefined;
+	  }
+	| undefined;
+
+type CoreSelectStore =
+	| { getEntityRecord?: ( kind: string, name: string, key?: number ) => unknown }
+	| undefined;
+
+const BIG_SKY_EVENT_PREFIX = 'jetpack_big_sky_';
+const AM_UNIFIED_EVENT_PREFIX = 'calypso_agents_manager_';
+
+// FIXME: Agents Manager has no per-user a11n signal today
+function getIsA11n(): boolean | undefined {
+	return undefined;
+}
+
+type BigSkyTracksData = {
+	bigSkyVersion: string;
+	sessionType: string;
+	screen: string;
+	isDevMode: boolean;
+};
+
+/**
+ * Resolves the Big Sky base props AM mirrors, from `window.bigSkyInitialState`.
+ */
+export function getBigSkyTracksData(): BigSkyTracksData {
+	const state = typeof window !== 'undefined' ? window.bigSkyInitialState : undefined;
+	if ( ! state ) {
+		return { bigSkyVersion: '0', sessionType: 'unknown', screen: 'site-editor', isDevMode: false };
+	}
+
+	// `isFreeTrial` missing/non-boolean → `unknown`
+	let sessionType = 'unknown';
+	if ( typeof state.isFreeTrial === 'boolean' ) {
+		sessionType = state.isFreeTrial ? 'free-trial-session' : 'paid-user-session';
+	}
+
+	return {
+		bigSkyVersion: state.bigSkyVersion ?? '0',
+		sessionType,
+		screen: state.currentScreen?.screen ?? 'site-editor',
+		isDevMode: !! state.isDevMode,
+	};
+}
+
+function getIsTest(): boolean {
+	if ( typeof agentsManagerData !== 'undefined' && agentsManagerData ) {
+		return !! agentsManagerData.isDevMode;
+	}
+	return getBigSkyTracksData().isDevMode;
+}
+
+/**
+ * Editor-surface page props, mirroring Big Sky's `getCurrentPageProperties`.
+ */
+function getBigSkyPageProps(): TracksProps {
+	const editor = select( 'core/editor' ) as EditorSelectStore;
+	const core = select( 'core' ) as CoreSelectStore;
+
+	const postId = editor?.getCurrentPostId?.();
+	const siteRecord = core?.getEntityRecord?.( 'root', 'site' ) as
+		| { page_on_front?: number }
+		| undefined;
+
+	return {
+		post_type: editor?.getCurrentPostType?.() ?? '',
+		is_home_page: postId !== undefined && postId === siteRecord?.page_on_front,
+	};
+}
+
+/**
+ * Records an event under Big Sky's exact name and props so the existing Big Sky
+ * dashboards keep working.
+ */
+export function recordBigSkyTracksEvent( eventName: string, props: TracksProps = {} ): void {
+	if ( isReaderChatAgent( getResolvedAgentId() ) ) {
+		return; // Big Sky parity events are editor-only; never on reader-chat.
+	}
+
+	const bigSky = getBigSkyTracksData();
+	const baseProps: TracksProps = {
+		is_test: getIsTest(),
+		sessionid: getSessionId(),
+		session_type: bigSky.sessionType,
+		// AM has no onboarding flow, so the phase is always the editor.
+		phase: 'editor',
+		big_sky_version: bigSky.bigSkyVersion,
+		screen: bigSky.screen,
+		...getBigSkyPageProps(),
+	};
+
+	recordTracksEvent( `${ BIG_SKY_EVENT_PREFIX }${ eventName }`, { ...baseProps, ...props } );
+}
+
+/**
+ * Records an Agents Manager event using the shared unified property names.
+ */
+export function recordAgentsManagerTracksEvent( eventName: string, props: TracksProps = {} ): void {
+	const baseProps: TracksProps = {
+		ai_session_id: getSessionId(),
+		agent_name: 'dolly',
+		surface: isReaderChatHost() ? 'reader-chat' : 'editor',
+		path: typeof window !== 'undefined' ? window.location.pathname : '',
+		is_test: getIsTest(),
+		is_a11n: getIsA11n(),
+	};
+
+	recordTracksEvent( `${ AM_UNIFIED_EVENT_PREFIX }${ eventName }`, { ...baseProps, ...props } );
+}


### PR DESCRIPTION
Resolves AI-990

## Proposed Changes

Brings Agents Manager's Tracks instrumentation to parity with Big Sky:

- Adds a central Tracks wrapper with two functions — `recordBigSkyTracksEvent` fires Big Sky's exact `jetpack_big_sky_*` event names and base-prop schema; `recordAgentsManagerTracksEvent` fires Agents Manager's own events under the unified `calypso_agents_manager_*` property schema.
- Wires the replicated Big Sky chat events (message send, suggestions, feedback, dock/sidebar, file upload, checkpoint) at the matching Agents Manager call sites.
- Sources Big Sky's real base props (`session_type`, `screen`, `big_sky_version`, `is_test`) from `bigSkyInitialState` when present, with safe fallbacks.
- Centralizes the event-name prefix and the reader-chat suppression guard so `jetpack_big_sky_*` events never fire from the public reader-chat surface.

## Why are these changes being made

Dolly is being brought into the site editor in production to replace the legacy Big Sky chat UI with the Agents Manager sidebar. Agents Manager was firing very few Tracks events, so the cutover would have broken the existing Big Sky analytics dashboards.

Having Agents Manager replicate Big Sky's events with identical names and properties keeps those dashboards working through the transition with zero remapping. New or Agents-Manager-specific events use the unified Tracks property schema so they can be analyzed consistently across the new AI products going forward.



## Events

Big Sky events replicated in Agents Manager (`jetpack_big_sky_*`):

| Event Name | How to trigger |
| --- | --- |
| chat_input_send_message | Send a message in the chat input |
| chat_suggestions_rendered | Suggestions render in the empty chat |
| chat_suggestion_click | Click one of the suggested prompts |
| response_action_thumbs_up | Click thumbs-up on an agent response |
| response_action_thumbs_down | Click thumbs-down on an agent response |
| dock_assistant_icon_click | Click the assistant icon to open/expand the dock |
| dock_back_button_click | Click the back button to close the dock |
| ai_chat_docked | Chat docks into the sidebar |
| ai_chat_undocked | Chat undocks into the floating window |
| ai_chat_more_options_click | Pick a "more options" menu item (New chat / dock / undock) |
| sidebar_open_click | Open the docked sidebar |
| sidebar_close_click | Close the docked sidebar |
| file_upload_success | Images finish uploading to the media library on send |
| file_upload_click | Browse/select files via the upload button |
| file_upload_drop | Drop files onto the chat to upload |
| file_upload_remove | Remove an attached image before sending |
| file_upload_drag_start | Start dragging an uploaded image |
| file_upload_invalid | Attempt to upload an invalid/unsupported file |
| restore_checkpoint_action | Click "Undo"/restore on a message checkpoint |

Agents Manager-only events (unified schema, `calypso_agents_manager_*`):

| Event Name | How to trigger |
| --- | --- |
| chat_history_open | Click the history button in the chat header |
| chat_minimize | Click the minimize button in the chat header |
| link_click | Click a link inside an agent response |
| search_traintracks_render | Help search results render (one event per result) |
| response_feedback_submitted | Submit written feedback after a thumbs-down |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and sync the Agents Manager app with your sandbox
* Open the side editor and include the `flags=unified-big-sky` URL parameter - It should load Agents Manager
* Test if the events above are firing as expected
  * Open the Network tab of DevTools and filter requests by `t.gif` 
  * Check the request payload, and you should see the event parameters
  * (I'm not aware of a different way to check the Tracks events)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
