### PR TITLE
Domains: group bundle members into one row in the domain-search cart panel

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -1153,6 +1153,7 @@ describe( 'useWPCOMDomainSearchProps', () => {
 				item_subtotal_integer: 13_00,
 				extra: {
 					domain_bundle_group_id: 'v1.test.deadbeef',
+					domain_bundle_role: 'primary',
 				},
 			} ),
 			buildProduct( {
@@ -1165,6 +1166,7 @@ describe( 'useWPCOMDomainSearchProps', () => {
 				item_subtotal_integer: 18_00,
 				extra: {
 					domain_bundle_group_id: 'v1.test.deadbeef',
+					domain_bundle_role: 'companion',
 				},
 			} ),
 		];
@@ -1194,11 +1196,11 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			expect( result.current.cart.items ).toEqual( [
 				expect.objectContaining( {
 					uuid: 'bundle-net',
-					bundle: { groupId: 'v1.test.deadbeef', price: '$31' },
+					bundle: { groupId: 'v1.test.deadbeef', price: '$31', isPrimary: false },
 				} ),
 				expect.objectContaining( {
 					uuid: 'bundle-com',
-					bundle: { groupId: 'v1.test.deadbeef', price: '$31' },
+					bundle: { groupId: 'v1.test.deadbeef', price: '$31', isPrimary: true },
 				} ),
 				expect.objectContaining( { uuid: 'standalone', bundle: undefined } ),
 			] );

--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -1141,6 +1141,97 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		} );
 	} );
 
