### PR TITLE
Logged out reader - fix topbar color

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -41,7 +41,6 @@ $studio-blue-15: #e5f4ff;
 }
 
 .is-section-patterns,
-.is-section-reader,
 .is-section-site-profiler,
 .is-section-performance-profiler,
 .is-section-theme,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # p1781200410833079-slack-C03NLNTPZ2T

## Proposed Changes

* Remove .is-section-reader from style rule breaking the logged out masterbar color.

BEFORE
<img width="1218" height="444" alt="Screenshot 2026-06-11 at 2 16 13 PM" src="https://github.com/user-attachments/assets/683f0dc2-874a-463e-b2bb-f1edf5b4bd79" />

AFTER
<img width="1224" height="507" alt="Screenshot 2026-06-11 at 2 16 32 PM" src="https://github.com/user-attachments/assets/7a2f8f07-6364-4ad0-b77d-1855df5264d6" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

AI sponsored summary:

What caused it

The light-blue masterbar rule for .is-section-reader has been in universal-header-navigation/style.scss since 2023, when logged-out Reader got the universal nav. That was mostly fine because Reader also had its own override in client/reader/style.scss — transparent background, white text on the dark hero (has-header-section pages like tags, search, discover).

The regression came from Global Nav 2026 (#111319, June 2026), which added :not(:has(.x-nav--2026-redesign)) to the shared blue-bar selector. That bumped specificity from 3 classes to 4, tying with Reader’s override. The universal-header rule then won on source order, applying #e5f4ff while Reader’s white text still applied — invisible nav.

Why this fix

Reader never really belonged in that shared block with themes/patterns. It has its own nav styling in client/reader/style.scss. Removing .is-section-reader from the shared rule lets Reader’s transparent/white-text styles win again on hero pages. It doesn’t affect the 2026 nav path, since that block is already skipped when .x-nav--2026-redesign is present.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In incognito window, load this branch of calypso to `*/discover`, `*/tags` and `*/tag/{tagName}`.
* Verify the top bar color is now as expected and readable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?