### PR TITLE
InfiniteList: expose container node so author-selector can drop findDOMNode

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -3,7 +3,6 @@ import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
-import ReactDom from 'react-dom';
 import AsyncLoad from 'calypso/components/async-load';
 import InfiniteList from 'calypso/components/infinite-list';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -101,7 +100,7 @@ class AuthorSwitcherShell extends Component {
 
 	setListContext = ( infiniteListInstance ) => {
 		this.setState( {
-			listContext: ReactDom.findDOMNode( infiniteListInstance ),
+			listContext: infiniteListInstance?.getDOMNode(),
 		} );
 	};
 
@@ -127,7 +126,7 @@ class AuthorSwitcherShell extends Component {
 	};
 
 	onClose = ( event ) => {
-		const toggleElement = ReactDom.findDOMNode( this.authorSelectorToggleRef.current );
+		const toggleElement = this.authorSelectorToggleRef.current;
 
 		if ( event && toggleElement.contains( event.target ) ) {
 			// let toggleShowAuthor() handle this case

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -46,6 +46,7 @@ export default class InfiniteList extends Component {
 	isScrolling = false;
 	_isMounted = false;
 	smartSetState = smartSetState;
+	containerRef = createRef();
 	topPlaceholderRef = createRef();
 	bottomPlaceholderRef = createRef();
 
@@ -340,6 +341,9 @@ export default class InfiniteList extends Component {
 		return null;
 	};
 
+	// Instance method that is called externally (via a ref) by a parent component
+	getDOMNode = () => this.containerRef.current;
+
 	getTopPlaceholderBounds = () =>
 		this.topPlaceholderRef.current && this.topPlaceholderRef.current.getBoundingClientRect();
 
@@ -357,7 +361,7 @@ export default class InfiniteList extends Component {
 	 * @returns {Array} This list of indexes
 	 */
 	getVisibleItemIndexes( options ) {
-		const container = ReactDom.findDOMNode( this );
+		const container = this.containerRef.current;
 		const visibleItemIndexes = [];
 		const firstIndex = this.state.firstRenderedIndex;
 		const lastIndex = this.state.lastRenderedIndex;
@@ -423,7 +427,7 @@ export default class InfiniteList extends Component {
 		}
 
 		return (
-			<div className={ this.props.className }>
+			<div className={ this.props.className } ref={ this.containerRef }>
 				<div
 					ref={ this.topPlaceholderRef }
 					className={ spacerClassName }


### PR DESCRIPTION
Part of the Calypso → React 19 migration. Follow-up to #111506.

## Proposed Changes

* `InfiniteList` attaches a ref to its rendered container `<div>` and exposes it via a public `getDOMNode()` method, and reads its own container through that ref instead of `ReactDom.findDOMNode( this )`.
* `author-selector` uses `getDOMNode()` for the popover scroll context and reads its toggle node directly off its existing ref, removing both `ReactDom.findDOMNode` calls and the `react-dom` import.

## Why are these changes being made?

#111506 made `client/blocks` forward-compatible with React 19 but deliberately left `author-selector` on `ReactDom.findDOMNode` — removing it depended on an `InfiniteList` (`client/components`) change that hadn't landed yet, and removing it prematurely would have been a React 18 regression. This lands that prerequisite and completes the `author-selector` migration.

`findDOMNode` is removed in React 19, so consumers need a supported way to read `InfiniteList`'s rendered node. The `getDOMNode()` name matches the convention already encoded in `author-selector`'s `ignoreContext` prop type.

All changes are behavior-preserving on the current React 18.

## Scope notes

The `boundsForRef` string-ref path in `InfiniteList` is intentionally left as-is. It's coupled to the Reader stream's direct use of `InfiniteList`'s string-ref map (`listRef.current.refs[…]` plus `ref={ itemKey }` string refs on items) and is a separate, larger migration that should get its own focused review.

## Testing Instructions

* `yarn eslint` on both changed files — clean (the two remaining `react/no-find-dom-node` warnings are the pre-existing `boundsForRef` path, untouched here).
* `yarn test-client client/reader/stream` — all suites pass, including keyboard-navigation paths that exercise `getVisibleItemIndexes` and the scroll logic (the deepest `InfiniteList` consumer).
* `yarn typecheck-client` — no errors in either changed file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
