### PR TITLE
client/components: React 19 forward-compatible (behavior-preserving)

### DIFF
--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -2,7 +2,7 @@ import { Button, Tooltip } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
-import React from 'react';
+import React, { type JSX } from 'react';
 
 const ICON_SIZE = 32;
 

--- a/client/components/backup-storage-space/usage-warning/action-button.tsx
+++ b/client/components/backup-storage-space/usage-warning/action-button.tsx
@@ -4,6 +4,7 @@ import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { StorageUsageLevelName } from 'calypso/state/rewind/storage/types';
 import useStorageStatusText from './use-storage-status-text';
+import type { JSX } from 'react';
 
 type OwnProps = {
 	className?: string;

--- a/client/components/connect-screen/action-buttons/index.tsx
+++ b/client/components/connect-screen/action-buttons/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Spinner } from '@wordpress/components';
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/brand-header/index.tsx
+++ b/client/components/connect-screen/brand-header/index.tsx
@@ -1,6 +1,6 @@
 import { isValidElement } from '@wordpress/element';
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/consent-text/index.tsx
+++ b/client/components/connect-screen/consent-text/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/features-section/index.tsx
+++ b/client/components/connect-screen/features-section/index.tsx
@@ -1,7 +1,7 @@
 import { isValidElement } from '@wordpress/element';
 import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/loading-screen/index.tsx
+++ b/client/components/connect-screen/loading-screen/index.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/login-page-wrapper/index.tsx
+++ b/client/components/connect-screen/login-page-wrapper/index.tsx
@@ -12,7 +12,7 @@ import { BrandHeader } from '../brand-header';
 import { ConsentText } from '../consent-text';
 import { LoadingScreen } from '../loading-screen';
 import { ScreenLayout } from '../screen-layout';
