### PR TITLE
@automattic/ui: move Stepper changelog entry to Unreleased and revert version to 1.0.2

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - `Icon`: Remove component. Use `Icon` from `@wordpress/ui` instead.
 
-## 1.1.0
-
 ### Enhancements
 
 - `Stepper`, `VerticalStepper`, `HorizontalStepper`: Add Stepper component suite with vertical and horizontal orientations, step indicators, linear flow support, and accessible ARIA semantics ([#111036](https://github.com/Automattic/wp-calypso/pull/111036)).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/ui",
-	"version": "1.1.0",
+	"version": "1.0.2",
 	"description": "Automattic Design System UI components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed Changes

* Remove the premature `## 1.1.0` version heading from `packages/ui/CHANGELOG.md`, keeping the Stepper component suite entry under the Unreleased section.
* Revert the `@automattic/ui` package version from `1.1.0` back to `1.0.2` to match (1.1.0 was never published).

## Why are these changes being made?

* The Stepper suite (#111036) has not shipped in a published `@automattic/ui` release yet, so its changelog entry should sit under Unreleased until a version bump actually happens.

## Testing Instructions

* Review `packages/ui/CHANGELOG.md` and confirm the Stepper enhancement entry is listed under the Unreleased section with no stray version heading.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
