### PR TITLE
Layout: migrate JSX.Element to React.JSX.Element for React 19 compat

### DIFF
--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -14,7 +14,7 @@ const ICON_SIZE = 24;
 
 interface Props {
 	id?: string;
-	icon: JSX.Element;
+	icon: React.JSX.Element;
 	path: string;
 	link: string;
 	title: TranslateResult;
@@ -23,7 +23,7 @@ interface Props {
 	isExternalLink?: boolean;
 	isSelected?: boolean;
 	openInSameTab?: boolean;
-	extraContent?: JSX.Element;
+	extraContent?: React.JSX.Element;
 }
 
 export const SidebarNavigatorMenuItem = ( {
@@ -39,7 +39,7 @@ export const SidebarNavigatorMenuItem = ( {
 	openInSameTab = false,
 	extraContent,
 }: Props ) => {
-	const SidebarItem = ( { children }: { children?: JSX.Element } ) => {
+	const SidebarItem = ( { children }: { children?: React.JSX.Element } ) => {
 		return (
 			<Item
 				className={ clsx( 'sidebar-v2__menu-item', {

--- a/client/layout/sidebar-v2/navigator/navigator-menu.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu.tsx
@@ -12,7 +12,7 @@ interface Props {
 	title?: React.ReactNode;
 	description?: string;
 	backButtonProps?: {
-		icon: JSX.Element;
+		icon: React.JSX.Element;
 		label?: string;
 		onClick: () => void;
 	};


### PR DESCRIPTION
Part of DOTCOM-17400

## Proposed Changes

Applies the `types-react-codemod` `scoped-jsx` transform to `client/layout`, the next folder in the incremental [Migrate Calypso to React 19](https://github.com/Automattic/wp-calypso/pull/111325) effort (follow-up to the validation spike #111325 and the first folder PR #111585).

- `client/layout/sidebar-v2/navigator/navigator-menu.tsx`
- `client/layout/sidebar-v2/navigator/navigator-menu-item.tsx`

The only change is global `JSX.Element` → `React.JSX.Element` (4 references across 2 files). No import is needed — these files already reference the ambient global `React` namespace un-imported (e.g. `React.ReactNode` in the same file).

The change is **forward-compatible**: it type-checks identically under React 18 and React 19, so it can land ahead of the version flip.

### Out of scope (intentionally untouched)

- The 5 `static defaultProps` in `client/layout` (`sidebar/button.jsx`, `masterbar/item.tsx`, `masterbar/logged-out.jsx`, `guided-tours/config-elements/site-link.jsx`, `guided-tours/config-elements/step.tsx`) are all on **class components**, where `defaultProps` is still supported in React 19. Only function-component `defaultProps` need migrating, and there are none here.
- No argless `useRef<T>()` and no `findDOMNode` usages exist in this folder.

## Why are these changes being made?

`JSX.Element` resolves against the global `JSX` namespace, which React 19's types move under `React.JSX`. Migrating folder-by-folder ahead of the version bump keeps each PR small and reviewable and avoids a single mega-diff. Part of DOTCOM-17400.

## Testing Instructions

- `yarn eslint client/layout/sidebar-v2/navigator/navigator-menu.tsx client/layout/sidebar-v2/navigator/navigator-menu-item.tsx` — passes.
- `yarn typecheck-client` — no new errors introduced by these files (purely a type-namespace alias; `React.JSX.Element` ≡ `JSX.Element`).
- No runtime/behavior change — these are type-only annotations.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)