### PR TITLE
A4A Plugins: remove list layout from the plugins DataView

### DIFF
--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -12,12 +12,14 @@ import {
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import { DataViews } from 'calypso/components/dataviews';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
 import { useFields } from './use-fields';
+import type { SupportedLayouts } from '@wordpress/dataviews';
 import './style.scss';
 
 interface Props {
@@ -28,8 +30,6 @@ interface Props {
 	onSearch?: ( search: string ) => void;
 	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void;
 }
-
-const defaultLayouts = { table: {}, list: {} };
 
 const openPluginSitesPane = ( plugin: Plugin ) => {
 	recordTracksEvent( 'calypso_plugins_list_open_plugin_sites_pane', {
@@ -50,6 +50,13 @@ export default function PluginsListDataViews( {
 	const dispatch = useDispatch();
 	const isDesktopView = isDesktop();
 	const shouldUseListView = pluginSlug !== undefined || ! isDesktopView;
+
+	// In A4A, the list layout offers no benefit and hides vital information, so we restrict the
+	// available layouts to the one actually in use, which also removes the layout switcher option.
+	let defaultLayouts: SupportedLayouts = { table: {}, list: {} };
+	if ( isA8CForAgencies() ) {
+		defaultLayouts = shouldUseListView ? { list: {} } : { table: {} };
+	}
 	const pluginUpdateCount = currentPlugins.filter(
 		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
 	).length;
@@ -145,7 +152,7 @@ export default function PluginsListDataViews( {
 
 	useEffect( () => {
 		if ( dataViewsState.search !== initialSearch ) {
-			onSearch && onSearch( dataViewsState.search || '' );
+			onSearch?.( dataViewsState.search || '' );
 		}
 	}, [ dataViewsState.search, onSearch, initialSearch ] );
 


### PR DESCRIPTION
Part of A4A-2739

Before:

<img width="1105" height="54" alt="Screenshot 2026-06-11 at 16 31 59" src="https://github.com/user-attachments/assets/50e508c6-4c3e-4258-820f-fcd9310a91bb" />

After:

<img width="1108" height="53" alt="Screenshot 2026-06-11 at 16 31 17" src="https://github.com/user-attachments/assets/efd6786e-1000-4e15-b128-b532596ea533" />

## Proposed Changes

* **`client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx`** — restrict the DataViews `defaultLayouts` so the **list** layout is no longer offered in A4A. The shared `PluginsListDataViews` is also used by classic Calypso and Jetpack Cloud, so the change is gated on `isA8CForAgencies()` and those clients keep both layouts. In A4A, `defaultLayouts` now follows the layout actually in use — `table` on the desktop listing, `list` on mobile and in the per-plugin sites pane (where the view type is already forced to `list`). With a single layout available, the layout switcher in the view settings disappears.
* Incidental: replaced a `onSearch && onSearch(…)` short-circuit with `onSearch?.(…)` to satisfy the linter on the touched file.

## Why are these changes being made?

The plugins DataView settings let users switch to a list view that drops the columns agencies rely on (sites count, available updates) without offering anything in return. Removing it from A4A keeps the table — the useful view — as the only desktop option.

`defaultLayouts` in `@wordpress/dataviews` is a hard gate, not just UI: a view whose `type` isn't in `defaultLayouts` renders nothing. Since this component forces `type: 'list'` on mobile and in the sites pane, the gate has to track that condition rather than be set to table-only across the board.

## Testing Instructions

1. Open the live link and go to **A4A → Plugins** (`/plugins/manage/sites`) on desktop.
2. Open the DataView view settings (the layout/options control) and confirm there is no longer a **List** option — the table is the only layout.
3. Confirm the plugins still render in table view with the sites count and update columns intact.
4. Click into a plugin's **sites** pane (`/plugins/manage/sites/:slug`) and confirm it still renders correctly as a list (no blank view).
5. Resize to mobile width on the main listing and confirm it still renders as a list (no blank view).
6. In classic Calypso (`/plugins`) and Jetpack Cloud, confirm the list/table switcher is unchanged.
7. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
