### PR TITLE
PremiumBadge: use useIsomorphicLayoutEffect for SSR safety

### DIFF
--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -1,6 +1,7 @@
+import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import Gridicon from '../../gridicon';
 import Popover from '../../popover';
 
@@ -58,7 +59,9 @@ const PremiumBadge = ( {
 	const labelText = customLabelText || __( 'Premium' );
 
 	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
-	useLayoutEffect( () => {
+	// useIsomorphicLayoutEffect falls back to useEffect on the server, avoiding React's
+	// "useLayoutEffect does nothing on the server" warning when the badge is server-rendered.
+	useIsomorphicLayoutEffect( () => {
 		const scrollWidth = labelRef?.current?.scrollWidth ?? 0;
 		const offsetWidth = labelRef?.current?.offsetWidth ?? 0;
 		setDisplayLabelAsTooltip( !! shouldHideTooltip && scrollWidth > offsetWidth );


### PR DESCRIPTION
Part of DOTCOM-17052

## Proposed Changes

- `PremiumBadge` measures its label width in a `useLayoutEffect` to decide compact mode. Switch to `@wordpress/compose`'s `useIsomorphicLayoutEffect`, which falls back to `useEffect` on the server.

## Why are these changes being made?

Surfaced while restoring SSR for the modern logged-out Theme Showcase, where `PremiumBadge` is server-rendered once per premium/partner card. React warns that "useLayoutEffect does nothing on the server". `useIsomorphicLayoutEffect` resolves to `useLayoutEffect` in the browser, so client behavior is unchanged; this only silences the server-side warning. No hydration mismatch was occurring — the badge's initial state matches on the server and the client's first render — so this is a cleanliness fix.

Note: `PremiumBadge` lives in the shared `@automattic/components` package, so this affects every consumer of the badge, not only the Theme Showcase. The change is behavior-preserving on the client.

## Testing Instructions

- Server-render a page containing `PremiumBadge` (e.g. the logged-out `/themes` showcase). The "useLayoutEffect does nothing on the server" warning no longer appears for `PremiumBadge`.
- Confirm the badge renders and behaves identically in the browser (label measurement, compact mode, tooltip).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
