### PR TITLE
MSD: percentage-based forced rollout behind dashboard/enable-percentage-rollout

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -42,6 +42,7 @@ import {
 	isSiteAction,
 	type SiteAction,
 } from '../../me/billing-purchases/site-level-actions/constants';
+import { isOptInToggleVisible } from '../../utils/hosting-dashboard-enrollment';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { reauthRequiredLink } from '../../utils/link';
 import {
@@ -53,10 +54,11 @@ import {
 	CANCEL_FLOW_TYPE,
 	type CancelIntent,
 } from '../../utils/purchase';
+import { AUTH_QUERY_KEY } from '../auth';
 import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
-import type { Purchase } from '@automattic/api-core';
+import type { Purchase, User } from '@automattic/api-core';
 import type { AnyRoute } from '@tanstack/react-router';
 
 export const meRoute = createRoute( {
@@ -991,6 +993,13 @@ export const hostingDashboardRoute = createRoute( {
 	} ),
 	getParentRoute: () => preferencesRoute,
 	path: 'hosting-dashboard',
+	beforeLoad: async () => {
+		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+		const preferences = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+		if ( ! isOptInToggleVisible( preferences[ 'hosting-dashboard-opt-in' ], user?.ID ) ) {
+			throw dashboardRedirect( { to: '/me/preferences', replace: true } );
+		}
+	},
 	loader: async () => {
 		await Promise.all( [
 			queryClient.ensureQueryData( userSettingsQuery() ),

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { createRootRouteWithContext } from '@tanstack/react-router';
+import { getHostingDashboardEnrollment } from '../../utils/hosting-dashboard-enrollment';
 import { wpcomLink } from '../../utils/link';
 import { AUTH_QUERY_KEY } from '../auth';
 import Root from '../root';
@@ -51,6 +52,14 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 			return;
 		}
 
+		// Once the staged rollout has begun the dashboard is publicly marketed, so
+		// anyone who navigates to it directly is let in. Enrollment still governs
+		// where users land by default (see the dashboard opt-in selectors); it no
+		// longer blocks users who navigate directly to the dashboard.
+		if ( config.isEnabled( 'dashboard/enable-percentage-rollout' ) ) {
+			return;
+		}
+
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 		if ( user && user.ID <= OLDEST_ELIGIBLE_USER ) {
 			return;
@@ -58,11 +67,7 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 
 		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 		const optIn = userPreference[ 'hosting-dashboard-opt-in' ];
-		const isDashboardEnrolled =
-			optIn?.value === 'opt-in' ||
-			optIn?.value === 'forced-opt-in' ||
-			config.isEnabled( 'dashboard/forced-opt-in' );
-		if ( isDashboardEnrolled ) {
+		if ( getHostingDashboardEnrollment( optIn, user?.ID ).enrolled ) {
 			return;
 		}
 

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -1,22 +1,19 @@
 import { userPreferenceQuery } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { grid } from '@wordpress/icons';
 import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { isOptInToggleVisible } from '../../utils/hosting-dashboard-enrollment';
 import type { Density } from '@automattic/components/src/summary-button/types';
-
-const OLDEST_ELIGIBLE_USER: number = config( 'dashboard_opt_in_oldest_eligible_user' );
 
 export default function PreferencesNewHostingDashboard( { density }: { density?: Density } ) {
 	const { user } = useAuth();
 	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
 	const isOptedIn = optIn.value === 'opt-in';
 
-	// Only users created before 22 December 2025 can manually opt in or out.
-	if ( user.ID > OLDEST_ELIGIBLE_USER ) {
+	if ( ! isOptInToggleVisible( optIn, user.ID ) ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/welcome-modal/opt-in-welcome-modal.tsx
+++ b/client/dashboard/sites/welcome-modal/opt-in-welcome-modal.tsx
@@ -15,13 +15,16 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
+import { useAuth } from '../../app/auth';
 import ComponentViewTracker from '../../components/component-view-tracker';
+import { getHostingDashboardEnrollment } from '../../utils/hosting-dashboard-enrollment';
 import illustrationUrl from './opt-in-welcome-modal-illustration.webp';
 import './opt-in-welcome-modal.scss';
 
 const preferenceName = 'hosting-dashboard-opt-in-welcome-modal-dismissed' as const;
 
 export default function OptInWelcomeModal() {
+	const { user } = useAuth();
 	const { recordTracksEvent } = useAnalytics();
 	const hasEnTranslation = useHasEnTranslation();
 	const isLargeViewport = useViewportMatch( 'small', '>=' );
@@ -40,7 +43,9 @@ export default function OptInWelcomeModal() {
 		updateDismissed( new Date().toISOString() );
 	};
 
-	if ( dashboardOptIn?.value === 'forced-opt-in' ) {
+	// Users who didn't choose the dashboard themselves shouldn't get the opt-in pitch.
+	const dashboardEnrollment = getHostingDashboardEnrollment( dashboardOptIn, user.ID );
+	if ( dashboardEnrollment.enrolled && dashboardEnrollment.reason === 'forced' ) {
 		return null;
 	}
 

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -1,0 +1,65 @@
+import config from '@automattic/calypso-config';
+import type { HostingDashboardOptIn } from '@automattic/api-core';
+
+/**
+ * Whether the user belongs to the percentage-rollout cohort. Membership is
+ * derived from the user ID so it is stable across sessions and reproducible
+ * in analytics queries; nothing is ever persisted.
+ */
+function isInRolloutCohort( userId: number | undefined ): boolean {
+	return (
+		config.isEnabled( 'dashboard/enable-percentage-rollout' ) &&
+		userId !== undefined &&
+		userId % 100 < 50
+	);
+}
+
+type HostingDashboardEnrollment =
+	| { enrolled: true; reason: 'opt-in' | 'forced' }
+	| { enrolled: false };
+
+/**
+ * Is a user's default experience is the hosting dashboard, and why.
+ */
+export function getHostingDashboardEnrollment(
+	preference: HostingDashboardOptIn | undefined,
+	userId: number | undefined
+): HostingDashboardEnrollment {
+	// Support provided escape hatch, wins over everything.
+	if ( preference?.value === 'forced-opt-out' ) {
+		return { enrolled: false };
+	}
+
+	if ( preference?.value === 'opt-in' ) {
+		return { enrolled: true, reason: 'opt-in' };
+	}
+
+	if ( preference?.value === 'forced-opt-in' || isInRolloutCohort( userId ) ) {
+		return { enrolled: true, reason: 'forced' };
+	}
+
+	return { enrolled: false };
+}
+
+/**
+ * Whether the user-facing opt-in toggle should be shown. Hidden for the
+ * rollout cohort (the choice no longer exists) and for escape-hatched
+ * users (their enrollment changes only via support tooling).
+ */
+export function isOptInToggleVisible(
+	preference: HostingDashboardOptIn | undefined,
+	userId: number | undefined
+): boolean {
+	// Useful for allowing internal testing for proxied a12s.
+	if ( config.isEnabled( 'dashboard/force-opt-in-visibility' ) ) {
+		return true;
+	}
+
+	if ( isInRolloutCohort( userId ) || preference?.value === 'forced-opt-out' ) {
+		return false;
+	}
+
+	// Only users created before 22 December 2025 can manually opt in or out.
+	const oldestEligibleUser: number = config( 'dashboard_opt_in_oldest_eligible_user' );
+	return userId !== undefined && userId <= oldestEligibleUser;
+}

--- a/client/dashboard/utils/test/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/test/hosting-dashboard-enrollment.ts
@@ -1,0 +1,128 @@
+import config from '@automattic/calypso-config';
+import {
+	getHostingDashboardEnrollment,
+	isOptInToggleVisible,
+} from '../hosting-dashboard-enrollment';
+import type { HostingDashboardOptIn } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = jest.fn();
+	return Object.assign( mock, { isEnabled: jest.fn() } );
+} );
+
+const mockedConfig = jest.mocked( config );
+const mockedIsEnabled = jest.mocked( config.isEnabled );
+
+const CUTOFF_USER_ID = 275231967;
+const PRE_CUTOFF_IN_COHORT = 100; // % 100 === 0, below the cutoff
+// The out-of-cohort fixtures assume the current 50% rollout (last two digits
+// >= 50). At 100% no user is outside the cohort, so the cases using these no
+// longer apply.
+const PRE_CUTOFF_OUT_OF_COHORT = 99; // % 100 === 99, below the cutoff
+const POST_CUTOFF_OUT_OF_COHORT = ( Math.floor( CUTOFF_USER_ID / 100 ) + 1 ) * 100 + 99; // % 100 === 99, above the cutoff
+
+const preference = ( value: HostingDashboardOptIn[ 'value' ] ): HostingDashboardOptIn => ( {
+	value,
+	updated_at: '2026-06-01T00:00:00.000Z',
+} );
+
+const enableFlags = ( ...flags: string[] ) => {
+	mockedIsEnabled.mockImplementation( ( flag: string ) => flags.includes( flag ) );
+};
+
+beforeEach( () => {
+	mockedConfig.mockImplementation( ( key: string ) =>
+		key === 'dashboard_opt_in_oldest_eligible_user' ? CUTOFF_USER_ID : undefined
+	);
+	mockedIsEnabled.mockReturnValue( false );
+} );
+
+describe( 'getHostingDashboardEnrollment', () => {
+	it( 'leaves cohort-range users unenrolled while the rollout flag is off', () => {
+		expect( getHostingDashboardEnrollment( undefined, PRE_CUTOFF_IN_COHORT ) ).toEqual( {
+			enrolled: false,
+		} );
+	} );
+
+	describe( 'with the rollout flag on', () => {
+		beforeEach( () => enableFlags( 'dashboard/enable-percentage-rollout' ) );
+
+		it( 'the escape hatch (forced-opt-out) wins over cohort membership', () => {
+			expect(
+				getHostingDashboardEnrollment( preference( 'forced-opt-out' ), PRE_CUTOFF_IN_COHORT )
+			).toEqual( { enrolled: false } );
+		} );
+
+		it( 'keeps opted-in users enrolled even when outside the cohort', () => {
+			expect(
+				getHostingDashboardEnrollment( preference( 'opt-in' ), PRE_CUTOFF_OUT_OF_COHORT )
+			).toEqual( { enrolled: true, reason: 'opt-in' } );
+		} );
+
+		it( 'the cohort overrides an explicit opt-out', () => {
+			expect(
+				getHostingDashboardEnrollment( preference( 'opt-out' ), PRE_CUTOFF_IN_COHORT )
+			).toEqual( { enrolled: true, reason: 'forced' } );
+		} );
+
+		it( 'enrolls cohort members who have no preference', () => {
+			expect( getHostingDashboardEnrollment( undefined, PRE_CUTOFF_IN_COHORT ) ).toEqual( {
+				enrolled: true,
+				reason: 'forced',
+			} );
+		} );
+
+		it( 'leaves non-cohort users who never opted in unenrolled', () => {
+			expect(
+				getHostingDashboardEnrollment( preference( 'opt-out' ), PRE_CUTOFF_OUT_OF_COHORT )
+			).toEqual( { enrolled: false } );
+		} );
+	} );
+} );
+
+describe( 'isOptInToggleVisible', () => {
+	it( 'shows the toggle to pre-cutoff users', () => {
+		expect( isOptInToggleVisible( preference( 'opt-out' ), PRE_CUTOFF_OUT_OF_COHORT ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'hides the toggle from post-cutoff users', () => {
+		expect( isOptInToggleVisible( undefined, POST_CUTOFF_OUT_OF_COHORT ) ).toBe( false );
+	} );
+
+	it( 'hides the toggle from escape-hatched users even while the rollout flag is off', () => {
+		expect( isOptInToggleVisible( preference( 'forced-opt-out' ), PRE_CUTOFF_OUT_OF_COHORT ) ).toBe(
+			false
+		);
+	} );
+
+	describe( 'with the rollout flag on', () => {
+		beforeEach( () => enableFlags( 'dashboard/enable-percentage-rollout' ) );
+
+		it( 'hides the toggle from cohort members', () => {
+			expect( isOptInToggleVisible( preference( 'opt-in' ), PRE_CUTOFF_IN_COHORT ) ).toBe( false );
+		} );
+
+		it( 'still shows the toggle to non-cohort users', () => {
+			expect( isOptInToggleVisible( preference( 'opt-out' ), PRE_CUTOFF_OUT_OF_COHORT ) ).toBe(
+				true
+			);
+		} );
+	} );
+
+	describe( 'with force-opt-in-visibility on', () => {
+		it( 'shows the toggle to post-cutoff users who would otherwise not see it', () => {
+			enableFlags( 'dashboard/force-opt-in-visibility' );
+			expect( isOptInToggleVisible( undefined, POST_CUTOFF_OUT_OF_COHORT ) ).toBe( true );
+		} );
+
+		it( 'overrides the cohort and the escape hatch', () => {
+			enableFlags( 'dashboard/force-opt-in-visibility', 'dashboard/enable-percentage-rollout' );
+			expect( isOptInToggleVisible( undefined, PRE_CUTOFF_IN_COHORT ) ).toBe( true );
+			expect(
+				isOptInToggleVisible( preference( 'forced-opt-out' ), PRE_CUTOFF_OUT_OF_COHORT )
+			).toBe( true );
+		} );
+	} );
+} );

--- a/client/state/dashboard/selectors/has-dashboard-forced-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-forced-opt-in.ts
@@ -1,4 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
+import { getHostingDashboardEnrollment } from 'calypso/dashboard/utils/hosting-dashboard-enrollment';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
@@ -7,6 +8,8 @@ export const hasDashboardForcedOptIn = ( state: AppState ): boolean => {
 	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
 		| HostingDashboardOptIn
 		| undefined;
+	const userId = getCurrentUserId( state ) ?? undefined;
+	const enrollment = getHostingDashboardEnrollment( preference, userId );
 
-	return preference?.value === 'forced-opt-in' || isEnabled( 'dashboard/forced-opt-in' );
+	return enrollment.enrolled && enrollment.reason === 'forced';
 };

--- a/client/state/dashboard/selectors/has-dashboard-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-opt-in.ts
@@ -1,4 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
+import { getHostingDashboardEnrollment } from 'calypso/dashboard/utils/hosting-dashboard-enrollment';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
@@ -7,10 +8,7 @@ export const hasDashboardOptIn = ( state: AppState ): boolean => {
 	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
 		| HostingDashboardOptIn
 		| undefined;
+	const userId = getCurrentUserId( state ) ?? undefined;
 
-	return (
-		preference?.value === 'opt-in' ||
-		preference?.value === 'forced-opt-in' ||
-		isEnabled( 'dashboard/forced-opt-in' )
-	);
+	return getHostingDashboardEnrollment( preference, userId ).enrolled;
 };

--- a/client/state/dashboard/selectors/is-dashboard-toggle-enabled.ts
+++ b/client/state/dashboard/selectors/is-dashboard-toggle-enabled.ts
@@ -1,23 +1,14 @@
-import config from '@automattic/calypso-config';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { isOptInToggleVisible } from 'calypso/dashboard/utils/hosting-dashboard-enrollment';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 
-const OLDEST_ELIGIBLE_USER: number = config( 'dashboard_opt_in_oldest_eligible_user' ); // Cut-off on 22 December 2025
-
-/**
- * Determine whether to display the dashboard toggle. Only users created
- * before 22 December 2025 can manually opt in or out.
- */
 export const isDashboardToggleEnabled = ( state: AppState ): boolean => {
-	// Useful for allowing internal testing for proxied a12s.
-	if ( config.isEnabled( 'dashboard/force-opt-in-visibility' ) ) {
-		return true;
-	}
+	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
+		| HostingDashboardOptIn
+		| undefined;
+	const userId = getCurrentUserId( state ) ?? undefined;
 
-	const user = getCurrentUser( state ); // Ensure current user is loaded.
-	if ( ! user || user.ID > OLDEST_ELIGIBLE_USER ) {
-		return false;
-	}
-
-	return true;
+	return isOptInToggleVisible( preference, userId );
 };

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -29,6 +29,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"dark-mode": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/omnibar": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/plans": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -25,6 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/omnibar": true,
 		"dashboard/plans": true,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -26,6 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": true,
 		"dark-mode": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"domain-transfer-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -25,6 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"dev/store-sandbox-helper": true,

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/omnibar-radical": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,

--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/wp-beta-program": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,

--- a/config/test.json
+++ b/config/test.json
@@ -34,6 +34,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-banners": false,
 		"emails/titan-tiers": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,6 +37,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,


### PR DESCRIPTION
Part of DOTMSD-1173

## Proposed Changes

Introduce the mechanism for the staged, forced rollout of the Multi-site Dashboard (MSD), committed inert behind a new `dashboard/enable-percentage-rollout` feature flag (`false` in every config).

- **New shared helper** `client/dashboard/utils/hosting-dashboard-enrollment.ts` — single source of truth for whether a user's default experience is MSD, with this precedence:
  1. `forced-opt-out` (the HE escape hatch, set via internal staff tooling) — wins over everything.
  2. `opt-in` / `forced-opt-in` — enrolled.
  3. Rollout cohort: `user_id % 100 < 50` when the flag is on — enrolled, overriding an explicit `opt-out`.
  4. Otherwise — classic.
- Enrollment is **derived, never written**: no preference writes, no migration. The flag is a clean on/off; turning it off is a full rollback.
- The classic Calypso selectors (`has-dashboard-opt-in`, `has-dashboard-forced-opt-in`, `is-dashboard-toggle-enabled`) and the dashboard router now delegate to the helper, so the two clients can't drift.
- **Opt-in toggle** (in `/me/account` and the dashboard's `/me/preferences`) is hidden for cohort members and escape-hatched users.
- **Opt-in welcome modal** is suppressed for users enrolled by force (cohort / `forced-opt-in`) — they didn't choose it, so they don't get the "try it out" pitch. First-use experience for force-enrolled users is a separate PR.
- **Dashboard router**: once the rollout flag is on, the dashboard is no longer redirect-gated — anyone who navigates to it directly is let in (enrollment still governs where users land by default). Before rollout, behavior is unchanged.
- Removes the never-enabled `dashboard/forced-opt-in` flag, which this replaces.

## Why are these changes being made?

To execute the [MSD 100% rollout](https://linear.app/a8c/project/multi-site-dashboard-100percent-rollout-5ef36617dc68) — a staged (50% → 100%), reversible forced rollout. The cohort is a deterministic function of the user ID so it is stable per user and reproducible in analytics (computed in SQL), and the escape hatch lets Happiness Engineers move individual users back to classic during the rollout window (DOTMSD-1173).

Launch mechanics: flip the flag to start stage 1 (50%); bump the `50` in the helper to `100` for stage 2; turn the flag off to roll back.

## Testing Instructions

- `yarn test-client client/dashboard/utils/test/hosting-dashboard-enrollment.ts` — unit tests cover the full precedence table.
- With the flag off (default), behavior is unchanged: opt-in/opt-out via the toggle works as before.
- Locally enable `dashboard/enable-percentage-rollout` and confirm:
  - A user whose ID ends in `00`–`49` defaults into MSD; `50`–`99` stays on classic.
  - The opt-in toggle is hidden for cohort members.
  - Setting the `hosting-dashboard-opt-in` preference to `forced-opt-out` keeps a user on classic by default but still lets them open MSD directly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
