### PR TITLE
happy-blocks: fix mobile support nav dropdown causing horizontal scroll

### DIFF
--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -166,6 +166,10 @@ $breakpoint-desktop: 1440px; //Desktop size.
 		.dropdown-menu {
 			position: absolute;
 			top: 100%;
+			// Anchor to the positioned ancestor's edge: without it the box keeps
+			// its static 16px offset while width:100% spans the full card, pushing
+			// 16px past the viewport (a horizontal scrollbar even while hidden).
+			inset-inline-start: 0;
 			width: 100%;
 			background: #fff;
 			list-style: none;


### PR DESCRIPTION
Fixes the horizontal scrollbar on /forums and /support on screens under 783px.

## Proposed Changes

* The support pages' mobile sub-nav dropdown ("Support Center / Guides / …") no longer extends 16px past the right edge of the screen. Its box is laid out even while hidden, so every support/forums page showed a horizontal scrollbar at mobile widths.

## Why are these changes being made?

* The absolutely-positioned dropdown had no inline anchor: it kept its static 16px offset while `width: 100%` resolved against the full-width sticky card, overflowing the viewport by 16px — visible as a horizontal scrollbar (and a clipped right edge when the dropdown is open).

## Testing Instructions

* On /forums or /support at a viewport narrower than 783px, check there is no horizontal scrollbar.
* Open the mobile sub-nav dropdown: it spans the full width without spilling past the right edge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
