### PR TITLE
Fix: route post-import "Customize site" to site editor for block themes

### DIFF
--- a/client/my-sites/importer/success-panel.tsx
+++ b/client/my-sites/importer/success-panel.tsx
@@ -4,8 +4,11 @@ import { SiteDetails } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
-import { useDispatch } from 'calypso/state';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { resetImport } from 'calypso/state/imports/actions';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 
 import './success-panel.scss';
 
@@ -23,6 +26,10 @@ const SuccessPanel = ( { site, importerStatus, onClose }: SuccessPanelProps ) =>
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const engine = importerStatus.type;
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { data: activeThemeData } = useActiveThemeQuery( site.ID, isLoggedIn );
+	const isBlockTheme = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
+	const siteEditorUrl = useSelector( ( state ) => getSiteEditorUrl( state, site.ID ) );
 
 	useEffect( () => {
 		dispatch( resetImport( site.ID, importerStatus.importerId ) );
@@ -35,8 +42,13 @@ const SuccessPanel = ( { site, importerStatus, onClose }: SuccessPanelProps ) =>
 			action: 'customize',
 		} );
 
-		page( '/customize/' + ( site.slug || '' ) );
-	}, [ engine, site.ID, site.slug ] );
+		if ( isBlockTheme ) {
+			// Block themes are customized in the site editor, not the legacy Customizer.
+			window.location.assign( siteEditorUrl );
+		} else {
+			page( '/customize/' + ( site.slug || '' ) );
+		}
+	}, [ engine, site.ID, site.slug, isBlockTheme, siteEditorUrl ] );
 
 	const handleImportMoreContent = useCallback( () => {
 		recordTracksEvent( 'calypso_importer_main_done_clicked', {

--- a/client/my-sites/importer/test/success-panel.test.tsx
+++ b/client/my-sites/importer/test/success-panel.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import SuccessPanel from '../success-panel';
+import type { SiteDetails } from '@automattic/data-stores';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+// `resetImport` is dispatched on mount and calls the importer API; not under test here.
+jest.mock( 'calypso/state/imports/actions', () => ( {
+	resetImport: jest.fn( () => ( { type: 'TEST_RESET_IMPORT' } ) ),
+} ) );
+
+jest.mock( 'calypso/data/themes/use-active-theme-query', () => ( {
+	useActiveThemeQuery: jest.fn(),
+} ) );
+
+const SITE_ID = 123;
+const SITE_SLUG = 'example.wordpress.com';
+
+const site = {
+	ID: SITE_ID,
+	slug: SITE_SLUG,
+	title: 'Example Site',
+} as SiteDetails;
+
+const importerStatus = {
+	importerId: 'test-importer-id',
+	type: 'importer-type-wordpress',
+};
+
+const initialState = {
+	currentUser: { id: 456 },
+	sites: {
+		items: {
+			[ SITE_ID ]: {
+				ID: SITE_ID,
+				slug: SITE_SLUG,
+				options: { admin_url: `https://${ SITE_SLUG }/wp-admin/` },
+			},
+		},
+	},
+};
+
+function mockActiveTheme( isBlockTheme: boolean ) {
+	( useActiveThemeQuery as jest.Mock ).mockReturnValue( {
+		data: [ { is_block_theme: isBlockTheme } ],
+		isLoading: false,
+	} );
+}
+
+describe( 'SuccessPanel', () => {
+	let assignMock: jest.Mock;
+	let originalLocation: Location;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		originalLocation = window.location;
+		assignMock = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { ...originalLocation, assign: assignMock },
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	it( 'routes "Customize site" to the Customizer for classic themes', async () => {
+		const user = userEvent.setup();
+		mockActiveTheme( false );
+
+		renderWithProvider( <SuccessPanel site={ site } importerStatus={ importerStatus } />, {
+			initialState,
+		} );
+		await user.click( screen.getByRole( 'button', { name: /Customize site/ } ) );
+
+		expect( page ).toHaveBeenCalledWith( `/customize/${ SITE_SLUG }` );
+		expect( assignMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'routes "Customize site" to the site editor for block themes', async () => {
+		const user = userEvent.setup();
+		mockActiveTheme( true );
+
+		renderWithProvider( <SuccessPanel site={ site } importerStatus={ importerStatus } />, {
+			initialState,
+		} );
+		await user.click( screen.getByRole( 'button', { name: /Customize site/ } ) );
+
+		expect( assignMock ).toHaveBeenCalledWith(
+			expect.stringContaining( `https://${ SITE_SLUG }/wp-admin/site-editor.php` )
+		);
+		expect( page ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Related to [DOTCON-150](https://linear.app/a8c/issue/DOTCON-150/redirect-customize-site-to-site-editor-for-block-themes-after-import)

## Proposed Changes

* After a content import completes, the importer success panel's **"Customize site"** button always routed to `/customize/<slug>` (the legacy Customizer), regardless of theme type.
* The button now detects whether the active theme is a block theme — via the existing `useActiveThemeQuery` (the same source `withIsFSEActive` uses) — and routes block themes to the Site Editor (`getSiteEditorUrl`). Classic themes keep the existing Customizer routing, unchanged.
* Adds unit tests covering both routings (`client/my-sites/importer/test/success-panel.test.tsx`).

## Why are these changes being made?

Block themes aren't customized in the legacy Customizer; landing there after an import is confusing and makes the platform look limited (see DOTCON-150 — confirmed repro on Simple sites, with triage video). This mirrors the established pattern in `client/blocks/product-purchase-features-list/customize-theme.jsx`, which makes the same Site Editor/Customizer decision through `is_block_theme`.

**Notes for reviewers:**
- If the active-theme query hasn't resolved when the user clicks, the code falls back to the current behavior (Customizer) — graceful degradation, no loading gate added.
- `client/my-sites/importer/importer-action-buttons/done-button.jsx` contains a similar hardcoded `/customize/` path behind a `customizeSiteVariant` prop, but no caller ever sets that prop (dead path). Left untouched to keep this diff minimal.
- The Linear issue was auto-marked "In Progress" when this PR opened. This is a Bug Blitz contribution that is review-ready, not actively being worked by an engineer.

## Testing Instructions

* Unit: `yarn test-client client/my-sites/importer/test/success-panel.test.tsx`
* Manual (Simple site): with a block theme active (e.g. Twenty Twenty-Four), run a content import via Tools → Import. On the success panel, click "Customize site" → should open the Site Editor. Repeat with a classic theme → should open the Customizer, as before.
* Verified via unit tests + code review; not tested on a live site. Reviewer input on live-site behavior requested.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)