### PR TITLE
Reader Chat: fetch suggestions on first open, fix Tracks click/keydown events

### DIFF
--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -560,4 +560,38 @@ describe( 'watchFirstChatOpen', () => {
 		expect( () => watchFirstChatOpen( onFirstOpen, deps ) ).not.toThrow();
 		expect( onFirstOpen ).not.toHaveBeenCalled();
 	} );
+
+	it( 'treats a select() that throws as chat-closed instead of crashing', () => {
+		const onFirstOpen = jest.fn();
+		const listeners = new Set();
+		const deps = {
+			select: () => {
+				throw new Error( 'store not registered' );
+			},
+			subscribe: ( fn ) => {
+				listeners.add( fn );
+				return () => listeners.delete( fn );
+			},
+		};
+		expect( () => watchFirstChatOpen( onFirstOpen, deps ) ).not.toThrow();
+		expect( () => listeners.forEach( ( fn ) => fn() ) ).not.toThrow();
+		expect( onFirstOpen ).not.toHaveBeenCalled();
+	} );
+
+	it( 'handles a subscribe implementation that fires synchronously during registration', () => {
+		const onFirstOpen = jest.fn();
+		const unsubscribeSpy = jest.fn();
+		let isOpen = false;
+		const deps = {
+			select: () => ( { getAgentsManagerState: () => ( { isOpen } ) } ),
+			subscribe: ( fn ) => {
+				isOpen = true;
+				fn();
+				return unsubscribeSpy;
+			},
+		};
+		watchFirstChatOpen( onFirstOpen, deps );
+		expect( onFirstOpen ).toHaveBeenCalledTimes( 1 );
+		expect( unsubscribeSpy ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -76,6 +76,7 @@ const {
 	parseSuggestionsResponse,
 	getSuggestionsFetchHeaders,
 	injectScopedReset,
+	watchFirstChatOpen,
 } = require( '../reader-chat' );
 
 // ---------------------------------------------------------------------------
@@ -484,5 +485,79 @@ describe( 'getFallbackSuggestions', () => {
 			expect( typeof s.prompt ).toBe( 'string' );
 			expect( s.label.length ).toBeLessThan( s.prompt.length );
 		}
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// watchFirstChatOpen
+// ---------------------------------------------------------------------------
+
+describe( 'watchFirstChatOpen', () => {
+	// Minimal fake of the @wordpress/data store accessors: tests control
+	// isOpen and trigger store-change notifications explicitly.
+	const makeStore = ( initialOpen = false ) => {
+		let isOpen = initialOpen;
+		const listeners = new Set();
+		return {
+			deps: {
+				select: () => ( {
+					getAgentsManagerState: () => ( { isOpen } ),
+				} ),
+				subscribe: ( fn ) => {
+					listeners.add( fn );
+					return () => listeners.delete( fn );
+				},
+			},
+			setOpen( value ) {
+				isOpen = value;
+				for ( const fn of [ ...listeners ] ) {
+					fn();
+				}
+			},
+			get listenerCount() {
+				return listeners.size;
+			},
+		};
+	};
+
+	it( 'fires immediately when the chat is already open', () => {
+		const store = makeStore( true );
+		const onFirstOpen = jest.fn();
+		watchFirstChatOpen( onFirstOpen, store.deps );
+		expect( onFirstOpen ).toHaveBeenCalledTimes( 1 );
+		expect( store.listenerCount ).toBe( 0 );
+	} );
+
+	it( 'does not fire while the chat stays closed', () => {
+		const store = makeStore( false );
+		const onFirstOpen = jest.fn();
+		watchFirstChatOpen( onFirstOpen, store.deps );
+		store.setOpen( false );
+		expect( onFirstOpen ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fires once on the first open and unsubscribes', () => {
+		const store = makeStore( false );
+		const onFirstOpen = jest.fn();
+		watchFirstChatOpen( onFirstOpen, store.deps );
+
+		store.setOpen( true );
+		expect( onFirstOpen ).toHaveBeenCalledTimes( 1 );
+		expect( store.listenerCount ).toBe( 0 );
+
+		// Close + reopen must not re-fire.
+		store.setOpen( false );
+		store.setOpen( true );
+		expect( onFirstOpen ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'survives a store that is not registered yet', () => {
+		const onFirstOpen = jest.fn();
+		const deps = {
+			select: () => ( {} ), // no getAgentsManagerState selector
+			subscribe: () => () => {},
+		};
+		expect( () => watchFirstChatOpen( onFirstOpen, deps ) ).not.toThrow();
+		expect( onFirstOpen ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -1116,12 +1116,10 @@ if ( container ) {
 
 	// Defer the suggestions fetch until the reader actually opens the
 	// chat. The widget mounts on every public page view of an enabled
-	// site, and fetching at mount meant every page load hit the
-	// suggestions agent even though the vast majority of visitors never
-	// open the chat (production Tracks showed ~10 suggestion runs per
-	// open). On sites over their AI Search quota it also logged a failed
-	// run on every page view. First open → fetch once; the wpcom-side
-	// 24h cache keeps repeat opens fast.
+	// site, but most visitors never open the chat — and on sites over
+	// their AI Search quota an at-mount fetch logs a failed run on every
+	// page view. First open → fetch once; the wpcom-side 24h cache keeps
+	// repeat opens fast.
 	watchFirstChatOpen( setupInitialSuggestions );
 }
 

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -671,6 +671,20 @@ Questions should feel like natural next-step curiosity: clarify a detail, go dee
 }
 
 /**
+ * Read the shared Agents Manager store state, treating an unusable store
+ * as "no state". `select( storeName )` can throw in some @wordpress/data
+ * implementations when the store isn't registered.
+ * @param {Function} [selectFn] @wordpress/data select, injectable for tests.
+ */
+function getAgentsManagerState( selectFn = select ) {
+	try {
+		return selectFn( AGENTS_MANAGER_STORE )?.getAgentsManagerState?.();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Append a "follow-up chips" strip below the chat panel. Clicking a chip
  * fills the input and submits it. Observes the chat thread for new
  * assistant messages via MutationObserver; after each one, fires a
@@ -850,8 +864,7 @@ function setupFollowupChips() {
 	}
 
 	unsubscribeOpen = subscribe( () => {
-		const state = select( AGENTS_MANAGER_STORE ).getAgentsManagerState?.();
-		if ( state?.isOpen ) {
+		if ( getAgentsManagerState()?.isOpen ) {
 			scheduleObserve();
 		}
 	} );
@@ -872,7 +885,7 @@ function setupFollowupChips() {
  * @param {Function} deps.subscribe @wordpress/data subscribe.
  */
 function watchFirstChatOpen( onFirstOpen, deps = { select, subscribe } ) {
-	const isOpenNow = () => !! deps.select( AGENTS_MANAGER_STORE ).getAgentsManagerState?.()?.isOpen;
+	const isOpenNow = () => !! getAgentsManagerState( deps.select )?.isOpen;
 
 	if ( isOpenNow() ) {
 		onFirstOpen();
@@ -880,14 +893,20 @@ function watchFirstChatOpen( onFirstOpen, deps = { select, subscribe } ) {
 	}
 
 	let fired = false;
-	const unsubscribe = deps.subscribe( () => {
+	let unsubscribe = null;
+	unsubscribe = deps.subscribe( () => {
 		if ( fired || ! isOpenNow() ) {
 			return;
 		}
 		fired = true;
-		unsubscribe();
+		unsubscribe?.();
 		onFirstOpen();
 	} );
+	// If the subscribe implementation invoked the callback synchronously,
+	// the handle wasn't available inside the callback — release it now.
+	if ( fired ) {
+		unsubscribe();
+	}
 }
 
 function setupInitialSuggestions() {
@@ -939,8 +958,7 @@ function setupTracksEvents() {
 	// false -> true. Fires once per open; closing + reopening re-fires.
 	let wasOpen = false;
 	const unsubscribe = subscribe( () => {
-		const state = select( AGENTS_MANAGER_STORE ).getAgentsManagerState?.();
-		const isOpen = !! state?.isOpen;
+		const isOpen = !! getAgentsManagerState()?.isOpen;
 		if ( isOpen && ! wasOpen ) {
 			recordTracksEvent( 'jetpack_reader_chat_opened', baseProps );
 		}

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -859,6 +859,37 @@ function setupFollowupChips() {
 	tryObserve();
 }
 
+/**
+ * Invoke `onFirstOpen` the first time the chat panel opens.
+ *
+ * Checks current state first (covers a relaunch where the panel is
+ * already open), then watches the shared store for isOpen turning
+ * true. Fires at most once.
+ *
+ * @param {Function} onFirstOpen    Callback to run on the first open.
+ * @param {Object}   deps           Store accessors, injectable for tests.
+ * @param {Function} deps.select    @wordpress/data select.
+ * @param {Function} deps.subscribe @wordpress/data subscribe.
+ */
+function watchFirstChatOpen( onFirstOpen, deps = { select, subscribe } ) {
+	const isOpenNow = () => !! deps.select( AGENTS_MANAGER_STORE ).getAgentsManagerState?.()?.isOpen;
+
+	if ( isOpenNow() ) {
+		onFirstOpen();
+		return;
+	}
+
+	let fired = false;
+	const unsubscribe = deps.subscribe( () => {
+		if ( fired || ! isOpenNow() ) {
+			return;
+		}
+		fired = true;
+		unsubscribe();
+		onFirstOpen();
+	} );
+}
+
 function setupInitialSuggestions() {
 	const controller = createAbortController();
 	window.addEventListener(
@@ -960,15 +991,20 @@ function setupTracksEvents() {
 			trigger: 'enter',
 		} );
 	};
-	document.addEventListener( 'click', handleClick );
-	document.addEventListener( 'keydown', handleKeydown );
+	// Capture phase: agenttic-ui stops propagation on suggestion-chip
+	// clicks (Suggestions.tsx) and composer Enter keydowns (ChatInput.tsx),
+	// so bubble-phase listeners on document never see those events —
+	// suggestion_click recorded zero events in production. Capture runs
+	// top-down before any handler can stop propagation.
+	document.addEventListener( 'click', handleClick, true );
+	document.addEventListener( 'keydown', handleKeydown, true );
 
 	window.addEventListener(
 		'pagehide',
 		() => {
 			unsubscribe?.();
-			document.removeEventListener( 'click', handleClick );
-			document.removeEventListener( 'keydown', handleKeydown );
+			document.removeEventListener( 'click', handleClick, true );
+			document.removeEventListener( 'keydown', handleKeydown, true );
 		},
 		{ once: true }
 	);
@@ -1060,7 +1096,15 @@ if ( container ) {
 	const root = createRoot( container );
 	root.render( <ReaderChatApp /> );
 
-	setupInitialSuggestions();
+	// Defer the suggestions fetch until the reader actually opens the
+	// chat. The widget mounts on every public page view of an enabled
+	// site, and fetching at mount meant every page load hit the
+	// suggestions agent even though the vast majority of visitors never
+	// open the chat (production Tracks showed ~10 suggestion runs per
+	// open). On sites over their AI Search quota it also logged a failed
+	// run on every page view. First open → fetch once; the wpcom-side
+	// 24h cache keeps repeat opens fast.
+	watchFirstChatOpen( setupInitialSuggestions );
 }
 
 // Exported for unit tests only; injectScopedReset mutates document.head.
@@ -1077,4 +1121,5 @@ export {
 	parseSuggestionsResponse,
 	getSuggestionsFetchHeaders,
 	injectScopedReset,
+	watchFirstChatOpen,
 };


### PR DESCRIPTION
## Proposed Changes

* **Defer the initial suggestions fetch until the reader first opens the chat.** `setupInitialSuggestions()` previously ran unconditionally at mount, so every page view of every Reader-Chat-enabled site fired a POST to `/wpcom/v2/ai/agent/reader-chat-suggestions`. A new `watchFirstChatOpen()` helper watches the shared store and runs the fetch once, on the first `isOpen` transition (or immediately if already open).
* **Move the delegated Tracks listeners to the capture phase.** agenttic-ui calls `stopPropagation()` on suggestion-chip clicks (`Suggestions.tsx`) and composer Enter keydowns (`ChatInput.tsx`), so the document-level bubble listeners never saw those events. Capture-phase listeners run before any handler can stop propagation.
* Adds unit tests for `watchFirstChatOpen` (fires immediately when already open, fires once on first open, unsubscribes, survives unregistered store).

## Why are these changes being made?

Production Tracks data (Apr 1 – Jun 11):

| Metric | Count |
|---|---|
| Suggestion agent runs (LLM calls) | 12,970 |
| Chat opens | 1,601 |
| `jetpack_reader_chat_suggestion_click` | **0 — ever** |
| `jetpack_reader_chat_message_sent` | 8 (vs 510 server-side answered messages) |

* ~10 suggestion generations per chat open means ~90% of suggestion agent runs served visitors who never opened the panel. Fetch-on-first-open eliminates that waste; the wpcom-side 24h cache keeps repeat opens fast, and the empty view already handles late-arriving chips (fallback chips on failure).
* This also addresses the current failure spike: suggestions are failing at ~44% over the last week, ~95% of them `reader_chat_search_over_limit` from a single high-traffic site that exhausted its AI Search quota — every page view on that site logs a doomed suggestions run. After this change, over-limit sites only attempt the fetch when a reader actually opens the chat.
* The two click/keydown Tracks events have been effectively dead since launch because of `stopPropagation()` in agenttic-ui. Without `suggestion_click` we can't tell whether the AI chips contribute to the enable → open → answered funnel at all.

## Testing Instructions

1. `cd apps/agents-manager && yarn dev --sync` with `widgets.wp.com` sandboxed.
2. Visit a Reader-Chat-enabled site and open DevTools → Network, filter `reader-chat-suggestions`.
3. On page load: **no** suggestions request fires.
4. Open the chat: the request fires once; chips appear in the empty view (or fallback chips if the agent fails).
5. Close and reopen the chat: no additional request.
6. With Tracks debugging (`window._tkq`), click a suggestion chip → `jetpack_reader_chat_suggestion_click` is queued; send a message via Enter and via the send button → `jetpack_reader_chat_message_sent` with `trigger: enter|button`.
7. `yarn jest -c=test/apps/jest.config.js apps/agents-manager/__tests__/reader-chat.test.js` — 44 tests pass.