### PR TITLE
Help Center: refresh the messenger auth query on Smooch onInvalidAuth

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -34,12 +34,17 @@ const initSmooch = async (
 			async onInvalidAuth() {
 				recordTracksEvent( 'calypso_smooch_messenger_auth_error' );
 
-				await queryClient.invalidateQueries( {
-					queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode ],
-				} );
+				// Refresh the exact query the component subscribes to via
+				// useAuthenticateZendeskMessaging( allowChat, 'messenger' ) — same type
+				// ('messenger') and initializeWidget (true). The refreshed JWT then flows
+				// back into authData → authJwtRef, so the next Smooch re-init uses a valid
+				// token. A mismatched key would only update an orphan cache entry and leave
+				// the component holding the expired JWT, breaking re-initialization.
+				const queryKey = [ 'getMessagingAuth', 'messenger', isTestMode, true ];
+				await queryClient.invalidateQueries( { queryKey } );
 				const authData = await queryClient.fetchQuery( {
-					queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode ],
-					queryFn: () => fetchMessagingAuth( 'zendesk' ),
+					queryKey,
+					queryFn: () => fetchMessagingAuth( 'messenger', true ),
 				} );
 
 				return authData.jwt;

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -35,11 +35,9 @@ const initSmooch = async (
 				recordTracksEvent( 'calypso_smooch_messenger_auth_error' );
 
 				// Refresh the exact query the component subscribes to via
-				// useAuthenticateZendeskMessaging( allowChat, 'messenger' ) — same type
-				// ('messenger') and initializeWidget (true). The refreshed JWT then flows
-				// back into authData → authJwtRef, so the next Smooch re-init uses a valid
-				// token. A mismatched key would only update an orphan cache entry and leave
-				// the component holding the expired JWT, breaking re-initialization.
+				// useAuthenticateZendeskMessaging( allowChat, 'messenger' ).
+				// The refreshed JWT then flows back into authData → authJwtRef, so the next
+				// Smooch re-init uses a valid token.
 				const queryKey = [ 'getMessagingAuth', 'messenger', isTestMode, true ];
 				await queryClient.invalidateQueries( { queryKey } );
 				const authData = await queryClient.fetchQuery( {

--- a/packages/help-center/src/components/test/help-center-smooch.tsx
+++ b/packages/help-center/src/components/test/help-center-smooch.tsx
@@ -79,13 +79,21 @@ jest.mock( '../../components/utils', () => ( {
 	getZendeskConversations: jest.fn().mockReturnValue( [] ),
 } ) );
 
-jest.mock( '@tanstack/react-query', () => ( {
-	useQueryClient: () => ( {
-		invalidateQueries: jest.fn(),
-		fetchQuery: jest.fn(),
-	} ),
-	QueryClient: jest.fn(),
-} ) );
+// eslint-disable-next-line no-var
+var mockInvalidateQueries: jest.Mock;
+// eslint-disable-next-line no-var
+var mockFetchQuery: jest.Mock;
+jest.mock( '@tanstack/react-query', () => {
+	mockInvalidateQueries = jest.fn().mockResolvedValue( undefined );
+	mockFetchQuery = jest.fn();
+	return {
+		useQueryClient: () => ( {
+			invalidateQueries: mockInvalidateQueries,
+			fetchQuery: mockFetchQuery,
+		} ),
+		QueryClient: jest.fn(),
+	};
+} );
 
 const mockSetIsChatLoaded = jest.fn();
 jest.mock( '@wordpress/data', () => ( {
@@ -111,6 +119,7 @@ jest.mock( '@wordpress/element', () => ( {
 } ) );
 
 import '@testing-library/jest-dom';
+import { fetchMessagingAuth } from '@automattic/zendesk-client';
 import { act, render } from '@testing-library/react';
 import HelpCenterSmooch from '../help-center-smooch';
 
@@ -180,5 +189,51 @@ describe( 'HelpCenterSmooch – Smooch.destroy() error handling (regression)', (
 		}
 
 		expect( unhandledErrors ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'HelpCenterSmooch – onInvalidAuth refreshes the messenger auth (regression)', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockSmooch.render.mockImplementation( () => {} );
+		mockSmooch.destroy.mockResolvedValue( undefined );
+		mockSmooch.init.mockResolvedValue( undefined );
+	} );
+
+	it( 'refreshes the same messenger query the component subscribes to and returns the fresh JWT', async () => {
+		await act( async () => {
+			render( <HelpCenterSmooch enableAuth /> );
+			await new Promise( ( r ) => setTimeout( r, 0 ) );
+		} );
+
+		// Grab the delegate Smooch was initialized with.
+		const initOptions = mockSmooch.init.mock.calls[ 0 ][ 0 ];
+		const { onInvalidAuth } = initOptions.delegate;
+
+		mockFetchQuery.mockResolvedValueOnce( {
+			jwt: 'fresh-jwt',
+			externalId: 'test-ext-id',
+			isLoggedIn: true,
+		} );
+
+		let returnedJwt: string | undefined;
+		await act( async () => {
+			returnedJwt = await onInvalidAuth();
+		} );
+
+		// Smooch receives the refreshed token.
+		expect( returnedJwt ).toBe( 'fresh-jwt' );
+
+		// It must refresh the exact key the component reads (type 'messenger',
+		// initializeWidget true) — NOT the old orphan 'zendesk' key — so authJwtRef
+		// picks up the new token. isTestModeEnvironment() is mocked to false.
+		const expectedKey = [ 'getMessagingAuth', 'messenger', false, true ];
+		expect( mockInvalidateQueries ).toHaveBeenCalledWith( { queryKey: expectedKey } );
+		const fetchArgs = mockFetchQuery.mock.calls[ 0 ][ 0 ];
+		expect( fetchArgs.queryKey ).toEqual( expectedKey );
+
+		// The query function fetches the messenger auth with the widget login flow.
+		fetchArgs.queryFn();
+		expect( fetchMessagingAuth ).toHaveBeenCalledWith( 'messenger', true );
 	} );
 } );


### PR DESCRIPTION
Part of DOTCOM-15974

## Proposed Changes

* In `help-center-smooch.tsx`, make Smooch's `onInvalidAuth` delegate refresh the **same** TanStack Query the component subscribes to — `['getMessagingAuth', 'messenger', isTestMode, true]` via `fetchMessagingAuth( 'messenger', true )` — instead of the unrelated `['getMessagingAuth', 'zendesk', isTestMode]` key.
* Add a regression test that invokes the `onInvalidAuth` delegate captured from `Smooch.init` and asserts it refreshes the messenger key and returns the fresh JWT.

## Why are these changes being made?

* The component reads its JWT from `useAuthenticateZendeskMessaging( allowChat, 'messenger' )` → query key `['getMessagingAuth', 'messenger', isTestMode, true]`, and that JWT flows into `authJwtRef`, which the Smooch (re-)init effect reads.
* When the JWT expired, `onInvalidAuth` invalidated/refetched `['getMessagingAuth', 'zendesk', isTestMode]` — a key **no component reads** (the only `'zendesk'` consumer uses a different 4-element `…, false` key). So Smooch got a fresh token from the delegate's return value, but the React query feeding `authJwtRef` was never updated.
* As a result, the next time Smooch re-initialized (e.g. a dependency change or the post-failure retry), it read the **stale/expired** JWT from `authJwtRef` → `Smooch.init` failed → the 30-second retry loop kicked in, during which users could not receive messages. This is one of the contributing causes in DOTCOM-15974.
* Refreshing the matching `'messenger'` key updates `authData` → `authJwtRef`, so re-initialization uses a valid token. Other `getMessagingAuth` consumers use distinct keys and are unaffected.

This follows #111559 (re-fetch chat history on Smooch re-init), addressing a separate contributing cause from the same investigation.

## Testing Instructions

### Calypso

1. Run `yarn start`, open the Help Center, and start a live chat so Smooch initializes.
2. Simulate a JWT expiry so Smooch calls `onInvalidAuth` (e.g. have the messaging auth return an expired token, or trigger the delegate in devtools).
3. Confirm the `['getMessagingAuth', 'messenger', …]` query is refreshed (React Query devtools) and that a subsequent Smooch re-init succeeds rather than entering the 30s retry loop — messages keep arriving.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Repeat the steps above and verify the messenger auth refreshes and chat recovers after a JWT expiry.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
