### PR TITLE
Notifications: page load-more with a `before` cursor instead of a growing window

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -31,7 +31,7 @@ const DEFAULT_LAYOUTS = {
 // window (`perPage` rows) must be tall enough to overflow the panel and
 // produce a scrollbar. It must also match the REST client's `increment_limit`
 // so the window never advances past the notes already fetched.
-const NOTES_PER_PAGE = 20;
+const NOTES_PER_PAGE = 10;
 
 type NoteListProps = {
 	filterName: FilterName;

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -28,10 +28,11 @@ const DEFAULT_LAYOUTS = {
 };
 
 // DataViews 14 only loads more in response to scroll events, so the rendered
-// window (`perPage` rows) must be tall enough to overflow the panel and
-// produce a scrollbar. It must also match the REST client's `increment_limit`
-// so the window never advances past the notes already fetched.
-const NOTES_PER_PAGE = 10;
+// window (`perPage` rows) must be tall enough to overflow the panel and produce
+// a scrollbar. The REST client may fetch smaller network pages
+// (`increment_limit`); the effect below loads as many as needed to fill this
+// window, so it never outruns the loaded notes.
+const NOTES_PER_PAGE = 20;
 
 type NoteListProps = {
 	filterName: FilterName;
@@ -80,6 +81,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	} );
 
 	const view = { ...initialView, perPage: NOTES_PER_PAGE };
+	const startPosition = view.startPosition ?? 1;
 
 	const fields = getFields();
 
@@ -107,30 +109,20 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		}
 	}, [ client, isLoading ] );
 
-	// Bootstrap: keep loading until enough notes exist to fill a window and
-	// overflow the panel. Without this the initial batch can be too short to
-	// produce a scrollbar, and scroll-driven loading would never start.
+	// Keep enough notes loaded to cover the current scroll window, and to
+	// overflow the panel on first paint so a scrollbar exists for DataViews to
+	// drive further loading. A network page (`increment_limit`) can be smaller
+	// than this window, so fetch one page at a time until the window is filled or
+	// the server runs out — re-runs after each page as `visibleNotes` grows.
 	useEffect( () => {
-		if ( visibleNotes.length <= NOTES_PER_PAGE && ! isLoading ) {
+		if ( startPosition + NOTES_PER_PAGE > visibleNotes.length && ! isLoading && hasMoreNotes ) {
 			infiniteScrollHandler();
 		}
-	}, [ visibleNotes.length, isLoading, infiniteScrollHandler ] );
+	}, [ startPosition, visibleNotes.length, isLoading, hasMoreNotes, infiniteScrollHandler ] );
 
