### PR TITLE
MSD Emails: Add upgrade path and reorder cards on the email plan page

### DIFF
--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -195,9 +195,10 @@ export default function ChooseEmailSolution() {
 	const pageHeader = (
 		<PageHeader
 			prefix={ <Breadcrumbs length={ 2 } /> }
+			title={ isUpgradeIntent ? __( 'Professional Email plans' ) : undefined }
 			description={
 				isUpgradeIntent
-					? __( 'Choose a Professional Email plan that fits your needs.' )
+					? __( 'Explore our plans to find the right fit for your needs.' )
 					: __( 'Choose between Professional Email and Google Workspace for your domain.' )
 			}
 		/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
@@ -8,7 +8,7 @@ import { Button } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { currencyDollar, envelope } from '@wordpress/icons';
 import { useAnalytics } from '../../../app/analytics';
-import { addMailboxRoute, chooseEmailSolutionRoute } from '../../../app/router/emails';
+import { addMailboxRoute } from '../../../app/router/emails';
 import { ActionList } from '../../../components/action-list';
 import OverviewCard from '../../../components/overview-card';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../../emails/types';
@@ -18,10 +18,8 @@ import { isTitanMail } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
 /**
- * Whether the Titan-tier email plan management UI (tier upgrade, add mailboxes,
- * redesigned overview cards) should be shown for this purchase. Gated behind the
- * same flag as the MSD plan-selection grid it links to (DOTEMP-111), since the
- * upgrade path is meaningless without that grid.
+ * Gated behind the same flag as the tier-selection grid (DOTEMP-111), since the
+ * upgrade path is meaningless without it.
  */
 export function isEmailPlanManagementEnabled( purchase: Purchase ): boolean {
 	return config.isEnabled( 'emails/titan-tiers' ) && isTitanMail( purchase );
@@ -38,22 +36,6 @@ function getEmailPlanInterval( purchase: Purchase ): IntervalLength {
 function getPerMailboxPriceInteger( purchase: Purchase ): number {
 	const quantity = purchase.renewal_price_tier_usage_quantity || 1;
 	return Math.round( purchase.price_integer / quantity );
-}
-
-function useEmailUpgradeNavigation( purchase: Purchase ) {
-	const navigate = useNavigate();
-	const { recordTracksEvent } = useAnalytics();
-
-	return () => {
-		recordTracksEvent( 'calypso_purchases_email_upgrade_plan_click', {
-			product_slug: purchase.product_slug,
-		} );
-		navigate( {
-			to: chooseEmailSolutionRoute.to,
-			params: { domain: purchase.meta ?? '' },
-			search: { intent: 'upgrade' },
-		} );
-	};
 }
 
 function useAddMailboxesNavigation( purchase: Purchase ) {
@@ -76,35 +58,6 @@ function useAddMailboxesNavigation( purchase: Purchase ) {
 			search: { tier: tier === TitanPlanTier.Pro ? undefined : tier },
 		} );
 	};
-}
-
-/**
- * Primary "Upgrade plan" button shown next to the product title in the page header.
- */
-export function EmailUpgradePlanButton( { purchase }: { purchase: Purchase } ) {
-	const onUpgrade = useEmailUpgradeNavigation( purchase );
-
-	return (
-		<Button __next40pxDefaultSize variant="primary" onClick={ onUpgrade }>
-			{ __( 'Upgrade plan' ) }
-		</Button>
-	);
-}
-
-export function EmailUpgradePlanActionItem( { purchase }: { purchase: Purchase } ) {
-	const onUpgrade = useEmailUpgradeNavigation( purchase );
-
-	return (
-		<ActionList.ActionItem
-			title={ __( 'Upgrade plan' ) }
-			description={ __( 'Find the best fit for your business.' ) }
-			actions={
-				<Button variant="secondary" size="compact" onClick={ onUpgrade }>
-					{ __( 'Upgrade plan' ) }
-				</Button>
-			}
-		/>
-	);
 }
 
 export function AddMailboxesActionItem( { purchase }: { purchase: Purchase } ) {
@@ -136,9 +89,6 @@ export function AddMailboxesActionItem( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-/**
- * Overview card showing the per-mailbox renewal price for an email plan.
- */
 export function EmailPlanPriceCard( { purchase }: { purchase: Purchase } ) {
 	return (
 		<OverviewCard
@@ -156,10 +106,6 @@ export function EmailPlanPriceCard( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-/**
- * Overview card summarizing the mailboxes covered by an email plan. Replaces the
- * generic "Owner" card for email purchases and links to the email management page.
- */
 export function EmailPlanMailboxCard( { purchase }: { purchase: Purchase } ) {
 	const { data: accounts, isLoading } = useQuery( {
 		...mailboxAccountsQuery( purchase.blog_id, purchase.meta ?? '' ),

--- a/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
@@ -1,0 +1,195 @@
+import { EmailProvider } from '@automattic/api-core';
+import { mailboxAccountsQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { currencyDollar, envelope } from '@wordpress/icons';
+import { useAnalytics } from '../../../app/analytics';
+import { addMailboxRoute, chooseEmailSolutionRoute } from '../../../app/router/emails';
+import { ActionList } from '../../../components/action-list';
+import OverviewCard from '../../../components/overview-card';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../../emails/types';
+import { isMonthlyEmailProduct } from '../../../emails/utils/is-monthly-email-product';
+import { getTitanTierFromSlug } from '../../../emails/utils/titan-tiers';
+import { isTitanMail } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+/**
+ * Whether the Titan-tier email plan management UI (tier upgrade, add mailboxes,
+ * redesigned overview cards) should be shown for this purchase. Gated behind the
+ * same flag as the MSD plan-selection grid it links to (DOTEMP-111), since the
+ * upgrade path is meaningless without that grid.
+ */
+export function isEmailPlanManagementEnabled( purchase: Purchase ): boolean {
+	return config.isEnabled( 'emails/titan-tiers' ) && isTitanMail( purchase );
+}
+
+function getEmailPlanInterval( purchase: Purchase ): IntervalLength {
+	return isMonthlyEmailProduct( purchase ) ? IntervalLength.Monthly : IntervalLength.Annually;
+}
+
+/**
+ * The per-mailbox renewal price in the smallest currency unit. Titan is billed
+ * per mailbox, so the stored price is the term total across all mailboxes.
+ */
+function getPerMailboxPriceInteger( purchase: Purchase ): number {
+	const quantity = purchase.renewal_price_tier_usage_quantity || 1;
+	return Math.round( purchase.price_integer / quantity );
+}
+
+function useEmailUpgradeNavigation( purchase: Purchase ) {
+	const navigate = useNavigate();
+	const { recordTracksEvent } = useAnalytics();
+
+	return () => {
+		recordTracksEvent( 'calypso_purchases_email_upgrade_plan_click', {
+			product_slug: purchase.product_slug,
+		} );
+		navigate( {
+			to: chooseEmailSolutionRoute.to,
+			params: { domain: purchase.meta ?? '' },
+			search: { intent: 'upgrade' },
+		} );
+	};
+}
+
+function useAddMailboxesNavigation( purchase: Purchase ) {
+	const navigate = useNavigate();
+	const { recordTracksEvent } = useAnalytics();
+
+	return () => {
+		const tier = getTitanTierFromSlug( purchase.product_slug );
+		recordTracksEvent( 'calypso_purchases_email_add_mailboxes_click', {
+			product_slug: purchase.product_slug,
+		} );
+		navigate( {
+			to: addMailboxRoute.to,
+			params: {
+				domain: purchase.meta ?? '',
+				provider: MailboxProvider.Titan,
+				interval: getEmailPlanInterval( purchase ),
+			},
+			// Omit the default tier so existing Pro URLs stay unchanged.
+			search: { tier: tier === TitanPlanTier.Pro ? undefined : tier },
+		} );
+	};
+}
+
+/**
+ * Primary "Upgrade plan" button shown next to the product title in the page header.
+ */
+export function EmailUpgradePlanButton( { purchase }: { purchase: Purchase } ) {
+	const onUpgrade = useEmailUpgradeNavigation( purchase );
+
+	return (
+		<Button __next40pxDefaultSize variant="primary" onClick={ onUpgrade }>
+			{ __( 'Upgrade plan' ) }
+		</Button>
+	);
+}
+
+export function EmailUpgradePlanActionItem( { purchase }: { purchase: Purchase } ) {
+	const onUpgrade = useEmailUpgradeNavigation( purchase );
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Upgrade plan' ) }
+			description={ __( 'Find the best fit for your business.' ) }
+			actions={
+				<Button variant="secondary" size="compact" onClick={ onUpgrade }>
+					{ __( 'Upgrade plan' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+export function AddMailboxesActionItem( { purchase }: { purchase: Purchase } ) {
+	const onAdd = useAddMailboxesNavigation( purchase );
+	const perMailbox = formatCurrency(
+		getPerMailboxPriceInteger( purchase ),
+		purchase.currency_code,
+		{
+			isSmallestUnit: true,
+			stripZeros: true,
+		}
+	);
+	const description = isMonthlyEmailProduct( purchase )
+		? /* translators: %s is a per-mailbox monthly price, e.g. "$3.50". */
+		  sprintf( __( 'Need more? Starts at %s/month/mailbox' ), perMailbox )
+		: /* translators: %s is a per-mailbox yearly price, e.g. "$42". */
+		  sprintf( __( 'Need more? Starts at %s/year/mailbox' ), perMailbox );
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Add new mailboxes' ) }
+			description={ description }
+			actions={
+				<Button variant="secondary" size="compact" onClick={ onAdd }>
+					{ __( 'Add' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+/**
+ * Overview card showing the per-mailbox renewal price for an email plan.
+ */
+export function EmailPlanPriceCard( { purchase }: { purchase: Purchase } ) {
+	return (
+		<OverviewCard
+			icon={ currencyDollar }
+			title={ __( 'Renewal price' ) }
+			heading={ formatCurrency( getPerMailboxPriceInteger( purchase ), purchase.currency_code, {
+				isSmallestUnit: true,
+			} ) }
+			description={
+				isMonthlyEmailProduct( purchase )
+					? __( 'Per mailbox/month. Excludes taxes.' )
+					: __( 'Per mailbox/year. Excludes taxes.' )
+			}
+		/>
+	);
+}
+
+/**
+ * Overview card summarizing the mailboxes covered by an email plan. Replaces the
+ * generic "Owner" card for email purchases and links to the email management page.
+ */
+export function EmailPlanMailboxCard( { purchase }: { purchase: Purchase } ) {
+	const { data: accounts, isLoading } = useQuery( {
+		...mailboxAccountsQuery( purchase.blog_id, purchase.meta ?? '' ),
+		enabled: Boolean( purchase.blog_id && purchase.meta ),
+	} );
+
+	const titanAccount = accounts?.find(
+		( account ) => account.account_type === EmailProvider.Titan
+	);
+	const mailboxes = titanAccount?.emails?.filter( ( email ) => email.email_type === 'email' ) ?? [];
+	const count = mailboxes.length || purchase.renewal_price_tier_usage_quantity || 0;
+	const firstMailbox = mailboxes[ 0 ];
+
+	const heading =
+		count === 1 && firstMailbox
+			? `${ firstMailbox.mailbox }@${ firstMailbox.domain }`
+			: sprintf(
+					// translators: %d is a number of mailboxes.
+					_n( '%d mailbox', '%d mailboxes', count ),
+					count
+			  );
+
+	return (
+		<OverviewCard
+			icon={ envelope }
+			title={ _n( 'Mailbox', 'Mailboxes', count ) }
+			heading={ heading }
+			description={ count === 1 && firstMailbox ? undefined : purchase.meta ?? undefined }
+			link="/emails"
+			isLoading={ isLoading }
+		/>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -116,8 +116,6 @@ import {
 	AddMailboxesActionItem,
 	EmailPlanMailboxCard,
 	EmailPlanPriceCard,
-	EmailUpgradePlanActionItem,
-	EmailUpgradePlanButton,
 	isEmailPlanManagementEnabled,
 } from './email-plan';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
@@ -273,7 +271,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
 	const { recordTracksEvent } = useAnalytics();
 	const menuItems = [
-		purchase.is_upgradable && upgradeUrl && (
+		canUpgradePurchase( purchase ) && upgradeUrl && (
 			<MenuItem
 				onClick={ () => {
 					recordTracksEvent( 'calypso_purchases_upgrade_plan', {
@@ -489,9 +487,21 @@ function shouldShowChangePlan( purchase: Purchase ): boolean {
 	return expiredOrRefundDowngrade || delayedDowngrade;
 }
 
+// Titan email upgrades route through the flag-gated tier grid; without the flag the
+// upgrade URL would fall through to the wrong (site plan) page, so hide the action.
+function canUpgradePurchase( purchase: Purchase ): boolean {
+	if ( ! purchase.is_upgradable ) {
+		return false;
+	}
+	if ( isTitanMail( purchase ) && ! config.isEnabled( 'emails/titan-tiers' ) ) {
+		return false;
+	}
+	return true;
+}
+
 function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
-	if ( ! purchase.is_upgradable ) {
+	if ( ! canUpgradePurchase( purchase ) ) {
 		return null;
 	}
 	// When "Change plan" is offered (downgrade-eligible), it supersedes the
@@ -726,13 +736,9 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 			<ActionList>
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
-				{ isEmailPlanManagementEnabled( purchase ) ? (
-					<>
-						<EmailUpgradePlanActionItem purchase={ purchase } />
-						<AddMailboxesActionItem purchase={ purchase } />
-					</>
-				) : (
-					<UpgradeActionButton purchase={ purchase } />
+				<UpgradeActionButton purchase={ purchase } />
+				{ isEmailPlanManagementEnabled( purchase ) && (
+					<AddMailboxesActionItem purchase={ purchase } />
 				) }
 				<ReSubscribeActionButton purchase={ purchase } />
 				<ChangePlanActionItem purchase={ purchase } />
@@ -1561,15 +1567,10 @@ export default function PurchaseSettings() {
 							site?.options?.admin_url &&
 							! isCentennial && (
 								<HStack justify="space-between">
-									{ isEmailPlanManagementEnabled( purchase ) ? (
-										<EmailUpgradePlanButton purchase={ purchase } />
-									) : (
-										purchase.is_upgradable &&
-										upgradeUrl && (
-											<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
-												{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
-											</Button>
-										)
+									{ canUpgradePurchase( purchase ) && upgradeUrl && (
+										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
+											{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
+										</Button>
 									) }
 									{ /* Email plans surface every action in the list below, so the
 									     quick-actions menu would only duplicate them. */ }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -112,6 +112,14 @@ import { useIsSplitCancelRemoveEnabled } from '../cancel-purchase/use-is-split-c
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import AkismetApiKeyCard from './akismet-api-key-card';
 import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
+import {
+	AddMailboxesActionItem,
+	EmailPlanMailboxCard,
+	EmailPlanPriceCard,
+	EmailUpgradePlanActionItem,
+	EmailUpgradePlanButton,
+	isEmailPlanManagementEnabled,
+} from './email-plan';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
 import JetpackLicenseKeyCard from './jetpack-license-key-card';
 import { PurchaseNotice } from './purchase-notice';
@@ -718,7 +726,14 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 			<ActionList>
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
-				<UpgradeActionButton purchase={ purchase } />
+				{ isEmailPlanManagementEnabled( purchase ) ? (
+					<>
+						<EmailUpgradePlanActionItem purchase={ purchase } />
+						<AddMailboxesActionItem purchase={ purchase } />
+					</>
+				) : (
+					<UpgradeActionButton purchase={ purchase } />
+				) }
 				<ReSubscribeActionButton purchase={ purchase } />
 				<ChangePlanActionItem purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
@@ -944,6 +959,14 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 
 function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
 	const isCentennial = isCentennialPurchase( purchase );
+	// Email plans are billed per mailbox; show the per-mailbox renewal price.
+	if (
+		isEmailPlanManagementEnabled( purchase ) &&
+		! isExpired( purchase ) &&
+		! purchase.is_trial_plan
+	) {
+		return <EmailPlanPriceCard purchase={ purchase } />;
+	}
 	if ( isCentennial ) {
 		return (
 			<OverviewCard
@@ -1480,6 +1503,48 @@ export default function PurchaseSettings() {
 	const columns = isSmallViewport ? 1 : 2;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
 
+	// Email plans order the overview cards as Renews, Renewal price, Mailbox, Site;
+	// every other purchase keeps Site, Owner, Renews, Price. Extract the two cards
+	// that move so they can be rendered before or after the price card.
+	const isEmailPlan = isEmailPlanManagementEnabled( purchase );
+	const siteCard =
+		site &&
+		( site.options?.is_domain_only &&
+		purchase.is_domain &&
+		purchase.product_slug !== DomainProductSlugs.TRANSFER_IN &&
+		domain?.can_transfer_to_other_site ? (
+			<OverviewCard
+				icon={ <Icon icon={ layout } /> }
+				title={ __( 'Attach to a site' ) }
+				heading={ __( 'No site attached' ) }
+				description={ __( 'Attach this domain name to an existing site.' ) }
+				link={ `/domains/${ purchase.meta }/transfer/other-site` }
+				intent="upsell"
+			/>
+		) : (
+			<OverviewCard
+				icon={ <SiteIcon site={ site } /> }
+				title={ __( 'Site' ) }
+				heading={ site.name }
+				description={ purchase.site_slug }
+				link={ `/sites/${ purchase.site_slug }` }
+			/>
+		) );
+	const ownerOrMailboxCard = isEmailPlan ? (
+		<EmailPlanMailboxCard purchase={ purchase } />
+	) : (
+		<OverviewCard
+			icon={ commentAuthorAvatar }
+			title={ __( 'Owner' ) }
+			heading={
+				String( user.ID ) === String( purchase.user_id )
+					? user.display_name
+					: __( 'Owned by a different user' )
+			}
+			description={ String( user.ID ) === String( purchase.user_id ) ? user.email : undefined }
+		/>
+	);
+
 	return (
 		<PageLayout
 			size="small"
@@ -1496,14 +1561,23 @@ export default function PurchaseSettings() {
 							site?.options?.admin_url &&
 							! isCentennial && (
 								<HStack justify="space-between">
-									{ purchase.is_upgradable && upgradeUrl && (
-										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
-											{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
-										</Button>
+									{ isEmailPlanManagementEnabled( purchase ) ? (
+										<EmailUpgradePlanButton purchase={ purchase } />
+									) : (
+										purchase.is_upgradable &&
+										upgradeUrl && (
+											<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
+												{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
+											</Button>
+										)
 									) }
-									<PageHeader.ActionMenu>
-										<PurchaseActionMenu purchase={ purchase } />
-									</PageHeader.ActionMenu>
+									{ /* Email plans surface every action in the list below, so the
+									     quick-actions menu would only duplicate them. */ }
+									{ ! isEmailPlanManagementEnabled( purchase ) && (
+										<PageHeader.ActionMenu>
+											<PurchaseActionMenu purchase={ purchase } />
+										</PageHeader.ActionMenu>
+									) }
 								</HStack>
 							)
 						}
@@ -1527,41 +1601,13 @@ export default function PurchaseSettings() {
 		>
 			<VStack spacing={ 6 }>
 				<PurchaseNotice purchase={ purchase } />
-				<Grid columns={ columns } gap={ spacing }>
-					{ site &&
-						( site.options?.is_domain_only &&
-						purchase.is_domain &&
-						purchase.product_slug !== DomainProductSlugs.TRANSFER_IN &&
-						domain?.can_transfer_to_other_site ? (
-							<OverviewCard
-								icon={ <Icon icon={ layout } /> }
-								title={ __( 'Attach to a site' ) }
-								heading={ __( 'No site attached' ) }
-								description={ __( 'Attach this domain name to an existing site.' ) }
-								link={ `/domains/${ purchase.meta }/transfer/other-site` }
-								intent="upsell"
-							/>
-						) : (
-							<OverviewCard
-								icon={ <SiteIcon site={ site } /> }
-								title={ __( 'Site' ) }
-								heading={ site.name }
-								description={ purchase.site_slug }
-								link={ `/sites/${ purchase.site_slug }` }
-							/>
-						) ) }
-					<OverviewCard
-						icon={ commentAuthorAvatar }
-						title={ __( 'Owner' ) }
-						heading={
-							String( user.ID ) === String( purchase.user_id )
-								? user.display_name
-								: __( 'Owned by a different user' )
-						}
-						description={
-							String( user.ID ) === String( purchase.user_id ) ? user.email : undefined
-						}
-					/>
+				<Grid
+					columns={ columns }
+					gap={ spacing }
+					className={ isEmailPlan ? 'purchase-settings__email-overview-cards' : undefined }
+				>
+					{ ! isEmailPlan && siteCard }
+					{ ! isEmailPlan && ownerOrMailboxCard }
 					{ hasExpiryInfo &&
 						( isExpired( purchase ) ? (
 							<OverviewCard icon={ info } title={ __( 'Status' ) } heading={ __( 'Removed' ) } />
@@ -1620,6 +1666,8 @@ export default function PurchaseSettings() {
 							/>
 						) ) }
 					<PurchasePriceCard purchase={ purchase } />
+					{ isEmailPlan && ownerOrMailboxCard }
+					{ isEmailPlan && siteCard }
 					{ purchase.is_jetpack_plan_or_product && (
 						<JetpackLicenseKeyCard purchaseId={ purchase.ID } />
 					) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -31,3 +31,12 @@
 	border-block-start: 1px solid $gray-100;
 	margin: 0;
 }
+
+// Email plan overview cards use the primary text color for their icons to match
+// the design, rather than the default admin theme accent.
+.purchase-settings__email-overview-cards {
+	.dashboard-overview-card__icon {
+		color: var(--dashboard__text-color);
+		fill: var(--dashboard__text-color);
+	}
+}

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,10 +1,11 @@
 import { ProductUpgradeMap, AkismetUpgradesProductMap } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { getCurrentDashboard } from '../app/routing';
 import { isSitePlanTrial, isSitePlanWooHosted } from '../sites/plans';
 import { isDashboardBackport } from './is-dashboard-backport';
 import { dashboardLink, redirectToDashboardLink, wpcomLink } from './link';
-import { isAkismetProduct, isJetpackT1SecurityPlan } from './purchase';
+import { isAkismetProduct, isJetpackT1SecurityPlan, isTitanMail } from './purchase';
 import { isSelfHostedJetpackConnected } from './site-types';
 import type { Purchase, Site } from '@automattic/api-core';
 
@@ -113,6 +114,11 @@ export function getChangedPlanRedirectUrl(): string {
 }
 
 export function getSitePurchaseUpgradeUrl( purchase: Purchase, redirectTo?: string ) {
+	// Titan plans upgrade through the email tier grid, not the generic checkout.
+	if ( config.isEnabled( 'emails/titan-tiers' ) && isTitanMail( purchase ) && purchase.meta ) {
+		return dashboardLink( `/emails/choose-email-solution/${ purchase.meta }?intent=upgrade` );
+	}
+
 	if ( isAkismetProduct( purchase ) ) {
 		// For the first Iteration of Calypso Akismet checkout we are only suggesting
 		// for immediate upgrades to the next plan. We will change this in the future


### PR DESCRIPTION
Part of DOTEMP-112

> [!NOTE]
> The dependency #112096 (DOTEMP-111, the Titan tier selection grid) has merged into `trunk`. This branch has been rebased onto `trunk`, so the diff shown here is just the manage-purchase page changes.

## Proposed Changes

* On the Dashboard manage-purchase page for a Titan email plan, add an upgrade entry point that links into the email solution chooser with `?intent=upgrade`, behind the `emails/titan-tiers` feature flag.
* Reuse the existing generic upgrade button (`UpgradeActionButton` / header button) for the email upgrade instead of bespoke email-specific buttons. The Titan upgrade destination lives in `getSitePurchaseUpgradeUrl` (flag-gated), and a `canUpgradePurchase()` helper gates both call sites on `is_upgradable` plus the flag for Titan.
* Reorder the plan overview cards to Renews, Price, Mailbox, Site.
* Switch the plan card icons to black and drop the redundant quick actions menu.
* Update the upgrade page copy to "Professional Email plans" / "Explore our plans to find the right fit for your needs."

## Why are these changes being made?

* This gives existing Titan subscribers a way to reach the new tier selection grid (added in #112096) directly from the page where they manage their email plan, and tidies the overview cards to match the intended layout.

## Known limitation / follow-up

* The actual upgrade action **from the plan grid** (clicking a higher tier on the chooser in `?intent=upgrade` mode) is not wired to a real tier-change flow yet — it currently routes into the add-mailbox flow and dead-ends. The backend tier-change/upgrade flow is being built separately, and the front-end wiring will land in a **follow-up PR**.
* This is acceptable to merge as-is: the entire path is behind the `emails/titan-tiers` feature flag (off in production), so no user can reach the dead-end. Once the backend is ready, the follow-up will resolve the grid's upgrade action (and the placeholder destination in `getSitePurchaseUpgradeUrl` can move into `ProductUpgradeMap`).

## Testing Instructions

* Enable the `emails/titan-tiers` feature flag.
* Open the Dashboard manage-purchase page for a Titan email plan (`/purchases/<purchaseId>`).
* Confirm the overview cards appear in the order Renews, Price, Mailbox, Site, the icons are black, and the quick actions menu is gone.
* Confirm the upgrade button navigates to the email solution chooser in upgrade mode (`?intent=upgrade`). (Reaching this requires `is_upgradable` to be set for the purchase; see the known limitation above for the grid's upgrade action.)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
