### PR TITLE
Global Nav 2026: design hamburger SVG + collapse hidden app banner

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -679,11 +679,21 @@ const UniversalNavbarHeader = ( {
 											onClick={ nav2026 ? openMobileMenu : openLegacyMobileMenu }
 										>
 											<span className="x-hidden">{ __( 'Menu', __i18n_text_domain__ ) }</span>
-											<span className="x-icon x-icon__menu">
-												<span></span>
-												<span></span>
-												<span></span>
-											</span>
+											<svg
+												className="x-icon x-icon__menu"
+												xmlns="http://www.w3.org/2000/svg"
+												width="18"
+												height="14"
+												viewBox="0 0 18 14"
+												role="presentation"
+												aria-hidden="true"
+												focusable="false"
+											>
+												<path
+													d="M18 13.5H0V12H18V13.5ZM18 7.5H0V6H18V7.5ZM18 1.5H0V0H18V1.5Z"
+													fill="currentColor"
+												/>
+											</svg>
 										</button>
 									</li>
 								</ul>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -116,12 +116,8 @@ $studio-blue-15: #e5f4ff;
 }
 
 .x-icon__menu {
-	width: 26px;
-	padding-top: 10px;
-}
-
-.x-icon__menu span + span {
-	margin-top: 4px;
+	width: 18px;
+	padding: 11px 0;
 }
 
 .x-icon,
@@ -1790,6 +1786,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 	/* Footer overlays the scroller's bottom (translucent + blurred, like the header) so the nav list scrolls beneath; the scroller pads its bottom by the footer's measured height. */
 	.x-menu-mobile-footer {
+		--x-menu-2026-footer-gap: 16px;
 		position: absolute;
 		bottom: 0;
 		inset-inline: 0;
@@ -1806,7 +1803,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		&:has( .x-menu-mobile-app-banner ) {
 			flex-direction: column;
 			align-items: stretch;
-			gap: 16px;
+			gap: var( --x-menu-2026-footer-gap );
 		}
 
 		// Only the footer's CONTENTS fade in on open; the blurred bar stays put so nav items slide behind it. Base snaps out with the panel (0s / panel-delay).
@@ -1835,17 +1832,31 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		}
 	}
 
-	// Top-level screen only; fades in, snaps out on drill (is-hidden).
+	// Top-level screen only; collapses away on drill (is-hidden).
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner {
 		opacity: 0;
 		pointer-events: none;
-		transition: opacity 0.27s var( --x-menu-2026-easing );
+		max-height: 120px;
+		overflow: hidden;
+		transition:
+			opacity 0.25s cubic-bezier( 0.16, 1, 0.3, 1 ),
+			max-height 0.25s cubic-bezier( 0.16, 1, 0.3, 1 ),
+			padding 0.25s cubic-bezier( 0.16, 1, 0.3, 1 ),
+			margin 0.25s cubic-bezier( 0.16, 1, 0.3, 1 );
 	}
 
+	// Hide direction only: fade first, then collapse the height after.
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner.is-hidden {
 		opacity: 0;
 		pointer-events: none;
-		transition: none;
+		max-height: 0;
+		padding-block: 0;
+		margin-bottom: calc( -1 * var( --x-menu-2026-footer-gap, 16px ) );
+		transition:
+			opacity 0.2s ease,
+			max-height 0.25s cubic-bezier( 0.16, 1, 0.3, 1 ) 0.1s,
+			padding 0.25s cubic-bezier( 0.16, 1, 0.3, 1 ) 0.1s,
+			margin 0.25s cubic-bezier( 0.16, 1, 0.3, 1 ) 0.1s;
 	}
 
 	// Overlapping WordPress + Jetpack badge icons.


### PR DESCRIPTION
Part of [Dotcom Global Nav Redesign 2026](https://linear.app/a8c/project/dotcom-global-nav-redesign-2026-6315496e8e23/activity#project-update-3159a9c6&comment-db9a77f3)

## Proposed Changes

* The 2026 nav hamburger uses the design's SVG (equal bar weights).
* The mobile menu's Jetpack banner no longer leaves blank space when hidden.

## Why are these changes being made?

* Design QA found the hamburger's middle bar rendered thinner than the design, and the Jetpack banner left a blank gap in the mobile menu when hidden.

## Testing Instructions

* `/themes?flags=nav-redesign/2026` at a mobile width: the hamburger has three equal bars; on an iOS/Android user agent, drill into a category — the banner shrinks away.
* `yarn test-packages packages/wpcom-template-parts`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
