### PR TITLE
client/components: migrate .jsx function-component defaultProps to default params (React 19)

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-clipboard-button.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-clipboard-button.jsx
@@ -7,7 +7,7 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 
 import './style.scss';
 
-export default function ConnectDomainStepClipboardButton( { baseClassName, classes, text } ) {
+export default function ConnectDomainStepClipboardButton( { baseClassName, classes = [], text } ) {
 	const { __ } = useI18n();
 	const [ copiedText, setCopiedText ] = useState( false );
 	const copied = () => setCopiedText( true );
@@ -41,8 +41,4 @@ ConnectDomainStepClipboardButton.propTypes = {
 	baseClassName: PropTypes.string.isRequired,
 	classes: PropTypes.array,
 	text: PropTypes.string.isRequired,
-};
-
-ConnectDomainStepClipboardButton.defaultProps = {
-	classes: [],
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -17,7 +17,7 @@ export default function ConnectDomainStepLogin( {
 	className,
 	pageSlug,
 	domain,
-	isOwnershipVerificationFlow,
+	isOwnershipVerificationFlow = false,
 	mode,
 	onNextStep,
 	progressStepList,
@@ -167,8 +167,4 @@ ConnectDomainStepLogin.propTypes = {
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
-};
-
-ConnectDomainStepLogin.defaultProps = {
-	isOwnershipVerificationFlow: false,
 };

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -5,7 +5,12 @@ import { Input } from 'calypso/my-sites/domains/components/form';
 const noop = () => {};
 
 const EuAddressFieldset = ( props ) => {
-	const { getFieldProps, translate, contactDetailsErrors, arePostalCodesSupported } = props;
+	const {
+		getFieldProps = noop,
+		translate,
+		contactDetailsErrors,
+		arePostalCodesSupported = true,
+	} = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields eu-address-fieldset">
 			{ arePostalCodesSupported && (
@@ -29,11 +34,6 @@ EuAddressFieldset.propTypes = {
 	translate: PropTypes.func,
 	contactDetailsErrors: PropTypes.object,
 	arePostalCodesSupported: PropTypes.bool,
-};
-
-EuAddressFieldset.defaultProps = {
-	getFieldProps: noop,
-	arePostalCodesSupported: true,
 };
 
 export default localize( EuAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -5,7 +5,12 @@ import { Input } from 'calypso/my-sites/domains/components/form';
 const noop = () => {};
 
 const UkAddressFieldset = ( props ) => {
-	const { getFieldProps, translate, contactDetailsErrors, arePostalCodesSupported } = props;
+	const {
+		getFieldProps = noop,
+		translate,
+		contactDetailsErrors,
+		arePostalCodesSupported = true,
+	} = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields uk-address-fieldset">
 			<Input
@@ -31,8 +36,4 @@ UkAddressFieldset.propTypes = {
 	arePostalCodesSupported: PropTypes.bool,
 };
 
-UkAddressFieldset.defaultProps = {
-	getFieldProps: noop,
-	arePostalCodesSupported: true,
-};
 export default localize( UkAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -6,8 +6,13 @@ import { getStateLabelText, getPostCodeLabelText, STATE_SELECT_TEXT } from './ut
 const noop = () => {};
 
 const UsAddressFieldset = ( props ) => {
-	const { getFieldProps, translate, countryCode, contactDetailsErrors, arePostalCodesSupported } =
-		props;
+	const {
+		getFieldProps = noop,
+		translate,
+		countryCode = 'US',
+		contactDetailsErrors,
+		arePostalCodesSupported = true,
+	} = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields us-address-fieldset">
 			<Input
@@ -41,12 +46,6 @@ UsAddressFieldset.propTypes = {
 	translate: PropTypes.func,
 	contactDetailsErrors: PropTypes.object,
 	arePostalCodesSupported: PropTypes.bool,
-};
-
-UsAddressFieldset.defaultProps = {
-	countryCode: 'US',
-	getFieldProps: noop,
-	arePostalCodesSupported: true,
 };
 
 export default localize( UsAddressFieldset );

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -14,12 +14,12 @@ import './style.scss';
 function UseMyDomainInput( {
 	baseClassName,
 	domainName,
-	isBusy,
+	isBusy = false,
 	isSignupStep,
 	onChange,
 	onClear,
 	onNext,
-	shouldSetFocus,
+	shouldSetFocus = false,
 	validationError,
 } ) {
 	const domainNameInput = useRef( null );
@@ -108,11 +108,6 @@ UseMyDomainInput.propTypes = {
 	onNext: PropTypes.func.isRequired,
 	shouldSetFocus: PropTypes.bool,
 	validationError: PropTypes.node,
-};
-
-UseMyDomainInput.defaultProps = {
-	isBusy: false,
-	shouldSetFocus: false,
 };
 
 export default connect()( UseMyDomainInput );

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-export default function FormTelInput( { className, isError, isValid, ...props } ) {
+export default function FormTelInput( { className, isError = false, isValid = false, ...props } ) {
 	const classes = clsx( 'form-tel-input', className, {
 		'is-error': isError,
 		'is-valid': isValid,
@@ -15,9 +15,4 @@ FormTelInput.propTypes = {
 	className: PropTypes.string,
 	isError: PropTypes.bool,
 	isValid: PropTypes.bool,
-};
-
-FormTelInput.defaultProps = {
-	isError: false,
-	isValid: false,
 };

--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -9,7 +9,7 @@ import GSuiteSingleFeature from 'calypso/components/gsuite/gsuite-features/singl
 
 import './style.scss';
 
-const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
+const GSuiteFeatures = ( { compact = false, domainName, productSlug, type = 'grid' } ) => {
 	const translate = useTranslate();
 
 	const getStorageText = () => {
@@ -90,15 +90,10 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 };
 
 GSuiteFeatures.propTypes = {
-	compact: PropTypes.bool.isRequired,
+	compact: PropTypes.bool,
 	domainName: PropTypes.string.isRequired,
 	productSlug: PropTypes.string,
-	type: PropTypes.oneOf( [ 'grid', 'list' ] ).isRequired,
-};
-
-GSuiteFeatures.defaultProps = {
-	compact: false,
-	type: 'grid',
+	type: PropTypes.oneOf( [ 'grid', 'list' ] ),
 };
 
 export default GSuiteFeatures;

--- a/client/components/gsuite/gsuite-learn-more/index.jsx
+++ b/client/components/gsuite/gsuite-learn-more/index.jsx
@@ -8,7 +8,7 @@ import './style.scss';
 
 const noop = () => {};
 
-const GSuiteLearnMore = ( { onLearnMoreClick, productSlug } ) => {
+const GSuiteLearnMore = ( { onLearnMoreClick = noop, productSlug } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -43,10 +43,6 @@ const GSuiteLearnMore = ( { onLearnMoreClick, productSlug } ) => {
 
 GSuiteLearnMore.propTypes = {
 	onLearnMoreClick: PropTypes.func,
-};
-
-GSuiteLearnMore.defaultProps = {
-	onLearnMoreClick: noop,
 };
 
 export default GSuiteLearnMore;

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -93,9 +93,9 @@ const CloneButton = ( { disabled, rewindId, primary, onClickClone } ) => {
 };
 
 const ActionButtons = ( {
-	rewindId = null,
+	rewindId,
 	disabled = false,
-	isMultiSite = false,
+	isMultiSite,
 	hasWarnings = false,
 	availableActions = [ 'rewind', 'download' ],
 	onClickClone = () => {},

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -93,12 +93,12 @@ const CloneButton = ( { disabled, rewindId, primary, onClickClone } ) => {
 };
 
 const ActionButtons = ( {
-	rewindId,
-	disabled,
-	isMultiSite,
-	hasWarnings,
-	availableActions,
-	onClickClone,
+	rewindId = null,
+	disabled = false,
+	isMultiSite = false,
+	hasWarnings = false,
+	availableActions = [ 'rewind', 'download' ],
+	onClickClone = () => {},
 } ) => (
 	<>
 		{ availableActions && availableActions.includes( 'download' ) && (
@@ -133,15 +133,6 @@ ActionButtons.propTypes = {
 	hasWarnings: PropTypes.bool,
 	availableActions: PropTypes.arrayOf( PropTypes.string ),
 	onClickClone: PropTypes.func,
-};
-
-ActionButtons.defaultProps = {
-	rewindId: null,
-	disabled: false,
-	isMultiSite: false,
-	hasWarnings: false,
-	availableActions: [ 'rewind', 'download' ],
-	onClickClone: () => {},
 };
 
 export default ActionButtons;

--- a/client/components/jetpack/jetpack-header/index.jsx
+++ b/client/components/jetpack/jetpack-header/index.jsx
@@ -4,7 +4,7 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 
 import './style.scss';
 
-function JetpackHeader( { className } ) {
+function JetpackHeader( { className = '' } ) {
 	const classes = clsx( 'jetpack-header', className );
 
 	return (
@@ -16,10 +16,6 @@ function JetpackHeader( { className } ) {
 
 JetpackHeader.propTypes = {
 	className: PropTypes.string,
-};
-
-JetpackHeader.defaultProps = {
-	className: '',
 };
 
 export default JetpackHeader;

--- a/client/components/multiple-choice-question/answer.jsx
+++ b/client/components/multiple-choice-question/answer.jsx
@@ -5,12 +5,12 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
 const MultipleChoiceAnswer = ( {
-	disabled,
+	disabled = false,
 	answer: { id, answerText, textInput, textInputPrompt, children },
 	name,
 	isSelected,
 	onAnswerChange,
-	selectedAnswerText,
+	selectedAnswerText = '',
 } ) => {
 	const [ textResponse, setTextResponse ] = useState( selectedAnswerText );
 
@@ -60,11 +60,6 @@ MultipleChoiceAnswer.propTypes = {
 	} ).isRequired,
 	selectedAnswerText: PropTypes.string,
 	name: PropTypes.string.isRequired,
-};
-
-MultipleChoiceAnswer.defaultProps = {
-	disabled: false,
-	selectedAnswerText: '',
 };
 
 export default MultipleChoiceAnswer;

--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -24,7 +24,7 @@ const MultipleChoiceQuestion = ( {
 	name,
 	onAnswerChange,
 	question,
-	selectedAnswerId = null,
+	selectedAnswerId,
 	selectedAnswerText = '',
 	shouldShuffleAnswers = true,
 } ) => {

--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -19,14 +19,14 @@ const shuffleAnswers = memoize(
 );
 
 const MultipleChoiceQuestion = ( {
-	disabled,
+	disabled = false,
 	answers,
 	name,
 	onAnswerChange,
 	question,
-	selectedAnswerId,
-	selectedAnswerText,
-	shouldShuffleAnswers,
+	selectedAnswerId = null,
+	selectedAnswerText = '',
+	shouldShuffleAnswers = true,
 } ) => {
 	const [ selectedAnswer, setSelectedAnswer ] = useState( selectedAnswerId );
 	const shuffledAnswers = shouldShuffleAnswers ? shuffleAnswers( answers ) : answers;
@@ -76,13 +76,6 @@ MultipleChoiceQuestion.propTypes = {
 	selectedAnswerId: PropTypes.string,
 	selectedAnswerText: PropTypes.string,
 	shouldShuffleAnswers: PropTypes.bool,
-};
-
-MultipleChoiceQuestion.defaultProps = {
-	disabled: false,
-	selectedAnswerId: null,
-	selectedAnswerText: '',
-	shouldShuffleAnswers: true,
 };
 
 export default MultipleChoiceQuestion;

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const noop = () => {};
 
-const ProductCardAction = ( { intro, label, onClick, primary, href } ) => (
+const ProductCardAction = ( { intro, label, onClick = noop, primary = true, href = null } ) => (
 	<div className="product-card__action">
 		{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
 		<Button
@@ -23,12 +23,6 @@ ProductCardAction.propTypes = {
 	onClick: PropTypes.func,
 	href: PropTypes.string,
 	primary: PropTypes.bool,
-};
-
-ProductCardAction.defaultProps = {
-	href: null,
-	onClick: noop,
-	primary: true,
 };
 
 export default ProductCardAction;

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -24,7 +24,7 @@ const services = ( translate = ( string ) => string ) => ( {
 const noop = () => {};
 
 export const SocialItem = ( props ) => {
-	const { isSelected, onClick, service, translate } = props;
+	const { isSelected = false, onClick = noop, service, translate } = props;
 
 	const { icon, label } = get( services( translate ), service );
 	const classes = clsx( 'vertical-menu__social-item', 'vertical-menu__items', {
@@ -48,11 +48,6 @@ SocialItem.propTypes = {
 	onClick: PropTypes.func,
 	service: PropTypes.oneOf( Object.keys( services() ) ).isRequired,
 	translate: PropTypes.func,
-};
-
-SocialItem.defaultProps = {
-	isSelected: false,
-	onClick: noop,
 };
 
 export default localize( SocialItem );


### PR DESCRIPTION
## Proposed Changes

Continues the React 19 forward-compatibility audit of `client/components` (follow-up to #111556, #111566, #111597, #111602). React 19 ignores `defaultProps` on function components, so this moves the defaults into destructuring default parameters for 15 `.jsx` function components.

This is the `.jsx` companion to #111566 — that PR's audit grep was TypeScript-only, so it missed every `.jsx` component. Class components keep `defaultProps` (still supported in React 19) and are untouched.

Files: `connect-domain-step-{clipboard-button,login}`, `use-my-domain/domain-input`, `forms/form-tel-input`, `gsuite/gsuite-{features,learn-more}`, `contact-details-form-fields/custom-form-fieldsets/{us,uk,eu}-address-fieldset`, `vertical-menu/items/social-item`, `jetpack/jetpack-header`, `jetpack/daily-backup-status/action-buttons`, `multiple-choice-question/{index,answer}`, `product-card/action`.

Each default is copied verbatim from the `defaultProps` value to preserve behavior. One extra adjustment: in `gsuite-features`, `compact` and `type` were relaxed from PropTypes `.isRequired` to optional — with `defaultProps` gone, the default now applies *inside* the component rather than before the propTypes check, so leaving `.isRequired` would produce a spurious "is required" warning when those props are omitted.

## Why are these changes being made?

`defaultProps` on function components is a no-op in React 19, so these defaults would silently disappear on the upgrade. Migrating now keeps behavior unchanged.

## Testing Instructions

* `yarn test-client client/components/{gsuite,multiple-choice-question,domains/contact-details-form-fields}` — affected components with tests pass (44 tests).
* `yarn eslint` clean on all 15 files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
