### PR TITLE
Login: standardize React 19 JSX on the import style

### DIFF
--- a/client/login/magic-login/utils/heading-utils.tsx
+++ b/client/login/magic-login/utils/heading-utils.tsx
@@ -1,11 +1,12 @@
 import { createElement } from '@wordpress/element';
 import type { TranslateResult } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 type TranslateFn = (
 	text: string,
 	options?: {
 		args?: Record< string, unknown >;
-		components?: Record< string, React.JSX.Element >;
+		components?: Record< string, JSX.Element >;
 	}
 ) => TranslateResult;
 

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { type JSX } from 'react';
 import { useSelector } from 'react-redux';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -8,11 +9,11 @@ interface OneLoginFooterProps {
 	/**
 	 * When `isLoginView` is true, this is the "lost password" link.
 	 */
-	lostPasswordLink?: React.JSX.Element;
+	lostPasswordLink?: JSX.Element;
 	/**
 	 * When `isLoginView` is false, this is the "back to login" link.
 	 */
-	loginLink?: React.JSX.Element;
+	loginLink?: JSX.Element;
 	/**
 	 * The content of the footer. If provided, it will be rendered instead of the default links.
 	 */
@@ -20,7 +21,7 @@ interface OneLoginFooterProps {
 	/**
 	 * When `isLoginView` is false, this is the "support" link.
 	 */
-	supportLink?: React.JSX.Element;
+	supportLink?: JSX.Element;
 	/**
 	 * When true, this is the footer for the main login screen.
 	 */

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { type JSX } from 'react';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useLoginContext } from 'calypso/login/login-context';
@@ -143,7 +144,7 @@ const OneLoginLayout = ( {
 		);
 	};
 
-	const topBar = (): React.JSX.Element => {
+	const topBar = (): JSX.Element => {
 		const rightElement = (
 			<nav className="wp-login__one-login-layout-top-right">
 				{ isSectionSignup ? <LoginLink /> : <SignUpLink /> }


### PR DESCRIPTION
Part of DOTCOM-17400 — Migrate Calypso to React 19.
Follow-up to #111585.

## Proposed Changes

#111585 migrated `client/login` for React 19 using the `React.JSX.Element` **prefix** style.
The rest of the migration effort uses the **import** style instead — `import { type JSX } from 'react'`
with a bare `JSX.Element` reference (dozens of files codebase-wide; e.g. #111584 for `client/me`).

This PR standardizes the three `client/login` files onto the import style so the React 19 work is
consistent across folders:

- `client/login/wp-login/components/one-login-footer.tsx` (3 props)
- `client/login/wp-login/components/one-login-layout.tsx` (`topBar` return type)
- `client/login/magic-login/utils/heading-utils.tsx` (`components` record)

Both forms are valid under `@types/react@18` and `@types/react@19`; this is a pure style change
with no behavior or type change. (`React.ReactNode` usages are left as-is — out of scope for the
JSX standardization.)

## Why are these changes being made?

To keep the folder-by-folder React 19 migration consistent on a single JSX style, matching the
convention already used across `client/` from the validation spike (#111325).

## Testing Instructions

- `yarn eslint client/login/...` — no new errors (import/order verified).
- `yarn typecheck-client` — passes (type-only change).
- No runtime behavior changes; the login and magic-login flows render identically.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)