### PR TITLE
Site Setup: return to Newsletter UI from importer back button for wp-admin-newsletter-ui ref

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -552,6 +552,13 @@ const siteSetupFlow: Flow = {
 						return window.location.assign( `${ adminUrl }import.php` );
 					}
 
+					// Importers launched from the wp-admin Newsletter UI (e.g. the Substack
+					// importer in the Subscribers screen) should return there, not to the
+					// importer list.
+					if ( entryPoint === 'wp-admin-newsletter-ui' ) {
+						return window.location.assign( `${ adminUrl }admin.php?page=jetpack-newsletter` );
+					}
+
 					return navigate( addQueryArgs( { origin, siteSlug }, 'importList' ) );
 
 				case 'importerWordpress':


### PR DESCRIPTION
Related https://github.com/Automattic/jetpack/pull/49538 

## Proposed Changes

* In the `site-setup` stepper's `goBack` handler, add a `wp-admin-newsletter-ui` entry point for the importer steps. When an importer (e.g. the Substack importer) is opened with `?ref=wp-admin-newsletter-ui`, clicking **Back** now returns the user to the wp-admin Newsletter UI (`admin.php?page=jetpack-newsletter`) instead of the importer list / wp-admin importer tool.

## Why are these changes being made?

* The Jetpack Newsletter → Subscribers screen links out to the Substack importer (`/setup/site-setup/importerSubstack`). Today the importer's Back button always lands on the importer list (or, with the `wp-admin-importers-list-direct-importer` ref, on `import.php`) — never back where the user came from. This adds a dedicated entry point so launching the importer from the Newsletter UI returns the user to that screen, matching their mental model of the flow.

## Testing Instructions

* Open the Substack importer with the new ref, e.g.:
  `/setup/site-setup/importerSubstack?ref=wp-admin-newsletter-ui&siteSlug=<your-site>`
* Click the **Back** button on the importer.
* Confirm the browser navigates to `https://<your-site>/wp-admin/admin.php?page=jetpack-newsletter` (the Newsletter/Subscribers screen).
* Regression check: open the importer with `?ref=wp-admin-importers-list-direct-importer` and confirm Back still goes to `import.php`; open without a `ref` and confirm Back still goes to the importer list.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
