### PR TITLE
client/components: migrate snapshot tests off react-test-renderer for React 19

### DIFF
--- a/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
@@ -2,13 +2,13 @@
 
 exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
 <div
-  className="gsuite-features__list"
+  class="gsuite-features__list"
 >
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Gmail Logo"
@@ -16,10 +16,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         A custom @testing123.com email address
       </h5>
@@ -29,10 +29,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Docs Logo"
@@ -40,10 +40,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Docs, spreadsheets and more
       </h5>
@@ -53,10 +53,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Drive Logo"
@@ -64,10 +64,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Keep all your files secure
       </h5>
@@ -77,10 +77,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Meet Logo"
@@ -88,10 +88,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Connect with your team
       </h5>
@@ -105,13 +105,13 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
 
 exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
 <div
-  className="gsuite-features__grid"
+  class="gsuite-features__grid"
 >
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Gmail Logo"
@@ -119,10 +119,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         A custom @testing123.com email address
       </h5>
@@ -132,10 +132,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Docs Logo"
@@ -143,10 +143,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Docs, spreadsheets and more
       </h5>
@@ -156,10 +156,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Drive Logo"
@@ -167,10 +167,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Keep all your files secure
       </h5>
@@ -180,10 +180,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Meet Logo"
@@ -191,10 +191,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Connect with your team
       </h5>
@@ -208,13 +208,13 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
 
 exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
 <div
-  className="gsuite-features__grid"
+  class="gsuite-features__grid"
 >
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Gmail Logo"
@@ -222,10 +222,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         A custom @testing123.com email address
       </h5>
@@ -235,10 +235,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Docs Logo"
@@ -246,10 +246,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Docs, spreadsheets and more
       </h5>
@@ -259,10 +259,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Drive Logo"
@@ -270,10 +270,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Keep all your files secure
       </h5>
@@ -283,10 +283,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Meet Logo"
@@ -294,10 +294,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Connect with your team
       </h5>
@@ -311,13 +311,13 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
 
 exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
 <div
-  className="gsuite-features__grid"
+  class="gsuite-features__grid"
 >
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Gmail Logo"
@@ -325,10 +325,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         A custom @testing123.com email address
       </h5>
@@ -338,10 +338,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Docs Logo"
@@ -349,10 +349,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Docs, spreadsheets and more
       </h5>
@@ -362,10 +362,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Drive Logo"
@@ -373,10 +373,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Keep all your files secure
       </h5>
@@ -386,10 +386,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
     </div>
   </div>
   <div
-    className="gsuite-features__feature"
+    class="gsuite-features__feature"
   >
     <div
-      className="gsuite-features__feature-image"
+      class="gsuite-features__feature-image"
     >
       <img
         alt="Google Meet Logo"
@@ -397,10 +397,10 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
       />
     </div>
     <div
-      className="gsuite-features__feature-block"
+      class="gsuite-features__feature-block"
     >
       <h5
-        className="gsuite-features__feature-header"
+        class="gsuite-features__feature-header"
       >
         Connect with your team
       </h5>

--- a/client/components/gsuite/gsuite-features/test/__snapshots__/single-feature.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/single-feature.js.snap
@@ -2,10 +2,10 @@
 
 exports[`GSuiteSingleFeature it renders GSuiteSingleFeature 1`] = `
 <div
-  className="gsuite-features__feature"
+  class="gsuite-features__feature"
 >
   <div
-    className="gsuite-features__feature-image"
+    class="gsuite-features__feature-image"
   >
     <img
       alt="image alt"
@@ -13,10 +13,10 @@ exports[`GSuiteSingleFeature it renders GSuiteSingleFeature 1`] = `
     />
   </div>
   <div
-    className="gsuite-features__feature-block"
+    class="gsuite-features__feature-block"
   >
     <h5
-      className="gsuite-features__feature-header"
+      class="gsuite-features__feature-header"
     >
       title
     </h5>

