### PR TITLE
client/components: migrate tests to @testing-library/react for React 19

### DIFF
--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -18,12 +18,9 @@ describe( 'index', () => {
 		translate: ( string ) => string,
 	};
 
-	// Render a DropZone into a container with a known id so the tests can assert on the
-	// node's placement in the tree, and return the component instance via a ref.
+	// Renders into a container with a known id so tests can assert on the node's placement,
+	// and returns the instance via a ref. Testing Library removes the container on cleanup.
 	function renderDropZone( props = {} ) {
-		// Render into a container with a known id so the tests can assert on the node's
-		// placement in the tree. Testing Library removes this container on cleanup since it
-		// is a direct child of document.body.
 		const container = document.body.appendChild( document.createElement( 'div' ) );
 		container.id = 'container';
 

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -96,8 +96,8 @@ describe( 'index', () => {
 			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
 
-		expect( tree.state.isDraggingOverDocument ).toBeTruthy();
-		expect( tree.state.isDraggingOverElement ).toBeFalsy();
+		expect( tree.zoneRef.current ).toHaveClass( 'is-dragging-over-document' );
+		expect( tree.zoneRef.current ).not.toHaveClass( 'is-dragging-over-element' );
 	} );
 
 	test( 'should start observing the body for mutations when dragging over', () => {
@@ -130,8 +130,8 @@ describe( 'index', () => {
 			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
 
-		expect( tree.state.isDraggingOverDocument ).toBeFalsy();
-		expect( tree.state.isDraggingOverElement ).toBeFalsy();
+		expect( tree.zoneRef.current ).not.toHaveClass( 'is-dragging-over-document' );
+		expect( tree.zoneRef.current ).not.toHaveClass( 'is-dragging-over-element' );
 	} );
 
 	test( 'should further highlight the drop zone when dragging over the element', () => {
@@ -142,8 +142,8 @@ describe( 'index', () => {
 			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
 
-		expect( tree.state.isDraggingOverDocument ).toBeTruthy();
-		expect( tree.state.isDraggingOverElement ).toBeTruthy();
+		expect( tree.zoneRef.current ).toHaveClass( 'is-dragging-over-document' );
+		expect( tree.zoneRef.current ).toHaveClass( 'is-dragging-over-element' );
 	} );
 
 	test( 'should further highlight the drop zone when dragging over the body if fullScreen', () => {
@@ -153,8 +153,8 @@ describe( 'index', () => {
 			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
 
-		expect( tree.state.isDraggingOverDocument ).toBeTruthy();
-		expect( tree.state.isDraggingOverElement ).toBeTruthy();
+		expect( tree.zoneRef.current ).toHaveClass( 'is-dragging-over-document' );
+		expect( tree.zoneRef.current ).toHaveClass( 'is-dragging-over-element' );
 	} );
 
 	test( 'should call onDrop with the raw event data when a drop occurs', () => {
@@ -207,11 +207,10 @@ describe( 'index', () => {
 	} );
 
 	test( 'should allow more than one rendered DropZone on a page', () => {
-		const refs = [ createRef(), createRef() ];
 		render(
 			<Wrapper>
-				<DropZone { ...requiredProps } ref={ refs[ 0 ] } />
-				<DropZone { ...requiredProps } ref={ refs[ 1 ] } />
+				<DropZone { ...requiredProps } />
+				<DropZone { ...requiredProps } />
 			</Wrapper>
 		);
 
@@ -219,10 +218,11 @@ describe( 'index', () => {
 			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
 
-		expect( refs ).toHaveLength( 2 );
-		refs.forEach( ( ref ) => {
-			expect( ref.current.state.isDraggingOverDocument ).toBeTruthy();
-			expect( ref.current.state.isDraggingOverElement ).toBeFalsy();
+		const zones = document.querySelectorAll( '.drop-zone' );
+		expect( zones ).toHaveLength( 2 );
+		zones.forEach( ( zone ) => {
+			expect( zone ).toHaveClass( 'is-dragging-over-document' );
+			expect( zone ).not.toHaveClass( 'is-dragging-over-element' );
 		} );
 	} );
 

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -1,9 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { Component, createElement } from 'react';
-import ReactDom from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
+import { Component, createRef } from 'react';
 import { DropZone } from '../';
 
 class Wrapper extends Component {
@@ -13,165 +12,146 @@ class Wrapper extends Component {
 }
 
 describe( 'index', () => {
-	let container;
 	const requiredProps = {
 		hideDropZone: () => {},
 		showDropZone: () => {},
 		translate: ( string ) => string,
 	};
 
-	beforeAll( function () {
-		container = document.createElement( 'div' );
+	// Render a DropZone into a container with a known id so the tests can assert on the
+	// node's placement in the tree, and return the component instance via a ref.
+	function renderDropZone( props = {} ) {
+		// Render into a container with a known id so the tests can assert on the node's
+		// placement in the tree. Testing Library removes this container on cleanup since it
+		// is a direct child of document.body.
+		const container = document.body.appendChild( document.createElement( 'div' ) );
 		container.id = 'container';
+
+		const ref = createRef();
+		render( <DropZone { ...requiredProps } { ...props } ref={ ref } />, { container } );
+		return ref.current;
+	}
+
+	beforeAll( () => {
 		window.MutationObserver = jest.fn( () => ( {
 			observe: jest.fn(),
 			disconnect: jest.fn(),
 		} ) );
 	} );
 
-	afterAll( function () {
+	afterAll( () => {
 		if ( global.window && global.window.MutationObserver ) {
 			delete global.window.MutationObserver;
 		}
 	} );
 
 	afterEach( () => {
-		ReactDom.unmountComponentAtNode( container );
+		// Restore the instance and HTMLElement.prototype.contains spies some tests install.
+		jest.restoreAllMocks();
 	} );
 
 	test( 'should render as a child of its container by default', () => {
-		const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
+		const tree = renderDropZone();
 
 		expect( tree.zoneRef.current.parentNode.id ).toEqual( 'container' );
 	} );
 
 	test( 'should accept a fullScreen prop to be rendered at the root', () => {
-		const tree = ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				fullScreen: true,
-			} ),
-			container
-		);
+		const tree = renderDropZone( { fullScreen: true } );
 
 		expect( tree.zoneRef.current.parentNode.id ).not.toEqual( 'container' );
 		expect( tree.zoneRef.current.parentNode.parentNode ).toBe( document.body );
 	} );
 
 	test( 'should render default content if none is provided', () => {
-		const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
-		const content = TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content' );
+		const tree = renderDropZone();
+		const zone = tree.zoneRef.current;
 
-		TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content-icon' );
-		TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content-text' );
-		expect( content.textContent ).toEqual( 'Drop files to upload' );
+		expect( zone.querySelector( '.drop-zone__content-icon' ) ).toBeVisible();
+		expect( zone.querySelector( '.drop-zone__content-text' ) ).toBeVisible();
+		expect( zone.querySelector( '.drop-zone__content' ) ).toHaveTextContent(
+			'Drop files to upload'
+		);
 	} );
 
 	test( 'should accept children to override the default content', () => {
-		const tree = ReactDom.render(
-			createElement( DropZone, requiredProps, 'Hello World' ),
-			container
-		);
-		const content = TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content' );
+		const tree = renderDropZone( { children: 'Hello World' } );
 
-		expect( content.textContent ).toEqual( 'Hello World' );
+		expect( tree.zoneRef.current.querySelector( '.drop-zone__content' ) ).toHaveTextContent(
+			'Hello World'
+		);
 	} );
 
 	test( 'should accept an icon to override the default icon', () => {
-		const tree = ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				icon: <div className="customIconClassName" />,
-			} ),
-			container
-		);
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		const tree = renderDropZone( { icon: <div className="customIconClassName" /> } );
 
-		const icon = TestUtils.findRenderedDOMComponentWithClass( tree, 'customIconClassName' );
-
-		expect( TestUtils.isDOMComponent( icon ) ).toEqual( true );
+		expect( tree.zoneRef.current.querySelector( '.customIconClassName' ) ).toBeVisible();
 	} );
 
 	test( 'should highlight the drop zone when dragging over the body', () => {
-		const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
-		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
+		const tree = renderDropZone();
 
-		window.dispatchEvent( dragEnterEvent );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
+		} );
 
 		expect( tree.state.isDraggingOverDocument ).toBeTruthy();
 		expect( tree.state.isDraggingOverElement ).toBeFalsy();
 	} );
 
 	test( 'should start observing the body for mutations when dragging over', () => {
-		return new Promise( ( done ) => {
-			const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
-			const dragEnterEvent = new window.MouseEvent( 'dragenter' );
+		const tree = renderDropZone();
 
-			window.dispatchEvent( dragEnterEvent );
-
-			process.nextTick( function () {
-				expect( tree.observer ).toBeTruthy();
-				done();
-			} );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
+
+		expect( tree.observer ).toBeTruthy();
 	} );
 
 	test( 'should stop observing the body for mutations upon drag ending', () => {
-		return new Promise( ( done ) => {
-			const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
-			const dragEnterEvent = new window.MouseEvent( 'dragenter' );
-			const dragLeaveEvent = new window.MouseEvent( 'dragleave' );
+		const tree = renderDropZone();
 
-			window.dispatchEvent( dragEnterEvent );
-			window.dispatchEvent( dragLeaveEvent );
-
-			process.nextTick( function () {
-				expect( tree.observer ).toBeUndefined();
-				done();
-			} );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
 		} );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragleave' ) );
+		} );
+
+		expect( tree.observer ).toBeUndefined();
 	} );
 
 	test( 'should not highlight if onVerifyValidTransfer returns false', () => {
-		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
+		const tree = renderDropZone( { onVerifyValidTransfer: () => false } );
 
-		const tree = ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				onVerifyValidTransfer: function () {
-					return false;
-				},
-			} ),
-			container
-		);
-
-		window.dispatchEvent( dragEnterEvent );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
+		} );
 
 		expect( tree.state.isDraggingOverDocument ).toBeFalsy();
 		expect( tree.state.isDraggingOverElement ).toBeFalsy();
 	} );
 
 	test( 'should further highlight the drop zone when dragging over the element', () => {
-		const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
+		const tree = renderDropZone();
 		jest.spyOn( tree, 'isWithinZoneBounds' ).mockReturnValue( true );
 
-		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
-		window.dispatchEvent( dragEnterEvent );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
+		} );
 
 		expect( tree.state.isDraggingOverDocument ).toBeTruthy();
 		expect( tree.state.isDraggingOverElement ).toBeTruthy();
 	} );
 
 	test( 'should further highlight the drop zone when dragging over the body if fullScreen', () => {
-		const tree = ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				fullScreen: true,
-			} ),
-			container
-		);
+		const tree = renderDropZone( { fullScreen: true } );
 
-		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
-		window.dispatchEvent( dragEnterEvent );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
+		} );
 
 		expect( tree.state.isDraggingOverDocument ).toBeTruthy();
 		expect( tree.state.isDraggingOverElement ).toBeTruthy();
@@ -179,19 +159,14 @@ describe( 'index', () => {
 
 	test( 'should call onDrop with the raw event data when a drop occurs', () => {
 		const spyDrop = jest.fn();
-
 		jest.spyOn( window.HTMLElement.prototype, 'contains' ).mockReturnValue( true );
 
-		ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				onDrop: spyDrop,
-			} ),
-			container
-		);
+		renderDropZone( { onDrop: spyDrop } );
 
 		const dropEvent = new window.MouseEvent( 'drop' );
-		window.dispatchEvent( dropEvent );
+		act( () => {
+			window.dispatchEvent( dropEvent );
+		} );
 
 		expect( spyDrop ).toHaveBeenCalledTimes( 1 );
 		expect( spyDrop.mock.calls[ 0 ][ 0 ] ).toBe( dropEvent );
@@ -199,19 +174,15 @@ describe( 'index', () => {
 
 	test( 'should call onFilesDrop with the files array when a drop occurs', () => {
 		const spyDrop = jest.fn();
-
 		jest.spyOn( window.HTMLElement.prototype, 'contains' ).mockReturnValue( true );
-		ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				onFilesDrop: spyDrop,
-			} ),
-			container
-		);
+
+		renderDropZone( { onFilesDrop: spyDrop } );
 
 		const dropEvent = new window.MouseEvent( 'drop' );
 		dropEvent.dataTransfer = { files: [ 1, 2, 3 ] };
-		window.dispatchEvent( dropEvent );
+		act( () => {
+			window.dispatchEvent( dropEvent );
+		} );
 
 		expect( spyDrop ).toHaveBeenCalledTimes( 1 );
 		expect( spyDrop.mock.calls[ 0 ][ 0 ] ).toEqual( [ 1, 2, 3 ] );
@@ -219,74 +190,55 @@ describe( 'index', () => {
 
 	test( 'should not call onFilesDrop if onVerifyValidTransfer returns false', () => {
 		const spyDrop = jest.fn();
+
+		renderDropZone( {
+			fullScreen: true, // bypass a Node.contains check on the drop event
+			onFilesDrop: spyDrop,
+			onVerifyValidTransfer: () => false,
+		} );
+
 		const dropEvent = new window.MouseEvent( 'drop' );
-
-		ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				fullScreen: true, // bypass a Node.contains check on the drop event
-				onFilesDrop: spyDrop,
-				onVerifyValidTransfer: function () {
-					return false;
-				},
-			} ),
-			container
-		);
-
 		dropEvent.dataTransfer = { files: [ 1, 2, 3 ] };
-		window.dispatchEvent( dropEvent );
+		act( () => {
+			window.dispatchEvent( dropEvent );
+		} );
 
 		expect( spyDrop ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should allow more than one rendered DropZone on a page', () => {
-		const tree = ReactDom.render(
-			createElement(
-				Wrapper,
-				null,
-				createElement( DropZone, requiredProps ),
-				createElement( DropZone, requiredProps )
-			),
-			container
+		const refs = [ createRef(), createRef() ];
+		render(
+			<Wrapper>
+				<DropZone { ...requiredProps } ref={ refs[ 0 ] } />
+				<DropZone { ...requiredProps } ref={ refs[ 1 ] } />
+			</Wrapper>
 		);
 
-		const rendered = TestUtils.scryRenderedComponentsWithType( tree, DropZone );
+		act( () => {
+			window.dispatchEvent( new window.MouseEvent( 'dragenter' ) );
+		} );
 
-		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
-		window.dispatchEvent( dragEnterEvent );
-
-		expect( rendered ).toHaveLength( 2 );
-		rendered.forEach( function ( zone ) {
-			expect( zone.state.isDraggingOverDocument ).toBeTruthy();
-			expect( zone.state.isDraggingOverElement ).toBeFalsy();
+		expect( refs ).toHaveLength( 2 );
+		refs.forEach( ( ref ) => {
+			expect( ref.current.state.isDraggingOverDocument ).toBeTruthy();
+			expect( ref.current.state.isDraggingOverElement ).toBeFalsy();
 		} );
 	} );
 
 	test( 'should accept a custom textLabel to override the default text', () => {
-		const tree = ReactDom.render(
-			createElement( DropZone, {
-				...requiredProps,
-				textLabel: 'Custom Drop Zone Label',
-			} ),
-			container
-		);
+		const tree = renderDropZone( { textLabel: 'Custom Drop Zone Label' } );
 
-		const textContent = TestUtils.findRenderedDOMComponentWithClass(
-			tree,
-			'drop-zone__content-text'
+		expect( tree.zoneRef.current.querySelector( '.drop-zone__content-text' ) ).toHaveTextContent(
+			'Custom Drop Zone Label'
 		);
-
-		expect( textContent.textContent ).toEqual( 'Custom Drop Zone Label' );
 	} );
 
 	test( 'should show the default text label if none specified', () => {
-		const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
+		const tree = renderDropZone();
 
-		const textContent = TestUtils.findRenderedDOMComponentWithClass(
-			tree,
-			'drop-zone__content-text'
+		expect( tree.zoneRef.current.querySelector( '.drop-zone__content-text' ) ).toHaveTextContent(
+			'Drop files to upload'
 		);
-
-		expect( textContent.textContent ).toEqual( 'Drop files to upload' );
 	} );
 } );

--- a/client/components/forms/counted-textarea/test/index.jsx
+++ b/client/components/forms/counted-textarea/test/index.jsx
@@ -1,11 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { CountedTextarea } from '../';
 
 const getWrapper = ( container ) => container.querySelector( '.counted-textarea' );
-const getTextarea = ( container ) => container.querySelector( 'textarea' );
 const getCountPanel = ( container ) => container.querySelector( '.counted-textarea__count-panel' );
 
 describe( 'index', () => {
@@ -36,10 +35,10 @@ describe( 'index', () => {
 		const value = 'Hello World!';
 		const placeholder = 'placeholder test';
 
-		const { container } = render(
+		render(
 			<CountedTextarea value={ value } className="custom-class" placeholder={ placeholder } />
 		);
-		const textarea = getTextarea( container );
+		const textarea = screen.getByRole( 'textbox' );
 
 		expect( textarea ).toHaveValue( value );
 		expect( textarea ).toHaveAttribute( 'placeholder', placeholder );
@@ -82,10 +81,8 @@ describe( 'index', () => {
 	test( 'should not pass acceptableLength prop to the child textarea', () => {
 		const value = 'Hello World!';
 
-		const { container } = render(
-			<CountedTextarea value={ value } className="custom-class" acceptableLength={ 140 } />
-		);
-		const textarea = getTextarea( container );
+		render( <CountedTextarea value={ value } className="custom-class" acceptableLength={ 140 } /> );
+		const textarea = screen.getByRole( 'textbox' );
 
 		expect( textarea ).toHaveValue( value );
 		expect( textarea ).not.toHaveAttribute( 'acceptablelength' );

--- a/client/components/forms/counted-textarea/test/index.jsx
+++ b/client/components/forms/counted-textarea/test/index.jsx
@@ -1,148 +1,116 @@
-import ShallowRenderer from 'react-test-renderer/shallow';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import { CountedTextarea } from '../';
 
+const getWrapper = ( container ) => container.querySelector( '.counted-textarea' );
+const getTextarea = ( container ) => container.querySelector( 'textarea' );
+const getCountPanel = ( container ) => container.querySelector( '.counted-textarea__count-panel' );
+
 describe( 'index', () => {
-	let renderer;
-
-	beforeEach( () => {
-		renderer = new ShallowRenderer();
-	} );
-
 	test( 'should render the character count of the passed value', () => {
-		renderer.render( <CountedTextarea value="Hello World!" /> );
-		const result = renderer.getRenderOutput();
+		const { container } = render( <CountedTextarea value="Hello World!" /> );
 
-		expect( result.props.className ).toEqual( 'counted-textarea' );
-		expect( result.props.children ).toHaveLength( 2 );
-		expect( result.props.children[ 1 ].props.children[ 0 ] ).toEqual( '12 characters' );
+		expect( getWrapper( container ) ).toHaveClass( 'counted-textarea' );
+		expect( getCountPanel( container ) ).toHaveTextContent( '12 characters' );
 	} );
 
 	test( 'should render warning styles when the acceptable length is exceeded', () => {
-		renderer.render( <CountedTextarea value="Hello World!" acceptableLength={ 10 } /> );
-		const result = renderer.getRenderOutput();
+		const { container } = render(
+			<CountedTextarea value="Hello World!" acceptableLength={ 10 } />
+		);
 
-		expect( result.props.className ).toEqual( 'counted-textarea is-exceeding-acceptable-length' );
+		expect( getWrapper( container ) ).toHaveClass( 'is-exceeding-acceptable-length' );
 	} );
 
 	test( 'should apply className to the wrapper element', () => {
-		renderer.render( <CountedTextarea value="Hello World!" className="custom-class" /> );
-		const result = renderer.getRenderOutput();
+		const { container } = render(
+			<CountedTextarea value="Hello World!" className="custom-class" />
+		);
 
-		expect( result.props.className ).toEqual( 'counted-textarea custom-class' );
+		expect( getWrapper( container ) ).toHaveClass( 'counted-textarea', 'custom-class' );
 	} );
 
 	test( 'should pass props to the child textarea', () => {
 		const value = 'Hello World!';
 		const placeholder = 'placeholder test';
 
-		renderer.render(
+		const { container } = render(
 			<CountedTextarea value={ value } className="custom-class" placeholder={ placeholder } />
 		);
-		const result = renderer.getRenderOutput();
+		const textarea = getTextarea( container );
 
-		expect( result.props.children ).toHaveLength( 2 );
-		expect( result.props.children[ 0 ].props.value ).toEqual( value );
-		expect( result.props.children[ 0 ].props.placeholder ).toEqual( placeholder );
-		expect( result.props.children[ 0 ].props.className ).toEqual( 'counted-textarea__input' );
+		expect( textarea ).toHaveValue( value );
+		expect( textarea ).toHaveAttribute( 'placeholder', placeholder );
+		expect( textarea ).toHaveClass( 'counted-textarea__input' );
 	} );
 
 	test( 'should not use the placeholder as the counted item if value is empty and countPlaceholderLength is not set', () => {
-		const value = '';
-		const placeholder = 'placeholder test';
-
-		renderer.render(
-			<CountedTextarea value={ value } className="custom-class" placeholder={ placeholder } />
+		const { container } = render(
+			<CountedTextarea value="" className="custom-class" placeholder="placeholder test" />
 		);
-		const result = renderer.getRenderOutput();
 
-		expect( result.props.children[ 1 ].props.children[ 0 ] ).toEqual( '0 characters' );
+		expect( getCountPanel( container ) ).toHaveTextContent( '0 characters' );
 	} );
 
 	test( 'should use the placeholder as the counted item if value is empty and countPlaceholderLength is true', () => {
-		const value = '';
-		const placeholder = 'placeholder test';
-
-		renderer.render(
+		const { container } = render(
 			<CountedTextarea
-				value={ value }
+				value=""
 				className="custom-class"
-				placeholder={ placeholder }
+				placeholder="placeholder test"
 				countPlaceholderLength
 			/>
 		);
-		const result = renderer.getRenderOutput();
 
-		expect( result.props.children[ 1 ].props.children[ 0 ] ).toEqual( '16 characters' );
+		expect( getCountPanel( container ) ).toHaveTextContent( '16 characters' );
 	} );
 
 	test( 'should use the value as the counted item if value is set', () => {
-		const value = 'Hello World!';
-		const placeholder = 'placeholder test';
-
-		renderer.render(
-			<CountedTextarea value={ value } className="custom-class" placeholder={ placeholder } />
+		const { container } = render(
+			<CountedTextarea
+				value="Hello World!"
+				className="custom-class"
+				placeholder="placeholder test"
+			/>
 		);
-		const result = renderer.getRenderOutput();
 
-		expect( result.props.children[ 1 ].props.children[ 0 ] ).toEqual( '12 characters' );
+		expect( getCountPanel( container ) ).toHaveTextContent( '12 characters' );
 	} );
 
 	test( 'should not pass acceptableLength prop to the child textarea', () => {
 		const value = 'Hello World!';
-		const acceptableLength = 140;
 
-		renderer.render(
-			<CountedTextarea
-				value={ value }
-				className="custom-class"
-				acceptableLength={ acceptableLength }
-			/>
+		const { container } = render(
+			<CountedTextarea value={ value } className="custom-class" acceptableLength={ 140 } />
 		);
-		const result = renderer.getRenderOutput();
+		const textarea = getTextarea( container );
 
-		expect( result.props.children ).toHaveLength( 2 );
-		expect( result.props.children[ 0 ].props.value ).toEqual( value );
-		expect( result.props.children[ 0 ].props.acceptableLength ).toBeUndefined();
-		expect( result.props.children[ 0 ].props.className ).toEqual( 'counted-textarea__input' );
+		expect( textarea ).toHaveValue( value );
+		expect( textarea ).not.toHaveAttribute( 'acceptablelength' );
+		expect( textarea ).toHaveClass( 'counted-textarea__input' );
 	} );
 
 	test( 'should render a reversed count when set to showRemainingCount', () => {
-		const value = 'Hello World!';
-		const acceptableLength = 140;
-
-		renderer.render(
-			<CountedTextarea
-				value={ value }
-				acceptableLength={ acceptableLength }
-				showRemainingCharacters
-			/>
+		const { container } = render(
+			<CountedTextarea value="Hello World!" acceptableLength={ 140 } showRemainingCharacters />
 		);
-		const result = renderer.getRenderOutput();
 
-		expect( result.props.className ).toEqual( 'counted-textarea' );
-		expect( result.props.children ).toHaveLength( 2 );
-		expect( result.props.children[ 1 ].props.children[ 0 ] ).toEqual( '128 characters remaining' );
+		expect( getWrapper( container ) ).toHaveClass( 'counted-textarea' );
+		expect( getCountPanel( container ) ).toHaveTextContent( '128 characters remaining' );
 	} );
 
 	test( 'should render additional panel content when set', () => {
-		const value = 'Hello World!';
-		const acceptableLength = 140;
-		const additionalPanelContent = 'Extra stuff';
-
-		renderer.render(
-			<CountedTextarea
-				value={ value }
-				acceptableLength={ acceptableLength }
-				showRemainingCharacters
-			>
-				{ additionalPanelContent }
+		const { container } = render(
+			<CountedTextarea value="Hello World!" acceptableLength={ 140 } showRemainingCharacters>
+				Extra stuff
 			</CountedTextarea>
 		);
-		const result = renderer.getRenderOutput();
+		const countPanel = getCountPanel( container );
 
-		expect( result.props.className ).toEqual( 'counted-textarea' );
-		expect( result.props.children ).toHaveLength( 2 );
-		expect( result.props.children[ 1 ].props.children[ 0 ] ).toEqual( '128 characters remaining' );
-		expect( result.props.children[ 1 ].props.children[ 1 ] ).toEqual( 'Extra stuff' );
+		expect( getWrapper( container ) ).toHaveClass( 'counted-textarea' );
+		expect( countPanel ).toHaveTextContent( '128 characters remaining' );
+		expect( countPanel ).toHaveTextContent( 'Extra stuff' );
 	} );
 } );

--- a/client/components/forms/multi-checkbox/test/index.jsx
+++ b/client/components/forms/multi-checkbox/test/index.jsx
@@ -2,11 +2,8 @@
  * @jest-environment jsdom
  */
 
-import ReactDOM from 'react-dom';
-import { act, Simulate } from 'react-dom/test-utils';
+import { fireEvent, render } from '@testing-library/react';
 import MultiCheckbox from '../';
-
-let container;
 
 describe( 'index', () => {
 	const options = [
@@ -14,46 +11,29 @@ describe( 'index', () => {
 		{ value: 2, label: 'Two' },
 	];
 
-	beforeEach( () => {
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
-	} );
-
-	afterEach( () => {
-		document.body.removeChild( container );
-		ReactDOM.unmountComponentAtNode( container );
-		container = null;
-	} );
-
 	describe( 'rendering', () => {
 		test( 'should render a set of checkboxes', () => {
-			act( () => {
-				ReactDOM.render( <MultiCheckbox name="favorite_colors" options={ options } />, container );
-			} );
+			const { container } = render( <MultiCheckbox name="favorite_colors" options={ options } /> );
 
 			const labels = container.querySelectorAll( 'label' );
-			expect( labels.length ).toEqual( options.length );
+			expect( labels ).toHaveLength( options.length );
 
 			labels.forEach( ( label, i ) => {
-				const labelNode = label;
-				const inputNode = labelNode.querySelector( 'input' );
+				const inputNode = label.querySelector( 'input' );
 				expect( inputNode.name ).toEqual( 'favorite_colors[]' );
 				expect( inputNode.value ).toEqual( options[ i ].value.toString() );
-				expect( labelNode.textContent ).toEqual( options[ i ].label );
+				expect( label.textContent ).toEqual( options[ i ].label );
 			} );
 		} );
 
 		test( 'should accept an array of checked values', () => {
-			act( () => {
-				ReactDOM.render(
-					<MultiCheckbox
-						name="favorite_colors"
-						options={ options }
-						checked={ [ options[ 0 ].value ] }
-					/>,
-					container
-				);
-			} );
+			const { container } = render(
+				<MultiCheckbox
+					name="favorite_colors"
+					options={ options }
+					checked={ [ options[ 0 ].value ] }
+				/>
+			);
 			const labels = container.querySelectorAll( 'label' );
 
 			expect( labels[ 0 ].querySelector( 'input' ).checked ).toBe( true );
@@ -61,16 +41,13 @@ describe( 'index', () => {
 		} );
 
 		test( 'should accept an array of defaultChecked', () => {
-			act( () => {
-				ReactDOM.render(
-					<MultiCheckbox
-						name="favorite_colors"
-						options={ options }
-						defaultChecked={ [ options[ 0 ].value ] }
-					/>,
-					container
-				);
-			} );
+			const { container } = render(
+				<MultiCheckbox
+					name="favorite_colors"
+					options={ options }
+					defaultChecked={ [ options[ 0 ].value ] }
+				/>
+			);
 			const labels = container.querySelectorAll( 'label' );
 
 			expect( labels[ 0 ].querySelector( 'input' ).checked ).toBe( true );
@@ -78,38 +55,21 @@ describe( 'index', () => {
 		} );
 
 		test( 'should accept an onChange event handler', () => {
-			return new Promise( ( done ) => {
-				const finishTest = ( event ) => {
-					expect( event.value ).toEqual( [ options[ 0 ].value ] );
-					done();
-				};
+			const onChange = jest.fn();
+			const { container } = render(
+				<MultiCheckbox name="favorite_colors" options={ options } onChange={ onChange } />
+			);
 
-				act( () => {
-					ReactDOM.render(
-						<MultiCheckbox name="favorite_colors" options={ options } onChange={ finishTest } />,
-						container
-					);
-				} );
-				const labels = container.querySelectorAll( 'label' );
+			// Checkbox values come back from the DOM as strings.
+			fireEvent.click( container.querySelector( 'label input' ) );
 
-				act( () => {
-					Simulate.change( labels[ 0 ].querySelector( 'input' ), {
-						target: {
-							value: options[ 0 ].value,
-							checked: true,
-						},
-					} );
-				} );
-			} );
+			expect( onChange ).toHaveBeenCalledWith( { value: [ options[ 0 ].value.toString() ] } );
 		} );
 
 		test( 'should accept a disabled boolean', () => {
-			act( () => {
-				ReactDOM.render(
-					<MultiCheckbox name="favorite_colors" options={ options } disabled />,
-					container
-				);
-			} );
+			const { container } = render(
+				<MultiCheckbox name="favorite_colors" options={ options } disabled />
+			);
 			const labels = container.querySelectorAll( 'label' );
 
 			expect( labels[ 0 ].querySelector( 'input' ).disabled ).toBe( true );
@@ -118,15 +78,11 @@ describe( 'index', () => {
 
 		test( 'should transfer props to the rendered element', () => {
 			const className = 'transferred-class';
-			act( () => {
-				ReactDOM.render(
-					<MultiCheckbox name="favorite_colors" options={ options } className={ className } />,
-					container
-				);
-			} );
-			const div = container.querySelector( 'div' );
+			const { container } = render(
+				<MultiCheckbox name="favorite_colors" options={ options } className={ className } />
+			);
 
-			expect( div.className ).toContain( className );
+			expect( container.querySelector( 'div' ) ).toHaveClass( className );
 		} );
 	} );
 } );

--- a/client/components/forms/multi-checkbox/test/index.jsx
+++ b/client/components/forms/multi-checkbox/test/index.jsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import MultiCheckbox from '../';
 
 describe( 'index', () => {
@@ -13,67 +14,60 @@ describe( 'index', () => {
 
 	describe( 'rendering', () => {
 		test( 'should render a set of checkboxes', () => {
-			const { container } = render( <MultiCheckbox name="favorite_colors" options={ options } /> );
+			render( <MultiCheckbox name="favorite_colors" options={ options } /> );
 
-			const labels = container.querySelectorAll( 'label' );
-			expect( labels ).toHaveLength( options.length );
+			const checkboxes = screen.getAllByRole( 'checkbox' );
+			expect( checkboxes ).toHaveLength( options.length );
 
-			labels.forEach( ( label, i ) => {
-				const inputNode = label.querySelector( 'input' );
-				expect( inputNode.name ).toEqual( 'favorite_colors[]' );
-				expect( inputNode.value ).toEqual( options[ i ].value.toString() );
-				expect( label.textContent ).toEqual( options[ i ].label );
+			checkboxes.forEach( ( checkbox, i ) => {
+				expect( checkbox ).toHaveAttribute( 'name', 'favorite_colors[]' );
+				expect( checkbox ).toHaveAttribute( 'value', options[ i ].value.toString() );
+				expect( checkbox ).toHaveAccessibleName( options[ i ].label );
 			} );
 		} );
 
 		test( 'should accept an array of checked values', () => {
-			const { container } = render(
+			render(
 				<MultiCheckbox
 					name="favorite_colors"
 					options={ options }
 					checked={ [ options[ 0 ].value ] }
 				/>
 			);
-			const labels = container.querySelectorAll( 'label' );
 
-			expect( labels[ 0 ].querySelector( 'input' ).checked ).toBe( true );
-			expect( labels[ 1 ].querySelector( 'input' ).checked ).toBe( false );
+			expect( screen.getByRole( 'checkbox', { name: 'One' } ) ).toBeChecked();
+			expect( screen.getByRole( 'checkbox', { name: 'Two' } ) ).not.toBeChecked();
 		} );
 
 		test( 'should accept an array of defaultChecked', () => {
-			const { container } = render(
+			render(
 				<MultiCheckbox
 					name="favorite_colors"
 					options={ options }
 					defaultChecked={ [ options[ 0 ].value ] }
 				/>
 			);
-			const labels = container.querySelectorAll( 'label' );
 
-			expect( labels[ 0 ].querySelector( 'input' ).checked ).toBe( true );
-			expect( labels[ 1 ].querySelector( 'input' ).checked ).toBe( false );
+			expect( screen.getByRole( 'checkbox', { name: 'One' } ) ).toBeChecked();
+			expect( screen.getByRole( 'checkbox', { name: 'Two' } ) ).not.toBeChecked();
 		} );
 
-		test( 'should accept an onChange event handler', () => {
+		test( 'should accept an onChange event handler', async () => {
 			const onChange = jest.fn();
-			const { container } = render(
-				<MultiCheckbox name="favorite_colors" options={ options } onChange={ onChange } />
-			);
+			render( <MultiCheckbox name="favorite_colors" options={ options } onChange={ onChange } /> );
+
+			await userEvent.click( screen.getByRole( 'checkbox', { name: 'One' } ) );
 
 			// Checkbox values come back from the DOM as strings.
-			fireEvent.click( container.querySelector( 'label input' ) );
-
 			expect( onChange ).toHaveBeenCalledWith( { value: [ options[ 0 ].value.toString() ] } );
 		} );
 
 		test( 'should accept a disabled boolean', () => {
-			const { container } = render(
-				<MultiCheckbox name="favorite_colors" options={ options } disabled />
-			);
-			const labels = container.querySelectorAll( 'label' );
+			render( <MultiCheckbox name="favorite_colors" options={ options } disabled /> );
 
-			expect( labels[ 0 ].querySelector( 'input' ).disabled ).toBe( true );
-			expect( labels[ 1 ].querySelector( 'input' ).disabled ).toBe( true );
+			screen.getAllByRole( 'checkbox' ).forEach( ( checkbox ) => {
+				expect( checkbox ).toBeDisabled();
+			} );
 		} );
 
 		test( 'should transfer props to the rendered element', () => {

--- a/client/components/forms/range/test/index.jsx
+++ b/client/components/forms/range/test/index.jsx
@@ -2,56 +2,42 @@
  * @jest-environment jsdom
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["TestUtils.*"] }] */
-
 import { Gridicon } from '@automattic/components';
-import ReactDom from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import FormRange from '../';
 
 describe( 'index', () => {
-	afterEach( () => {
-		ReactDom.unmountComponentAtNode( document.body );
-	} );
-
 	test( 'should render beginning content if passed a `minContent` prop', () => {
-		const range = TestUtils.renderIntoDocument(
-			<FormRange minContent={ <Gridicon icon="minus-small" /> } />
-		);
-		TestUtils.findRenderedDOMComponentWithClass( range, 'gridicons-minus-small' );
+		const { container } = render( <FormRange minContent={ <Gridicon icon="minus-small" /> } /> );
+
+		expect( container.querySelector( '.gridicons-minus-small' ) ).toBeVisible();
 	} );
 
 	test( 'should not render ending content if not passed a `maxContent` prop', () => {
-		const range = TestUtils.renderIntoDocument(
-			<FormRange minContent={ <Gridicon icon="minus-small" /> } />
-		);
-		const content = TestUtils.scryRenderedDOMComponentsWithClass( range, 'range__content' );
+		const { container } = render( <FormRange minContent={ <Gridicon icon="minus-small" /> } /> );
+		const content = container.querySelectorAll( '.range__content' );
 
 		expect( content ).toHaveLength( 1 );
-		expect( content[ 0 ].getAttribute( 'class' ) ).toEqual( expect.stringContaining( 'is-min' ) );
+		expect( content[ 0 ] ).toHaveClass( 'is-min' );
 	} );
 
 	test( 'should render ending content if passed a `maxContent` prop', () => {
-		const range = TestUtils.renderIntoDocument(
-			<FormRange maxContent={ <Gridicon icon="plus-small" /> } />
-		);
-		TestUtils.findRenderedDOMComponentWithClass( range, 'gridicons-plus-small' );
+		const { container } = render( <FormRange maxContent={ <Gridicon icon="plus-small" /> } /> );
+
+		expect( container.querySelector( '.gridicons-plus-small' ) ).toBeVisible();
 	} );
 
 	test( 'should not render beginning content if not passed a `minContent` prop', () => {
-		const range = TestUtils.renderIntoDocument(
-			<FormRange maxContent={ <Gridicon icon="plus-small" /> } />
-		);
-		const content = TestUtils.scryRenderedDOMComponentsWithClass( range, 'range__content' );
+		const { container } = render( <FormRange maxContent={ <Gridicon icon="plus-small" /> } /> );
+		const content = container.querySelectorAll( '.range__content' );
 
 		expect( content ).toHaveLength( 1 );
-		expect( content[ 0 ].getAttribute( 'class' ) ).toEqual( expect.stringContaining( 'is-max' ) );
+		expect( content[ 0 ] ).toHaveClass( 'is-max' );
 	} );
 
 	test( 'should render a value label if passed a truthy `showValueLabel` prop', () => {
-		const range = TestUtils.renderIntoDocument( <FormRange value={ 8 } showValueLabel readOnly /> );
-		const label = TestUtils.findRenderedDOMComponentWithClass( range, 'range__label' );
+		const { container } = render( <FormRange value={ 8 } showValueLabel readOnly /> );
 
-		expect( label.textContent ).toEqual( '8' );
+		expect( container.querySelector( '.range__label' ) ).toHaveTextContent( '8' );
 	} );
 } );

--- a/client/components/search/test/index.jsx
+++ b/client/components/search/test/index.jsx
@@ -1,48 +1,23 @@
 /**
  * @jest-environment jsdom
  */
-import { createElement } from 'react';
-import TestUtils from 'react-dom/test-utils';
-import searchClass from '../';
+import { render, screen } from '@testing-library/react';
+import Search from '../';
 
 jest.mock( 'calypso/lib/analytics/ga', () => ( {} ) );
 
 describe( 'Search', () => {
 	describe( 'initialValue', () => {
-		let onSearch;
-		let rendered;
+		test( 'should seed the input with the initialValue after mount', () => {
+			render( <Search initialValue="hello" onSearch={ jest.fn() } /> );
 
-		beforeEach( () => {
-			onSearch = jest.fn();
+			expect( screen.getByRole( 'searchbox' ) ).toHaveValue( 'hello' );
 		} );
 
-		describe( 'with initialValue', () => {
-			const initialValue = 'hello';
+		test( 'should start with an empty input without an initialValue', () => {
+			render( <Search onSearch={ jest.fn() } /> );
 
-			beforeEach( () => {
-				const searchElement = createElement( searchClass, {
-					initialValue,
-					onSearch,
-				} );
-				rendered = TestUtils.renderIntoDocument( searchElement );
-			} );
-
-			test( 'should set state.keyword with the initialValue after mount', () => {
-				expect( rendered.state.keyword ).toEqual( initialValue );
-			} );
-		} );
-
-		describe( 'without initialValue', () => {
-			beforeEach( () => {
-				const searchElement = createElement( searchClass, {
-					onSearch,
-				} );
-				rendered = TestUtils.renderIntoDocument( searchElement );
-			} );
-
-			test( 'should set state.keyword empty string after mount', () => {
-				expect( rendered.state.keyword ).toEqual( '' );
-			} );
+			expect( screen.getByRole( 'searchbox' ) ).toHaveValue( '' );
 		} );
 	} );
 } );

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -21,9 +21,8 @@ window.IntersectionObserver = jest.fn( () => ( {
 	unobserve: jest.fn(),
 } ) );
 
-// SectionNav clones its children with internal props (hasSiblingControls,
-// closeSectionNavMobilePanel). A component child consumes them instead of forwarding
-// unknown attributes onto a DOM element and triggering React warnings.
+// SectionNav clones children with internal props; a component child consumes them instead
+// of leaking unknown attributes onto a DOM element (which React warns about).
 const Panel = ( { children } ) => <div>{ children }</div>;
 
 describe( 'section-nav', () => {

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SectionNav from '../';
 import NavItem from '../item';
 import NavTabs from '../tabs';
@@ -123,7 +124,7 @@ describe( 'section-nav', () => {
 	} );
 
 	describe( 'interaction', () => {
-		test( 'should toggle the panel and call onMobileNavPanelOpen twice when tapped three times', () => {
+		test( 'should toggle the panel and call onMobileNavPanelOpen twice when tapped three times', async () => {
 			const onMobileNavPanelOpen = jest.fn();
 			const { container } = render(
 				<SectionNav selectedText="placeholder" onMobileNavPanelOpen={ onMobileNavPanelOpen }>
@@ -131,14 +132,14 @@ describe( 'section-nav', () => {
 				</SectionNav>
 			);
 			const nav = container.querySelector( '.section-nav' );
-			const header = container.querySelector( '.section-nav__mobile-header' );
+			const header = screen.getByRole( 'button' );
 
 			expect( nav ).not.toHaveClass( 'is-open' );
-			fireEvent.click( header );
+			await userEvent.click( header );
 			expect( nav ).toHaveClass( 'is-open' );
-			fireEvent.click( header );
+			await userEvent.click( header );
 			expect( nav ).not.toHaveClass( 'is-open' );
-			fireEvent.click( header );
+			await userEvent.click( header );
 			expect( nav ).toHaveClass( 'is-open' );
 
 			expect( onMobileNavPanelOpen ).toHaveBeenCalledTimes( 2 );

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -21,12 +21,17 @@ window.IntersectionObserver = jest.fn( () => ( {
 	unobserve: jest.fn(),
 } ) );
 
+// SectionNav clones its children with internal props (hasSiblingControls,
+// closeSectionNavMobilePanel). A component child consumes them instead of forwarding
+// unknown attributes onto a DOM element and triggering React warnings.
+const Panel = ( { children } ) => <div>{ children }</div>;
+
 describe( 'section-nav', () => {
 	describe( 'rendering', () => {
 		test( 'should render a header and a panel', () => {
 			const { container } = render(
 				<SectionNav selectedText="test">
-					<p>mmyellow</p>
+					<Panel>mmyellow</Panel>
 				</SectionNav>
 			);
 
@@ -38,7 +43,7 @@ describe( 'section-nav', () => {
 		test( 'should render selectedText within mobile header', () => {
 			const { container } = render(
 				<SectionNav selectedText="test">
-					<p>mmyellow</p>
+					<Panel>mmyellow</Panel>
 				</SectionNav>
 			);
 
@@ -50,7 +55,7 @@ describe( 'section-nav', () => {
 		test( 'should render children', () => {
 			render(
 				<SectionNav selectedText="test">
-					<p>mmyellow</p>
+					<Panel>mmyellow</Panel>
 				</SectionNav>
 			);
 
@@ -60,7 +65,7 @@ describe( 'section-nav', () => {
 		test( 'should not render a header if dropdown disabled', () => {
 			const { container } = render(
 				<SectionNav selectedText="test" allowDropdown={ false }>
-					<p>mmyellow</p>
+					<Panel>mmyellow</Panel>
 				</SectionNav>
 			);
 
@@ -128,7 +133,7 @@ describe( 'section-nav', () => {
 			const onMobileNavPanelOpen = jest.fn();
 			const { container } = render(
 				<SectionNav selectedText="placeholder" onMobileNavPanelOpen={ onMobileNavPanelOpen }>
-					<p>placeholder</p>
+					<Panel>placeholder</Panel>
 				</SectionNav>
 			);
 			const nav = container.querySelector( '.section-nav' );

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -1,11 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
-import { createElement, Children } from 'react';
-import ReactDom from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
-import ShallowRenderer from 'react-test-renderer/shallow';
+import { fireEvent, render, screen } from '@testing-library/react';
 import SectionNav from '../';
 import NavItem from '../item';
 import NavTabs from '../tabs';
@@ -24,76 +20,50 @@ window.IntersectionObserver = jest.fn( () => ( {
 	unobserve: jest.fn(),
 } ) );
 
-function createComponent( component, props, children ) {
-	const renderer = new ShallowRenderer();
-
-	renderer.render( createElement( component, props, children ) );
-	return renderer.getRenderOutput();
-}
-
 describe( 'section-nav', () => {
 	describe( 'rendering', () => {
-		let headerElem;
-		let headerTextElem;
-		let panelElem;
-		let sectionNav;
-		let text;
-
-		beforeAll( function () {
-			const selectedText = 'test';
-			const children = <p>mmyellow</p>;
-
-			sectionNav = createComponent(
-				SectionNav,
-				{
-					selectedText: selectedText,
-				},
-				children
+		test( 'should render a header and a panel', () => {
+			const { container } = render(
+				<SectionNav selectedText="test">
+					<p>mmyellow</p>
+				</SectionNav>
 			);
 
-			panelElem = sectionNav.props.children[ 1 ];
-			headerElem = sectionNav.props.children[ 0 ];
-			headerTextElem = headerElem.props.children[ 0 ];
-			text = headerTextElem.props.children;
-		} );
-
-		test( 'should render a header and a panel', () => {
-			expect( headerElem.props.className ).toEqual( 'section-nav__mobile-header' );
-			expect( panelElem.props.className ).toEqual( 'section-nav__panel' );
-			expect( headerTextElem.props.className ).toEqual( 'section-nav__mobile-header-text' );
+			expect( container.querySelector( '.section-nav__mobile-header' ) ).toBeVisible();
+			expect( container.querySelector( '.section-nav__panel' ) ).toBeVisible();
+			expect( container.querySelector( '.section-nav__mobile-header-text' ) ).toBeVisible();
 		} );
 
 		test( 'should render selectedText within mobile header', () => {
-			expect( text ).toEqual( 'test' );
+			const { container } = render(
+				<SectionNav selectedText="test">
+					<p>mmyellow</p>
+				</SectionNav>
+			);
+
+			expect( container.querySelector( '.section-nav__mobile-header-text' ) ).toHaveTextContent(
+				'test'
+			);
 		} );
 
 		test( 'should render children', () => {
-			return new Promise( ( done ) => {
-				//React.Children.only should work here but gives an error about not being the only child
-				Children.map(
-					panelElem.props.children.filter( ( o ) => o.type === 'p' ),
-					function ( obj ) {
-						expect( obj.props.children ).toEqual( 'mmyellow' );
-						done();
-					}
-				);
-			} );
+			render(
+				<SectionNav selectedText="test">
+					<p>mmyellow</p>
+				</SectionNav>
+			);
+
+			expect( screen.getByText( 'mmyellow' ) ).toBeVisible();
 		} );
 
 		test( 'should not render a header if dropdown disabled', () => {
-			const component = createComponent(
-				SectionNav,
-				{
-					selectedText: 'test',
-					allowDropdown: false,
-				},
-				<p>mmyellow</p>
+			const { container } = render(
+				<SectionNav selectedText="test" allowDropdown={ false }>
+					<p>mmyellow</p>
+				</SectionNav>
 			);
 
-			const header = component.props.children.find(
-				( child ) => child && child.className === 'section-nav__mobile-header'
-			);
-			expect( header ).toBeUndefined();
+			expect( container.querySelector( '.section-nav__mobile-header' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -153,65 +123,25 @@ describe( 'section-nav', () => {
 	} );
 
 	describe( 'interaction', () => {
-		test( 'should call onMobileNavPanelOpen function passed as a prop when tapped', () => {
-			return new Promise( ( done ) => {
-				const elem = createElement(
-					SectionNav,
-					{
-						selectedText: 'placeholder',
-						onMobileNavPanelOpen: function () {
-							done();
-						},
-					},
+		test( 'should toggle the panel and call onMobileNavPanelOpen twice when tapped three times', () => {
+			const onMobileNavPanelOpen = jest.fn();
+			const { container } = render(
+				<SectionNav selectedText="placeholder" onMobileNavPanelOpen={ onMobileNavPanelOpen }>
 					<p>placeholder</p>
-				);
-				const tree = TestUtils.renderIntoDocument( elem );
-				expect( tree.state.mobileOpen ).toBe( false );
-				TestUtils.Simulate.click(
-					ReactDom.findDOMNode(
-						TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
-					)
-				);
-				expect( tree.state.mobileOpen ).toBe( true );
-			} );
-		} );
+				</SectionNav>
+			);
+			const nav = container.querySelector( '.section-nav' );
+			const header = container.querySelector( '.section-nav__mobile-header' );
 
-		test( 'should call onMobileNavPanelOpen function passed as a prop twice when tapped three times', () => {
-			return new Promise( ( done ) => {
-				const spy = jest.fn();
-				const elem = createElement(
-					SectionNav,
-					{
-						selectedText: 'placeholder',
-						onMobileNavPanelOpen: spy,
-					},
-					<p>placeholder</p>
-				);
-				const tree = TestUtils.renderIntoDocument( elem );
+			expect( nav ).not.toHaveClass( 'is-open' );
+			fireEvent.click( header );
+			expect( nav ).toHaveClass( 'is-open' );
+			fireEvent.click( header );
+			expect( nav ).not.toHaveClass( 'is-open' );
+			fireEvent.click( header );
+			expect( nav ).toHaveClass( 'is-open' );
 
-				expect( tree.state.mobileOpen ).toBe( false );
-				TestUtils.Simulate.click(
-					ReactDom.findDOMNode(
-						TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
-					)
-				);
-				expect( tree.state.mobileOpen ).toBe( true );
-				TestUtils.Simulate.click(
-					ReactDom.findDOMNode(
-						TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
-					)
-				);
-				expect( tree.state.mobileOpen ).toBe( false );
-				TestUtils.Simulate.click(
-					ReactDom.findDOMNode(
-						TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
-					)
-				);
-				expect( tree.state.mobileOpen ).toBe( true );
-
-				expect( spy ).toHaveBeenCalledTimes( 2 );
-				done();
-			} );
+			expect( onMobileNavPanelOpen ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
 } );

--- a/client/components/track-input-changes/test/index.jsx
+++ b/client/components/track-input-changes/test/index.jsx
@@ -1,9 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { Component } from 'react';
-import ReactDom from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import { Component, createRef } from 'react';
 import TrackInputChanges from '../';
 
 /**
@@ -30,31 +29,20 @@ class DummyInput extends Component {
 }
 
 describe( 'TrackInputChanges#onNewValue', () => {
-	let tree;
 	let dummyInput;
-	let container;
-
-	beforeAll( () => {
-		container = document.createElement( 'div' );
-	} );
-
-	afterEach( () => {
-		ReactDom.unmountComponentAtNode( container );
-	} );
 
 	beforeEach( () => {
 		for ( const spy in spies ) {
 			spies[ spy ] = jest.fn();
 		}
-		tree = ReactDom.render(
+
+		const ref = createRef();
+		render(
 			<TrackInputChanges onNewValue={ spies.onNewValue }>
-				<DummyInput onChange={ spies.onChange } onBlur={ spies.onBlur } />
-			</TrackInputChanges>,
-			container
+				<DummyInput ref={ ref } onChange={ spies.onChange } onBlur={ spies.onBlur } />
+			</TrackInputChanges>
 		);
-		dummyInput = TestUtils.findRenderedComponentWithType( tree, DummyInput );
-		// Rendering appears to trigger a 'change' event on the input
-		TestUtils.findRenderedComponentWithType( tree, TrackInputChanges ).inputEdited = false;
+		dummyInput = ref.current;
 	} );
 
 	test( 'should pass through callbacks but not trigger on a change event', () => {
@@ -99,12 +87,11 @@ describe( 'TrackInputChanges#onNewValue', () => {
 
 	test( 'should throw if multiple child elements', () => {
 		expect( () =>
-			ReactDom.render(
+			render(
 				<TrackInputChanges onNewValue={ spies.onNewValue }>
 					<DummyInput onChange={ spies.onChange } onBlur={ spies.onBlur } />
 					<DummyInput onChange={ spies.onChange } onBlur={ spies.onBlur } />
-				</TrackInputChanges>,
-				container
+				</TrackInputChanges>
 			)
 		).toThrow();
 	} );

--- a/client/components/track-input-changes/test/index.jsx
+++ b/client/components/track-input-changes/test/index.jsx
@@ -86,6 +86,10 @@ describe( 'TrackInputChanges#onNewValue', () => {
 	} );
 
 	test( 'should throw if multiple child elements', () => {
+		// React logs the expected render error to console.error; suppress it so real
+		// warnings stay visible.
+		const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
 		expect( () =>
 			render(
 				<TrackInputChanges onNewValue={ spies.onNewValue }>
@@ -94,5 +98,7 @@ describe( 'TrackInputChanges#onNewValue', () => {
 				</TrackInputChanges>
 			)
 		).toThrow();
+
+		consoleError.mockRestore();
 	} );
 } );

--- a/client/components/videos-ui/test/video-player.jsx
+++ b/client/components/videos-ui/test/video-player.jsx
@@ -2,12 +2,10 @@
  * @jest-environment jsdom
  */
 
-import ShallowRenderer from 'react-test-renderer/shallow';
+import { fireEvent, render } from '@testing-library/react';
 import VideoPlayer from '../video-player';
 
 describe( 'Video player', () => {
-	let renderer;
-
 	const videoData = {
 		poster: 'image.png',
 		url: 'video.mp4',
@@ -15,19 +13,26 @@ describe( 'Video player', () => {
 	const course = { slug: 'course-slug' };
 
 	beforeEach( () => {
-		renderer = new ShallowRenderer();
-
 		window._tkq = {
 			push: jest.fn(),
 		};
 	} );
 
-	test( 'Track event with intent prop', () => {
-		renderer.render( <VideoPlayer intent="build" course={ course } videoData={ videoData } /> );
-		const result = renderer.getRenderOutput();
+	const renderPlayer = ( props ) =>
+		render(
+			<VideoPlayer
+				course={ course }
+				videoData={ videoData }
+				onVideoPlayStatusChanged={ jest.fn() }
+				onVideoCompleted={ jest.fn() }
+				{ ...props }
+			/>
+		);
 
-		// Video element.
-		result.props.children[ 0 ].props.onPlay();
+	test( 'Track event with intent prop', () => {
+		const { container } = renderPlayer( { intent: 'build' } );
+
+		fireEvent.play( container.querySelector( 'video' ) );
 
 		expect( window._tkq.push ).toHaveBeenCalledWith( [
 			'recordEvent',
@@ -40,11 +45,9 @@ describe( 'Video player', () => {
 	} );
 
 	test( 'Track event without intent prop', () => {
-		renderer.render( <VideoPlayer course={ course } videoData={ videoData } /> );
-		const result = renderer.getRenderOutput();
+		const { container } = renderPlayer();
 
-		// Video element.
-		result.props.children[ 0 ].props.onPlay();
+		fireEvent.play( container.querySelector( 'video' ) );
 
 		expect( window._tkq.push ).toHaveBeenCalledWith( [
 			'recordEvent',


### PR DESCRIPTION
## Proposed Changes

Continues the React 19 forward-compatibility audit of `client/components` (follow-up to #111556 and #111566), this time covering the test suite. Migrates eight tests off `react-dom` testing APIs that React 19 removes, onto `@testing-library/react`:

* Removed APIs replaced: `react-dom/test-utils` (`renderIntoDocument`, `Simulate`, `act`), `ReactDom.render` / `unmountComponentAtNode`, and `react-test-renderer/shallow`.
* Files: `drop-zone`, `section-nav`, `forms/multi-checkbox`, `forms/range`, `forms/counted-textarea`, `track-input-changes`, `search`, `videos-ui/video-player`.

The migration is behavior-preserving and follows current Testing Library conventions: `screen` role/text queries, accessible-name assertions, `userEvent` for interactions, and assertions on rendered output (text, classes, attributes, fired callbacks) rather than component internals. Class-based `container` queries remain only for elements without an ARIA role (count panels, drag-zone content, icons, the section-nav root), and a few class-instance reads via refs are kept where there is genuinely no DOM equivalent (`DropZone`'s `MutationObserver` wiring and `isWithinZoneBounds`).

Intentional, called-out changes:

* The `multi-checkbox` `onChange` test asserts the realistic DOM **string** value (`'1'`) rather than the numeric `1` the old synthetic `Simulate` event injected via a fake target — real DOM inputs always stringify their value.
* A `section-nav` interaction test was dropped as fully redundant: the remaining "tapped three times" test is a strict superset (it also catches the callback firing on close, which the removed single-tap test could not).
* `DropZone`'s drag-state tests assert on the `is-dragging-over-document` / `is-dragging-over-element` classes (a 1:1 mirror of the internal state) instead of reading `instance.state`, and the multi-zone test queries the rendered `.drop-zone` nodes.
* Expected-error noise is kept out of test output: `track-input-changes`'s render-throw test suppresses the React `console.error`, and `section-nav` renders children through a small component that consumes SectionNav's cloned internal props instead of leaking them onto a `<p>`.

## Why are these changes being made?

These APIs are removed in React 19, so the suites would fail to run after the upgrade. Migrating now keeps the tests green through the bump without changing what they verify.

## Testing Instructions

* `yarn test-client client/components/{drop-zone,section-nav,forms/multi-checkbox,forms/range,forms/counted-textarea,track-input-changes,search,videos-ui}/test` — 55 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
