### PR TITLE
Image Studio: hide the Feature Clip panel on Jetpack sites without a paid AI plan

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -684,5 +684,14 @@ describe( 'feature-clip-sidebar-extension', () => {
 
 			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
 		} );
+
+		it( 'does not dispatch the fetch when the feature is already confirmed absent', () => {
+			setJetpackSite();
+			mockAiFeature = { hasFeature: false };
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -669,6 +669,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 			render( <FeatureClipPanel /> );
 
 			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
 		} );
 
 		it( 'does not hide on Simple sites even when the feature is absent', () => {
@@ -681,6 +682,8 @@ describe( 'feature-clip-sidebar-extension', () => {
 			render( <FeatureClipPanel /> );
 
 			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+			// The hook is disabled outside self-hosted Jetpack — no plans request.
+			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
 		} );
 
 		it( 'dispatches the store fetch once per session, even across remounts', () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -693,5 +693,15 @@ describe( 'feature-clip-sidebar-extension', () => {
 
 			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
 		} );
+
+		it( 'does not fetch plans data on unsupported post types', () => {
+			setJetpackSite();
+			mockPostType = 'jetpack_form';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+
+			expect( container ).toBeEmptyDOMElement();
+			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -21,6 +21,7 @@ const mockTrackAddedToPost = jest.fn();
 const mockTrackPanelViewed = jest.fn();
 const mockFill = jest.fn();
 const mockNotice = jest.fn();
+const mockFetchAiFeature = jest.fn();
 const mockSetCurrentVideoUrl = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentAttachmentId = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentDurationSeconds = jest.fn().mockResolvedValue( undefined );
@@ -36,6 +37,9 @@ let mockMedia: Record< string, unknown > | null = null;
 let mockHasResolvedMedia = true;
 let mockResolutionError: unknown = null;
 let mockHasBlockEditor = true;
+let mockHasPlansStore = true;
+let mockAiFeature: Record< string, unknown > | undefined = { hasFeature: true };
+let mockAiFeatureRequesting = false;
 let mockReelVisible = false;
 let mockGenericVisible = false;
 let mockReelIsConfirming = false;
@@ -112,6 +116,9 @@ jest.mock( '@wordpress/data', () => ( {
 		if ( store === 'core/block-editor' ) {
 			return mockHasBlockEditor ? { insertBlocks: mockInsertBlocks } : {};
 		}
+		if ( store === 'wordpress-com/plans' ) {
+			return { fetchAiAssistantFeature: mockFetchAiFeature };
+		}
 		return { openImageStudio: mockOpenImageStudio };
 	} ),
 	useSelect: ( selector: ( s: ( name: string ) => unknown ) => unknown ) => {
@@ -125,6 +132,14 @@ jest.mock( '@wordpress/data', () => ( {
 					hasFinishedResolution: () => mockHasResolvedMedia,
 					getResolutionError: () => mockResolutionError,
 				};
+			}
+			if ( name === 'wordpress-com/plans' ) {
+				return mockHasPlansStore
+					? {
+							getAiAssistantFeature: () => mockAiFeature,
+							getIsRequestingAiAssistantFeature: () => mockAiFeatureRequesting,
+					  }
+					: undefined;
 			}
 			return undefined;
 		} );
@@ -229,6 +244,10 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockTrackPanelViewed.mockClear();
 		mockFill.mockClear();
 		mockNotice.mockClear();
+		mockFetchAiFeature.mockClear();
+		mockHasPlansStore = true;
+		mockAiFeature = { hasFeature: true };
+		mockAiFeatureRequesting = false;
 		mockSetCurrentVideoUrl.mockClear();
 		mockSetCurrentAttachmentId.mockClear();
 		mockSetCurrentDurationSeconds.mockClear();
@@ -597,6 +616,73 @@ describe( 'feature-clip-sidebar-extension', () => {
 
 			expect( mockInsertBlocks ).not.toHaveBeenCalled();
 			expect( mockTrackAddedToPost ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'plan gating (self-hosted Jetpack)', () => {
+		const setJetpackSite = () => {
+			( window as Record< string, unknown > ).imageStudioData = {
+				canGenerateVideoClips: true,
+				siteType: 'jetpack',
+			};
+		};
+
+		it( 'hides the panel entirely when the site lacks a qualifying AI plan', () => {
+			setJetpackSite();
+			mockAiFeature = { hasFeature: false };
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+
+			expect( container ).toBeEmptyDOMElement();
+			expect( mockFill ).not.toHaveBeenCalled();
+			expect( mockTrackPanelViewed ).not.toHaveBeenCalled();
+		} );
+
+		it( 'renders the panel when the site has a qualifying AI plan', () => {
+			setJetpackSite();
+			mockAiFeature = { hasFeature: true };
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'fails open when the plans store is not registered', () => {
+			setJetpackSite();
+			mockHasPlansStore = false;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not hide on Simple sites even when the feature is absent', () => {
+			( window as Record< string, unknown > ).imageStudioData = {
+				canGenerateVideoClips: true,
+				siteType: 'simple',
+			};
+			mockAiFeature = { hasFeature: false };
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'dispatches the store fetch once when data is not already loading', () => {
+			setJetpackSite();
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( mockFetchAiFeature ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not dispatch the fetch while a request is already in flight', () => {
+			setJetpackSite();
+			mockAiFeatureRequesting = true;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -116,8 +116,9 @@ jest.mock( '@wordpress/data', () => ( {
 		if ( store === 'core/block-editor' ) {
 			return mockHasBlockEditor ? { insertBlocks: mockInsertBlocks } : {};
 		}
+		// Like real wp.data: dispatch() for an unregistered store is undefined.
 		if ( store === 'wordpress-com/plans' ) {
-			return { fetchAiAssistantFeature: mockFetchAiFeature };
+			return mockHasPlansStore ? { fetchAiAssistantFeature: mockFetchAiFeature } : undefined;
 		}
 		return { openImageStudio: mockOpenImageStudio };
 	} ),
@@ -654,6 +655,20 @@ describe( 'feature-clip-sidebar-extension', () => {
 			render( <FeatureClipPanel /> );
 
 			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+			// No store, no fetch — and no crash from the undefined dispatch.
+			expect( mockFetchAiFeature ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not hide on Atomic sites even when the feature is absent', () => {
+			( window as Record< string, unknown > ).imageStudioData = {
+				canGenerateVideoClips: true,
+				siteType: 'atomic',
+			};
+			mockAiFeature = { hasFeature: false };
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
 		} );
 
 		it( 'does not hide on Simple sites even when the feature is absent', () => {
@@ -668,11 +683,14 @@ describe( 'feature-clip-sidebar-extension', () => {
 			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
 		} );
 
-		it( 'dispatches the store fetch once when data is not already loading', () => {
+		it( 'dispatches the store fetch once per session, even across remounts', () => {
 			setJetpackSite();
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { unmount } = render( <FeatureClipPanel /> );
+			unmount();
 			render( <FeatureClipPanel /> );
 
+			// Two mounts, two effect runs — the module-level dedupe holds it to one.
 			expect( mockFetchAiFeature ).toHaveBeenCalledTimes( 1 );
 		} );
 

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -254,13 +254,6 @@ function FeatureClipPanel(): JSX.Element | null {
 		};
 	}, [] );
 
-	const hasAiFeature = useHasAiAssistantFeature();
-	// Site-type scoping lives here, not in the hook: hiding only applies to
-	// self-hosted Jetpack, where generation is server-gated on the paid AI
-	// feature. The wpcom plans that surface this panel already include it.
-	const isSelfHostedJetpack =
-		typeof window !== 'undefined' && window.imageStudioData?.siteType === 'jetpack';
-
 	// Bail until the post type is both known and supported, before any of the
 	// body's hooks run — so the panel never mounts (and never fires a phantom
 	// panel-viewed impression) on editors like the Jetpack Form editor, nor in
@@ -268,6 +261,25 @@ function FeatureClipPanel(): JSX.Element | null {
 	if ( ! postType || ! SUPPORTED_POST_TYPES.includes( postType ) ) {
 		return null;
 	}
+
+	return <FeatureClipPlanGate postType={ postType } postId={ postId } />;
+}
+
+/**
+ * Sits between the post-type gate and the panel body so the AI plan lookup
+ * (and its potential store fetch) only runs on editors where the panel could
+ * actually render.
+ */
+function FeatureClipPlanGate( {
+	postType,
+	postId,
+}: FeatureClipPanelBodyProps ): JSX.Element | null {
+	const hasAiFeature = useHasAiAssistantFeature();
+	// Site-type scoping lives here, not in the hook: hiding only applies to
+	// self-hosted Jetpack, where generation is server-gated on the paid AI
+	// feature. The wpcom plans that surface this panel already include it.
+	const isSelfHostedJetpack =
+		typeof window !== 'undefined' && window.imageStudioData?.siteType === 'jetpack';
 
 	// Hide the panel entirely rather than offer an entry point to a dead end.
 	// Fails open while the plan data loads.

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -274,12 +274,14 @@ function FeatureClipPlanGate( {
 	postType,
 	postId,
 }: FeatureClipPanelBodyProps ): JSX.Element | null {
-	const hasAiFeature = useHasAiAssistantFeature();
 	// Site-type scoping lives here, not in the hook: hiding only applies to
 	// self-hosted Jetpack, where generation is server-gated on the paid AI
-	// feature. The wpcom plans that surface this panel already include it.
+	// feature. The wpcom plans that surface this panel already include it,
+	// so the hook (and its one plans request per editor load) stays disabled
+	// everywhere else.
 	const isSelfHostedJetpack =
 		typeof window !== 'undefined' && window.imageStudioData?.siteType === 'jetpack';
+	const hasAiFeature = useHasAiAssistantFeature( { enabled: isSelfHostedJetpack } );
 
 	// Hide the panel entirely rather than offer an entry point to a dead end.
 	// Fails open while the plan data loads.

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -342,7 +342,9 @@ function FeatureClipPanelBody( { postType, postId }: FeatureClipPanelBodyProps )
 	);
 
 	// Fire one impression per panel mount — the denominator for sidebar
-	// engagement rates. Empty deps: the panel mounts once per editor load.
+	// engagement rates. Empty deps: fires per PanelBody mount, which is once
+	// per editor load except when the plan gate flips mid-session (the
+	// fail-open window on unentitled Jetpack sites can mount-then-hide).
 	useEffect( () => {
 		trackImageStudioFeatureClipPanelViewed();
 	}, [] );

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -25,6 +25,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { SocialLogo } from 'social-logos';
 import { ExperimentalBadge } from '../components/experimental-badge';
 import { ReelShareConfirmationDialog } from '../components/reel-share-confirmation-dialog';
+import { useHasAiAssistantFeature } from '../hooks/use-ai-assistant-feature';
 import { useGenericShare } from '../hooks/use-generic-share';
 import { useReelShare } from '../hooks/use-reel-share';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
@@ -253,11 +254,24 @@ function FeatureClipPanel(): JSX.Element | null {
 		};
 	}, [] );
 
+	const hasAiFeature = useHasAiAssistantFeature();
+	// Site-type scoping lives here, not in the hook: hiding only applies to
+	// self-hosted Jetpack, where generation is server-gated on the paid AI
+	// feature. The wpcom plans that surface this panel already include it.
+	const isSelfHostedJetpack =
+		typeof window !== 'undefined' && window.imageStudioData?.siteType === 'jetpack';
+
 	// Bail until the post type is both known and supported, before any of the
 	// body's hooks run — so the panel never mounts (and never fires a phantom
 	// panel-viewed impression) on editors like the Jetpack Form editor, nor in
 	// the transient window before the current post type is available.
 	if ( ! postType || ! SUPPORTED_POST_TYPES.includes( postType ) ) {
+		return null;
+	}
+
+	// Hide the panel entirely rather than offer an entry point to a dead end.
+	// Fails open while the plan data loads.
+	if ( isSelfHostedJetpack && ! hasAiFeature ) {
 		return null;
 	}
 

--- a/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
+++ b/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
@@ -47,7 +47,14 @@ export function useHasAiAssistantFeature(): boolean {
 		if ( hasFeature === false ) {
 			return;
 		}
-		if ( ! storeAvailable || fetchDispatched || isRequesting ) {
+		if ( ! storeAvailable || fetchDispatched ) {
+			return;
+		}
+		// An in-flight request means someone else (Jetpack's own AI surfaces)
+		// owns the fetch — claim the session flag so we don't dispatch a
+		// redundant one when it resolves.
+		if ( isRequesting ) {
+			fetchDispatched = true;
 			return;
 		}
 		const plansDispatch = dispatch( PLANS_STORE ) as

--- a/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
+++ b/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
@@ -1,0 +1,56 @@
+import { dispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Jetpack's editor bundle registers this store and its AI Assistant
+ * extensions populate it. Its default state fails open (`hasFeature: true`
+ * until real data arrives), so reading early can never misreport an
+ * entitled site as unentitled.
+ */
+const PLANS_STORE = 'wordpress-com/plans';
+
+interface AiFeatureData {
+	hasFeature?: boolean;
+}
+
+interface PlansStoreSelectors {
+	getAiAssistantFeature?: () => AiFeatureData | undefined;
+	getIsRequestingAiAssistantFeature?: () => boolean;
+}
+
+// One fetch per editor session, deduped against Jetpack's own AI nudges via
+// the store's isRequesting flag.
+let fetchDispatched = false;
+
+/**
+ * Whether the site has the paid AI Assistant feature, read from Jetpack's
+ * `wordpress-com/plans` store. `hasFeature` is `wpcom_site_has_feature(
+ * 'ai-assistant' )` — granted by Jetpack AI plans, wpcom Personal and
+ * higher, or Jetpack Complete — the same flag the video-generation server
+ * gate checks. Returns false ONLY on confirmed data; store absent or data
+ * not yet loaded fails open to true. Callers decide where the result
+ * applies (e.g. site-type scoping).
+ */
+export function useHasAiAssistantFeature(): boolean {
+	const { hasFeature, isRequesting, storeAvailable } = useSelect( ( select ) => {
+		const store = select( PLANS_STORE ) as PlansStoreSelectors | undefined;
+		return {
+			hasFeature: store?.getAiAssistantFeature?.()?.hasFeature,
+			isRequesting: store?.getIsRequestingAiAssistantFeature?.() ?? false,
+			storeAvailable: !! store?.getAiAssistantFeature,
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( ! storeAvailable || fetchDispatched || isRequesting ) {
+			return;
+		}
+		fetchDispatched = true;
+		const plansDispatch = dispatch( PLANS_STORE ) as
+			| { fetchAiAssistantFeature?: () => void }
+			| undefined;
+		plansDispatch?.fetchAiAssistantFeature?.();
+	}, [ storeAvailable, isRequesting ] );
+
+	return hasFeature !== false;
+}

--- a/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
+++ b/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
@@ -42,15 +42,23 @@ export function useHasAiAssistantFeature(): boolean {
 	}, [] );
 
 	useEffect( () => {
+		// A false hasFeature is necessarily real data (the store's default is
+		// true), so there's nothing left to fetch.
+		if ( hasFeature === false ) {
+			return;
+		}
 		if ( ! storeAvailable || fetchDispatched || isRequesting ) {
 			return;
 		}
-		fetchDispatched = true;
 		const plansDispatch = dispatch( PLANS_STORE ) as
 			| { fetchAiAssistantFeature?: () => void }
 			| undefined;
-		plansDispatch?.fetchAiAssistantFeature?.();
-	}, [ storeAvailable, isRequesting ] );
+		if ( typeof plansDispatch?.fetchAiAssistantFeature !== 'function' ) {
+			return;
+		}
+		fetchDispatched = true;
+		plansDispatch.fetchAiAssistantFeature();
+	}, [ storeAvailable, isRequesting, hasFeature ] );
 
 	return hasFeature !== false;
 }

--- a/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
+++ b/packages/image-studio/src/hooks/use-ai-assistant-feature.ts
@@ -2,10 +2,12 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
- * Jetpack's editor bundle registers this store and its AI Assistant
- * extensions populate it. Its default state fails open (`hasFeature: true`
- * until real data arrives), so reading early can never misreport an
- * entitled site as unentitled.
+ * Jetpack's editor bundle registers this store with fail-open defaults
+ * (`hasFeature: true`), so reading early can never misreport an entitled
+ * site as unentitled. Nothing populates it at editor boot — the store's
+ * resolver is inert because the defaults pre-fill the state, and Jetpack's
+ * own surfaces only refresh it after an AI request — so when this hook is
+ * enabled it owns the fetch.
  */
 const PLANS_STORE = 'wordpress-com/plans';
 
@@ -18,8 +20,17 @@ interface PlansStoreSelectors {
 	getIsRequestingAiAssistantFeature?: () => boolean;
 }
 
-// One fetch per editor session, deduped against Jetpack's own AI nudges via
-// the store's isRequesting flag.
+interface UseHasAiAssistantFeatureOptions {
+	/**
+	 * When false, the hook reads nothing and fetches nothing, and reports
+	 * entitled. Lets callers scope the (one per editor load) plans request
+	 * to the surfaces that actually consume the verdict.
+	 */
+	enabled?: boolean;
+}
+
+// One fetch per editor session; the isRequesting claim below also covers
+// Jetpack's own post-AI-request refreshes.
 let fetchDispatched = false;
 
 /**
@@ -27,19 +38,27 @@ let fetchDispatched = false;
  * `wordpress-com/plans` store. `hasFeature` is `wpcom_site_has_feature(
  * 'ai-assistant' )` — granted by Jetpack AI plans, wpcom Personal and
  * higher, or Jetpack Complete — the same flag the video-generation server
- * gate checks. Returns false ONLY on confirmed data; store absent or data
- * not yet loaded fails open to true. Callers decide where the result
- * applies (e.g. site-type scoping).
+ * gate checks. Returns false ONLY on confirmed data; disabled, store
+ * absent, or data not yet loaded all fail open to true. Callers decide
+ * where the result applies (e.g. site-type scoping via `enabled`).
  */
-export function useHasAiAssistantFeature(): boolean {
-	const { hasFeature, isRequesting, storeAvailable } = useSelect( ( select ) => {
-		const store = select( PLANS_STORE ) as PlansStoreSelectors | undefined;
-		return {
-			hasFeature: store?.getAiAssistantFeature?.()?.hasFeature,
-			isRequesting: store?.getIsRequestingAiAssistantFeature?.() ?? false,
-			storeAvailable: !! store?.getAiAssistantFeature,
-		};
-	}, [] );
+export function useHasAiAssistantFeature( {
+	enabled = true,
+}: UseHasAiAssistantFeatureOptions = {} ): boolean {
+	const { hasFeature, isRequesting, storeAvailable } = useSelect(
+		( select ) => {
+			if ( ! enabled ) {
+				return { hasFeature: undefined, isRequesting: false, storeAvailable: false };
+			}
+			const store = select( PLANS_STORE ) as PlansStoreSelectors | undefined;
+			return {
+				hasFeature: store?.getAiAssistantFeature?.()?.hasFeature,
+				isRequesting: store?.getIsRequestingAiAssistantFeature?.() ?? false,
+				storeAvailable: !! store?.getAiAssistantFeature,
+			};
+		},
+		[ enabled ]
+	);
 
 	useEffect( () => {
 		// A false hasFeature is necessarily real data (the store's default is


### PR DESCRIPTION
## Summary

Jetpack 15.9 shows the Feature Clip panel on every connected self-hosted site, but video generation is server-gated on the paid AI feature. Users without it currently open the panel, write a prompt, wait for the agent round trip, and get "Generating videos requires an AI subscription." — a dead end that shows up as a sustained error spike. This hides the panel for that population instead.

## How

- New `useHasAiAssistantFeature()` hook reads Jetpack's own `wordpress-com/plans` wp.data store (registered by the Jetpack editor bundle, populated by its AI Assistant extensions). If nothing has loaded the data yet, the hook dispatches the store's own `fetchAiAssistantFeature` once — deduped via the store's `isRequesting` flag, so no duplicate network call.
- The store's `hasFeature` field is `wpcom_site_has_feature( 'ai-assistant' )` — granted by Jetpack AI plans, wpcom Personal and higher, or Jetpack Complete — which is the **same flag the video server gate checks**, so the panel's visibility and the server's verdict cannot disagree.
- The hook is site-type-agnostic; `FeatureClipPanel` applies the scoping: hide only when `siteType === 'jetpack'` **and** `hasFeature === false`. The wpcom plans that surface the panel already include the AI feature, so Simple/Atomic are untouched.

## Fail-open by design

Every ambiguous state renders the panel exactly as today, with the server gate as backstop:
- plans store not registered on the page
- feature data not yet loaded (the store's default is `hasFeature: true`)
- non-Jetpack site types

A brief appearance-then-hide is possible on slow sites (panel renders during the fail-open window, disappears when the data arrives). The inverse — hide until confirmed — would penalize every entitled user instead.

## Notes for reviewers

- `wordpress-com/plans` is an internal store of the Jetpack plugin, not a public API. Every access is optional-chained; if a future Jetpack renames it, the gate silently stops hiding (back to today's behavior) rather than breaking the panel.
- Sidebar impression metrics will shift when this ships: non-entitled Jetpack users currently fire `panel-viewed` impressions and mostly won't anymore — engagement denominators change across the deploy boundary.

## Test plan

- [ ] Self-hosted Jetpack site **without** Jetpack AI / Complete: Feature Clip panel absent from both the document sidebar and the Jetpack sidebar.
- [ ] Self-hosted Jetpack site **with** Jetpack AI or Complete: panel present and functional.
- [ ] wpcom Simple/Atomic: unchanged.
- [ ] Jest: `yarn test-packages packages/image-studio --testPathPattern feature-clip-sidebar-extension`