### PR TITLE
Dashboard: only add A4A signup routing when on dashboard or a4a dev env

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1201,14 +1201,6 @@ export default function pages() {
 	 * SSR middleware if the request wasn't going to be resolved with SSR anyways.
 	 */
 	function handleSectionPath( section, sectionPath, entrypoint, reqFilter, extraMiddleware ) {
-		// Some callers resolve a section via `sections.find( … )`, which returns
-		// undefined when that section is disabled for the current env and thus
-		// stripped from the (development) server bundle — e.g. `a8c-for-agencies-signup`,
-		// disabled in config/_shared.json, is absent under a plain `yarn start`.
-		// Skip registration in that case instead of crashing on boot.
-		if ( ! section ) {
-			return;
-		}
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get(
@@ -1246,14 +1238,6 @@ export default function pages() {
 		handleSectionPath( STEPPER_SECTION_DEFINITION, '/setup', 'entry-stepper', ( req ) =>
 			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
 		);
-		const a4aSignupSectionDefinition = sections.find(
-			( s ) => s.name === 'a8c-for-agencies-signup'
-		);
-		A4A_SIGNUP_PATHS.forEach( ( a4aSignupPath ) => {
-			handleSectionPath( a4aSignupSectionDefinition, a4aSignupPath, undefined, ( req ) =>
-				isAllowedA4ADashboardHostname( req.hostname )
-			);
-		} );
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
 			handleSectionPath(
 				DOTCOM_DASHBOARD_SECTION_DEFINITION,
@@ -1279,6 +1263,18 @@ export default function pages() {
 			( req ) => isAllowedCiabDashboardHostname( req.hostname ),
 			loadDashboardLocaleData
 		);
+	}
+
+	// Multi-site Dashboard (A4A) routing.
+	if ( isDashboardEnv() || calypsoEnv === 'a8c-for-agencies-development' ) {
+		const a4aSignupSectionDefinition = sections.find(
+			( s ) => s.name === 'a8c-for-agencies-signup'
+		);
+		A4A_SIGNUP_PATHS.forEach( ( a4aSignupPath ) => {
+			handleSectionPath( a4aSignupSectionDefinition, a4aSignupPath, undefined, ( req ) =>
+				isAllowedA4ADashboardHostname( req.hostname )
+			);
+		} );
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
 			handleSectionPath( A4A_DASHBOARD_SECTION_DEFINITION, route, 'entry-dashboard-a4a', ( req ) =>
 				isAllowedA4ADashboardHostname( req.hostname )


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/109357#discussion_r3396573568
Alternative to https://github.com/Automattic/wp-calypso/pull/111565

## Proposed Changes

Fixes crash during `yarn start` because the `a8c-for-agencies-signup` section is not defined for `development` env.

We fix this by adding that section only on the correct A4A dev env `a8c-for-agencies-development`.

This is because `yarn start` is assumed to run only Calypso and Dotcom MSD for development. For A4A development, we have `a8c-for-agencies-development`.

The alternative is to add `a8c-for-agencies-signup` to the `development` env. But I'm not sure if that's correct? Do we want to host the signup on `wordpress.com`?

## Testing Instructions

Ensure all the following runs correctly:

- `yarn start`
- `yarn start-dashboard`
- `yarn start-a8c-for-agencies`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