-	const handleChangeView = useCallback(
-		( nextView: View ) => {
-			setView( nextView );
-
-			// DataViews drives infinite scroll by advancing `startPosition`.
-			// Load more notes once the scroll window nears the end of those
-			// already loaded.
-			const start = nextView.startPosition ?? 1;
-			const perPage = nextView.perPage ?? NOTES_PER_PAGE;
-			if ( start + perPage > visibleNotes.length ) {
-				infiniteScrollHandler();
-			}
-		},
-		[ visibleNotes.length, infiniteScrollHandler ]
-	);
+	// DataViews drives infinite scroll by advancing `startPosition`; the effect
+	// above reacts to that and loads more as the window nears the loaded notes.
+	const handleChangeView = useCallback( ( nextView: View ) => setView( nextView ), [] );
 
 	const noteListRef = useRef< HTMLObjectElement >( null );
 

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -26,6 +26,12 @@ export function Client() {
 	this.isShowing = false;
 	this.lastSeenTime = 0;
 	this.noteRequestLimit = settings.initial_limit;
+	// Load-more pages backwards in time from the oldest loaded note (see
+	// getOlderNotes), so a separate in-flight guard keeps it from overlapping
+	// the polling path. `allNotesLoaded` latches once the server reports no
+	// older notes remain, stopping further paging.
+	this.gettingOlderNotes = false;
+	this.allNotesLoaded = false;
 	this.retries = 0;
 	this.subscribeTry = 0;
 	this.subscribeTries = 3;
@@ -209,7 +215,19 @@ function getNotes() {
 		const newNotes = data.notes.map( ( n ) => n.id );
 		const notesToRemove = oldNotes.filter( ( old ) => ! newNotes.includes( old ) );
 
-		notesToRemove.length && store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+		// A short window means the server has nothing older than what we hold, so
+		// stop load-more from paging further. Only ever latch it true here: a full
+		// window can't prove more exist, and unlatching is the pruning case below.
+		if ( data.notes.length < parameters.number ) {
+			this.allNotesLoaded = true;
+		}
+
+		// Pruning means new notes pushed older ones out of this top window, so
+		// notes we'd paged in may sit below it again — let load-more re-page them.
+		if ( notesToRemove.length ) {
+			this.allNotesLoaded = false;
+			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+		}
 		store.dispatch( actions.notes.addNotes( data.notes ) );
 
 		// Store id/hash pairs for now until properly reduxified
@@ -283,6 +301,9 @@ function getNotesList() {
 		const notesToRemove = localIds.filter( ( local ) => ! serverIds.includes( local ) );
 
 		if ( notesToRemove.length ) {
+			// The polling window shifted, so notes we'd paged in may sit below it
+			// again — let load-more re-page them (mirrors getNotes()).
+			this.allNotesLoaded = false;
 			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
 		}
 
@@ -295,6 +316,72 @@ function getNotesList() {
 
 		/* Grab updates/changes from server if they exist */
 		return serverHasChanges ? this.getNotes() : ready.call( this );
+	} );
+}
+
+/**
+ * Page backwards in time to load notes older than those already cached.
+ *
+ * Unlike the polling path (getNotes/getNotesList), which re-fetches the top
+ * window and treats its response as the authoritative set, this walks a fixed
+ * `before` cursor down the list and is purely additive: it never prunes, since
+ * an older slice is not a superset of what's loaded. It anchors on the oldest
+ * cached note's server timestamp (echoed back verbatim, no reformatting) and
+ * stops once a short page proves the server has nothing older.
+ */
+function getOlderNotes() {
+	if ( this.gettingOlderNotes ) {
+		return;
+	}
+
+	// getAllNotes is sorted newest-first, so the last entry is the oldest loaded
+	// note and the cursor for the next page. Without one there's nothing to page
+	// from; the initial getNotes seeds the list.
+	const notes = getAllNotes( store.getState() );
+	const oldest = notes[ notes.length - 1 ];
+	if ( ! oldest ) {
+		return;
+	}
+	this.gettingOlderNotes = true;
+
+	const parameters = {
+		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
+		number: settings.increment_limit,
+		before: oldest.timestamp,
+		locale: this.locale,
+	};
+
+	store.dispatch( actions.ui.loadNotes() );
+
+	listNotes( parameters, ( error, data ) => {
+		this.gettingOlderNotes = false;
+		store.dispatch( actions.ui.loadedNotes() );
+
+		if ( error ) {
+			// Leave pagination state untouched; scrolling again retries the page.
+			return;
+		}
+
+		// Additive only — never prune here (see the function comment).
+		store.dispatch( actions.notes.addNotes( data.notes ) );
+
+		// Mirror the new ids into the lightweight note-hash list the polling diff
+		// compares against, so the next getNotesList() doesn't see this page as a
+		// server-side change and trigger a redundant full getNotes(). The next
+		// poll overwrites this list wholesale, so any drift self-heals.
+		this.noteList = this.noteList.concat(
+			data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) )
+		);
+
+		// A short page (fewer than requested) means the server is exhausted. This
+		// compares the raw response count to the request, so it holds whether the
+		// `before` boundary is inclusive (the anchor note returns again, deduped
+		// by id on add) or exclusive.
+		if ( data.notes.length < parameters.number ) {
+			this.allNotesLoaded = true;
+		}
+
+		ready.call( this );
 	} );
 }
 
@@ -458,31 +545,29 @@ function handleStorageEvent( event ) {
 }
 
 function loadMore() {
-	const notes = getAllNotes( store.getState() );
-	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
-		// we're already attempting to load more notes
+	if ( this.gettingOlderNotes || ! this.hasMoreNotes() ) {
 		return;
-	}
-	if ( this.noteRequestLimit >= settings.max_limit ) {
-		return;
-	}
-	this.noteRequestLimit = this.noteRequestLimit + settings.increment_limit;
-	if ( this.noteRequestLimit > settings.max_limit ) {
-		this.noteRequestLimit = settings.max_limit;
 	}
 
-	this.getNotes();
+	// Grow the polling window so getNotes()/getNotesList() keep covering every
+	// note we've paged in — their diff treats the response as the full set, so a
+	// window shorter than the loaded list would prune the older notes back out.
+	this.noteRequestLimit = Math.min(
+		this.noteRequestLimit + settings.increment_limit,
+		settings.max_limit
+	);
+
+	this.getOlderNotes();
 }
 
