### PR TITLE
A4A Agency Tier: update influenced revenue tooltip copy

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -17,7 +17,7 @@ import type { AgencyTierType } from './types';
 import './influenced-revenue.scss';
 
 const LEARN_MORE_URL =
-	'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
+	'https://agencieshelp.automattic.com/knowledge-base/agency-tiers-and-benefits/';
 
 function InfluencedRevenueStrapline() {
 	const translate = useTranslate();
@@ -41,9 +41,9 @@ function InfluencedRevenueStrapline() {
 	const content = (
 		<div className="influenced-revenue__popover-content">
 			{ translate(
-				'Influenced revenue is revenue connected to your agency’s direct influence through referrals, client purchases, and managed sites using Automattic products.' +
+				'Automattic for Agencies tiers reward and support agencies based on their engagement with Automattic products. As you use our products, you generate Influenced Automattic Revenue (IAR). As you generate more IAR, you progress through tiers and unlock additional benefits.' +
 					'{{br/}}{{br/}}' +
-					'Earn commissions by referring Automattic products to your clients, receive revenue share from WooPayments transactions, and unlock savings through volume discounts on bulk purchases.' +
+					'Our tiering system is designed to be inclusive, recognizing contributions regardless of which Automattic products you specialize in.' +
 					'{{br/}}{{br/}}' +
 					'{{a}}Learn more{{/a}}',
 				{


### PR DESCRIPTION
Part of A4A-2621

## Proposed Changes

<img width="368" height="351" alt="Screenshot 2026-06-11 at 10 44 24" src="https://github.com/user-attachments/assets/b5edeaad-f5dc-45a6-b543-bee9180c5d9a" />

Updates the **Influenced revenue** info tooltip on the A4A Agency Tier overview with new copy, explaining how influenced revenue ties into the tier system.

* **`influenced-revenue.tsx`** — replaces the tooltip body with the two-paragraph explanation: how tiers reward engagement and how Influenced Automattic Revenue (IAR) drives tier progression, plus a note that the tiering system is inclusive across all Automattic products. Points the **Learn more** link at the `agency-tiers-and-benefits` help-center article.

## Why are these changes being made?

The previous copy described influenced revenue in isolation without connecting it to the tiers it powers. The new copy frames IAR in terms of tier progression and benefits, which is what agencies are actually looking at on this page.

## Testing Instructions

1. Open the live link and go to **A4A → Agency tier**.
2. Click the info icon next to **INFLUENCED REVENUE** in the progress card.
3. Confirm the popover shows the two new paragraphs and a **Learn more** link on its own line.
4. Click **Learn more** — the help-center widget should open on the "Agency tiers and benefits" article (`https://agencieshelp.automattic.com/knowledge-base/agency-tiers-and-benefits/`).
5. Resize to mobile width: clicking the icon should open the same content in an `InfoModal`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
