### PR TITLE
Help Center: re-fetch chat history on Smooch re-init to recover dropped messages

### DIFF
--- a/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useGetCombinedChat } from '../use-get-combined-chat';
+import type { Message } from '../../types';
+
+/**
+ * Mutable state backing the mocked dependencies. Each test mutates these and
+ * re-renders to drive the hook through the scenario under test.
+ */
+let mockIsChatLoaded = true;
+let mockConnectionStatus: string | undefined;
+let mockCurrentSupportInteraction: Record< string, unknown > | undefined;
+let mockConversation: { id: string; messages: Message[] } | null;
+const mockGetZendeskConversation = jest.fn();
+const mockStartNewInteraction = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	// The hook's only useSelect call returns { isChatLoaded, connectionStatus }.
+	useSelect: () => ( {
+		isChatLoaded: mockIsChatLoaded,
+		connectionStatus: mockConnectionStatus,
+	} ),
+} ) );
+
+jest.mock( '@tanstack/react-query', () => ( {
+	useIsMutating: () => 0,
+} ) );
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock(
+	'@automattic/help-center/src/stores',
+	() => ( {
+		HELP_CENTER_STORE: 'help-center-store',
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '../use-logged-out-session', () => ( {
+	useLoggedOutSession: () => ( {
+		loggedOutOdieChatId: undefined,
+		sessionId: undefined,
+		botSlug: undefined,
+	} ),
+} ) );
+
+jest.mock( '../../data', () => ( {
+	useGetZendeskConversation: () => mockGetZendeskConversation,
+	useManageSupportInteraction: () => ( { startNewInteraction: mockStartNewInteraction } ),
+	useOdieChat: () => ( { data: undefined, isFetching: false } ),
+} ) );
+
+jest.mock( '../../data/use-current-support-interaction', () => ( {
+	useCurrentSupportInteraction: () => ( {
+		data: mockCurrentSupportInteraction,
+		isLoading: false,
+	} ),
+} ) );
+
+jest.mock( '../../utils', () => ( {
+	getConversationIdFromInteraction: ( interaction: { conversationId?: string } ) =>
+		interaction?.conversationId ?? null,
+	getOdieIdFromInteraction: ( interaction: { odieId?: number } ) => interaction?.odieId ?? null,
+	getIsRequestingHumanSupport: () => false,
+} ) );
+
+jest.mock( '../../constants', () => ( {
+	getOdieTransferMessages: () => [],
+	getZendeskChatStartedMetaMessage: () => ( {
+		content: 'chat-started',
+		role: 'bot',
+		type: 'message',
+		metadata: { temporary_id: 'meta-started' },
+	} ),
+} ) );
+
+jest.mock( '../../context', () => ( {
+	emptyChat: {
+		odieId: null,
+		conversationId: null,
+		messages: [],
+		wpcomUserId: null,
+		provider: 'odie',
+		status: 'loading',
+	},
+} ) );
+
+const agentMessage = ( id: number, content: string ): Message =>
+	( {
+		content,
+		role: 'business',
+		type: 'message',
+		message_id: id,
+		metadata: {},
+	} ) as unknown as Message;
+
+const renderCombinedChat = () =>
+	renderHook( () => useGetCombinedChat( /* canConnectToZendesk */ true, /* isLoading */ false ) );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockIsChatLoaded = true;
+	mockConnectionStatus = undefined;
+	mockCurrentSupportInteraction = undefined;
+	mockConversation = null;
+	mockGetZendeskConversation.mockImplementation( () => Promise.resolve( mockConversation ) );
+} );
+
+describe( 'useGetCombinedChat — message recovery on Smooch re-init', () => {
+	it( 're-fetches the conversation and recovers gap messages when isChatLoaded flips false → true', async () => {
+		mockCurrentSupportInteraction = {
+			uuid: 'int-1',
+			conversationId: 'conv-1',
+			odieId: null,
+			status: 'open',
+		};
+		mockConversation = { id: 'conv-1', messages: [ agentMessage( 1, 'before re-init' ) ] };
+
+		const { result, rerender } = renderCombinedChat();
+
+		// Initial load fetches the conversation through the normal path.
+		await waitFor( () => {
+			expect( mockGetZendeskConversation ).toHaveBeenCalledWith( 'conv-1' );
+			expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 1 ) ).toBe(
+				true
+			);
+		} );
+		const callsAfterInitialLoad = mockGetZendeskConversation.mock.calls.length;
+
+		// Smooch tears down: isChatLoaded → false. No fetch happens in this window.
+		act( () => {
+			mockIsChatLoaded = false;
+		} );
+		rerender();
+
+		// A message arrives while the socket is down — it will only be present in
+		// the next history fetch, never via the (removed) message:received listener.
+		mockConversation = {
+			id: 'conv-1',
+			messages: [ agentMessage( 1, 'before re-init' ), agentMessage( 2, 'arrived during gap' ) ],
+		};
+
+		// Smooch finishes re-initializing: isChatLoaded → true.
+		act( () => {
+			mockIsChatLoaded = true;
+		} );
+		rerender();
+
+		// The re-init forces a fresh conversation fetch that recovers the gap message.
+		await waitFor( () => {
+			expect( mockGetZendeskConversation.mock.calls.length ).toBeGreaterThan(
+				callsAfterInitialLoad
+			);
+			expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 2 ) ).toBe(
+				true
+			);
+		} );
+	} );
+
+	it( 'does not re-fetch on re-init when there is no active Zendesk conversation', async () => {
+		mockCurrentSupportInteraction = {
+			uuid: 'int-2',
+			conversationId: undefined,
+			odieId: 5,
+		};
+
+		const { rerender } = renderCombinedChat();
+
+		// Let any initial effects settle.
+		await act( async () => {
+			await Promise.resolve();
+		} );
+		expect( mockGetZendeskConversation ).not.toHaveBeenCalled();
+
+		// Full re-init cycle: true → false → true.
+		act( () => {
+			mockIsChatLoaded = false;
+		} );
+		rerender();
+		act( () => {
+			mockIsChatLoaded = true;
+		} );
+		rerender();
+
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		// Pure-Odie chat: nothing to recover, so no conversation fetch is forced.
+		expect( mockGetZendeskConversation ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -62,6 +62,7 @@ export const useGetCombinedChat = (
 	}, [] );
 	const previousUuidRef = useRef< string | undefined >();
 	const previousOdieIdRef = useRef< string | null | undefined >();
+	const wasChatLoadedRef = useRef( isChatLoaded );
 	const [ mainChatState, setMainChatState ] = useState< Chat >( emptyChat );
 	const conversationId = getConversationIdFromInteraction( currentSupportInteraction );
 	const [ refreshingAfterReconnect, setRefreshingAfterReconnect ] = useState( false );
@@ -88,6 +89,27 @@ export const useGetCombinedChat = (
 			} ) );
 		}
 	}, [ connectionStatus, setRefreshingAfterReconnect ] );
