### PR TITLE
A4A: Fix localized WordPress.com URL 404 on "Prepare for launch"

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -70,6 +70,7 @@ export default function LicenseActions( {
 						<PopoverMenuItem
 							key={ action.name }
 							isExternalLink={ action?.isExternalLink }
+							localizeUrl={ false }
 							onClick={ () => handleActionClick( action ) }
 							href={ action?.href }
 							className={ action?.className }


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2686/a4a-dashboard-prepare-for-launch-uses-localized-wordpresscom-url-and

## Proposed Changes

* Pass `localizeUrl={ false }` to the `PopoverMenuItem` that renders the licenses-preview actions popover, so external links like "Prepare for launch" are no longer localized.

## Why are these changes being made?

The "Prepare for launch" action hardcodes a clean, locale-free URL (`https://wordpress.com/sites/{site}/settings/site-visibility`), but it is rendered through `PopoverMenuItem` with `isExternalLink`, which delegates to `<ExternalLink>`. That component localizes the `href` by default. For non-English accounts (e.g. Spanish), this rewrites the URL to include a locale prefix:

`https://wordpress.com/es/sites/{site}/settings/site-visibility/`

which returns a 404, blocking non-English agencies from launching development sites.

This is the same class of bug previously fixed for the sites actions popover in #94856, but the identical pattern in the licenses preview actions was missed. The sites DataViews "Prepare for launch" action is unaffected because it uses `window.open()` with the clean URL.

## Testing Instructions

1. Set the account/interface language to a non-English locale (e.g. Spanish).
2. Go to the A4A licenses page and open the actions menu for a development-site license.
3. Click "Prepare for launch".
4. Confirm the destination URL is `https://wordpress.com/sites/{site}/settings/site-visibility` (no `/es/` prefix) and loads the site visibility settings instead of a 404.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)