### PR TITLE
Agents Manager: bundle @wordpress/ui instead of externalizing it

### DIFF
--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -87,6 +87,14 @@ function getIndividualConfig( options = {} ) {
 					) {
 						return null;
 					}
+					// Bundle @wordpress/ui: neither WordPress core nor the Gutenberg
+					// plugin registers a wp-ui script handle yet, and WP_Scripts
+					// silently skips scripts with unregistered dependencies, so
+					// externalizing it prevents the bundle from loading on
+					// self-hosted sites.
+					if ( request === '@wordpress/ui' ) {
+						return null;
+					}
 				},
 			} ),
 			new ReadableJsAssetsWebpackPlugin(),


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOAI-589 · Regression from #111387

## Proposed Changes

* In the `apps/agents-manager` webpack config, return `null` from `requestToExternal` for `@wordpress/ui` so it is bundled instead of externalized to the `wp-ui` script handle. Same pattern already used for `@wordpress/abilities` (and by the `content-research` and `wpcom-smart-dictation` apps).

## Why are these changes being made?

#111387 made `@automattic/components` (Tabs) import `@wordpress/ui`, so every Agents Manager bundle's `.asset.json` started listing `wp-ui` as a script dependency. No environment registers a `wp-ui` handle (not WP core, not Gutenberg, not WP.com), and `WP_Scripts` silently skips scripts with unregistered dependencies — so since June 11 the Agents Manager JS never loads: confirmed broken on self-hosted sites **and production WP.com Simple sites** (CSS loads, JS tag is never printed; the only trace is a debug.log notice: *"agents-manager" was enqueued with dependencies that are not registered: wp-ui*).

Bundling the package (~130 bytes minified, one `Icon` component) restores loading everywhere without requiring sites to register the handle.

## Testing Instructions

1. Check out this branch, then `cd apps/agents-manager`.
2. Build and sync to your sandbox: `yarn dev --sync`
   * Sanity check: `grep -l '"wp-ui"' dist/*.asset.json` → no matches (on trunk, every variant matches).
3. In `/etc/hosts`, point **both** `widgets.wp.com` **and your test Simple site's hostname** at your sandbox. Sandboxing the site is required: the dependency check runs in PHP on the server rendering wp-admin, which reads the asset.json from its own disk — overriding only `widgets.wp.com` affects browser fetches but not that server-side check.
4. Evict the stale dependency cache (1-hour transient, shared with production): on the sandbox run `wp --url=<your-site>.wordpress.com transient delete agents-manager-asset-wp-admin.asset.json`
5. Load `/wp-admin/`:
   * **Broken (trunk)**: only `agents-manager-wp-admin.css` loads, no JS tag, no chat dock.
   * **Fixed (this branch)**: `agents-manager-wp-admin.min.js` loads and the chat dock renders — with `window.wp.ui` still `undefined` in the console, proving the bundle no longer needs the global.
6. Self-hosted variant (optional, e.g. wp-env + Woo AI plugin): same idea, but the *server* must also resolve `widgets.wp.com` to your sandbox (self-hosted fetches the asset.json over HTTP); transient name is `agents-manager-asset-wooai.asset.json`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- verified on Simple (sandboxed) and self-hosted (wp-env); build-only change -->
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
