### PR TITLE
Reader: make withFullPostNavigation test assertions React 18/19 compatible

### DIFF
--- a/client/blocks/reader-full-post/test/index.jsx
+++ b/client/blocks/reader-full-post/test/index.jsx
@@ -144,15 +144,15 @@ describe( 'withFullPostNavigation', () => {
 			{ siteId: 100, postId: 2 },
 			{ enabled: true }
 		);
-		expect( WrappedComponent ).toHaveBeenCalledWith(
+		expect( WrappedComponent ).toHaveBeenCalled();
+		expect( WrappedComponent.mock.calls[ 0 ][ 0 ] ).toEqual(
 			expect.objectContaining( {
 				post: { ID: 2, site_ID: 100 },
 				referralPost: { ID: 9, site_ID: 100 },
 				commentsApiDisabled: false,
 				previousPost: { ID: 1, site_ID: 100 },
 				nextPost: { ID: 3, site_ID: 100 },
-			} ),
-			{}
+			} )
 		);
 	} );
 
@@ -171,11 +171,11 @@ describe( 'withFullPostNavigation', () => {
 			</Provider>
 		);
 
-		expect( WrappedComponent ).toHaveBeenCalledWith(
+		expect( WrappedComponent ).toHaveBeenCalled();
+		expect( WrappedComponent.mock.calls[ 0 ][ 0 ] ).toEqual(
 			expect.objectContaining( {
 				commentsApiDisabled: true,
-			} ),
-			{}
+			} )
 		);
 	} );
 } );


### PR DESCRIPTION
Part of the Calypso → React 19 migration. Follow-up to #111506, which made `client/blocks` source forward-compatible but deferred two test assertions because their React-19-correct form is incompatible with React 18.

## Proposed Changes

* Rework the two `withFullPostNavigation` assertions in the Reader full-post test so they pass on both React 18 and React 19.

## Why are these changes being made?

The assertions checked the full call signature of a mocked function component, including the framework-supplied second argument. React 18 and React 19 pass a different second argument to function components, so an assertion pinned to one version breaks on the other. Asserting only on the first argument (the props the component actually cares about) keeps coverage intact while staying version-agnostic, removing a blocker for the eventual React 19 bump.

## Testing Instructions

* `yarn test-client client/blocks/reader-full-post` — all suites pass on the current React 18.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