+
+	useEffect( () => {
+		const isReinitialized = ! wasChatLoadedRef.current && isChatLoaded;
+		wasChatLoadedRef.current = isChatLoaded;
+
+		// When Smooch re-initializes, `isChatLoaded` flips false → true (it is set
+		// false right before `Smooch.destroy()` and true once `Smooch.init()`
+		// resolves). The WebSocket is down for that whole window, so any agent
+		// messages that arrive are never delivered through `message:received`.
+		// The `connected` event above only refreshes when there was a prior
+		// disconnect, so a React-driven re-init would otherwise silently drop them.
+		// Force a conversation re-fetch on every re-init to recover the gap; the
+		// merge in the main effect dedupes and preserves the user's queued messages.
+		if ( isReinitialized && conversationId ) {
+			setRefreshingAfterReconnect( true );
+			setMainChatState( ( chat ) => ( {
+				...chat,
+				status: 'loading',
+			} ) );
+		}
+	}, [ isChatLoaded, conversationId, setRefreshingAfterReconnect ] );
 
 	useEffect( () => {
 		// Logged out chats don't have interactions. Only direct odie IDs.

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -3,7 +3,7 @@ import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
 import { getOdieTransferMessages, getZendeskChatStartedMetaMessage } from '../constants';
 import { emptyChat } from '../context';
@@ -80,36 +80,41 @@ export const useGetCombinedChat = (
 		mutationKey: [ 'send-zendesk-messages' ],
 	} );
 
+	// Re-download the active Zendesk conversation and merge it into the chat.
+	// The merge in the main effect dedupes and preserves the user's queued
+	// messages, so it is safe to call whenever we may have missed live messages.
+	const refreshConversation = useCallback( () => {
+		setRefreshingAfterReconnect( true );
+		setMainChatState( ( chat ) => ( {
+			...chat,
+			status: 'loading',
+		} ) );
+	}, [ setRefreshingAfterReconnect ] );
+
+	// Recover messages missed while the connection was dropped: once Smooch
+	// reports it has reconnected, re-fetch the conversation.
 	useEffect( () => {
 		if ( connectionStatus === 'connected' ) {
-			setRefreshingAfterReconnect( true );
-			setMainChatState( ( chat ) => ( {
-				...chat,
-				status: 'loading',
-			} ) );
+			refreshConversation();
 		}
-	}, [ connectionStatus, setRefreshingAfterReconnect ] );
+	}, [ connectionStatus, refreshConversation ] );
 
