### PR TITLE
Login: migrate to React 19 scoped JSX namespace

### DIFF
--- a/client/login/magic-login/utils/heading-utils.tsx
+++ b/client/login/magic-login/utils/heading-utils.tsx
@@ -5,7 +5,7 @@ type TranslateFn = (
 	text: string,
 	options?: {
 		args?: Record< string, unknown >;
-		components?: Record< string, JSX.Element >;
+		components?: Record< string, React.JSX.Element >;
 	}
 ) => TranslateResult;
 

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -8,11 +8,11 @@ interface OneLoginFooterProps {
 	/**
 	 * When `isLoginView` is true, this is the "lost password" link.
 	 */
-	lostPasswordLink?: JSX.Element;
+	lostPasswordLink?: React.JSX.Element;
 	/**
 	 * When `isLoginView` is false, this is the "back to login" link.
 	 */
-	loginLink?: JSX.Element;
+	loginLink?: React.JSX.Element;
 	/**
 	 * The content of the footer. If provided, it will be rendered instead of the default links.
 	 */
@@ -20,7 +20,7 @@ interface OneLoginFooterProps {
 	/**
 	 * When `isLoginView` is false, this is the "support" link.
 	 */
-	supportLink?: JSX.Element;
+	supportLink?: React.JSX.Element;
 	/**
 	 * When true, this is the footer for the main login screen.
 	 */

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -143,7 +143,7 @@ const OneLoginLayout = ( {
 		);
 	};
 
-	const topBar = (): JSX.Element => {
+	const topBar = (): React.JSX.Element => {
 		const rightElement = (
 			<nav className="wp-login__one-login-layout-top-right">
 				{ isSectionSignup ? <LoginLink /> : <SignUpLink /> }


### PR DESCRIPTION
Part of DOTCOM-17400 — Migrate Calypso to React 19.
Follows the standalone-SPA validation spike (#111325).

## Proposed Changes

Migrate the `client/login` folder for React 19 compatibility by applying the
`types-react-codemod` **`scoped-jsx`** transform (the same mechanical codemod used
across the spike):

- Replace the global `JSX.Element` namespace with `React.JSX.Element` in:
  - `client/login/wp-login/components/one-login-footer.tsx` (3 props)
  - `client/login/wp-login/components/one-login-layout.tsx` (`topBar` return type)
  - `client/login/magic-login/utils/heading-utils.tsx` (`components` record)

The global `JSX` namespace is no longer declared by `@types/react@19`; it now lives
under `React.JSX`. `React.JSX.Element` is valid under both the current `@types/react@18`
and `@types/react@19`, so the change is fully backward-compatible and can land ahead of
the React version bump.

### Scope notes (no change required)

- **No `findDOMNode`** in `client/login` — so unlike `client/blocks/login/login-form.jsx`
  in the spike, no `ref`→`inputRef` rewrite is needed here. `magic-login`'s
  `FormTextInput` ref uses `this.usernameOrEmailRef.current?.focus()` against the class
  instance, which is unchanged in React 19.
- **No argless `useRef`** (`useRef-required-initial` codemod is a no-op here).
- **`FC<Props>`** usages define explicit props and don't rely on the implicit-children
  that React 19 removed; `FC` itself still exists in React 19.

## Why are these changes being made?

To incrementally move Calypso to React 19 folder-by-folder. The spike (#111325) proved
the standalone app bundles its own React and is not gated by the WordPress runtime
version; this PR lands the forward-compatible, codemod-driven type changes for the
`login` folder so the eventual version flip is a no-op for this surface.

## Testing Instructions

- `yarn typecheck-client` — passes (these are type-only annotation changes).
- No runtime behavior changes; the login and magic-login flows render identically.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
