### PR TITLE
Plans: remove getPlanTagline

### DIFF
--- a/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
+++ b/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
@@ -79,6 +79,11 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 		plans?.find( ( { product_slug } ) => product_slug === selectedPlanSlug )?.path_slug ||
 		selectedPlanSlug;
 
+	// Prefer the server-provided plan tagline (from the /plans endpoint). Fall
+	// back to the bundled getPlanTagline() until the server field is populated
+	// for every plan in production.
+	const serverTagline = plans?.find( ( { product_slug } ) => product_slug === planSlug )?.tagline;
+
 	// @ts-ignore - getSignupFeatures is not typed as existing on all plan types, but it is in practice
 	const featureSlugs: string[] = plan.getSignupFeatures();
 	const features = featureSlugs.map( getFeatureByKey ).filter( Boolean );
@@ -97,7 +102,7 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 				<p className="banner-modern__description plan-upgrade-banner__description">
 					{
 						// @ts-ignore - getPlanTagline is not typed as existing on all plan types, but it is in practice
-						preventWidows( plan.getPlanTagline() )
+						preventWidows( serverTagline ?? plan.getPlanTagline() )
 					}
 				</p>
 			</div>

--- a/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
+++ b/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
@@ -79,10 +79,8 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 		plans?.find( ( { product_slug } ) => product_slug === selectedPlanSlug )?.path_slug ||
 		selectedPlanSlug;
 
-	// Prefer the server-provided plan tagline (from the /plans endpoint). Fall
-	// back to the bundled getPlanTagline() until the server field is populated
-	// for every plan in production.
-	const serverTagline = plans?.find( ( { product_slug } ) => product_slug === planSlug )?.tagline;
+	// The plan tagline is provided by the /plans endpoint.
+	const tagline = plans?.find( ( { product_slug } ) => product_slug === planSlug )?.tagline;
 
 	// @ts-ignore - getSignupFeatures is not typed as existing on all plan types, but it is in practice
 	const featureSlugs: string[] = plan.getSignupFeatures();
@@ -100,10 +98,7 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 					}
 				</h2>
 				<p className="banner-modern__description plan-upgrade-banner__description">
-					{
-						// @ts-ignore - getPlanTagline is not typed as existing on all plan types, but it is in practice
-						preventWidows( serverTagline ?? plan.getPlanTagline() )
-					}
+					{ tagline ? preventWidows( tagline ) : null }
 				</p>
 			</div>
 			<div className="plan-upgrade-banner__features">

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -724,7 +724,6 @@ export type FilteredPlan = Plan &
 		WPComPlan,
 		| 'getPlanCompareFeatures'
 		| 'getAnnualPlansOnlyFeatures'
