### PR TITLE
Reader Spaces: wire the data layer to the real wpcom/v2 feeds/tags API

### DIFF
--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -5,15 +5,14 @@ import {
 	deleteReadSpaceSourceMutation,
 	readSpaceQuery,
 	readSpacesQuery,
+	updateReadSpaceMutation,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ReadSpace } from '@automattic/api-core';
 
 /**
- * The user's spaces for the sidebar and space views. Until the real list
- * endpoint lands (RSM-4145) this is the hard-coded placeholder set plus any
- * spaces created in the current session — the latter are held in the React
- * Query cache by the create mutation.
+ * The user's spaces for the sidebar and space views, from the live list
+ * endpoint. Summary shape only (no sources or tags) — use `useSpace` for those.
  */
 export function useSpaces(): ReadSpace[] {
 	const { data = [] } = useQuery( readSpacesQuery() );
@@ -21,11 +20,11 @@ export function useSpaces(): ReadSpace[] {
 }
 
 /**
- * A single space's details, loaded on demand (e.g. by the sources modal).
- * Disabled until an id is known; pass `enabled: false` to also hold it off
- * while the consumer (e.g. a closed modal) doesn't need it yet. The add/delete
- * source mutations patch this query optimistically, so consumers see source
- * changes immediately.
+ * A single space's details (its followed feeds and tags), loaded on demand from
+ * the live detail endpoint (e.g. by the sources modal). Disabled until an id is
+ * known; pass `enabled: false` to also hold it off while the consumer (e.g. a
+ * closed modal) doesn't need it yet. The add/delete source mutations write the
+ * returned detail back here, so consumers see source changes immediately.
  */
 export function useSpace(
 	spaceId: string | null | undefined,
@@ -45,6 +44,17 @@ export function useSpace(
 export function useCreateSpace() {
 	const queryClient = useQueryClient();
 	return useMutation( createReadSpaceMutation( queryClient ) );
+}
+
+/**
+ * Update-space mutation wired to Calypso's QueryClient. On success the returned
+ * detail is written to the detail cache and the matching list summary is
+ * refreshed. Not used by any UI yet — an edit control can adopt it when built.
+ * Note `tags` is a full replace of the tag set (there are no per-tag endpoints).
+ */
+export function useUpdateSpace() {
+	const queryClient = useQueryClient();
+	return useMutation( updateReadSpaceMutation( queryClient ) );
 }
 
 /**

--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -1,6 +1,7 @@
 import {
 	addReadSpaceSourceMutation,
 	createReadSpaceMutation,
+	deleteReadSpaceMutation,
 	deleteReadSpaceSourceMutation,
 	readSpaceQuery,
 	readSpacesQuery,
@@ -44,6 +45,17 @@ export function useSpace(
 export function useCreateSpace() {
 	const queryClient = useQueryClient();
 	return useMutation( createReadSpaceMutation( queryClient ) );
+}
+
+/**
+ * Delete-space mutation wired to Calypso's QueryClient. On success the space is
+ * removed from the cached list and its detail cache is discarded. Not used by
+ * any UI yet — a delete control (with a confirm, since it's a hard delete) can
+ * adopt this hook when one is built.
+ */
+export function useDeleteSpace() {
+	const queryClient = useQueryClient();
+	return useMutation( deleteReadSpaceMutation( queryClient ) );
 }
 
 export function useAddSpaceSource() {

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -4,8 +4,9 @@
 import { readSpacesQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { QueryClient } from '@tanstack/react-query';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { getSpacePath } from 'calypso/reader/spaces/routes';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ReaderSidebarSpaces } from '../index';
@@ -48,6 +49,8 @@ describe( 'ReaderSidebarSpaces', () => {
 		jest.mocked( page ).mockClear();
 		jest.mocked( page.replace ).mockClear();
 	} );
+
+	afterEach( () => nock.cleanAll() );
 
 	it( 'renders every space with a link to its page', () => {
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
@@ -93,14 +96,26 @@ describe( 'ReaderSidebarSpaces', () => {
 
 	it( 'redirects to the new space sources action after creating a space', async () => {
 		const user = userEvent.setup();
+		nock( 'https://public-api.wordpress.com' ).post( '/wpcom/v2/reader/spaces/new' ).reply( 201, {
+			id: 7,
+			title: 'Reading',
+			sites: [],
+			tags: [],
+			layout_color: 'blue',
+			layout_icon: 'inbox',
+		} );
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
 
 		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 
-		expect( page ).toHaveBeenCalledWith(
-			expect.stringMatching( /^\/reader\/spaces\/.+#action=manage-sources$/ )
+		// The redirect happens in the create mutation's onSuccess, after the POST
+		// resolves, so wait for it.
+		await waitFor( () =>
+			expect( page ).toHaveBeenCalledWith(
+				expect.stringMatching( /^\/reader\/spaces\/.+#action=manage-sources$/ )
+			)
 		);
 	} );
 

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -21,13 +21,11 @@ const SPACES: ReadSpace[] = [
 	{
 		id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
 		name: 'Work',
-		tags: [],
 		layout: { color: 'blue', icon: 'inbox' },
 	},
 	{
 		id: '5cc71d31-97d1-4b7d-93c7-42a5ce9d4cf1',
 		name: 'Gaming',
-		tags: [],
 		layout: { color: 'purple', icon: 'box' },
 	},
 ];
@@ -99,7 +97,7 @@ describe( 'ReaderSidebarSpaces', () => {
 		nock( 'https://public-api.wordpress.com' ).post( '/wpcom/v2/reader/spaces/new' ).reply( 201, {
 			id: 7,
 			title: 'Reading',
-			sites: [],
+			follows: [],
 			tags: [],
 			layout_color: 'blue',
 			layout_icon: 'inbox',

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -94,14 +94,15 @@ describe( 'ReaderSidebarSpaces', () => {
 
 	it( 'redirects to the new space sources action after creating a space', async () => {
 		const user = userEvent.setup();
-		nock( 'https://public-api.wordpress.com' ).post( '/wpcom/v2/reader/spaces/new' ).reply( 201, {
-			id: 7,
-			title: 'Reading',
-			follows: [],
-			tags: [],
-			layout_color: 'blue',
-			layout_icon: 'inbox',
-		} );
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/spaces' )
+			.reply( 201, {
+				id: 7,
+				title: 'Reading',
+				follows: [],
+				tags: [],
+				layout: { color: 'blue', icon: 'inbox' },
+			} );
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
 
 		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );

--- a/client/reader/spaces/AGENTS.md
+++ b/client/reader/spaces/AGENTS.md
@@ -1,21 +1,25 @@
 # Reader Spaces
 
-Spaces group subscriptions under a name plus optional tags. v0 is dark-shipped
-behind the `reader/spaces` feature flag and has **no backend yet** (epic
-RSM-4110); creating a space only writes the React Query cache for now.
+Spaces group followed feeds (the client calls them `sources`) and tags under a
+name. Dark-shipped behind the `reader/spaces` feature flag (epic RSM-4110), a8c
+only, and wired to the real `wpcom/v2` backend.
 
-> See [`README.md`](./README.md) for the endpoints and contracts the client
-> expects once the backend lands (and the placeholder-vs-real caching strategy).
+> See [`README.md`](./README.md) for the full endpoint contract, data shapes,
+> error codes, and caching strategy.
 
 ## Layout
 
 - **Model & data** — `@automattic/api-core` → `read-spaces/`: `ReadSpace`,
-  `CreateReadSpaceParams`, `MAX_SPACE_NAME_LENGTH`, and the placeholder list
-  returned by `fetchers.ts`. No JSX, no routes here — api-core stays serializable.
+  `ReadSpaceDetails`, `CreateReadSpaceParams`, `UpdateReadSpaceParams`,
+  `MAX_SPACE_NAME_LENGTH`, the fetchers/mutators, and the wire→client mapping in
+  `adapters.ts` (renames `follows` → `sources`). No JSX, no routes here — api-core
+  stays serializable.
 - **Queries & mutations** — `@automattic/api-queries` → `read-spaces.ts`:
-  `readSpacesQuery`, `createReadSpaceMutation`. The create mutation is
-  cache-only; `TODO(RSM-4139)` swaps in the real `POST`.
-- **Consumer hooks** — `client/reader/data/spaces/`: `useSpaces`, `useCreateSpace`.
+  `readSpacesQuery`/`readSpaceQuery` and the create/update/delete/feed mutations.
+  Each mutation returns the full detail and writes it back to the caches.
+- **Consumer hooks** — `client/reader/data/spaces/`: `useSpaces`, `useSpace`,
+  `useCreateSpace`, `useUpdateSpace`, `useDeleteSpace`, `useAddSpaceSource`,
+  `useDeleteSpaceSource`.
 - **UI (this folder)** — `view.tsx`, `controller.tsx`, `index.tsx` (routes),
   `icons.ts`, `routes.ts`, `create-modal/`.
 - **Sidebar entry point** — `client/reader/sidebar/spaces/`.

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -1,20 +1,21 @@
 # Reader Spaces — expected endpoints
 
-Spaces are dark-shipped behind the `reader/spaces` flag and have **no backend
-yet** (epic RSM-4110). Today the data layer resolves a hard-coded placeholder
-set and mutates the React Query cache in-memory. This document lists the
-endpoints the client already expects, and the contract each one needs to honor
-so the placeholders can be swapped for real requests with no changes above the
-`@automattic/api-core` layer.
+Spaces are dark-shipped behind the `reader/spaces` flag (epic RSM-4110). The
+**list, create, and delete** endpoints are now live on `wpcom/v2`; the
+**single-space (detail) and source** endpoints are still hard-coded placeholders
+that mutate the React Query cache in-memory. This document lists every endpoint
+the client expects and the contract each honors.
 
-> No endpoints are implemented yet — every REST path below is **proposed**. The
-> request/response shapes are defined by the client; the paths are not pinned.
+> Endpoints are marked **live** or **proposed** below. Live paths are pinned to
+> the real `wpcom/v2` routes; proposed paths are the shapes the client expects
+> and are not yet pinned.
 
 ## Data shapes
 
 These types live in `@automattic/api-core` → `read-spaces/types.ts`. The wire
-JSON will likely be snake_case; if so, the fetchers adapt it to these shapes
-(as `read-follows` already does for subscriptions).
+JSON is snake_case (`title`, `layout_color`, `layout_icon`, numeric `id`); the
+fetchers adapt it to these shapes in `read-spaces/adapters.ts` (as `read-follows`
+does for subscriptions).
 
 ```ts
 // List shape — NO sources. Returned by the list endpoint.
@@ -57,15 +58,15 @@ and must stay in sync with the backend (RSM-4139).
 
 ## Endpoints
 
-### 1. List spaces — `GET /read/spaces` · RSM-4145
+### 1. List spaces — `GET /reader/spaces` · RSM-4145 · **live**
 
 Returns the user's spaces **without** their sources.
 
 - **Request:** none (authenticated user).
-- **Response `200`:** `ReadSpace[]`
-- Placeholder: `fetchReadSpaces()` → in-memory set, stripped of sources.
+- **Response `200`:** array of wire items (snake_case), adapted to `ReadSpace[]`.
+- Wired: `fetchReadSpaces()` → real `GET`, mapped via `adaptReadSpace`.
 
-### 2. Get one space — `GET /read/spaces/{id}` · RSM-4145
+### 2. Get one space — `GET /reader/spaces/{id}` · RSM-4145 · **proposed**
 
 Returns a single space **with** its sources. This is the only endpoint that
 returns `sources`.
@@ -73,22 +74,25 @@ returns `sources`.
 - **Request:** path param `id`.
 - **Response `200`:** `ReadSpaceDetails`
 - **Response `404`:** unknown id.
-- Placeholder: `fetchReadSpace(id)` → matching placeholder space + `sources: []`.
+- Placeholder: `fetchReadSpace(id)` still resolves the in-memory set + `sources: []`.
 
-### 3. Create space — `POST /read/spaces` · RSM-4139
+### 3. Create space — `POST /reader/spaces/new` · RSM-4139 · **live**
 
-- **Request body:** `CreateReadSpaceParams` → `{ name, tags }`
-- **Response `201`:** `ReadSpaceDetails` (server-generated `id`, defaults applied:
-  `layout: { color: 'blue', icon: 'category' }`, `sources: []`).
-- **Response `422`:** empty name / name over `MAX_SPACE_NAME_LENGTH`.
-- Placeholder: `createReadSpace()` builds the space locally with a generated id.
+- **Request body:** `{ title, tags }` (the create form sends only these; the
+  endpoint also accepts optional `sites`, `layout_color`, `layout_icon`).
+- **Response `201`:** the created space (snake_case wire item), adapted to
+  `ReadSpaceDetails`. Server defaults a random palette `layout_color`/`layout_icon`
+  when omitted, and `sources: []`.
+- **Errors:** `403 rest_forbidden`, `400 reader_spaces_invalid_title`,
+  `400 reader_spaces_invalid_tag`, `409 reader_spaces_duplicate_slug`.
+- Wired: `createReadSpace()` → real `POST`, mapped via `adaptReadSpaceDetails`.
 
 > The create flow is **not** optimistic — the cache is written in `onSuccess`
 > using the returned space, so the list always carries the backend id (no temp-id
 > reconciliation). On success the list gets a `ReadSpace` (sources stripped) and
 > the detail cache is seeded with the full `ReadSpaceDetails`.
 
-### 4. Add a source to a space — `POST /read/spaces/{id}/sources` · ticket TBD
+### 4. Add a source to a space — `POST /reader/spaces/{id}/sources` · ticket TBD · **proposed**
 
 - **Request body:** a source identifier — at least one of
   `{ feed_id?: number; blog_id?: number; feed_url?: string }`.
@@ -96,11 +100,27 @@ returns `sources`.
   reconcile), or `204`.
 - Placeholder: `addReadSpaceSource()` is a no-op; the cache patch is optimistic.
 
-### 5. Remove a source from a space — `DELETE /read/spaces/{id}/sources/{sourceId}` · ticket TBD
+### 5. Remove a source from a space — `DELETE /reader/spaces/{id}/sources/{sourceId}` · ticket TBD · **proposed**
 
 - **Request:** identify the source by `feed_id`/`blog_id`/`feed_url` (path or query).
 - **Response `200`/`204`.**
 - Placeholder: `deleteReadSpaceSource()` is a no-op; the cache patch is optimistic.
+
+### 6. Delete a space — `POST /reader/spaces/{id}/delete` · RSM-4110 · **live**
+
+Permanently deletes a space (hard delete — no trash/undo). Owner-only, enforced
+server-side.
+
+- **Request:** path param `id`, no body.
+- **Response `200`:** `{ deleted: true, id }`.
+- **Response `403`:** `rest_forbidden` — logged out / not an Automattician.
+- **Response `404`:** `reader_spaces_not_found` — gone **or** not yours
+  (intentionally indistinguishable; we don't reveal other users' spaces, so the
+  UI must treat both the same).
+- **Response `500`:** `reader_spaces_delete_failed` — yours, but deletion failed.
+- Wired: `deleteReadSpace( id )` → real `POST`; `deleteReadSpaceMutation` removes
+  the space from the list cache and discards its detail cache `onSuccess`. No UI
+  consumer yet — `useDeleteSpace()` is ready for a (confirm-gated) delete control.
 
 ## Caching strategy (placeholder vs real)
 

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -12,10 +12,10 @@ only. All endpoints live under `wpcom/v2` and are wired to the real backend.
 ## Data shapes
 
 These types live in `@automattic/api-core` → `read-spaces/types.ts`. The wire JSON
-is snake_case (`title`, `layout_color`, `layout_icon`, numeric `id`, `follows`);
+is snake-cased (`title`, `layout_color`, `layout_icon`, numeric `id`, `follows`);
 `read-spaces/adapters.ts` maps it to the client shapes below (as `read-follows`
 does for subscriptions). Notably it renames the wire `follows` to `sources` and
-nests the flat `layout_*` fields under `layout`.
+nests the flat `layout_color` / `layout_icon` fields under `layout`.
 
 ```ts
 // Summary — returned by the list endpoint only. No sources, no tags.
@@ -57,15 +57,15 @@ All paths are under `https://public-api.wordpress.com/wpcom/v2/reader/spaces`.
 Every mutation returns the **full updated detail**, so the client writes that
 straight to the caches — no follow-up GET.
 
-| # | Method & path | Body | Returns | Wired as |
-| - | --- | --- | --- | --- |
-| 1 | `GET /reader/spaces` | — | `200` summary[] | `fetchReadSpaces()` |
-| 2 | `GET /reader/spaces/{id}` | — | `200` detail | `fetchReadSpace(id)` |
-| 3 | `POST /reader/spaces/new` | `{ title*, feeds?, tags?, layout_color?, layout_icon? }` | `201` detail | `createReadSpace()` |
-| 4 | `POST /reader/spaces/{id}/update` | `{ title?, tags?, layout_color?, layout_icon? }` (≥1) | `200` detail | `updateReadSpace()` |
-| 5 | `POST /reader/spaces/{id}/delete` | — | `200 { deleted, id }` | `deleteReadSpace()` |
-| 6 | `POST /reader/spaces/{id}/feeds/new` | `{ feed* }` (feed id or url) | `200` detail | `addReadSpaceSource()` |
-| 7 | `POST /reader/spaces/{id}/feeds/{feed_id}/delete` | — | `200` detail | `deleteReadSpaceSource()` |
+| #   | Method & path                                     | Body                                                     | Returns               | Wired as                  |
+| --- | ------------------------------------------------- | -------------------------------------------------------- | --------------------- | ------------------------- |
+| 1   | `GET /reader/spaces`                              | —                                                        | `200` summary[]       | `fetchReadSpaces()`       |
+| 2   | `GET /reader/spaces/{id}`                         | —                                                        | `200` detail          | `fetchReadSpace(id)`      |
+| 3   | `POST /reader/spaces/new`                         | `{ title*, feeds?, tags?, layout_color?, layout_icon? }` | `201` detail          | `createReadSpace()`       |
+| 4   | `POST /reader/spaces/{id}/update`                 | `{ title?, tags?, layout_color?, layout_icon? }` (≥1)    | `200` detail          | `updateReadSpace()`       |
+| 5   | `POST /reader/spaces/{id}/delete`                 | —                                                        | `200 { deleted, id }` | `deleteReadSpace()`       |
+| 6   | `POST /reader/spaces/{id}/feeds/new`              | `{ feed* }` (feed id or url)                             | `200` detail          | `addReadSpaceSource()`    |
+| 7   | `POST /reader/spaces/{id}/feeds/{feed_id}/delete` | —                                                        | `200` detail          | `deleteReadSpaceSource()` |
 
 Notes:
 
@@ -81,18 +81,18 @@ Notes:
 
 ## Error codes
 
-| HTTP | code | when |
-| - | --- | --- |
-| 403 | `rest_forbidden` | not logged in / not an Automattician |
-| 404 | `reader_spaces_not_found` | space doesn't exist or isn't yours |
-| 404 | `reader_spaces_item_not_found` | removing a feed not in the space |
-| 400 | `reader_spaces_invalid_title` | empty title (create or update) |
-| 400 | `reader_spaces_invalid_feed` | a feed isn't an existing feedbag feed |
-| 400 | `reader_spaces_invalid_tag` | a tag slug isn't a valid Reader tag |
-| 400 | `reader_spaces_no_changes` | `update` with no recognized fields |
-| 409 | `reader_spaces_duplicate_slug` | a space with that title already exists |
-| 409 | `reader_spaces_duplicate_feed` | feed already in the space |
-| 500 | `reader_spaces_delete_failed` | delete didn't persist (rare) |
+| HTTP | code                           | when                                   |
+| ---- | ------------------------------ | -------------------------------------- |
+| 403  | `rest_forbidden`               | not logged in / not an Automattician   |
+| 404  | `reader_spaces_not_found`      | space doesn't exist or isn't yours     |
+| 404  | `reader_spaces_item_not_found` | removing a feed not in the space       |
+| 400  | `reader_spaces_invalid_title`  | empty title (create or update)         |
+| 400  | `reader_spaces_invalid_feed`   | a feed isn't an existing feedbag feed  |
+| 400  | `reader_spaces_invalid_tag`    | a tag slug isn't a valid Reader tag    |
+| 400  | `reader_spaces_no_changes`     | `update` with no recognized fields     |
+| 409  | `reader_spaces_duplicate_slug` | a space with that title already exists |
+| 409  | `reader_spaces_duplicate_feed` | feed already in the space              |
+| 500  | `reader_spaces_delete_failed`  | delete didn't persist (rare)           |
 
 The create modal maps `rest_forbidden` / `reader_spaces_invalid_title` /
 `reader_spaces_invalid_tag` / `reader_spaces_duplicate_slug` to copy; other

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -12,10 +12,10 @@ only. All endpoints live under `wpcom/v2` and are wired to the real backend.
 ## Data shapes
 
 These types live in `@automattic/api-core` → `read-spaces/types.ts`. The wire JSON
-is snake-cased (`title`, `layout_color`, `layout_icon`, numeric `id`, `follows`);
-`read-spaces/adapters.ts` maps it to the client shapes below (as `read-follows`
-does for subscriptions). Notably it renames the wire `follows` to `sources` and
-nests the flat `layout_color` / `layout_icon` fields under `layout`.
+uses `title` (not `name`), a numeric `id`, a `layout` object (`{ color, icon }`),
+and `follows`; `read-spaces/adapters.ts` maps it to the client shapes below (as
+`read-follows` does for subscriptions) — chiefly renaming `title` to `name` and
+the wire `follows` to `sources`.
 
 ```ts
 // Summary — returned by the list endpoint only. No sources, no tags.
@@ -57,15 +57,15 @@ All paths are under `https://public-api.wordpress.com/wpcom/v2/reader/spaces`.
 Every mutation returns the **full updated detail**, so the client writes that
 straight to the caches — no follow-up GET.
 
-| #   | Method & path                                     | Body                                                     | Returns               | Wired as                  |
-| --- | ------------------------------------------------- | -------------------------------------------------------- | --------------------- | ------------------------- |
-| 1   | `GET /reader/spaces`                              | —                                                        | `200` summary[]       | `fetchReadSpaces()`       |
-| 2   | `GET /reader/spaces/{id}`                         | —                                                        | `200` detail          | `fetchReadSpace(id)`      |
-| 3   | `POST /reader/spaces/new`                         | `{ title*, feeds?, tags?, layout_color?, layout_icon? }` | `201` detail          | `createReadSpace()`       |
-| 4   | `POST /reader/spaces/{id}/update`                 | `{ title?, tags?, layout_color?, layout_icon? }` (≥1)    | `200` detail          | `updateReadSpace()`       |
-| 5   | `POST /reader/spaces/{id}/delete`                 | —                                                        | `200 { deleted, id }` | `deleteReadSpace()`       |
-| 6   | `POST /reader/spaces/{id}/feeds/new`              | `{ feed* }` (feed id or url)                             | `200` detail          | `addReadSpaceSource()`    |
-| 7   | `POST /reader/spaces/{id}/feeds/{feed_id}/delete` | —                                                        | `200` detail          | `deleteReadSpaceSource()` |
+| #   | Method & path                                | Body                                                           | Returns               | Wired as                  |
+| --- | -------------------------------------------- | -------------------------------------------------------------- | --------------------- | ------------------------- |
+| 1   | `GET /reader/spaces`                         | —                                                              | `200` summary[]       | `fetchReadSpaces()`       |
+| 2   | `GET /reader/spaces/{id}`                    | —                                                              | `200` detail          | `fetchReadSpace(id)`      |
+| 3   | `POST /reader/spaces`                        | `{ title*, feeds?, tags?, layout? }`                           | `201` detail          | `createReadSpace()`       |
+| 4   | `PUT /reader/spaces/{id}`                    | `{ title?, tags?, layout? }` (≥1; `layout` is a partial merge) | `200` detail          | `updateReadSpace()`       |
+| 5   | `DELETE /reader/spaces/{id}`                 | —                                                              | `200 { deleted, id }` | `deleteReadSpace()`       |
+| 6   | `POST /reader/spaces/{id}/feeds`             | `{ feed* }` (feed id or url)                                   | `200` detail          | `addReadSpaceSource()`    |
+| 7   | `DELETE /reader/spaces/{id}/feeds/{feed_id}` | —                                                              | `200` detail          | `deleteReadSpaceSource()` |
 
 Notes:
 

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -1,28 +1,27 @@
-# Reader Spaces — expected endpoints
+# Reader Spaces — API contract
 
-Spaces are dark-shipped behind the `reader/spaces` flag (epic RSM-4110). The
-**list, create, and delete** endpoints are now live on `wpcom/v2`; the
-**single-space (detail) and source** endpoints are still hard-coded placeholders
-that mutate the React Query cache in-memory. This document lists every endpoint
-the client expects and the contract each honors.
+A Space groups followed feeds (the client calls them `sources`) and followed tags
+under a name. Dark-shipped behind the `reader/spaces` flag (epic RSM-4110), a8c
+only. All endpoints live under `wpcom/v2` and are wired to the real backend.
 
-> Endpoints are marked **live** or **proposed** below. Live paths are pinned to
-> the real `wpcom/v2` routes; proposed paths are the shapes the client expects
-> and are not yet pinned.
+> Ownership: you only ever see or modify your own spaces. Another user's space
+> (or a non-existent id) returns `404 reader_spaces_not_found` — the two are
+> indistinguishable by design, so the UI must treat them the same. `403` is
+> purely the a8c gate.
 
 ## Data shapes
 
-These types live in `@automattic/api-core` → `read-spaces/types.ts`. The wire
-JSON is snake_case (`title`, `layout_color`, `layout_icon`, numeric `id`); the
-fetchers adapt it to these shapes in `read-spaces/adapters.ts` (as `read-follows`
-does for subscriptions).
+These types live in `@automattic/api-core` → `read-spaces/types.ts`. The wire JSON
+is snake_case (`title`, `layout_color`, `layout_icon`, numeric `id`, `follows`);
+`read-spaces/adapters.ts` maps it to the client shapes below (as `read-follows`
+does for subscriptions). Notably it renames the wire `follows` to `sources` and
+nests the flat `layout_*` fields under `layout`.
 
 ```ts
-// List shape — NO sources. Returned by the list endpoint.
+// Summary — returned by the list endpoint only. No sources, no tags.
 interface ReadSpace {
 	id: string;
-	name: string;
-	tags: string[];
+	name: string; // wire `title`
 	layout: SpaceLayout;
 }
 
@@ -32,134 +31,93 @@ interface SpaceLayout {
 	icon: SpaceIcon; // 'inbox'|'box'|'video'|'comment'|'cart'|'star'|'pages'|'category'
 }
 
-// Detail shape — list fields + sources. Returned ONLY by the single-space endpoint.
+// Detail — summary + followed feeds + tags. Returned by every endpoint but list.
 interface ReadSpaceDetails extends ReadSpace {
-	sources: SpaceSource[];
+	sources: SpaceSource[]; // wire `follows`
+	tags: string[]; // tag slugs
 }
 
+// A followed feed (wire `follows[]`).
 interface SpaceSource {
-	feedId?: number | string | null;
-	blogId?: number | string | null;
+	feedId: number; // numeric feedbag id; used to remove the feed
 	feedUrl: string;
-	siteUrl: string;
-	name: string;
-	siteIcon?: string | null;
-}
-
-interface CreateReadSpaceParams {
-	name: string; // required, <= MAX_SPACE_NAME_LENGTH (50)
-	tags: string[];
+	blogId: number | null; // null for external (non-WP/Jetpack) feeds
+	name: string | null;
+	siteIcon: string | null; // wire `icon`
 }
 ```
 
-`color`/`icon` are serializable string keys (mapped to glyphs/CSS in the UI),
-never rendered elements. `MAX_SPACE_NAME_LENGTH` (50) is enforced client-side
-and must stay in sync with the backend (RSM-4139).
+The layout palette is **not** validated server-side (only sanitized) and is
+random-until-set, so the client constrains the picker and should write a value
+early if it shouldn't drift between fetches.
 
 ## Endpoints
 
-### 1. List spaces — `GET /reader/spaces` · RSM-4145 · **live**
+All paths are under `https://public-api.wordpress.com/wpcom/v2/reader/spaces`.
+Every mutation returns the **full updated detail**, so the client writes that
+straight to the caches — no follow-up GET.
 
-Returns the user's spaces **without** their sources.
+| # | Method & path | Body | Returns | Wired as |
+| - | --- | --- | --- | --- |
+| 1 | `GET /reader/spaces` | — | `200` summary[] | `fetchReadSpaces()` |
+| 2 | `GET /reader/spaces/{id}` | — | `200` detail | `fetchReadSpace(id)` |
+| 3 | `POST /reader/spaces/new` | `{ title*, feeds?, tags?, layout_color?, layout_icon? }` | `201` detail | `createReadSpace()` |
+| 4 | `POST /reader/spaces/{id}/update` | `{ title?, tags?, layout_color?, layout_icon? }` (≥1) | `200` detail | `updateReadSpace()` |
+| 5 | `POST /reader/spaces/{id}/delete` | — | `200 { deleted, id }` | `deleteReadSpace()` |
+| 6 | `POST /reader/spaces/{id}/feeds/new` | `{ feed* }` (feed id or url) | `200` detail | `addReadSpaceSource()` |
+| 7 | `POST /reader/spaces/{id}/feeds/{feed_id}/delete` | — | `200` detail | `deleteReadSpaceSource()` |
 
-- **Request:** none (authenticated user).
-- **Response `200`:** array of wire items (snake_case), adapted to `ReadSpace[]`.
-- Wired: `fetchReadSpaces()` → real `GET`, mapped via `adaptReadSpace`.
+Notes:
 
-### 2. Get one space — `GET /reader/spaces/{id}` · RSM-4145 · **proposed**
+- **Feeds** must already exist (a feed id or url the backend can resolve); the
+  client only offers feeds the user already follows. Add/remove are one feed at a
+  time (endpoints 6 & 7); removal is keyed by the numeric `feed_id`.
+- **Tags** are a full replace via `update` (endpoint 4) — there are no per-tag
+  endpoints. Pass the complete desired set; `[]` clears them.
+- **Create** sends only `title` unless the caller supplies the optionals; the
+  create form sends `{ title, tags }` today.
+- **Delete** is a permanent hard delete (no trash/undo) — gate UI behind a
+  confirm. No UI consumer yet; `useDeleteSpace()` / `useUpdateSpace()` are ready.
 
-Returns a single space **with** its sources. This is the only endpoint that
-returns `sources`.
+## Error codes
 
-- **Request:** path param `id`.
-- **Response `200`:** `ReadSpaceDetails`
-- **Response `404`:** unknown id.
-- Placeholder: `fetchReadSpace(id)` still resolves the in-memory set + `sources: []`.
+| HTTP | code | when |
+| - | --- | --- |
+| 403 | `rest_forbidden` | not logged in / not an Automattician |
+| 404 | `reader_spaces_not_found` | space doesn't exist or isn't yours |
+| 404 | `reader_spaces_item_not_found` | removing a feed not in the space |
+| 400 | `reader_spaces_invalid_title` | empty title (create or update) |
+| 400 | `reader_spaces_invalid_feed` | a feed isn't an existing feedbag feed |
+| 400 | `reader_spaces_invalid_tag` | a tag slug isn't a valid Reader tag |
+| 400 | `reader_spaces_no_changes` | `update` with no recognized fields |
+| 409 | `reader_spaces_duplicate_slug` | a space with that title already exists |
+| 409 | `reader_spaces_duplicate_feed` | feed already in the space |
+| 500 | `reader_spaces_delete_failed` | delete didn't persist (rare) |
 
-### 3. Create space — `POST /reader/spaces/new` · RSM-4139 · **live**
+The create modal maps `rest_forbidden` / `reader_spaces_invalid_title` /
+`reader_spaces_invalid_tag` / `reader_spaces_duplicate_slug` to copy; other
+surfaces should map the relevant codes as they adopt the mutations.
 
-- **Request body:** `{ title, tags }` (the create form sends only these; the
-  endpoint also accepts optional `sites`, `layout_color`, `layout_icon`).
-- **Response `201`:** the created space (snake_case wire item), adapted to
-  `ReadSpaceDetails`. Server defaults a random palette `layout_color`/`layout_icon`
-  when omitted, and `sources: []`.
-- **Errors:** `403 rest_forbidden`, `400 reader_spaces_invalid_title`,
-  `400 reader_spaces_invalid_tag`, `409 reader_spaces_duplicate_slug`.
-- Wired: `createReadSpace()` → real `POST`, mapped via `adaptReadSpaceDetails`.
+## Caching
 
-> The create flow is **not** optimistic — the cache is written in `onSuccess`
-> using the returned space, so the list always carries the backend id (no temp-id
-> reconciliation). On success the list gets a `ReadSpace` (sources stripped) and
-> the detail cache is seeded with the full `ReadSpaceDetails`.
-
-### 4. Add a source to a space — `POST /reader/spaces/{id}/sources` · ticket TBD · **proposed**
-
-- **Request body:** a source identifier — at least one of
-  `{ feed_id?: number; blog_id?: number; feed_url?: string }`.
-- **Response `200`/`201`:** the created `SpaceSource` (lets the optimistic patch
-  reconcile), or `204`.
-- Placeholder: `addReadSpaceSource()` is a no-op; the cache patch is optimistic.
-
-### 5. Remove a source from a space — `DELETE /reader/spaces/{id}/sources/{sourceId}` · ticket TBD · **proposed**
-
-- **Request:** identify the source by `feed_id`/`blog_id`/`feed_url` (path or query).
-- **Response `200`/`204`.**
-- Placeholder: `deleteReadSpaceSource()` is a no-op; the cache patch is optimistic.
-
-### 6. Delete a space — `POST /reader/spaces/{id}/delete` · RSM-4110 · **live**
-
-Permanently deletes a space (hard delete — no trash/undo). Owner-only, enforced
-server-side.
-
-- **Request:** path param `id`, no body.
-- **Response `200`:** `{ deleted: true, id }`.
-- **Response `403`:** `rest_forbidden` — logged out / not an Automattician.
-- **Response `404`:** `reader_spaces_not_found` — gone **or** not yours
-  (intentionally indistinguishable; we don't reveal other users' spaces, so the
-  UI must treat both the same).
-- **Response `500`:** `reader_spaces_delete_failed` — yours, but deletion failed.
-- Wired: `deleteReadSpace( id )` → real `POST`; `deleteReadSpaceMutation` removes
-  the space from the list cache and discards its detail cache `onSuccess`. No UI
-  consumer yet — `useDeleteSpace()` is ready for a (confirm-gated) delete control.
-
-## Caching strategy (placeholder vs real)
-
-While the endpoints are placeholders, both `readSpacesQuery` and
-`readSpaceQuery` use `staleTime: Infinity` + `meta: { persist: false }`:
-mutations write the cache directly and we never refetch (a placeholder fetch
-would clobber created spaces). `persist: false` keeps the in-memory data out of
-the persisted cache, so **a full page reload already refetches a fresh list** —
-session-only writes don't leak across reloads.
+Both `readSpacesQuery` and `readSpaceQuery` use `staleTime: Infinity` +
+`meta: { persist: false }`. Every mutation returns the full detail and writes it
+back (the detail cache gets the returned space; the list gets its summary), so
+the caches stay authoritative without refetch churn — `staleTime: Infinity` only
+suppresses refetching already-cached data, so a space's detail still loads the
+first time its modal opens. `persist: false` keeps the layout (random-until-set)
+out of the persisted cache, so a reload refetches fresh rather than rehydrating
+stale colours.
 
 The sources modal stays mounted with `isOpen` toggling, so its queries — the
 space detail (`useSpace`) and site subscriptions (`useSiteSubscriptions`, which
 paginates all pages) — are gated on `isOpen` (`enabled: isOpen`) and only fetch
 while the modal is shown.
 
-When the real endpoints land:
-
-- Replace the manual `setQueryData` in the create / source mutations with
-  `queryClient.invalidateQueries( readSpacesQuery() )` (and the detail query) to
-  reconcile with canonical server state immediately, not just on reload.
-- Drop `staleTime: Infinity` and `meta: { persist: false }`.
-- Add `onMutate` + rollback hardening per the
-  [`client/reader/AGENTS.md`](../AGENTS.md) optimistic-mutation checklist
-  (`cancelQueries` in try/catch, `encodeURIComponent` on the path `id`).
-
-## Open questions for the backend
-
-- REST paths for every endpoint — none are implemented yet; the paths above are
-  proposed.
-- Source identifier shape for add/remove (numeric id vs object; what the add
-  endpoint returns).
-- Wire casing (snake_case vs camelCase) — decides whether the fetchers need an
-  adapter.
-- Tickets for source management (endpoints 4 & 5) — not yet filed.
-
 ## Related
 
 - Data & UI conventions: [`./AGENTS.md`](./AGENTS.md)
-- Reader data layer (three-layer pattern, optimistic hardening): [`../AGENTS.md`](../AGENTS.md)
+- Reader data layer (three-layer pattern): [`../AGENTS.md`](../AGENTS.md)
 - Model: `@automattic/api-core` → `read-spaces/`
 - Queries & mutations: `@automattic/api-queries` → `read-spaces.ts`
 - Consumer hooks: `client/reader/data/spaces/`

--- a/client/reader/spaces/create-modal/index.tsx
+++ b/client/reader/spaces/create-modal/index.tsx
@@ -46,6 +46,35 @@ function validateName(
 	return null;
 }
 
+/**
+ * Map a failed create-space request to user-facing copy. The wpcom transports
+ * surface the WP REST error code on `.code` (proxy) or `.error` (legacy xhr), so
+ * read both. Unknown codes fall back to the generic message.
+ */
+function getCreateSpaceErrorMessage( error: unknown, translate: TranslateFn ): string {
+	const generic = translate( 'Something went wrong. Please try again.' ) as string;
+	if ( ! error || typeof error !== 'object' ) {
+		return generic;
+	}
+	const record = error as { code?: unknown; error?: unknown };
+	// wpcom surfaces the code on `.code` (proxy) or `.error` (legacy xhr); take
+	// whichever is a string so the switch always compares `string | undefined`.
+	const rawCode = typeof record.code === 'string' ? record.code : record.error;
+	const code = typeof rawCode === 'string' ? rawCode : undefined;
+	switch ( code ) {
+		case 'reader_spaces_invalid_title':
+			return translate( 'Please enter a name for your space.' ) as string;
+		case 'reader_spaces_invalid_tag':
+			return translate( 'One or more of those tags is not an existing Reader tag.' ) as string;
+		case 'reader_spaces_duplicate_slug':
+			return translate( 'You already have a space with that name.' ) as string;
+		case 'rest_forbidden':
+			return translate( 'You do not have permission to create a space.' ) as string;
+		default:
+			return generic;
+	}
+}
+
 interface Props {
 	isOpen: boolean;
 	onClose: () => void;
@@ -143,10 +172,9 @@ function CreateSpaceModalContent( {
 							{ nameError }
 						</p>
 					) : null }
-					{ /* TODO(RSM-4139): map real backend error kinds once the endpoint exists. */ }
 					{ createSpace.isError ? (
 						<p className="create-space-modal__error" role="alert">
-							{ translate( 'Something went wrong. Please try again.' ) }
+							{ getCreateSpaceErrorMessage( createSpace.error, translate ) }
 						</p>
 					) : null }
 					<HStack justify="flex-end" spacing={ 2 }>

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -5,6 +5,7 @@ import { readSpacesQuery } from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { CreateSpaceModal } from '../index';
 import type { ReadSpace } from '@automattic/api-core';
@@ -15,6 +16,21 @@ const WORK: ReadSpace = {
 	tags: [],
 	layout: { color: 'blue', icon: 'inbox' },
 };
+
+// Mock the wpcom/v2 create endpoint, echoing the submitted name back as the wire
+// `title` so the adapted space carries it through to the cache and callbacks.
+function mockCreateEndpoint( name: string ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( '/wpcom/v2/reader/spaces/new' )
+		.reply( 201, {
+			id: 7,
+			title: name,
+			sites: [],
+			tags: [],
+			layout_color: 'blue',
+			layout_icon: 'inbox',
+		} );
+}
 
 function setup( { existing = [] as ReadSpace[], onCreated = jest.fn() } = {} ) {
 	const queryClient = new QueryClient();
@@ -28,6 +44,8 @@ function setup( { existing = [] as ReadSpace[], onCreated = jest.fn() } = {} ) {
 }
 
 describe( 'CreateSpaceModal', () => {
+	afterEach( () => nock.cleanAll() );
+
 	it( 'renders nothing when closed', () => {
 		renderWithProvider( <CreateSpaceModal isOpen={ false } onClose={ jest.fn() } /> );
 
@@ -75,6 +93,7 @@ describe( 'CreateSpaceModal', () => {
 
 	it( 'creates a space (tags optional), appends it to the cached list, and closes', async () => {
 		const { user, onClose, queryClient } = setup();
+		mockCreateEndpoint( 'Reading' );
 
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
@@ -90,6 +109,7 @@ describe( 'CreateSpaceModal', () => {
 
 	it( 'notifies the parent with the created space', async () => {
 		const { user, onCreated } = setup();
+		mockCreateEndpoint( 'Reading' );
 
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -20,14 +20,13 @@ const WORK: ReadSpace = {
 // `title` so the adapted space carries it through to the cache and callbacks.
 function mockCreateEndpoint( name: string ) {
 	return nock( 'https://public-api.wordpress.com' )
-		.post( '/wpcom/v2/reader/spaces/new' )
+		.post( '/wpcom/v2/reader/spaces' )
 		.reply( 201, {
 			id: 7,
 			title: name,
 			follows: [],
 			tags: [],
-			layout_color: 'blue',
-			layout_icon: 'inbox',
+			layout: { color: 'blue', icon: 'inbox' },
 		} );
 }
 

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -13,7 +13,6 @@ import type { ReadSpace } from '@automattic/api-core';
 const WORK: ReadSpace = {
 	id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
 	name: 'Work',
-	tags: [],
 	layout: { color: 'blue', icon: 'inbox' },
 };
 
@@ -25,7 +24,7 @@ function mockCreateEndpoint( name: string ) {
 		.reply( 201, {
 			id: 7,
 			title: name,
-			sites: [],
+			follows: [],
 			tags: [],
 			layout_color: 'blue',
 			layout_icon: 'inbox',
@@ -101,9 +100,10 @@ describe( 'CreateSpaceModal', () => {
 		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
 
 		const spaces = queryClient.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey );
-		expect( spaces ).toEqual( [ expect.objectContaining( { name: 'Reading', tags: [] } ) ] );
-		// Sources live only on the single-space detail cache, not on list items.
+		expect( spaces ).toEqual( [ expect.objectContaining( { name: 'Reading' } ) ] );
+		// The list is the slim summary — sources and tags live only on the detail cache.
 		expect( spaces?.[ 0 ] ).not.toHaveProperty( 'sources' );
+		expect( spaces?.[ 0 ] ).not.toHaveProperty( 'tags' );
 		expect( onClose ).toHaveBeenCalled();
 	} );
 

--- a/client/reader/spaces/sources-modal/test/index.test.tsx
+++ b/client/reader/spaces/sources-modal/test/index.test.tsx
@@ -11,6 +11,7 @@ import {
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { successNotice } from 'calypso/state/notices/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SourcesModal } from '../index';
@@ -100,6 +101,35 @@ function makeSiteSubscriptionsData(
 	};
 }
 
+const BASE = 'https://public-api.wordpress.com';
+const SPACE_FEEDS_PATH = `/wpcom/v2/reader/spaces/${ WORK.id }/feeds`;
+
+// The detail wire shape the feed endpoints return, carrying `follows`.
+const STRATECHERY_FOLLOW = {
+	feed_id: 456,
+	feed_url: 'https://stratechery.com/feed',
+	blog_id: 123,
+	name: 'Stratechery',
+	icon: 'https://stratechery.com/icon.png',
+};
+const detailWith = ( follows: object[] ) => ( {
+	id: WORK.id,
+	title: 'Work',
+	layout_color: 'blue',
+	layout_icon: 'inbox',
+	follows,
+	tags: [],
+} );
+
+// The client `SpaceSource` STRATECHERY_FOLLOW adapts to.
+const STRATECHERY_SOURCE = {
+	feedId: 456,
+	feedUrl: 'https://stratechery.com/feed',
+	blogId: 123,
+	name: 'Stratechery',
+	siteIcon: 'https://stratechery.com/icon.png',
+};
+
 function setup( {
 	space = WORK,
 	subscriptions = [ STRATECHERY, VERGE ],
@@ -132,6 +162,8 @@ describe( 'SourcesModal', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
+
+	afterEach( () => nock.cleanAll() );
 
 	it( 'does not fetch subscriptions or space details while closed', () => {
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
@@ -212,25 +244,21 @@ describe( 'SourcesModal', () => {
 		expect( screen.queryByText( 'No subscriptions found.' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'adds and removes a subscription in the space cache immediately', async () => {
+	it( 'writes the space detail cache from the endpoint response on add and remove', async () => {
 		const { queryClient, user } = setup();
+		nock( BASE )
+			.post( `${ SPACE_FEEDS_PATH }/new` )
+			.reply( 200, detailWith( [ STRATECHERY_FOLLOW ] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Add Stratechery' } ) );
 
 		await waitFor( () =>
 			expect(
 				queryClient.getQueryData< ReadSpaceDetails >( readSpaceQuery( WORK.id ).queryKey )?.sources
-			).toEqual( [
-				expect.objectContaining( {
-					feedId: 456,
-					blogId: 123,
-					feedUrl: 'https://stratechery.com/feed',
-					siteUrl: 'https://stratechery.com',
-					name: 'Stratechery',
-					siteIcon: 'https://stratechery.com/icon.png',
-				} ),
-			] )
+			).toEqual( [ STRATECHERY_SOURCE ] )
 		);
+
+		nock( BASE ).post( `${ SPACE_FEEDS_PATH }/456/delete` ).reply( 200, detailWith( [] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Remove Stratechery' } ) );
 
@@ -243,19 +271,7 @@ describe( 'SourcesModal', () => {
 
 	it( 'filters to subscriptions already in this space', async () => {
 		const { user } = setup( {
-			space: {
-				...WORK,
-				sources: [
-					{
-						feedId: 456,
-						blogId: 123,
-						feedUrl: 'https://stratechery.com/feed',
-						siteUrl: 'https://stratechery.com',
-						name: 'Stratechery',
-						siteIcon: 'https://stratechery.com/icon.png',
-					},
-				],
-			},
+			space: { ...WORK, sources: [ STRATECHERY_SOURCE ] },
 		} );
 
 		await user.click( screen.getByRole( 'button', { name: 'In this space · 1' } ) );
@@ -286,36 +302,32 @@ describe( 'SourcesModal', () => {
 
 	it( 'shows a success notice when a source is added', async () => {
 		const { user } = setup();
+		nock( BASE )
+			.post( `${ SPACE_FEEDS_PATH }/new` )
+			.reply( 200, detailWith( [ STRATECHERY_FOLLOW ] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Add Stratechery' } ) );
 
-		expect( successNotice ).toHaveBeenCalledWith( 'Source added to this space.', {
-			duration: 5000,
-		} );
+		await waitFor( () =>
+			expect( successNotice ).toHaveBeenCalledWith( 'Source added to this space.', {
+				duration: 5000,
+			} )
+		);
 	} );
 
 	it( 'shows a success notice when a source is removed', async () => {
 		const { user } = setup( {
-			space: {
-				...WORK,
-				sources: [
-					{
-						feedId: 456,
-						blogId: 123,
-						feedUrl: 'https://stratechery.com/feed',
-						siteUrl: 'https://stratechery.com',
-						name: 'Stratechery',
-						siteIcon: 'https://stratechery.com/icon.png',
-					},
-				],
-			},
+			space: { ...WORK, sources: [ STRATECHERY_SOURCE ] },
 		} );
+		nock( BASE ).post( `${ SPACE_FEEDS_PATH }/456/delete` ).reply( 200, detailWith( [] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Remove Stratechery' } ) );
 
-		expect( successNotice ).toHaveBeenCalledWith( 'Source removed from this space.', {
-			duration: 5000,
-		} );
+		await waitFor( () =>
+			expect( successNotice ).toHaveBeenCalledWith( 'Source removed from this space.', {
+				duration: 5000,
+			} )
+		);
 	} );
 
 	it( 'uses SiteIcon for each subscription row', () => {

--- a/client/reader/spaces/sources-modal/test/index.test.tsx
+++ b/client/reader/spaces/sources-modal/test/index.test.tsx
@@ -115,8 +115,7 @@ const STRATECHERY_FOLLOW = {
 const detailWith = ( follows: object[] ) => ( {
 	id: WORK.id,
 	title: 'Work',
-	layout_color: 'blue',
-	layout_icon: 'inbox',
+	layout: { color: 'blue', icon: 'inbox' },
 	follows,
 	tags: [],
 } );
@@ -247,7 +246,7 @@ describe( 'SourcesModal', () => {
 	it( 'writes the space detail cache from the endpoint response on add and remove', async () => {
 		const { queryClient, user } = setup();
 		nock( BASE )
-			.post( `${ SPACE_FEEDS_PATH }/new` )
+			.post( `${ SPACE_FEEDS_PATH }` )
 			.reply( 200, detailWith( [ STRATECHERY_FOLLOW ] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Add Stratechery' } ) );
@@ -258,7 +257,7 @@ describe( 'SourcesModal', () => {
 			).toEqual( [ STRATECHERY_SOURCE ] )
 		);
 
-		nock( BASE ).post( `${ SPACE_FEEDS_PATH }/456/delete` ).reply( 200, detailWith( [] ) );
+		nock( BASE ).delete( `${ SPACE_FEEDS_PATH }/456` ).reply( 200, detailWith( [] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Remove Stratechery' } ) );
 
@@ -303,7 +302,7 @@ describe( 'SourcesModal', () => {
 	it( 'shows a success notice when a source is added', async () => {
 		const { user } = setup();
 		nock( BASE )
-			.post( `${ SPACE_FEEDS_PATH }/new` )
+			.post( `${ SPACE_FEEDS_PATH }` )
 			.reply( 200, detailWith( [ STRATECHERY_FOLLOW ] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Add Stratechery' } ) );
@@ -319,7 +318,7 @@ describe( 'SourcesModal', () => {
 		const { user } = setup( {
 			space: { ...WORK, sources: [ STRATECHERY_SOURCE ] },
 		} );
-		nock( BASE ).post( `${ SPACE_FEEDS_PATH }/456/delete` ).reply( 200, detailWith( [] ) );
+		nock( BASE ).delete( `${ SPACE_FEEDS_PATH }/456` ).reply( 200, detailWith( [] ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Remove Stratechery' } ) );
 

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -3,8 +3,7 @@ import { adaptReadSpace, adaptReadSpaceDetails, type ReadSpaceApiItem } from '..
 const wireSpace = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
 	id: 3,
 	title: 'Work',
-	layout_color: 'blue',
-	layout_icon: 'inbox',
+	layout: { color: 'blue', icon: 'inbox' },
 	...overrides,
 } );
 
@@ -30,9 +29,9 @@ describe( 'read spaces adapters', () => {
 			expect( adaptReadSpace( wireSpace( { id: 42 } ) ).id ).toBe( '42' );
 		} );
 
-		it( 'nests the flat layout_color/layout_icon under layout', () => {
+		it( 'maps the layout object through', () => {
 			const { layout } = adaptReadSpace(
-				wireSpace( { layout_color: 'celadon', layout_icon: 'star' } )
+				wireSpace( { layout: { color: 'celadon', icon: 'star' } } )
 			);
 
 			expect( layout ).toEqual( { color: 'celadon', icon: 'star' } );

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -1,0 +1,62 @@
+import { adaptReadSpace, adaptReadSpaceDetails, type ReadSpaceApiItem } from '../adapters';
+
+const wireSpace = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
+	id: 3,
+	title: 'Work',
+	slug: 'work',
+	owner_id: 5107587,
+	sites: [ 242260508 ],
+	tags: [ 'business' ],
+	layout_color: 'blue',
+	layout_icon: 'inbox',
+	created: '2026-06-09 18:32:27',
+	...overrides,
+} );
+
+describe( 'read spaces adapters', () => {
+	describe( 'adaptReadSpace', () => {
+		it( 'maps the wire fields onto the client ReadSpace shape', () => {
+			expect( adaptReadSpace( wireSpace() ) ).toEqual( {
+				id: '3',
+				name: 'Work',
+				tags: [ 'business' ],
+				layout: { color: 'blue', icon: 'inbox' },
+			} );
+		} );
+
+		it( 'stringifies the numeric id', () => {
+			expect( adaptReadSpace( wireSpace( { id: 42 } ) ).id ).toBe( '42' );
+		} );
+
+		it( 'nests the flat layout_color/layout_icon under layout', () => {
+			const { layout } = adaptReadSpace(
+				wireSpace( { layout_color: 'celadon', layout_icon: 'star' } )
+			);
+
+			expect( layout ).toEqual( { color: 'celadon', icon: 'star' } );
+		} );
+
+		it( 'defaults tags to an empty array when absent', () => {
+			const item = wireSpace();
+			delete ( item as Partial< ReadSpaceApiItem > ).tags;
+
+			expect( adaptReadSpace( item ).tags ).toEqual( [] );
+		} );
+
+		it( 'does not carry sources onto the list shape', () => {
+			expect( adaptReadSpace( wireSpace() ) ).not.toHaveProperty( 'sources' );
+		} );
+	} );
+
+	describe( 'adaptReadSpaceDetails', () => {
+		it( 'extends the list shape with an empty sources array', () => {
+			expect( adaptReadSpaceDetails( wireSpace() ) ).toEqual( {
+				id: '3',
+				name: 'Work',
+				tags: [ 'business' ],
+				layout: { color: 'blue', icon: 'inbox' },
+				sources: [],
+			} );
+		} );
+	} );
+} );

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -3,23 +3,25 @@ import { adaptReadSpace, adaptReadSpaceDetails, type ReadSpaceApiItem } from '..
 const wireSpace = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
 	id: 3,
 	title: 'Work',
-	slug: 'work',
-	owner_id: 5107587,
-	sites: [ 242260508 ],
-	tags: [ 'business' ],
 	layout_color: 'blue',
 	layout_icon: 'inbox',
-	created: '2026-06-09 18:32:27',
 	...overrides,
 } );
 
+const wireFollow = {
+	feed_id: 9981,
+	feed_url: 'https://en.blog/feed/',
+	blog_id: 3584907,
+	name: 'The WordPress.com Blog',
+	icon: 'https://example.com/blavatar.png',
+};
+
 describe( 'read spaces adapters', () => {
-	describe( 'adaptReadSpace', () => {
+	describe( 'adaptReadSpace (summary)', () => {
 		it( 'maps the wire fields onto the client ReadSpace shape', () => {
 			expect( adaptReadSpace( wireSpace() ) ).toEqual( {
 				id: '3',
 				name: 'Work',
-				tags: [ 'business' ],
 				layout: { color: 'blue', icon: 'inbox' },
 			} );
 		} );
@@ -36,26 +38,67 @@ describe( 'read spaces adapters', () => {
 			expect( layout ).toEqual( { color: 'celadon', icon: 'star' } );
 		} );
 
-		it( 'defaults tags to an empty array when absent', () => {
-			const item = wireSpace();
-			delete ( item as Partial< ReadSpaceApiItem > ).tags;
-
-			expect( adaptReadSpace( item ).tags ).toEqual( [] );
-		} );
-
-		it( 'does not carry sources onto the list shape', () => {
-			expect( adaptReadSpace( wireSpace() ) ).not.toHaveProperty( 'sources' );
+		it( 'carries neither sources nor tags on the summary shape', () => {
+			const summary = adaptReadSpace( wireSpace() );
+			expect( summary ).not.toHaveProperty( 'sources' );
+			expect( summary ).not.toHaveProperty( 'tags' );
 		} );
 	} );
 
 	describe( 'adaptReadSpaceDetails', () => {
-		it( 'extends the list shape with an empty sources array', () => {
+		it( 'maps the wire follows array onto sources and carries tags', () => {
+			expect(
+				adaptReadSpaceDetails(
+					wireSpace( { follows: [ wireFollow ], tags: [ 'photography', 'travel' ] } )
+				)
+			).toEqual( {
+				id: '3',
+				name: 'Work',
+				layout: { color: 'blue', icon: 'inbox' },
+				tags: [ 'photography', 'travel' ],
+				sources: [
+					{
+						feedId: 9981,
+						feedUrl: 'https://en.blog/feed/',
+						blogId: 3584907,
+						name: 'The WordPress.com Blog',
+						siteIcon: 'https://example.com/blavatar.png',
+					},
+				],
+			} );
+		} );
+
+		it( 'keeps a null blog_id and null name/icon (external feeds)', () => {
+			const [ source ] = adaptReadSpaceDetails(
+				wireSpace( {
+					follows: [
+						{
+							feed_id: 9982,
+							feed_url: 'https://www.reddit.com/r/x/.rss',
+							blog_id: null,
+							name: null,
+							icon: null,
+						},
+					],
+				} )
+			).sources;
+
+			expect( source ).toEqual( {
+				feedId: 9982,
+				feedUrl: 'https://www.reddit.com/r/x/.rss',
+				blogId: null,
+				name: null,
+				siteIcon: null,
+			} );
+		} );
+
+		it( 'defaults sources and tags to empty arrays when absent', () => {
 			expect( adaptReadSpaceDetails( wireSpace() ) ).toEqual( {
 				id: '3',
 				name: 'Work',
-				tags: [ 'business' ],
 				layout: { color: 'blue', icon: 'inbox' },
 				sources: [],
+				tags: [],
 			} );
 		} );
 	} );

--- a/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
@@ -4,16 +4,11 @@ import type { ReadSpaceApiItem } from '../adapters';
 
 const BASE = 'https://public-api.wordpress.com';
 
-const wireSpace = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
+const wireSummary = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
 	id: 3,
 	title: 'Work',
-	slug: 'work',
-	owner_id: 5107587,
-	sites: [ 242260508 ],
-	tags: [ 'business' ],
 	layout_color: 'blue',
 	layout_icon: 'inbox',
-	created: '2026-06-09 18:32:27',
 	...overrides,
 } );
 
@@ -22,54 +17,25 @@ describe( 'read spaces fetchers', () => {
 
 	describe( 'fetchReadSpaces', () => {
 		it( 'fetches the list from the wpcom/v2 endpoint', async () => {
-			const scope = nock( BASE ).get( '/wpcom/v2/reader/spaces' ).reply( 200, [ wireSpace() ] );
+			const scope = nock( BASE ).get( '/wpcom/v2/reader/spaces' ).reply( 200, [ wireSummary() ] );
 
 			await fetchReadSpaces();
 
 			expect( scope.isDone() ).toBe( true );
 		} );
 
-		it( 'adapts the snake_case wire item to the client ReadSpace shape', async () => {
+		it( 'adapts each summary to the client ReadSpace shape (no sources/tags)', async () => {
 			nock( BASE )
 				.get( '/wpcom/v2/reader/spaces' )
 				.reply( 200, [
-					wireSpace( {
-						id: 4,
-						title: 'Gaming',
-						tags: [ 'games' ],
-						layout_color: 'purple',
-						layout_icon: 'box',
-					} ),
+					wireSummary( { id: 4, title: 'Gaming', layout_color: 'purple', layout_icon: 'box' } ),
 				] );
 
 			const spaces = await fetchReadSpaces();
 
 			expect( spaces ).toEqual( [
-				{
-					id: '4',
-					name: 'Gaming',
-					tags: [ 'games' ],
-					layout: { color: 'purple', icon: 'box' },
-				},
+				{ id: '4', name: 'Gaming', layout: { color: 'purple', icon: 'box' } },
 			] );
-		} );
-
-		it( 'stringifies the numeric wire id', async () => {
-			nock( BASE )
-				.get( '/wpcom/v2/reader/spaces' )
-				.reply( 200, [ wireSpace( { id: 42 } ) ] );
-
-			const [ space ] = await fetchReadSpaces();
-
-			expect( space.id ).toBe( '42' );
-		} );
-
-		it( 'omits sources from the list (they belong to the detail endpoint)', async () => {
-			nock( BASE ).get( '/wpcom/v2/reader/spaces' ).reply( 200, [ wireSpace() ] );
-
-			const [ space ] = await fetchReadSpaces();
-
-			expect( space ).not.toHaveProperty( 'sources' );
 		} );
 
 		it( 'returns an empty list when the response is not an array', async () => {
@@ -79,21 +45,69 @@ describe( 'read spaces fetchers', () => {
 		} );
 	} );
 
-	// The detail endpoint is still a placeholder (RSM-4145) — no network call,
-	// resolves from the in-memory set. Update these to nock once it's wired.
-	describe( 'fetchReadSpace (placeholder)', () => {
-		it( 'resolves a single placeholder space by id, with its sources', async () => {
-			await expect( fetchReadSpace( '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21' ) ).resolves.toEqual(
-				expect.objectContaining( {
-					id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
-					name: 'Work',
-					sources: [],
-				} )
-			);
+	describe( 'fetchReadSpace', () => {
+		it( 'fetches the detail from the wpcom/v2 single-space endpoint and adapts it', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/spaces/3' )
+				.reply( 200, {
+					id: 3,
+					title: 'Work',
+					layout_color: 'blue',
+					layout_icon: 'inbox',
+					tags: [ 'photography' ],
+					follows: [
+						{
+							feed_id: 9981,
+							feed_url: 'https://en.blog/feed/',
+							blog_id: 3584907,
+							name: 'The WordPress.com Blog',
+							icon: null,
+						},
+					],
+				} );
+
+			const space = await fetchReadSpace( '3' );
+
+			expect( scope.isDone() ).toBe( true );
+			expect( space ).toEqual( {
+				id: '3',
+				name: 'Work',
+				layout: { color: 'blue', icon: 'inbox' },
+				tags: [ 'photography' ],
+				sources: [
+					{
+						feedId: 9981,
+						feedUrl: 'https://en.blog/feed/',
+						blogId: 3584907,
+						name: 'The WordPress.com Blog',
+						siteIcon: null,
+					},
+				],
+			} );
 		} );
 
-		it( 'rejects when the space id is unknown', async () => {
-			await expect( fetchReadSpace( 'does-not-exist' ) ).rejects.toThrow( 'Space not found' );
+		it( 'encodes the space id into the path', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/spaces/a%2Fb' )
+				.reply( 200, { id: 7, title: 'X', layout_color: 'red', layout_icon: 'box' } );
+
+			await fetchReadSpace( 'a/b' );
+
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'rejects when the space is not found', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/spaces/999' )
+				.reply( 404, {
+					code: 'reader_spaces_not_found',
+					message: 'Space not found.',
+					data: { status: 404 },
+				} );
+
+			await expect( fetchReadSpace( '999' ) ).rejects.toMatchObject( {
+				code: 'reader_spaces_not_found',
+			} );
 		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
@@ -1,60 +1,99 @@
+import nock from 'nock';
 import { fetchReadSpace, fetchReadSpaces } from '../fetchers';
+import type { ReadSpaceApiItem } from '../adapters';
 
-// NOTE: these fetchers currently resolve the hard-coded placeholder set with no
-// network call, so there's nothing to intercept yet. Once the real list/detail
-// endpoints land (RSM-4145) and these issue `wpcom.req` GETs, mock the HTTP
-// layer with `nock` — `nock( BASE ).get( '/…/spaces' ).reply( 200, … )` for the
-// happy path and a 4xx/5xx reply for the "not found"/error path — instead of
-// asserting against the placeholder data. See the sibling
-// `read-site-recommendations` / `read-feeds` fetcher tests for the pattern.
+const BASE = 'https://public-api.wordpress.com';
+
+const wireSpace = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
+	id: 3,
+	title: 'Work',
+	slug: 'work',
+	owner_id: 5107587,
+	sites: [ 242260508 ],
+	tags: [ 'business' ],
+	layout_color: 'blue',
+	layout_icon: 'inbox',
+	created: '2026-06-09 18:32:27',
+	...overrides,
+} );
+
 describe( 'read spaces fetchers', () => {
-	it( 'returns placeholder spaces with opaque stable ids instead of name slugs', async () => {
-		const spaces = await fetchReadSpaces();
+	afterEach( () => nock.cleanAll() );
 
-		expect( spaces ).toEqual(
-			expect.arrayContaining( [
+	describe( 'fetchReadSpaces', () => {
+		it( 'fetches the list from the wpcom/v2 endpoint', async () => {
+			const scope = nock( BASE ).get( '/wpcom/v2/reader/spaces' ).reply( 200, [ wireSpace() ] );
+
+			await fetchReadSpaces();
+
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'adapts the snake_case wire item to the client ReadSpace shape', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/spaces' )
+				.reply( 200, [
+					wireSpace( {
+						id: 4,
+						title: 'Gaming',
+						tags: [ 'games' ],
+						layout_color: 'purple',
+						layout_icon: 'box',
+					} ),
+				] );
+
+			const spaces = await fetchReadSpaces();
+
+			expect( spaces ).toEqual( [
+				{
+					id: '4',
+					name: 'Gaming',
+					tags: [ 'games' ],
+					layout: { color: 'purple', icon: 'box' },
+				},
+			] );
+		} );
+
+		it( 'stringifies the numeric wire id', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/spaces' )
+				.reply( 200, [ wireSpace( { id: 42 } ) ] );
+
+			const [ space ] = await fetchReadSpaces();
+
+			expect( space.id ).toBe( '42' );
+		} );
+
+		it( 'omits sources from the list (they belong to the detail endpoint)', async () => {
+			nock( BASE ).get( '/wpcom/v2/reader/spaces' ).reply( 200, [ wireSpace() ] );
+
+			const [ space ] = await fetchReadSpaces();
+
+			expect( space ).not.toHaveProperty( 'sources' );
+		} );
+
+		it( 'returns an empty list when the response is not an array', async () => {
+			nock( BASE ).get( '/wpcom/v2/reader/spaces' ).reply( 200, {} );
+
+			await expect( fetchReadSpaces() ).resolves.toEqual( [] );
+		} );
+	} );
+
+	// The detail endpoint is still a placeholder (RSM-4145) — no network call,
+	// resolves from the in-memory set. Update these to nock once it's wired.
+	describe( 'fetchReadSpace (placeholder)', () => {
+		it( 'resolves a single placeholder space by id, with its sources', async () => {
+			await expect( fetchReadSpace( '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21' ) ).resolves.toEqual(
 				expect.objectContaining( {
 					id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
 					name: 'Work',
-				} ),
-				expect.objectContaining( {
-					id: '5cc71d31-97d1-4b7d-93c7-42a5ce9d4cf1',
-					name: 'Gaming',
-				} ),
-			] )
-		);
-		expect( spaces.map( ( space ) => space.id ) ).not.toEqual(
-			spaces.map( ( space ) => space.name.toLowerCase() )
-		);
-	} );
+					sources: [],
+				} )
+			);
+		} );
 
-	it( 'omits sources from the list (they belong to the detail endpoint)', async () => {
-		const spaces = await fetchReadSpaces();
-
-		expect( spaces[ 0 ] ).not.toHaveProperty( 'sources' );
-	} );
-
-	it( 'returns independent copies that cannot mutate the shared placeholders', async () => {
-		const first = await fetchReadSpaces();
-		first[ 0 ].tags.push( 'mutated' );
-		first[ 0 ].layout.color = 'red';
-
-		const second = await fetchReadSpaces();
-		expect( second[ 0 ].tags ).toEqual( [] );
-		expect( second[ 0 ].layout.color ).not.toBe( 'red' );
-	} );
-
-	it( 'resolves a single placeholder space by id, with its sources', async () => {
-		await expect( fetchReadSpace( '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21' ) ).resolves.toEqual(
-			expect.objectContaining( {
-				id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
-				name: 'Work',
-				sources: [],
-			} )
-		);
-	} );
-
-	it( 'rejects when the space id is unknown', async () => {
-		await expect( fetchReadSpace( 'does-not-exist' ) ).rejects.toThrow( 'Space not found' );
+		it( 'rejects when the space id is unknown', async () => {
+			await expect( fetchReadSpace( 'does-not-exist' ) ).rejects.toThrow( 'Space not found' );
+		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
@@ -7,8 +7,7 @@ const BASE = 'https://public-api.wordpress.com';
 const wireSummary = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
 	id: 3,
 	title: 'Work',
-	layout_color: 'blue',
-	layout_icon: 'inbox',
+	layout: { color: 'blue', icon: 'inbox' },
 	...overrides,
 } );
 
@@ -28,7 +27,7 @@ describe( 'read spaces fetchers', () => {
 			nock( BASE )
 				.get( '/wpcom/v2/reader/spaces' )
 				.reply( 200, [
-					wireSummary( { id: 4, title: 'Gaming', layout_color: 'purple', layout_icon: 'box' } ),
+					wireSummary( { id: 4, title: 'Gaming', layout: { color: 'purple', icon: 'box' } } ),
 				] );
 
 			const spaces = await fetchReadSpaces();
@@ -52,8 +51,7 @@ describe( 'read spaces fetchers', () => {
 				.reply( 200, {
 					id: 3,
 					title: 'Work',
-					layout_color: 'blue',
-					layout_icon: 'inbox',
+					layout: { color: 'blue', icon: 'inbox' },
 					tags: [ 'photography' ],
 					follows: [
 						{
@@ -89,7 +87,7 @@ describe( 'read spaces fetchers', () => {
 		it( 'encodes the space id into the path', async () => {
 			const scope = nock( BASE )
 				.get( '/wpcom/v2/reader/spaces/a%2Fb' )
-				.reply( 200, { id: 7, title: 'X', layout_color: 'red', layout_icon: 'box' } );
+				.reply( 200, { id: 7, title: 'X', layout: { color: 'red', icon: 'box' } } );
 
 			await fetchReadSpace( 'a/b' );
 

--- a/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
@@ -1,6 +1,13 @@
-import { addReadSpaceSource, createReadSpace, deleteReadSpaceSource } from '../mutators';
+import nock from 'nock';
+import {
+	addReadSpaceSource,
+	createReadSpace,
+	deleteReadSpace,
+	deleteReadSpaceSource,
+} from '../mutators';
 import type { SiteSubscriptionItem } from '../../read-follows';
 
+const BASE = 'https://public-api.wordpress.com';
 const SPACE_ID = '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21';
 
 const makeSubscription = (
@@ -17,38 +24,119 @@ const makeSubscription = (
 	...overrides,
 } );
 
-// NOTE: these mutators are placeholders that resolve locally without any
-// network call, so there's nothing to intercept yet. Once the real endpoints
-// land (create: RSM-4139; add/remove source) and these issue `wpcom.req`
-// requests, mock the HTTP layer with `nock` — replying 200 for the success
-// cases and a 4xx/5xx for the error cases — instead of asserting on the
-// resolved value. See the sibling `read-site-recommendations` / `read-feeds`
-// fetcher tests for the `nock( BASE ).post( … ).reply( … )` pattern.
 describe( 'read spaces mutators', () => {
-	it( 'creates a local read space until the create endpoint exists', async () => {
-		const space = await createReadSpace( {
-			name: 'Work',
-			tags: [ 'business', 'design' ],
+	afterEach( () => nock.cleanAll() );
+
+	describe( 'createReadSpace', () => {
+		it( 'posts { title, tags } to the wpcom/v2 create endpoint', async () => {
+			let requestBody: unknown;
+			const scope = nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/new', ( body ) => {
+					requestBody = body;
+					return true;
+				} )
+				.reply( 201, {
+					id: 42,
+					title: 'Work',
+					sites: [],
+					tags: [ 'business', 'design' ],
+					layout_color: 'celadon',
+					layout_icon: 'star',
+				} );
+
+			await createReadSpace( { name: 'Work', tags: [ 'business', 'design' ] } );
+
+			expect( scope.isDone() ).toBe( true );
+			// The form's `name` is sent as the wire field `title`.
+			expect( requestBody ).toEqual( { title: 'Work', tags: [ 'business', 'design' ] } );
 		} );
 
-		expect( space ).toMatchObject( {
-			name: 'Work',
-			tags: [ 'business', 'design' ],
-			layout: { color: 'blue', icon: 'category' },
-			sources: [],
+		it( 'adapts the 201 response to the client ReadSpaceDetails shape', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/new' )
+				.reply( 201, {
+					id: 42,
+					title: 'Work',
+					sites: [],
+					tags: [ 'business' ],
+					layout_color: 'celadon',
+					layout_icon: 'star',
+				} );
+
+			const space = await createReadSpace( { name: 'Work', tags: [ 'business' ] } );
+
+			expect( space ).toEqual( {
+				id: '42',
+				name: 'Work',
+				tags: [ 'business' ],
+				layout: { color: 'celadon', icon: 'star' },
+				sources: [],
+			} );
 		} );
-		expect( space.id ).toEqual( expect.any( String ) );
+
+		it( 'rejects when the endpoint returns an error', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/new' )
+				.reply( 409, {
+					code: 'reader_spaces_duplicate_slug',
+					message: 'You already have a space with this title.',
+					data: { status: 409 },
+				} );
+
+			await expect( createReadSpace( { name: 'Work', tags: [] } ) ).rejects.toMatchObject( {
+				code: 'reader_spaces_duplicate_slug',
+			} );
+		} );
 	} );
 
-	it( 'resolves when adding a source until the source endpoint exists', async () => {
-		await expect(
-			addReadSpaceSource( { spaceId: SPACE_ID, subscription: makeSubscription() } )
-		).resolves.toBeUndefined();
+	describe( 'deleteReadSpace', () => {
+		it( 'posts to the wpcom/v2 delete endpoint and resolves the result', async () => {
+			const scope = nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/42/delete' )
+				.reply( 200, { deleted: true, id: 42 } );
+
+			await expect( deleteReadSpace( '42' ) ).resolves.toEqual( { deleted: true, id: 42 } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'encodes the space id into the path', async () => {
+			const scope = nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/a%2Fb/delete' )
+				.reply( 200, { deleted: true, id: 7 } );
+
+			await deleteReadSpace( 'a/b' );
+
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'rejects on a not-found error', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/999/delete' )
+				.reply( 404, {
+					code: 'reader_spaces_not_found',
+					message: 'Space not found.',
+					data: { status: 404 },
+				} );
+
+			await expect( deleteReadSpace( '999' ) ).rejects.toMatchObject( {
+				code: 'reader_spaces_not_found',
+			} );
+		} );
 	} );
 
-	it( 'resolves when deleting a source until the source endpoint exists', async () => {
-		await expect(
-			deleteReadSpaceSource( { spaceId: SPACE_ID, subscription: makeSubscription() } )
-		).resolves.toBeUndefined();
+	// The source mutators are still placeholders (no-op, no network) until their
+	// endpoints land. Update to nock once wired.
+	describe( 'source mutators (placeholder)', () => {
+		it( 'resolves when adding a source', async () => {
+			await expect(
+				addReadSpaceSource( { spaceId: SPACE_ID, subscription: makeSubscription() } )
+			).resolves.toBeUndefined();
+		} );
+
+		it( 'resolves when deleting a source', async () => {
+			await expect(
+				deleteReadSpaceSource( { spaceId: SPACE_ID, subscription: makeSubscription() } )
+			).resolves.toBeUndefined();
+		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
@@ -4,11 +4,11 @@ import {
 	createReadSpace,
 	deleteReadSpace,
 	deleteReadSpaceSource,
+	updateReadSpace,
 } from '../mutators';
 import type { SiteSubscriptionItem } from '../../read-follows';
 
 const BASE = 'https://public-api.wordpress.com';
-const SPACE_ID = '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21';
 
 const makeSubscription = (
 	overrides: Partial< SiteSubscriptionItem > = {}
@@ -24,53 +24,90 @@ const makeSubscription = (
 	...overrides,
 } );
 
+// A detail wire response (returned by create/update/add-feed/remove-feed).
+const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
+	id: 42,
+	title: 'Work',
+	layout_color: 'celadon',
+	layout_icon: 'star',
+	follows: [],
+	tags: [ 'business' ],
+	...overrides,
+} );
+
 describe( 'read spaces mutators', () => {
 	afterEach( () => nock.cleanAll() );
 
 	describe( 'createReadSpace', () => {
-		it( 'posts { title, tags } to the wpcom/v2 create endpoint', async () => {
-			let requestBody: unknown;
-			const scope = nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/new', ( body ) => {
-					requestBody = body;
+		it( 'posts only { title } when no optional fields are given', async () => {
+			let body: unknown;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/new', ( sent ) => {
+					body = sent;
 					return true;
 				} )
-				.reply( 201, {
-					id: 42,
-					title: 'Work',
-					sites: [],
-					tags: [ 'business', 'design' ],
-					layout_color: 'celadon',
-					layout_icon: 'star',
-				} );
+				.reply( 201, detailResponse() );
 
-			await createReadSpace( { name: 'Work', tags: [ 'business', 'design' ] } );
+			await createReadSpace( { name: 'Work' } );
 
-			expect( scope.isDone() ).toBe( true );
 			// The form's `name` is sent as the wire field `title`.
-			expect( requestBody ).toEqual( { title: 'Work', tags: [ 'business', 'design' ] } );
+			expect( body ).toEqual( { title: 'Work' } );
 		} );
 
-		it( 'adapts the 201 response to the client ReadSpaceDetails shape', async () => {
+		it( 'sends optional feeds, tags, and layout when provided', async () => {
+			let body: unknown;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/new', ( sent ) => {
+					body = sent;
+					return true;
+				} )
+				.reply( 201, detailResponse() );
+
+			await createReadSpace( {
+				name: 'Design',
+				feeds: [ 'https://en.blog/feed/', 9982 ],
+				tags: [ 'design' ],
+				layoutColor: 'purple',
+				layoutIcon: 'pages',
+			} );
+
+			expect( body ).toEqual( {
+				title: 'Design',
+				feeds: [ 'https://en.blog/feed/', 9982 ],
+				tags: [ 'design' ],
+				layout_color: 'purple',
+				layout_icon: 'pages',
+			} );
+		} );
+
+		it( 'adapts the 201 detail response to the client shape', async () => {
 			nock( BASE )
 				.post( '/wpcom/v2/reader/spaces/new' )
-				.reply( 201, {
-					id: 42,
-					title: 'Work',
-					sites: [],
-					tags: [ 'business' ],
-					layout_color: 'celadon',
-					layout_icon: 'star',
-				} );
+				.reply(
+					201,
+					detailResponse( {
+						follows: [
+							{
+								feed_id: 9981,
+								feed_url: 'https://en.blog/feed/',
+								blog_id: 1,
+								name: 'B',
+								icon: null,
+							},
+						],
+					} )
+				);
 
 			const space = await createReadSpace( { name: 'Work', tags: [ 'business' ] } );
 
 			expect( space ).toEqual( {
 				id: '42',
 				name: 'Work',
-				tags: [ 'business' ],
 				layout: { color: 'celadon', icon: 'star' },
-				sources: [],
+				tags: [ 'business' ],
+				sources: [
+					{ feedId: 9981, feedUrl: 'https://en.blog/feed/', blogId: 1, name: 'B', siteIcon: null },
+				],
 			} );
 		} );
 
@@ -83,14 +120,49 @@ describe( 'read spaces mutators', () => {
 					data: { status: 409 },
 				} );
 
-			await expect( createReadSpace( { name: 'Work', tags: [] } ) ).rejects.toMatchObject( {
+			await expect( createReadSpace( { name: 'Work' } ) ).rejects.toMatchObject( {
 				code: 'reader_spaces_duplicate_slug',
 			} );
 		} );
 	} );
 
+	describe( 'updateReadSpace', () => {
+		it( 'posts only the changed fields (mapping name -> title, layout) and adapts the result', async () => {
+			let body: unknown;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/update', ( sent ) => {
+					body = sent;
+					return true;
+				} )
+				.reply( 200, detailResponse( { id: 3, title: 'Renamed', tags: [ 'a', 'b' ] } ) );
+
+			const space = await updateReadSpace( '3', {
+				name: 'Renamed',
+				tags: [ 'a', 'b' ],
+				layoutColor: 'green',
+			} );
+
+			expect( body ).toEqual( { title: 'Renamed', tags: [ 'a', 'b' ], layout_color: 'green' } );
+			expect( space ).toMatchObject( { id: '3', name: 'Renamed', tags: [ 'a', 'b' ] } );
+		} );
+
+		it( 'can clear tags by sending an empty array', async () => {
+			let body: unknown;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/update', ( sent ) => {
+					body = sent;
+					return true;
+				} )
+				.reply( 200, detailResponse( { id: 3, tags: [] } ) );
+
+			await updateReadSpace( '3', { tags: [] } );
+
+			expect( body ).toEqual( { tags: [] } );
+		} );
+	} );
+
 	describe( 'deleteReadSpace', () => {
-		it( 'posts to the wpcom/v2 delete endpoint and resolves the result', async () => {
+		it( 'posts to the delete endpoint and resolves the result', async () => {
 			const scope = nock( BASE )
 				.post( '/wpcom/v2/reader/spaces/42/delete' )
 				.reply( 200, { deleted: true, id: 42 } );
@@ -99,24 +171,10 @@ describe( 'read spaces mutators', () => {
 			expect( scope.isDone() ).toBe( true );
 		} );
 
-		it( 'encodes the space id into the path', async () => {
-			const scope = nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/a%2Fb/delete' )
-				.reply( 200, { deleted: true, id: 7 } );
-
-			await deleteReadSpace( 'a/b' );
-
-			expect( scope.isDone() ).toBe( true );
-		} );
-
 		it( 'rejects on a not-found error', async () => {
 			nock( BASE )
 				.post( '/wpcom/v2/reader/spaces/999/delete' )
-				.reply( 404, {
-					code: 'reader_spaces_not_found',
-					message: 'Space not found.',
-					data: { status: 404 },
-				} );
+				.reply( 404, { code: 'reader_spaces_not_found', message: '…', data: { status: 404 } } );
 
 			await expect( deleteReadSpace( '999' ) ).rejects.toMatchObject( {
 				code: 'reader_spaces_not_found',
@@ -124,19 +182,78 @@ describe( 'read spaces mutators', () => {
 		} );
 	} );
 
-	// The source mutators are still placeholders (no-op, no network) until their
-	// endpoints land. Update to nock once wired.
-	describe( 'source mutators (placeholder)', () => {
-		it( 'resolves when adding a source', async () => {
-			await expect(
-				addReadSpaceSource( { spaceId: SPACE_ID, subscription: makeSubscription() } )
-			).resolves.toBeUndefined();
+	describe( 'addReadSpaceSource', () => {
+		it( 'posts the feed id to feeds/new and adapts the returned detail', async () => {
+			let body: unknown;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/feeds/new', ( sent ) => {
+					body = sent;
+					return true;
+				} )
+				.reply(
+					200,
+					detailResponse( {
+						id: 3,
+						follows: [
+							{
+								feed_id: 456,
+								feed_url: 'https://stratechery.com/feed',
+								blog_id: 123,
+								name: 'Stratechery',
+								icon: null,
+							},
+						],
+					} )
+				);
+
+			const space = await addReadSpaceSource( {
+				spaceId: '3',
+				subscription: makeSubscription(),
+			} );
+
+			expect( body ).toEqual( { feed: 456 } );
+			expect( space.sources ).toEqual( [
+				{
+					feedId: 456,
+					feedUrl: 'https://stratechery.com/feed',
+					blogId: 123,
+					name: 'Stratechery',
+					siteIcon: null,
+				},
+			] );
 		} );
 
-		it( 'resolves when deleting a source', async () => {
-			await expect(
-				deleteReadSpaceSource( { spaceId: SPACE_ID, subscription: makeSubscription() } )
-			).resolves.toBeUndefined();
+		it( 'falls back to the feed URL when the subscription has no feed id', async () => {
+			let body: unknown;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/feeds/new', ( sent ) => {
+					body = sent;
+					return true;
+				} )
+				.reply( 200, detailResponse( { id: 3 } ) );
+
+			await addReadSpaceSource( {
+				spaceId: '3',
+				subscription: makeSubscription( { feed_ID: null } ),
+			} );
+
+			expect( body ).toEqual( { feed: 'https://stratechery.com/feed' } );
+		} );
+	} );
+
+	describe( 'deleteReadSpaceSource', () => {
+		it( 'posts to feeds/<feed_id>/delete and adapts the returned detail', async () => {
+			const scope = nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/feeds/456/delete' )
+				.reply( 200, detailResponse( { id: 3, follows: [] } ) );
+
+			const space = await deleteReadSpaceSource( {
+				spaceId: '3',
+				subscription: makeSubscription(),
+			} );
+
+			expect( scope.isDone() ).toBe( true );
+			expect( space.sources ).toEqual( [] );
 		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
@@ -28,8 +28,7 @@ const makeSubscription = (
 const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
 	id: 42,
 	title: 'Work',
-	layout_color: 'celadon',
-	layout_icon: 'star',
+	layout: { color: 'celadon', icon: 'star' },
 	follows: [],
 	tags: [ 'business' ],
 	...overrides,
@@ -42,7 +41,7 @@ describe( 'read spaces mutators', () => {
 		it( 'posts only { title } when no optional fields are given', async () => {
 			let body: unknown;
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/new', ( sent ) => {
+				.post( '/wpcom/v2/reader/spaces', ( sent ) => {
 					body = sent;
 					return true;
 				} )
@@ -57,7 +56,7 @@ describe( 'read spaces mutators', () => {
 		it( 'sends optional feeds, tags, and layout when provided', async () => {
 			let body: unknown;
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/new', ( sent ) => {
+				.post( '/wpcom/v2/reader/spaces', ( sent ) => {
 					body = sent;
 					return true;
 				} )
@@ -67,22 +66,20 @@ describe( 'read spaces mutators', () => {
 				name: 'Design',
 				feeds: [ 'https://en.blog/feed/', 9982 ],
 				tags: [ 'design' ],
-				layoutColor: 'purple',
-				layoutIcon: 'pages',
+				layout: { color: 'purple', icon: 'pages' },
 			} );
 
 			expect( body ).toEqual( {
 				title: 'Design',
 				feeds: [ 'https://en.blog/feed/', 9982 ],
 				tags: [ 'design' ],
-				layout_color: 'purple',
-				layout_icon: 'pages',
+				layout: { color: 'purple', icon: 'pages' },
 			} );
 		} );
 
 		it( 'adapts the 201 detail response to the client shape', async () => {
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/new' )
+				.post( '/wpcom/v2/reader/spaces' )
 				.reply(
 					201,
 					detailResponse( {
@@ -113,7 +110,7 @@ describe( 'read spaces mutators', () => {
 
 		it( 'rejects when the endpoint returns an error', async () => {
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/new' )
+				.post( '/wpcom/v2/reader/spaces' )
 				.reply( 409, {
 					code: 'reader_spaces_duplicate_slug',
 					message: 'You already have a space with this title.',
@@ -127,10 +124,10 @@ describe( 'read spaces mutators', () => {
 	} );
 
 	describe( 'updateReadSpace', () => {
-		it( 'posts only the changed fields (mapping name -> title, layout) and adapts the result', async () => {
+		it( 'PUTs only the changed fields (mapping name -> title) and adapts the result', async () => {
 			let body: unknown;
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/update', ( sent ) => {
+				.put( '/wpcom/v2/reader/spaces/3', ( sent ) => {
 					body = sent;
 					return true;
 				} )
@@ -139,17 +136,22 @@ describe( 'read spaces mutators', () => {
 			const space = await updateReadSpace( '3', {
 				name: 'Renamed',
 				tags: [ 'a', 'b' ],
-				layoutColor: 'green',
+				layout: { color: 'green' },
 			} );
 
-			expect( body ).toEqual( { title: 'Renamed', tags: [ 'a', 'b' ], layout_color: 'green' } );
+			// layout is a partial merge — only the changed field is sent.
+			expect( body ).toEqual( {
+				title: 'Renamed',
+				tags: [ 'a', 'b' ],
+				layout: { color: 'green' },
+			} );
 			expect( space ).toMatchObject( { id: '3', name: 'Renamed', tags: [ 'a', 'b' ] } );
 		} );
 
 		it( 'can clear tags by sending an empty array', async () => {
 			let body: unknown;
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/update', ( sent ) => {
+				.put( '/wpcom/v2/reader/spaces/3', ( sent ) => {
 					body = sent;
 					return true;
 				} )
@@ -162,9 +164,9 @@ describe( 'read spaces mutators', () => {
 	} );
 
 	describe( 'deleteReadSpace', () => {
-		it( 'posts to the delete endpoint and resolves the result', async () => {
+		it( 'DELETEs the space and resolves the result', async () => {
 			const scope = nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/42/delete' )
+				.delete( '/wpcom/v2/reader/spaces/42' )
 				.reply( 200, { deleted: true, id: 42 } );
 
 			await expect( deleteReadSpace( '42' ) ).resolves.toEqual( { deleted: true, id: 42 } );
@@ -173,7 +175,7 @@ describe( 'read spaces mutators', () => {
 
 		it( 'rejects on a not-found error', async () => {
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/999/delete' )
+				.delete( '/wpcom/v2/reader/spaces/999' )
 				.reply( 404, { code: 'reader_spaces_not_found', message: '…', data: { status: 404 } } );
 
 			await expect( deleteReadSpace( '999' ) ).rejects.toMatchObject( {
@@ -183,10 +185,10 @@ describe( 'read spaces mutators', () => {
 	} );
 
 	describe( 'addReadSpaceSource', () => {
-		it( 'posts the feed id to feeds/new and adapts the returned detail', async () => {
+		it( 'posts the feed id to feeds and adapts the returned detail', async () => {
 			let body: unknown;
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds/new', ( sent ) => {
+				.post( '/wpcom/v2/reader/spaces/3/feeds', ( sent ) => {
 					body = sent;
 					return true;
 				} )
@@ -226,7 +228,7 @@ describe( 'read spaces mutators', () => {
 		it( 'falls back to the feed URL when the subscription has no feed id', async () => {
 			let body: unknown;
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds/new', ( sent ) => {
+				.post( '/wpcom/v2/reader/spaces/3/feeds', ( sent ) => {
 					body = sent;
 					return true;
 				} )
@@ -242,9 +244,9 @@ describe( 'read spaces mutators', () => {
 	} );
 
 	describe( 'deleteReadSpaceSource', () => {
-		it( 'posts to feeds/<feed_id>/delete and adapts the returned detail', async () => {
+		it( 'DELETEs feeds/<feed_id> and adapts the returned detail', async () => {
 			const scope = nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds/456/delete' )
+				.delete( '/wpcom/v2/reader/spaces/3/feeds/456' )
 				.reply( 200, detailResponse( { id: 3, follows: [] } ) );
 
 			const space = await deleteReadSpaceSource( {

--- a/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
@@ -255,5 +255,15 @@ describe( 'read spaces mutators', () => {
 			expect( scope.isDone() ).toBe( true );
 			expect( space.sources ).toEqual( [] );
 		} );
+
+		it( 'rejects without a request when the subscription has no numeric feed id', async () => {
+			// No nock interceptor: the guard must throw before any request is made.
+			await expect(
+				deleteReadSpaceSource( {
+					spaceId: '3',
+					subscription: makeSubscription( { feed_ID: null } ),
+				} )
+			).rejects.toThrow( 'numeric feed id' );
+		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -1,46 +1,65 @@
-import type { ReadSpace, ReadSpaceDetails, SpaceColor, SpaceIcon } from './types';
+import type { ReadSpace, ReadSpaceDetails, SpaceColor, SpaceIcon, SpaceSource } from './types';
 
 /**
- * Wire shape returned by the wpcom/v2 Spaces endpoints (list, single, create).
- * Differs from the client `ReadSpace`: numeric id, `title` not `name`, and flat
- * `layout_color`/`layout_icon` rather than a nested `layout` object.
+ * A followed feed as returned in a detail response's `follows` array. The client
+ * calls these `sources`; see `adaptSpaceSource`.
+ */
+export interface ReadSpaceFollowApiItem {
+	feed_id: number;
+	feed_url: string;
+	blog_id: number | null;
+	name: string | null;
+	icon: string | null;
+}
+
+/**
+ * Wire shape for a space. The list (summary) endpoint returns only `id`,
+ * `title`, `layout_color`, `layout_icon`; every other endpoint returns the same
+ * plus `follows` and `tags` (the detail shape). Differs from the client model:
+ * numeric id, `title` not `name`, flat `layout_color`/`layout_icon` rather than a
+ * nested `layout`, and `follows` rather than `sources`.
  */
 export interface ReadSpaceApiItem {
 	id: number;
 	title: string;
-	sites: number[];
-	tags: string[];
 	layout_color: SpaceColor;
 	layout_icon: SpaceIcon;
-	// Returned by the list/detail endpoints but not by `POST /reader/spaces/new`.
-	slug?: string;
-	owner_id?: number;
-	created?: string;
+	// Detail-only — absent on the list (summary) response.
+	follows?: ReadSpaceFollowApiItem[];
+	tags?: string[];
 }
 
 /**
- * Map a wpcom/v2 response item onto the client `ReadSpace` (list) shape,
- * nesting the flat `layout_color`/`layout_icon` fields under `layout`.
+ * Map a wpcom/v2 summary item onto the client `ReadSpace` (list) shape, nesting
+ * the flat `layout_color`/`layout_icon` fields under `layout`.
  */
 export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
 	return {
 		id: String( item.id ),
 		name: item.title,
-		tags: item.tags ?? [],
 		layout: { color: item.layout_color, icon: item.layout_icon },
 	};
 }
 
+/** Map a wire `follows[]` entry onto the client `SpaceSource` shape. */
+function adaptSpaceSource( follow: ReadSpaceFollowApiItem ): SpaceSource {
+	return {
+		feedId: follow.feed_id,
+		feedUrl: follow.feed_url,
+		blogId: follow.blog_id,
+		name: follow.name,
+		siteIcon: follow.icon,
+	};
+}
+
 /**
- * Map a wpcom/v2 response item onto the client `ReadSpaceDetails` shape.
- *
- * TODO(RSM-4145): the detail/sources endpoint isn't wired yet, so `sources` is
- * empty here. A freshly created space has no sources, so this is correct for the
- * create response; hydrating `sites` into real `SpaceSource`s lands with detail.
+ * Map a wpcom/v2 detail item onto the client `ReadSpaceDetails` shape, mapping
+ * the wire `follows` array onto `sources` and carrying the tag slugs through.
  */
 export function adaptReadSpaceDetails( item: ReadSpaceApiItem ): ReadSpaceDetails {
 	return {
 		...adaptReadSpace( item ),
-		sources: [],
+		sources: ( item.follows ?? [] ).map( adaptSpaceSource ),
+		tags: item.tags ?? [],
 	};
 }

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -1,4 +1,4 @@
-import type { ReadSpace, ReadSpaceDetails, SpaceColor, SpaceIcon, SpaceSource } from './types';
+import type { ReadSpace, ReadSpaceDetails, SpaceLayout, SpaceSource } from './types';
 
 /**
  * A followed feed as returned in a detail response's `follows` array. The client
@@ -14,30 +14,26 @@ export interface ReadSpaceFollowApiItem {
 
 /**
  * Wire shape for a space. The list (summary) endpoint returns only `id`,
- * `title`, `layout_color`, `layout_icon`; every other endpoint returns the same
- * plus `follows` and `tags` (the detail shape). Differs from the client model:
- * numeric id, `title` not `name`, flat `layout_color`/`layout_icon` rather than a
- * nested `layout`, and `follows` rather than `sources`.
+ * `title`, `layout`; every other endpoint returns the same plus `follows` and
+ * `tags` (the detail shape). Differs from the client model: numeric id, `title`
+ * not `name`, and `follows` rather than `sources`. `layout` is now an object
+ * (`{ color, icon }`), matching the client `SpaceLayout`.
  */
 export interface ReadSpaceApiItem {
 	id: number;
 	title: string;
-	layout_color: SpaceColor;
-	layout_icon: SpaceIcon;
+	layout: SpaceLayout;
 	// Detail-only — absent on the list (summary) response.
 	follows?: ReadSpaceFollowApiItem[];
 	tags?: string[];
 }
 
-/**
- * Map a wpcom/v2 summary item onto the client `ReadSpace` (list) shape, nesting
- * the flat `layout_color`/`layout_icon` fields under `layout`.
- */
+/** Map a wpcom/v2 summary item onto the client `ReadSpace` (list) shape. */
 export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
 	return {
 		id: String( item.id ),
 		name: item.title,
-		layout: { color: item.layout_color, icon: item.layout_icon },
+		layout: { color: item.layout.color, icon: item.layout.icon },
 	};
 }
 

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -1,0 +1,46 @@
+import type { ReadSpace, ReadSpaceDetails, SpaceColor, SpaceIcon } from './types';
+
+/**
+ * Wire shape returned by the wpcom/v2 Spaces endpoints (list, single, create).
+ * Differs from the client `ReadSpace`: numeric id, `title` not `name`, and flat
+ * `layout_color`/`layout_icon` rather than a nested `layout` object.
+ */
+export interface ReadSpaceApiItem {
+	id: number;
+	title: string;
+	sites: number[];
+	tags: string[];
+	layout_color: SpaceColor;
+	layout_icon: SpaceIcon;
+	// Returned by the list/detail endpoints but not by `POST /reader/spaces/new`.
+	slug?: string;
+	owner_id?: number;
+	created?: string;
+}
+
+/**
+ * Map a wpcom/v2 response item onto the client `ReadSpace` (list) shape,
+ * nesting the flat `layout_color`/`layout_icon` fields under `layout`.
+ */
+export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
+	return {
+		id: String( item.id ),
+		name: item.title,
+		tags: item.tags ?? [],
+		layout: { color: item.layout_color, icon: item.layout_icon },
+	};
+}
+
+/**
+ * Map a wpcom/v2 response item onto the client `ReadSpaceDetails` shape.
+ *
+ * TODO(RSM-4145): the detail/sources endpoint isn't wired yet, so `sources` is
+ * empty here. A freshly created space has no sources, so this is correct for the
+ * create response; hydrating `sites` into real `SpaceSource`s lands with detail.
+ */
+export function adaptReadSpaceDetails( item: ReadSpaceApiItem ): ReadSpaceDetails {
+	return {
+		...adaptReadSpace( item ),
+		sources: [],
+	};
+}

--- a/packages/api-core/src/read-spaces/fetchers.ts
+++ b/packages/api-core/src/read-spaces/fetchers.ts
@@ -1,3 +1,5 @@
+import { wpcom } from '../wpcom-fetcher';
+import { adaptReadSpace, type ReadSpaceApiItem } from './adapters';
 import type { ReadSpace, ReadSpaceDetails } from './types';
 
 /**
@@ -54,29 +56,29 @@ const PLACEHOLDER_SPACES: ReadSpace[] = [
 ];
 
 /**
- * Fetch the current user's spaces.
- *
- * TODO(RSM-4145): replace with the real `GET` once the list endpoint exists.
- * Until then it resolves the hard-coded placeholder set; spaces created in the
- * session are appended to the React Query cache by the create mutation.
+ * Fetch the current user's spaces from the wpcom/v2 `GET /reader/spaces`
+ * endpoint, adapting each item from the snake_case wire shape (`title`,
+ * `layout_color`/`layout_icon`) to the client `ReadSpace` via `adaptReadSpace`.
  */
 export async function fetchReadSpaces(): Promise< ReadSpace[] > {
-	// Return fully independent copies (including nested `tags`/`layout`) so a
-	// consumer can't mutate the shared `PLACEHOLDER_SPACES`.
-	return PLACEHOLDER_SPACES.map( ( space ) => ( {
-		...space,
-		tags: [ ...space.tags ],
-		layout: { ...space.layout },
-	} ) );
+	const response = await wpcom.req.get( {
+		path: '/reader/spaces',
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	const items: ReadSpaceApiItem[] = Array.isArray( response ) ? response : [];
+	return items.map( adaptReadSpace );
 }
 
 /**
  * Fetch a single space's details, including its sources.
  *
- * TODO(RSM-4145): replace with the real `GET /spaces/{id}` once it exists.
- * Until then it resolves the matching placeholder space with an empty source
- * list. Spaces created in the session aren't in the placeholder set — the
- * create mutation seeds their detail cache directly, so this never runs for them.
+ * TODO(RSM-4145): the detail endpoint isn't wired yet — this still resolves the
+ * matching placeholder space with an empty source list. The create mutation
+ * seeds the detail cache for spaces created this session, but the live list now
+ * returns real spaces this set doesn't contain, so opening one's sources after a
+ * reload (which clears the seeded cache) currently throws. Wiring the real
+ * `GET /reader/spaces/{id}` closes that gap.
  */
 export async function fetchReadSpace( spaceId: string ): Promise< ReadSpaceDetails > {
 	const space = PLACEHOLDER_SPACES.find( ( item ) => item.id === spaceId );

--- a/packages/api-core/src/read-spaces/fetchers.ts
+++ b/packages/api-core/src/read-spaces/fetchers.ts
@@ -1,64 +1,11 @@
 import { wpcom } from '../wpcom-fetcher';
-import { adaptReadSpace, type ReadSpaceApiItem } from './adapters';
+import { adaptReadSpace, adaptReadSpaceDetails, type ReadSpaceApiItem } from './adapters';
 import type { ReadSpace, ReadSpaceDetails } from './types';
 
 /**
- * Hard-coded placeholder spaces returned while Spaces are dark-shipped behind
- * the `reader/spaces` feature flag. Ids are stable opaque values so deep links
- * survive a reload without teaching consumers to treat names as URL slugs.
- *
- * These are list-shaped (no `sources`); the single-space fetcher adds the
- * sources, matching the eventual list vs detail endpoints.
- */
-const PLACEHOLDER_SPACES: ReadSpace[] = [
-	{
-		id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
-		name: 'Work',
-		tags: [],
-		layout: { color: 'blue', icon: 'inbox' },
-	},
-	{
-		id: '5cc71d31-97d1-4b7d-93c7-42a5ce9d4cf1',
-		name: 'Gaming',
-		tags: [],
-		layout: { color: 'purple', icon: 'box' },
-	},
-	{
-		id: '9708ac5a-8edc-4c4c-9c2e-bb07cb40ff5c',
-		name: 'YouTube',
-		tags: [],
-		layout: { color: 'red', icon: 'video' },
-	},
-	{
-		id: 'c23779a1-b01b-491f-aa01-c32cc5bf6b16',
-		name: 'Humor',
-		tags: [],
-		layout: { color: 'orange', icon: 'comment' },
-	},
-	{
-		id: '0be74629-6b4f-4fd5-8d1d-0d6e53ac5703',
-		name: 'Food',
-		tags: [],
-		layout: { color: 'gray', icon: 'cart' },
-	},
-	{
-		id: 'd41c7eb4-11ad-4493-87cb-b0c3a70a99d5',
-		name: 'Health',
-		tags: [],
-		layout: { color: 'green', icon: 'star' },
-	},
-	{
-		id: 'b6f0f66a-c35f-49b2-9df8-9474e6e66a5b',
-		name: 'Cats',
-		tags: [],
-		layout: { color: 'celadon', icon: 'pages' },
-	},
-];
-
-/**
  * Fetch the current user's spaces from the wpcom/v2 `GET /reader/spaces`
- * endpoint, adapting each item from the snake_case wire shape (`title`,
- * `layout_color`/`layout_icon`) to the client `ReadSpace` via `adaptReadSpace`.
+ * endpoint. The list is the slim summary shape (no sources or tags), adapted to
+ * the client `ReadSpace` via `adaptReadSpace`.
  */
 export async function fetchReadSpaces(): Promise< ReadSpace[] > {
 	const response = await wpcom.req.get( {
@@ -71,21 +18,15 @@ export async function fetchReadSpaces(): Promise< ReadSpace[] > {
 }
 
 /**
- * Fetch a single space's details, including its sources.
- *
- * TODO(RSM-4145): the detail endpoint isn't wired yet — this still resolves the
- * matching placeholder space with an empty source list. The create mutation
- * seeds the detail cache for spaces created this session, but the live list now
- * returns real spaces this set doesn't contain, so opening one's sources after a
- * reload (which clears the seeded cache) currently throws. Wiring the real
- * `GET /reader/spaces/{id}` closes that gap.
+ * Fetch a single space's detail (its followed feeds and tags) from the wpcom/v2
+ * `GET /reader/spaces/{id}` endpoint, adapting the wire `follows` array onto the
+ * client `sources` shape.
  */
 export async function fetchReadSpace( spaceId: string ): Promise< ReadSpaceDetails > {
-	const space = PLACEHOLDER_SPACES.find( ( item ) => item.id === spaceId );
-	if ( ! space ) {
-		throw new Error( `Space not found: ${ spaceId }` );
-	}
-	// Independent copy (nested `tags`/`layout` cloned, fresh `sources`) so callers
-	// can't mutate the shared `PLACEHOLDER_SPACES`.
-	return { ...space, tags: [ ...space.tags ], layout: { ...space.layout }, sources: [] };
+	const item: ReadSpaceApiItem = await wpcom.req.get( {
+		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	return adaptReadSpaceDetails( item );
 }

--- a/packages/api-core/src/read-spaces/mutators.ts
+++ b/packages/api-core/src/read-spaces/mutators.ts
@@ -1,25 +1,54 @@
-import { DEFAULT_SPACE_LAYOUT } from './constants';
+import { wpcom } from '../wpcom-fetcher';
+import { adaptReadSpaceDetails, type ReadSpaceApiItem } from './adapters';
 import type {
 	CreateReadSpaceParams,
+	ReadSpaceDeletionResult,
 	ReadSpaceDetails,
 	ReadSpaceSourceMutationParams,
 } from './types';
 
 /**
- * Create a space.
- *
- * TODO(RSM-4139): call the real POST endpoint once it exists. For now the space
- * is constructed locally and the api-query layer writes it to the React Query
- * cache. Returns the detail shape (with an empty source list) so the create
- * flow can seed the single-space cache.
+ * Create a space via the wpcom/v2 `POST /reader/spaces/new` endpoint, returning
+ * the created space (detail shape) so the create flow can seed the caches.
  */
-export function createReadSpace( params: CreateReadSpaceParams ): Promise< ReadSpaceDetails > {
-	return Promise.resolve( {
-		id: generateSpaceId(),
-		name: params.name,
-		tags: params.tags,
-		layout: { ...DEFAULT_SPACE_LAYOUT },
-		sources: [],
+export async function createReadSpace(
+	params: CreateReadSpaceParams
+): Promise< ReadSpaceDetails > {
+	const item: ReadSpaceApiItem = await wpcom.req.post(
+		{
+			path: '/reader/spaces/new',
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			title: params.name,
+			tags: params.tags,
+			// The endpoint also accepts these optional fields, but the create form
+			// doesn't collect them yet, so we don't send them. The server applies
+			// defaults (a random color/icon from the palette, no sites). Wire these
+			// up once the form gains a source picker (sites) and a layout picker:
+			// sites: params.sites,             // int[] of wpcom blog_ids to follow
+			// layout_color: params.layoutColor, // SpaceColor — defaults server-side
+			// layout_icon: params.layoutIcon,   // SpaceIcon  — defaults server-side
+		}
+	);
+
+	return adaptReadSpaceDetails( item );
+}
+
+/**
+ * Permanently delete a space via the wpcom/v2 `POST /reader/spaces/{id}/delete`
+ * endpoint. Hard delete — there is no trash/undo, so callers should confirm
+ * first. Server enforces owner-only access; a missing-or-not-yours space and a
+ * truly-absent one both return `404 reader_spaces_not_found` (by design — we
+ * don't reveal other users' spaces).
+ * @param spaceId The space's id (the stringified numeric id the client holds).
+ */
+export async function deleteReadSpace( spaceId: string ): Promise< ReadSpaceDeletionResult > {
+	return wpcom.req.post( {
+		// `spaceId` is opaque to us — encode it so a non-numeric id can't smuggle
+		// extra path segments (matches the Reader route builders).
+		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/delete`,
+		apiNamespace: 'wpcom/v2',
 	} );
 }
 
@@ -31,13 +60,4 @@ export function addReadSpaceSource( params: ReadSpaceSourceMutationParams ): Pro
 export function deleteReadSpaceSource( params: ReadSpaceSourceMutationParams ): Promise< void > {
 	void params;
 	return Promise.resolve();
-}
-
-function generateSpaceId(): string {
-	// `crypto.randomUUID` is available in all supported browsers; fall back to a
-	// random base36 string in non-secure or test contexts where it is undefined.
-	if ( typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ) {
-		return crypto.randomUUID();
-	}
-	return Math.random().toString( 36 ).slice( 2, 12 );
 }

--- a/packages/api-core/src/read-spaces/mutators.ts
+++ b/packages/api-core/src/read-spaces/mutators.ts
@@ -115,10 +115,16 @@ export async function deleteReadSpaceSource( {
 	spaceId,
 	subscription,
 }: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
+	// Removal is keyed strictly by the numeric feedbag feed id (from
+	// `follows[].feed_id`). `feed_ID` is loosely typed, so guard against a
+	// missing/non-numeric value rather than POSTing a `/feeds/null/delete` path.
+	const feedId = Number( subscription.feed_ID );
+	if ( ! Number.isInteger( feedId ) || feedId <= 0 ) {
+		throw new Error( 'Cannot remove a space feed without a numeric feed id.' );
+	}
+
 	const item: ReadSpaceApiItem = await wpcom.req.post( {
-		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/${ encodeURIComponent(
-			String( subscription.feed_ID )
-		) }/delete`,
+		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/${ feedId }/delete`,
 		apiNamespace: 'wpcom/v2',
 	} );
 

--- a/packages/api-core/src/read-spaces/mutators.ts
+++ b/packages/api-core/src/read-spaces/mutators.ts
@@ -9,9 +9,9 @@ import type {
 } from './types';
 
 /**
- * Create a space via the wpcom/v2 `POST /reader/spaces/new` endpoint, returning
- * the created space (detail shape). Only `title` is required; `feeds`, `tags`,
- * and the layout fields are sent when provided (the server defaults the rest).
+ * Create a space via the wpcom/v2 `POST /reader/spaces` endpoint, returning the
+ * created space (detail shape). Only `title` is required; `feeds`, `tags`, and
+ * `layout` are sent when provided (the server defaults the rest).
  */
 export async function createReadSpace(
 	params: CreateReadSpaceParams
@@ -23,15 +23,12 @@ export async function createReadSpace(
 	if ( params.tags ) {
 		body.tags = params.tags;
 	}
-	if ( params.layoutColor ) {
-		body.layout_color = params.layoutColor;
-	}
-	if ( params.layoutIcon ) {
-		body.layout_icon = params.layoutIcon;
+	if ( params.layout ) {
+		body.layout = params.layout;
 	}
 
 	const item: ReadSpaceApiItem = await wpcom.req.post(
-		{ path: '/reader/spaces/new', apiNamespace: 'wpcom/v2' },
+		{ path: '/reader/spaces', apiNamespace: 'wpcom/v2' },
 		body
 	);
 
@@ -39,9 +36,10 @@ export async function createReadSpace(
 }
 
 /**
- * Update a space via `POST /reader/spaces/{id}/update`, returning the updated
- * detail. Sends only the provided fields (at least one is required server-side).
- * `tags` is a full replace of the tag set, not an add/remove.
+ * Update a space via `PUT /reader/spaces/{id}`, returning the updated detail.
+ * Sends only the provided fields (at least one is required server-side). `tags`
+ * is a full replace of the tag set; `layout` is a partial merge (send only the
+ * fields you're changing).
  */
 export async function updateReadSpace(
 	spaceId: string,
@@ -54,15 +52,16 @@ export async function updateReadSpace(
 	if ( params.tags !== undefined ) {
 		body.tags = params.tags;
 	}
-	if ( params.layoutColor !== undefined ) {
-		body.layout_color = params.layoutColor;
-	}
-	if ( params.layoutIcon !== undefined ) {
-		body.layout_icon = params.layoutIcon;
+	if ( params.layout !== undefined ) {
+		body.layout = params.layout;
 	}
 
 	const item: ReadSpaceApiItem = await wpcom.req.post(
-		{ path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/update`, apiNamespace: 'wpcom/v2' },
+		{
+			path: `/reader/spaces/${ encodeURIComponent( spaceId ) }`,
+			apiNamespace: 'wpcom/v2',
+			method: 'PUT',
+		},
 		body
 	);
 
@@ -70,7 +69,7 @@ export async function updateReadSpace(
 }
 
 /**
- * Permanently delete a space via the wpcom/v2 `POST /reader/spaces/{id}/delete`
+ * Permanently delete a space via the wpcom/v2 `DELETE /reader/spaces/{id}`
  * endpoint. Hard delete — there is no trash/undo, so callers should confirm
  * first. Server enforces owner-only access; a missing-or-not-yours space and a
  * truly-absent one both return `404 reader_spaces_not_found` (by design — we
@@ -81,15 +80,16 @@ export async function deleteReadSpace( spaceId: string ): Promise< ReadSpaceDele
 	return wpcom.req.post( {
 		// `spaceId` is opaque to us — encode it so a non-numeric id can't smuggle
 		// extra path segments (matches the Reader route builders).
-		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/delete`,
+		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }`,
 		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
 	} );
 }
 
 /**
- * Add a followed feed to a space via `POST /reader/spaces/{id}/feeds/new`,
- * returning the updated detail. The feed is identified by the subscription's
- * feed id (falling back to its feed URL); the server resolves it.
+ * Add a followed feed to a space via `POST /reader/spaces/{id}/feeds`, returning
+ * the updated detail. The feed is identified by the subscription's feed id
+ * (falling back to its feed URL); the server resolves it.
  */
 export async function addReadSpaceSource( {
 	spaceId,
@@ -97,7 +97,7 @@ export async function addReadSpaceSource( {
 }: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
 	const item: ReadSpaceApiItem = await wpcom.req.post(
 		{
-			path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/new`,
+			path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{ feed: subscription.feed_ID ?? subscription.feed_URL }
@@ -108,8 +108,8 @@ export async function addReadSpaceSource( {
 
 /**
  * Remove a followed feed from a space via
- * `POST /reader/spaces/{id}/feeds/{feed_id}/delete`, returning the updated
- * detail. Removal is keyed by the numeric feed id (from `follows[].feed_id`).
+ * `DELETE /reader/spaces/{id}/feeds/{feed_id}`, returning the updated detail.
+ * Removal is keyed by the numeric feed id (from `follows[].feed_id`).
  */
 export async function deleteReadSpaceSource( {
 	spaceId,
@@ -117,15 +117,16 @@ export async function deleteReadSpaceSource( {
 }: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
 	// Removal is keyed strictly by the numeric feedbag feed id (from
 	// `follows[].feed_id`). `feed_ID` is loosely typed, so guard against a
-	// missing/non-numeric value rather than POSTing a `/feeds/null/delete` path.
+	// missing/non-numeric value rather than issuing a `/feeds/null` request.
 	const feedId = Number( subscription.feed_ID );
 	if ( ! Number.isInteger( feedId ) || feedId <= 0 ) {
 		throw new Error( 'Cannot remove a space feed without a numeric feed id.' );
 	}
 
 	const item: ReadSpaceApiItem = await wpcom.req.post( {
-		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/${ feedId }/delete`,
+		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/${ feedId }`,
 		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
 	} );
 
 	return adaptReadSpaceDetails( item );

--- a/packages/api-core/src/read-spaces/mutators.ts
+++ b/packages/api-core/src/read-spaces/mutators.ts
@@ -5,31 +5,65 @@ import type {
 	ReadSpaceDeletionResult,
 	ReadSpaceDetails,
 	ReadSpaceSourceMutationParams,
+	UpdateReadSpaceParams,
 } from './types';
 
 /**
  * Create a space via the wpcom/v2 `POST /reader/spaces/new` endpoint, returning
- * the created space (detail shape) so the create flow can seed the caches.
+ * the created space (detail shape). Only `title` is required; `feeds`, `tags`,
+ * and the layout fields are sent when provided (the server defaults the rest).
  */
 export async function createReadSpace(
 	params: CreateReadSpaceParams
 ): Promise< ReadSpaceDetails > {
+	const body: Record< string, unknown > = { title: params.name };
+	if ( params.feeds ) {
+		body.feeds = params.feeds;
+	}
+	if ( params.tags ) {
+		body.tags = params.tags;
+	}
+	if ( params.layoutColor ) {
+		body.layout_color = params.layoutColor;
+	}
+	if ( params.layoutIcon ) {
+		body.layout_icon = params.layoutIcon;
+	}
+
 	const item: ReadSpaceApiItem = await wpcom.req.post(
-		{
-			path: '/reader/spaces/new',
-			apiNamespace: 'wpcom/v2',
-		},
-		{
-			title: params.name,
-			tags: params.tags,
-			// The endpoint also accepts these optional fields, but the create form
-			// doesn't collect them yet, so we don't send them. The server applies
-			// defaults (a random color/icon from the palette, no sites). Wire these
-			// up once the form gains a source picker (sites) and a layout picker:
-			// sites: params.sites,             // int[] of wpcom blog_ids to follow
-			// layout_color: params.layoutColor, // SpaceColor — defaults server-side
-			// layout_icon: params.layoutIcon,   // SpaceIcon  — defaults server-side
-		}
+		{ path: '/reader/spaces/new', apiNamespace: 'wpcom/v2' },
+		body
+	);
+
+	return adaptReadSpaceDetails( item );
+}
+
+/**
+ * Update a space via `POST /reader/spaces/{id}/update`, returning the updated
+ * detail. Sends only the provided fields (at least one is required server-side).
+ * `tags` is a full replace of the tag set, not an add/remove.
+ */
+export async function updateReadSpace(
+	spaceId: string,
+	params: UpdateReadSpaceParams
+): Promise< ReadSpaceDetails > {
+	const body: Record< string, unknown > = {};
+	if ( params.name !== undefined ) {
+		body.title = params.name;
+	}
+	if ( params.tags !== undefined ) {
+		body.tags = params.tags;
+	}
+	if ( params.layoutColor !== undefined ) {
+		body.layout_color = params.layoutColor;
+	}
+	if ( params.layoutIcon !== undefined ) {
+		body.layout_icon = params.layoutIcon;
+	}
+
+	const item: ReadSpaceApiItem = await wpcom.req.post(
+		{ path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/update`, apiNamespace: 'wpcom/v2' },
+		body
 	);
 
 	return adaptReadSpaceDetails( item );
@@ -52,12 +86,41 @@ export async function deleteReadSpace( spaceId: string ): Promise< ReadSpaceDele
 	} );
 }
 
-export function addReadSpaceSource( params: ReadSpaceSourceMutationParams ): Promise< void > {
-	void params;
-	return Promise.resolve();
+/**
+ * Add a followed feed to a space via `POST /reader/spaces/{id}/feeds/new`,
+ * returning the updated detail. The feed is identified by the subscription's
+ * feed id (falling back to its feed URL); the server resolves it.
+ */
+export async function addReadSpaceSource( {
+	spaceId,
+	subscription,
+}: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
+	const item: ReadSpaceApiItem = await wpcom.req.post(
+		{
+			path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/new`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ feed: subscription.feed_ID ?? subscription.feed_URL }
+	);
+
+	return adaptReadSpaceDetails( item );
 }
 
-export function deleteReadSpaceSource( params: ReadSpaceSourceMutationParams ): Promise< void > {
-	void params;
-	return Promise.resolve();
+/**
+ * Remove a followed feed from a space via
+ * `POST /reader/spaces/{id}/feeds/{feed_id}/delete`, returning the updated
+ * detail. Removal is keyed by the numeric feed id (from `follows[].feed_id`).
+ */
+export async function deleteReadSpaceSource( {
+	spaceId,
+	subscription,
+}: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
+	const item: ReadSpaceApiItem = await wpcom.req.post( {
+		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/${ encodeURIComponent(
+			String( subscription.feed_ID )
+		) }/delete`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	return adaptReadSpaceDetails( item );
 }

--- a/packages/api-core/src/read-spaces/source-keys.ts
+++ b/packages/api-core/src/read-spaces/source-keys.ts
@@ -1,5 +1,4 @@
 import type { SiteSubscriptionItem } from '../read-follows';
-import type { SpaceSource } from './types';
 
 export const normalizeReadSpaceSourceUrl = ( url?: string | null ): string =>
 	( url ?? '' ).trim().toLowerCase().replace( /\/+$/, '' );
@@ -33,9 +32,14 @@ const buildReadSpaceSourceKey = (
 	return `url:${ normalizeReadSpaceSourceUrl( url ) }`;
 };
 
-export const getReadSpaceSourceKey = (
-	source: Pick< SpaceSource, 'feedId' | 'blogId' | 'feedUrl' >
-): string => buildReadSpaceSourceKey( source.feedId, source.blogId, source.feedUrl );
+// Loosely typed (not `Pick<SpaceSource>`): the real `SpaceSource.feedId` is now
+// always a number, but this helper also keys partial/edge inputs (null/string
+// ids), so it accepts the lenient shape `buildReadSpaceSourceKey` already handles.
+export const getReadSpaceSourceKey = ( source: {
+	feedId?: number | string | null;
+	blogId?: number | string | null;
+	feedUrl?: string | null;
+} ): string => buildReadSpaceSourceKey( source.feedId, source.blogId, source.feedUrl );
 
 export const getSiteSubscriptionSourceKey = (
 	subscription: Pick< SiteSubscriptionItem, 'feed_ID' | 'blog_ID' | 'feed_URL' >

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -51,6 +51,15 @@ export interface CreateReadSpaceParams {
 	tags: string[];
 }
 
+/**
+ * Result of `POST /reader/spaces/{id}/delete`. Deletion is a permanent hard
+ * delete — there is no trash/undo.
+ */
+export interface ReadSpaceDeletionResult {
+	deleted: boolean;
+	id: number;
+}
+
 export interface SpaceSource {
 	feedId?: number | string | null;
 	blogId?: number | string | null;

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -1,13 +1,13 @@
 import type { SiteSubscriptionItem } from '../read-follows';
 
 /**
- * Reader Spaces — a Space groups subscriptions under a name plus optional tags.
- * v0 has a name and tags only, no description (see RSM-4110).
+ * Reader Spaces — a Space groups followed feeds (`sources`) and followed tags
+ * under a name (see RSM-4110).
  *
  * `color` and `icon` are serializable presentation hints (string keys, not
  * rendered glyphs); the client maps `icon` to a `@wordpress/icons` element and
- * `color` to a CSS variant. RSM-4119 will replace the seeded list with real,
- * server-derived data.
+ * `color` to a CSS variant. The API does not validate these against the lists
+ * below — it only sanitizes — so the client constrains the picker.
  */
 export type SpaceColor = 'blue' | 'purple' | 'red' | 'orange' | 'gray' | 'green' | 'celadon';
 
@@ -30,25 +30,47 @@ export interface SpaceLayout {
 	icon: SpaceIcon;
 }
 
+/**
+ * Summary shape returned by the list endpoint (`GET /reader/spaces`). The list
+ * is slim — no `sources` or `tags`; fetch the detail endpoint for those.
+ */
 export interface ReadSpace {
 	id: string;
 	name: string;
-	tags: string[];
 	layout: SpaceLayout;
 }
 
 /**
- * A space plus its sources. Sources are only returned by the single-space
- * endpoint (`GET /read/spaces/{id}`), not by the list endpoint — so the list
- * deals in `ReadSpace` and the detail view deals in `ReadSpaceDetails`.
+ * A space plus its followed feeds (`sources`) and tags. Returned by every
+ * endpoint except the list — the detail GET, create, update, and the feed
+ * mutations all resolve a `ReadSpaceDetails`.
  */
 export interface ReadSpaceDetails extends ReadSpace {
 	sources: SpaceSource[];
+	tags: string[];
 }
 
 export interface CreateReadSpaceParams {
 	name: string;
-	tags: string[];
+	// All optional on the API. Tags must be existing Reader tag slugs and feeds
+	// must be existing feeds (feed id or url); either rejects the whole request
+	// if unresolvable.
+	tags?: string[];
+	feeds?: Array< number | string >;
+	layoutColor?: SpaceColor;
+	layoutIcon?: SpaceIcon;
+}
+
+/**
+ * Params for `POST /reader/spaces/{id}/update`. Send only the fields you are
+ * changing; at least one is required. `tags` is a full replace of the tag set
+ * (pass `[]` to clear), not an add/remove — there are no per-tag endpoints.
+ */
+export interface UpdateReadSpaceParams {
+	name?: string;
+	tags?: string[];
+	layoutColor?: SpaceColor;
+	layoutIcon?: SpaceIcon;
 }
 
 /**
@@ -60,13 +82,18 @@ export interface ReadSpaceDeletionResult {
 	id: number;
 }
 
+/**
+ * A feed followed by a space. The API calls these `follows`; the client keeps
+ * the `sources` vocabulary. `feedId` is the numeric feedbag id used to remove
+ * the feed; `blogId` is null for external (non-WP/Jetpack) feeds; `name`/`icon`
+ * may be null when feedbag has none.
+ */
 export interface SpaceSource {
-	feedId?: number | string | null;
-	blogId?: number | string | null;
+	feedId: number;
 	feedUrl: string;
-	siteUrl: string;
-	name: string;
-	siteIcon?: string | null;
+	blogId: number | null;
+	name: string | null;
+	siteIcon: string | null;
 }
 
 export interface ReadSpaceSourceMutationParams {

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -57,20 +57,19 @@ export interface CreateReadSpaceParams {
 	// if unresolvable.
 	tags?: string[];
 	feeds?: Array< number | string >;
-	layoutColor?: SpaceColor;
-	layoutIcon?: SpaceIcon;
+	layout?: Partial< SpaceLayout >;
 }
 
 /**
- * Params for `POST /reader/spaces/{id}/update`. Send only the fields you are
- * changing; at least one is required. `tags` is a full replace of the tag set
- * (pass `[]` to clear), not an add/remove — there are no per-tag endpoints.
+ * Params for `PUT /reader/spaces/{id}`. Send only the fields you are changing; at
+ * least one is required. `tags` is a full replace of the tag set (pass `[]` to
+ * clear), not an add/remove — there are no per-tag endpoints. `layout` is a
+ * partial merge — send `{ color }` to change only the colour; the icon is kept.
  */
 export interface UpdateReadSpaceParams {
 	name?: string;
 	tags?: string[];
-	layoutColor?: SpaceColor;
-	layoutIcon?: SpaceIcon;
+	layout?: Partial< SpaceLayout >;
 }
 
 /**

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -61,8 +61,7 @@ const makeSubscription = (
 const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
 	id: 3,
 	title: 'Work',
-	layout_color: 'blue',
-	layout_icon: 'inbox',
+	layout: { color: 'blue', icon: 'inbox' },
 	follows: [],
 	tags: [],
 	...overrides,
@@ -75,7 +74,7 @@ describe( 'read spaces mutations', () => {
 		it( 'appends the summary to the list and seeds the detail cache', async () => {
 			const client = newClient();
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/new' )
+				.post( '/wpcom/v2/reader/spaces' )
 				.reply( 201, detailResponse( { id: 99, title: 'New' } ) );
 
 			await runMutation( client, createReadSpaceMutation( client ), { name: 'New' } );
@@ -102,10 +101,15 @@ describe( 'read spaces mutations', () => {
 				{ id: '3', name: 'Old', layout: { color: 'blue', icon: 'inbox' } },
 			] );
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/update' )
+				.put( '/wpcom/v2/reader/spaces/3' )
 				.reply(
 					200,
-					detailResponse( { id: 3, title: 'New name', layout_color: 'green', tags: [ 'x' ] } )
+					detailResponse( {
+						id: 3,
+						title: 'New name',
+						layout: { color: 'green', icon: 'inbox' },
+						tags: [ 'x' ],
+					} )
 				);
 
 			await runMutation( client, updateReadSpaceMutation( client ), {
@@ -131,9 +135,7 @@ describe( 'read spaces mutations', () => {
 				{ id: '3', name: 'Work', layout: { color: 'blue', icon: 'inbox' } },
 			] );
 			client.setQueryData( readSpaceQuery( '3' ).queryKey, detailResponse() );
-			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/delete' )
-				.reply( 200, { deleted: true, id: 3 } );
+			nock( BASE ).delete( '/wpcom/v2/reader/spaces/3' ).reply( 200, { deleted: true, id: 3 } );
 
 			await runMutation( client, deleteReadSpaceMutation( client ), '3' );
 
@@ -150,7 +152,7 @@ describe( 'read spaces mutations', () => {
 		it( 'writes the returned detail to the cache after adding a feed', async () => {
 			const client = newClient();
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds/new' )
+				.post( '/wpcom/v2/reader/spaces/3/feeds' )
 				.reply(
 					200,
 					detailResponse( {
@@ -187,7 +189,7 @@ describe( 'read spaces mutations', () => {
 		it( 'writes the returned detail to the cache after removing a feed', async () => {
 			const client = newClient();
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds/456/delete' )
+				.delete( '/wpcom/v2/reader/spaces/3/feeds/456' )
 				.reply( 200, detailResponse( { follows: [] } ) );
 
 			await runMutation( client, deleteReadSpaceSourceMutation( client ), {
@@ -211,7 +213,7 @@ describe( 'read spaces mutations', () => {
 			};
 			client.setQueryData( readSpaceQuery( '3' ).queryKey, seeded );
 			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds/new' )
+				.post( '/wpcom/v2/reader/spaces/3/feeds' )
 				.reply( 409, {
 					code: 'reader_spaces_duplicate_feed',
 					message: '…',

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -8,10 +8,13 @@ import {
 	deleteReadSpaceSourceMutation,
 	readSpaceQuery,
 	readSpacesQuery,
+	updateReadSpaceMutation,
 } from '../read-spaces';
 import type { ReadSpace, ReadSpaceDetails, SiteSubscriptionItem } from '@automattic/api-core';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
+
+const BASE = 'https://public-api.wordpress.com';
 
 function makeWrapper( client: QueryClient ) {
 	return function Wrapper( { children }: { children: ReactNode } ) {
@@ -25,14 +28,7 @@ function newClient() {
 	} );
 }
 
-// Drive the mutation through the real `useMutation` hook (matching the other
-// api-queries tests) so `onMutate`/`onError`/`onSuccess` fire in order — the
-// optimistic cache patch and rollback are the behavior under test.
-//
-// The error paths force a rejecting `mutationFn` because the Spaces mutators are
-// still local no-ops with no network call. Once the real endpoints land, drop
-// that override and drive success/error with a `nock` interceptor (200 vs
-// 4xx/5xx), asserting `scope.isDone()` — see `read-site-recommendations.test.tsx`.
+// Drive the mutation through the real `useMutation` hook so its onSuccess fires.
 async function runMutation< TData, TError, TVars, TContext >(
 	client: QueryClient,
 	mutation: UseMutationOptions< TData, TError, TVars, TContext >,
@@ -46,26 +42,6 @@ async function runMutation< TData, TError, TVars, TContext >(
 		await result.current.mutateAsync( variables ).catch( () => undefined );
 	} );
 }
-
-const SPACE_ID = '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21';
-
-const STRATECHERY_SOURCE = {
-	feedId: 456,
-	blogId: 123,
-	feedUrl: 'https://stratechery.com/feed',
-	siteUrl: 'https://stratechery.com',
-	name: 'Stratechery',
-	siteIcon: 'https://stratechery.com/icon.png',
-};
-
-const makeSpace = ( overrides: Partial< ReadSpaceDetails > = {} ): ReadSpaceDetails => ( {
-	id: SPACE_ID,
-	name: 'Work',
-	tags: [],
-	layout: { color: 'blue', icon: 'inbox' },
-	sources: [],
-	...overrides,
-} );
 
 const makeSubscription = (
 	overrides: Partial< SiteSubscriptionItem > = {}
@@ -81,219 +57,175 @@ const makeSubscription = (
 	...overrides,
 } );
 
-const rejectingMutationFn = () => Promise.reject( new Error( 'nope' ) );
-
-// Sources live only on the single-space detail cache, so the add/delete
-// mutations patch `readSpaceQuery`, not the list.
-const detailSources = ( client: QueryClient ) =>
-	client.getQueryData< ReadSpaceDetails >( readSpaceQuery( SPACE_ID ).queryKey )?.sources;
-
-describe( 'read space source mutations', () => {
-	it( 'optimistically adds a source from a site subscription to the detail cache', async () => {
-		const client = newClient();
-		client.setQueryData( readSpaceQuery( SPACE_ID ).queryKey, makeSpace() );
-
-		await runMutation( client, addReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription(),
-		} );
-
-		expect( detailSources( client ) ).toEqual( [ STRATECHERY_SOURCE ] );
-	} );
-
-	it( 'cancels an in-flight detail fetch before patching, so it cannot clobber the patch', async () => {
-		const client = newClient();
-		client.setQueryData( readSpaceQuery( SPACE_ID ).queryKey, makeSpace() );
-		const cancelQueries = jest.spyOn( client, 'cancelQueries' );
-
-		await runMutation( client, addReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription(),
-		} );
-
-		expect( cancelQueries ).toHaveBeenCalledWith( {
-			queryKey: readSpaceQuery( SPACE_ID ).queryKey,
-		} );
-		expect( detailSources( client ) ).toEqual( [ STRATECHERY_SOURCE ] );
-	} );
-
-	it( 'does not add the same subscription twice', async () => {
-		const client = newClient();
-		const subscription = makeSubscription();
-		client.setQueryData( readSpaceQuery( SPACE_ID ).queryKey, makeSpace() );
-
-		await runMutation( client, addReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription,
-		} );
-		await runMutation( client, addReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription,
-		} );
-
-		expect( detailSources( client ) ).toHaveLength( 1 );
-	} );
-
-	it( 'leaves the detail cache untouched when adding before it is cached', async () => {
-		const client = newClient();
-
-		await runMutation( client, addReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription(),
-		} );
-
-		expect(
-			client.getQueryData< ReadSpaceDetails >( readSpaceQuery( SPACE_ID ).queryKey )
-		).toBeUndefined();
-	} );
-
-	it( 'rolls back the optimistic add when the request fails', async () => {
-		const client = newClient();
-		client.setQueryData( readSpaceQuery( SPACE_ID ).queryKey, makeSpace() );
-
-		await runMutation(
-			client,
-			{ ...addReadSpaceSourceMutation( client ), mutationFn: rejectingMutationFn },
-			{ spaceId: SPACE_ID, subscription: makeSubscription() }
-		);
-
-		expect( detailSources( client ) ).toEqual( [] );
-	} );
-
-	it( 'optimistically deletes a subscription from the detail cache', async () => {
-		const client = newClient();
-		client.setQueryData(
-			readSpaceQuery( SPACE_ID ).queryKey,
-			makeSpace( { sources: [ STRATECHERY_SOURCE ] } )
-		);
-
-		await runMutation( client, deleteReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription(),
-		} );
-
-		expect( detailSources( client ) ).toEqual( [] );
-	} );
-
-	it( 'deletes a source matched only by blog id', async () => {
-		const client = newClient();
-		client.setQueryData(
-			readSpaceQuery( SPACE_ID ).queryKey,
-			makeSpace( { sources: [ { ...STRATECHERY_SOURCE, feedId: null } ] } )
-		);
-
-		await runMutation( client, deleteReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription( { feed_ID: null } ),
-		} );
-
-		expect( detailSources( client ) ).toEqual( [] );
-	} );
-
-	it( 'deletes a source matched only by feed url', async () => {
-		const client = newClient();
-		client.setQueryData(
-			readSpaceQuery( SPACE_ID ).queryKey,
-			makeSpace( { sources: [ { ...STRATECHERY_SOURCE, feedId: null, blogId: null } ] } )
-		);
-
-		await runMutation( client, deleteReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription( { feed_ID: null, blog_ID: null } ),
-		} );
-
-		expect( detailSources( client ) ).toEqual( [] );
-	} );
-
-	it( 'leaves the detail cache untouched when deleting before it is cached', async () => {
-		const client = newClient();
-
-		await runMutation( client, deleteReadSpaceSourceMutation( client ), {
-			spaceId: SPACE_ID,
-			subscription: makeSubscription(),
-		} );
-
-		expect(
-			client.getQueryData< ReadSpaceDetails >( readSpaceQuery( SPACE_ID ).queryKey )
-		).toBeUndefined();
-	} );
-
-	it( 'rolls back the optimistic delete when the request fails', async () => {
-		const client = newClient();
-		client.setQueryData(
-			readSpaceQuery( SPACE_ID ).queryKey,
-			makeSpace( { sources: [ STRATECHERY_SOURCE ] } )
-		);
-
-		await runMutation(
-			client,
-			{ ...deleteReadSpaceSourceMutation( client ), mutationFn: rejectingMutationFn },
-			{ spaceId: SPACE_ID, subscription: makeSubscription() }
-		);
-
-		expect( detailSources( client ) ).toEqual( [ STRATECHERY_SOURCE ] );
-	} );
+// A detail wire response (create/update/add-feed/remove-feed all return one).
+const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
+	id: 3,
+	title: 'Work',
+	layout_color: 'blue',
+	layout_icon: 'inbox',
+	follows: [],
+	tags: [],
+	...overrides,
 } );
 
-describe( 'create space cache seeding', () => {
+describe( 'read spaces mutations', () => {
 	afterEach( () => nock.cleanAll() );
 
-	it( 'appends a list item without sources and seeds the detail cache with sources', async () => {
-		const client = newClient();
-		nock( 'https://public-api.wordpress.com' ).post( '/wpcom/v2/reader/spaces/new' ).reply( 201, {
-			id: 99,
-			title: 'New',
-			sites: [],
-			tags: [],
-			layout_color: 'blue',
-			layout_icon: 'inbox',
+	describe( 'createReadSpaceMutation', () => {
+		it( 'appends the summary to the list and seeds the detail cache', async () => {
+			const client = newClient();
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/new' )
+				.reply( 201, detailResponse( { id: 99, title: 'New' } ) );
+
+			await runMutation( client, createReadSpaceMutation( client ), { name: 'New' } );
+
+			expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( [
+				{ id: '99', name: 'New', layout: { color: 'blue', icon: 'inbox' } },
+			] );
+			expect( client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '99' ).queryKey ) ).toEqual(
+				{
+					id: '99',
+					name: 'New',
+					layout: { color: 'blue', icon: 'inbox' },
+					sources: [],
+					tags: [],
+				}
+			);
+		} );
+	} );
+
+	describe( 'updateReadSpaceMutation', () => {
+		it( 'refreshes the matching list summary and the detail cache', async () => {
+			const client = newClient();
+			client.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, [
+				{ id: '3', name: 'Old', layout: { color: 'blue', icon: 'inbox' } },
+			] );
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/update' )
+				.reply(
+					200,
+					detailResponse( { id: 3, title: 'New name', layout_color: 'green', tags: [ 'x' ] } )
+				);
+
+			await runMutation( client, updateReadSpaceMutation( client ), {
+				spaceId: '3',
+				params: { name: 'New name' },
+			} );
+
+			expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( [
+				{ id: '3', name: 'New name', layout: { color: 'green', icon: 'inbox' } },
+			] );
+			expect(
+				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )
+			).toMatchObject( { id: '3', name: 'New name', tags: [ 'x' ] } );
+		} );
+	} );
+
+	describe( 'deleteReadSpaceMutation', () => {
+		it( 'removes the deleted space from the list and discards its detail cache', async () => {
+			const client = newClient();
+			const keep: ReadSpace = { id: 'keep', name: 'Keep', layout: { color: 'red', icon: 'box' } };
+			client.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, [
+				keep,
+				{ id: '3', name: 'Work', layout: { color: 'blue', icon: 'inbox' } },
+			] );
+			client.setQueryData( readSpaceQuery( '3' ).queryKey, detailResponse() );
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/delete' )
+				.reply( 200, { deleted: true, id: 3 } );
+
+			await runMutation( client, deleteReadSpaceMutation( client ), '3' );
+
+			expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( [
+				keep,
+			] );
+			expect(
+				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )
+			).toBeUndefined();
+		} );
+	} );
+
+	describe( 'feed (source) mutations', () => {
+		it( 'writes the returned detail to the cache after adding a feed', async () => {
+			const client = newClient();
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/feeds/new' )
+				.reply(
+					200,
+					detailResponse( {
+						follows: [
+							{
+								feed_id: 456,
+								feed_url: 'https://stratechery.com/feed',
+								blog_id: 123,
+								name: 'Stratechery',
+								icon: null,
+							},
+						],
+					} )
+				);
+
+			await runMutation( client, addReadSpaceSourceMutation( client ), {
+				spaceId: '3',
+				subscription: makeSubscription(),
+			} );
+
+			expect(
+				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )?.sources
+			).toEqual( [
+				{
+					feedId: 456,
+					feedUrl: 'https://stratechery.com/feed',
+					blogId: 123,
+					name: 'Stratechery',
+					siteIcon: null,
+				},
+			] );
 		} );
 
-		await runMutation( client, createReadSpaceMutation( client ), { name: 'New', tags: [] } );
+		it( 'writes the returned detail to the cache after removing a feed', async () => {
+			const client = newClient();
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/feeds/456/delete' )
+				.reply( 200, detailResponse( { follows: [] } ) );
 
-		const spaces = client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey );
-		expect( spaces ).toHaveLength( 1 );
+			await runMutation( client, deleteReadSpaceSourceMutation( client ), {
+				spaceId: '3',
+				subscription: makeSubscription(),
+			} );
 
-		const listItem = spaces![ 0 ];
-		expect( listItem ).not.toHaveProperty( 'sources' );
+			expect(
+				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )?.sources
+			).toEqual( [] );
+		} );
 
-		expect(
-			client.getQueryData< ReadSpaceDetails >( readSpaceQuery( listItem.id ).queryKey )
-		).toEqual( { ...listItem, sources: [] } );
-	} );
-} );
+		it( 'leaves the detail cache untouched when the add request fails', async () => {
+			const client = newClient();
+			const seeded: ReadSpaceDetails = {
+				id: '3',
+				name: 'Work',
+				layout: { color: 'blue', icon: 'inbox' },
+				sources: [],
+				tags: [],
+			};
+			client.setQueryData( readSpaceQuery( '3' ).queryKey, seeded );
+			nock( BASE )
+				.post( '/wpcom/v2/reader/spaces/3/feeds/new' )
+				.reply( 409, {
+					code: 'reader_spaces_duplicate_feed',
+					message: '…',
+					data: { status: 409 },
+				} );
 
-describe( 'delete space cache removal', () => {
-	afterEach( () => nock.cleanAll() );
+			await runMutation( client, addReadSpaceSourceMutation( client ), {
+				spaceId: '3',
+				subscription: makeSubscription(),
+			} );
 
-	it( 'removes the deleted space from the list and discards its detail cache', async () => {
-		const client = newClient();
-		const other: ReadSpace = {
-			id: 'keep-id',
-			name: 'Keep',
-			tags: [],
-			layout: { color: 'red', icon: 'box' },
-		};
-		const target: ReadSpace = {
-			id: SPACE_ID,
-			name: 'Work',
-			tags: [],
-			layout: { color: 'blue', icon: 'inbox' },
-		};
-		client.setQueryData( readSpacesQuery().queryKey, [ other, target ] );
-		client.setQueryData( readSpaceQuery( SPACE_ID ).queryKey, makeSpace() );
-
-		nock( 'https://public-api.wordpress.com' )
-			.post( `/wpcom/v2/reader/spaces/${ SPACE_ID }/delete` )
-			.reply( 200, { deleted: true, id: SPACE_ID } );
-
-		await runMutation( client, deleteReadSpaceMutation( client ), SPACE_ID );
-
-		// Only the deleted space is dropped from the list...
-		expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( [ other ] );
-		// ...and its detail cache is gone.
-		expect(
-			client.getQueryData< ReadSpaceDetails >( readSpaceQuery( SPACE_ID ).queryKey )
-		).toBeUndefined();
+			expect( client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey ) ).toEqual(
+				seeded
+			);
+		} );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider, useMutation } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
+import nock from 'nock';
 import {
 	addReadSpaceSourceMutation,
 	createReadSpaceMutation,
+	deleteReadSpaceMutation,
 	deleteReadSpaceSourceMutation,
 	readSpaceQuery,
 	readSpacesQuery,
@@ -31,9 +33,9 @@ function newClient() {
 // still local no-ops with no network call. Once the real endpoints land, drop
 // that override and drive success/error with a `nock` interceptor (200 vs
 // 4xx/5xx), asserting `scope.isDone()` — see `read-site-recommendations.test.tsx`.
-async function runMutation< TData, TVars, TContext >(
+async function runMutation< TData, TError, TVars, TContext >(
 	client: QueryClient,
-	mutation: UseMutationOptions< TData, Error, TVars, TContext >,
+	mutation: UseMutationOptions< TData, TError, TVars, TContext >,
 	variables: TVars
 ) {
 	const { result } = renderHook( () => useMutation( mutation ), {
@@ -234,8 +236,18 @@ describe( 'read space source mutations', () => {
 } );
 
 describe( 'create space cache seeding', () => {
+	afterEach( () => nock.cleanAll() );
+
 	it( 'appends a list item without sources and seeds the detail cache with sources', async () => {
 		const client = newClient();
+		nock( 'https://public-api.wordpress.com' ).post( '/wpcom/v2/reader/spaces/new' ).reply( 201, {
+			id: 99,
+			title: 'New',
+			sites: [],
+			tags: [],
+			layout_color: 'blue',
+			layout_icon: 'inbox',
+		} );
 
 		await runMutation( client, createReadSpaceMutation( client ), { name: 'New', tags: [] } );
 
@@ -248,5 +260,40 @@ describe( 'create space cache seeding', () => {
 		expect(
 			client.getQueryData< ReadSpaceDetails >( readSpaceQuery( listItem.id ).queryKey )
 		).toEqual( { ...listItem, sources: [] } );
+	} );
+} );
+
+describe( 'delete space cache removal', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'removes the deleted space from the list and discards its detail cache', async () => {
+		const client = newClient();
+		const other: ReadSpace = {
+			id: 'keep-id',
+			name: 'Keep',
+			tags: [],
+			layout: { color: 'red', icon: 'box' },
+		};
+		const target: ReadSpace = {
+			id: SPACE_ID,
+			name: 'Work',
+			tags: [],
+			layout: { color: 'blue', icon: 'inbox' },
+		};
+		client.setQueryData( readSpacesQuery().queryKey, [ other, target ] );
+		client.setQueryData( readSpaceQuery( SPACE_ID ).queryKey, makeSpace() );
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( `/wpcom/v2/reader/spaces/${ SPACE_ID }/delete` )
+			.reply( 200, { deleted: true, id: SPACE_ID } );
+
+		await runMutation( client, deleteReadSpaceMutation( client ), SPACE_ID );
+
+		// Only the deleted space is dropped from the list...
+		expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( [ other ] );
+		// ...and its detail cache is gone.
+		expect(
+			client.getQueryData< ReadSpaceDetails >( readSpaceQuery( SPACE_ID ).queryKey )
+		).toBeUndefined();
 	} );
 } );

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -5,14 +5,12 @@ import {
 	deleteReadSpaceSource,
 	fetchReadSpace,
 	fetchReadSpaces,
-	getReadSpaceSourceKey,
-	getSiteSubscriptionSourceKey,
+	updateReadSpace,
 	type ReadSpace,
 	type ReadSpaceDeletionResult,
 	type ReadSpaceDetails,
 	type ReadSpaceSourceMutationParams,
-	type SpaceSource,
-	type SiteSubscriptionItem,
+	type UpdateReadSpaceParams,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions, type QueryClient } from '@tanstack/react-query';
 
@@ -24,13 +22,13 @@ export const readSpacesQuery = () =>
 	queryOptions( {
 		queryKey: readSpacesListKey,
 		queryFn: () => fetchReadSpaces(),
-		// The list endpoint is real, but the create flow patches this cache
-		// directly and the detail endpoint is still a placeholder (RSM-4145), so
-		// hold refetches off to avoid clobbering those in-memory writes.
+		// Every mutation returns the full detail and writes it back to these caches,
+		// so they stay authoritative without refetch churn — hold refetches off.
+		// (First load still fetches; staleTime only suppresses refetching fresh data.)
 		staleTime: Infinity,
-		// Keep this out of Calypso's persisted query cache so a reload always
-		// refetches a fresh list from the server rather than rehydrating a stale
-		// dehydrated copy.
+		// Keep the list out of Calypso's persisted query cache: layout_color/icon
+		// are random-until-set server-side, so a dehydrated copy could show stale
+		// colours across reloads. A reload refetches fresh instead.
 		meta: { persist: false },
 	} );
 
@@ -38,51 +36,62 @@ export const readSpaceQuery = ( spaceId: string ) =>
 	queryOptions( {
 		queryKey: readSpaceDetailKey( spaceId ),
 		queryFn: () => fetchReadSpace( spaceId ),
-		// The single-space/detail endpoint isn't wired yet (RSM-4145): its data is
-		// seeded by the create mutation and patched by the source mutations in
-		// memory, so never refetch it out from under those writes.
 		staleTime: Infinity,
 		meta: { persist: false },
 	} );
 
+// The summary (list) shape is the detail minus its `sources` and `tags`.
+const toSummary = ( space: ReadSpaceDetails ): ReadSpace => {
+	const { sources, tags, ...summary } = space;
+	return summary;
+};
+
 // Calypso boots its own QueryClient (see `client/state/query-client.ts`) instead
-// of the singleton from this package, so the mutation factory accepts the
+// of the singleton from this package, so each mutation factory accepts the
 // caller's QueryClient and uses it to write the cache. Pass `useQueryClient()`
 // from the consuming component.
+//
+// Every mutation returns the full updated detail, so we write that straight into
+// the caches (no follow-up GET, no optimistic patch/rollback): the detail cache
+// gets the returned space, and the list cache gets its summary.
+
 export const createReadSpaceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
 		mutationFn: createReadSpace,
 		onSuccess: ( space ) => {
-			// Create hits the real POST and returns the canonical space, so append
-			// it straight to the list cache for instant feedback — the same entry
-			// comes back on the next real list fetch, so there's no temp-id
-			// reconciliation to do. Append the list-shaped space (sources live only
-			// on the detail cache) so the sidebar reflects it at once...
-			//
-			// TODO(RSM-4145): once the detail endpoint is also real, switch these
-			// manual writes to `queryClient.invalidateQueries( readSpacesQuery() )`
-			// and drop the `staleTime: Infinity` / `meta: { persist: false }` so the
-			// list and detail reconcile against canonical server state.
-			const { sources, ...listSpace } = space;
+			// Append the summary to the list and seed the detail cache so the sidebar
+			// and the (just-opened) sources modal both reflect the new space at once.
 			queryClient.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, ( previous ) => [
 				...( previous ?? [] ),
-				listSpace,
+				toSummary( space ),
 			] );
-			// ...and seed the detail cache so the sources modal can open the freshly
-			// created space without hitting `fetchReadSpace`, which is still a
-			// placeholder that only knows the seeded set (RSM-4145).
-			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, {
-				...listSpace,
-				sources,
-			} );
+			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
 		},
 	} );
 
-// Delete a space, then drop it from the caches. Like the other factories this
-// takes the consumer's QueryClient (Calypso boots its own — see above). Not
-// wired to any UI yet; a delete control can adopt it via a `useDeleteSpace()`
-// consumer hook. The server hard-deletes (no undo), so the caller should
-// confirm before mutating.
+type UpdateReadSpaceVariables = {
+	spaceId: string;
+	params: UpdateReadSpaceParams;
+};
+
+export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
+	mutationOptions< ReadSpaceDetails, unknown, UpdateReadSpaceVariables >( {
+		mutationFn: ( { spaceId, params } ) => updateReadSpace( spaceId, params ),
+		onSuccess: ( space ) => {
+			// Update may change summary fields (title/layout), so refresh the matching
+			// list item as well as the detail cache.
+			const summary = toSummary( space );
+			queryClient.setQueryData< ReadSpace[] >(
+				readSpacesQuery().queryKey,
+				( previous ) => previous?.map( ( item ) => ( item.id === space.id ? summary : item ) )
+			);
+			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
+		},
+	} );
+
+// Delete a space, then drop it from the caches. Not wired to any UI yet; a
+// delete control can adopt it via a `useDeleteSpace()` consumer hook. The server
+// hard-deletes (no undo), so the caller should confirm before mutating.
 export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSpaceDeletionResult, unknown, string >( {
 		mutationFn: deleteReadSpace,
@@ -97,92 +106,20 @@ export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 		},
 	} );
 
-const createSpaceSource = ( subscription: SiteSubscriptionItem ): SpaceSource => ( {
-	feedId: subscription.feed_ID ?? null,
-	blogId: subscription.blog_ID ?? null,
-	feedUrl: subscription.feed_URL,
-	siteUrl: subscription.URL || subscription.feed_URL,
-	name: subscription.name || subscription.URL || subscription.feed_URL,
-	siteIcon: subscription.site_icon ?? null,
-} );
-
-type ReadSpaceSourceMutationContext = {
-	previousSpace?: ReadSpaceDetails;
-};
-
-// Optimistically patch a space's sources in the single-space detail cache
-// (sources only live there, not in the list), returning the pre-patch snapshot
-// so `onError` can roll back. We deliberately don't invalidate on settle: spaces
-// have no real endpoint yet (RSM-4145) — the detail lives in-memory with
-// `staleTime: Infinity`, so a refetch would clobber the optimistic state.
-const patchSpaceSources = async (
-	queryClient: QueryClient,
-	spaceId: string,
-	updateSources: ( sources: SpaceSource[] ) => SpaceSource[]
-): Promise< ReadSpaceSourceMutationContext > => {
-	const detailKey = readSpaceQuery( spaceId ).queryKey;
-
-	// Cancel an in-flight detail fetch (e.g. the modal just opened) so it can't
-	// resolve after our optimistic write and clobber it. Best-effort per TanStack
-	// docs; if cancel fails the optimistic patch below must still run.
-	try {
-		await queryClient.cancelQueries( { queryKey: detailKey } );
-	} catch {
-		// ignore — the optimistic patch must still run
-	}
-
-	const previousSpace = queryClient.getQueryData< ReadSpaceDetails >( detailKey );
-
-	queryClient.setQueryData< ReadSpaceDetails >( detailKey, ( previous ) =>
-		previous ? { ...previous, sources: updateSources( previous.sources ) } : previous
-	);
-
-	return { previousSpace };
-};
-
-const rollbackSpaceSources = (
-	queryClient: QueryClient,
-	spaceId: string,
-	context?: ReadSpaceSourceMutationContext
-) => {
-	if ( context?.previousSpace ) {
-		queryClient.setQueryData( readSpaceQuery( spaceId ).queryKey, context.previousSpace );
-	}
-};
+// Add/remove a followed feed. Both endpoints return the updated detail, so we
+// write it straight to the detail cache (the list summary is unaffected by
+// feeds). `subscription` carries the feed id/url the api-core mutator sends.
+const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails ) =>
+	queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
 
 export const addReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
-	mutationOptions< void, Error, ReadSpaceSourceMutationParams, ReadSpaceSourceMutationContext >( {
+	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {
 		mutationFn: addReadSpaceSource,
-		// Optimistically append the source so the modal reflects the change at
-		// once; `onError` rolls back if the (future, RSM-4139) endpoint rejects.
-		onMutate: ( { spaceId, subscription } ) => {
-			const source = createSpaceSource( subscription );
-			const sourceKey = getReadSpaceSourceKey( source );
-
-			return patchSpaceSources( queryClient, spaceId, ( sources ) =>
-				sources.some( ( existingSource ) => getReadSpaceSourceKey( existingSource ) === sourceKey )
-					? sources
-					: [ ...sources, source ]
-			);
-		},
-		onError: ( _error, { spaceId }, context ) =>
-			rollbackSpaceSources( queryClient, spaceId, context ),
+		onSuccess: ( space ) => writeReadSpaceDetail( queryClient, space ),
 	} );
 
 export const deleteReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
-	mutationOptions< void, Error, ReadSpaceSourceMutationParams, ReadSpaceSourceMutationContext >( {
+	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {
 		mutationFn: deleteReadSpaceSource,
-		// Optimistically remove the source; `onError` restores it if the
-		// (future, RSM-4139) endpoint rejects.
-		onMutate: ( { spaceId, subscription } ) => {
-			const subscriptionKey = getSiteSubscriptionSourceKey( subscription );
-
-			return patchSpaceSources( queryClient, spaceId, ( sources ) =>
-				sources.filter(
-					( existingSource ) => getReadSpaceSourceKey( existingSource ) !== subscriptionKey
-				)
-			);
-		},
-		onError: ( _error, { spaceId }, context ) =>
-			rollbackSpaceSources( queryClient, spaceId, context ),
+		onSuccess: ( space ) => writeReadSpaceDetail( queryClient, space ),
 	} );

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -1,12 +1,14 @@
 import {
 	addReadSpaceSource,
 	createReadSpace,
+	deleteReadSpace,
 	deleteReadSpaceSource,
 	fetchReadSpace,
 	fetchReadSpaces,
 	getReadSpaceSourceKey,
 	getSiteSubscriptionSourceKey,
 	type ReadSpace,
+	type ReadSpaceDeletionResult,
 	type ReadSpaceDetails,
 	type ReadSpaceSourceMutationParams,
 	type SpaceSource,
@@ -22,12 +24,13 @@ export const readSpacesQuery = () =>
 	queryOptions( {
 		queryKey: readSpacesListKey,
 		queryFn: () => fetchReadSpaces(),
-		// No real list endpoint yet (RSM-4145). The list is seeded and mutated
-		// in-memory, so never refetch it out from under the create flow.
+		// The list endpoint is real, but the create flow patches this cache
+		// directly and the detail endpoint is still a placeholder (RSM-4145), so
+		// hold refetches off to avoid clobbering those in-memory writes.
 		staleTime: Infinity,
-		// Keep the placeholder data out of Calypso's persisted query cache:
-		// with `staleTime: Infinity` a dehydrated copy would survive reloads for
-		// days and mask the real list once the endpoint ships.
+		// Keep this out of Calypso's persisted query cache so a reload always
+		// refetches a fresh list from the server rather than rehydrating a stale
+		// dehydrated copy.
 		meta: { persist: false },
 	} );
 
@@ -35,7 +38,9 @@ export const readSpaceQuery = ( spaceId: string ) =>
 	queryOptions( {
 		queryKey: readSpaceDetailKey( spaceId ),
 		queryFn: () => fetchReadSpace( spaceId ),
-		// Same in-memory placeholder caveats as the list query above (RSM-4145).
+		// The single-space/detail endpoint isn't wired yet (RSM-4145): its data is
+		// seeded by the create mutation and patched by the source mutations in
+		// memory, so never refetch it out from under those writes.
 		staleTime: Infinity,
 		meta: { persist: false },
 	} );
@@ -48,29 +53,47 @@ export const createReadSpaceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
 		mutationFn: createReadSpace,
 		onSuccess: ( space ) => {
-			// TODO(RSM-4145): once the real list endpoint exists, replace these
-			// manual cache writes with `queryClient.invalidateQueries( readSpacesQuery() )`
-			// so the list refetches the canonical server state (real id, ordering)
-			// instead of relying on the locally-written entry — and drop the
-			// `staleTime: Infinity` / `meta: { persist: false }` on the queries.
-			// We can't invalidate today because `fetchReadSpaces` is a placeholder
-			// that would wipe the just-created space.
+			// Create hits the real POST and returns the canonical space, so append
+			// it straight to the list cache for instant feedback — the same entry
+			// comes back on the next real list fetch, so there's no temp-id
+			// reconciliation to do. Append the list-shaped space (sources live only
+			// on the detail cache) so the sidebar reflects it at once...
 			//
-			// No network round-trip yet (RSM-4139). Append the list-shaped space
-			// (sources live only on the detail cache) so the sidebar reflects it at
-			// once...
+			// TODO(RSM-4145): once the detail endpoint is also real, switch these
+			// manual writes to `queryClient.invalidateQueries( readSpacesQuery() )`
+			// and drop the `staleTime: Infinity` / `meta: { persist: false }` so the
+			// list and detail reconcile against canonical server state.
 			const { sources, ...listSpace } = space;
 			queryClient.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, ( previous ) => [
 				...( previous ?? [] ),
 				listSpace,
 			] );
 			// ...and seed the detail cache so the sources modal can open the freshly
-			// created space without hitting `fetchReadSpace` (which only knows the
-			// placeholder set).
+			// created space without hitting `fetchReadSpace`, which is still a
+			// placeholder that only knows the seeded set (RSM-4145).
 			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, {
 				...listSpace,
 				sources,
 			} );
+		},
+	} );
+
+// Delete a space, then drop it from the caches. Like the other factories this
+// takes the consumer's QueryClient (Calypso boots its own — see above). Not
+// wired to any UI yet; a delete control can adopt it via a `useDeleteSpace()`
+// consumer hook. The server hard-deletes (no undo), so the caller should
+// confirm before mutating.
+export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
+	mutationOptions< ReadSpaceDeletionResult, unknown, string >( {
+		mutationFn: deleteReadSpace,
+		onSuccess: ( _result, spaceId ) => {
+			// Remove the deleted space from the cached list...
+			queryClient.setQueryData< ReadSpace[] >(
+				readSpacesQuery().queryKey,
+				( previous ) => previous?.filter( ( space ) => space.id !== spaceId )
+			);
+			// ...and discard its now-defunct detail cache.
+			queryClient.removeQueries( { queryKey: readSpaceQuery( spaceId ).queryKey } );
 		},
 	} );
 


### PR DESCRIPTION
Part of RSM-4110  , RSM-4139  ,  RSM-4145

## Proposed Changes

Wires the dark-shipped Reader Spaces data layer to the real `wpcom/v2` feeds/tags API, using the modern REST-verb convention and a `layout` object. The client keeps its existing `sources` vocabulary; the adapter maps the wire `follows` onto it, so the UI (sidebar, space view, sources modal, create modal) is unchanged — this PR is data layer + types + tests + docs only.

- **List** — `GET /reader/spaces` returns the slim summary (`id`, `title`, `layout`). `ReadSpace` carries no `tags`/`sources`; those live on `ReadSpaceDetails`.
- **Detail** — `GET /reader/spaces/{id}` adapts the wire `follows` array onto `sources` (`{ feedId, feedUrl, blogId, name, siteIcon }`) plus `tags`.
- **Create** — `POST /reader/spaces` with `{ title, feeds?, tags?, layout? }`, returning the created detail.
- **Update** — `PUT /reader/spaces/{id}` (`useUpdateSpace`) with `{ title?, tags?, layout? }`; `tags` is a full replace and `layout` is a partial merge. No UI consumer yet.
- **Delete** — `DELETE /reader/spaces/{id}` (`useDeleteSpace`). No UI consumer yet.
- **Feeds** — add via `POST /reader/spaces/{id}/feeds`, remove via `DELETE /reader/spaces/{id}/feeds/{feed_id}`; both return the full detail. The optimistic patch machinery is gone — each mutation writes the returned detail to cache.
- **layout** is an object (`{ color, icon }`) in both request and response; the adapter and params were updated accordingly.
- **Tests/docs** — read-spaces tests rewritten for the new verbs/paths/shapes (mocked with `nock`); README contract refreshed.

## Why are these changes being made?

The Spaces API moved to feeds + tags, slimmed the list to a summary, added real detail/update endpoints, then (PR #222908) switched to real REST verbs and made `layout` an object — all breaking, pre-launch. This brings the client data layer in line: it maps the new wire shapes, exposes update + feed mutations, and relies on every mutation returning the full detail (written straight to cache, no follow-up GET) — all contained within `@automattic/api-core` / `@automattic/api-queries`, so no UI changes were needed.

## Testing Instructions

1. Enable the `reader/spaces` flag (on by default in `development`).
2. Visit `/reader/spaces` — the list loads from `GET /reader/spaces` (summary only).
3. Open a space's "Manage sources" — loads real detail from `GET /reader/spaces/{id}`, including after a reload.
4. Add/remove a feed — confirm `POST .../feeds` and `DELETE .../feeds/{feed_id}`, and the list reflects the returned detail.
5. Create a space — confirm `POST /reader/spaces` and that it appears in the list and after a reload.
6. `update` (PUT) and `delete` (DELETE) are data-layer only (no UI yet); covered by unit tests.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
