### PR TITLE
Theme Showcase: stabilize useThemeCollection per-theme getters

### DIFF
--- a/client/my-sites/themes/collections/use-theme-collection.ts
+++ b/client/my-sites/themes/collections/use-theme-collection.ts
@@ -1,5 +1,8 @@
-import { useSelector } from 'calypso/state';
+import { useCallback } from 'react';
+import { shallowEqual } from 'react-redux';
+import { useSelector, useStore } from 'calypso/state';
 import {
+	getActiveTheme,
 	getIsLivePreviewStarted,
 	getPremiumThemePrice,
 	getThemeDetailsUrl as getThemeDetailsUrlSelector,
@@ -7,7 +10,6 @@ import {
 	getThemeType as getThemeTypeSelector,
 	getThemeTierForTheme as getThemeTierForThemeSelector,
 	isInstallingTheme,
-	isThemeActive,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -29,33 +31,70 @@ export function useThemeCollection( query: ThemesQuery ) {
 
 	const siteId = useSelector( getSelectedSiteId );
 
-	const isInstalling = useSelector(
-		( state ) => ( themeId: string ) => isInstallingTheme( state, themeId, siteId as number )
+	// Per-theme state that changes on user actions (activate / install / live preview) is
+	// selected reactively, so the cards re-render when it flips. These were previously
+	// `useSelector( state => themeId => … )`, which returned a fresh function on every render —
+	// react-redux flagged the unstable result and re-rendered every section on each dispatch.
+	const activeThemeId = useSelector( ( state ) => getActiveTheme( state, siteId as number ) );
+	const isActive = useCallback(
+		( themeId: string ) => themeId === activeThemeId,
+		[ activeThemeId ]
 	);
 
-	const isLivePreviewStarted = useSelector(
-		( state ) => ( themeId: string ) => getIsLivePreviewStarted( state, themeId )
+	// isInstallingTheme and getIsLivePreviewStarted are parameterized by themeId, so derive a
+	// themeId→boolean map over the visible themes and compare it shallowly: stable reference,
+	// and a re-render only when one of those states actually changes.
+	const isInstallingMap = useSelector(
+		( state ) =>
+			Object.fromEntries(
+				themes.map( ( theme ) => [
+					theme.id,
+					isInstallingTheme( state, theme.id, siteId as number ),
+				] )
+			),
+		shallowEqual
+	);
+	const isInstalling = useCallback(
+		( themeId: string ) => isInstallingMap[ themeId ] ?? false,
+		[ isInstallingMap ]
 	);
 
-	const getPrice = useSelector(
-		( state ) => ( themeId: string ) => getPremiumThemePrice( state, themeId, siteId as number )
+	const isLivePreviewStartedMap = useSelector(
+		( state ) =>
+			Object.fromEntries(
+				themes.map( ( theme ) => [ theme.id, getIsLivePreviewStarted( state, theme.id ) ] )
+			),
+		shallowEqual
+	);
+	const isLivePreviewStarted = useCallback(
+		( themeId: string ) => isLivePreviewStartedMap[ themeId ] ?? false,
+		[ isLivePreviewStartedMap ]
 	);
 
-	const isActive = useSelector(
-		( state ) => ( themeId: string ) => isThemeActive( state, themeId, siteId as number )
+	// These getters depend only on data that already triggers a render when it changes (the
+	// themes list and siteId), so reading the latest store state at call time via useStore keeps
+	// their references stable without losing reactivity.
+	const store = useStore();
+
+	const getPrice = useCallback(
+		( themeId: string ) => getPremiumThemePrice( store.getState(), themeId, siteId as number ),
+		[ store, siteId ]
 	);
 
-	const getThemeType = useSelector(
-		( state ) => ( themeId: string ) => getThemeTypeSelector( state, themeId )
+	const getThemeType = useCallback(
+		( themeId: string ) => getThemeTypeSelector( store.getState(), themeId ),
+		[ store ]
 	);
 
-	const getThemeTierForTheme = useSelector(
-		( state ) => ( themeId: string ) => getThemeTierForThemeSelector( state, themeId )
+	const getThemeTierForTheme = useCallback(
+		( themeId: string ) => getThemeTierForThemeSelector( store.getState(), themeId ),
+		[ store ]
 	);
 
-	const getThemeDetailsUrl = useSelector(
-		( state ) => ( themeId: string ) =>
-			getThemeDetailsUrlSelector( state, themeId, siteId as number )
+	const getThemeDetailsUrl = useCallback(
+		( themeId: string ) =>
+			getThemeDetailsUrlSelector( store.getState(), themeId, siteId as number ),
+		[ store, siteId ]
 	);
 
 	const filterString = useSelector( ( state ) => prependThemeFilterKeys( state, query.filter ) );

--- a/client/my-sites/themes/collections/use-theme-collection.ts
+++ b/client/my-sites/themes/collections/use-theme-collection.ts
@@ -30,12 +30,18 @@ export function useThemeCollection( query: ThemesQuery ) {
 	const themes = query.number ? allThemes.slice( 0, query.number ) : allThemes;
 
 	const siteId = useSelector( getSelectedSiteId );
+	// getSelectedSiteId can return null/undefined (logged-out showcase). Normalize once so the
+	// site-contexted theme selectors get a `number | undefined` rather than a `null` smuggled
+	// through `as number`, which would key store lookups under `null`.
+	const siteIdForThemeSelectors = siteId ?? undefined;
 
 	// Per-theme state that changes on user actions (activate / install / live preview) is
 	// selected reactively, so the cards re-render when it flips. These were previously
 	// `useSelector( state => themeId => … )`, which returned a fresh function on every render —
 	// react-redux flagged the unstable result and re-rendered every section on each dispatch.
-	const activeThemeId = useSelector( ( state ) => getActiveTheme( state, siteId as number ) );
+	const activeThemeId = useSelector( ( state ) =>
+		getActiveTheme( state, siteIdForThemeSelectors )
+	);
 	const isActive = useCallback(
 		( themeId: string ) => themeId === activeThemeId,
 		[ activeThemeId ]
@@ -46,12 +52,14 @@ export function useThemeCollection( query: ThemesQuery ) {
 	// and a re-render only when one of those states actually changes.
 	const isInstallingMap = useSelector(
 		( state ) =>
-			Object.fromEntries(
-				themes.map( ( theme ) => [
-					theme.id,
-					isInstallingTheme( state, theme.id, siteId as number ),
-				] )
-			),
+			siteIdForThemeSelectors === undefined
+				? {}
+				: Object.fromEntries(
+						themes.map( ( theme ) => [
+							theme.id,
+							isInstallingTheme( state, theme.id, siteIdForThemeSelectors ),
+						] )
+				  ),
 		shallowEqual
 	);
 	const isInstalling = useCallback(
@@ -77,8 +85,9 @@ export function useThemeCollection( query: ThemesQuery ) {
 	const store = useStore();
 
 	const getPrice = useCallback(
-		( themeId: string ) => getPremiumThemePrice( store.getState(), themeId, siteId as number ),
-		[ store, siteId ]
+		( themeId: string ) =>
+			getPremiumThemePrice( store.getState(), themeId, siteIdForThemeSelectors ),
+		[ store, siteIdForThemeSelectors ]
 	);
 
 	const getThemeType = useCallback(
@@ -93,8 +102,8 @@ export function useThemeCollection( query: ThemesQuery ) {
 
 	const getThemeDetailsUrl = useCallback(
 		( themeId: string ) =>
-			getThemeDetailsUrlSelector( store.getState(), themeId, siteId as number ),
-		[ store, siteId ]
+			getThemeDetailsUrlSelector( store.getState(), themeId, siteIdForThemeSelectors ),
+		[ store, siteIdForThemeSelectors ]
 	);
 
 	const filterString = useSelector( ( state ) => prependThemeFilterKeys( state, query.filter ) );

--- a/client/state/themes/selectors/get-premium-theme-price.js
+++ b/client/state/themes/selectors/get-premium-theme-price.js
@@ -10,7 +10,7 @@ import 'calypso/state/themes/init';
  * Returns the price string to display for a given theme on a given site.
  * @param  {Object}  state   Global state tree
  * @param  {string}  themeId Theme ID
- * @param  {number}  siteId  Site ID
+ * @param  {number}  [siteId] Site ID, omitted on the logged-out showcase
  * @returns {string}          Price
  */
 export function getPremiumThemePrice( state, themeId, siteId ) {

--- a/client/state/themes/selectors/get-theme-details-url.js
+++ b/client/state/themes/selectors/get-theme-details-url.js
@@ -7,7 +7,7 @@ import 'calypso/state/themes/init';
  * Returns the URL for a given theme's details sheet.
  * @param  {Object}  state   Global state tree
  * @param  {string}  themeId Theme ID
- * @param  {?number} siteId  Site ID to optionally use as context
+ * @param  {?number} [siteId] Site ID to optionally use as context
  * @param  {Object}  options The options for the theme details url
  * @returns {?string}         Theme details sheet URL
  */

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -175,7 +175,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
-		"themes/showcase-modern": false,
+		"themes/showcase-modern": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"two-factor/enhanced-security": true,


### PR DESCRIPTION
Part of DOTCOM-17052

## Proposed Changes

- Stabilize the per-theme getters returned by `useThemeCollection`. They were selected via `useSelector( state => ( themeId ) => … )`, which returns a new function on every render — react-redux flags the unstable result ("Selector unknown returned a different result when called with the same parameters") and re-renders every `ThemeSection` on each dispatch.
- `isActive`, `isInstalling` and `isLivePreviewStarted` change on user actions, so they are now selected reactively — `isActive` from the active-theme id, the other two as shallow-compared `themeId → boolean` maps over the visible themes — and re-render only when a value actually flips.
- `getPrice`, `getThemeType`, `getThemeTierForTheme` and `getThemeDetailsUrl` depend only on the themes list / `siteId`, which already trigger a render, so they read the latest store state at call time via `useStore` + `useCallback`.

## Why are these changes being made?

Surfaced while restoring SSR for the modern logged-out Theme Showcase (the cards render server-side, so this warning became visible). The getter functions were unstable references, so react-redux re-rendered every section on every dispatched action. Stabilizing them removes the warning and the unnecessary re-renders, while keeping the cards reactive — which matters once the showcase renders logged-in, where per-theme install / active / live-preview state changes independently.

No behavior change for the current logged-out showcase: without a selected site, the per-theme install / active / live-preview state is inert.

## Testing Instructions

- Open the logged-out `/themes` showcase. The "Selector … returned a different result when called with the same parameters" react-redux warning no longer appears for `ThemeSection`.
- Cards render and behave exactly as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
