### PR TITLE
A4A WooPayments: left-align link in commission-eligibility tooltip

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -119,7 +119,8 @@
 	.woopayments-status-popover__link {
 		@include body-medium;
 		display: inline-flex;
-		justify-content: left;
+		align-self: flex-start;
+		justify-content: flex-start;
 		gap: 4px;
 		color: var( --color-primary );
 


### PR DESCRIPTION
Part of A4A-2740

## Proposed Changes

<img width="355" height="172" alt="Screenshot 2026-06-11 at 15 21 54" src="https://github.com/user-attachments/assets/f70fdd8f-76bd-4dcd-a1ec-77877b0ff618" />

* **`woopayments/dashboard-content/style.scss`** — left-align the link in the commission-eligibility tooltip (the info icon next to the **Not eligible** pill). The link is a `Button` inside a `flex-direction: column` popover whose default `align-items: stretch` was spanning the `inline-flex` button across the full 300px width. Adding `align-self: flex-start` makes it hug its text and sit flush left, and the invalid `justify-content: left` becomes a valid `flex-start`.

## Why are these changes being made?

The link in the tooltip wasn't left-aligned to match our design patterns.

## Testing Instructions

1. Open the live link and go to **A4A → WooPayments**.
2. Find a site showing the **Not eligible** pill and click the info icon next to it.
3. Confirm the link at the bottom of the tooltip ("Learn more about the incentive ↗" or "Contact Stripe support ↗") sits flush left, hugging its text.
4. Click the link and confirm it still opens the correct article in a new tab.
5. Check both the desktop table view and the mobile/responsive view.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
