### PR TITLE
A4A: Add agencies-beta.automattic.com to dashboard configs

### DIFF
--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
-	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai", "agencies-beta.automattic.com" ],
 	"hostname_overrides": {
 		"my.woo.ai": {
 			"oauth_client_id": 134405,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -5,12 +5,17 @@
 	"client_slug": "browser",
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
-	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai", "agencies-beta.automattic.com" ],
 	"hostname_overrides": {
 		"my.woo.ai": {
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"features": { "oauth": true, "wpcom-user-bootstrap": false }
+		},
+		"agencies-beta.automattic.com": {
+			"oauth_client_id": 95932,
+			"wpcom_login_url": false,
+			"features": { "oauth": true, "always_use_logout_url": true, "wpcom-user-bootstrap": false }
 		}
 	},
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -5,12 +5,17 @@
 	"client_slug": "browser",
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
-	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai", "agencies-beta.automattic.com" ],
 	"hostname_overrides": {
 		"my.woo.ai": {
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"features": { "oauth": true, "wpcom-user-bootstrap": false }
+		},
+		"agencies-beta.automattic.com": {
+			"oauth_client_id": 95931,
+			"wpcom_login_url": false,
+			"features": { "oauth": true, "always_use_logout_url": true, "wpcom-user-bootstrap": false }
 		}
 	},
 	"i18n_default_locale_slug": "en",


### PR DESCRIPTION
Resolves A4A-2765

## Proposed changes

Registers the canonical A4A Multi-site Dashboard host `agencies-beta.automattic.com` across the dashboard configs, mirroring how `my.woo.ai` (CIAB) is wired.

- **production / stage**: added to `hostname_allowlist` + a `hostname_overrides` entry (`oauth: true`, `always_use_logout_url: true`, `wpcom-user-bootstrap: false`).
- **horizon**: added to `hostname_allowlist` only — **no override/client**. Horizon never initiates login for A4A (cf. `a8c-for-agencies-horizon.json`, which sets no client); users authenticate on production and the proxied horizon build at the same origin reuses that session.

OAuth client per-env (matching the A4A app, not Woo's single-client model):

| Config | `oauth_client_id` |
|---|---|
| `dashboard-production.json` | `95932` (A4A production) |
| `dashboard-stage.json` | `95931` (A4A staging) |
| `dashboard-development.json` | `95928` (A4A dev — from #109357) |
| `dashboard-horizon.json` | none (recognize-only) |

## Why are these changes being made?

Follow-up to #109357. The prod/stage dashboard envs must recognize the new A4A host and authenticate it via the A4A OAuth flow — the same way the existing A4A app does today. A companion wpcom backend PR adds the trusted-origin allowlists; the subdomain (DNS/TLS/edge routing) is requested separately from Systems.

`agencies-beta.automattic.com` is a temporary host for testing and gathering feedback; `agencies.automattic.com` is intended to be routed to the dashboard Calypso instances later.

## Testing instructions

- Config-only change; `JSON.parse` validates and Prettier passed via pre-commit.
- Confirm the host appears in `hostname_allowlist` across prod/stage/horizon, and in `hostname_overrides` for prod (`95932`) and stage (`95931`).
- Note: the host must be registered as an allowed redirect URI on OAuth clients `95932` (prod) and `95931` (stage) — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
