### PR TITLE
A4A: Implement a dedicated agency Sites screen (foundation)

### DIFF
--- a/client/dashboard/agency/sites/dataviews/actions.tsx
+++ b/client/dashboard/agency/sites/dataviews/actions.tsx
@@ -1,0 +1,35 @@
+import { __ } from '@wordpress/i18n';
+import { getAdminUrl, getSiteUrl } from './site-data';
+import type { AnalyticsClient } from '../../../app/analytics';
+import type { AgencySite } from '@automattic/api-core';
+import type { Action } from '@wordpress/dataviews';
+
+export function getAgencyActions(
+	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
+): Action< AgencySite >[] {
+	return [
+		{
+			id: 'site',
+			label: __( 'Visit site ↗' ),
+			callback: ( sites: AgencySite[] ) => {
+				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'site' } );
+				if ( site ) {
+					window.open( getSiteUrl( site ), '_blank' );
+				}
+			},
+		},
+		{
+			id: 'admin',
+			isPrimary: true,
+			label: __( 'WP Admin ↗' ),
+			callback: ( sites: AgencySite[] ) => {
+				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'admin' } );
+				if ( site ) {
+					window.open( getAdminUrl( site ), '_blank' );
+				}
+			},
+		},
+	];
+}

--- a/client/dashboard/agency/sites/dataviews/backup.tsx
+++ b/client/dashboard/agency/sites/dataviews/backup.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, check } from '@wordpress/icons';
+import type { AgencySite } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+export function getBackupField(): Field< AgencySite > {
+	return {
+		id: 'agency_backup',
+		label: __( 'Backup' ),
+		enableSorting: false,
+		getValue: ( { item } ) => !! item.has_backup,
+		render: ( { item } ) =>
+			item.has_backup ? (
+				<Icon icon={ check } />
+			) : (
+				// TODO: wire up the Backup setup flow; this button is inert for now.
+				<Button variant="tertiary">{ __( 'Add' ) }</Button>
+			),
+	};
+}

--- a/client/dashboard/agency/sites/dataviews/boost.tsx
+++ b/client/dashboard/agency/sites/dataviews/boost.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { AgencySite } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+function getBoostRating( score: number ): string {
+	if ( score > 90 ) {
+		return 'A';
+	}
+	if ( score > 75 ) {
+		return 'B';
+	}
+	if ( score > 50 ) {
+		return 'C';
+	}
+	if ( score > 35 ) {
+		return 'D';
+	}
+	if ( score > 25 ) {
+		return 'E';
+	}
+	return 'F';
+}
+
+export function getBoostField(): Field< AgencySite > {
+	return {
+		id: 'agency_boost',
+		label: __( 'Boost' ),
+		enableSorting: false,
+		getValue: ( { item } ) => item.jetpack_boost_scores?.overall ?? 0,
+		render: ( { item } ) => {
+			const score = item.jetpack_boost_scores?.overall;
+			return score ? (
+				<>{ getBoostRating( score ) }</>
+			) : (
+				// TODO: wire up the Boost setup flow; this button is inert for now.
+				<Button variant="tertiary">{ __( 'Add' ) }</Button>
+			);
+		},
+	};
+}

