### PR TITLE
Lib: forward-compatible React 19 changes

### DIFF
--- a/client/lib/detect-window-boundary/index.ts
+++ b/client/lib/detect-window-boundary/index.ts
@@ -13,8 +13,8 @@ import { RefObject, useEffect, useRef, useState } from 'react';
 const useDetectWindowBoundary = (
 	offsetY = 0
 ): [ RefObject< HTMLDivElement | undefined >, boolean | undefined ] => {
-	const elementRef = useRef< HTMLDivElement >();
-	const observerRef = useRef< IntersectionObserver >();
+	const elementRef = useRef< HTMLDivElement >( undefined );
+	const observerRef = useRef< IntersectionObserver >( undefined );
 
 	const [ borderCrossed, setBorderCrossed ] = useState< boolean | undefined >( undefined );
 

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -3,7 +3,7 @@ import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import { isCiabOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -1,5 +1,6 @@
 import { Purchases } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
+import { type JSX } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { ResponseDomain } from '../domains/types';
 

--- a/client/lib/use-memo-compare/index.ts
+++ b/client/lib/use-memo-compare/index.ts
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 // See https://usehooks.com/useMemoCompare/
 export function useMemoCompare< T >( next: T, compare: ( previous: T, next: T ) => boolean ): T {
 	// Ref for storing previous value
-	const previousRef = useRef< T >();
+	const previousRef = useRef< T >( undefined );
 
 	// If not equal update previousRef to next value.
 	// We only update if not equal so that this hook continues to return


### PR DESCRIPTION
Part of DOTCOM-17400 — Migrate Calypso to React 19.
Follows the standalone-SPA validation spike (#111325) and the `client/me` migration (#111584).

## Proposed Changes

Migrate the `client/lib` folder for React 19 compatibility by applying the
`types-react-codemod` transforms, using the **import-based JSX style** that is already
the established convention across the codebase (dozens of files; e.g. #111584 for `client/me`).

**`scoped-jsx`** — `@types/react@19` no longer declares the global `JSX` namespace, so import
the `JSX` type from `react` where `JSX.Element` is referenced:
- `client/lib/partner-branding.tsx` — `import { useMemo, type JSX } from 'react'`
- `client/lib/purchases/types.ts` — `import { type JSX } from 'react'`

**`useRef-required-initial`** — give argless `useRef<T>()` an explicit `undefined` initial value:
- `client/lib/use-memo-compare/index.ts`
- `client/lib/detect-window-boundary/index.ts` (2 refs)

Both transforms are valid under `@types/react@18` and `@types/react@19`, so the change is fully
backward-compatible and can land ahead of the React version bump.

### Scope notes (no change required)

- **No `findDOMNode`** in `client/lib`.
- **No function-component `defaultProps`** — the three `defaultProps` usages in `client/lib`
  (`hover-intent`, `url-search`, `analytics/track-component-view`) are all on **class** components,
  which React 19 still supports.

## Why are these changes being made?

To incrementally move Calypso to React 19 folder-by-folder. The spike (#111325) proved the
standalone app bundles its own React and is not gated by the WordPress runtime version; this PR
lands the forward-compatible, codemod-driven type changes for the `lib` folder so the eventual
version flip is a no-op for this surface.

## Testing Instructions

- `yarn typecheck-client` — passes (these are type-only / argument-only changes).
- `yarn eslint client/lib/partner-branding.tsx client/lib/purchases/types.ts` — no new errors.
- No runtime behavior changes; `useRef` semantics are unchanged (it already initialized to `undefined`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)