### PR TITLE
Notifications: Fetch unread notes only for Unread tab.

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -151,12 +151,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
-	// On the server-filtered Unread tab, DataViews would flash its `empty` prop
-	// ("all caught up") while the unread fetch is still in flight, since it
-	// ignores `isLoading`. Hold the loader until that fetch settles. Scoped to
-	// "unread" only: client-filtered tabs page through the shared cache, so an
-	// empty-while-loading view there is expected — applying this to them would
-	// re-show the spinner on every page and look like it keeps restarting.
+	// Hold the loader while the Unread fetch is in flight (DataViews shows `empty`
+	// regardless of `isLoading`). Unread only — other tabs page through the cache
+	// while empty and would otherwise flicker the spinner on every page.
 	const showInitialLoader =
 		! hasRenderedDataViews.current ||
 		( filterName === 'unread' && isLoading && visibleNotes.length === 0 );

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -151,12 +151,15 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
-	// DataViews renders its `empty` prop whenever `data` is empty, ignoring
-	// `isLoading` — so a filtered fetch with no results yet would flash the
-	// "all caught up" message while the request is still in flight. Show the
-	// loader instead until the fetch settles with real results (or a real empty).
+	// On the server-filtered Unread tab, DataViews would flash its `empty` prop
+	// ("all caught up") while the unread fetch is still in flight, since it
+	// ignores `isLoading`. Hold the loader until that fetch settles. Scoped to
+	// "unread" only: client-filtered tabs page through the shared cache, so an
+	// empty-while-loading view there is expected — applying this to them would
+	// re-show the spinner on every page and look like it keeps restarting.
 	const showInitialLoader =
-		! hasRenderedDataViews.current || ( isLoading && visibleNotes.length === 0 );
+		! hasRenderedDataViews.current ||
+		( filterName === 'unread' && isLoading && visibleNotes.length === 0 );
 
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
+import getUnreadNoteIds from '../../panel/state/selectors/get-unread-note-ids';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
 import { getFields } from './dataviews';
