### PR TITLE
Fix dev server boot crash when a8c-for-agencies-signup section is disabled

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1201,6 +1201,14 @@ export default function pages() {
 	 * SSR middleware if the request wasn't going to be resolved with SSR anyways.
 	 */
 	function handleSectionPath( section, sectionPath, entrypoint, reqFilter, extraMiddleware ) {
+		// Some callers resolve a section via `sections.find( … )`, which returns
+		// undefined when that section is disabled for the current env and thus
+		// stripped from the (development) server bundle — e.g. `a8c-for-agencies-signup`,
+		// disabled in config/_shared.json, is absent under a plain `yarn start`.
+		// Skip registration in that case instead of crashing on boot.
+		if ( ! section ) {
+			return;
+		}
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get(


### PR DESCRIPTION
Part of #109357

## Proposed Changes

* Add a defensive `if ( ! section ) { return; }` guard at the top of `handleSectionPath` in `client/server/pages/index.js`, so a section resolved via `sections.find( … )` that is absent from the (env-filtered) server bundle is skipped instead of crashing server boot.

## Why are these changes being made?

* #109357 added a dev-routing block that does `sections.find( ( s ) => s.name === 'a8c-for-agencies-signup' )` and passes the result to `handleSectionPath`.
* In the default `development` env, `config/_shared.json` disables `a8c-for-agencies-signup` (`enable_all_sections` is `true`, but the `sections` map sets `"a8c-for-agencies-signup": false`). `filterSectionsInDevelopment` (`build-tools/webpack/sections-loader.js`, invoked by `client/webpack.config.node.js` with `forceAll: !isDevelopment`) therefore strips it from the server bundle.
* `sections.find( … )` then returns `undefined`, and the `A4A_SIGNUP_PATHS.forEach(...)` block passes it into `handleSectionPath`, which dereferences `section.name` in `setupDefaultContext`:

  ```
  TypeError: Cannot read properties of undefined (reading 'name')
      at handleSectionPath (client/server/pages/index.js)
  ```

* This crashes the server on **every fresh `yarn start`** in the default development env. `start-dashboard` is unaffected because it sets `SECTION_LIMIT=signup,checkout,a8c-for-agencies-signup`, forcing the section into the bundle. The two new `A4A_DASHBOARD_SECTION_DEFINITION` routing blocks are unaffected because they use the imported constant rather than resolving from the env-filtered `sections` array.
* Guarding inside `handleSectionPath` is the most robust fix: it also protects the other `sections.find( … )` call sites (`signup`, `checkout`) from the same failure mode should those sections ever be disabled.

## Testing Instructions

1. On a clean checkout of `trunk`, run `yarn start`. Observe the boot crash: `TypeError: Cannot read properties of undefined (reading 'name')` in `handleSectionPath`.
2. With this change, run `yarn start` again. The server boots normally: `wp-calypso booted in … - http://calypso.localhost:3000`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
