### PR TITLE
A4A Agent Studio: Paginate the one-pager preview deck once before splitting

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -8,7 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useAgentStudioCollateral, {
@@ -29,6 +29,7 @@ import { formatAnnotationInstructions } from './format-annotation-instructions';
 import { type PdfViewerPage } from './pdf-viewer';
 import RefineWithAiDock from './refine-with-ai-dock';
 import SocialAssetsViewer from './social-assets-viewer';
+import { paginateDeck } from './paginate-deck';
 import { splitIntoPages, wrapAsDocument } from './split-pages';
 import type { AgentStudioOutput } from '../../types';
 
@@ -138,12 +139,25 @@ function OnePagerOutputDetail( { output }: Props ) {
 		return split[ 0 ] ? wrapAsDocument( split[ 0 ] ) : undefined;
 	}, [ selectedVariantHtml.data ] );
 
-	const bodySrcDocs = useMemo< string[] >( () => {
+	// Body pages come from the whole base deck, paginated once (reflow →
+	// continuation pages) so the preview shows the same page set the PDF will
+	// — see paginate-deck.ts. Async because fitting needs a layout pass; until
+	// it resolves only the cover renders.
+	const [ bodySrcDocs, setBodySrcDocs ] = useState< string[] >( [] );
+	useEffect( () => {
 		if ( ! baseVariantHtml.data ) {
-			return [];
+			setBodySrcDocs( [] );
+			return;
 		}
-		const split = splitIntoPages( baseVariantHtml.data );
-		return split.slice( 1 ).map( ( page ) => wrapAsDocument( page ) );
+		let cancelled = false;
+		paginateDeck( baseVariantHtml.data ).then( ( pages ) => {
+			if ( ! cancelled ) {
+				setBodySrcDocs( pages.slice( 1 ).map( ( page ) => wrapAsDocument( page ) ) );
+			}
+		} );
+		return () => {
+			cancelled = true;
+		};
 	}, [ baseVariantHtml.data ] );
 
 	const pages = useMemo< PdfViewerPage[] >( () => {

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/paginate-deck.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/paginate-deck.ts
@@ -1,0 +1,88 @@
+// Fit the WHOLE deck once, then return the resulting pages.
+//
+// The deck's inlined `fit.js` reflows any section that overflows its grid
+// cell onto a continuation `.ela-page` — but only when it can see the whole
+// deck (it inserts a new page and renumbers footers across all pages). The
+// preview otherwise splits the deck into one card per page *before* fitting
+// (`splitIntoPages`), so a continuation inserted at fit-time lands inside a
+// fixed-height card host and is clipped, and per-card footer renumbering
+// can't see global order.
+//
+// This mirrors the Browserless/PDF path: mount the whole deck off-screen,
+// run the fitter once, and read back the final page set (originals +
+// continuations, footers already renumbered). The caller then splits that
+// final set into per-card srcDocs exactly as before, so each continuation
+// becomes its own card and the preview matches the PDF.
+//
+// Falls back to a plain `splitIntoPages` when the DOM/fitter isn't available
+// (SSR, fitter failed to load) so the preview still renders.
+
+import { rewriteRootSelectors, hoistFontFaces } from './pdf-viewer';
+import { splitIntoPages, type SplitPage } from './split-pages';
+
+export async function paginateDeck( html: string ): Promise< SplitPage[] > {
+	if ( typeof window === 'undefined' || ! html ) {
+		return splitIntoPages( html );
+	}
+
+	const doc = new DOMParser().parseFromString( html, 'text/html' );
+	const head = doc.head.innerHTML;
+
+	// Inline `<body>`-level scripts (the deck's fit.js) — snapshot, then strip
+	// so they don't get serialized back into every per-card srcDoc twice.
+	const bodyScripts = Array.from( doc.body.children )
+		.filter( ( c ): c is HTMLScriptElement => c.tagName === 'SCRIPT' )
+		.map( ( s ) => s.textContent ?? '' )
+		.filter( Boolean );
+	doc.body.querySelectorAll( 'script' ).forEach( ( s ) => s.remove() );
+
+	// Same style handling as the per-card preview: rewrite root selectors to
+	// `:host` and hoist `@font-face` to the document so text measures with the
+	// real fonts (fit.js waits on `document.fonts`).
+	const styleMarkup = Array.from(
+		doc.head.querySelectorAll< HTMLElement >( 'style, link[rel="stylesheet"]' )
+	)
+		.map( ( node ) =>
+			node.tagName === 'STYLE'
+				? `<style>${ rewriteRootSelectors( hoistFontFaces( node.textContent ?? '' ) ) }</style>`
+				: node.outerHTML
+		)
+		.join( '' );
+
+	// Off-screen host holding the WHOLE deck (all pages stacked, unclipped) so
+	// the fitter can measure every page. Each `.ela-page` carries its own fixed
+	// 816×1056 size from the deck CSS, so an `auto`-height host doesn't distort
+	// measurement.
+	const host = document.createElement( 'div' );
+	host.style.cssText =
+		'position:fixed;left:-99999px;top:0;width:816px;height:auto;opacity:0;pointer-events:none;z-index:-1;';
+	document.body.appendChild( host );
+	const shadow = host.attachShadow( { mode: 'open' } );
+	shadow.innerHTML = '<style>:host{display:block;width:816px;}</style>' + styleMarkup + doc.body.innerHTML;
+
+	// Load the fitter once per tab (same marker the per-card viewer uses), then
+	// run it on the whole deck.
+	if ( ! window.applyA4aFit ) {
+		const fitter = bodyScripts.find( ( s ) => s.includes( 'applyA4aFit' ) );
+		if ( fitter ) {
+			const el = document.createElement( 'script' );
+			el.textContent = fitter;
+			document.head.appendChild( el );
+		}
+	}
+
+	try {
+		if ( window.applyA4aFit ) {
+			await window.applyA4aFit( shadow );
+		}
+	} catch {
+		// Fitter threw — fall through and read whatever pages exist.
+	}
+
+	const pages = Array.from( shadow.querySelectorAll< HTMLElement >( '.ela-page' ) ).map(
+		( page ) => ( { head, body: page.outerHTML, bodyScripts } )
+	);
+	host.remove();
+
+	return pages.length > 0 ? pages : splitIntoPages( html );
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.tsx
@@ -95,7 +95,7 @@ export default function PdfViewer( { pages, coverNavigation, renderPageOverlay }
 // Inside a shadow tree there is no `html`, `body`, or `:root` — they're
 // outside the boundary. The variant CSS targets the document root for
 // width / font / color, so rewrite those selectors to `:host`.
-const rewriteRootSelectors = ( css: string ): string =>
+export const rewriteRootSelectors = ( css: string ): string =>
 	css
 		.replace( /\bhtml\s*,\s*body\b/g, ':host' )
 		.replace( /(^|[\s,{}])html(?=[\s,{[:.])/g, '$1:host' )
@@ -114,7 +114,7 @@ const rewriteRootSelectors = ( css: string ): string =>
 // payload) does not register the same face N times.
 const hoistedFontFaces = new Set< string >();
 
-function hoistFontFaces( css: string ): string {
+export function hoistFontFaces( css: string ): string {
 	return css.replace( /@font-face\s*\{[^}]*\}/g, ( rule ) => {
 		if ( ! hoistedFontFaces.has( rule ) ) {
 			hoistedFontFaces.add( rule );


### PR DESCRIPTION
## Summary

The Agent Studio one-pager preview renders each page as its own card. `output-detail-content.tsx` derives the body pages by calling `splitIntoPages()` on the raw deck HTML, and `PdfViewer` mounts each page in its own shadow-root card that is a fixed 816×1056 with `overflow: hidden`. Each card then runs the deck's inlined `fit.js` independently.

The shared wpcom `fit.js` recently gained a reflow pass (Automattic/wpcom#222424) that moves a `.b-section` whose text overflows its grid cell onto a continuation `.ela-page` instead of shrinking the type and clipping the rest. That pass assumes it can see the whole deck: it inserts a new page and renumbers footers across all pages. When it instead runs per-card in the preview, two things break:

- The continuation page it inserts lands **inside** the source card's fixed-height `overflow: hidden` host, so it is clipped and never shown — the preview visually loses the reflowed content.
- Footer renumbering runs per fragment, so each single-page card numbers itself from 1 and the footers read `1, 1, 1, 2, 1` instead of `2, 3, 4, 5, 6`.

The exported PDF is correct, because Browserless renders the whole deck as one document and the reflow/renumber see global page order. Only the preview diverges.

This change makes the preview paginate the same unit the PDF does. New `paginate-deck.ts` mounts the whole deck off-screen, runs the deck's `fit.js` once (reflow → continuation pages, footers renumbered across the full deck), and returns the final page set as `SplitPage[]`; it falls back to the previous `splitIntoPages` when the DOM or fitter isn't available. `output-detail-content.tsx` now derives `bodySrcDocs` from `paginateDeck()` (async) rather than splitting the raw HTML, so each continuation becomes its own full-height card and footers number sequentially. `pdf-viewer.tsx` exports `rewriteRootSelectors` and `hoistFontFaces` so the new helper reuses the same shadow-style handling. Annotate mode is unaffected — it receives `pages` as a prop from the same parent.

Depends on the wpcom companion change (reflow pass + whole-deck footer gate) in `fit.js`: Automattic/wpcom#222424. The preview runs whatever `fit.js` wpcom inlines into the deck HTML, so that needs to be deployed for the reflow to happen.

## Testing Instructions

Prerequisites: a sandbox/build serving Automattic/wpcom#222424's `fit.js`, and an Agent Studio one-pager generated from a source long enough to overflow a page (the "Enterprise Shift" A4A blog post is a good repro — paste its body as the content).

1. Open the deliverable's preview in Agent Studio.
2. Confirm the section that overflows a page now continues onto its **own** card in the preview (previously the overflow was clipped/hidden), with all of its text visible.
3. Confirm body paragraphs render at a uniform 16px (no shrunk/tiny page).
4. Confirm footer page numbers read sequentially across the deck (cover, then 2, 3, 4, …) with no duplicates or `1,1,1`.
5. Click **Download PDF** and confirm the preview's page set matches the PDF.
6. Open a short one-pager that already fit on its pages and confirm it renders unchanged — same page count, no spurious continuation cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