@@ -43,7 +44,21 @@ type NoteListProps = {
 const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListProps ) => {
 	const filter = getFilters()[ filterName ];
 	const allNotes = useSelector( ( state ) => getAllNotes( state ) || [] ) as Note[];
-	const notes = allNotes.filter( ( note ) => filter.filter( note ) );
+	const unreadNoteIds = useSelector( ( state ) => getUnreadNoteIds( state ) ) as number[];
+
+	// "Unread" renders the server's id list; other tabs client-filter the cache.
+	// `filter.filter` still runs on top so an in-app read drops out before a refetch.
+	let notes: Note[];
+	if ( filterName === 'unread' ) {
+		const notesById = new Map( allNotes.map( ( note ) => [ note.id, note ] ) );
+		notes = unreadNoteIds
+			.map( ( id ) => notesById.get( id ) )
+			.filter( ( note ): note is Note => !! note )
+			.filter( ( note ) => filter.filter( note ) );
+	} else {
+		notes = allNotes.filter( ( note ) => filter.filter( note ) );
+	}
+
 	// Filter out hidden notes, i.e. notes that have been just marked as spam or moved to the trash.
 	const hiddenNoteIds = useSelector( ( state ) => getHiddenNoteIds( state ) );
 	const visibleNotes = notes.filter( ( note ) => hiddenNoteIds[ note.id ] !== true );
@@ -63,6 +78,12 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	if ( ! isLoading ) {
 		hasRenderedDataViews.current = true;
 	}
+
+	// Drive the client's server-side filter from the active tab. Only "unread"
+	// maps to a filter today; other tabs stay client-filtered.
+	useEffect( () => {
+		client?.setFilter( filterName === 'unread' ? { unread: 1 } : null );
+	}, [ client, filterName ] );
 
 	const onChangeSelection = ( selection: string[] ) => {
 		const noteId = selection[ 0 ];
@@ -130,9 +151,16 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
+	// DataViews renders its `empty` prop whenever `data` is empty, ignoring
+	// `isLoading` — so a filtered fetch with no results yet would flash the
+	// "all caught up" message while the request is still in flight. Show the
+	// loader instead until the fetch settles with real results (or a real empty).
+	const showInitialLoader =
+		! hasRenderedDataViews.current || ( isLoading && visibleNotes.length === 0 );
+
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">
-			{ hasRenderedDataViews.current ? (
+			{ ! showInitialLoader ? (
 				<DataViews< Note >
 					data={ filteredData }
 					fields={ fields }

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -126,4 +126,23 @@ describe( 'NoteList loading state', () => {
 		expect( screen.getByText( 'A comment' ) ).toBeVisible();
 		expect( screen.queryByText( 'A like' ) ).not.toBeInTheDocument();
 	} );
+
+	// A client-filtered tab pages through the shared cache and is often empty
+	// mid-paging. The full loader must not re-take over on each page (that looked
+	// like it continually restarted); the empty/DataViews view stays put.
+	it( 'keeps the view (not the loader) while a client-filtered tab pages empty', () => {
+		const store = initStore();
+		// Settle once with no notes so DataViews has mounted on the Comments tab.
+		store.dispatch( actions.ui.loadedNotes() );
+		renderTab( store, 'comments' as FilterName );
+		expect( screen.getByText( 'No new comments yet!' ) ).toBeVisible();
+
+		// A paging fetch begins while no comments are loaded yet.
+		act( () => {
+			store.dispatch( actions.ui.loadNotes() );
+		} );
+
+		// The empty view stays — the full loader does not take over per page.
+		expect( screen.getByText( 'No new comments yet!' ) ).toBeVisible();
+	} );
 } );

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { init as initStore } from '../../../panel/state';
+import actions from '../../../panel/state/actions';
+import { AppProvider } from '../../context';
+import NoteList from '../index';
+import type { FilterName } from '../../types';
+
+const noop = () => {};
+const client = { hasMoreNotes: () => false, loadMore: noop, setFilter: noop };
+
+const makeNote = ( id: number, label: string, type = 'comment' ) => ( {
+	id,
+	type,
+	read: 0,
+	noticon: '',
+	timestamp: `2026-06-0${ id % 10 }T00:00:00+00:00`,
+	title: `${ label } title`,
+	subject: [ { text: label, ranges: [], media: [] } ],
+} );
+
+const renderTab = ( store: ReturnType< typeof initStore >, filterName: FilterName ) =>
+	render(
+		<Provider store={ store }>
+			<AppProvider client={ client as never } locale="en">
+				<NoteList
+					filterName={ filterName }
+					selectedNoteId={ undefined }
+					setSelectedNoteId={ noop }
+				/>
+			</AppProvider>
+		</Provider>
+	);
+
+const renderUnread = ( store: ReturnType< typeof initStore > ) =>
+	renderTab( store, 'unread' as FilterName );
+
+describe( 'NoteList loading state', () => {
+	beforeAll( () => {
+		Element.prototype.scrollIntoView = noop;
+	} );
+
+	it( 'shows the loader, not the empty message, while a filtered fetch is in flight', () => {
+		const store = initStore();
+		// Settle once with no notes so DataViews has mounted and shows its empty state.
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderUnread( store );
+		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
+
+		// A filtered fetch begins: loading is true while the data is still empty.
+		act( () => {
+			store.dispatch( actions.ui.loadNotes() );
+		} );
+
+		// The "all caught up" message must not show until the fetch settles.
+		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
+	} );
+
+	it( 'renders only the notes in the unread id list, not the whole cache', () => {
+		const store = initStore();
+		// Two cached notes the client would both treat as unread; only one is in
+		// the server's unread id list.
+		store.dispatch(
+			actions.notes.addNotes( [
+				makeNote( 800, 'In unread list' ),
+				makeNote( 801, 'Only in cache' ),
+			] )
+		);
+		store.dispatch( actions.notes.setUnreadNoteIds( [ 800 ] ) );
+		store.dispatch( actions.ui.loadedNotes() );
+
+		renderUnread( store );
+
+		expect( screen.getByText( 'In unread list' ) ).toBeVisible();
+		expect( screen.queryByText( 'Only in cache' ) ).not.toBeInTheDocument();
+	} );
+
+	// A note read in-app leaves the Unread view even though the server id list
+	// still contains it (the read predicate runs on top of the list).
+	it( 'excludes a read note from the Unread view even if it is in the id list', () => {
+		const store = initStore();
+		store.dispatch(
+			actions.notes.addNotes( [ makeNote( 800, 'Unread one' ), makeNote( 801, 'Unread two' ) ] )
+		);
+		store.dispatch( actions.notes.setUnreadNoteIds( [ 800, 801 ] ) );
+		store.dispatch( actions.notes.readNote( 800 ) );
+		store.dispatch( actions.ui.loadedNotes() );
+
+		renderUnread( store );
+
+		expect( screen.queryByText( 'Unread one' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Unread two' ) ).toBeVisible();
+	} );
+
+	it( 'excludes a trashed note from the Unread view', () => {
+		const store = initStore();
+		store.dispatch(
+			actions.notes.addNotes( [ makeNote( 810, 'Keep me' ), makeNote( 811, 'Trash me' ) ] )
+		);
+		store.dispatch( actions.notes.setUnreadNoteIds( [ 810, 811 ] ) );
+		store.dispatch( actions.notes.trashNote( 811 ) );
+		store.dispatch( actions.ui.loadedNotes() );
+
+		renderUnread( store );
+
+		expect( screen.getByText( 'Keep me' ) ).toBeVisible();
+		expect( screen.queryByText( 'Trash me' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'client-filters the Comments tab from the shared cache', () => {
+		const store = initStore();
+		store.dispatch(
+			actions.notes.addNotes( [
+				makeNote( 900, 'A comment', 'comment' ),
+				makeNote( 901, 'A like', 'like' ),
+			] )
+		);
+		store.dispatch( actions.ui.loadedNotes() );
+
+		renderTab( store, 'comments' as FilterName );
+
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
+		expect( screen.queryByText( 'A like' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -131,6 +131,10 @@ export interface Client {
 	isShowing: boolean;
 	lastSeenTime: number;
 	noteRequestLimit: number;
+	filter: Record< string, unknown > | null;
+	filteredRequestLimit: number;
+	filteredHasMore: boolean;
+	gettingFilteredNotes: boolean;
 	retries: number;
 	subscribeTry: number;
 	subscribeTries: number;
@@ -145,6 +149,8 @@ export interface Client {
 	getNote: ( note_id: number ) => void;
 	getNotes: () => void;
 	getNotesList: () => void;
+	getFilteredNotes: () => void;
+	setFilter: ( filter: Record< string, unknown > | null ) => void;
 	updateLastSeenTime: ( proposedTime: number, fromStorage: boolean ) => boolean;
 	loadMore: () => void;
 	hasMoreNotes: () => boolean;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -28,6 +28,12 @@ export function Client() {
 	this.noteRequestLimit = settings.initial_limit;
 	// Latches once the server has no older notes left, so load-more stops paging.
 	this.allNotesLoaded = false;
+	// Active tab's server-side filter (e.g. `{ unread: 1 }`), or null for the
+	// unfiltered "all" list. When set, getFilteredNotes fetches matching notes.
+	this.filter = null;
+	this.filteredRequestLimit = settings.initial_limit;
+	this.filteredHasMore = false;
+	this.gettingFilteredNotes = false;
 	this.retries = 0;
 	this.subscribeTry = 0;
 	this.subscribeTries = 3;
@@ -247,7 +253,10 @@ function getNotes( before ) {
 			const oldIds = getAllNotes( store.getState() ).map( ( { id } ) => id );
 			const newIds = data.notes.map( ( n ) => n.id );
 			const notesToRemove = oldIds.filter( ( id ) => ! newIds.includes( id ) );
-			if ( notesToRemove.length ) {
+			// Skip pruning while a server-side filter is active: the filtered fetch
+			// loads notes outside this top window, and pruning would remove them
+			// from under the filtered view. Pruning resumes on the unfiltered tab.
+			if ( notesToRemove.length && ! this.filter ) {
 				this.allNotesLoaded = false;
 				store.dispatch( actions.notes.removeNotes( notesToRemove ) );
 			}
@@ -272,6 +281,13 @@ function getNotes( before ) {
 		}
 		this.retries = 0;
 		ready.call( this );
+
+		// New notes arriving via polling/push land in the shared store but not in
+		// the active filter's id list. Refresh that list so a filtered view (e.g.
+		// Unread) reflects new arrivals live instead of only on re-entry.
+		if ( this.filter ) {
+			this.getFilteredNotes();
+		}
 	} );
 }
 
@@ -339,6 +355,80 @@ function getNotesList() {
 
 		/* Grab updates/changes from server if they exist */
 		return serverHasChanges ? this.getNotes() : ready.call( this );
+	} );
+}
+
+/**
+ * Set the active server-side filter for the visible tab and (re)fetch.
+ *
+ * Pass `null` for the unfiltered "all" tab, or a query fragment such as
+ * `{ unread: 1 }` for a filtered tab. Switching tabs resets the filtered
+ * pagination window and, for a filtered tab, kicks off a fresh fetch so the
+ * list reflects the server's filtered results immediately.
+ * @param {?Object} filter Query fragment to send to the notes endpoint, or null.
+ */
+function setFilter( filter ) {
+	this.filter = filter ?? null;
+	this.filteredRequestLimit = settings.initial_limit;
+	this.filteredHasMore = false;
+
+	// Reset the filtered view's id list so the tab doesn't show a stale set
+	// before the fresh fetch lands.
+	store.dispatch( actions.notes.setUnreadNoteIds( [] ) );
+
+	if ( this.filter && this.isVisible ) {
+		this.getFilteredNotes();
+	}
+}
+
+/**
+ * Fetch notes matching the active filter from the server.
+ *
+ * Content is added to the shared `allNotes` store (never removed here); the
+ * server's answer for which notes belong to the view is kept as an ordered id
+ * list (`unreadNoteIds`) that the Unread tab renders looked up in the store.
+ */
+function getFilteredNotes() {
+	if ( ! this.filter || this.gettingFilteredNotes ) {
+		return;
+	}
+	this.gettingFilteredNotes = true;
+
+	const parameters = {
+		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
+		number: this.filteredRequestLimit,
+		locale: this.locale,
+		...this.filter,
+	};
+
+	// Only show the full-panel spinner for the first page; later pages stream in.
+	if ( this.filteredRequestLimit === settings.initial_limit ) {
+		store.dispatch( actions.ui.loadNotes() );
+	}
+
+	listNotes( parameters, ( error, data ) => {
+		this.gettingFilteredNotes = false;
+		store.dispatch( actions.ui.loadedNotes() );
+
+		if ( error ) {
+			// Leave the polling path's state untouched; it will recover on its
+			// own schedule. A retry happens when the user re-enters the tab.
+			return;
+		}
+
+		store.dispatch( actions.notes.addNotes( data.notes ) );
+
+		// The latest response is authoritative, so replace the id list — notes the
+		// server no longer returns (read/deleted elsewhere) drop from the view.
+		// Guard on the filter so a response landing after a tab switch is ignored,
+		// and so only `unread` writes the unread list.
+		if ( this.filter?.unread ) {
+			store.dispatch( actions.notes.setUnreadNoteIds( data.notes.map( ( note ) => note.id ) ) );
+		}
+
+		// A full page back implies the server may have more matching notes.
+		this.filteredHasMore =
+			data.notes.length >= parameters.number && this.filteredRequestLimit < settings.max_limit;
 	} );
 }
 
@@ -502,6 +592,20 @@ function handleStorageEvent( event ) {
 }
 
 function loadMore() {
+	// Filtered tabs paginate their own window, advancing only while the server
+	// still has matching notes.
+	if ( this.filter ) {
+		if ( this.gettingFilteredNotes || ! this.filteredHasMore ) {
+			return;
+		}
+		this.filteredRequestLimit = Math.min(
+			this.filteredRequestLimit + settings.increment_limit,
+			settings.max_limit
+		);
+		this.getFilteredNotes();
+		return;
+	}
+
 	if ( this.gettingNotes || ! this.hasMoreNotes() ) {
 		return;
 	}
@@ -533,6 +637,9 @@ function loadMore() {
 // keep its optimistic `totalItems` ahead of the scroll window so DataViews
 // keeps advancing it.
 function hasMoreNotes() {
+	if ( this.filter ) {
+		return this.filteredHasMore;
+	}
 	const notes = getAllNotes( store.getState() );
 	return ! this.allNotesLoaded && notes.length < settings.max_limit;
 }
@@ -562,6 +669,8 @@ Client.prototype.reschedule = reschedule;
 Client.prototype.getNote = getNote;
 Client.prototype.getNotes = getNotes;
 Client.prototype.getNotesList = getNotesList;
+Client.prototype.getFilteredNotes = getFilteredNotes;
+Client.prototype.setFilter = setFilter;
 Client.prototype.updateLastSeenTime = updateLastSeenTime;
 Client.prototype.loadMore = loadMore;
 Client.prototype.hasMoreNotes = hasMoreNotes;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -339,9 +339,11 @@ function getNotesList() {
 		/* Actually remove the notes from the local copy */
 		const notesToRemove = localIds.filter( ( local ) => ! serverIds.includes( local ) );
 
-		if ( notesToRemove.length ) {
-			// The polling window shifted, so notes we'd paged in may sit below it
-			// again — let load-more re-page them (mirrors getNotes()).
+		// Don't prune while a filter is active: the filtered view shares this cache,
+		// and a note that fell out of the unfiltered window could be dropped from it
+		// (mirrors getNotes()). The shifted window otherwise means load-more should
+		// re-page these, so clear allNotesLoaded.
+		if ( notesToRemove.length && ! this.filter ) {
 			this.allNotesLoaded = false;
 			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
 		}

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -289,5 +289,28 @@ describe( 'RestClient', () => {
 
 			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [ 900, 901 ] );
 		} );
+
+		// Polling's getNotesList() prunes against the unfiltered window. While a
+		// filter is active it must not drop a note that fell out of that window —
+		// the Unread view still resolves it through the shared store.
+		it( 'does not prune the shared store via getNotesList while a filter is active', () => {
+			// Seed the polling window: 100 and 99 are in this.noteList and the store.
+			client.getNotes();
+			getCalls[ 0 ].callback( null, {
+				notes: [ makeNote( 100 ), makeNote( 99 ) ],
+				last_seen_time: 0,
+			} );
+			getCalls.length = 0;
+
+			// A filter is active (e.g. the Unread tab).
+			client.filter = { unread: 1 };
+
+			// Polling sees 99 has dropped out of the unfiltered top window.
+			client.getNotesList();
+			getCalls[ 0 ].callback( null, { notes: [ makeNote( 100 ) ], last_seen_time: 0 } );
+
+			// 99 stays in the store so the Unread view can still resolve it.
+			expect( getAllNotes( store.getState() ).map( ( note ) => note.id ) ).toContain( 99 );
+		} );
 	} );
 } );

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -4,6 +4,7 @@
 import { store } from '../../state';
 import actions from '../../state/actions';
 import getAllNotes from '../../state/selectors/get-all-notes';
+import getUnreadNoteIds from '../../state/selectors/get-unread-note-ids';
 import Client from '../index';
 import { init } from '../wpcom';
 
@@ -20,7 +21,7 @@ const makeNote = ( id ) => ( {
 const fullPage = ( count, startId ) =>
 	Array.from( { length: count }, ( _, i ) => makeNote( startId - i ) );
 
-describe( 'RestClient load-more pagination', () => {
+describe( 'RestClient', () => {
 	let getCalls;
 	let client;
 
@@ -61,91 +62,232 @@ describe( 'RestClient load-more pagination', () => {
 		getCalls.length = 0;
 	};
 
-	it( 'pages backwards with before=<oldest timestamp> and merges additively', () => {
-		seedFirstWindow();
-		const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ];
+	describe( 'load-more pagination', () => {
+		it( 'pages backwards with before=<oldest timestamp> and merges additively', () => {
+			seedFirstWindow();
+			const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ];
 
-		client.loadMore();
+			client.loadMore();
 
-		expect( getCalls ).toHaveLength( 1 );
-		// Fixed page size, anchored on the oldest loaded note's timestamp expressed
-		// as the UNIX epoch seconds the endpoint's `before` cursor expects.
-		expect( getCalls[ 0 ].query ).toMatchObject( {
-			number: 10,
-			before: Math.floor( Date.parse( oldest.timestamp ) / 1000 ),
+			expect( getCalls ).toHaveLength( 1 );
+			// Fixed page size, anchored on the oldest loaded note's timestamp expressed
+			// as the UNIX epoch seconds the endpoint's `before` cursor expects.
+			expect( getCalls[ 0 ].query ).toMatchObject( {
+				number: 10,
+				before: Math.floor( Date.parse( oldest.timestamp ) / 1000 ),
+			} );
+
+			// A full older page merges in without dropping the first window.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
+			const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
+			expect( ids ).toContain( 100 ); // first window kept
+			expect( ids ).toContain( 91 ); // first window kept
+			expect( ids ).toContain( 71 ); // older page added
 		} );
 
-		// A full older page merges in without dropping the first window.
-		getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
-		const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
-		expect( ids ).toContain( 100 ); // first window kept
-		expect( ids ).toContain( 91 ); // first window kept
-		expect( ids ).toContain( 71 ); // older page added
+		it( 'does not send before on the initial window fetch', () => {
+			client.getNotes();
+			expect( getCalls[ 0 ].query ).not.toHaveProperty( 'before' );
+		} );
+
+		it( 'advances the cursor on each successive page', () => {
+			seedFirstWindow();
+
+			client.loadMore();
+			const firstBefore = getCalls[ 0 ].query.before;
+			getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
+
+			getCalls.length = 0;
+			client.loadMore();
+
+			expect( getCalls ).toHaveLength( 1 );
+			const secondBefore = getCalls[ 0 ].query.before;
+			// Cursor (epoch seconds) walked further back in time as older notes loaded.
+			expect( secondBefore ).toBeLessThan( firstBefore );
+		} );
+
+		it( 'stops paging once the server returns a short page', () => {
+			seedFirstWindow();
+
+			client.loadMore();
+			// Fewer than the requested page means the server has nothing older.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } );
+
+			expect( client.hasMoreNotes() ).toBe( false );
+
+			getCalls.length = 0;
+			client.loadMore();
+			// No further request: load-more settles instead of walking to the max.
+			expect( getCalls ).toHaveLength( 0 );
+		} );
+
+		it( 'stops paging when a capped page echoes back only the anchor', () => {
+			// 99 loaded leaves one slot under max_limit, so the next page is capped to
+			// number=1. An inclusive `before` echoes that single anchor note back, so
+			// the page is full-size (1 of 1) yet adds nothing new. Without the no-new-id
+			// check this never latches and the catch-up loop refetches forever.
+			store.dispatch( actions.notes.addNotes( fullPage( 99, 100 ) ) ); // ids 100..2
+
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 1 );
+			expect( getCalls[ 0 ].query.number ).toBe( 1 ); // capped to the remaining slot
+
+			const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ]; // id 2
+			getCalls[ 0 ].callback( null, { notes: [ oldest ], last_seen_time: 0 } );
+
+			expect( client.hasMoreNotes() ).toBe( false );
+
+			getCalls.length = 0;
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 0 );
+		} );
+
+		it( 'reports no more notes once the cap is reached', () => {
+			// 100 notes (settings.max_limit) loaded means we never page past the cap.
+			store.dispatch( actions.notes.addNotes( fullPage( 100, 100 ) ) );
+			expect( client.hasMoreNotes() ).toBe( false );
+
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 0 );
+		} );
 	} );
 
-	it( 'does not send before on the initial window fetch', () => {
-		client.getNotes();
-		expect( getCalls[ 0 ].query ).not.toHaveProperty( 'before' );
-	} );
+	describe( 'server-side (unread) filtering', () => {
+		it( 'sends unread=1 to the server and adds the returned notes', () => {
+			client.setFilter( { unread: 1 } );
 
-	it( 'advances the cursor on each successive page', () => {
-		seedFirstWindow();
+			expect( getCalls ).toHaveLength( 1 );
+			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 10 } );
 
-		client.loadMore();
-		const firstBefore = getCalls[ 0 ].query.before;
-		getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
+			getCalls[ 0 ].callback( null, { notes: [ makeNote( 101 ) ], last_seen_time: 0 } );
 
-		getCalls.length = 0;
-		client.loadMore();
+			const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
+			expect( ids ).toContain( 101 );
+		} );
 
-		expect( getCalls ).toHaveLength( 1 );
-		const secondBefore = getCalls[ 0 ].query.before;
-		// Cursor (epoch seconds) walked further back in time as older notes loaded.
-		expect( secondBefore ).toBeLessThan( firstBefore );
-	} );
+		it( 'stops paginating when the server returns a short page (empty Unread case)', () => {
+			client.setFilter( { unread: 1 } );
+			// A short page (fewer than `number`) means the server is exhausted.
+			getCalls[ 0 ].callback( null, { notes: [], last_seen_time: 0 } );
 
-	it( 'stops paging once the server returns a short page', () => {
-		seedFirstWindow();
+			expect( client.filteredHasMore ).toBe( false );
 
-		client.loadMore();
-		// Fewer than the requested page means the server has nothing older.
-		getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } );
+			getCalls.length = 0;
+			client.loadMore();
+			// No further request once the server is exhausted.
+			expect( getCalls ).toHaveLength( 0 );
+		} );
 
-		expect( client.hasMoreNotes() ).toBe( false );
+		it( 'keeps paginating with a larger window while the server has more', () => {
+			client.setFilter( { unread: 1 } );
+			// A full page back implies more may exist.
+			const firstPage = Array.from( { length: 10 }, ( _, i ) => makeNote( 200 + i ) );
+			getCalls[ 0 ].callback( null, { notes: firstPage, last_seen_time: 0 } );
 
-		getCalls.length = 0;
-		client.loadMore();
-		// No further request: load-more settles instead of walking to the max.
-		expect( getCalls ).toHaveLength( 0 );
-	} );
+			expect( client.filteredHasMore ).toBe( true );
 
-	it( 'stops paging when a capped page echoes back only the anchor', () => {
-		// 99 loaded leaves one slot under max_limit, so the next page is capped to
-		// number=1. An inclusive `before` echoes that single anchor note back, so
-		// the page is full-size (1 of 1) yet adds nothing new. Without the no-new-id
-		// check this never latches and the catch-up loop refetches forever.
-		store.dispatch( actions.notes.addNotes( fullPage( 99, 100 ) ) ); // ids 100..2
+			getCalls.length = 0;
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 1 );
+			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 20 } );
+		} );
 
-		client.loadMore();
-		expect( getCalls ).toHaveLength( 1 );
-		expect( getCalls[ 0 ].query.number ).toBe( 1 ); // capped to the remaining slot
+		it( 'replaces the unread id list with the response, leaving the shared store intact', () => {
+			// A note already cached (e.g. read on another device since it was loaded).
+			store.dispatch( actions.notes.addNotes( [ makeNote( 500 ) ] ) );
 
-		const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ]; // id 2
-		getCalls[ 0 ].callback( null, { notes: [ oldest ], last_seen_time: 0 } );
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: [ makeNote( 501 ) ], last_seen_time: 0 } );
 
-		expect( client.hasMoreNotes() ).toBe( false );
+			// The Unread view follows the server's id list, so 500 drops out of it…
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [ 501 ] );
+			// …but the shared store is untouched, so the "All" view keeps both notes.
+			const allIds = getAllNotes( store.getState() ).map( ( note ) => note.id );
+			expect( allIds ).toEqual( expect.arrayContaining( [ 500, 501 ] ) );
+		} );
 
-		getCalls.length = 0;
-		client.loadMore();
-		expect( getCalls ).toHaveLength( 0 );
-	} );
+		it( 'clears the unread id list when the filter changes', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: [ makeNote( 700 ) ], last_seen_time: 0 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [ 700 ] );
 
-	it( 'reports no more notes once the cap is reached', () => {
-		// 100 notes (settings.max_limit) loaded means we never page past the cap.
-		store.dispatch( actions.notes.addNotes( fullPage( 100, 100 ) ) );
-		expect( client.hasMoreNotes() ).toBe( false );
+			client.setFilter( null ); // switch back to "All"
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [] );
+		} );
 
-		client.loadMore();
-		expect( getCalls ).toHaveLength( 0 );
+		// A filtered fetch must never remove notes from the shared store, so the
+		// "All" view's count can't drop after a visit to the Unread tab.
+		it( 'never removes notes from the shared store on a filtered fetch', () => {
+			const all = Array.from( { length: 100 }, ( _, i ) => makeNote( 1000 + i ) );
+			store.dispatch( actions.notes.addNotes( all ) );
+			const before = getAllNotes( store.getState() ).length;
+
+			client.setFilter( { unread: 1 } );
+			// The unread response is a subset of what's already cached.
+			getCalls[ 0 ].callback( null, {
+				notes: [ makeNote( 1000 ), makeNote( 1001 ) ],
+				last_seen_time: 0,
+			} );
+
+			expect( getAllNotes( store.getState() ).length ).toBe( before );
+		} );
+
+		it( 'accumulates unread notes across load-more pages and stops when exhausted', () => {
+			// Each fetch re-requests a growing top-N window, so every response is a
+			// superset; the id list is replaced and therefore grows.
+			const page = ( count ) => Array.from( { length: count }, ( _, i ) => makeNote( 300 + i ) );
+
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: page( 10 ), last_seen_time: 0 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 10 );
+			expect( client.filteredHasMore ).toBe( true );
+
+			// Page 2: load-more requests number=20 and the list grows to 20.
+			getCalls.length = 0;
+			client.loadMore();
+			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 20 } );
+			getCalls[ 0 ].callback( null, { notes: page( 20 ), last_seen_time: 0 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 20 );
+			expect( client.filteredHasMore ).toBe( true );
+
+			// Page 3: requests number=30 but the server returns fewer (25) — exhausted.
+			getCalls.length = 0;
+			client.loadMore();
+			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 30 } );
+			getCalls[ 0 ].callback( null, { notes: page( 25 ), last_seen_time: 0 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 25 );
+			expect( client.filteredHasMore ).toBe( false );
+
+			// No more pages: load-more is a no-op.
+			getCalls.length = 0;
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 0 );
+		} );
+
+		// A new note arriving via the polling/push path (getNotes) while a filter is
+		// active should refresh the filtered id list so the view picks it up live.
+		it( 'refreshes the unread list when new notes arrive via the polling path', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: [ makeNote( 900 ) ], last_seen_time: 0 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [ 900 ] );
+
+			// The polling/push path fetches the unfiltered list (no `unread` param).
+			getCalls.length = 0;
+			client.getNotes();
+			const pollCall = getCalls.find( ( call ) => call.query.unread === undefined );
+			expect( pollCall ).toBeTruthy();
+
+			// Its response includes a newly-arrived note and triggers a fresh filtered
+			// fetch, which updates the unread list to include it.
+			pollCall.callback( null, { notes: [ makeNote( 900 ), makeNote( 901 ) ], last_seen_time: 0 } );
+			const refreshCall = getCalls.find( ( call ) => call.query.unread );
+			expect( refreshCall ).toBeTruthy();
+			refreshCall.callback( null, {
+				notes: [ makeNote( 900 ), makeNote( 901 ) ],
+				last_seen_time: 0,
+			} );
+
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [ 900, 901 ] );
+		} );
 	} );
 } );