-// Whether the server may still have notes beyond those already loaded.
-// A fully-filled request (`notes.length >= noteRequestLimit`) means the
-// server had at least that many, so requesting more could yield more;
-// a short response means the server is exhausted. The window-driven note
-// list uses this to keep its optimistic `totalItems` ahead of the scroll
-// window so DataViews keeps advancing it.
+// Whether the server may still have notes older than those already loaded.
+// `allNotesLoaded` latches once a short page (or short polling window) proves
+// the server is exhausted; until then there may be more, capped at max_limit.
+// The window-driven note list uses this to keep its optimistic `totalItems`
+// ahead of the scroll window so DataViews keeps advancing it.
 function hasMoreNotes() {
 	const notes = getAllNotes( store.getState() );
-	return notes.length >= this.noteRequestLimit && this.noteRequestLimit < settings.max_limit;
+	return ! this.allNotesLoaded && notes.length < settings.max_limit;
 }
 
 function setVisibility( { isShowing, isVisible } ) {
@@ -510,6 +595,7 @@ Client.prototype.reschedule = reschedule;
 Client.prototype.getNote = getNote;
 Client.prototype.getNotes = getNotes;
 Client.prototype.getNotesList = getNotesList;
+Client.prototype.getOlderNotes = getOlderNotes;
 Client.prototype.updateLastSeenTime = updateLastSeenTime;
 Client.prototype.loadMore = loadMore;
 Client.prototype.hasMoreNotes = hasMoreNotes;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -11,9 +11,9 @@ const settings = {
 	max_refresh_ms: 180000,
 	refresh_ms: 30000,
 	initial_limit: 10,
-	// Matches NOTES_PER_PAGE in the DataViews note list: DataViews advances its
-	// infinite-scroll window by `perPage` rows per scroll, so each loadMore()
-	// must fetch at least that many or the window outruns the loaded notes.
+	// Network page size for load-more. May be smaller than the note list's render
+	// window (NOTES_PER_PAGE); the list fetches as many pages as needed to fill
+	// the window, so the window never outruns the loaded notes.
 	increment_limit: 10,
 	max_limit: 100,
 };
@@ -179,16 +179,21 @@ function getNotes( before ) {
 	}
 	this.gettingNotes = true;
 
+	const notes = getAllNotes( store.getState() );
+
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		number: before ? settings.increment_limit : this.noteRequestLimit,
+		// Older pages only request what's left under max_limit, so an additive
+		// page can't push the loaded count past the cap.
+		number: before
+			? Math.min( settings.increment_limit, settings.max_limit - notes.length )
+			: this.noteRequestLimit,
 		locale: this.locale,
 	};
 	if ( before ) {
 		parameters.before = before;
 	}
 
-	const notes = getAllNotes( store.getState() );
 	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