-import type { ChangeEvent, MouseEvent, ReactNode } from 'react';
+import type { ChangeEvent, MouseEvent, ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/permissions-list/index.tsx
+++ b/client/components/connect-screen/permissions-list/index.tsx
@@ -3,7 +3,7 @@ import { useState } from '@wordpress/element';
 import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/screen-layout/index.tsx
+++ b/client/components/connect-screen/screen-layout/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/connect-screen/user-card/index.tsx
+++ b/client/components/connect-screen/user-card/index.tsx
@@ -1,6 +1,7 @@
 import { Card, Gravatar } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 import './style.scss';
 

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -1,4 +1,5 @@
 import { DateRangePickerShortcut } from 'calypso/components/date-range/shortcuts';
+import type { JSX } from 'react';
 
 interface DateControlProps {
 	onApplyButtonClick: ( startDate: Moment, endDate: Moment, selectedShortcutId?: string ) => void;

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -1,6 +1,7 @@
 import { stepSlug, useMyDomainInputMode } from '../constants';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { DashboardType } from 'calypso/dashboard/app/types';
+import type { JSX } from 'react';
 
 type ValueOf< T > = T[ keyof T ];
 export type Maybe< T > = T | null | undefined;

--- a/client/components/domains/layout/types.ts
+++ b/client/components/domains/layout/types.ts
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 export type TwoColumnsLayoutProps = {
 	className?: string;
 	content?: JSX.Element | null;

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import { includes, without } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
-import ReactDom from 'react-dom';
 import TranslatableString from 'calypso/components/translatable/proptype';
 
 import './style.scss';
@@ -172,10 +171,7 @@ export class DropZone extends Component {
 		// prevent the browser default action, which navigates to the file.
 		event.preventDefault();
 
-		if (
-			! this.props.fullScreen &&
-			! ReactDom.findDOMNode( this.zoneRef.current ).contains( event.target )
-		) {
+		if ( ! this.props.fullScreen && ! this.zoneRef.current.contains( event.target ) ) {
 			return;
 		}
 

--- a/client/components/empty-content/index.tsx
+++ b/client/components/empty-content/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React, { LegacyRef, RefObject } from 'react';
+import React, { LegacyRef, RefObject, type JSX } from 'react';
 import './style.scss';
 
 interface EmptyContentProps {

--- a/client/components/forms/form-currency-input/index.tsx
+++ b/client/components/forms/form-currency-input/index.tsx
@@ -1,7 +1,7 @@
 import './style.scss';
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, type JSX } from 'react';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 

--- a/client/components/forms/form-text-input/stories/index.stories.tsx
+++ b/client/components/forms/form-text-input/stories/index.stories.tsx
@@ -1,5 +1,6 @@
 import FormTextInput from '../index';
-import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 
 export type FormTextInputStory = StoryObj< typeof FormTextInput >;
 
@@ -7,7 +8,7 @@ const meta: Meta = {
 	title: 'client/components/Forms/Form Text Input',
 	component: FormTextInput,
 	decorators: [
-		( Story: StoryFn ) => (
+		( Story: ComponentType ) => (
 			<div style={ { maxWidth: '360px', padding: '30px' } }>
 				<Story />
 			</div>

--- a/client/components/guided-tour/data/guided-tour-context.tsx
+++ b/client/components/guided-tour/data/guided-tour-context.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
+import { ReactNode, createContext, useCallback, useMemo, useState, type JSX } from 'react';
 
 export type TourStep = {
 	id: string;

--- a/client/components/guided-tour/step/index.tsx
+++ b/client/components/guided-tour/step/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Popover } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo, type JSX } from 'react';
 import { GuidedTourContext } from 'calypso/components/guided-tour/data/guided-tour-context';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -5,7 +5,7 @@ import BluehostLogo from 'calypso/components/bluehost-logo';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
-import type { MutableRefObject } from 'react';
+import type { MutableRefObject, JSX } from 'react';
 
 type Props = {
 	showMainButtonLabel?: boolean;

--- a/client/components/jetpack/intro-pricing-banner/hooks/use-previous.ts
+++ b/client/components/jetpack/intro-pricing-banner/hooks/use-previous.ts
@@ -8,7 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
  * @returns previous value of requested state or prop value
  */
 export function usePrevious< T >( value: T ): T | undefined {
-	const ref = useRef< T >();
+	const ref = useRef< T >( undefined );
 
 	useEffect( () => {
 		ref.current = value;

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -4,7 +4,7 @@ import LanguagePicker, { createLanguageGroups } from '@automattic/language-picke
 import { Modal, Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import QueryLanguageNames from 'calypso/components/data/query-language-names';

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -24,7 +24,7 @@ export default function JetpackCancellationSurvey( {
 }: JetpackCancellationSurveyProps ) {
 	const translate = useTranslate();
 	const [ customAnswerText, setCustomAnswerText ] = useState( '' );
-	const customAnswerInputRef = useRef< HTMLInputElement | null >();
+	const customAnswerInputRef = useRef< HTMLInputElement | null >( null );
 
 	const choices: Choice[] = [
 		{

--- a/client/components/phone-input/index.tsx
+++ b/client/components/phone-input/index.tsx
@@ -173,7 +173,7 @@ function getLastCursorPosition( recentPositions: number[] ) {
 function useSharedRef(
 	inputRef: MutableRefObject< HTMLInputElement | undefined > | RefFunction | undefined
 ) {
-	const numberInputRef = useRef< HTMLInputElement | undefined >();
+	const numberInputRef = useRef< HTMLInputElement | undefined >( undefined );
 	useEffect( () => {
 		if ( ! inputRef ) {
 			return;

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, type JSX } from 'react';
 import ActionPanelCta from 'calypso/components/action-panel/cta';
 import { URL } from 'calypso/types';
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 import { flow } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
@@ -119,7 +118,7 @@ export class SiteSelector extends Component {
 			return;
 		}
 
-		const selectorElement = ReactDom.findDOMNode( this.siteSelectorRef );
+		const selectorElement = this.siteSelectorRef;
 
 		if ( ! selectorElement ) {
 			return;
@@ -230,7 +229,7 @@ export class SiteSelector extends Component {
 			return;
 		}
 
-		const node = ReactDom.findDOMNode( this.siteSelectorRef );
+		const node = this.siteSelectorRef;
 		if ( node ) {
 			node.scrollTop = 0;
 		}

--- a/client/components/social-buttons/stories/shared.tsx
+++ b/client/components/social-buttons/stories/shared.tsx
@@ -6,10 +6,11 @@ import { GoogleSocialButton } from '../google';
 import { MagicLoginButton } from '../magic-login';
 import QrCodeLoginButton from '../qr-code';
 import { UsernameOrEmailButton } from '../username-or-email';
-import type { StoryFn, StoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import './style.scss';
 
-export const AuthFormSocial = ( Story: StoryFn ) => (
+export const AuthFormSocial = ( Story: ComponentType ) => (
 	<div className="auth-form__social" style={ { maxWidth: '300px', padding: '30px' } }>
 		<div className="auth-form__social-buttons">
 			<div className="auth-form__social-buttons-container">
@@ -19,37 +20,37 @@ export const AuthFormSocial = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const A4AWrapper = ( Story: StoryFn ) => (
+export const A4AWrapper = ( Story: ComponentType ) => (
 	<div className="a8c-for-agencies">
 		<Story />
 	</div>
 );
 
-export const AkismetWrapper = ( Story: StoryFn ) => (
+export const AkismetWrapper = ( Story: ComponentType ) => (
 	<div className="is-akismet">
 		<Story />
 	</div>
 );
 
-export const BlazeWrapper = ( Story: StoryFn ) => (
+export const BlazeWrapper = ( Story: ComponentType ) => (
 	<div className="blaze-pro">
 		<Story />
 	</div>
 );
 
-export const WooWrapper = ( Story: StoryFn ) => (
+export const WooWrapper = ( Story: ComponentType ) => (
 	<div className="woo is-woo-passwordless">
 		<Story />
 	</div>
 );
 
-export const JetpackCloudWrapper = ( Story: StoryFn ) => (
+export const JetpackCloudWrapper = ( Story: ComponentType ) => (
 	<div className="jetpack-cloud">
 		<Story />
 	</div>
 );
 
-export const JetpackLoginWrapper = ( Story: StoryFn ) => (
+export const JetpackLoginWrapper = ( Story: ComponentType ) => (
 	<div className="layout is-jetpack-login">
 		<div className="login is-jetpack" style={ { maxWidth: '360px', padding: '30px' } }>
 			<div className="login__form">
@@ -59,7 +60,7 @@ export const JetpackLoginWrapper = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const GravatarWrapper = ( Story: StoryFn ) => (
+export const GravatarWrapper = ( Story: ComponentType ) => (
 	<div className="layout is-section-login is-grav-powered-client">
 		<div className="login">
 			<Story />
@@ -67,7 +68,7 @@ export const GravatarWrapper = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const WPJobManagerWrapper = ( Story: StoryFn ) => (
+export const WPJobManagerWrapper = ( Story: ComponentType ) => (
 	<div className="layout is-section-login is-grav-powered-client is-wp-job-manager">
 		<div className="login">
 			<Story />
@@ -116,7 +117,7 @@ export const gitHubStory: StoryObj< typeof GitHubLoginButton > = {
 		isLogin: true,
 	},
 	decorators: [
-		( Story: StoryFn ) => (
+		( Story: ComponentType ) => (
 			<Provider store={ gitHubStore }>
 				<Story />
 			</Provider>
@@ -175,7 +176,7 @@ export const qrCodeStory: StoryObj< typeof QrCodeLoginButton > = {
 		loginUrl: 'https://example.com/login',
 	},
 	decorators: [
-		( Story: StoryFn ) => (
+		( Story: ComponentType ) => (
 			<Provider store={ qrCodeStore }>
 				<Story />
 			</Provider>
@@ -197,7 +198,7 @@ export const usernameOrEmailStory: StoryObj< typeof UsernameOrEmailButton > = {
 		onClick: () => {},
 	},
 	decorators: [
-		( Story: StoryFn ) => (
+		( Story: ComponentType ) => (
 			<Provider store={ usernameOrEmailStore }>
 				<Story />
 			</Provider>

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'calypso/state';
 import getSiteId from 'calypso/state/sites/selectors/get-site-id';
 import DateControl from '../date-control';
 import { DateRangePickerShortcut } from '../date-range/shortcuts';
+import type { JSX } from 'react';
 
 type DateRange = {
 	chartStart: string;
@@ -204,12 +205,13 @@ const StatsDateControl = ( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 
 		if ( shortcut.isGated ) {
-			onGatedHandler &&
+			if ( onGatedHandler ) {
 				onGatedHandler(
 					[ { name: eventNames[ event_from ][ shortcut.id as EventNameKey ] } ],
 					event_from,
 					shortcut.statType ?? shortcut.id
 				);
+			}
 		} else {
 			recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ] );
 			if ( shortcut.id !== 'custom_date_range' ) {

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -1,6 +1,7 @@
 import { TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 import { Theme } from 'calypso/types';
+import type { JSX } from 'react';
 
 export type ThankYouNextStepProps = {
 	stepCta?: React.ReactNode;

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -33,7 +33,7 @@ import { useSelect } from '@wordpress/data';
 import { Icon as WpIcon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useBundleSettings } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';


### PR DESCRIPTION
Part of the [Calypso → React 19 migration](https://linear.app/a8c/project/migrate-calypso-to-react-19-ed8301da230e/overview). Covers the `client/components` area of the area-split plan, and follows the same approach as the `client/blocks` PR #111506.

## Proposed Changes

Make `client/components` source forward-compatible with React 19. Every change compiles cleanly on the current React 18 and is behavior-preserving:

* Import the `JSX` namespace explicitly wherever `JSX.Element` is referenced — React 19 no longer exposes `JSX` as a global.
* Pass an explicit initial value to `useRef` (a required argument in React 19's types).
* Type Storybook decorators as `ComponentType` instead of the removed `StoryFn` argument shape.
* Replace removed `ReactDom.findDOMNode` calls with the existing element refs in `drop-zone` and `site-selector`, where the ref already points directly at the host node.

## Why are these changes being made?

Gutenberg and the `@wordpress/*` packages Calypso depends on are moving to React 19. Landing the forward-compatible source changes per area now lets the final `package.json` React 19 bump happen as a single low-risk PR once every area is ready.

## Scope notes

Kept deliberately limited to mechanical, behavior-preserving changes. Excluded from this PR:

* **section-nav** — its `findDOMNode` is injected into cloned child components, so removing it needs ref-forwarding into those children; left for a focused follow-up.
* **infinite-list** — uses legacy string refs (removed in React 19); a larger migration that is being handled separately.
* **`findDOMNode` in tests** — left as-is alongside the not-yet-migrated source.

## Testing Instructions

* `yarn typecheck-client` — passes (no new errors in `client/components`).
* `yarn test-client client/components/...` — touched suites pass (connect-screen, language-picker, marketing-survey, phone-input, drop-zone).
* Drop-zone drop handling verified by its existing test suite (the `contains` path that previously used `findDOMNode`).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
