### PR TITLE
Dashboard: port modern platform/architecture detection to the Apps screen

### DIFF
--- a/client/dashboard/me/apps/apps-desktop-card.tsx
+++ b/client/dashboard/me/apps/apps-desktop-card.tsx
@@ -379,8 +379,8 @@ export default function AppsDesktopCard( { appSlug }: { appSlug: keyof typeof De
 						) ) }
 					</Wrapper>
 				) }
-				<Wrapper spacing={ 2 } justify="flex-start">
-					<Text as="p" variant="muted" lineHeight="20px">
+				<HStack spacing={ 2 } justify="flex-start" alignment="center" wrap>
+					<Text as="p" variant="muted" lineHeight="20px" style={ { flexShrink: 0 } }>
 						{ downloadEntries.length === 0 ? __( 'Available for:' ) : __( 'Also available for:' ) }
 					</Text>
 					{ alsoAvailableEntries.map( ( [ key, config ] ) => (
@@ -398,7 +398,7 @@ export default function AppsDesktopCard( { appSlug }: { appSlug: keyof typeof De
 							{ config.name }
 						</Button>
 					) ) }
-				</Wrapper>
+				</HStack>
 			</VStack>
 		</AppsCard>
 	);

--- a/client/dashboard/me/apps/apps-desktop-card.tsx
+++ b/client/dashboard/me/apps/apps-desktop-card.tsx
@@ -7,6 +7,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import SVGIcon from '../../components/svg-icon';
 import { Text } from '../../components/text';
@@ -16,13 +17,17 @@ import WordPressDesktopAppLogo from './images/desktop-app-logo.svg';
 import Linux from './images/linux-logo.svg';
 import WordPressStudioLogo from './images/studio-app-logo.svg';
 import Windows from './images/windows-logo.svg';
+import { detectPlatformAndArchitecture } from './platform-detection';
 
 enum PlatformType {
-	MacIntel = 'MacIntel',
 	MacSilicon = 'MacSilicon',
+	MacIntel = 'MacIntel',
+	WindowsX64 = 'WindowsX64',
+	WindowsARM64 = 'WindowsARM64',
 	Linux = 'Linux',
 	LinuxDeb = 'LinuxDeb',
-	Windows = 'Windows',
+	LinuxX64 = 'LinuxX64',
+	LinuxARM64 = 'LinuxARM64',
 }
 
 interface BasePlatformConfig {
@@ -47,23 +52,29 @@ interface DesktopAppConfig {
 }
 
 const BaseAppProperties: Record< PlatformType, BasePlatformConfig > = {
-	[ PlatformType.MacIntel ]: {
-		group: 'mac',
-		icon: Apple,
-		iconName: 'apple-logo',
-		name: __( 'Mac (Intel)' ),
-	},
 	[ PlatformType.MacSilicon ]: {
 		group: 'mac',
 		icon: Apple,
 		iconName: 'apple-logo',
 		name: __( 'Mac (Apple Silicon)' ),
 	},
-	[ PlatformType.Windows ]: {
+	[ PlatformType.MacIntel ]: {
+		group: 'mac',
+		icon: Apple,
+		iconName: 'apple-logo',
+		name: __( 'Mac (Intel)' ),
+	},
+	[ PlatformType.WindowsX64 ]: {
 		group: 'windows',
 		icon: Windows,
 		iconName: 'windows-logo',
-		name: __( 'Windows' ),
+		name: __( 'Windows (x64)' ),
+	},
+	[ PlatformType.WindowsARM64 ]: {
+		group: 'windows',
+		icon: Windows,
+		iconName: 'windows-logo',
+		name: __( 'Windows on ARM' ),
 	},
 	[ PlatformType.Linux ]: {
 		group: 'linux',
@@ -76,6 +87,18 @@ const BaseAppProperties: Record< PlatformType, BasePlatformConfig > = {
 		icon: Linux,
 		iconName: 'linux-logo',
 		name: __( 'Linux (.deb)' ),
+	},
+	[ PlatformType.LinuxX64 ]: {
+		group: 'linux',
+		icon: Linux,
+		iconName: 'linux-logo',
+		name: __( 'Linux (x64)' ),
+	},
+	[ PlatformType.LinuxARM64 ]: {
+		group: 'linux',
+		icon: Linux,
+		iconName: 'linux-logo',
+		name: __( 'Linux (ARM)' ),
 	},
 };
 
@@ -106,9 +129,15 @@ const DesktopApps: Record< string, DesktopAppConfig > = {
 				// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 				link: 'https://apps.wordpress.com/d/osx?ref=getapps',
 			},
-			[ PlatformType.Windows ]: {
-				...BaseAppProperties[ PlatformType.Windows ],
-				eventName: 'calypso_dashboard_app_download_windows_click',
+			[ PlatformType.WindowsX64 ]: {
+				...BaseAppProperties[ PlatformType.WindowsX64 ],
+				eventName: 'calypso_dashboard_app_download_windows_x64_click',
+				// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+				link: 'https://apps.wordpress.com/d/windows?ref=getapps',
+			},
+			[ PlatformType.WindowsARM64 ]: {
+				...BaseAppProperties[ PlatformType.WindowsARM64 ],
+				eventName: 'calypso_dashboard_app_download_windows_arm64_click',
 				// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 				link: 'https://apps.wordpress.com/d/windows?ref=getapps',
 			},
@@ -148,102 +177,227 @@ const DesktopApps: Record< string, DesktopAppConfig > = {
 			[ PlatformType.MacSilicon ]: {
 				...BaseAppProperties[ PlatformType.MacSilicon ],
 				eventName: 'calypso_dashboard_studio_download_mac_silicon_click',
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.5.6.dmg',
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-silicon/latest',
 			},
 			[ PlatformType.MacIntel ]: {
 				...BaseAppProperties[ PlatformType.MacIntel ],
 				eventName: 'calypso_dashboard_studio_download_mac_click',
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.5.6.dmg',
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-intel/latest',
 			},
-			[ PlatformType.Windows ]: {
-				...BaseAppProperties[ PlatformType.Windows ],
-				eventName: 'calypso_dashboard_studio_download_windows_click',
-				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.5.6.exe',
+			[ PlatformType.WindowsX64 ]: {
+				...BaseAppProperties[ PlatformType.WindowsX64 ],
+				eventName: 'calypso_dashboard_studio_download_windows_x64_click',
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/windows-x64/latest',
+			},
+			[ PlatformType.WindowsARM64 ]: {
+				...BaseAppProperties[ PlatformType.WindowsARM64 ],
+				eventName: 'calypso_dashboard_studio_download_windows_arm64_click',
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/windows-arm64/latest',
+			},
+			[ PlatformType.LinuxX64 ]: {
+				...BaseAppProperties[ PlatformType.LinuxX64 ],
+				eventName: 'calypso_dashboard_studio_download_linux_x64_click',
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/linux-x64/latest/update',
+			},
+			[ PlatformType.LinuxARM64 ]: {
+				...BaseAppProperties[ PlatformType.LinuxARM64 ],
+				eventName: 'calypso_dashboard_studio_download_linux_arm64_click',
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/linux-arm64/latest/update',
 			},
 		},
 	},
 };
 
-const getCurrentPlatform = (): PlatformType => {
-	switch ( navigator.platform ) {
-		case 'MacIntel':
-			return PlatformType.MacIntel;
-		case 'MacSilicon':
-			return PlatformType.MacSilicon;
-		case 'Linux i686':
-		case 'Linux i686 on x86_64':
-			return PlatformType.Linux;
-		default:
-			return PlatformType.Windows;
+const getCurrentPlatform = async (): Promise< {
+	platform: PlatformType;
+	detectionFailed: boolean;
+} > => {
+	// Try User-Agent Client Hints API first (works across all platforms)
+	const detection = await detectPlatformAndArchitecture();
+
+	if ( detection && detection.detectionMethod === 'client-hints' ) {
+		const { platform, architecture } = detection;
+
+		if ( platform === 'macos' ) {
+			if ( architecture === 'arm64' ) {
+				return { platform: PlatformType.MacSilicon, detectionFailed: false };
+			} else if ( architecture === 'x64' ) {
+				return { platform: PlatformType.MacIntel, detectionFailed: false };
+			}
+			// Client Hints available but no architecture - fallback to MacSilicon
+			return { platform: PlatformType.MacSilicon, detectionFailed: true };
+		}
+
+		if ( platform === 'windows' ) {
+			if ( architecture === 'arm64' ) {
+				return { platform: PlatformType.WindowsARM64, detectionFailed: false };
+			} else if ( architecture === 'x64' ) {
+				return { platform: PlatformType.WindowsX64, detectionFailed: false };
+			}
+			// Client Hints available but no architecture - fallback
+			return { platform: PlatformType.WindowsX64, detectionFailed: true };
+		}
+
+		if ( platform === 'linux' ) {
+			if ( architecture === 'arm64' ) {
+				return { platform: PlatformType.LinuxARM64, detectionFailed: false };
+			} else if ( architecture === 'x64' ) {
+				return { platform: PlatformType.LinuxX64, detectionFailed: false };
+			}
+			// Client Hints available but no architecture - fallback to x64
+			return { platform: PlatformType.LinuxX64, detectionFailed: true };
+		}
 	}
+
+	// Fallback to navigator.platform (Client Hints API not available)
+	// Cannot trust architecture detection here
+	if ( detection && detection.detectionMethod === 'navigator-platform' ) {
+		const { platform } = detection;
+
+		if ( platform === 'macos' ) {
+			// Cannot detect Mac architecture reliably - show both options,
+			// but default to Apple Silicon (more common now)
+			return { platform: PlatformType.MacSilicon, detectionFailed: true };
+		}
+
+		if ( platform === 'windows' ) {
+			// Cannot detect Windows architecture - show both options
+			return { platform: PlatformType.WindowsX64, detectionFailed: true };
+		}
+
+		if ( platform === 'linux' ) {
+			// Cannot detect Linux architecture - default to x64 (more common)
+			return { platform: PlatformType.LinuxX64, detectionFailed: true };
+		}
+	}
+
+	// Ultimate fallback - couldn't detect anything
+	return { platform: PlatformType.WindowsX64, detectionFailed: true };
 };
+
+const isMobileDevice = () =>
+	navigator.userAgentData?.mobile ?? /Android|iPhone|iPad|iPod|Mobile/i.test( navigator.userAgent );
 
 export default function AppsDesktopCard( { appSlug }: { appSlug: keyof typeof DesktopApps } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const isDesktop = useViewportMatch( 'medium' );
 	const Wrapper = isDesktop ? HStack : VStack;
 	const app = DesktopApps[ appSlug ];
+	const [ platform, setPlatform ] = useState< PlatformType | null >( null );
+	const [ detectionFailed, setDetectionFailed ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	useEffect( () => {
+		getCurrentPlatform()
+			.then( ( result ) => {
+				setPlatform( result.platform );
+				setDetectionFailed( result.detectionFailed );
+			} )
+			.catch( () => {
+				setDetectionFailed( true );
+				setPlatform( PlatformType.WindowsX64 );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [] );
+
+	const platformConfig = useMemo( () => {
+		if ( ! app || ! platform ) {
+			return undefined;
+		}
+		const config = app.platforms[ platform ];
+		if ( config ) {
+			return config;
+		}
+		// Apps without arch-specific Linux entries (e.g. the WordPress.com
+		// desktop app) fall back to the generic Linux entry.
+		if ( platform === PlatformType.LinuxX64 || platform === PlatformType.LinuxARM64 ) {
+			return app.platforms[ PlatformType.Linux ];
+		}
+		return undefined;
+	}, [ app, platform ] );
 
 	if ( ! app ) {
 		return null;
 	}
 
-	const platform = getCurrentPlatform();
-	const platformConfig = app.platforms[ platform ];
+	const cardProps = {
+		logo: app.logo,
+		logoAlt: app.logoAlt,
+		title: app.title,
+		description: app.description,
+	};
+
+	if ( isMobileDevice() ) {
+		return (
+			<AppsCard { ...cardProps }>
+				<Text as="p" variant="muted" lineHeight="20px">
+					{ app.link }
+				</Text>
+			</AppsCard>
+		);
+	}
+
+	if ( isLoading ) {
+		return <AppsCard { ...cardProps } />;
+	}
+
+	const platformEntries = Object.entries( app.platforms );
+	// Architecture detected with confidence: a single download button for the
+	// exact platform. Detection failed or imprecise: one button per option in
+	// the detected platform group. Everything else goes to "Also available for".
+	const downloadEntries = ! platformConfig
+		? []
+		: platformEntries.filter( ( [ , config ] ) =>
+				detectionFailed ? config.group === platformConfig.group : config === platformConfig
+		  );
+	const alsoAvailableEntries = platformEntries.filter(
+		( [ , config ] ) => ! downloadEntries.some( ( [ , download ] ) => download === config )
+	);
 
 	return (
-		<AppsCard
-			logo={ app.logo }
-			logoAlt={ app.logoAlt }
-			title={ app.title }
-			description={ app.description }
-		>
+		<AppsCard { ...cardProps }>
 			<VStack spacing={ 4 }>
-				{ platformConfig && (
+				{ downloadEntries.length > 0 && (
 					<Wrapper spacing={ 2 } justify="flex-start" alignment="flex-start">
-						{ Object.entries( app.platforms )
-							.filter( ( [ , config ] ) => config.group === platformConfig?.group )
-							.map( ( [ key, config ], index ) => (
-								<Button
-									__next40pxDefaultSize
-									key={ key }
-									href={ config.link }
-									icon={ <SVGIcon icon={ config.icon } name={ config.iconName } /> }
-									variant={ index === 0 ? 'primary' : 'secondary' }
-									onClick={ () => recordTracksEvent( config.eventName ) }
-								>
-									{ sprintf(
-										// translators: %s is the platform name
-										__( 'Download for %s' ),
-										config.name
-									) }
-								</Button>
-							) ) }
+						{ downloadEntries.map( ( [ key, config ], index ) => (
+							<Button
+								__next40pxDefaultSize
+								key={ key }
+								href={ config.link }
+								icon={ <SVGIcon icon={ config.icon } name={ config.iconName } /> }
+								variant={ index === 0 ? 'primary' : 'secondary' }
+								onClick={ () => recordTracksEvent( config.eventName ) }
+							>
+								{ sprintf(
+									// translators: %s is the platform name
+									__( 'Download for %s' ),
+									config.name
+								) }
+							</Button>
+						) ) }
 					</Wrapper>
 				) }
 				<Wrapper spacing={ 2 } justify="flex-start">
 					<Text as="p" variant="muted" lineHeight="20px">
-						{ ! platformConfig ? __( 'Available for:' ) : __( 'Also available for:' ) }
+						{ downloadEntries.length === 0 ? __( 'Available for:' ) : __( 'Also available for:' ) }
 					</Text>
-					{ Object.entries( app.platforms )
-						.filter(
-							( [ , config ] ) => ! platformConfig || config.group !== platformConfig?.group
-						)
-						.map( ( [ key, config ] ) => (
-							<Button
-								key={ key }
-								href={ config.link }
-								icon={ <SVGIcon icon={ config.icon } name={ config.iconName } /> }
-								iconSize={ 16 }
-								name={ config.iconName }
-								size="compact"
-								variant="link"
-								style={ { padding: 0 } }
-								onClick={ () => recordTracksEvent( config.eventName ) }
-							>
-								{ config.name }
-							</Button>
-						) ) }
+					{ alsoAvailableEntries.map( ( [ key, config ] ) => (
+						<Button
+							key={ key }
+							href={ config.link }
+							icon={ <SVGIcon icon={ config.icon } name={ config.iconName } /> }
+							iconSize={ 16 }
+							name={ config.iconName }
+							size="compact"
+							variant="link"
+							style={ { padding: 0 } }
+							onClick={ () => recordTracksEvent( config.eventName ) }
+						>
+							{ config.name }
+						</Button>
+					) ) }
 				</Wrapper>
 			</VStack>
 		</AppsCard>

--- a/client/dashboard/me/apps/platform-detection.ts
+++ b/client/dashboard/me/apps/platform-detection.ts
@@ -1,0 +1,97 @@
+/**
+ * Type definitions for User-Agent Client Hints API
+ */
+interface UADataValues {
+	platform: string;
+	architecture?: string;
+	bitness?: string;
+	platformVersion?: string;
+}
+
+interface NavigatorUAData {
+	brands: ReadonlyArray< { brand: string; version: string } >;
+	mobile: boolean;
+	platform: string;
+	getHighEntropyValues( hints: string[] ): Promise< UADataValues >;
+}
+
+declare global {
+	interface Navigator {
+		userAgentData?: NavigatorUAData;
+	}
+}
+
+export interface PlatformDetectionResult {
+	platform: string;
+	architecture?: 'arm64' | 'x64';
+	detectionMethod: 'client-hints' | 'navigator-platform';
+}
+
+/**
+ * Detects platform and architecture using User-Agent Client Hints API
+ * Returns platform info with architecture if detected, or null if detection fails
+ */
+export const detectPlatformAndArchitecture =
+	async (): Promise< PlatformDetectionResult | null > => {
+		// Try User-Agent Client Hints API first (most reliable)
+		if ( 'userAgentData' in navigator && navigator.userAgentData ) {
+			try {
+				const uaData = await navigator.userAgentData.getHighEntropyValues( [
+					'architecture',
+					'bitness',
+					'platform',
+				] );
+
+				const platform = uaData.platform?.toLowerCase() || '';
+
+				let architecture: 'arm64' | 'x64' | undefined;
+
+				// Detect architecture for all platforms
+				if ( uaData.architecture === 'arm' || uaData.architecture === 'arm64' ) {
+					architecture = 'arm64';
+				} else if ( uaData.architecture === 'x86' && uaData.bitness === '64' ) {
+					architecture = 'x64';
+				} else if ( uaData.architecture === 'x86' ) {
+					architecture = 'x64'; // Assume x64 for x86 architecture
+				}
+
+				return {
+					platform,
+					architecture,
+					detectionMethod: 'client-hints',
+				};
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.warn( 'Failed to get high entropy values:', error );
+			}
+		}
+
+		// Fallback to navigator.platform (unreliable, frozen in modern browsers)
+		const platformName = navigator.platform.toLowerCase();
+
+		if ( platformName.includes( 'mac' ) ) {
+			return {
+				platform: 'macos',
+				architecture: undefined, // Cannot reliably detect Mac architecture
+				detectionMethod: 'navigator-platform',
+			};
+		}
+
+		if ( platformName.includes( 'linux' ) ) {
+			return {
+				platform: 'linux',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			};
+		}
+
+		if ( platformName.includes( 'win' ) ) {
+			return {
+				platform: 'windows',
+				architecture: undefined, // Cannot detect Windows architecture without Client Hints
+				detectionMethod: 'navigator-platform',
+			};
+		}
+
+		return null; // Unable to detect platform
+	};

--- a/client/dashboard/me/apps/test/apps-desktop-card.test.tsx
+++ b/client/dashboard/me/apps/test/apps-desktop-card.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import AppsDesktopCard from '../apps-desktop-card';
+
+const setUserAgentData = ( value: unknown ) => {
+	Object.defineProperty( window.navigator, 'userAgentData', {
+		value,
+		writable: true,
+		configurable: true,
+	} );
+};
+
+const setNavigatorPlatform = ( value: string ) => {
+	Object.defineProperty( window.navigator, 'platform', {
+		value,
+		writable: true,
+		configurable: true,
+	} );
+};
+
+describe( 'AppsDesktopCard', () => {
+	const originalNavigator = global.navigator;
+
+	afterEach( () => {
+		Object.defineProperty( global, 'navigator', {
+			value: originalNavigator,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'shows a single download button when architecture is detected via Client Hints', async () => {
+		setUserAgentData( {
+			brands: [],
+			mobile: false,
+			platform: 'macOS',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'macOS',
+				architecture: 'arm64',
+				bitness: '64',
+			} ),
+		} );
+
+		render( <AppsDesktopCard appSlug="wordpress" /> );
+
+		const button = await screen.findByRole( 'link', {
+			name: /Download for Mac \(Apple Silicon\)/,
+		} );
+		expect( button ).toHaveAttribute(
+			'href',
+			'https://apps.wordpress.com/d/osx-silicon?ref=getapps'
+		);
+
+		// The other architecture of the same group moves to "Also available for".
+		expect( screen.getByText( 'Also available for:' ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Mac (Intel)' } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'link', { name: /Download for Mac \(Intel\)/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows one button per architecture when detection falls back to navigator.platform', async () => {
+		setUserAgentData( undefined );
+		setNavigatorPlatform( 'Win32' );
+
+		render( <AppsDesktopCard appSlug="studio" /> );
+
+		const x64Button = await screen.findByRole( 'link', { name: /Download for Windows \(x64\)/ } );
+		expect( x64Button ).toHaveAttribute(
+			'href',
+			'https://appscdn.wordpress.com/downloads/wordpress-com-studio/windows-x64/latest'
+		);
+
+		const armButton = screen.getByRole( 'link', { name: /Download for Windows on ARM/ } );
+		expect( armButton ).toHaveAttribute(
+			'href',
+			'https://appscdn.wordpress.com/downloads/wordpress-com-studio/windows-arm64/latest'
+		);
+	} );
+
+	it( 'falls back to the generic Linux entry for apps without arch-specific Linux builds', async () => {
+		setUserAgentData( {
+			brands: [],
+			mobile: false,
+			platform: 'Linux',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Linux',
+				architecture: 'x86',
+				bitness: '64',
+			} ),
+		} );
+
+		render( <AppsDesktopCard appSlug="wordpress" /> );
+
+		const button = await screen.findByRole( 'link', { name: /Download for Linux \(.tar.gz\)/ } );
+		expect( button ).toHaveAttribute( 'href', 'https://apps.wordpress.com/d/linux?ref=getapps' );
+	} );
+
+	it( 'shows a visit-on-desktop message instead of download buttons on mobile devices', async () => {
+		setUserAgentData( {
+			brands: [],
+			mobile: true,
+			platform: 'Android',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Android',
+				architecture: 'arm64',
+				bitness: '64',
+			} ),
+		} );
+
+		render( <AppsDesktopCard appSlug="wordpress" /> );
+
+		expect( await screen.findByText( /on your desktop/ ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: /Download for/ } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/apps/test/platform-detection.test.ts
+++ b/client/dashboard/me/apps/test/platform-detection.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @jest-environment jsdom
+ */
+import { detectPlatformAndArchitecture } from '../platform-detection';
+
+describe( 'detectPlatformAndArchitecture', () => {
+	const originalNavigator = global.navigator;
+
+	afterEach( () => {
+		// Restore original navigator
+		Object.defineProperty( global, 'navigator', {
+			value: originalNavigator,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	describe( 'Client Hints API detection', () => {
+		it( 'should detect Windows ARM64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'Windows',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'Windows',
+					architecture: 'arm64',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: 'arm64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+
+		it( 'should detect Windows x64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'Windows',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'Windows',
+					architecture: 'x86',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: 'x64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+
+		it( 'should detect macOS ARM64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'macOS',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'macOS',
+					architecture: 'arm64',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'macos',
+				architecture: 'arm64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+
+		it( 'should detect macOS x64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'macOS',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'macOS',
+					architecture: 'x86',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'macos',
+				architecture: 'x64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+
+		it( 'should detect Linux via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'Linux',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'Linux',
+					architecture: 'x86',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'linux',
+				architecture: 'x64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+	} );
+
+	describe( 'navigator.platform fallback', () => {
+		it( 'should fallback to navigator.platform for macOS', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'MacIntel',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'macos',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+		} );
+
+		it( 'should fallback to navigator.platform for Windows', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Win32',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+		} );
+
+		it( 'should fallback to navigator.platform for Linux', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Linux x86_64',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'linux',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+		} );
+	} );
+
+	describe( 'Error handling', () => {
+		it( 'should fallback to navigator.platform when Client Hints throws error', async () => {
+			const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+			const mockError = new Error( 'Permission denied' );
+
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'Windows',
+				getHighEntropyValues: jest.fn().mockRejectedValue( mockError ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Win32',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+			expect( consoleWarnSpy ).toHaveBeenCalledWith(
+				'Failed to get high entropy values:',
+				mockError
+			);
+
+			consoleWarnSpy.mockRestore();
+		} );
+
+		it( 'should return null when no detection method works', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Unknown Platform',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toBeNull();
+		} );
+	} );
+} );


### PR DESCRIPTION
Related to DOTDEV-422

## Proposed Changes

The desktop app cards on the Dashboard's `/me/apps` screen were migrated from the classic Get Apps page before that page's download logic was modernized, so the two implementations drifted apart. This PR ports the modernized logic from `client/blocks/get-apps` to `client/dashboard/me/apps`:

* Detect platform **and CPU architecture** asynchronously via the User-Agent Client Hints API, falling back to `navigator.platform` where Client Hints are unavailable (Firefox, Safari). The old code used a synchronous `navigator.platform` switch with a dead `MacSilicon` case and defaulted everything else to Windows.
* Split Windows into x64 / ARM64 variants, and add Linux x64 / ARM entries for Studio.
* Replace Studio download links pinned to `v1.5.6` on `cdn.a8c-ci.services` with the versionless `appscdn.wordpress.com/downloads/wordpress-com-studio/<platform>/latest` URLs already used by the classic page, so links no longer go stale when Studio ships a new release.
* When architecture is detected with confidence, show a single download button for the exact platform (the sibling architecture moves to "Also available for:"). When detection is imprecise, keep one button per option in the detected platform group.
* On mobile devices, show the "Visit … on your desktop" message instead of desktop download buttons. The `link` config field existed for this but was never rendered.
* Make the "Also available for:" row wrap onto multiple lines (same flex-wrap approach as #107295) instead of switching to a vertical stack below the medium breakpoint.
* New analytics events for the added variants: `calypso_dashboard_app_download_windows_{x64,arm64}_click` and `calypso_dashboard_studio_download_{windows_x64,windows_arm64,linux_x64,linux_arm64}_click`.

`platform-detection.ts` is copied verbatim from `client/blocks/get-apps/platform-detection.ts` (with its unit tests) since the Dashboard client is intentionally self-contained and does not import classic Calypso code.

|**Before**|**After**|
|---|---|
|<img width="2188" height="1644" alt="CleanShot 2026-06-11 at 18 05 37@2x" src="https://github.com/user-attachments/assets/abbb9ea8-30b6-46c2-b882-aa9893d3e09b" />|<img width="2188" height="1656" alt="CleanShot 2026-06-11 at 18 05 25@2x" src="https://github.com/user-attachments/assets/014c01b3-0e67-4e9d-b39e-9537fa3a7ba8" />|

## Why are these changes being made?

* The Dashboard's Apps screen offered Windows downloads to most non-Mac users (including Linux), never distinguished Windows/Linux architectures, and linked to a stale, pinned Studio version. The classic Get Apps page already solved all of this; this brings the new Dashboard to parity.

## Testing Instructions

* Run unit tests: `yarn test-client client/dashboard/me/apps/test/`
* Start the dashboard: `yarn start-dashboard`, then open the Apps screen at `/me/apps`.
* On a Chromium browser, verify a single primary "Download for …" button matching your exact platform/architecture appears for both the WordPress.com desktop app and Studio, with the remaining platforms listed under "Also available for:".
* On Firefox or Safari (no Client Hints), verify one button per architecture of your platform group appears instead.
* Verify Studio buttons link to `https://appscdn.wordpress.com/downloads/wordpress-com-studio/<platform>/latest` URLs.
* In responsive mode with a mobile user agent, verify the cards show the "Visit … on your desktop" message instead of download buttons.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