@@ -221,15 +226,24 @@ function getNotes( before ) {
 
 		store.dispatch( actions.ui.loadedNotes() );
 
-		// Short page means the server has nothing older — stop load-more paging.
+		// Short page (fewer than requested) means the server has nothing more.
 		if ( data.notes.length < parameters.number ) {
 			this.allNotesLoaded = true;
 		}
 
-		// Authoritative top window: prune notes the server dropped. A prune means
-		// newer notes pushed older ones below the window, so let load-more
-		// re-fetch them. The additive `before` path never prunes.
-		if ( ! before ) {
+		if ( before ) {
+			// Also stop when an older page adds no new ids — e.g. an inclusive
+			// `before` echoes back only the anchor note, or capping near max_limit
+			// left room for just that anchor. Such a page isn't "short", so without
+			// this the catch-up loop would refetch the same notes forever.
+			const knownIds = new Set( getAllNotes( store.getState() ).map( ( n ) => n.id ) );
+			if ( ! data.notes.some( ( n ) => ! knownIds.has( n.id ) ) ) {
+				this.allNotesLoaded = true;
+			}
+		} else {
+			// Authoritative top window: prune notes the server dropped. A prune
+			// means newer notes pushed older ones below the window, so let
+			// load-more re-fetch them. The additive `before` path never prunes.
 			const oldIds = getAllNotes( store.getState() ).map( ( { id } ) => id );
 			const newIds = data.notes.map( ( n ) => n.id );
 			const notesToRemove = oldIds.filter( ( id ) => ! newIds.includes( id ) );

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -26,11 +26,7 @@ export function Client() {
 	this.isShowing = false;
 	this.lastSeenTime = 0;
 	this.noteRequestLimit = settings.initial_limit;
-	// Load-more pages backwards in time from the oldest loaded note (see
-	// getOlderNotes), so a separate in-flight guard keeps it from overlapping
-	// the polling path. `allNotesLoaded` latches once the server reports no
-	// older notes remain, stopping further paging.
-	this.gettingOlderNotes = false;
+	// Latches once the server has no older notes left, so load-more stops paging.
 	this.allNotesLoaded = false;
 	this.retries = 0;
 	this.subscribeTry = 0;
@@ -169,7 +165,15 @@ function getNote( note_id ) {
 	} );
 }
 
-function getNotes() {
+/**
+ * Fetch notes from the server.
+ *
+ * Without `before` this refreshes the top window and treats the response as
+ * authoritative, pruning notes the server no longer returns. With `before`
+ * (UNIX epoch seconds) it pages older notes in additively for load-more and
+ * never prunes, since an older slice isn't a superset of what's loaded.
+ */
+function getNotes( before ) {
 	if ( this.gettingNotes ) {
 		return;
 	}
@@ -177,9 +181,12 @@ function getNotes() {
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		number: this.noteRequestLimit,
+		number: before ? settings.increment_limit : this.noteRequestLimit,
 		locale: this.locale,
 	};
+	if ( before ) {
+		parameters.before = before;
+	}
 
 	const notes = getAllNotes( store.getState() );
 	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
@@ -188,15 +195,18 @@ function getNotes() {
 
 	listNotes( parameters, ( error, data ) => {
 		this.gettingNotes = false;
+
 		if ( error ) {
+			// Load-more: clear the spinner, leave state untouched; scrolling retries.
+			if ( before ) {
+				store.dispatch( actions.ui.loadedNotes() );
+				return;
+			}
 			/*
-			 * Something failed, so try again and
-			 * reset the local noteList copy. We
-			 * might have optimistically modified
-			 * it when we last compared it to the
-			 * server, but there's been a failure
-			 * here so resetting it will force a
-			 * full refresh.
+			 * Something failed, so try again and reset the local noteList copy.
+			 * We might have optimistically modified it when we last compared it
+			 * to the server, but there's been a failure here so resetting it
+			 * will force a full refresh.
 			 */
 			this.retries = this.retries + 1;
 			const backoff_ms = Math.min(
@@ -211,38 +221,37 @@ function getNotes() {
 
 		store.dispatch( actions.ui.loadedNotes() );
 
-		const oldNotes = getAllNotes( store.getState() ).map( ( { id } ) => id );
-		const newNotes = data.notes.map( ( n ) => n.id );
-		const notesToRemove = oldNotes.filter( ( old ) => ! newNotes.includes( old ) );
-
-		// A short window means the server has nothing older than what we hold, so
-		// stop load-more from paging further. Only ever latch it true here: a full
-		// window can't prove more exist, and unlatching is the pruning case below.
+		// Short page means the server has nothing older — stop load-more paging.
 		if ( data.notes.length < parameters.number ) {
 			this.allNotesLoaded = true;
 		}
 
-		// Pruning means new notes pushed older ones out of this top window, so
-		// notes we'd paged in may sit below it again — let load-more re-page them.
-		if ( notesToRemove.length ) {
-			this.allNotesLoaded = false;
-			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+		// Authoritative top window: prune notes the server dropped. A prune means
+		// newer notes pushed older ones below the window, so let load-more
+		// re-fetch them. The additive `before` path never prunes.
+		if ( ! before ) {
+			const oldIds = getAllNotes( store.getState() ).map( ( { id } ) => id );
+			const newIds = data.notes.map( ( n ) => n.id );
+			const notesToRemove = oldIds.filter( ( id ) => ! newIds.includes( id ) );
+			if ( notesToRemove.length ) {
+				this.allNotesLoaded = false;
+				store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+			}
 		}
+
+		// The lightweight id/hash list the polling diff compares against: a fresh
+		// top window replaces it; an older page appends to it.
+		const pageList = data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) );
+		this.noteList = before ? this.noteList.concat( pageList ) : pageList;
+
 		store.dispatch( actions.notes.addNotes( data.notes ) );
-
-		// Store id/hash pairs for now until properly reduxified
-		// this is used as a network optimization to quickly determine
-		// changes without downloading all the data
-		this.noteList = data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) );
-
 		this.updateLastSeenTime( Number( data.last_seen_time ) );
+
 		if ( parameters.number === settings.max_limit ) {
 			/*
-			 * Since we store note data in a local cache,
-			 * we want to purge the data if the notes
-			 * no longer exist, but we only want to do it
-			 * if we have loaded all the notes, otherwise
-			 * we might expunge legitimate entries that
+			 * Since we store note data in a local cache, we want to purge the
+			 * data if the notes no longer exist, but only once we've loaded all
+			 * the notes, otherwise we might expunge legitimate entries that
 			 * simply haven't been loaded yet.
 			 */
 			cleanupLocalCache.call( this );
@@ -316,76 +325,6 @@ function getNotesList() {
 
 		/* Grab updates/changes from server if they exist */
 		return serverHasChanges ? this.getNotes() : ready.call( this );
-	} );
-}
-
-/**
- * Page backwards in time to load notes older than those already cached.
- *
- * Unlike the polling path (getNotes/getNotesList), which re-fetches the top
- * window and treats its response as the authoritative set, this walks a fixed
- * `before` cursor down the list and is purely additive: it never prunes, since
- * an older slice is not a superset of what's loaded. It anchors on the oldest
- * cached note's timestamp, converted to the UNIX epoch seconds the endpoint's
- * `before` cursor expects, and stops once a short page proves the server has
- * nothing older.
- */
-function getOlderNotes() {
-	if ( this.gettingOlderNotes ) {
-		return;
-	}
-
-	// getAllNotes is sorted newest-first, so the last entry is the oldest loaded
-	// note and the cursor for the next page. Without one there's nothing to page
-	// from; the initial getNotes seeds the list.
-	const notes = getAllNotes( store.getState() );
-	const oldest = notes[ notes.length - 1 ];
-	if ( ! oldest ) {
-		return;
-	}
-	this.gettingOlderNotes = true;
-
-	const parameters = {
-		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		number: settings.increment_limit,
-		// The endpoint keys `before`/`since` on UNIX epoch seconds, not the ISO
-		// timestamp the note carries; an unparsed string is ignored and the server
-		// just returns the top window again, stalling load-more after one page.
-		before: Math.floor( Date.parse( oldest.timestamp ) / 1000 ),
-		locale: this.locale,
-	};
-
-	store.dispatch( actions.ui.loadNotes() );
-
-	listNotes( parameters, ( error, data ) => {
-		this.gettingOlderNotes = false;
-		store.dispatch( actions.ui.loadedNotes() );
-
-		if ( error ) {
-			// Leave pagination state untouched; scrolling again retries the page.
-			return;
-		}
-
-		// Additive only — never prune here (see the function comment).
-		store.dispatch( actions.notes.addNotes( data.notes ) );
-
-		// Mirror the new ids into the lightweight note-hash list the polling diff
-		// compares against, so the next getNotesList() doesn't see this page as a
-		// server-side change and trigger a redundant full getNotes(). The next
-		// poll overwrites this list wholesale, so any drift self-heals.
-		this.noteList = this.noteList.concat(
-			data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) )
-		);
-
-		// A short page (fewer than requested) means the server is exhausted. This
-		// compares the raw response count to the request, so it holds whether the
-		// `before` boundary is inclusive (the anchor note returns again, deduped
-		// by id on add) or exclusive.
-		if ( data.notes.length < parameters.number ) {
-			this.allNotesLoaded = true;
-		}
-
-		ready.call( this );
 	} );
 }
 
@@ -549,26 +488,36 @@ function handleStorageEvent( event ) {
 }
 
 function loadMore() {
-	if ( this.gettingOlderNotes || ! this.hasMoreNotes() ) {
+	if ( this.gettingNotes || ! this.hasMoreNotes() ) {
+		return;
+	}
+
+	// getAllNotes is newest-first, so the last entry is the oldest loaded note —
+	// the cursor for the next, older page.
+	const notes = getAllNotes( store.getState() );
+	const oldest = notes[ notes.length - 1 ];
+	if ( ! oldest ) {
 		return;
 	}
 
 	// Grow the polling window so getNotes()/getNotesList() keep covering every
-	// note we've paged in — their diff treats the response as the full set, so a
-	// window shorter than the loaded list would prune the older notes back out.
+	// note we've paged in; their diff treats the response as the full set, so a
+	// shorter window would prune the older notes back out.
 	this.noteRequestLimit = Math.min(
 		this.noteRequestLimit + settings.increment_limit,
 		settings.max_limit
 	);
 
-	this.getOlderNotes();
+	// The endpoint's `before` cursor is UNIX epoch seconds, not the note's ISO
+	// timestamp; a raw string is ignored and load-more would refetch page one.
+	this.getNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
 }
 
 // Whether the server may still have notes older than those already loaded.
-// `allNotesLoaded` latches once a short page (or short polling window) proves
-// the server is exhausted; until then there may be more, capped at max_limit.
-// The window-driven note list uses this to keep its optimistic `totalItems`
-// ahead of the scroll window so DataViews keeps advancing it.
+// `allNotesLoaded` latches once a short page proves the server is exhausted;
+// until then there may be more, capped at max_limit. The note list uses this to
+// keep its optimistic `totalItems` ahead of the scroll window so DataViews
+// keeps advancing it.
 function hasMoreNotes() {
 	const notes = getAllNotes( store.getState() );
 	return ! this.allNotesLoaded && notes.length < settings.max_limit;
@@ -599,7 +548,6 @@ Client.prototype.reschedule = reschedule;
 Client.prototype.getNote = getNote;
 Client.prototype.getNotes = getNotes;
 Client.prototype.getNotesList = getNotesList;
-Client.prototype.getOlderNotes = getOlderNotes;
 Client.prototype.updateLastSeenTime = updateLastSeenTime;
 Client.prototype.loadMore = loadMore;
 Client.prototype.hasMoreNotes = hasMoreNotes;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -14,7 +14,7 @@ const settings = {
 	// Matches NOTES_PER_PAGE in the DataViews note list: DataViews advances its
 	// infinite-scroll window by `perPage` rows per scroll, so each loadMore()
 	// must fetch at least that many or the window outruns the loaded notes.
-	increment_limit: 20,
+	increment_limit: 10,
 	max_limit: 100,
 };
 
@@ -326,8 +326,9 @@ function getNotesList() {
  * window and treats its response as the authoritative set, this walks a fixed
  * `before` cursor down the list and is purely additive: it never prunes, since
  * an older slice is not a superset of what's loaded. It anchors on the oldest
- * cached note's server timestamp (echoed back verbatim, no reformatting) and
- * stops once a short page proves the server has nothing older.
+ * cached note's timestamp, converted to the UNIX epoch seconds the endpoint's
+ * `before` cursor expects, and stops once a short page proves the server has
+ * nothing older.
  */
 function getOlderNotes() {
 	if ( this.gettingOlderNotes ) {
@@ -347,7 +348,10 @@ function getOlderNotes() {
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
 		number: settings.increment_limit,
-		before: oldest.timestamp,
+		// The endpoint keys `before`/`since` on UNIX epoch seconds, not the ISO
+		// timestamp the note carries; an unparsed string is ignored and the server
+		// just returns the top window again, stalling load-more after one page.
+		before: Math.floor( Date.parse( oldest.timestamp ) / 1000 ),
 		locale: this.locale,
 	};
 

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -108,7 +108,7 @@ describe( 'RestClient load-more pagination', () => {
 		seedFirstWindow();
 
 		client.loadMore();
-		// Fewer than the requested 20 means the server has nothing older.
+		// Fewer than the requested page means the server has nothing older.
 		getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } );
 
 		expect( client.hasMoreNotes() ).toBe( false );
@@ -116,6 +116,27 @@ describe( 'RestClient load-more pagination', () => {
 		getCalls.length = 0;
 		client.loadMore();
 		// No further request: load-more settles instead of walking to the max.
+		expect( getCalls ).toHaveLength( 0 );
+	} );
+
+	it( 'stops paging when a capped page echoes back only the anchor', () => {
+		// 99 loaded leaves one slot under max_limit, so the next page is capped to
+		// number=1. An inclusive `before` echoes that single anchor note back, so
+		// the page is full-size (1 of 1) yet adds nothing new. Without the no-new-id
+		// check this never latches and the catch-up loop refetches forever.
+		store.dispatch( actions.notes.addNotes( fullPage( 99, 100 ) ) ); // ids 100..2
+
+		client.loadMore();
+		expect( getCalls ).toHaveLength( 1 );
+		expect( getCalls[ 0 ].query.number ).toBe( 1 ); // capped to the remaining slot
+
+		const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ]; // id 2
+		getCalls[ 0 ].callback( null, { notes: [ oldest ], last_seen_time: 0 } );
+
+		expect( client.hasMoreNotes() ).toBe( false );
+
+		getCalls.length = 0;
+		client.loadMore();
 		expect( getCalls ).toHaveLength( 0 );
 	} );
 

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -68,10 +68,11 @@ describe( 'RestClient load-more pagination', () => {
 		client.loadMore();
 
 		expect( getCalls ).toHaveLength( 1 );
-		// Fixed page size, anchored on the oldest loaded note's server timestamp.
+		// Fixed page size, anchored on the oldest loaded note's timestamp expressed
+		// as the UNIX epoch seconds the endpoint's `before` cursor expects.
 		expect( getCalls[ 0 ].query ).toMatchObject( {
-			number: 20,
-			before: oldest.timestamp,
+			number: 10,
+			before: Math.floor( Date.parse( oldest.timestamp ) / 1000 ),
 		} );
 
 		// A full older page merges in without dropping the first window.
@@ -99,8 +100,8 @@ describe( 'RestClient load-more pagination', () => {
 
 		expect( getCalls ).toHaveLength( 1 );
 		const secondBefore = getCalls[ 0 ].query.before;
-		// Cursor walked further back in time as older notes loaded.
-		expect( Date.parse( secondBefore ) ).toBeLessThan( Date.parse( firstBefore ) );
+		// Cursor (epoch seconds) walked further back in time as older notes loaded.
+		expect( secondBefore ).toBeLessThan( firstBefore );
 	} );
 
 	it( 'stops paging once the server returns a short page', () => {

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ */
+import { store } from '../../state';
+import actions from '../../state/actions';
+import getAllNotes from '../../state/selectors/get-all-notes';
+import Client from '../index';
+import { init } from '../wpcom';
+
+// Distinct, monotonic timestamps so ordering is unambiguous: a higher id is a
+// newer note, so the lowest id is always the oldest (last) in the sorted list.
+const makeNote = ( id ) => ( {
+	id,
+	type: 'comment',
+	timestamp: new Date( Date.UTC( 2026, 5, 1, 0, 0, id ) ).toISOString(),
+	subject: [ { text: `note ${ id }` } ],
+	note_hash: `hash-${ id }`,
+} );
+
+const fullPage = ( count, startId ) =>
+	Array.from( { length: count }, ( _, i ) => makeNote( startId - i ) );
+
+describe( 'RestClient load-more pagination', () => {
+	let getCalls;
+	let client;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+
+		// The redux store is a shared singleton; clear it so each test starts empty.
+		const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
+		if ( ids.length ) {
+			store.dispatch( actions.notes.removeNotes( ids ) );
+		}
+
+		getCalls = [];
+		init( {
+			req: {
+				get: ( path, query, callback ) => getCalls.push( { path, query, callback } ),
+				post: () => {},
+			},
+			pinghub: { connect: () => {} },
+		} );
+		client = new Client();
+		// Pretend the panel is open without going through setVisibility(), which
+		// would kick off an unrelated fetch.
+		client.isVisible = true;
+		getCalls.length = 0;
+	} );
+
+	afterEach( () => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	} );
+
+	// Seed the first window via the polling path and return its callback's notes.
+	const seedFirstWindow = () => {
+		client.getNotes();
+		const firstWindow = fullPage( 10, 100 ); // ids 100..91, oldest is 91
+		getCalls[ 0 ].callback( null, { notes: firstWindow, last_seen_time: 0 } );
+		getCalls.length = 0;
+	};
+
+	it( 'pages backwards with before=<oldest timestamp> and merges additively', () => {
+		seedFirstWindow();
+		const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ];
+
+		client.loadMore();
+
+		expect( getCalls ).toHaveLength( 1 );
+		// Fixed page size, anchored on the oldest loaded note's server timestamp.
+		expect( getCalls[ 0 ].query ).toMatchObject( {
+			number: 20,
+			before: oldest.timestamp,
+		} );
+
+		// A full older page merges in without dropping the first window.
+		getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
+		const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
+		expect( ids ).toContain( 100 ); // first window kept
+		expect( ids ).toContain( 91 ); // first window kept
+		expect( ids ).toContain( 71 ); // older page added
+	} );
+
+	it( 'does not send before on the initial window fetch', () => {
+		client.getNotes();
+		expect( getCalls[ 0 ].query ).not.toHaveProperty( 'before' );
+	} );
+
+	it( 'advances the cursor on each successive page', () => {
+		seedFirstWindow();
+
+		client.loadMore();
+		const firstBefore = getCalls[ 0 ].query.before;
+		getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
+
+		getCalls.length = 0;
+		client.loadMore();
+
+		expect( getCalls ).toHaveLength( 1 );
+		const secondBefore = getCalls[ 0 ].query.before;
+		// Cursor walked further back in time as older notes loaded.
+		expect( Date.parse( secondBefore ) ).toBeLessThan( Date.parse( firstBefore ) );
+	} );
+
+	it( 'stops paging once the server returns a short page', () => {
+		seedFirstWindow();
+
+		client.loadMore();
+		// Fewer than the requested 20 means the server has nothing older.
+		getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } );
+
+		expect( client.hasMoreNotes() ).toBe( false );
+
+		getCalls.length = 0;
+		client.loadMore();
+		// No further request: load-more settles instead of walking to the max.
+		expect( getCalls ).toHaveLength( 0 );
+	} );
+
+	it( 'reports no more notes once the cap is reached', () => {
+		// 100 notes (settings.max_limit) loaded means we never page past the cap.
+		store.dispatch( actions.notes.addNotes( fullPage( 100, 100 ) ) );
+		expect( client.hasMoreNotes() ).toBe( false );
+
+		client.loadMore();
+		expect( getCalls ).toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
Part of #

## Proposed Changes

- Rework the Notifications panel's load-more to paginate with a `before` cursor instead of an ever-growing request `number`.
  - **Before:** each load-more grew `number` (10 → 30 → 50 → … → 100) and re-fetched the *entire* window from the top, so loading the fifth page re-downloaded all 100 notes.
  - **After:** load-more keeps a fixed page size and walks a `before` cursor backwards in time — `GET /notifications/?number=10&before=<oldest loaded note's timestamp>` — fetching only the next slice of older notes.
- **`before` is sent as UNIX epoch seconds**, which is what the endpoint's `before`/`since` cursors expect. Sending the raw ISO `timestamp` was silently ignored, so every page re-fetched the top window and load-more stalled after the first page.
- Load-more **reuses `getNotes()`** via an optional `before` argument rather than a separate function. Without `before` it refreshes the top window and prunes notes the server dropped (the polling path, unchanged); with `before` it appends an older page additively and never prunes (an older slice is not a superset of the loaded window).
- End-of-list detection latches an `allNotesLoaded` flag when a `before` page returns **fewer notes than requested** *or* **adds no new ids** (e.g. an inclusive `before` echoes back only the anchor note). The flag unlatches when the polling window shifts and prunes, so older notes that drop below the window can be re-paged.
- Each `before` page requests only the **remaining capacity under `max_limit`**, so an additive page can't push the loaded count past the cap.

### Page size & the render window

- Network pages are **10** notes (`increment_limit`). The DataViews note list renders a **20**-row window (`NOTES_PER_PAGE`): it must overflow the full-viewport panel so a scrollbar exists for DataViews (which only loads more on scroll events) to drive further loading. Because the render window is larger than a network page, a **catch-up effect** fetches successive 10-note pages until the current scroll window is filled — or the server is exhausted — so the smaller pages never let the window outrun the loaded notes.

## Why are these changes being made?

The previous growing-`number` strategy re-downloaded the full note set on every load-more, wasting bandwidth that grows with each page. Cursor pagination fetches only the incremental page, so cost stays flat per load-more regardless of how deep the user scrolls.

## Testing Instructions

- Run the unit tests: `yarn test-apps apps/notifications/src/panel/rest-client`.
- In the Notifications panel, open the bell and scroll to trigger load-more. With devtools open on the Network tab, confirm:
  - the panel produces a scrollbar on first open (the render window overflows the panel);
  - each load-more issues `GET /notifications/?number=10&before=<epoch seconds>` — fetching only the next slice, not a growing `number=` re-fetch;
  - older notes append without the existing list flickering or reordering;
  - scrolling stops issuing requests once the list is exhausted (no request loop near the end of the list).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