+	describe( 'bundle grouping', () => {
+		const buildBundleCartProducts = () => [
+			buildProduct( {
+				uuid: 'bundle-com',
+				product_slug: 'dotcom_domain',
+				meta: 'my-bundle.com',
+				is_domain_registration: true,
+				item_original_cost_integer: 13_00,
+				item_original_subtotal_integer: 13_00,
+				item_subtotal_integer: 13_00,
+				extra: {
+					domain_bundle_group_id: 'v1.test.deadbeef',
+				},
+			} ),
+			buildProduct( {
+				uuid: 'bundle-net',
+				product_slug: 'dotnet_domain',
+				meta: 'my-bundle.net',
+				is_domain_registration: true,
+				item_original_cost_integer: 18_00,
+				item_original_subtotal_integer: 18_00,
+				item_subtotal_integer: 18_00,
+				extra: {
+					domain_bundle_group_id: 'v1.test.deadbeef',
+				},
+			} ),
+		];
+
+		it( 'attaches the bundle group id and the summed group price to every bundle member', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [
+							...buildBundleCartProducts(),
+							buildProduct( {
+								uuid: 'standalone',
+								product_slug: 'dotorg_domain',
+								meta: 'my-standalone.org',
+								is_domain_registration: true,
+								item_original_cost_integer: 10_00,
+								item_original_subtotal_integer: 10_00,
+								item_subtotal_integer: 10_00,
+							} ),
+						],
+					},
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			expect( result.current.cart.items ).toEqual( [
+				expect.objectContaining( {
+					uuid: 'bundle-net',
+					bundle: { groupId: 'v1.test.deadbeef', price: '$31' },
+				} ),
+				expect.objectContaining( {
+					uuid: 'bundle-com',
+					bundle: { groupId: 'v1.test.deadbeef', price: '$31' },
+				} ),
+				expect.objectContaining( { uuid: 'standalone', bundle: undefined } ),
+			] );
+		} );
+
+		it( 'removes every member of the bundle, and nothing else, in a single cart call', async () => {
+			const replaceProductsInCart = jest.fn().mockResolvedValue( { products: [] } );
+
+			const standaloneProduct = buildProduct( {
+				uuid: 'standalone',
+				product_slug: 'dotorg_domain',
+				meta: 'my-standalone.org',
+				is_domain_registration: true,
+			} );
+
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [ ...buildBundleCartProducts(), standaloneProduct ],
+					},
+					replaceProductsInCart,
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			await result.current.cart.onRemoveBundle?.( 'v1.test.deadbeef' );
+
+			expect( replaceProductsInCart ).toHaveBeenCalledTimes( 1 );
+			expect( replaceProductsInCart ).toHaveBeenCalledWith( [ standaloneProduct ] );
+		} );
+	} );
+
 	describe( 'showBundleSuggestions', () => {
 		it( 'is enabled for a regular flow when the domain-bundling flag is on', () => {
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -17,7 +17,7 @@ import { ComponentProps, useMemo } from 'react';
 const wpcomCartToDomainSearchCart = (
 	domain: ResponseCartProduct,
 	isEffectivelyFree: boolean,
-	bundle?: { groupId: string; price: string }
+	bundle?: { groupId: string; price: string; isPrimary: boolean }
 ) => {
 	const [ domainName, ...tld ] = domain.meta.split( '.' );
 
@@ -146,6 +146,7 @@ export const useWPCOMDomainSearchCart = ( {
 					isSmallestUnit: true,
 					stripZeros: true,
 				} ),
+				isPrimary: item.extra?.domain_bundle_role === 'primary',
 			};
 		};
 

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -14,7 +14,11 @@ import {
 } from '@automattic/shopping-cart';
 import { ComponentProps, useMemo } from 'react';
 
-const wpcomCartToDomainSearchCart = ( domain: ResponseCartProduct, isEffectivelyFree: boolean ) => {
+const wpcomCartToDomainSearchCart = (
+	domain: ResponseCartProduct,
+	isEffectivelyFree: boolean,
+	bundle?: { groupId: string; price: string }
+) => {
 	const [ domainName, ...tld ] = domain.meta.split( '.' );
 
 	const hasPromotion =
@@ -41,6 +45,7 @@ const wpcomCartToDomainSearchCart = ( domain: ResponseCartProduct, isEffectively
 		tld: tld.join( '.' ),
 		salePrice: hasPromotion ? currentPrice : undefined,
 		price: hasPromotion ? originalPrice : currentPrice,
+		bundle,
 	};
 };
 
@@ -114,6 +119,36 @@ export const useWPCOMDomainSearchCart = ( {
 			stripZeros: true,
 		} );
 
+		// Sum each bundle group's current prices so the domain-search cart panel
+		// can render the group as a single row with one price. Bundle members are
+		// never effectively free (they're excluded from the free-domain promo
+		// above), so the sum is simply the members' subtotals.
+		const bundleTotalsByGroup = new Map< string, number >();
+		for ( const item of domainItems ) {
+			const groupId = item.extra?.domain_bundle_group_id;
+			if ( groupId ) {
+				bundleTotalsByGroup.set(
+					groupId,
+					( bundleTotalsByGroup.get( groupId ) ?? 0 ) + item.item_subtotal_integer
+				);
+			}
+		}
+
+		const getBundleForItem = ( item: ResponseCartProduct ) => {
+			const groupId = item.extra?.domain_bundle_group_id;
+			if ( ! groupId ) {
+				return undefined;
+			}
+
+			return {
+				groupId,
+				price: formatCurrency( bundleTotalsByGroup.get( groupId ) ?? 0, item.currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+				} ),
+			};
+		};
+
 		const cart: ComponentProps< typeof DomainSearch >[ 'cart' ] = {
 			items: domainItems.map( ( domainItem ) => {
 				const isCoveredByCredits =
@@ -122,7 +157,8 @@ export const useWPCOMDomainSearchCart = ( {
 					domainItem.meta === firstNonPremiumDomain?.meta;
 				return wpcomCartToDomainSearchCart(
 					domainItem,
-					freeDomainName === domainItem.meta || isCoveredByCredits
+					freeDomainName === domainItem.meta || isCoveredByCredits,
+					getBundleForItem( domainItem )
 				);
 			} ),
 			total,
@@ -209,6 +245,17 @@ export const useWPCOMDomainSearchCart = ( {
 				return cartItems;
 			},
 			onRemoveItem: ( uuid ) => removeProductFromCart( uuid ),
+			onRemoveBundle: ( bundleGroupId ) => {
+				// Remove every member of the bundle in a single cart call so the
+				// removal is all-or-nothing, mirroring how onAddBundle batches the
+				// add. Serial per-member removals could leave orphaned members in
+				// the cart if one of the calls fails.
+				return replaceProductsInCart(
+					responseCart.products.filter(
+						( product ) => product.extra?.domain_bundle_group_id !== bundleGroupId
+					)
+				);
+			},
 		};
 
 		return {

--- a/packages/domain-search/src/components/cart/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/full-cart.tsx
@@ -6,7 +6,10 @@ import {
 	DomainsFullCartItems,
 	DomainsFullCartSkipButton,
 	DomainsFullCartItem,
+	DomainsFullCartBundleItem,
 } from '../../ui';
+import { groupCartItems } from './group-cart-items';
+import type { BundleCartEntry } from './group-cart-items';
 import type { SelectedDomain } from '../../page/types';
 
 const FullCartItem = ( { item }: { item: SelectedDomain } ) => {
@@ -45,6 +48,48 @@ const FullCartItem = ( { item }: { item: SelectedDomain } ) => {
 	);
 };
 
+const FullCartBundle = ( { bundle }: { bundle: BundleCartEntry } ) => {
+	const { cart } = useDomainSearch();
+
+	const { mutationId, isCurrentMutation } = useIsCurrentMutation();
+
+	const {
+		mutate: removeBundleFromCart,
+		isPending,
+		reset,
+		error,
+	} = useMutation( {
+		meta: {
+			mutationId,
+		},
+		mutationFn: () => {
+			// Prefer the app layer's batched all-or-nothing removal; fall back to
+			// removing each member individually when it isn't provided.
+			if ( cart.onRemoveBundle ) {
+				return cart.onRemoveBundle( bundle.groupId );
+			}
+
+			return Promise.all( bundle.members.map( ( member ) => cart.onRemoveItem( member.uuid ) ) );
+		},
+		networkMode: 'always',
+		retry: false,
+	} );
+
+	const isMutating = !! useIsMutating();
+
+	return (
+		<DomainsFullCartBundleItem
+			members={ bundle.members }
+			price={ bundle.price }
+			disabled={ isMutating }
+			isBusy={ isPending }
+			onRemove={ () => removeBundleFromCart() }
+			errorMessage={ isCurrentMutation ? error?.message : undefined }
+			removeErrorMessage={ reset }
+		/>
+	);
+};
+
 export const FullCart = () => {
 	const { cart, isFullCartOpen, closeFullCart, events, slots, config } = useDomainSearch();
 
@@ -64,9 +109,13 @@ export const FullCart = () => {
 		>
 			{ slots?.BeforeFullCartItems && <slots.BeforeFullCartItems /> }
 			<DomainsFullCartItems>
-				{ cart.items.map( ( item ) => (
-					<FullCartItem key={ item.uuid } item={ item } />
-				) ) }
+				{ groupCartItems( cart.items ).map( ( entry ) =>
+					entry.type === 'bundle' ? (
+						<FullCartBundle key={ `bundle-${ entry.groupId }` } bundle={ entry } />
+					) : (
+						<FullCartItem key={ entry.item.uuid } item={ entry.item } />
+					)
+				) }
 			</DomainsFullCartItems>
 			{ config.skippable && (
 				<div>

--- a/packages/domain-search/src/components/cart/group-cart-items.ts
+++ b/packages/domain-search/src/components/cart/group-cart-items.ts
@@ -1,0 +1,82 @@
+import type { SelectedDomain } from '../../page/types';
+
+/**
+ * A single, ungrouped cart item rendered on its own row.
+ */
+export interface SingleCartEntry {
+	type: 'item';
+	item: SelectedDomain;
+}
+
+/**
+ * A set of cart items that belong to the same domain bundle, rendered as one
+ * grouped row with a single summed price and a single remove action.
+ */
+export interface BundleCartEntry {
+	type: 'bundle';
+	groupId: string;
+	price: string;
+	members: SelectedDomain[];
+}
+
+export type CartEntry = SingleCartEntry | BundleCartEntry;
+
+/**
+ * Fold cart items that share a bundle group id into a single grouped entry,
+ * leaving every other item untouched.
+ *
+ * The result preserves cart order: a bundle group appears at the position of
+ * its first member, and ungrouped items stay exactly where they were.
+ *
+ * A "group" of fewer than two surviving members is degenerate (the backend
+ * enforces all-or-nothing membership, so it shouldn't happen) and is rendered
+ * as a plain item rather than as a one-item bundle.
+ * @param items The cart's items, in cart order.
+ * @returns Render entries in cart order: plain items and bundle groups.
+ */
+export function groupCartItems( items: SelectedDomain[] ): CartEntry[] {
+	const membersByGroup = new Map< string, SelectedDomain[] >();
+
+	for ( const item of items ) {
+		const groupId = item.bundle?.groupId;
+
+		if ( ! groupId ) {
+			continue;
+		}
+
+		if ( ! membersByGroup.has( groupId ) ) {
+			membersByGroup.set( groupId, [] );
+		}
+
+		membersByGroup.get( groupId )?.push( item );
+	}
+
+	const entries: CartEntry[] = [];
+	const emittedGroups = new Set< string >();
+
+	for ( const item of items ) {
+		const groupId = item.bundle?.groupId;
+		const members = groupId ? membersByGroup.get( groupId ) ?? [] : [];
+
+		// Group ids that ended up with a single member fall back to plain items.
+		if ( ! groupId || members.length < 2 ) {
+			entries.push( { type: 'item', item } );
+			continue;
+		}
+
+		// Emit the whole bundle once, at the position of its first member.
+		if ( emittedGroups.has( groupId ) ) {
+			continue;
+		}
+
+		emittedGroups.add( groupId );
+		entries.push( {
+			type: 'bundle',
+			groupId,
+			price: item.bundle?.price ?? item.price,
+			members,
+		} );
+	}
+
+	return entries;
+}

--- a/packages/domain-search/src/components/cart/group-cart-items.ts
+++ b/packages/domain-search/src/components/cart/group-cart-items.ts
@@ -10,7 +10,8 @@ export interface SingleCartEntry {
 
 /**
  * A set of cart items that belong to the same domain bundle, rendered as one
- * grouped row with a single summed price and a single remove action.
+ * grouped row with a single summed price and a single remove action. `members`
+ * is ordered primary-first, then companions in their original cart order.
  */
 export interface BundleCartEntry {
 	type: 'bundle';
@@ -26,7 +27,8 @@ export type CartEntry = SingleCartEntry | BundleCartEntry;
  * leaving every other item untouched.
  *
  * The result preserves cart order: a bundle group appears at the position of
- * its first member, and ungrouped items stay exactly where they were.
+ * its first member, and ungrouped items stay exactly where they were. Within a
+ * group, the primary member is listed first, then companions in cart order.
  *
  * A "group" of fewer than two surviving members is degenerate (the backend
  * enforces all-or-nothing membership, so it shouldn't happen) and is rendered
@@ -55,28 +57,43 @@ export function groupCartItems( items: SelectedDomain[] ): CartEntry[] {
 	const emittedGroups = new Set< string >();
 
 	for ( const item of items ) {
-		const groupId = item.bundle?.groupId;
-		const members = groupId ? membersByGroup.get( groupId ) ?? [] : [];
+		const bundle = item.bundle;
+		const members = bundle ? membersByGroup.get( bundle.groupId ) ?? [] : [];
 
 		// Group ids that ended up with a single member fall back to plain items.
-		if ( ! groupId || members.length < 2 ) {
+		if ( ! bundle || members.length < 2 ) {
 			entries.push( { type: 'item', item } );
 			continue;
 		}
 
 		// Emit the whole bundle once, at the position of its first member.
-		if ( emittedGroups.has( groupId ) ) {
+		if ( emittedGroups.has( bundle.groupId ) ) {
 			continue;
 		}
 
-		emittedGroups.add( groupId );
+		emittedGroups.add( bundle.groupId );
 		entries.push( {
 			type: 'bundle',
-			groupId,
-			price: item.bundle?.price ?? item.price,
-			members,
+			groupId: bundle.groupId,
+			price: bundle.price,
+			members: orderBundleMembers( members ),
 		} );
 	}
 
 	return entries;
+}
+
+/**
+ * Order a bundle's members primary-first, preserving the original cart order
+ * for everything else, mirroring `orderBundleMembers` in wpcom-checkout's
+ * `groupBundleLineItems` so the panel lists members in the same order as the
+ * masterbar mini-cart and checkout surfaces.
+ * @param members The bundle's members, in cart order.
+ * @returns The members with the primary role moved to the front.
+ */
+function orderBundleMembers( members: SelectedDomain[] ): SelectedDomain[] {
+	const primaries = members.filter( ( member ) => member.bundle?.isPrimary );
+	const rest = members.filter( ( member ) => ! member.bundle?.isPrimary );
+
+	return [ ...primaries, ...rest ];
 }

--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -1,12 +1,21 @@
 /**
  * @jest-environment jsdom
  */
-import { getByRole, getByText, queryByText, render, screen, waitFor } from '@testing-library/react';
+import {
+	getAllByRole,
+	getByLabelText,
+	getByRole,
+	getByText,
+	queryByText,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useEffect } from 'react';
 import { useDomainSearch } from '../../../page/context';
-import { buildCartItem } from '../../../test-helpers/factories/cart';
-import { TestDomainSearchWithCart } from '../../../test-helpers/renderer';
+import { buildCart, buildCartItem } from '../../../test-helpers/factories/cart';
+import { TestDomainSearch, TestDomainSearchWithCart } from '../../../test-helpers/renderer';
 import { FullCart } from '../full-cart';
 
 const OpenFullCart = () => {
@@ -317,5 +326,170 @@ describe( 'FullCart', () => {
 		);
 
 		expect( await screen.findByText( 'Before Full Cart Items' ) ).toBeInTheDocument();
+	} );
+
+	describe( 'bundle grouping', () => {
+		const buildBundleMembers = () => [
+			buildCartItem( {
+				uuid: '1',
+				domain: 'example',
+				tld: 'com',
+				salePrice: undefined,
+				price: '$22',
+				bundle: { groupId: 'group-1', price: '$40' },
+			} ),
+			buildCartItem( {
+				uuid: '2',
+				domain: 'example',
+				tld: 'net',
+				salePrice: undefined,
+				price: '$18',
+				bundle: { groupId: 'group-1', price: '$40' },
+			} ),
+		];
+
+		it( 'renders items sharing a bundle group as one row with the members, one summed price and one remove action', async () => {
+			render(
+				<TestDomainSearchWithCart initialCartItems={ buildBundleMembers() }>
+					<OpenFullCart />
+					<FullCart />
+				</TestDomainSearchWithCart>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Cart' ) ).toBeVisible();
+			} );
+
+			const bundleRow = await screen.findByTitle( 'Domain bundle' );
+
+			expect( getByLabelText( bundleRow, 'example.com' ) ).toBeInTheDocument();
+			expect( getByLabelText( bundleRow, 'example.net' ) ).toBeInTheDocument();
+
+			expect( getByLabelText( bundleRow, 'Price: $40' ) ).toBeInTheDocument();
+			expect( queryByText( bundleRow, '$22' ) ).not.toBeInTheDocument();
+			expect( queryByText( bundleRow, '$18' ) ).not.toBeInTheDocument();
+
+			expect( getAllByRole( bundleRow, 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
+		} );
+
+		it( 'renders standalone items on their own rows next to a bundle', async () => {
+			render(
+				<TestDomainSearchWithCart
+					initialCartItems={ [
+						...buildBundleMembers(),
+						buildCartItem( {
+							uuid: '3',
+							domain: 'standalone',
+							tld: 'org',
+							salePrice: undefined,
+							price: '$10',
+						} ),
+					] }
+				>
+					<OpenFullCart />
+					<FullCart />
+				</TestDomainSearchWithCart>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Cart' ) ).toBeVisible();
+			} );
+
+			expect( await screen.findByTitle( 'Domain bundle' ) ).toBeInTheDocument();
+
+			const standaloneRow = await screen.findByTitle( 'standalone.org' );
+			expect( getByLabelText( standaloneRow, 'Price: $10' ) ).toBeInTheDocument();
+
+			// One remove action for the bundle, one for the standalone item.
+			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 2 );
+		} );
+
+		it( 'removes the whole bundle, and only the bundle, with a single remove action', async () => {
+			const fireEvent = userEvent.setup();
+
+			render(
+				<TestDomainSearchWithCart
+					initialCartItems={ [
+						...buildBundleMembers(),
+						buildCartItem( { uuid: '3', domain: 'standalone', tld: 'org' } ),
+					] }
+				>
+					<OpenFullCart />
+					<FullCart />
+				</TestDomainSearchWithCart>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Cart' ) ).toBeVisible();
+			} );
+
+			const bundleRow = await screen.findByTitle( 'Domain bundle' );
+
+			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove' } ) );
+
+			await waitFor( () => {
+				expect( screen.queryByTitle( 'Domain bundle' ) ).not.toBeInTheDocument();
+			} );
+
+			expect( screen.queryByLabelText( 'example.com' ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( 'example.net' ) ).not.toBeInTheDocument();
+			expect( screen.getByTitle( 'standalone.org' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls back to removing each member individually when onRemoveBundle is not provided', async () => {
+			const fireEvent = userEvent.setup();
+			const onRemoveItem = jest.fn().mockResolvedValue( undefined );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: buildBundleMembers(),
+						onRemoveItem,
+						onRemoveBundle: undefined,
+					} ) }
+				>
+					<OpenFullCart />
+					<FullCart />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Cart' ) ).toBeVisible();
+			} );
+
+			const bundleRow = await screen.findByTitle( 'Domain bundle' );
+
+			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove' } ) );
+
+			await waitFor( () => {
+				expect( onRemoveItem ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			expect( onRemoveItem ).toHaveBeenCalledWith( '1' );
+			expect( onRemoveItem ).toHaveBeenCalledWith( '2' );
+		} );
+
+		it( 'renders a degenerate single-member group as a plain item', async () => {
+			render(
+				<TestDomainSearchWithCart
+					initialCartItems={ [
+						buildCartItem( {
+							uuid: '1',
+							domain: 'example',
+							tld: 'com',
+							salePrice: undefined,
+							price: '$22',
+							bundle: { groupId: 'group-1', price: '$40' },
+						} ),
+					] }
+				>
+					<OpenFullCart />
+					<FullCart />
+				</TestDomainSearchWithCart>
+			);
+
+			expect( await screen.findByTitle( 'example.com' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'Domain bundle' ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -404,6 +404,55 @@ describe( 'FullCart', () => {
 			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 2 );
 		} );
 
+		it( 'renders two bundles as two separate grouped rows', async () => {
+			render(
+				<TestDomainSearchWithCart
+					initialCartItems={ [
+						...buildBundleMembers(),
+						buildCartItem( {
+							uuid: '3',
+							domain: 'other',
+							tld: 'com',
+							salePrice: undefined,
+							price: '$12',
+							bundle: { groupId: 'group-2', price: '$25' },
+						} ),
+						buildCartItem( {
+							uuid: '4',
+							domain: 'other',
+							tld: 'net',
+							salePrice: undefined,
+							price: '$13',
+							bundle: { groupId: 'group-2', price: '$25' },
+						} ),
+					] }
+				>
+					<OpenFullCart />
+					<FullCart />
+				</TestDomainSearchWithCart>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Cart' ) ).toBeVisible();
+			} );
+
+			const bundleRows = await screen.findAllByTitle( 'Domain bundle' );
+			expect( bundleRows ).toHaveLength( 2 );
+
+			const [ firstBundle, secondBundle ] = bundleRows;
+
+			expect( getByLabelText( firstBundle, 'example.com' ) ).toBeInTheDocument();
+			expect( getByLabelText( firstBundle, 'example.net' ) ).toBeInTheDocument();
+			expect( getByLabelText( firstBundle, 'Price: $40' ) ).toBeInTheDocument();
+
+			expect( getByLabelText( secondBundle, 'other.com' ) ).toBeInTheDocument();
+			expect( getByLabelText( secondBundle, 'other.net' ) ).toBeInTheDocument();
+			expect( getByLabelText( secondBundle, 'Price: $25' ) ).toBeInTheDocument();
+
+			// One remove action per bundle.
+			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 2 );
+		} );
+
 		it( 'removes the whole bundle, and only the bundle, with a single remove action', async () => {
 			const fireEvent = userEvent.setup();
 

--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -369,7 +369,7 @@ describe( 'FullCart', () => {
 			expect( queryByText( bundleRow, '$22' ) ).not.toBeInTheDocument();
 			expect( queryByText( bundleRow, '$18' ) ).not.toBeInTheDocument();
 
-			expect( getAllByRole( bundleRow, 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
+			expect( getAllByRole( bundleRow, 'button', { name: 'Remove bundle' } ) ).toHaveLength( 1 );
 		} );
 
 		it( 'renders standalone items on their own rows next to a bundle', async () => {
@@ -401,7 +401,8 @@ describe( 'FullCart', () => {
 			expect( getByLabelText( standaloneRow, 'Price: $10' ) ).toBeInTheDocument();
 
 			// One remove action for the bundle, one for the standalone item.
-			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 2 );
+			expect( await screen.findAllByRole( 'button', { name: 'Remove bundle' } ) ).toHaveLength( 1 );
+			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
 		} );
 
 		it( 'renders two bundles as two separate grouped rows', async () => {
@@ -450,7 +451,7 @@ describe( 'FullCart', () => {
 			expect( getByLabelText( secondBundle, 'Price: $25' ) ).toBeInTheDocument();
 
 			// One remove action per bundle.
-			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 2 );
+			expect( await screen.findAllByRole( 'button', { name: 'Remove bundle' } ) ).toHaveLength( 2 );
 		} );
 
 		it( 'removes the whole bundle, and only the bundle, with a single remove action', async () => {
@@ -474,7 +475,7 @@ describe( 'FullCart', () => {
 
 			const bundleRow = await screen.findByTitle( 'Domain bundle' );
 
-			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove' } ) );
+			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove bundle' } ) );
 
 			await waitFor( () => {
 				expect( screen.queryByTitle( 'Domain bundle' ) ).not.toBeInTheDocument();
@@ -508,7 +509,7 @@ describe( 'FullCart', () => {
 
 			const bundleRow = await screen.findByTitle( 'Domain bundle' );
 
-			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove' } ) );
+			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove bundle' } ) );
 
 			await waitFor( () => {
 				expect( onRemoveItem ).toHaveBeenCalledTimes( 2 );

--- a/packages/domain-search/src/components/cart/test/group-cart-items.ts
+++ b/packages/domain-search/src/components/cart/test/group-cart-items.ts
@@ -1,0 +1,69 @@
+import { buildCartItem } from '../../../test-helpers/factories/cart';
+import { groupCartItems } from '../group-cart-items';
+
+describe( 'groupCartItems', () => {
+	it( 'leaves items without bundle metadata untouched', () => {
+		const items = [
+			buildCartItem( { uuid: '1', domain: 'one', tld: 'com' } ),
+			buildCartItem( { uuid: '2', domain: 'two', tld: 'com' } ),
+		];
+
+		expect( groupCartItems( items ) ).toEqual( [
+			{ type: 'item', item: items[ 0 ] },
+			{ type: 'item', item: items[ 1 ] },
+		] );
+	} );
+
+	it( 'folds items sharing a bundle group into a single entry at the first member position', () => {
+		const memberCom = buildCartItem( {
+			uuid: '1',
+			domain: 'example',
+			tld: 'com',
+			bundle: { groupId: 'group-1', price: '$40' },
+		} );
+		const standalone = buildCartItem( { uuid: '2', domain: 'standalone', tld: 'org' } );
+		const memberNet = buildCartItem( {
+			uuid: '3',
+			domain: 'example',
+			tld: 'net',
+			bundle: { groupId: 'group-1', price: '$40' },
+		} );
+
+		expect( groupCartItems( [ memberCom, standalone, memberNet ] ) ).toEqual( [
+			{
+				type: 'bundle',
+				groupId: 'group-1',
+				price: '$40',
+				members: [ memberCom, memberNet ],
+			},
+			{ type: 'item', item: standalone },
+		] );
+	} );
+
+	it( 'keeps distinct bundle groups separate', () => {
+		const firstGroupMembers = [
+			buildCartItem( { uuid: '1', bundle: { groupId: 'group-1', price: '$40' } } ),
+			buildCartItem( { uuid: '2', bundle: { groupId: 'group-1', price: '$40' } } ),
+		];
+		const secondGroupMembers = [
+			buildCartItem( { uuid: '3', bundle: { groupId: 'group-2', price: '$30' } } ),
+			buildCartItem( { uuid: '4', bundle: { groupId: 'group-2', price: '$30' } } ),
+		];
+
+		expect( groupCartItems( [ ...firstGroupMembers, ...secondGroupMembers ] ) ).toEqual( [
+			{ type: 'bundle', groupId: 'group-1', price: '$40', members: firstGroupMembers },
+			{ type: 'bundle', groupId: 'group-2', price: '$30', members: secondGroupMembers },
+		] );
+	} );
+
+	it( 'renders a degenerate single-member group as a plain item', () => {
+		const lonelyMember = buildCartItem( {
+			uuid: '1',
+			bundle: { groupId: 'group-1', price: '$40' },
+		} );
+
+		expect( groupCartItems( [ lonelyMember ] ) ).toEqual( [
+			{ type: 'item', item: lonelyMember },
+		] );
+	} );
+} );

--- a/packages/domain-search/src/components/cart/test/group-cart-items.ts
+++ b/packages/domain-search/src/components/cart/test/group-cart-items.ts
@@ -40,6 +40,30 @@ describe( 'groupCartItems', () => {
 		] );
 	} );
 
+	it( 'lists the primary member first even when a companion precedes it in cart order', () => {
+		const companion = buildCartItem( {
+			uuid: '1',
+			domain: 'example',
+			tld: 'net',
+			bundle: { groupId: 'group-1', price: '$40', isPrimary: false },
+		} );
+		const primary = buildCartItem( {
+			uuid: '2',
+			domain: 'example',
+			tld: 'com',
+			bundle: { groupId: 'group-1', price: '$40', isPrimary: true },
+		} );
+
+		expect( groupCartItems( [ companion, primary ] ) ).toEqual( [
+			{
+				type: 'bundle',
+				groupId: 'group-1',
+				price: '$40',
+				members: [ primary, companion ],
+			},
+		] );
+	} );
+
 	it( 'keeps distinct bundle groups separate', () => {
 		const firstGroupMembers = [
 			buildCartItem( { uuid: '1', bundle: { groupId: 'group-1', price: '$40' } } ),

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -24,6 +24,18 @@ export interface SelectedDomain {
 	tld: string;
 	salePrice?: string;
 	price: string;
+	/**
+	 * Bundle membership, present only when the item was added to the cart as
+	 * part of a domain bundle. `groupId` is the server-issued bundle group id,
+	 * passed through verbatim by the app layer; items sharing a `groupId` are
+	 * rendered as a single grouped cart row. `price` is the formatted sum of
+	 * the bundle members' current prices, computed and formatted at the app
+	 * layer (the same value for every member of the group).
+	 */
+	bundle?: {
+		groupId: string;
+		price: string;
+	};
 }
 
 export interface DomainSearchCart {
@@ -37,6 +49,12 @@ export interface DomainSearchCart {
 	 */
 	onAddBundle?: ( bundle: BundleSuggestion ) => Promise< unknown >;
 	onRemoveItem: ( uuid: string ) => Promise< unknown >;
+	/**
+	 * Remove every member of a bundle group from the cart in a single,
+	 * all-or-nothing operation. Implemented at the app layer; when absent the
+	 * grouped cart row falls back to removing each member individually.
+	 */
+	onRemoveBundle?: ( bundleGroupId: string ) => Promise< unknown >;
 	hasItem: ( domainName: string ) => boolean;
 }
 

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -30,11 +30,14 @@ export interface SelectedDomain {
 	 * passed through verbatim by the app layer; items sharing a `groupId` are
 	 * rendered as a single grouped cart row. `price` is the formatted sum of
 	 * the bundle members' current prices, computed and formatted at the app
-	 * layer (the same value for every member of the group).
+	 * layer (the same value for every member of the group). `isPrimary` marks
+	 * the bundle's anchor domain so the grouped row can list it first,
+	 * matching the masterbar mini-cart and checkout member ordering.
 	 */
 	bundle?: {
 		groupId: string;
 		price: string;
+		isPrimary?: boolean;
 	};
 }
 
@@ -52,7 +55,10 @@ export interface DomainSearchCart {
 	/**
 	 * Remove every member of a bundle group from the cart in a single,
 	 * all-or-nothing operation. Implemented at the app layer; when absent the
-	 * grouped cart row falls back to removing each member individually.
+	 * grouped cart row falls back to removing each member individually. That
+	 * fallback is not all-or-nothing — a failed member removal can leave the
+	 * rest of the group orphaned in the cart — so consumers should provide
+	 * this callback whenever their cart backend can batch the removal.
 	 */
 	onRemoveBundle?: ( bundleGroupId: string ) => Promise< unknown >;
 	hasItem: ( domainName: string ) => boolean;

--- a/packages/domain-search/src/test-helpers/factories/cart.ts
+++ b/packages/domain-search/src/test-helpers/factories/cart.ts
@@ -7,6 +7,7 @@ export const buildCart = ( overrides: Partial< DomainSearchCart > = {} ): Domain
 		onAddItem: jest.fn(),
 		onAddBundle: jest.fn(),
 		onRemoveItem: jest.fn(),
+		onRemoveBundle: jest.fn(),
 		hasItem: jest.fn(),
 		...overrides,
 	};

--- a/packages/domain-search/src/test-helpers/renderer.tsx
+++ b/packages/domain-search/src/test-helpers/renderer.tsx
@@ -97,6 +97,21 @@ export const TestDomainSearchWithCart = ( {
 
 					return Promise.resolve();
 				},
+				onRemoveBundle: async ( bundleGroupId ) => {
+					if ( operationPromise ) {
+						try {
+							await operationPromise;
+						} catch ( error ) {
+							return Promise.reject( error );
+						}
+					}
+
+					setTimeout( () => {
+						setItems( items.filter( ( item ) => item.bundle?.groupId !== bundleGroupId ) );
+					}, 0 );
+
+					return Promise.resolve();
+				},
 			} ) }
 		>
 			{ children }

--- a/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
@@ -1,0 +1,101 @@
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+	Notice,
+} from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import type { DomainInCart } from './types';
+
+/**
+ * Render a domain bundle as a single grouped cart row: a "Domain bundle"
+ * label, the member domains listed beneath it, one summed price, and a single
+ * remove action that clears every member from the cart at once (matching the
+ * backend's all-or-nothing rule).
+ */
+export const DomainsFullCartBundleItem = ( {
+	members,
+	price,
+	disabled,
+	isBusy,
+	onRemove,
+	errorMessage,
+	removeErrorMessage,
+}: {
+	members: DomainInCart[];
+	price: string;
+	disabled: boolean;
+	isBusy: boolean;
+	onRemove: () => void;
+	errorMessage?: string;
+	removeErrorMessage: () => void;
+} ) => {
+	const { __ } = useI18n();
+
+	const bundleLabel = __( 'Domain bundle' );
+
+	return (
+		<Card title={ bundleLabel }>
+			<CardBody size="small">
+				<VStack spacing={ 4 }>
+					<HStack alignment="top" justify="space-between" spacing={ 6 }>
+						<VStack spacing={ 2 } alignment="left">
+							<Text size="medium" weight={ 500 }>
+								{ bundleLabel }
+							</Text>
+							{ members.map( ( member ) => {
+								const domainName = `${ member.domain }.${ member.tld }`;
+
+								return (
+									<Text
+										key={ member.uuid }
+										size="medium"
+										aria-label={ domainName }
+										style={ { wordBreak: 'break-all' } }
+									>
+										{ member.domain }
+										<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
+											.{ member.tld }
+										</Text>
+									</Text>
+								);
+							} ) }
+							<Button
+								disabled={ disabled }
+								isBusy={ isBusy }
+								variant="link"
+								className="domains-full-cart-items__remove"
+								onClick={ onRemove }
+							>
+								{ __( 'Remove' ) }
+							</Button>
+						</VStack>
+						<VStack className="domains-full-cart-items__price">
+							<HStack alignment="right" spacing={ 2 }>
+								<Text
+									size="small"
+									aria-label={ sprintf(
+										// translators: %(price)s is the total price of the domain bundle.
+										__( 'Price: %(price)s' ),
+										{ price }
+									) }
+								>
+									{ price }
+								</Text>
+							</HStack>
+						</VStack>
+					</HStack>
+					{ errorMessage && (
+						<Notice status="error" onRemove={ removeErrorMessage }>
+							{ errorMessage }
+						</Notice>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+};

--- a/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
@@ -71,7 +71,7 @@ export const DomainsFullCartBundleItem = ( {
 								className="domains-full-cart-items__remove"
 								onClick={ onRemove }
 							>
-								{ __( 'Remove' ) }
+								{ __( 'Remove bundle' ) }
 							</Button>
 						</VStack>
 						<VStack className="domains-full-cart-items__price">

--- a/packages/domain-search/src/ui/index.ts
+++ b/packages/domain-search/src/ui/index.ts
@@ -5,6 +5,7 @@ export { DomainsMiniCart } from './domains-mini-cart';
 export { DomainsFullCart } from './domains-full-cart';
 export { DomainsFullCartItems } from './domains-full-cart-items';
 export { DomainsFullCartItem } from './domains-full-cart-items/item';
+export { DomainsFullCartBundleItem } from './domains-full-cart-items/bundle';
 export { DomainsFullCartSkipButton } from './domains-full-cart-skip-button';
 export { DomainSuggestionsList } from './domain-suggestions-list';
 export { FeaturedDomainSuggestionsList } from './featured-domain-suggestions-list';


### PR DESCRIPTION
Related to DOMAINS-2191

## Proposed Changes

<img width="876" height="966" alt="CleanShot 2026-06-11 at 11 27 58@2x" src="https://github.com/user-attachments/assets/100559ef-f04c-4ddb-aa5f-4f37524b18f9" />


The domain-search page's sliding "Cart" sidebar panel showed bundle members as individual flat rows with individual Remove links — every manual tester so far has read that as a bug. DOMAINS-2171 grouped the masterbar mini-cart and checkout order review but this panel was never in scope. This PR groups it:

- **One bundle row per group**: "Domain bundle" label, member domains listed, a single summed price, and a single Remove action.
- `SelectedDomain` gains an optional `bundle?: { groupId: string; price: string }` — `groupId` is the server-issued `extra.domain_bundle_group_id` passed through verbatim; `price` is the formatted summed group price, computed at the app layer (sum of members' `item_subtotal_integer`, formatted identically to the panel's footer total). No currency math in the package.
- `DomainSearchCart` gains an optional `onRemoveBundle( bundleGroupId )`, mirroring `onAddBundle`. The app layer implements it as **one** `replaceProductsInCart` call (products minus the group's members) — serial per-member removals can strand orphans when the server flag is off, since the all-or-nothing invariant only sweeps incomplete groups when the flag is on. The package falls back to per-member `onRemoveItem` if a consumer omits the callback.
- Grouping applies **whenever bundle metadata is present** — deliberately not gated on `showBundleSuggestions`. That flag gates *offering* bundles; a bundle already in the cart should never render ungrouped (that misread is exactly what this PR exists to fix). The metadata only exists when the server flag issued it. Single-member groups degenerate to plain rows, mirroring `groupBundleLineItems` in wpcom-checkout.
- No remove confirmation, matching the panel's existing per-item remove UX (the checkout `BundleLineItem` modal belongs to checkout's visual language, not this surface).
- No term selector (locked decision), no analytics in the package, no strikethrough (that's #111518's pattern for the mini-cart/checkout surfaces).

## Testing Instructions

```
yarn test-packages packages/domain-search
yarn test-client client/components/domains/wpcom-domain-search
```

New coverage: grouping-helper unit tests; FullCart renders one bundle row with members/summed price/single remove; mixed bundle + standalone cart; whole-bundle removal in one batched call; per-member fallback; degenerate single-member group.

### Manual (sandbox required)

Prerequisites: `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` on your sandbox, `public-api.wordpress.com` sandboxed, logged in, `?flags=domain-bundling` on every page load. This branch includes #111519, so the full flow works.

1. Search a clearly-unregistered domain with a bundle-eligible TLD (.com/.net/.org/.co/.blog/.me/.inc/.llc), e.g. `mytestdomain789.com`.
2. Click **Get bundle** on the suggestion card.
3. Open the sidebar Cart panel: the members render as **one "Domain bundle" row** — domains listed, one summed (discounted) price, one Remove link. No per-member rows, no per-member Removes.
4. Add a standalone domain from the regular suggestions — it renders as a normal individual row alongside the bundle row.
5. Click the bundle row's **Remove** → all members leave the cart in a single operation (Network tab: one cart POST, not N). The standalone domain stays.
6. Footer total and the free-domain promo behave as on the base branch (the promo never lands on a bundle member; account credits may zero the footer total — pre-existing display).
