### PR TITLE
Update Site Spec to v1.10.0

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -224,8 +224,8 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "e16ecd5d7848b169d97088e4c69065d8",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.6.0/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.6.0/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.10.0/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.10.0/style.css"
 	},
 	"dashboard_opt_in_oldest_eligible_user": 275231967
 }


### PR DESCRIPTION
Bumping Site Spec to 1.10.0 for the setup site builder flow.

See 222399-ghe-Automattic/wpcom for the Site Spec change.

## Testing

- Sandbox widgets.wp.com
- `yarn start`
- Visit http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec and confirm it loads Site Spec 1.10.0
- Confirm Site Spec functions as expected