### PR TITLE
Pricing differentiation: enable new features in all onboarding flows

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { renderHook } from '@testing-library/react';
 import { useSelector } from 'calypso/state';
 import usePlanDifferentiatorsExperiment from '../use-plan-differentiators-experiment';

--- a/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
@@ -1,0 +1,105 @@
+import { renderHook } from '@testing-library/react';
+import { useSelector } from 'calypso/state';
+import usePlanDifferentiatorsExperiment from '../use-plan-differentiators-experiment';
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+const ELIGIBLE_RESULT = {
+	showDifferentiatorHeader: false,
+	useVar42NoAiFeatures: true,
+	showPricingDifferentiationFeaturePills: true,
+	useFocusedNewCopyTaglines: true,
+	isExperimentVariant: true,
+};
+
+const INELIGIBLE_RESULT = {
+	showDifferentiatorHeader: false,
+	useVar42NoAiFeatures: false,
+	showPricingDifferentiationFeaturePills: false,
+	useFocusedNewCopyTaglines: false,
+	isExperimentVariant: false,
+};
+
+function mockSite( isGatingBusinessQ1: boolean | undefined ) {
+	( useSelector as jest.Mock ).mockImplementation( () =>
+		isGatingBusinessQ1 !== undefined
+			? { ID: 123, options: { is_gating_business_q1: isGatingBusinessQ1 } }
+			: null
+	);
+}
+
+describe( 'usePlanDifferentiatorsExperiment', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	describe( 'signup flows (no siteId yet)', () => {
+		test( 'is eligible when isInSignup=true and siteId is null', () => {
+			mockSite( undefined );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: null } )
+			);
+			expect( result.current ).toEqual( ELIGIBLE_RESULT );
+		} );
+
+		test( 'is eligible when isInSignup=true and siteId is undefined', () => {
+			mockSite( undefined );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: true } )
+			);
+			expect( result.current ).toEqual( ELIGIBLE_RESULT );
+		} );
+	} );
+
+	describe( 'existing sites in signup flows', () => {
+		test( 'is not eligible when isInSignup=true but siteId is set and gating flag is absent', () => {
+			mockSite( false );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: 123 } )
+			);
+			expect( result.current ).toEqual( INELIGIBLE_RESULT );
+		} );
+
+		test( 'is eligible when isInSignup=true, siteId is set, and gating flag is true', () => {
+			mockSite( true );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: 123 } )
+			);
+			expect( result.current ).toEqual( ELIGIBLE_RESULT );
+		} );
+	} );
+
+	describe( 'logged-in flows (not in signup)', () => {
+		test( 'is eligible when site has the gating flag', () => {
+			mockSite( true );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
+			);
+			expect( result.current ).toEqual( ELIGIBLE_RESULT );
+		} );
+
+		test( 'is not eligible when site does not have the gating flag', () => {
+			mockSite( false );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
+			);
+			expect( result.current ).toEqual( INELIGIBLE_RESULT );
+		} );
+
+		test( 'is not eligible when site is not found', () => {
+			mockSite( undefined );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
+			);
+			expect( result.current ).toEqual( INELIGIBLE_RESULT );
+		} );
+
+		test( 'is not eligible when there is no siteId', () => {
+			mockSite( undefined );
+			const { result } = renderHook( () =>
+				usePlanDifferentiatorsExperiment( { isInSignup: false } )
+			);
+			expect( result.current ).toEqual( INELIGIBLE_RESULT );
+		} );
+	} );
+} );

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -166,7 +166,6 @@ function useGenerateActionCallback( {
 	sitePlanSlug,
 	siteId,
 	coupon,
-	isGatingBusinessQ1,
 	redirectTo,
 	pluginSlug,
 }: {
@@ -179,11 +178,6 @@ function useGenerateActionCallback( {
 	sitePlanSlug?: PlanSlug | null;
 	siteId?: number | null;
 	coupon?: string;
-	/**
-	 * When true, adds `is_gating_business_q1` to the plan cart item extra data
-	 * for the rolled-out pricing differentiation cohort.
-	 */
-	isGatingBusinessQ1?: boolean;
 	redirectTo?: string;
 	pluginSlug?: string;
 } ): UseActionCallback {
@@ -289,21 +283,8 @@ function useGenerateActionCallback( {
 				} );
 			}
 
-			// Augment the cart item with pricing differentiation experiment data if applicable.
-			let augmentedCartItemForPlan = cartItemForPlan;
-
-			if ( cartItemForPlan && isGatingBusinessQ1 ) {
-				augmentedCartItemForPlan = {
-					...cartItemForPlan,
-					extra: {
-						...cartItemForPlan.extra,
-						is_gating_business_q1: true,
-					},
-				};
-			}
-
 			handleUpgradeClick( {
-				cartItemForPlan: augmentedCartItemForPlan,
+				cartItemForPlan,
 				selectedStorageAddOn,
 			} );
 			return;

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -73,7 +73,6 @@ export default function useGenerateActionHook( {
 	coupon,
 	showBillingDescriptionForIncreasedRenewalPrice,
 	enableCategorisedFeatures,
-	isGatingBusinessQ1,
 	redirectTo,
 	pluginSlug,
 }: {
@@ -87,11 +86,6 @@ export default function useGenerateActionHook( {
 	coupon?: string;
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 	enableCategorisedFeatures?: boolean;
-	/**
-	 * When true, adds `is_gating_business_q1` to the plan cart item extra data
-	 * for the rolled-out pricing differentiation cohort.
-	 */
-	isGatingBusinessQ1?: boolean;
 	redirectTo?: string;
 	pluginSlug?: string;
 } ): UseAction {
@@ -124,7 +118,6 @@ export default function useGenerateActionHook( {
 		sitePlanSlug,
 		siteId,
 		coupon,
-		isGatingBusinessQ1,
 		redirectTo,
 		pluginSlug,
 	} );

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -27,13 +27,11 @@ type PlanDifferentiatorsResult = {
 };
 
 interface UsePlanDifferentiatorsParams {
-	flowName?: string | null;
 	isInSignup: boolean;
 	siteId?: number | null;
 }
 
 function usePlanDifferentiatorsExperiment( {
-	flowName,
 	isInSignup,
 	siteId,
 }: UsePlanDifferentiatorsParams ): PlanDifferentiatorsResult {
@@ -41,7 +39,7 @@ function usePlanDifferentiatorsExperiment( {
 
 	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
 
-	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
+	const isEligibleSignupFlow = isInSignup;
 	const isEligibleAdminIntent = ! isInSignup && hasGatingFlag;
 	const isEligible =
 		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -41,8 +41,7 @@ function usePlanDifferentiatorsExperiment( {
 
 	// New-site signups (no siteId yet) are always eligible.
 	// Flows operating on an existing site are eligible only when the gating flag is set.
-	const isEligible =
-		process.env.NODE_ENV !== 'test' && ( ( isInSignup && ! siteId ) || hasGatingFlag );
+	const isEligible = ( isInSignup && ! siteId ) || hasGatingFlag;
 
 	return {
 		showDifferentiatorHeader: false,

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -39,10 +39,10 @@ function usePlanDifferentiatorsExperiment( {
 
 	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
 
-	const isEligibleSignupFlow = isInSignup;
-	const isEligibleAdminIntent = ! isInSignup && hasGatingFlag;
+	// New-site signups (no siteId yet) are always eligible.
+	// Flows operating on an existing site are eligible only when the gating flag is set.
 	const isEligible =
-		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );
+		process.env.NODE_ENV !== 'test' && ( ( isInSignup && ! siteId ) || hasGatingFlag );
 
 	return {
 		showDifferentiatorHeader: false,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -580,7 +580,7 @@ const PlansFeaturesMain = ( {
 		showPricingDifferentiationFeaturePills,
 		useFocusedNewCopyTaglines,
 		isExperimentVariant,
-	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup, siteId } );
+	} = usePlanDifferentiatorsExperiment( { isInSignup, siteId } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
@@ -642,7 +642,6 @@ const PlansFeaturesMain = ( {
 		coupon,
 		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
 		enableCategorisedFeatures: showSimplifiedFeatures,
-		isGatingBusinessQ1: isExperimentVariant,
 		redirectTo,
 		pluginSlug,
 	} );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1067,12 +1067,6 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 *
 	 */
 	hosting_intent?: string;
-
-	/**
-	 * Indicates the user was in the rolled-out pricing differentiation cohort.
-	 * Used to add the `gating-business-q1` blog sticker on purchase.
-	 */
-	is_gating_business_q1?: boolean;
 }
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-16677

## Proposed Changes

* Enable the new features on all onboarding flows.
* Remove unneeded code for setting the sticker on plan activation since the stickers are set on site creation.


**Onboarding PM Before**
<img width="1376" height="917" alt="onboarding-pm-before" src="https://github.com/user-attachments/assets/fbd9a273-5f73-4ee9-9421-c99576657390" />

**Onboarding PM After**
<img width="1376" height="917" alt="onboarding-pm-after" src="https://github.com/user-attachments/assets/356c7478-019c-4919-b578-93ee77c0f239" />

**Launch Site Before**
<img width="1376" height="917" alt="launch-site-before" src="https://github.com/user-attachments/assets/d649a647-6768-4570-be9e-a4e89cd26ea7" />

**Launch Site After**
<img width="1376" height="917" alt="launch-site-after" src="https://github.com/user-attachments/assets/b8129c87-a61b-4d04-ad34-2a7fe06997a5" />

**Domain and Plan Before**
<img width="1376" height="917" alt="domain-and-plan-before" src="https://github.com/user-attachments/assets/a0d509d8-bc41-402c-9031-bd08e198af4f" />

**Domain and Plan After**
<img width="1376" height="917" alt="domain-and-plan-after" src="https://github.com/user-attachments/assets/96798f34-190d-423c-aec5-842b5c8b864a" />

**AI Site Builder Before**
<img width="1376" height="893" alt="ai-site-builder-before" src="https://github.com/user-attachments/assets/2a3bb0fd-864d-468b-8ef2-30621bcee945" />

**AI Site Builder After**
<img width="1376" height="893" alt="ai-site-builder-after" src="https://github.com/user-attachments/assets/fac22f28-eb25-4b9a-bc73-86f9b72220a7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the project to update the features in the pricing grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use 222740-ghe-Automattic/wpcom on the sandbox.
* From calypso.localhost or calypso.live compare the onboarding flows to production:
  * /start/onboarding-pm/plans
  * /setup/ai-site-builder/plans
  * /setup/start-writing/plans
  * /setup/newsletter/plans
* Create a new free site, then check the following flows and confirm that the new features appear there:
  * /start/launch-site/plans?siteSlug=your-site-url
  * /setup/domain-and-plan/plans?siteSlug=your-site-url
* Create a new site with one of these flows and confirm that the new features appear on /plans/ page for the site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