-		| 'getPlanTagline'
 		| 'getNewsletterTagLine'
 		| 'getBlogOnboardingTagLine'
 		| 'getVisualSplitBusinessFeatures'

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -537,7 +537,6 @@ import {
 	getPlanPremiumTitle,
 	getPlanBusinessTrialTitle,
 	getPlanCommerceTrialTitle,
-	getPlanBusinessTrialTagline,
 } from './plans';
 import type {
 	BillingTerm,
@@ -619,7 +618,6 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_FREE,
 	getTitle: () => i18n.translate( 'Free' ),
-	getPlanTagline: () => i18n.translate( 'Get started with all the basics.' ),
 	getNewsletterTagLine: () =>
 		i18n.translate( 'Start fresh or make the switch, bringing your first 100 readers with you.' ),
 	getBlogOnboardingTagLine: () =>
@@ -841,7 +839,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PERSONAL,
 	getTitle: getPlanPersonalTitle,
-	getPlanTagline: () => i18n.translate( 'Make your mark with a custom domain.' ),
 	getNewsletterTagLine: () =>
 		i18n.translate( 'Monetize your writing, go ad-free, and expand your media content.' ),
 	getBlogOnboardingTagLine: () =>
@@ -1032,8 +1029,6 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_ECOMMERCE,
 	getTitle: getPlanEcommerceTitle,
-	getPlanTagline: () =>
-		i18n.translate( 'Grow your online store with commerce-optimized extensions.' ),
 	getDescription: () => {
 		return i18n.translate(
 			'{{strong}}Best for online stores:{{/strong}} Sell confidently with zero transaction fees and full flexibility.',
@@ -1423,7 +1418,6 @@ const getWooExpressPlanCompareFeatures = (): string[] => [
 const getPlanWooExpressMediumDetails = (): IncompleteWPcomPlan => ( {
 	...getPlanEcommerceDetails(),
 	getTitle: () => i18n.translate( 'Performance' ),
-	getPlanTagline: () => i18n.translate( 'Accelerate your growth with advanced features.' ),
 	get2023PricingGridSignupWpcomFeatures: () => [
 		FEATURE_200GB_STORAGE,
 		FEATURE_BACK_IN_STOCK_NOTIFICATIONS,
@@ -1467,8 +1461,6 @@ const getPlanWooExpressSmallDetails = (): IncompleteWPcomPlan => ( {
 	get2023PlanComparisonFeatureOverride: () => getWooExpressSmallPlanCompareFeatures(),
 	getStorageFeature: () => FEATURE_50GB_STORAGE,
 	getTitle: () => i18n.translate( 'Essential' ),
-	getPlanTagline: () =>
-		i18n.translate( 'Everything you need to set up your store and start selling your products.' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Express Essential and take advantage of its powerful marketplace features.'
@@ -1536,7 +1528,6 @@ const getPlanWooHostedBasicDetails = (): IncompleteWPcomPlan => ( {
 	} ),
 	getStorageFeature: () => FEATURE_50GB_STORAGE,
 	getTitle: () => i18n.translate( 'Basic' ),
-	getPlanTagline: () => i18n.translate( 'Everything you need to build and run your online store.' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Basic and take advantage of its powerful marketplace features.'
@@ -1581,8 +1572,6 @@ const getPlanWooHostedProDetails = (): IncompleteWPcomPlan => ( {
 	} ),
 	getStorageFeature: () => FEATURE_100GB_STORAGE,
 	getTitle: () => i18n.translate( 'Pro' ),
-	getPlanTagline: () =>
-		i18n.translate( 'For businesses selling anywhere, reaching more customers, and growing fast.' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Pro and take advantage of its powerful marketplace features.'
@@ -1594,8 +1583,6 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PREMIUM,
 	getTitle: getPlanPremiumTitle,
-	getPlanTagline: () =>
-		i18n.translate( 'Step up site customization with premium design features.' ),
 	getNewsletterTagLine: () =>
 		i18n.translate( 'Make it even more memorable with premium designs and style customization.' ),
 	getBlogOnboardingTagLine: () =>
@@ -1859,19 +1846,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_BUSINESS,
 	getTitle: getPlanBusinessTitle,
-	getPlanTagline: () => {
-		if (
-			i18n.getLocaleSlug()?.startsWith( 'en' ) ||
-			i18n.hasTranslation(
-				'Unlock business tools, priority support, developer power with predictable costs.'
-			)
-		) {
-			return i18n.translate(
-				'Unlock business tools, priority support, developer power with predictable costs.'
-			);
-		}
-		return i18n.translate( 'Unlock next-level WordPress with all custom plugins and themes.' );
-	},
 	getBlogOnboardingTagLine: () =>
 		i18n.translate( 'Expand your blog with plugins and powerful tools to help you scale.' ),
 	getDescription: () =>
@@ -2241,7 +2215,6 @@ const getPlanStudentDetails = (): IncompleteWPcomPlan => ( {
 	...getPlanBusinessDetails(),
 	type: TYPE_STUDENT,
 	getTitle: () => i18n.translate( 'Student' ),
-	getPlanTagline: () => i18n.translate( 'Build your site with student-friendly tools.' ),
 	getNewsletterTagLine: () =>
 		i18n.translate( 'Create, share, and grow your work with a custom domain.' ),
 	getBlogOnboardingTagLine: () =>
@@ -3142,7 +3115,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		type: TYPE_100_YEAR,
 		// Todo: ¯\_(ツ)_/¯ on the copy.
 		getTitle: () => i18n.translate( '100-Year Plan' ),
-		getPlanTagline: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
 		getDescription: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
 		getTagline: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
 		getBlogOnboardingTagLine: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
@@ -3235,7 +3207,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		...getMonthlyTimeframe(),
 		type: isEnabled( 'ciab/allow-domain-features' ) ? TYPE_WOO_HOSTED_FREE_TRIAL : TYPE_FREE,
 		getTitle: () => 'Free Trial',
-		getPlanTagline: () => "Get a taste of the world's most popular eCommerce software.",
 		getDescription: () =>
 			i18n.translate(
 				'Try Woo Hosted for free and explore all the features before committing to a plan.'
@@ -3733,11 +3704,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		type: TYPE_P2_PLUS,
 		getTitle: () => i18n.translate( 'P2+' ),
 		getDescription: () => '',
-		getPlanTagline: () =>
-			i18n.translate(
-				'{{strong}}Best for professionals:{{/strong}} Enhance your P2 with more space for audio and video, advanced search, an activity overview panel, and priority customer support.',
-				plansDescriptionHeadingComponent
-			),
 		get2023PricingGridSignupWpcomFeatures: () => [
 			FEATURE_P2_13GB_STORAGE,
 			FEATURE_P2_ADVANCED_SEARCH,
@@ -3892,7 +3858,6 @@ if ( isEnabled( 'plans/migration-trial' ) ) {
 
 PLANS_LIST[ PLAN_HOSTING_TRIAL_MONTHLY ] = {
 	...getPlanBusinessDetails(),
-	getPlanTagline: getPlanBusinessTrialTagline,
 	type: TYPE_BUSINESS,
 	group: GROUP_WPCOM,
 	getProductId: () => 1058,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2348,8 +2348,6 @@ const getPlanWooExpressPlusDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_WOO_EXPRESS_PLUS,
 	getTitle: () => i18n.translate( 'Plus' ),
-	getPlanTagline: () =>
-		i18n.translate( 'For fast-growing businesses that need access to the most powerful tools.' ),
 	getDescription: () => '',
 	get2023PricingGridSignupWpcomFeatures: () => [],
 	get2023PricingGridSignupJetpackFeatures: () => [],
@@ -2363,8 +2361,6 @@ const get2023EnterprisGrideDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_ENTERPRISE_GRID_WPCOM,
 	getTitle: () => i18n.translate( 'Enterprise' ),
-	getPlanTagline: () =>
-		i18n.translate( 'Level up to bespoke Enterprise-grade performance and security.' ),
 	getDescription: () => '',
 	get2023PricingGridSignupWpcomFeatures: () => [],
 	get2023PricingGridSignupJetpackFeatures: () => [],
@@ -3745,11 +3741,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 PLANS_LIST[ PLAN_P2_FREE ] = {
 	...PLANS_LIST[ PLAN_FREE ],
 	group: GROUP_P2,
-	getPlanTagline: () =>
-		i18n.translate(
-			'{{strong}}Best for small groups:{{/strong}} All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.',
-			plansDescriptionHeadingComponent
-		),
 	getTitle: () => i18n.translate( 'P2 Free' ),
 	get2023PricingGridSignupWpcomFeatures: () => [
 		FEATURE_P2_3GB_STORAGE,

--- a/packages/calypso-products/src/plans.tsx
+++ b/packages/calypso-products/src/plans.tsx
@@ -25,10 +25,6 @@ export const getPlanBusinessTrialTitle = () =>
 	// translators: Business Trial is a plan name
 	i18n.translate( 'Business Trial' );
 
-export const getPlanBusinessTrialTagline = () =>
-	// translators: Business is a plan name
-	i18n.translate( 'Try all the features of our Business plan.' );
-
 export const getPlanCommerceTrialTitle = () =>
 	// translators: Commerce Trial is a plan name
 	i18n.translate( 'Commerce Trial' );

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -130,7 +130,6 @@ export type WPComSpaceUpgradeProductSlug = ( typeof WPCOM_SPACE_UPGRADE_PRODUCTS
 export type WPComOtherProductSlug = ( typeof WPCOM_OTHER_PRODUCTS )[ number ];
 
 export interface WPComPlan extends Plan {
-	getPlanTagline?: () => TranslateResult;
 	getNewsletterTagLine?: () => TranslateResult;
 	getBlogOnboardingTagLine?: () => TranslateResult;
 	getPlanCompareFeatures?: (

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -47,7 +47,9 @@ function usePlans( {
 	const queryKeys = useQueryKeysFactory();
 	const locale = useLocale();
 	const params = new URLSearchParams();
-	coupon && params.append( 'coupon_code', coupon );
+	if ( coupon ) {
+		params.append( 'coupon_code', coupon );
+	}
 	params.append( 'locale', locale );
 
 	// Auto-detect Jetpack context and use appropriate request function
@@ -77,6 +79,7 @@ function usePlans( {
 							productId: plan.product_id,
 							pathSlug: plan.path_slug,
 							productNameShort: plan.product_name_short,
+							tagline: plan.tagline,
 							pricing: {
 								billPeriod: plan.bill_period,
 								currencyCode: plan.currency_code,

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -188,6 +188,11 @@ export interface PlanNext {
 	/* END: Same SitePlan/PlanNext props */
 	productNameShort: string;
 	pathSlug?: string;
+	/**
+	 * The plan's marketing tagline, sourced from the `/plans` endpoint. May be
+	 * absent for plans the server doesn't provide a tagline for.
+	 */
+	tagline?: string | null;
 }
 
 export interface PricedAPIPlanIntroductoryOffer {
@@ -254,6 +259,7 @@ export interface PricedAPIPlan extends PricedAPIPlanPricing, PricedAPIPlanIntrod
 	product_slug: StorePlanSlug;
 	product_name_short: string;
 	product_type?: string;
+	tagline?: string | null;
 
 	/**
 	 * The product price as a float.

--- a/packages/plans-grid-next/src/hooks/data-store/fallback-plan-taglines.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/fallback-plan-taglines.ts
@@ -1,0 +1,37 @@
+import {
+	PLAN_ENTERPRISE_GRID_WPCOM,
+	PLAN_WOOEXPRESS_PLUS,
+	PLAN_P2_FREE,
+} from '@automattic/calypso-products';
+import type { TranslateResult } from 'i18n-calypso';
+
+/**
+ * Taglines for the handful of plans the `/plans` endpoint does not provide a
+ * tagline for: non-purchasable contact-sales plans (Enterprise, Woo Express
+ * Plus) and the relabeled P2 Free (which shares WP.com Free's product id, so it
+ * cannot have a distinct server tagline).
+ *
+ * This list is intentionally separate from the plan definitions in
+ * `@automattic/calypso-products` and is used only as a fallback when the server
+ * does not supply a tagline. Prefer the server-provided tagline; only add to
+ * this list for plans the server genuinely cannot describe.
+ */
+export default function getFallbackPlanTagline(
+	planSlug: string,
+	translate: ( text: string ) => TranslateResult
+): TranslateResult {
+	switch ( planSlug ) {
+		case PLAN_WOOEXPRESS_PLUS:
+			return translate(
+				'For fast-growing businesses that need access to the most powerful tools.'
+			);
+		case PLAN_ENTERPRISE_GRID_WPCOM:
+			return translate( 'Level up to bespoke Enterprise-grade performance and security.' );
+		case PLAN_P2_FREE:
+			return translate(
+				'All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.'
+			);
+		default:
+			return '';
+	}
+}

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -31,6 +31,7 @@ import {
 import { Plans } from '@automattic/data-stores';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { isSamePlan } from '../../lib/is-same-plan';
+import getFallbackPlanTagline from './fallback-plan-taglines';
 import { UseGridPlansParams, UseGridPlansType } from './types';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
@@ -430,10 +431,10 @@ const useGridPlans: UseGridPlansType = ( {
 					'For serious stores. Priority support, advanced extensions, and premium store themes.'
 				);
 			} else {
-				tagline = planObject?.tagline ?? planConstantObj.getPlanTagline?.() ?? '';
+				tagline = planObject?.tagline ?? getFallbackPlanTagline( planSlug, translate );
 			}
 		} else {
-			tagline = planObject?.tagline ?? planConstantObj.getPlanTagline?.() ?? '';
+			tagline = planObject?.tagline ?? getFallbackPlanTagline( planSlug, translate );
 		}
 
 		if ( useFocusedNewCopyTaglines ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -430,10 +430,10 @@ const useGridPlans: UseGridPlansType = ( {
 					'For serious stores. Priority support, advanced extensions, and premium store themes.'
 				);
 			} else {
-				tagline = planConstantObj.getPlanTagline?.() ?? '';
+				tagline = planObject?.tagline ?? planConstantObj.getPlanTagline?.() ?? '';
 			}
 		} else {
-			tagline = planConstantObj.getPlanTagline?.() ?? '';
+			tagline = planObject?.tagline ?? planConstantObj.getPlanTagline?.() ?? '';
 		}
 
 		if ( useFocusedNewCopyTaglines ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2137/

## Proposed changes

This sources the plan-card tagline from the server (`/plans` and `/sites/%s/plans`) instead of the hardcoded `getPlanTagline` getter in `@automattic/calypso-products`, then removes `getPlanTagline` from the package entirely so it can't be reached by new code.

> [!IMPORTANT]
> There's currently an ongoing AB test for taglines (see https://github.com/Automattic/wp-calypso/pull/109760), so code remains in packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx to override these taglines when the experiment is active. That code remains after this PR but if we wish to launch the treatment branch to everyone, we will need to update the server-side definitions like 222897-ghe-Automattic/wpcom

## Screenshots

This view should be unchanged before and after this PR:

Stepper             |  Home
:-------------------------:|:-------------------------:
<img width="1390" height="384" alt="Screenshot 2026-06-11 at 2 19 49 PM" src="https://github.com/user-attachments/assets/970d8bde-5b6b-4627-b8b5-80f0ae6d8c5b" /> | <img width="997" height="295" alt="Screenshot 2026-06-11 at 2 21 04 PM" src="https://github.com/user-attachments/assets/1f708b65-a4cc-4a7b-b6f7-7fc1bbbafa51" />

> [!NOTE]
> The logged-out pricing page displays a similar price grid, but its taglines (what it calls `subtitle`) are hard-coded in the PHP that drives it and not related to this package.

## Why are these changes being made?

`@automattic/calypso-products` is a frozen, oversized client-side duplicate of product data the backend already owns; the standing goal is to chip away at `PLANS_LIST` by moving per-plan data server-side. The plan-card tagline is a good candidate now that the `/plans` endpoint provides it.

Rather than leave `getPlanTagline` in place as a fallback (where it would keep getting referenced), the remaining cases — non-purchasable contact-sales plans (Enterprise, Woo Express Plus) and the relabeled P2 Free, which shares WP.com Free's product id and so can't have a distinct server tagline — are moved to a small, explicitly-named fallback list in the grid that consumes it. Removing the getter and its type field entirely makes it impossible to reach for the bundled tagline in new code, while the server stays the source of truth for every real product.

## Testing instructions

* On a WordPress.com site, open the plans comparison page (`/plans/:site`).
* Confirm each plan card shows the expected tagline (Free, Personal, Premium, Business, Ecommerce, Woo plans) sourced from the server.
* Confirm Enterprise, Woo Express Plus, and P2 Free still show their taglines (served from the fallback list).
* On the theme showcase, confirm the plan upgrade banner shows the plan tagline.
* Confirm the newsletter / blog-onboarding / Woo-hosting plan intents still show their intent-specific taglines.