### PR TITLE
Legacy Contact: read contact from wpcom/v2/me/legacy-contacts

### DIFF
--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -1,5 +1,5 @@
 import { legacyContactsQuery } from '@automattic/api-queries';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -12,7 +12,7 @@ import './style.scss';
 export default function LegacyContact() {
 	const translate = useTranslate();
 
-	const { data: [ contact ] = [] } = useQuery( legacyContactsQuery() );
+	const { data: [ contact ] = [], isLoading } = useQuery( legacyContactsQuery() );
 
 	return (
 		<Main wideLayout className="legacy-contact">
@@ -27,14 +27,24 @@ export default function LegacyContact() {
 					) }
 				</p>
 
-				{ contact && (
-					<p>
-						{ translate( 'Your legacy contact is {{strong}}%(email)s{{/strong}}.', {
-							args: { email: contact.email },
-							components: { strong: <strong /> },
-						} ) }
-					</p>
-				) }
+				{ ! isLoading &&
+					( contact ? (
+						<p>
+							{ translate( 'Your legacy contact is {{strong}}%(email)s{{/strong}}.', {
+								args: { email: contact.email },
+								components: { strong: <strong /> },
+							} ) }
+						</p>
+					) : (
+						<Button
+							primary
+							onClick={ () => {
+								// TODO: open the legacy contact setup flow.
+							} }
+						>
+							{ translate( 'Set up legacy contact' ) }
+						</Button>
+					) ) }
 			</Card>
 		</Main>
 	);

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -29,7 +29,7 @@ export default function LegacyContact() {
 
 				{ ! isLoading &&
 					( contact ? (
-						<p className="legacy-contact__current">
+						<p className="legacy-contact__assigned-contact">
 							{ translate( 'Your legacy contact is {{strong}}%(email)s{{/strong}}.', {
 								args: { email: contact.email },
 								components: { strong: <strong /> },

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -37,6 +37,7 @@ export default function LegacyContact() {
 						</p>
 					) : (
 						<Button
+							className="legacy-contact__action"
 							primary
 							onClick={ () => {
 								// TODO: open the legacy contact setup flow.

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -12,8 +12,7 @@ import './style.scss';
 export default function LegacyContact() {
 	const translate = useTranslate();
 
-	const { data: contacts = [], isLoading } = useQuery( legacyContactsQuery() );
-	const contact = contacts[ 0 ];
+	const { data: [ contact ] = [] } = useQuery( legacyContactsQuery() );
 
 	return (
 		<Main wideLayout className="legacy-contact">
@@ -28,8 +27,8 @@ export default function LegacyContact() {
 					) }
 				</p>
 
-				{ ! isLoading && contact && (
-					<p className="legacy-contact__current">
+				{ contact && (
+					<p>
 						{ translate( 'Your legacy contact is {{strong}}%(email)s{{/strong}}.', {
 							args: { email: contact.email },
 							components: { strong: <strong /> },

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -29,7 +29,7 @@ export default function LegacyContact() {
 
 				{ ! isLoading &&
 					( contact ? (
-						<p>
+						<p className="legacy-contact__current">
 							{ translate( 'Your legacy contact is {{strong}}%(email)s{{/strong}}.', {
 								args: { email: contact.email },
 								components: { strong: <strong /> },

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -1,4 +1,6 @@
+import { legacyContactsQuery } from '@automattic/api-queries';
 import { Card } from '@automattic/components';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -9,6 +11,9 @@ import './style.scss';
 
 export default function LegacyContact() {
 	const translate = useTranslate();
+
+	const { data: contacts = [], isLoading } = useQuery( legacyContactsQuery() );
+	const contact = contacts[ 0 ];
 
 	return (
 		<Main wideLayout className="legacy-contact">
@@ -22,6 +27,15 @@ export default function LegacyContact() {
 						'A legacy contact is someone you trust to have access to your account after your death.'
 					) }
 				</p>
+
+				{ ! isLoading && contact && (
+					<p className="legacy-contact__current">
+						{ translate( 'Your legacy contact is {{strong}}%(email)s{{/strong}}.', {
+							args: { email: contact.email },
+							components: { strong: <strong /> },
+						} ) }
+					</p>
+				) }
 			</Card>
 		</Main>
 	);

--- a/client/me/legacy-contact/style.scss
+++ b/client/me/legacy-contact/style.scss
@@ -4,4 +4,8 @@
 	p {
 		margin-bottom: 0;
 	}
+
+	.legacy-contact__action {
+		margin-block-start: 16px;
+	}
 }

--- a/client/me/legacy-contact/style.scss
+++ b/client/me/legacy-contact/style.scss
@@ -5,7 +5,8 @@
 		margin-bottom: 0;
 	}
 
-	.legacy-contact__action {
+	.legacy-contact__action,
+	.legacy-contact__current {
 		margin-block-start: 16px;
 	}
 }

--- a/client/me/legacy-contact/style.scss
+++ b/client/me/legacy-contact/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	.legacy-contact__action,
-	.legacy-contact__current {
+	.legacy-contact__assigned-contact {
 		margin-block-start: 16px;
 	}
 }

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -48,6 +48,7 @@ export * from './me-billing-history';
 export * from './me-blocked-sites';
 export * from './me-connected-applications';
 export * from './me-dpa';
+export * from './me-legacy-contacts';
 export * from './me-mailboxes';
 export * from './me-memberships';
 export * from './me-notification-devices';

--- a/packages/api-core/src/me-legacy-contacts/fetchers.ts
+++ b/packages/api-core/src/me-legacy-contacts/fetchers.ts
@@ -1,0 +1,9 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { LegacyContact } from './types';
+
+export async function fetchLegacyContacts(): Promise< LegacyContact[] > {
+	return wpcom.req.get( {
+		path: '/me/legacy-contacts',
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-core/src/me-legacy-contacts/index.ts
+++ b/packages/api-core/src/me-legacy-contacts/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/me-legacy-contacts/types.ts
+++ b/packages/api-core/src/me-legacy-contacts/types.ts
@@ -1,0 +1,4 @@
+export interface LegacyContact {
+	email: string;
+	token: string;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -42,6 +42,7 @@ export * from './me-billing-history';
 export * from './me-blocked-sites';
 export * from './me-connected-applications';
 export * from './me-dpa';
+export * from './me-legacy-contacts';
 export * from './me-mailboxes';
 export * from './me-monetize';
 export * from './me-notifications-devices';

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -1,0 +1,8 @@
+import { fetchLegacyContacts } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const legacyContactsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'legacy-contacts' ],
+		queryFn: fetchLegacyContacts,
+	} );


### PR DESCRIPTION
## Proposed Changes

* Adds a read-only data layer for the new `wpcom/v2/me/legacy-contacts` endpoint.
* Wires the `/me/legacy-contact` view up to the query, displaying the contact's email when one is set.

The endpoint can return multiple contacts. The UI intentionally surfaces only the first one for now.

<img width="707" height="251" alt="Screenshot 2026-06-11 at 17 05 34" src="https://github.com/user-attachments/assets/c109cf88-7217-4e13-8d45-31d9b2a8d56f" />
<img width="790" height="284" alt="Screenshot 2026-06-11 at 17 06 15" src="https://github.com/user-attachments/assets/73f46d7e-8f29-4a73-bd55-9ffdce408fc6" />

## Why are these changes being made?

The `/me/legacy-contact` view was previously a static placeholder. This connects it to the backend so it reflects the user's actual legacy contact, using the current recommended data-fetching approach rather than the legacy Redux data layer.

## Testing Instructions

* Run Calypso locally and navigate to `/me/legacy-contact`.
* With no legacy contact set, the view shows only the introductory copy.
* With a legacy contact set on the account, the view additionally shows “Your legacy contact is <email>.”
* Confirm no TypeScript or console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
