### PR TITLE
Image Studio: hide the Feature Clip document panel on self-hosted sites

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -317,6 +317,47 @@ describe( 'feature-clip-sidebar-extension', () => {
 		} );
 	} );
 
+	describe( 'self-hosted gating (siteType: jetpack)', () => {
+		it( 'suppresses the document-sidebar panel but keeps the Jetpack sidebar', () => {
+			( window as Record< string, unknown > ).imageStudioData = {
+				canGenerateVideoClips: true,
+				siteType: 'jetpack',
+			};
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+			// All visible DOM comes from the document panel's <section>; the
+			// Fill mock renders nothing — so an empty container proves the
+			// document copy is gone while the Fill call proves the Jetpack
+			// sidebar copy survives.
+			expect( container.querySelector( 'section' ) ).toBeNull();
+			expect( mockFill ).toHaveBeenCalledWith( 'JetpackPluginSidebar' );
+		} );
+
+		it( 'still registers the plugin so the Jetpack sidebar copy mounts', () => {
+			( window as Record< string, unknown > ).imageStudioData = {
+				canGenerateVideoClips: true,
+				siteType: 'jetpack',
+			};
+			const { registerFeatureClipSidebar } = require( './feature-clip-sidebar-extension' );
+			registerFeatureClipSidebar();
+			expect( mockRegisterPlugin ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it.each( [ 'simple', 'atomic', 'wpcom', 'woa', undefined ] )(
+			'renders the document-sidebar panel when siteType is %s',
+			( siteType ) => {
+				( window as Record< string, unknown > ).imageStudioData = {
+					canGenerateVideoClips: true,
+					...( siteType ? { siteType } : {} ),
+				};
+				const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+				const { container } = render( <FeatureClipPanel /> );
+				expect( container.querySelector( 'section' ) ).not.toBeNull();
+				expect( mockFill ).toHaveBeenCalledWith( 'JetpackPluginSidebar' );
+			}
+		);
+	} );
+
 	describe( 'post-type gating', () => {
 		it( 'renders nothing on an unsupported post type (jetpack_form)', () => {
 			mockPostType = 'jetpack_form';

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -359,17 +359,26 @@ function FeatureClipPanelBody( { postType, postId }: FeatureClipPanelBodyProps )
 		return <FeatureClipEmptyState hasLoadError={ hasLoadError } />;
 	} )();
 
+	// Self-hosted sites get the Jetpack-sidebar copy only. Off-WPCOM the
+	// `canGenerateVideoClips` flag can't see the paid AI entitlement (it's
+	// true on any connected site), so the always-visible document-sidebar
+	// copy would invite generate attempts the server then rejects with
+	// `ai_assistant_required` for unentitled sites.
+	const showDocumentPanel = window.imageStudioData?.siteType !== 'jetpack';
+
 	return (
 		<>
-			<PluginDocumentSettingPanel
-				name={ PANEL_NAME }
-				// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
-				// the badge must live in the title row so it stays visible when the panel is collapsed.
-				title={ titleNode as unknown as string }
-				className="image-studio-feature-clip-panel"
-			>
-				{ body }
-			</PluginDocumentSettingPanel>
+			{ showDocumentPanel && (
+				<PluginDocumentSettingPanel
+					name={ PANEL_NAME }
+					// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
+					// the badge must live in the title row so it stays visible when the panel is collapsed.
+					title={ titleNode as unknown as string }
+					className="image-studio-feature-clip-panel"
+				>
+					{ body }
+				</PluginDocumentSettingPanel>
+			) }
 			<Fill name="JetpackPluginSidebar">
 				<PanelBody
 					// PanelBody.title is typed as string but renders any ReactNode


### PR DESCRIPTION
## Proposed Changes

* Suppress the Feature Clip `PluginDocumentSettingPanel` (default document sidebar) in the post editor when `window.imageStudioData.siteType === 'jetpack'` (self-hosted sites).
* The `JetpackPluginSidebar` Fill still renders, so the feature remains available inside the Jetpack plugin sidebar on those sites. Simple and Atomic sites are unchanged.

## Why are these changes being made?

Jetpack 15.9 ships the Feature Clip panel to every connected self-hosted site. Off-WPCOM, `image_studio_can_generate_video_clips()` cannot see the paid AI entitlement (`wpcom_site_can_upload_videos()` is unavailable and `has_jetpack_ai_features()` only checks the connection), so `canGenerateVideoClips` is always `true` and the panel renders in the always-visible document sidebar.

Unentitled users then compose a prompt whose generation the server rejects with `WP_Error( 'ai_assistant_required' )`. As 15.9 rolled out (tagged Jun 9), this drove the `jetpack_big_sky_image_studio_error` spike on Jun 11: 79 `generation_failed` events / 71 uniques, 68 of them on `site_type: jetpack`, matching 77 `image_studio_passthrough:ai_assistant_required` rejections (each a distinct blog) in the agent logs — and 70 of 71 erroring users never had a single successful generation.

Hiding the prominent document-sidebar copy on self-hosted removes the accidental-exposure surface while keeping the feature discoverable in Jetpack's own sidebar. The bundle ships from widgets.wp.com, so this needs no Jetpack plugin release. A durable follow-up is to make the PHP gate entitlement-aware off-WPCOM (or have the panel consult `wpcom/v2/jetpack-ai/ai-assistant-feature`'s `has-feature`, which mirrors the server's `WPCOM_Features::AI_ASSISTANT` check) and render an upgrade CTA instead.

## Testing Instructions

* `yarn test-packages packages/image-studio` — 1029 tests pass, including new coverage for the self-hosted gating.
* On a self-hosted Jetpack site (with this bundle deployed to widgets.wp.com horizon/stage): open the post editor → the "Feature Clip" panel should no longer appear in the Document settings sidebar, but should still appear in the Jetpack sidebar (plug icon).
* On Simple and Atomic sites: the panel should appear in both sidebars, unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)