### PR TITLE
Theme Showcase: SSR modern logged-out cards

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,14 +1,22 @@
+import { isEnabled } from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import trackScrollPage from 'calypso/lib/track-scroll-page';
 import wpcom from 'calypso/lib/wp';
 import performanceMark from 'calypso/server/lib/performance-mark';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { THEME_FILTERS_ADD } from 'calypso/state/themes/action-types';
 import { requestThemes } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemeFilters, getThemesForQuery } from 'calypso/state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 import LoggedOutComponent from './logged-out';
+import {
+	FAVORITES_QUERY,
+	FRESH_QUERY,
+	PARTNER_QUERY,
+} from './sections-modern/recommended-sections';
+import { buildThemesSelectionQuery } from './themes-selection';
 
 const debug = debugFactory( 'calypso:themes' );
 
@@ -80,6 +88,57 @@ export function fetchThemeData( context, next ) {
 	context.store
 		.dispatch( requestThemes( siteId, query, context.lang ) )
 		.then( next )
+		.catch( next );
+}
+
+// SSR pre-fetch for the modern logged-out showcase. Without this, cards only appear
+// after the client-side fetch resolves; the legacy fetchThemeData uses a different
+// query shape than what the modern components read, so its result is unused here.
+export function fetchModernShowcaseData( context, next ) {
+	if ( context.cachedMarkup ) {
+		debug( 'Skipping modern showcase data fetch (cached markup)' );
+		return next();
+	}
+
+	if (
+		! context.isServerSide ||
+		! isEnabled( 'themes/showcase-modern' ) ||
+		isUserLoggedIn( context.store.getState() )
+	) {
+		return next();
+	}
+
+	performanceMark( context, 'fetchModernShowcaseData' );
+
+	const { category, tier, filter, vertical, view } = context.params;
+	const search = context.query.s;
+	const isShowcaseRoot = ! category && ! tier && ! filter && ! vertical && ! view && ! search;
+
+	const queries = isShowcaseRoot
+		? [ FAVORITES_QUERY, FRESH_QUERY, PARTNER_QUERY ]
+		: [
+				buildThemesSelectionQuery( {
+					search: search || '',
+					page: 1,
+					tier: tier || '',
+					filter: filter || '',
+					vertical: vertical || '',
+					tabFilter: category || 'recommended',
+				} ),
+		  ];
+
+	return Promise.all(
+		queries.map( ( query ) =>
+			context.store.dispatch( requestThemes( 'wpcom', query, context.lang ) )
+		)
+	)
+		.then( () => {
+			logServerEvent( 'themes', {
+				name: `ssr.modern_showcase_fetch.${ isShowcaseRoot ? 'root' : 'tier' }`,
+				type: 'counting',
+			} );
+			next();
+		} )
 		.catch( next );
 }
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -3,6 +3,7 @@ import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { setupPreferences } from 'calypso/controller/preferences';
 import {
+	fetchModernShowcaseData,
 	fetchThemeData,
 	fetchThemeFilters,
 	redirectSearchAndType,
@@ -39,6 +40,7 @@ export default function ( router ) {
 		validateVertical,
 		validateFilters,
 		fetchThemeData,
+		fetchModernShowcaseData,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
 		renderThemes,
@@ -64,5 +66,12 @@ export default function ( router ) {
 			redirectToThemeDetails( res.redirect, site, theme, section, next )
 	);
 	// The following route definition is needed so direct hits on `/themes/<mysite>` don't result in a 404.
-	router( '/themes/*', setupPreferences, fetchThemeData, renderThemes, makeLayout );
+	router(
+		'/themes/*',
+		setupPreferences,
+		fetchThemeData,
+		fetchModernShowcaseData,
+		renderThemes,
+		makeLayout
+	);
 }

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -6,7 +6,7 @@ import DIFMBanner from '../banners-modern/difm-banner';
 import PlanUpgradeBanner from '../banners-modern/plan-upgrade-banner';
 import ThemeSection from './theme-section';
 
-const FAVORITES_QUERY: ThemesQuery = {
+export const FAVORITES_QUERY: ThemesQuery = {
 	collection: 'recommended',
 	number: 6,
 	tier: '',
@@ -15,7 +15,7 @@ const FAVORITES_QUERY: ThemesQuery = {
 	page: 1,
 };
 
-const FRESH_QUERY: ThemesQuery = {
+export const FRESH_QUERY: ThemesQuery = {
 	number: 6,
 	tier: '',
 	filter: '',
@@ -24,7 +24,7 @@ const FRESH_QUERY: ThemesQuery = {
 	sort: 'date',
 };
 
-const PARTNER_QUERY: ThemesQuery = {
+export const PARTNER_QUERY: ThemesQuery = {
 	collection: 'recommended',
 	number: 6,
 	tier: 'marketplace',

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -315,6 +315,32 @@ function bindGetThemeTierForTheme( state ) {
 	return ( themeId ) => getThemeTierForTheme( state, themeId );
 }
 
+// Exported so SSR pre-fetch dispatches the exact query shape <ThemesSelection> reads,
+// avoiding cache-key drift between server fetch and client selector. number: 2000 for
+// non-paginating Jetpack endpoints.
+export function buildThemesSelectionQuery( {
+	search = '',
+	page = 1,
+	tier = '',
+	filter = '',
+	vertical = '',
+	hiddenFilters = [],
+	tabFilter,
+	sourceSiteId = 'wpcom',
+	premiumThemesEnabled = true,
+} = {} ) {
+	const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
+	return {
+		search,
+		page,
+		tier: premiumThemesEnabled ? tier : 'free',
+		filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
+		number,
+		...( tabFilter === 'recommended' && { collection: 'recommended' } ),
+		...( tabFilter === 'all' && { sort: 'date' } ),
+	};
+}
+
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
 export const ConnectedThemesSelection = connect(
@@ -333,20 +359,17 @@ export const ConnectedThemesSelection = connect(
 			sourceSiteId = siteId ? siteId : 'wpcom';
 		}
 
-		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
-		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
-		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
-		// Jetpack themes endpoint.
-		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
-		const query = {
+		const query = buildThemesSelectionQuery( {
 			search,
 			page,
-			tier: premiumThemesEnabled ? tier : 'free',
-			filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
-			number,
-			...( tabFilter === 'recommended' && { collection: 'recommended' } ),
-			...( tabFilter === 'all' && { sort: 'date' } ),
-		};
+			tier,
+			filter,
+			vertical,
+			hiddenFilters,
+			tabFilter,
+			sourceSiteId,
+			premiumThemesEnabled,
+		} );
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query );
 


### PR DESCRIPTION
Fixes DOTCOM-17052

## Proposed Changes

- Re-land the SSR portion of #110544 (reverted in #110586). The e2e test changes from that PR are intentionally omitted — #110561 already stabilized the `signup__with-theme` specs.
- Add a `fetchModernShowcaseData` SSR middleware that pre-fetches the queries the modern logged-out showcase reads on hydration. The showcase root fans out the three `RecommendedSections` queries (FAVORITES / FRESH / PARTNER); tier and category paths dispatch one `ThemesSelection`-shaped query.
- Extract `buildThemesSelectionQuery` from `themes-selection.jsx` so the middleware and the `connect` mapper share a single query shape, avoiding cache-key drift.

## Why are these changes being made?

The modern logged-out Theme Showcase renders its structural elements (hero, filter bar, section headings, FAQ) in SSR, but the theme cards arrive only after a client-side fetch. The modern `RecommendedSections` queries don't match anything `fetchThemeData` pre-fetches, and on tier paths the query shape `ThemesSelection` reads had drifted from `fetchThemeData`'s. Net effect: 0 theme cards in the initial HTML on every logged-out showcase route, hurting LCP/CLS and SEO.

This was originally part of #110544 but got reverted together with the coupled e2e test changes that failed pre-release E2E. Re-landing the SSR change on its own — with no test changes — avoids that failure mode, and #110561's wait-tolerant specs stay green once the SSR is restored.

## Testing Instructions

Build and run the SSR server locally, then count `data-e2e-theme` occurrences in the initial server HTML for the logged-out routes:

| Route | Cards in SSR (trunk) | Cards in SSR (this PR) |
|---|---|---|
| `/themes` | 0 | 18 |
| `/themes/free` | 0 | 87 |
| `/themes/recommended/premium` | 0 | 64 |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
