### PR TITLE
client/components: migrate function-component defaultProps to default params (React 19)

### DIFF
--- a/client/components/jetpack/videopress-iframe/index.tsx
+++ b/client/components/jetpack/videopress-iframe/index.tsx
@@ -6,18 +6,18 @@ interface Props {
 	videoURL: string;
 	title?: string;
 	className?: string;
-	maintainAspectRatio: boolean;
-	fullWidth: boolean;
-	allowFullScreen: boolean;
+	maintainAspectRatio?: boolean;
+	fullWidth?: boolean;
+	allowFullScreen?: boolean;
 }
 
 const VideoPressIframe = ( {
 	videoURL,
 	title,
 	className,
-	maintainAspectRatio,
-	fullWidth,
-	allowFullScreen,
+	maintainAspectRatio = true,
+	fullWidth = true,
+	allowFullScreen = true,
 }: Props ) => {
 	return (
 		<iframe
@@ -34,12 +34,6 @@ const VideoPressIframe = ( {
 			allowFullScreen={ allowFullScreen }
 		></iframe>
 	);
-};
-
-VideoPressIframe.defaultProps = {
-	maintainAspectRatio: true,
-	fullWidth: true,
-	allowFullScreen: true,
 };
 
 export default VideoPressIframe;

--- a/client/components/localized-moment/README.md
+++ b/client/components/localized-moment/README.md
@@ -58,13 +58,12 @@ locale slug.
 ### Usage
 
 ```jsx
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 
-ReactDom.render(
+createRoot( document.getElementById( 'root' ) ).render(
 	<MomentProvider currentLocale="cs">
 		<Label date="2019-02-26T16:20:00" />
-	</MomentProvider>,
-	document.getElementById( 'root' )
+	</MomentProvider>
 );
 ```

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -53,8 +53,8 @@ export const checkShouldShowBreadcrumb = (): boolean => {
 
 const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
 	const {
-		id,
-		className,
+		id = '',
+		className = '',
 		style,
 		children,
 		navigationItems = [],
@@ -113,10 +113,5 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 } );
 
 NavigationHeader.displayName = 'NavigationHeader';
-
-NavigationHeader.defaultProps = {
-	id: '',
-	className: '',
-};
 
 export default NavigationHeader;

--- a/client/components/reviews-rating-stars/star.tsx
+++ b/client/components/reviews-rating-stars/star.tsx
@@ -28,18 +28,18 @@ export type StarProps = {
 
 const Star = forwardRef< SVGSVGElement, StarProps >( ( props, ref ) => {
 	const {
-		index = 0,
+		index = 1,
 		rating,
 		hoverRating,
 		size = 24,
 		title,
-		onClick,
+		onClick = null,
 		className,
 		onMouseEnter,
 		onMouseLeave,
 		tracksEvent,
 		tracksProperties,
-		isChecked,
+		isChecked = false,
 		isInteractive,
 		ariaLabel,
 		tabIndex,
@@ -153,11 +153,6 @@ const Star = forwardRef< SVGSVGElement, StarProps >( ( props, ref ) => {
 	);
 } );
 
-Star.defaultProps = {
-	index: 1,
-	size: 24,
-	onClick: null,
-	isChecked: false,
-};
+Star.displayName = 'Star';
 
 export default Star;

--- a/client/components/site-offset/README.md
+++ b/client/components/site-offset/README.md
@@ -58,14 +58,13 @@ The `SiteOffsetProvider` component takes one prop: `site`. It is a string that i
 ### Usage
 
 ```jsx
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { SiteOffsetProvider } from 'calypso/components/site-offset/context';
 
-ReactDom.render(
+createRoot( document.getElementById( 'root' ) ).render(
 	<SiteOffsetProvider siteId={ siteId }>
 		<Label date="2019-02-26T16:20:00" />
-	</SiteOffsetProvider>,
-	document.getElementById( 'root' )
+	</SiteOffsetProvider>
 );
 ```
 

--- a/client/components/ssh-key-card/index.tsx
+++ b/client/components/ssh-key-card/index.tsx
@@ -40,9 +40,8 @@ const StyledButton = styled( CoreButton )( {
 	flexShrink: 0,
 } );
 
-// `scary` defaults to true; callers can still override it via props. This used to rely on
-// `defaultProps`, which React 19 ignores on function components (styled components included).
-// Wrapped in forwardRef so a ref passed to SSHKeyCard.Button still reaches CoreButton.
+// `scary` defaults to true while staying overridable; wrapped in forwardRef so a ref
+// passed to SSHKeyCard.Button still reaches CoreButton.
 export const Button = forwardRef<
 	ComponentRef< typeof StyledButton >,
 	ComponentProps< typeof StyledButton >

--- a/client/components/ssh-key-card/index.tsx
+++ b/client/components/ssh-key-card/index.tsx
@@ -1,6 +1,7 @@
 import { Button as CoreButton, CompactCard } from '@automattic/components';
 import styled from '@emotion/styled';
-import type { ComponentProps } from 'react';
+import { forwardRef } from 'react';
+import type { ComponentProps, ComponentRef } from 'react';
 
 export const Root = styled( CompactCard )( {
 	display: 'flex',
@@ -41,6 +42,12 @@ const StyledButton = styled( CoreButton )( {
 
 // `scary` defaults to true; callers can still override it via props. This used to rely on
 // `defaultProps`, which React 19 ignores on function components (styled components included).
-export const Button = ( props: ComponentProps< typeof StyledButton > ) => (
-	<StyledButton scary { ...props } />
-);
+// Wrapped in forwardRef so a ref passed to SSHKeyCard.Button still reaches CoreButton.
+export const Button = forwardRef<
+	ComponentRef< typeof StyledButton >,
+	ComponentProps< typeof StyledButton >
+>( ( { scary = true, ...props }, ref ) => (
+	<StyledButton ref={ ref } scary={ scary } { ...props } />
+) );
+
+Button.displayName = 'Button';

--- a/client/components/ssh-key-card/index.tsx
+++ b/client/components/ssh-key-card/index.tsx
@@ -1,5 +1,6 @@
 import { Button as CoreButton, CompactCard } from '@automattic/components';
 import styled from '@emotion/styled';
+import type { ComponentProps } from 'react';
 
 export const Root = styled( CompactCard )( {
 	display: 'flex',
@@ -33,11 +34,13 @@ export const Date = styled.span( {
 	color: 'var( --color-text-subtle )',
 } );
 
-export const Button = styled( CoreButton )( {
+const StyledButton = styled( CoreButton )( {
 	marginInlineStart: 'auto',
 	flexShrink: 0,
 } );
 
-Button.defaultProps = {
-	scary: true,
-};
+// `scary` defaults to true; callers can still override it via props. This used to rely on
+// `defaultProps`, which React 19 ignores on function components (styled components included).
+export const Button = ( props: ComponentProps< typeof StyledButton > ) => (
+	<StyledButton scary { ...props } />
+);


### PR DESCRIPTION
## Proposed Changes

Follow-up to #111556, continuing the React 19 forward-compatibility audit of `client/components`. This batch covers function components that still rely on `defaultProps`, which React 19 ignores on function components (including `forwardRef` and styled components).

* `videopress-iframe` — boolean props made optional with `= true` default parameters
* `navigation-header` — `id`/`className` defaulted to `''`
* `reviews-rating-stars/star` — defaults moved to parameters; `index` defaults to `1` to match the previous `defaultProps` value rather than the stale `= 0` destructure default, and the missing `forwardRef` display name is added
* `ssh-key-card` — the styled `Button` is wrapped so its `scary` default survives while staying overridable by callers
* `site-offset` / `localized-moment` READMEs — example code moved off the removed `ReactDom.render` to `createRoot`

All changes are behavior-preserving.

## Why are these changes being made?

`defaultProps` on function components is a no-op in React 19, so these defaults would silently vanish on upgrade — in two cases with visible effects (`star`'s default index and `ssh-key-card`'s destructive-button styling). Migrating now keeps the upgrade behavior-neutral.

## Testing Instructions

* `yarn typecheck-client` passes for the changed files.
* Verify the SSH key card still renders its remove button in the destructive (red) style, and that the "Update SSH key" button (which passes `scary={ false }`) does not.
* Verify rating stars render unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