--- a/client/components/gsuite/gsuite-features/test/index.js
+++ b/client/components/gsuite/gsuite-features/test/index.js
@@ -1,37 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
 import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from '@automattic/calypso-products';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import GSuiteFeatures from '../';
 
 describe( 'GSuiteFeatures', () => {
 	test( 'it renders GSuiteFeatures with basic plan', () => {
-		const tree = renderer
-			.create( <GSuiteFeatures domainName="testing123.com" productSlug={ GSUITE_BASIC_SLUG } /> )
-			.toJSON();
+		const { container } = render(
+			<GSuiteFeatures domainName="testing123.com" productSlug={ GSUITE_BASIC_SLUG } />
+		);
 
-		expect( tree ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteFeatures with business plan', () => {
-		const tree = renderer
-			.create( <GSuiteFeatures domainName="testing123.com" productSlug={ GSUITE_BUSINESS_SLUG } /> )
-			.toJSON();
+		const { container } = render(
+			<GSuiteFeatures domainName="testing123.com" productSlug={ GSUITE_BUSINESS_SLUG } />
+		);
 
-		expect( tree ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteFeatures without a productSlug', () => {
-		const tree = renderer.create( <GSuiteFeatures domainName="testing123.com" /> ).toJSON();
+		const { container } = render( <GSuiteFeatures domainName="testing123.com" /> );
 
-		expect( tree ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteFeatures in a list', () => {
-		const tree = renderer
-			.create(
-				<GSuiteFeatures domainName="testing123.com" productSlug={ GSUITE_BASIC_SLUG } type="list" />
-			)
-			.toJSON();
+		const { container } = render(
+			<GSuiteFeatures domainName="testing123.com" productSlug={ GSUITE_BASIC_SLUG } type="list" />
+		);
 
-		expect( tree ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/gsuite/gsuite-features/test/single-feature.js
+++ b/client/components/gsuite/gsuite-features/test/single-feature.js
@@ -1,19 +1,21 @@
-import renderer from 'react-test-renderer';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import GSuiteSingleFeature from '../single-feature';
 
 describe( 'GSuiteSingleFeature', () => {
 	test( 'it renders GSuiteSingleFeature', () => {
-		const tree = renderer
-			.create(
-				<GSuiteSingleFeature
-					title="title"
-					description="description"
-					imagePath="/test/image/path.svg"
-					imageAlt="image alt"
-					compact={ false }
-				/>
-			)
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const { container } = render(
+			<GSuiteSingleFeature
+				title="title"
+				description="description"
+				imagePath="/test/image/path.svg"
+				imageAlt="image alt"
+				compact={ false }
+			/>
+		);
+
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`GSuiteLearnMore it renders GSuiteLearnMore with no props 1`] = `
 <div
-  className="gsuite-learn-more"
+  class="gsuite-learn-more"
 >
   <p>
     <strong>
@@ -10,9 +10,8 @@ exports[`GSuiteLearnMore it renders GSuiteLearnMore with no props 1`] = `
     </strong>
      
     <a
-      className="gsuite-learn-more__link"
+      class="gsuite-learn-more__link"
       href="https://wordpress.com/support/add-email/adding-google-workspace-to-your-site/"
-      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/components/gsuite/gsuite-learn-more/test/index.js
+++ b/client/components/gsuite/gsuite-learn-more/test/index.js
@@ -1,9 +1,13 @@
-import renderer from 'react-test-renderer';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import GSuiteLearnMore from '../';
 
 describe( 'GSuiteLearnMore', () => {
 	test( 'it renders GSuiteLearnMore with no props', () => {
-		const tree = renderer.create( <GSuiteLearnMore /> ).toJSON();
-		expect( tree ).toMatchSnapshot();
+		const { container } = render( <GSuiteLearnMore /> );
+
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
@@ -2,10 +2,10 @@
 
 exports[`GSuitePrice renders correctly 1`] = `
 <div
-  className="gsuite-price"
+  class="gsuite-price"
 >
   <h4
-    className="gsuite-price__monthly-price"
+    class="gsuite-price__monthly-price"
   >
     <strong>
       €6.40
@@ -13,7 +13,7 @@ exports[`GSuitePrice renders correctly 1`] = `
      /user /month
   </h4>
   <h5
-    className="gsuite-price__annual-price"
+    class="gsuite-price__annual-price"
   >
     €76 billed annually
   </h5>

--- a/client/components/gsuite/gsuite-price/test/index.js
+++ b/client/components/gsuite/gsuite-price/test/index.js
@@ -1,4 +1,7 @@
-import renderer from 'react-test-renderer';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import GSuitePrice from '../';
 
 describe( 'GSuitePrice', () => {
@@ -15,8 +18,8 @@ describe( 'GSuitePrice', () => {
 	};
 
 	test( 'renders correctly', () => {
-		const tree = renderer.create( <GSuitePrice product={ product } currencyCode="EUR" /> ).toJSON();
+		const { container } = render( <GSuitePrice product={ product } currencyCode="EUR" /> );
 
-		expect( tree ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
+++ b/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
@@ -2,86 +2,73 @@
 
 exports[`MultipleChoiceQuestion should render with the minimum required properties ( plus extra prop to guarantee order ) 1`] = `
 <fieldset
-  className="multiple-choice-question form-fieldset"
-  onClick={[Function]}
+  class="multiple-choice-question form-fieldset"
   role="group"
 >
   <legend
-    className="form-legend"
+    class="form-legend"
   >
     Test Question One
   </legend>
   <div
-    className="multiple-choice-question__answers"
+    class="multiple-choice-question__answers"
   >
     <label
-      className="form-label"
+      class="form-label"
     >
       <input
-        checked={false}
-        className="form-radio"
-        disabled={false}
+        class="form-radio"
         name="test-question"
-        onChange={[Function]}
         type="radio"
         value="test-answer-1"
       />
       <span
-        className="form-radio__label"
+        class="form-radio__label"
       >
         Test Answer One
       </span>
     </label>
     <label
-      className="form-label"
+      class="form-label"
     >
       <input
-        checked={false}
-        className="form-radio"
-        disabled={false}
+        class="form-radio"
         name="test-question"
-        onChange={[Function]}
         type="radio"
         value="test-answer-2"
       />
       <span
-        className="form-radio__label"
+        class="form-radio__label"
       >
         Test Answer Two
       </span>
     </label>
     <label
-      className="form-label"
+      class="form-label"
     >
       <input
-        checked={false}
-        className="form-radio"
-        disabled={false}
+        class="form-radio"
         name="test-question"
-        onChange={[Function]}
         type="radio"
         value="test-answer-3"
       />
       <span
-        className="form-radio__label"
+        class="form-radio__label"
       >
         Test Answer Three
       </span>
     </label>
     <label
-      className="form-label"
+      class="form-label"
     >
       <input
-        checked={false}
-        className="form-radio"
-        disabled={false}
+        class="form-radio"
         name="test-question"
-        onChange={[Function]}
         type="radio"
         value="test-answer-4"
       />
       <span
-        className="form-radio__label"
+        class="form-radio__label"
       >
         Test Answer Four
       </span>

--- a/client/components/multiple-choice-question/test/index.js
+++ b/client/components/multiple-choice-question/test/index.js
@@ -1,25 +1,27 @@
-import renderer from 'react-test-renderer';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import MultipleChoiceQuestion from '../';
 
 const noop = () => {};
 
 describe( 'MultipleChoiceQuestion', () => {
 	test( 'should render with the minimum required properties ( plus extra prop to guarantee order )', () => {
-		const tree = renderer
-			.create(
-				<MultipleChoiceQuestion
-					name="test-question"
-					question="Test Question One"
-					answers={ [
-						{ id: 'test-answer-1', answerText: 'Test Answer One', doNotShuffle: true },
-						{ id: 'test-answer-2', answerText: 'Test Answer Two', doNotShuffle: true },
-						{ id: 'test-answer-3', answerText: 'Test Answer Three', doNotShuffle: true },
-						{ id: 'test-answer-4', answerText: 'Test Answer Four', doNotShuffle: true },
-					] }
-					onAnswerChange={ noop }
-				/>
-			)
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const { container } = render(
+			<MultipleChoiceQuestion
+				name="test-question"
+				question="Test Question One"
+				answers={ [
+					{ id: 'test-answer-1', answerText: 'Test Answer One', doNotShuffle: true },
+					{ id: 'test-answer-2', answerText: 'Test Answer Two', doNotShuffle: true },
+					{ id: 'test-answer-3', answerText: 'Test Answer Three', doNotShuffle: true },
+					{ id: 'test-answer-4', answerText: 'Test Answer Four', doNotShuffle: true },
+				] }
+				onAnswerChange={ noop }
+			/>
+		);
+
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/sticky-panel/test/index.js
+++ b/client/components/sticky-panel/test/index.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import ReactDom from 'react-dom';
 import { calculateOffset, getBlockStyle, getDimensions, getDimensionUpdates } from '..';
 
 beforeAll( () => {
@@ -12,7 +11,6 @@ beforeAll( () => {
 	jest
 		.spyOn( document, 'getElementById' )
 		.mockImplementation( ( id ) => ( id === 'header' ? header : null ) );
-	jest.spyOn( ReactDom, 'findDOMNode' ).mockImplementation( ( node ) => node );
 	jest.spyOn( window, 'getComputedStyle' ).mockImplementation( () => ( { position: 'fixed' } ) );
 } );
 


### PR DESCRIPTION
## Proposed Changes

Continues the React 19 forward-compatibility audit of `client/components` (follow-up to #111556, #111566, #111597). Migrates the remaining snapshot tests off `react-test-renderer`, which is deprecated in React 19, onto `@testing-library/react`:

* `gsuite/gsuite-price`, `gsuite/gsuite-learn-more`, `gsuite/gsuite-features` (+ `single-feature`), `multiple-choice-question` — `renderer.create( … ).toJSON()` → `render( … )` snapshotting `container.firstChild` (matching existing tests such as `date-range`, which drops the redundant wrapper `<div>`).
* `sticky-panel` test — removes a stale `jest.spyOn( ReactDom, 'findDOMNode' )` mock and its `import`. The component was already refactored to refs and the tested helpers never call `findDOMNode`, so the spy is dead and would throw once `findDOMNode` is gone in React 19.

The snapshot migration is 1:1 — the components render standalone with no providers, so the rendered output is unchanged. Snapshots were regenerated and eyeballed to confirm they capture the expected output (price strings, feature blocks, the question and its answers) rather than empty/error output.

## Why are these changes being made?

`react-test-renderer` is deprecated in React 19 (and slated for removal), and the `findDOMNode` mock targets an API React 19 removes outright. This clears the last `react-test-renderer` / `findDOMNode` references from `client/components` test code so the suite stays clean through the upgrade.

## Testing Instructions

* `yarn test-client client/components/{gsuite,multiple-choice-question,sticky-panel}/**/test` — 15 tests / 8 snapshots pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