+	// Recover messages missed during a Smooch re-initialization. When Smooch is
+	// re-initialized, `isChatLoaded` flips false → true (it is set false right
+	// before `Smooch.destroy()` and true once `Smooch.init()` resolves). The
+	// WebSocket is down for that whole window, so any agent messages that arrive
+	// are never delivered through `message:received`. The connection-recovery
+	// effect only calls `refreshConversation` after a prior disconnect
+	// (`connectionStatus === 'connected'`), so a React-driven re-init would
+	// otherwise silently drop them — refresh here to recover the gap.
 	useEffect( () => {
 		const isReinitialized = ! wasChatLoadedRef.current && isChatLoaded;
 		wasChatLoadedRef.current = isChatLoaded;
 
-		// When Smooch re-initializes, `isChatLoaded` flips false → true (it is set
-		// false right before `Smooch.destroy()` and true once `Smooch.init()`
-		// resolves). The WebSocket is down for that whole window, so any agent
-		// messages that arrive are never delivered through `message:received`.
-		// The `connected` event above only refreshes when there was a prior
-		// disconnect, so a React-driven re-init would otherwise silently drop them.
-		// Force a conversation re-fetch on every re-init to recover the gap; the
-		// merge in the main effect dedupes and preserves the user's queued messages.
 		if ( isReinitialized && conversationId ) {
-			setRefreshingAfterReconnect( true );
-			setMainChatState( ( chat ) => ( {
-				...chat,
-				status: 'loading',
-			} ) );
+			refreshConversation();
 		}
-	}, [ isChatLoaded, conversationId, setRefreshingAfterReconnect ] );
+	}, [ isChatLoaded, conversationId, refreshConversation ] );
 
 	useEffect( () => {
 		// Logged out chats don't have interactions. Only direct odie IDs.


### PR DESCRIPTION
Part of DOTCOM-15974

## Proposed Changes

* Add a re-fetch trigger in `use-get-combined-chat.ts` keyed off the Smooch **re-init signal** (`isChatLoaded` flipping `false → true`). On re-init, while there is an active Zendesk conversation, it forces a conversation history re-fetch by reusing the existing reconnect-recovery path (`setRefreshingAfterReconnect(true)` + `status: 'loading'`).

## Why are these changes being made?

* Users intermittently stop receiving Help Center chat messages. When Smooch re-initializes (`Smooch.destroy()` → `Smooch.init()`), `isChatLoaded` is set `false` then `true`, and the WebSocket is down for that entire window. Any agent message that arrives in the gap is never delivered through the `message:received` listener.
* The only existing recovery is the `connected`-event effect, which re-fetches **only when `connectionStatus` was already truthy** (i.e. there was a prior `disconnected`/`reconnecting` event). A React-driven re-init (a dependency change, or the 30s init-retry loop) has no preceding disconnect, so `connectionStatus` stays falsy and the missed messages are silently and permanently dropped.
* Keying recovery off `isChatLoaded` rather than `connectionStatus` decouples it from the UI connection notices, so it does not fire a spurious "connection recovered" notice. The conversation merge already dedupes (`deduplicateZDMessages`) and preserves the user's queued messages, so no duplication or loss of unsent text.
* This is a follow-up to #109914 (which stopped Smooch re-initializing on JWT rotation). That removed the most frequent re-init trigger; this PR recovers messages for the re-inits that still happen.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center and start a live chat so Smooch fully initializes (`isChatLoaded` true, an active Zendesk conversation).
3. Force a Smooch re-init **without** a prior socket disconnect — e.g. trigger the init effect to re-run, or force an init failure so the 30s retry path runs and then succeeds. During the destroy → init window, have an agent send a message.
4. **Before this change:** the message never appears in the chat. **After this change:** once `isChatLoaded` returns true, the conversation is re-fetched and the missed message appears, with no duplicate messages and no "connection recovered" notice.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Repeat the steps above and verify missed messages are recovered after a Smooch re-init.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

