### PR TITLE
Fix missing CSS prop in MSD

### DIFF
--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -1,3 +1,6 @@
+@import "@automattic/typography/styles/variables";
+@import "calypso/assets/stylesheets/shared/mixins/long-content-fade";
+
 .taxonomy-manager {
 	box-shadow:
 		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -12,6 +12,14 @@
 @import './dataviews-overrides.scss';
 
 // Global Styles
+:root {
+	--masterbar-height: 46px;
+
+	@media only screen and (min-width: 782px) {
+		--masterbar-height: 32px;
+	}
+}
+
 html,
 body,
 #wpcom {

--- a/client/my-sites/media-library/list-item-file-details.scss
+++ b/client/my-sites/media-library/list-item-file-details.scss
@@ -1,3 +1,5 @@
+@import "calypso/assets/stylesheets/shared/mixins/long-content-fade";
+
 .media-library__list-item-file-details {
 	left: auto #{"/*rtl:ignore*/"};
 	transform: translateY(-50%);

--- a/client/post-editor/media-modal/content.scss
+++ b/client/post-editor/media-modal/content.scss
@@ -1,3 +1,5 @@
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+
 .editor-media-modal__content {
 	display: flex;
 	flex-direction: column;

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -1,3 +1,7 @@
+@import "@automattic/typography/styles/variables";
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+@import "calypso/assets/stylesheets/shared/mixins/long-content-fade";
+
 .editor-media-modal-detail .header-cake.card {
 	padding-top: 0;
 	padding-bottom: 0;

--- a/client/post-editor/media-modal/dialog.scss
+++ b/client/post-editor/media-modal/dialog.scss
@@ -1,4 +1,6 @@
 @import "calypso/assets/stylesheets/shared/functions/z-index";
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+@import "calypso/assets/stylesheets/shared/mixins/long-content-fade";
 
 .editor-media-modal.dialog.card {
 	position: absolute;

--- a/client/post-editor/media-modal/fieldset.scss
+++ b/client/post-editor/media-modal/fieldset.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+
 .editor-media-modal__fieldset {
 	margin-bottom: 16px;
 }

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -1,3 +1,4 @@
+@import "calypso/assets/stylesheets/shared/typography";
 @import "calypso/assets/stylesheets/shared/functions/z-index";
 
 .editor-media-modal-gallery__preview {

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -1,3 +1,6 @@
+@import "@automattic/typography/styles/variables";
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+
 .editor-media-modal__gallery-help {
 	position: absolute;
 	bottom: 8px;


### PR DESCRIPTION
Follow up for [111540](https://github.com/Automattic/wp-calypso/pull/111540).

## Proposed Changes
Removing the SCSS prelude removed 4 CSS props from that used to be available to every SCSS file. I traced most of them and tested everywhere (Jetpack cloud, A4A, and of course Calypso) but missed the MSD. This fixes the MSD. 