--- a/apps/notifications/src/panel/state/action-types.js
+++ b/apps/notifications/src/panel/state/action-types.js
@@ -5,6 +5,7 @@ export const NOTES_ADD = 'NOTES_ADD';
 export const NOTES_REMOVE = 'NOTES_REMOVE';
 export const NOTES_LOADING = 'NOTES_LOADING';
 export const NOTES_LOADED = 'NOTES_LOADED';
+export const SET_UNREAD_NOTE_IDS = 'SET_UNREAD_NOTE_IDS';
 export const SELECT_NOTE = 'SELECT_NOTE';
 export const READ_NOTE = 'READ_NOTE';
 export const RESET_LOCAL_APPROVAL = 'RESET_LOCAL_APPROVAL';

--- a/apps/notifications/src/panel/state/notes/actions.js
+++ b/apps/notifications/src/panel/state/notes/actions.js
@@ -11,6 +11,13 @@ export const removeNotes = ( noteIds, isComment = false ) => ( {
 	isComment,
 } );
 
+// Replace the "Unread" view's id list. This only sets the list; note content
+// lives in `allNotes` and is unaffected.
+export const setUnreadNoteIds = ( noteIds ) => ( {
+	type: types.SET_UNREAD_NOTE_IDS,
+	noteIds,
+} );
+
 export const noteAction = ( action ) => ( noteId ) => ( {
 	type: action,
 	noteId,
@@ -72,6 +79,7 @@ export default {
 	removeNotes,
 	resetLocalApproval,
 	resetLocalLike,
+	setUnreadNoteIds,
 	spamNote,
 	trashNote,
 };

--- a/apps/notifications/src/panel/state/notes/reducer.js
+++ b/apps/notifications/src/panel/state/notes/reducer.js
@@ -61,6 +61,16 @@ export const noteLikes = ( state = {}, { type, noteId, isLiked } ) => {
 	return state;
 };
 
+// Ordered id list backing the server-filtered "Unread" view. Holds the server's
+// answer for which notes are unread; the notes themselves live in `allNotes`.
+export const unreadNoteIds = ( state = [], { type, noteIds } ) => {
+	if ( types.SET_UNREAD_NOTE_IDS === type ) {
+		return noteIds;
+	}
+
+	return state;
+};
+
 export const noteReads = ( state = {}, { type, noteId } ) => {
 	if ( ( types.READ_NOTE === type || types.SELECT_NOTE === type ) && noteId ) {
 		return { ...state, [ noteId ]: true };
@@ -83,6 +93,7 @@ export const filteredNoteReads = ( state = [], { type, noteId } ) => {
 
 export default combineReducers( {
 	allNotes,
+	unreadNoteIds,
 	hiddenNoteIds,
 	noteApprovals,
 	noteLikes,

--- a/apps/notifications/src/panel/state/selectors/get-unread-note-ids.js
+++ b/apps/notifications/src/panel/state/selectors/get-unread-note-ids.js
@@ -1,0 +1,5 @@
+import getNotes from './get-notes';
+
+export const getUnreadNoteIds = ( notesState ) => notesState.unreadNoteIds;
+
+export default ( state ) => getUnreadNoteIds( getNotes( state ) );


### PR DESCRIPTION
Fixes DOTMSD-1032

## Proposed Changes

* The **Unread** tab filters server-side (`unread=1`) instead of pulling the full note list and filtering in the browser.
* Unread results are tracked in a **separate ordered id list**, kept distinct from the shared note cache. The cache holds note content (shared by every tab and the detail view); the Unread tab renders the ids in its list looked up against that cache. The filtered fetch only updates the list and adds content — it never removes notes from the shared cache.
* Each filtered fetch replaces the list with the server's current result, so notes that are no longer unread fall out of it. The polling/websocket path refreshes the list so new arrivals show up live.
* A spinner shows while a filtered fetch is in flight; pagination grows the list as you scroll and stops once the server is exhausted.

## Why are these changes being made?

The Unread tab re-fetched the whole list at a growing size (10 → 100) to find unread notes in the browser — slow, especially when everything is already read. The endpoint can filter unread at the database, so we let it.

## Testing Instructions
~~Apply 222759-ghe-Automattic/wpcom to sandbox.~~

1. `yarn start-dashboard`, open notifications, click **Unread** → one `unread=1` request, spinner then results (no empty-state flash).
2. With an aggregated note (`unread >= 2`), it appears on first open.
3. Switch between **All** and **Unread** — each shows the right notes; a newly-arriving notification appears on Unread without leaving the tab.
4. Other tabs still load/paginate; reading a note removes it from Unread.

Automated: `yarn test-apps apps/notifications`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)