### PR TITLE
Legacy Contact: add dashboard /me/security/legacy-contact view behind feature flag

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -848,7 +848,7 @@ export const securityLegacyContactRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Legacy Contact' ),
+				title: __( 'Legacy contact' ),
 			},
 		],
 	} ),

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -844,6 +844,24 @@ export const securitySocialLoginsRoute = createRoute( {
 	)
 );
 
+export const securityLegacyContactRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Legacy Contact' ),
+			},
+		],
+	} ),
+	getParentRoute: () => securityRoute,
+	path: '/legacy-contact',
+} ).lazy( () =>
+	import( '../../me/security-legacy-contact' ).then( ( d ) =>
+		createLazyRoute( 'security-legacy-contact' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const privacyRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1319,6 +1337,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 				: [] ),
 			securityConnectedAppsRoute,
 			securitySocialLoginsRoute,
+			...( isEnabled( 'me/legacy-contact' ) ? [ securityLegacyContactRoute ] : [] ),
 		] )
 	);
 

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,0 +1,21 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function SecurityLegacyContact() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Legacy Contact' ) }
+					description={ __(
+						'A legacy contact is someone you trust to have access to your account after your death.'
+					) }
+				/>
+			}
+		>
+			{ /* Content goes here */ }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -8,7 +8,7 @@ export default function SecurityLegacyContact() {
 			size="small"
 			header={
 				<PageHeader
-					title={ __( 'Legacy Contact' ) }
+					title={ __( 'Legacy contact' ) }
 					description={ __(
 						'A legacy contact is someone you trust to have access to your account after your death.'
 					) }

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
@@ -8,6 +9,7 @@ export default function SecurityLegacyContact() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Legacy contact' ) }
 					description={ __(
 						'A legacy contact is someone you trust to have access to your account after your death.'

--- a/client/dashboard/me/security-legacy-contact/summary.tsx
+++ b/client/dashboard/me/security-legacy-contact/summary.tsx
@@ -9,7 +9,7 @@ export default function SecurityLegacyContactSummary( { density }: { density?: D
 		<RouterLinkSummaryButton
 			density={ density }
 			to="/me/security/legacy-contact"
-			title={ __( 'Legacy Contact' ) }
+			title={ __( 'Legacy contact' ) }
 			description={ __( 'Choose someone you trust to manage your account after your death.' ) }
 			decoration={ <Icon icon={ people } /> }
 		/>

--- a/client/dashboard/me/security-legacy-contact/summary.tsx
+++ b/client/dashboard/me/security-legacy-contact/summary.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function SecurityLegacyContactSummary( { density }: { density?: Density } ) {
+	return (
+		<RouterLinkSummaryButton
+			density={ density }
+			to="/me/security/legacy-contact"
+			title={ __( 'Legacy Contact' ) }
+			description={ __( 'Choose someone you trust to manage your account after your death.' ) }
+			decoration={ <Icon icon={ people } /> }
+		/>
+	);
+}

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
@@ -6,6 +7,7 @@ import PageLayout from '../../components/page-layout';
 import { SummaryButtonList } from '../../components/summary-button-list';
 import SecurityAccountRecoverySummary from '../security-account-recovery/summary';
 import SecurityConnectedAppsSummary from '../security-connected-apps/summary';
+import SecurityLegacyContactSummary from '../security-legacy-contact/summary';
 import SecurityPasswordSummary from '../security-password/summary';
 import SecuritySocialLoginsSummary from '../security-social-logins/summary';
 import SecuritySshKeySummary from '../security-ssh-key/summary';
@@ -36,6 +38,7 @@ function Security() {
 				{ supportsSecurity.sshKey ? <SecuritySshKeySummary /> : null }
 				<SecurityConnectedAppsSummary />
 				<SecuritySocialLoginsSummary />
+				{ isEnabled( 'me/legacy-contact' ) ? <SecurityLegacyContactSummary /> : null }
 			</SummaryButtonList>
 			<PerformanceTrackerStop />
 		</PageLayout>

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -40,6 +40,7 @@
 		"emails/titan-tiers": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
+		"me/legacy-contact": true,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
 		"plans/expired-downgrade": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -35,6 +35,7 @@
 		"emails/titan-tiers": false,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
+		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
 		"plans/expired-downgrade": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -32,6 +32,7 @@
 		"emails/titan-tiers": false,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
+		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
 		"plans/expired-downgrade": false,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -32,6 +32,7 @@
 		"emails/titan-tiers": false,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
+		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
 		"plans/expired-downgrade": true,


### PR DESCRIPTION
## Proposed Changes

* Add a `/me/security/legacy-contact` view to the Dashboard client (`client/dashboard`), nested under the **Security** section.
* Add a "Legacy Contact" summary button to the Security screen that links to the new view.
* Register the route as a child of the existing `securityRoute`, gated behind the existing `me/legacy-contact` calypso-config feature flag (on in `development`, off everywhere else). The view currently renders placeholder copy.

This ports the scaffolding from #111493 (which added the equivalent view to classic Calypso at `/me/legacy-contact`) into the new multi-site Dashboard, where the feature should actually be built. A follow-up cleanup PR will remove the classic Calypso version.

<img width="718" height="513" alt="Screenshot 2026-06-12 at 14 08 21" src="https://github.com/user-attachments/assets/2f45f04c-78d4-429b-82dd-b60a071f9bf6" />

Fixes RSM-4328.

## Why are these changes being made?

* The Legacy Contact account-management surface needs to live in the new Dashboard client rather than classic Calypso. Scaffolding it behind the existing development-only flag lets it be built out incrementally without exposing an unfinished surface in production.

## Testing Instructions

* With the flag enabled (default in `development`), run the Dashboard (`yarn start-dashboard`) and open `/me/security`.
* Confirm a "Legacy Contact" summary button appears in the Security list and navigates to `/me/security/legacy-contact`, rendering the page with its heading and intro copy.
* Confirm that in environments where `me/legacy-contact` is `false`, the summary button is hidden and `/me/security/legacy-contact` does not resolve to this view.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
