### PR TITLE
ui: Stepper CSS cleanups from #111036 review feedback

### DIFF
--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -65,12 +65,12 @@
 }
 
 // Current: 16px solid gray-900 ring, transparent background + half-circle dome
-// margin: 1px compensates for the 2px size reduction vs upcoming (18px → 16px)
+// The margin compensates for the size reduction vs upcoming (size → size-sm)
 // so the indicator centres stay aligned vertically across states.
 .indicator.is-current[data-indicator-variant='bullet'] {
 	width: var( --a8c-ui-stepper-indicator-size-sm );
 	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: 1px;
+	margin: calc( ( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5 );
 	border-style: solid;
 	border-color: var( --wpds-color-fg-content-neutral );
 	background: transparent;
@@ -81,7 +81,7 @@
 .indicator.is-completed[data-indicator-variant='bullet'] {
 	width: var( --a8c-ui-stepper-indicator-size-sm );
 	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: 1px;
+	margin: calc( ( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5 );
 	border-style: solid;
 }
 
@@ -187,9 +187,10 @@
 // Title and Description
 // ---------------------------------------------------------------------------
 
+// Title color is set by the `[data-indicator-variant] … .title` rules above;
+// the root always renders `data-indicator-variant`, so no base color is needed.
 .title {
 	font-weight: inherit;
-	color: var( --wpds-color-fg-content-neutral );
 }
 
 .description {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -7,6 +7,10 @@
 .root {
 	--a8c-ui-stepper-indicator-size: 18px;
 	--a8c-ui-stepper-indicator-size-sm: 16px;
+	// Centers the smaller current/completed bullets against upcoming ones.
+	--a8c-ui-stepper-indicator-offset: calc(
+		( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -70,7 +74,7 @@
 .indicator.is-current[data-indicator-variant='bullet'] {
 	width: var( --a8c-ui-stepper-indicator-size-sm );
 	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: calc( ( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5 );
+	margin: var( --a8c-ui-stepper-indicator-offset );
 	border-style: solid;
 	border-color: var( --wpds-color-fg-content-neutral );
 	background: transparent;
@@ -81,7 +85,7 @@
 .indicator.is-completed[data-indicator-variant='bullet'] {
 	width: var( --a8c-ui-stepper-indicator-size-sm );
 	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: calc( ( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5 );
+	margin: var( --a8c-ui-stepper-indicator-offset );
 	border-style: solid;
 }
 


### PR DESCRIPTION
Part of the follow-up work for the Stepper review feedback in #111036.

## Proposed Changes

* Remove the dead `color` declaration from the base `.title` rule. It never applied: the stepper root always renders `data-indicator-variant`, so the higher-specificity `[data-indicator-variant] .title` rules always win. Addresses [this comment](https://github.com/Automattic/wp-calypso/pull/111036#discussion_r3390057864).
* Replace the magic `margin: 1px` on the bullet indicator variant (current and completed states) with `calc( ( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5 )`, so the centre-alignment compensation is derived from the size variables instead of a hardcoded number. Addresses [this comment](https://github.com/Automattic/wp-calypso/pull/111036#discussion_r3389854244).

## Why are these changes being made?

* Review feedback on #111036 flagged a never-applied CSS declaration and a magic number. Removing dead code and deriving the margin from the existing size tokens keeps the styles self-documenting and resilient to future size changes.

## Testing Instructions

* Run the Stepper Storybook stories for `VerticalStepper` and `HorizontalStepper` with the `bullet` indicator variant.
* Verify the bullet indicators stay vertically centre-aligned across upcoming, current, and completed states (computed margin should still resolve to `1px`: `(18px - 16px) / 2`).
* Verify step title colors are unchanged in all states (upcoming, current, completed, hover, disabled).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
