### PR TITLE
client/sites: React 19 forward-compatible (behavior-preserving)

### DIFF
--- a/client/sites/components/panel-sidebar/index.tsx
+++ b/client/sites/components/panel-sidebar/index.tsx
@@ -40,8 +40,10 @@ export function SidebarItem( {
 export function Sidebar( { children }: { children: ReactNode } ) {
 	const isDesktop = useViewportMatch( 'small', '>=' );
 	const activeElement = Children.toArray( children ).find(
-		( child ) => isValidElement( child ) && window.location.pathname.startsWith( child.props.href )
-	) as ReactElement;
+		( child ) =>
+			isValidElement< { href: string } >( child ) &&
+			window.location.pathname.startsWith( child.props.href )
+	) as ReactElement< { href: string; children?: ReactNode } >;
 
 	if ( isDesktop ) {
 		return <ul className="panel-sidebar">{ children }</ul>;
@@ -55,7 +57,9 @@ export function Sidebar( { children }: { children: ReactNode } ) {
 			{ Children.toArray( children )
 				.filter( ( child ) => child && isValidElement( child ) )
 				.map( ( child, index ) => {
-					const { href, ...childProps } = ( child as ReactElement ).props;
+					const { href, ...childProps } = (
+						child as ReactElement< { href: string; children?: ReactNode } >
+					 ).props;
 					return (
 						<SelectDropdown.Item
 							{ ...childProps }

--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -9,7 +9,7 @@ import { HostingActivationCallout, HostingUpsellCallout } from './components/hos
 import HostingFeatures from './components/hosting-features';
 import { isHostingFeatureSupported } from './features';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
-import type { ComponentType } from 'react';
+import type { ComponentType, JSX } from 'react';
 
 import './style.scss';
 

--- a/client/sites/marketing/sharing/preview-button.jsx
+++ b/client/sites/marketing/sharing/preview-button.jsx
@@ -17,6 +17,7 @@ class SharingButtonsPreviewButton extends Component {
 		onMouseOver: PropTypes.func,
 		onClick: PropTypes.func,
 		path: PropTypes.string,
+		elementRef: PropTypes.oneOfType( [ PropTypes.func, PropTypes.object ] ),
 	};
 
 	static defaultProps = {
@@ -78,6 +79,7 @@ class SharingButtonsPreviewButton extends Component {
 
 		return (
 			<div
+				ref={ this.props.elementRef }
 				className={ classes }
 				onClick={ this.onClick }
 				// eslint-disable-next-line jsx-a11y/mouse-events-have-key-events

--- a/client/sites/marketing/sharing/preview-buttons.jsx
+++ b/client/sites/marketing/sharing/preview-buttons.jsx
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import { filter, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
-import { findDOMNode } from 'react-dom';
 import ResizableIframe from 'calypso/components/resizable-iframe';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import ButtonsPreviewButton from './preview-button';
@@ -130,7 +129,7 @@ class SharingButtonsPreviewButtons extends Component {
 		} else {
 			// For custom styles, we can calculate the offset using the
 			// position of the rendered button
-			moreButton = findDOMNode( this.moreButtonRef.current );
+			moreButton = this.moreButtonRef.current;
 			offset = {
 				top: moreButton.offsetTop + moreButton.clientHeight,
 				left: moreButton.offsetLeft,
@@ -199,7 +198,7 @@ class SharingButtonsPreviewButtons extends Component {
 		if ( this.props.showMore ) {
 			buttons.push(
 				<ButtonsPreviewButton
-					ref={ this.moreButtonRef }
+					elementRef={ this.moreButtonRef }
 					key="more"
 					button={ {
 						ID: 'more',

--- a/client/sites/staging-site/hooks/use-site-sync-status.tsx
+++ b/client/sites/staging-site/hooks/use-site-sync-status.tsx
@@ -29,7 +29,7 @@ export const useCheckSyncStatus = ( siteId: number ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const intervalIdRef = useRef< NodeJS.Timeout >();
+	const intervalIdRef = useRef< NodeJS.Timeout >( undefined );
 	const syncStatus = useSelector( ( state ) => getSyncStatus( state, siteId ) );
 	const syncProgress = useSelector( ( state ) => getSyncProgress( state, siteId ) );
 	const isSyncInProgress = useSelector( ( state ) => getIsSyncingInProgress( state, siteId ) );


### PR DESCRIPTION
Part of DOTCOM-17400

## Proposed Changes

Forward-compatible React 19 changes for `client/sites` (area **A1h** in the pet6gk-2Xb-p2). These update the source to be ready for React 19 while still compiling cleanly under React 18, with **no behavior change**. The changes mirror the spike branch (#111325) for this area.

- **`scoped-jsx` codemod** — React 19's types removed the global `JSX` namespace, so files referencing it must import `JSX` from `react`:
  - `hosting/controller.tsx`: `import type { ComponentType, JSX } from 'react'`.
- **`useRef-required-initial` codemod** — React 19 requires an explicit initial argument:
  - `staging-site/hooks/use-site-sync-status.tsx`: `useRef< NodeJS.Timeout >( undefined )`.
- **`isValidElement` / `ReactElement` generics** — React 19 no longer infers `props` as `any` on an untyped `ReactElement`, so the element props are typed explicitly:
  - `components/panel-sidebar/index.tsx`.
- **Drop `findDOMNode`** — removed from `react-dom` in React 19. `marketing/sharing/preview-buttons.jsx` now reads the DOM node through a forwarded `elementRef` prop on `preview-button.jsx` instead of `findDOMNode( ref.current )`. Functionally equivalent on React 18.

## Why are these changes being made?

Gutenberg and the `@wordpress/*` packages Calypso depends on are moving to React 19. The strategy (per the plan P2) is to land behavior-preserving, forward-compatible source changes per area on trunk first, then flip the runtime React version in a single final `package.json` bump. This PR covers the `client/sites` slice.

## Testing Instructions

These are mechanical, behavior-preserving changes. To verify:

1. `yarn typecheck-client` — passes for the touched files (no new errors).
2. `yarn eslint client/sites/...` — clean.

Manual smoke test (no behavior change expected):

1. Open a site's **Marketing → Sharing buttons** preview. Confirm the "More" button and its custom-style preview offset render and position correctly (this exercises the `findDOMNode` → `elementRef` change).
2. Open **Hosting** for a site and confirm the panel sidebar renders and navigation works on mobile (dropdown) and desktop (`components/panel-sidebar`).
3. On a site with a staging site, trigger a staging sync and confirm the sync-status polling still works (`use-site-sync-status`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)