### PR TITLE
client/components: remove section-nav findDOMNode + migrate docs-example defaultProps (React 19)

### DIFF
--- a/client/components/action-card/docs/example.jsx
+++ b/client/components/action-card/docs/example.jsx
@@ -2,14 +2,8 @@ import ActionCard from '../index';
 
 ActionCard.displayName = 'ActionCard';
 
-function ActionCardExample( props ) {
-	return props.exampleCode;
-}
-
-ActionCardExample.displayName = 'ActionCard';
-
-ActionCardExample.defaultProps = {
-	exampleCode: (
+function ActionCardExample( {
+	exampleCode = (
 		<div>
 			<ActionCard
 				headerText="This is a header text"
@@ -33,6 +27,10 @@ ActionCardExample.defaultProps = {
 			/>
 		</div>
 	),
-};
+} ) {
+	return exampleCode;
+}
+
+ActionCardExample.displayName = 'ActionCard';
 
 export default ActionCardExample;

--- a/client/components/animate/docs/example.jsx
+++ b/client/components/animate/docs/example.jsx
@@ -1,18 +1,16 @@
 import Animate from '../index';
 
-function AnimateExample( props ) {
-	return props.exampleCode;
-}
-
-Animate.displayName = 'Animate';
-AnimateExample.displayName = 'Animate';
-
-AnimateExample.defaultProps = {
-	exampleCode: (
+function AnimateExample( {
+	exampleCode = (
 		<Animate type="appear">
 			This content will animate on rendering. You may have to reload the page to see the effect.
 		</Animate>
 	),
-};
+} ) {
+	return exampleCode;
+}
+
+Animate.displayName = 'Animate';
+AnimateExample.displayName = 'Animate';
 
 export default AnimateExample;

--- a/client/components/back-button/docs/example.jsx
+++ b/client/components/back-button/docs/example.jsx
@@ -1,9 +1,7 @@
-const BackButtonExample = ( props ) => props.exampleCode;
+const BackButtonExample = ( {
+	exampleCode = '<div className="back-button__example"><BackButton /></div>',
+} ) => exampleCode;
 
 BackButtonExample.displayName = 'BackButton';
-
-BackButtonExample.defaultProps = {
-	exampleCode: '<div className="back-button__example"><BackButton /></div>',
-};
 
 export default BackButtonExample;

--- a/client/components/diff-viewer/docs/example.jsx
+++ b/client/components/diff-viewer/docs/example.jsx
@@ -2,12 +2,8 @@ import DiffViewer from '../index';
 
 DiffViewer.displayName = 'DiffViewer';
 
-const DiffViewerExample = ( { exampleCode } ) => exampleCode;
-
-DiffViewerExample.displayName = 'DiffViewer';
-
-DiffViewerExample.defaultProps = {
-	exampleCode: `<DiffViewer diff={ \`diff --git a/circle.yml b/circle.yml
+const DiffViewerExample = ( {
+	exampleCode = `<DiffViewer diff={ \`diff --git a/circle.yml b/circle.yml
 index 51455bdb14..bc0622d001 100644
 --- a/circle.yml
 +++ b/circle.yml
@@ -20,6 +16,8 @@ index 51455bdb14..bc0622d001 100644
    pre:
      - ? |
 \` } />`,
-};
+} ) => exampleCode;
+
+DiffViewerExample.displayName = 'DiffViewer';
 
 export default DiffViewerExample;

--- a/client/components/empty-content/docs/example.jsx
+++ b/client/components/empty-content/docs/example.jsx
@@ -1,13 +1,7 @@
 import EmptyContent from 'calypso/components/empty-content';
 
-const EmptyContentExample = ( props ) => {
-	return props.exampleCode;
-};
-
-EmptyContentExample.displayName = 'EmptyContent';
-
-EmptyContentExample.defaultProps = {
-	exampleCode: (
+const EmptyContentExample = ( {
+	exampleCode = (
 		<div className="design-assets__group">
 			<div>
 				<EmptyContent
@@ -27,6 +21,10 @@ EmptyContentExample.defaultProps = {
 			</div>
 		</div>
 	),
+} ) => {
+	return exampleCode;
 };
+
+EmptyContentExample.displayName = 'EmptyContent';
 
 export default EmptyContentExample;

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -20,6 +20,7 @@ class NavItem extends PureComponent {
 		compactCount: PropTypes.bool,
 		className: PropTypes.string,
 		preloadSectionName: PropTypes.string,
+		forwardedRef: PropTypes.oneOfType( [ PropTypes.func, PropTypes.object ] ),
 	};
 
 	_preloaded = false;
@@ -52,7 +53,7 @@ class NavItem extends PureComponent {
 		}
 
 		return (
-			<li className={ itemClassName } role="none">
+			<li className={ itemClassName } role="none" ref={ this.props.forwardedRef }>
 				<a
 					href={ this.props.path }
 					target={ target }

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component } from 'react';
-import ReactDom from 'react-dom';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
 import './tabs.scss';
@@ -97,7 +96,7 @@ class NavTabs extends Component {
 	render() {
 		const { isFirstOverflow, isLastOverflow } = this.state;
 		const tabs = Children.map( this.props.children, ( child, index ) => {
-			return child && cloneElement( child, { ref: this.storeTabRefs( index ) } );
+			return child && cloneElement( child, { forwardedRef: this.storeTabRefs( index ) } );
 		} );
 
 		const isDropdownEnabled = this.isDropdownEnabled();
@@ -146,7 +145,7 @@ class NavTabs extends Component {
 		let totalWidth = 0;
 
 		this.tabRefMap.forEach( ( tabElement ) => {
-			const tabWidth = ReactDom.findDOMNode( tabElement ).offsetWidth;
+			const tabWidth = tabElement.offsetWidth;
 			totalWidth += tabWidth;
 		} );
 

--- a/client/components/textarea-autosize/docs/example.jsx
+++ b/client/components/textarea-autosize/docs/example.jsx
@@ -3,12 +3,8 @@ import TextareaAutosize from '../index';
 TextareaAutosize.displayName = 'TextareaAutosize';
 TextareaAutosizeExample.displayName = 'TextareaAutosize';
 
-function TextareaAutosizeExample( props ) {
-	return props.exampleCode;
-}
-
-TextareaAutosizeExample.defaultProps = {
-	exampleCode: (
+function TextareaAutosizeExample( {
+	exampleCode = (
 		<TextareaAutosize
 			rows="1"
 			defaultValue={
@@ -17,6 +13,8 @@ TextareaAutosizeExample.defaultProps = {
 			}
 		/>
 	),
-};
+} ) {
+	return exampleCode;
+}
 
 export default TextareaAutosizeExample;

--- a/client/components/vertical-nav/docs/example.jsx
+++ b/client/components/vertical-nav/docs/example.jsx
@@ -9,12 +9,8 @@ VerticalNavItem.displayName = 'VerticalNavItem';
 VerticalNavItemEnhanced.displayName = 'VerticalNavItemEnhanced';
 VerticalNavExample.displayName = 'VerticalNav';
 
-function VerticalNavExample( props ) {
-	return props.exampleCode;
-}
-
-VerticalNavExample.defaultProps = {
-	exampleCode: (
+function VerticalNavExample( {
+	exampleCode = (
 		<VerticalNav>
 			<VerticalNavItem path="/stats" key="0">
 				Stats
@@ -48,6 +44,8 @@ VerticalNavExample.defaultProps = {
 			/>
 		</VerticalNav>
 	),
-};
+} ) {
+	return exampleCode;
+}
 
 export default VerticalNavExample;


### PR DESCRIPTION
## Proposed Changes

Continues the React 19 forward-compatibility audit of `client/components` (follow-up to #111556, #111566, #111597, #111602, #111609).

* **`section-nav` — remove `ReactDom.findDOMNode`** (removed in React 19). `NavTabs` measured each tab's width via `findDOMNode` on the cloned `NavItem` class instances. `NavItem` now forwards a ref to its root `<li>` via a `forwardedRef` callback prop, and `NavTabs` reads `offsetWidth` off the DOM node directly. Using a plain prop instead of wrapping `NavItem` in `forwardRef` keeps its class export and inferred TypeScript prop types intact for `.tsx` consumers.
* **Seven `components/*/docs/example.jsx`** — migrate off `defaultProps` (ignored on function components in React 19) to a default parameter for the `exampleCode` prop: `action-card`, `animate`, `back-button`, `diff-viewer`, `empty-content`, `textarea-autosize`, `vertical-nav`.

Both changes are behavior-preserving.

## Why are these changes being made?

`findDOMNode` is removed in React 19, and `defaultProps` is ignored on function components. These are the remaining instances of both in `client/components` outside of `infinite-list` (which combines `findDOMNode` with a legacy string-ref migration and will be handled separately).

## Testing Instructions

* `yarn test-client client/components/section-nav` — 8 tests pass.
* `yarn typecheck-client` clean for the changed files (including `NavItem` `.tsx` consumers).
* Section-nav tabs still collapse into the dropdown when the container is narrower than the tabs.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