--- a/client/dashboard/agency/sites/dataviews/boost.tsx
+++ b/client/dashboard/agency/sites/dataviews/boost.tsx
@@ -30,7 +30,8 @@ export function getBoostField(): Field< AgencySite > {
 		getValue: ( { item } ) => item.jetpack_boost_scores?.overall ?? 0,
 		render: ( { item } ) => {
 			const score = item.jetpack_boost_scores?.overall;
-			return score ? (
+			// A score of 0 is a valid rating (F), so check for presence, not truthiness.
+			return typeof score === 'number' ? (
 				<>{ getBoostRating( score ) }</>
 			) : (
 				// TODO: wire up the Boost setup flow; this button is inert for now.

--- a/client/dashboard/agency/sites/dataviews/index.ts
+++ b/client/dashboard/agency/sites/dataviews/index.ts
@@ -1,0 +1,20 @@
+import { getBackupField } from './backup';
+import { getBoostField } from './boost';
+import { getSiteIconField, getSiteNameField, getSiteUrlField } from './site';
+import type { AgencySite } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+export { getAgencyActions } from './actions';
+
+export function getAgencyFields(
+	viewType?: string,
+	onSiteClick?: ( site: AgencySite ) => void
+): Field< AgencySite >[] {
+	return [
+		getSiteIconField( viewType ),
+		getSiteNameField( onSiteClick ),
+		getSiteUrlField(),
+		getBoostField(),
+		getBackupField(),
+	];
+}

--- a/client/dashboard/agency/sites/dataviews/site-data.ts
+++ b/client/dashboard/agency/sites/dataviews/site-data.ts
@@ -1,0 +1,19 @@
+import type { AgencySite } from '@automattic/api-core';
+
+// The endpoint may omit the scheme, so normalize to a full URL.
+export function getSiteUrl( site: AgencySite ): string {
+	return site.url_with_scheme || `https://${ site.url }`;
+}
+
+// The endpoint doesn't return an admin URL; derive it from the site URL.
+export function getAdminUrl( site: AgencySite ): string {
+	return `${ getSiteUrl( site ).replace( /\/$/, '' ) }/wp-admin/`;
+}
+
+export function getSiteName( site: AgencySite ): string {
+	return site.blogname || site.url;
+}
+
+export function getDisplayUrl( site: AgencySite ): string {
+	return getSiteUrl( site ).replace( /^https?:\/\//, '' );
+}

--- a/client/dashboard/agency/sites/dataviews/site.tsx
+++ b/client/dashboard/agency/sites/dataviews/site.tsx
@@ -61,7 +61,7 @@ export function getSiteNameField(
 		id: 'name',
 		label: __( 'Site' ),
 		enableHiding: false,
-		enableSorting: false,
+		enableSorting: true,
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => getSiteName( item ),
 		// TODO: temporary raw link to wp-admin; replace with the full site-link

--- a/client/dashboard/agency/sites/dataviews/site.tsx
+++ b/client/dashboard/agency/sites/dataviews/site.tsx
@@ -1,0 +1,96 @@
+import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { getAdminUrl, getDisplayUrl, getSiteName, getSiteUrl } from './site-data';
+import type { AgencySite } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+// TODO: make this fallback themeable (incl. dark mode) once A4A supports dark mode.
+const FALLBACK_SITE_COLOR = 'linear-gradient( 45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4 )';
+
+function AgencySiteIcon( { site, size }: { site: AgencySite; size: number } ) {
+	const ico = site.icon?.img || site.icon?.ico;
+
+	if ( ico ) {
+		return (
+			<img
+				src={ ico }
+				alt=""
+				width={ size }
+				height={ size }
+				loading="lazy"
+				style={ { borderRadius: 4, objectFit: 'cover', display: 'block' } }
+			/>
+		);
+	}
+
+	return (
+		<span
+			aria-hidden="true"
+			style={ {
+				display: 'block',
+				width: size,
+				height: size,
+				borderRadius: 4,
+				background: site.site_color || FALLBACK_SITE_COLOR,
+			} }
+		/>
+	);
+}
+
+export function getSiteIconField( viewType?: string ): Field< AgencySite > {
+	const isGrid = viewType === 'grid';
+	return {
+		id: 'site_icon',
+		label: __( 'Site icon' ),
+		enableSorting: false,
+		render: ( { item } ) =>
+			isGrid ? (
+				<HStack alignment="center" justify="center" style={ { width: '100%', height: '100%' } }>
+					<AgencySiteIcon site={ item } size={ 64 } />
+				</HStack>
+			) : (
+				<AgencySiteIcon site={ item } size={ 48 } />
+			),
+	};
+}
+
+export function getSiteNameField(
+	onSiteClick?: ( site: AgencySite ) => void
+): Field< AgencySite > {
+	return {
+		id: 'name',
+		label: __( 'Site' ),
+		enableHiding: false,
+		enableSorting: false,
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => getSiteName( item ),
+		// TODO: temporary raw link to wp-admin; replace with the full site-link
+		// implementation once the agency site detail experience exists.
+		render: ( { item } ) => (
+			<a
+				href={ getAdminUrl( item ) }
+				target="_blank"
+				rel="noreferrer"
+				style={ { color: 'inherit', textDecoration: 'none' } }
+				onClick={ () => onSiteClick?.( item ) }
+			>
+				{ getSiteName( item ) }
+			</a>
+		),
+	};
+}
+
+export function getSiteUrlField(): Field< AgencySite > {
+	return {
+		id: 'URL',
+		label: __( 'URL' ),
+		enableSorting: true,
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => getDisplayUrl( item ),
+		render: ( { item } ) => (
+			<ExternalLink className="dataviews-url-field" href={ getSiteUrl( item ) }>
+				{ getDisplayUrl( item ) }
+			</ExternalLink>
+		),
+	};
+}

--- a/client/dashboard/agency/sites/index.tsx
+++ b/client/dashboard/agency/sites/index.tsx
@@ -1,0 +1,118 @@
+import { paginatedAgencySitesQuery } from '@automattic/api-queries';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { usePersistentView } from '../../app/hooks/use-persistent-view';
+import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { agencySitesRoute } from '../../app/router/agency';
+import { DataViews, DataViewsCard, DataViewsEmptyStateLayout } from '../../components/dataviews';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { DEFAULT_PER_PAGE, DEFAULT_CONFIG, recordViewChanges } from '../../sites/dataviews/views';
+import { getAgencyFields, getAgencyActions } from './dataviews';
+import type { AgencySite, FetchAgencySitesOptions } from '@automattic/api-core';
+import type { SupportedLayouts, View } from '@wordpress/dataviews';
+
+const AGENCY_LAYOUTS: SupportedLayouts = {
+	table: {
+		showMedia: true,
+		mediaField: 'site_icon',
+		titleField: 'name',
+		descriptionField: 'URL',
+	},
+	grid: {
+		showMedia: true,
+		mediaField: 'site_icon',
+		titleField: 'name',
+		descriptionField: 'URL',
+	},
+};
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	perPage: DEFAULT_PER_PAGE,
+	mediaField: 'site_icon',
+	titleField: 'name',
+	descriptionField: 'URL',
+	fields: [ 'agency_boost', 'agency_backup' ],
+	sort: { field: 'URL', direction: 'asc' },
+} as View;
+
+// The agency endpoint only supports sorting by URL.
+const SORT_FIELD_MAP: Record< string, 'url' > = { URL: 'url' };
+
+function toAgencyFetchOptions( view: View ): FetchAgencySitesOptions {
+	return {
+		search: view.search,
+		sort_field: view.sort?.field ? SORT_FIELD_MAP[ view.sort.field ] : undefined,
+		sort_direction: view.sort?.direction,
+		page: view.page,
+		per_page: view.perPage,
+	};
+}
+
+export default function AgencySites() {
+	const { recordTracksEvent } = useAnalytics();
+	const currentSearchParams = agencySitesRoute.useSearch();
+
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'agency-sites',
+		defaultView: DEFAULT_VIEW,
+		queryParams: currentSearchParams,
+	} );
+
+	const { data, isLoading, isPlaceholderData } = useQuery( {
+		...paginatedAgencySitesQuery( toAgencyFetchOptions( view ) ),
+		placeholderData: keepPreviousData,
+	} );
+
+	const sites = data?.sites ?? [];
+	const totalItems = data?.total ?? 0;
+
+	const handleViewChange = ( nextView: View ) => {
+		recordViewChanges( view, nextView, recordTracksEvent );
+		updateView( nextView );
+	};
+
+	const paginationInfo = {
+		totalItems,
+		totalPages: view.perPage ? Math.ceil( totalItems / view.perPage ) : 1,
+	};
+
+	return (
+		<PageLayout header={ <PageHeader title={ __( 'Sites' ) } /> }>
+			{ ! isLoading && <PerformanceTrackerStop /> }
+			<DataViewsCard>
+				<DataViews< AgencySite >
+					getItemId={ ( item ) => item.blog_id.toString() }
+					data={ sites }
+					fields={ getAgencyFields( view.type, ( site ) =>
+						recordTracksEvent( 'calypso_dashboard_sites_item_click', { site_id: site.blog_id } )
+					) }
+					actions={ getAgencyActions( recordTracksEvent ) }
+					view={ view }
+					isLoading={ isLoading }
+					isPlaceholderData={ isPlaceholderData }
+					onChangeView={ handleViewChange }
+					onReset={ resetView }
+					defaultLayouts={ AGENCY_LAYOUTS }
+					paginationInfo={ paginationInfo }
+					config={ DEFAULT_CONFIG }
+					empty={
+						view.search ? (
+							<DataViewsEmptyStateLayout
+								title={ __( 'No sites match your search' ) }
+								description={ __( 'Try a different search term.' ) }
+							/>
+						) : (
+							<DataViewsEmptyStateLayout
+								title={ __( 'No sites' ) }
+								description={ __( 'No agency-managed sites were found.' ) }
+							/>
+						)
+					}
+				/>
+			</DataViewsCard>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -21,9 +21,16 @@ boot( {
 	mainRoute: '/overview',
 	Logo,
 	supports: {
-		agency: { overview: true, tiers: true, exclusiveOffers: true, learn: true, mcp: true },
+		agency: {
+			overview: true,
+			tiers: true,
+			exclusiveOffers: true,
+			learn: true,
+			mcp: true,
+			sites: true,
+		},
 		agencyClient: { subscriptions: true },
-		sites: true,
+		sites: false,
 		domains: false,
 		emails: false,
 		themes: false,
@@ -42,12 +49,10 @@ boot( {
 	},
 	optIn: false,
 	components: {
-		// Temporary: reuse generic sites components until A4A-specific ones are built.
-		sites: () => import( '../sites' ),
+		// Temporary: reuse the generic site switcher until it's agency-scoped.
 		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 	queries: {
-		// Temporary: reuse "all sites" filters; these will be tightened to agency sites later.
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
 		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
 			paginatedSitesQuery( 'all', fetchSiteOptions ),

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -20,6 +20,7 @@ export type AgencySupports = {
 	exclusiveOffers: boolean;
 	learn: boolean;
 	mcp: boolean;
+	sites: boolean;
 };
 
 export type AgencyClientSupports = {
@@ -75,7 +76,7 @@ export type AppConfig = {
 	};
 	optIn: boolean;
 	components: {
-		sites: () => Promise< { default: React.FC } >;
+		sites?: () => Promise< { default: React.FC } >;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		siteSwitcher: () => Promise< { default: React.FC< any > } >;
 	};

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -1,7 +1,7 @@
 import { agencyQuery, activeAgencyQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { home, globe, pages, tag } from '@wordpress/icons';
+import { home, globe, layout, pages, tag } from '@wordpress/icons';
 import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sidebar';
 import { useAppContext } from '../context';
 
@@ -9,23 +9,28 @@ export default function AgencySidebar() {
 	const { supports } = useAppContext();
 	const { data: agency } = useSuspenseQuery( agencyQuery() );
 	const { data: activeAgency } = useSuspenseQuery( activeAgencyQuery() );
-	if ( agency.isClientUser ) {
+	if ( agency.isClientUser || ! supports.agency ) {
 		return null;
 	}
 
-	const canAccessMcp = !! ( supports.agency && supports.agency.mcp && activeAgency?.mcp?.allowed );
+	const canAccessMcp = !! ( supports.agency.mcp && activeAgency?.mcp?.allowed );
 
 	return (
 		<>
 			<SidebarMenuItem icon={ home } to="/overview">
 				{ __( 'Home' ) }
 			</SidebarMenuItem>
-			{ supports.agency && supports.agency.tiers && (
+			{ supports.agency.sites && (
+				<SidebarMenuItem icon={ layout } to="/sites">
+					{ __( 'Sites' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.agency.tiers && (
 				<SidebarExpandableMenuItem label={ __( 'Agency' ) } icon={ globe } to="/agency/tiers">
 					<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
-			{ supports.agency && supports.agency.exclusiveOffers && (
+			{ supports.agency.exclusiveOffers && (
 				<SidebarExpandableMenuItem
 					label={ __( 'Marketplace' ) }
 					icon={ tag }
@@ -36,7 +41,7 @@ export default function AgencySidebar() {
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
-			{ supports.agency && ( supports.agency.learn || canAccessMcp ) && (
+			{ ( supports.agency.learn || canAccessMcp ) && (
 				<SidebarExpandableMenuItem label={ __( 'Resources' ) } icon={ pages } to="/resources">
 					{ supports.agency.learn && (
 						<SidebarMenuItem to="/resources/learn">{ __( 'Learn' ) }</SidebarMenuItem>

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -4,6 +4,7 @@ import {
 	agencyResourcesQuery,
 	mcpSettingsQuery,
 	queryClient,
+	rawUserPreferencesQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
@@ -163,6 +164,22 @@ const mcpConnectRoute = createRoute( {
 	)
 );
 
+// `/sites` – agency-managed sites
+export const agencySitesRoute = createRoute( {
+	head: () => ( {
+		meta: [ { title: __( 'Sites' ) } ],
+	} ),
+	getParentRoute: () => agencyRoute,
+	path: 'sites',
+	loader: () => queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+} ).lazy( () =>
+	import( '../../agency/sites' ).then( ( d ) =>
+		createLazyRoute( 'agency-sites' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -170,5 +187,6 @@ export const createAgencyRoutes = () => [
 		exclusiveOffersRoute,
 		learnRoute,
 		mcpRoute.addChildren( [ mcpOverviewRoute, mcpAvailableToolsRoute, mcpConnectRoute ] ),
+		agencySitesRoute,
 	] ),
 ];

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1795,11 +1795,10 @@ export const sitePlansRoute = createRoute( {
 );
 
 export const createSitesRoutes = ( config: AppConfig ) => {
-	if ( ! config.supports.sites || ! config.components.sites ) {
+	const sitesComponent = config.components.sites;
+	if ( ! config.supports.sites || ! sitesComponent ) {
 		return [];
 	}
-
-	const sitesComponent = config.components.sites;
 
 	const siteRoutes: AnyRoute[] = [
 		siteOverviewRoute,

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1795,9 +1795,11 @@ export const sitePlansRoute = createRoute( {
 );
 
 export const createSitesRoutes = ( config: AppConfig ) => {
-	if ( ! config.supports.sites ) {
+	if ( ! config.supports.sites || ! config.components.sites ) {
 		return [];
 	}
+
+	const sitesComponent = config.components.sites;
 
 	const siteRoutes: AnyRoute[] = [
 		siteOverviewRoute,
@@ -1895,7 +1897,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 	return [
 		sitesRoute.lazy( () =>
-			config.components.sites().then( ( d ) =>
+			sitesComponent().then( ( d ) =>
 				createLazyRoute( 'sites' )( {
 					component: d.default,
 				} )

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -35,6 +35,7 @@ export * from './emails';
 export * from './geo';
 export * from './hosting-github';
 export * from './hosting-update-schedules';
+export * from './jetpack-agency-sites';
 export * from './jetpack-user-license';
 export * from './marketplace-products';
 export * from './marketplace-search';

--- a/packages/api-core/src/jetpack-agency-sites/fetchers.ts
+++ b/packages/api-core/src/jetpack-agency-sites/fetchers.ts
@@ -1,0 +1,33 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { FetchAgencySitesOptions, FetchAgencySitesResponse } from './types';
+
+export async function fetchAgencySites(
+	agencyId: number,
+	{
+		search,
+		sort_field = 'url',
+		sort_direction = 'asc',
+		page,
+		per_page,
+	}: FetchAgencySitesOptions = {}
+): Promise< FetchAgencySitesResponse > {
+	const data: FetchAgencySitesResponse = await wpcom.req.get(
+		{
+			path: '/jetpack-agency/sites',
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			agency_id: agencyId,
+			...( search ? { query: search } : {} ),
+			...( page ? { page } : {} ),
+			...( per_page ? { per_page } : {} ),
+			...( sort_field ? { sort_field } : {} ),
+			...( sort_direction ? { sort_direction } : {} ),
+		}
+	);
+
+	return {
+		sites: data.sites ?? [],
+		total: data.total ?? 0,
+	};
+}

--- a/packages/api-core/src/jetpack-agency-sites/index.ts
+++ b/packages/api-core/src/jetpack-agency-sites/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/jetpack-agency-sites/types.ts
+++ b/packages/api-core/src/jetpack-agency-sites/types.ts
@@ -1,0 +1,29 @@
+export interface AgencySite {
+	blog_id: number;
+	url: string;
+	blogname?: string;
+	url_with_scheme?: string;
+	has_backup?: boolean;
+	jetpack_boost_scores?: {
+		overall: number;
+	};
+	site_color?: string;
+	icon?: {
+		img: string;
+		ico: string;
+	};
+}
+
+export interface FetchAgencySitesOptions {
+	search?: string;
+	sort_field?: 'url';
+	sort_direction?: 'asc' | 'desc';
+	page?: number;
+	per_page?: number;
+}
+
+export interface FetchAgencySitesResponse {
+	sites: AgencySite[];
+	total: number;
+	per_page?: number;
+}

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -24,6 +24,7 @@ function applyMcpUpdate( previous: McpSettings, update: McpSettingsUpdate ): Mcp
 }
 
 type AgencyQueryResult = {
+	id?: number;
 	isClientUser: boolean;
 	hasAgency: boolean;
 };
@@ -36,7 +37,7 @@ export const agencyQuery = () =>
 			let agency: AgencyQueryResult;
 
 			if ( Array.isArray( data ) ) {
-				agency = { isClientUser: false, hasAgency: data.length > 0 };
+				agency = { id: data[ 0 ]?.id, isClientUser: false, hasAgency: data.length > 0 };
 			} else {
 				agency = {
 					isClientUser: !! data.is_client_user,

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -30,6 +30,7 @@ export * from './emails';
 export * from './geo';
 export * from './github';
 export * from './hosting-update-schedules';
+export * from './jetpack-agency-sites';
 export * from './jetpack-site-collisions';
 export * from './jetpack-user-license';
 export * from './marketplace-search';

--- a/packages/api-queries/src/jetpack-agency-sites.ts
+++ b/packages/api-queries/src/jetpack-agency-sites.ts
@@ -1,0 +1,27 @@
+import { fetchAgencySites } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+import { agencyQuery } from './agency';
+import { queryClient } from './query-client';
+import type { FetchAgencySitesOptions } from '@automattic/api-core';
+
+export const agencySitesQueryKey = [ 'agency-sites' ];
+
+async function resolveAgencyId(): Promise< number > {
+	const agency = await queryClient.ensureQueryData( agencyQuery() );
+	if ( ! agency.id ) {
+		throw new Error( 'No active agency found for the current user.' );
+	}
+	return agency.id;
+}
+
+export const paginatedAgencySitesQuery = ( options: FetchAgencySitesOptions = {} ) =>
+	queryOptions( {
+		queryKey: [ ...agencySitesQueryKey, 'paginated', options ],
+		queryFn: async () => fetchAgencySites( await resolveAgencyId(), options ),
+	} );
+
+export const agencySitesQuery = ( options: FetchAgencySitesOptions = {} ) =>
+	queryOptions( {
+		queryKey: [ ...agencySitesQueryKey, options ],
+		queryFn: async () => ( await fetchAgencySites( await resolveAgencyId(), options ) ).sites,
+	} );


### PR DESCRIPTION
Part of A4A-2743

Resolves A4A-2760

> **Foundation PR.** This establishes the A4A Sites experience as a *separate, standalone* dashboard surface and the data layer behind it. It is intentionally read-only for now; richer columns, filters, and actions build on top of this.

<img width="1894" height="510" alt="Screenshot 2026-06-15 at 11 12 06 AM" src="https://github.com/user-attachments/assets/cbe00212-c439-4c91-8c25-b07ba926272b" />

## Proposed Changes

* **Dedicated A4A Sites route + screen.** A4A gets its own `/sites` route, registered as a child of the agency layout route (`client/dashboard/app/router/agency.tsx`) so it inherits the guard that blocks client users. It renders a self-contained screen under `client/dashboard/agency/sites/`, loading only the active agency's managed sites from `GET /wpcom/v2/jetpack-agency/sites` — it does not pull in the signed-in user's `/me/sites` or merge multiple agencies.
* **No shared-sites coupling.** Rather than reusing the dotcom/CIAB sites route and its `components.sites()` / `queries.sitesQuery()` config abstraction, A4A renders its **own** DataViews over its own `AgencySite` type. The shared `router/sites.tsx`, `SitesDataViews`, and the dotcom/CIAB screens are left untouched — the only shared change is making `components.sites` optional so agency variants can omit it.
* **Raw data layer.** The new `agency-sites` api-core module returns the endpoint response in its raw shape (no adaptation layer); the api-queries layer is a thin passthrough. The screen reads the raw fields directly and derives the wp-admin URL and display name/URL in small helpers, since the endpoint doesn't return them.
* **Columns & actions:** site icon, **Site** (name, linking to wp-admin), sortable **URL**, **Boost** (Jetpack Boost A–F rating, or “Add”), **Backup** (enabled check, or “Add”), plus **Visit site** / **WP Admin** row actions and working search.
* **Navigation.** A4A's **Sites** item lives in the agency sidebar behind a new `supports.agency.sites` flag; `supports.sites` is off for A4A.

## Why are these changes being made?

* A4A is a *separate experience*, not a dotcom-style consolidated dashboard. Agencies manage a distinct set of Jetpack-connected client sites scoped to the active agency, and that data diverges from dotcom in every dimension — a different endpoint, a different type, different columns, actions, and loaders. The shared `components.sites()` / `queries.sitesQuery()` abstraction exists so variants can share and invalidate the *same* sites query; it breaks down here because A4A reuses none of it. So rather than contorting the shared route and components to fit (which only adds confusing abstraction), A4A gets a dedicated route and renders its own DataViews, leaving the shared sites code unchanged.
* Keeping the data layer raw (no mapping in api-core/api-queries) keeps the fetcher a thin passthrough and lets the consumer derive exactly what it needs.

## Testing Instructions

* Check out this branch and start the Dashboard client (`yarn start-dashboard`) or open the Dashboard Live (A4A) > Replace the `/sites` with `/overview` 
* As an agency user, open the Sites screen and confirm it lists the agency-managed sites with **Site** (icon + name), **URL**, **Boost**, and **Backup** columns.
* Confirm sorting the **URL** column, searching by name/URL, and the **Visit site** / **WP Admin** row actions all work.
* Confirm the dotcom Dashboard Sites screen and the CIAB Sites screen are unchanged.
* Check for TypeScript / React console errors.

### Follow-ups (not in this PR)

* **Site switcher** still uses the shared sites query, so for A4A it reflects `/me/sites` rather than agency sites — it needs the same agency-scoped treatment.
* The site-name link is a temporary raw link to wp-admin (marked with a `TODO`), pending a proper agency site-detail experience.
* Custom filters and interactive column actions (Boost/Backup setup) are future work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
