### PR TITLE
Dashboard: add is_staging_site to calypso_dashboard_sites_item_click

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -211,8 +211,6 @@ export class SiteSelector extends Component {
 	};
 
 	onSiteSelect = ( event, siteId ) => {
-		const selectedSite = this.props.sites.find( ( site ) => site.ID === siteId );
-
 		if ( siteId !== ALL_SITES ) {
 			const visibleSites = this.visibleSites.filter( ( ID ) => ID !== ALL_SITES );
 			this.props.recordTracksEvent( 'calypso_switch_site_click_item', {
@@ -221,9 +219,10 @@ export class SiteSelector extends Component {
 				is_searching: this.state.searchTerm.length > 0,
 				sort_key: this.props.sitesSorting.sortKey,
 				sort_order: this.props.sitesSorting.sortOrder,
-				is_staging_site: selectedSite?.is_wpcom_staging_site ?? false,
 			} );
 		}
+
+		const selectedSite = this.props.sites.find( ( site ) => site.ID === siteId );
 		const handledByHost = this.props.onSiteSelect( siteId, selectedSite );
 		this.props.onClose( event, siteId );
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -211,6 +211,8 @@ export class SiteSelector extends Component {
 	};
 
 	onSiteSelect = ( event, siteId ) => {
+		const selectedSite = this.props.sites.find( ( site ) => site.ID === siteId );
+
 		if ( siteId !== ALL_SITES ) {
 			const visibleSites = this.visibleSites.filter( ( ID ) => ID !== ALL_SITES );
 			this.props.recordTracksEvent( 'calypso_switch_site_click_item', {
@@ -219,10 +221,9 @@ export class SiteSelector extends Component {
 				is_searching: this.state.searchTerm.length > 0,
 				sort_key: this.props.sitesSorting.sortKey,
 				sort_order: this.props.sitesSorting.sortOrder,
+				is_staging_site: selectedSite?.is_wpcom_staging_site ?? false,
 			} );
 		}
-
-		const selectedSite = this.props.sites.find( ( site ) => site.ID === siteId );
 		const handledByHost = this.props.onSiteSelect( siteId, selectedSite );
 		this.props.onClose( event, siteId );
 

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -57,7 +57,11 @@ export function SitesDataViews( {
 							{ ...props }
 							site={ item }
 							expanded={ view.type === 'grid' }
-							onClick={ () => recordTracksEvent( 'calypso_dashboard_sites_item_click' ) }
+							onClick={ () =>
+								recordTracksEvent( 'calypso_dashboard_sites_item_click', {
+									is_staging_site: item.is_wpcom_staging_site,
+								} )
+							}
 						/>
 					) }
 				/>

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -385,6 +385,7 @@ const SitesDashboard = ( {
 				recordTracksEvent( 'calypso_sites_dashboard_open_site_preview_pane', {
 					site_id: site.ID,
 					source,
+					is_staging_site: site.is_wpcom_staging_site ?? false,
 				} );
 				showSitesPage( sitePreviewPane.getUrl( site ), openInNewTab );
 			},

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -385,7 +385,7 @@ const SitesDashboard = ( {
 				recordTracksEvent( 'calypso_sites_dashboard_open_site_preview_pane', {
 					site_id: site.ID,
 					source,
-					is_staging_site: site.is_wpcom_staging_site ?? false,
+					is_staging_site: site.is_wpcom_staging_site ?? null,
 				} );
 				showSitesPage( sitePreviewPane.getUrl( site ), openInNewTab );
 			},

--- a/client/sites/components/types.ts
+++ b/client/sites/components/types.ts
@@ -2,7 +2,7 @@ import type { SiteExcerptData } from '@automattic/sites';
 
 export type SitePreviewPane = {
 	open: (
-		site: Pick< SiteExcerptData, 'ID' | 'slug' >,
+		site: Pick< SiteExcerptData, 'ID' | 'slug' | 'is_wpcom_staging_site' >,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher',
 		openInNewTab?: boolean
 	) => void;


### PR DESCRIPTION
Part of #

## Proposed Changes

* Adds `is_staging_site` to the Tracks events that fire when a user clicks a site in the sites list, so we can measure navigation into staging sites.
* The sites list emits two different events depending on whether the site preview pane is open, so the property is added to both:
  * `calypso_dashboard_sites_item_click` — fires when the preview pane is closed (Dashboard / backported v2 list, `client/dashboard/sites/dataviews/sites-dataviews.tsx`).
  * `calypso_sites_dashboard_open_site_preview_pane` — fires when the preview pane is open and a row is clicked (classic `DefaultSitesDataViews`, `client/sites/components/sites-dashboard.tsx`).
* Widens the `SitePreviewPane.open` site param to include `is_wpcom_staging_site` so the value is available where the event fires.

## Why are these changes being made?

* We want to measure how often users navigate into staging sites from the sites list. Because clicks fire two different events depending on the preview-pane state, both need the property for complete coverage.

## Testing Instructions

* With the preview pane closed, click into a site and confirm `calypso_dashboard_sites_item_click` fires with `is_staging_site: true` for a staging site and `false` otherwise.
* With the preview pane open, click a row and confirm `calypso_sites_dashboard_open_site_preview_pane` fires with `is_staging_site: true` for a staging site and `false` otherwise.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?