### PR TITLE
Reader: confirm subscription in suggested follows dialog

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -136,7 +136,10 @@ const ReaderSuggestedFollowsDialog = ( {
 				{ ! isLoading && (
 					<>
 						<div className="reader-recommended-follows-dialog__header">
-							<h2 className="reader-recommended-follows-dialog__title">{ ! isLoading && title }</h2>
+							<h2 className="reader-recommended-follows-dialog__subscribed-confirmation">
+								{ translate( 'You’re now subscribed!' ) }
+							</h2>
+							<h3 className="reader-recommended-follows-dialog__title">{ ! isLoading && title }</h3>
 							<p className="reader-recommended-follows-dialog__description">{ description }</p>
 						</div>
 

--- a/client/blocks/reader-suggested-follows/style.scss
+++ b/client/blocks/reader-suggested-follows/style.scss
@@ -25,7 +25,7 @@
 	scrollbar-gutter: stable;
 	padding: 0 32px;
 	overflow-y: auto;
-	max-height: calc(var(--feed-height) * 5 + 16px);
+	max-height: calc( var( --feed-height ) * 5 + 16px );
 }
 
 .reader-recommended-follows-dialog__content {
@@ -38,10 +38,10 @@
 		.reader-recommended-follows-dialog__header {
 			position: sticky;
 			top: 0;
-			border-bottom-color:var(--color-neutral-5);
+			border-bottom-color: var( --color-neutral-5 );
 		}
 	}
-	&:not(.has-scrolled-content) {
+	&:not( .has-scrolled-content ) {
 		.reader-recommended-follows-dialog__header {
 			position: relative;
 			border-bottom-color: transparent;
@@ -51,16 +51,25 @@
 	.reader-recommended-follows-dialog__header {
 		border-bottom: 1px solid transparent;
 		transition: border-bottom-color 0.3s ease-in-out;
-		h2 {
-			color: var(--color-neutral-70);
+		text-align: center;
+
+		.reader-recommended-follows-dialog__subscribed-confirmation {
+			color: var( --color-neutral-70 );
 			font-size: $font-title-large;
+			font-weight: 600;
+			margin-bottom: 9px;
+		}
+
+		.reader-recommended-follows-dialog__title {
+			color: var( --color-neutral-70 );
+			font-size: $font-title-small;
 			font-weight: 600;
 			margin-bottom: 9px;
 		}
 	}
 
 	.reader-recommended-follows-dialog__description {
-		color: var(--color-neutral-50);
+		color: var( --color-neutral-50 );
 		font-size: $font-body;
 		font-weight: 400;
 	}
@@ -83,23 +92,22 @@
 			flex-wrap: nowrap;
 			gap: 11px;
 			justify-content: flex-start;
-
 		}
 
 		.reader-suggested-follow-item_sitename {
-			color: var(--color-neutral-100);
+			color: var( --color-neutral-100 );
 			font-weight: 600;
 			font-size: $font-body;
 			display: flex;
 			flex-direction: column;
 
 			&:hover {
-				color: var(--color-text-subtle);
+				color: var( --color-text-subtle );
 			}
 		}
 
 		.reader-suggested-follow-item_description {
-			color: var(--color-text-subtle);
+			color: var( --color-text-subtle );
 			font-weight: 400;
 			font-size: $font-body-small;
 			line-height: 18px;
@@ -114,8 +122,8 @@
 			margin-bottom: 3px;
 		}
 		.reader-suggested-follow-item_nameurl::after {
-			content: "";
-			background-image: url("data:image/svg+xml,%3Csvg fill='none' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23101517' stroke-linecap='square' stroke-width='1.5'%3E%3Cpath d='m5.8335 14.1666 7.3333-7.33335' stroke-linejoin='round'/%3E%3Cpath d='m6.8335 5.83325h7.3333v7.33335'/%3E%3C/g%3E%3C/svg%3E"); /* stylelint-disable function-url-quotes */
+			content: '';
+			background-image: url( "data:image/svg+xml,%3Csvg fill='none' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23101517' stroke-linecap='square' stroke-width='1.5'%3E%3Cpath d='m5.8335 14.1666 7.3333-7.33335' stroke-linejoin='round'/%3E%3Cpath d='m6.8335 5.83325h7.3333v7.33335'/%3E%3C/g%3E%3C/svg%3E" ); /* stylelint-disable function-url-quotes */
 			background-repeat: no-repeat;
 			background-size: 20px 20px;
 			display: inline-block;
@@ -129,7 +137,7 @@
 
 	.reader-recommended-follows-dialog__follow-item {
 		padding: 20px 0;
-		border-bottom: 1px solid var(--color-neutral-5);
+		border-bottom: 1px solid var( --color-neutral-5 );
 
 		.reader-related-card__meta {
 			display: flex;
@@ -159,7 +167,7 @@
 
 		.is-placeholder {
 			@include placeholder();
-			background-color: var(--color-neutral-0);
+			background-color: var( --color-neutral-0 );
 			height: 60px;
 			border-radius: 6px;
 		}
@@ -174,7 +182,7 @@
 		}
 	}
 }
-@media only screen and (max-width: 600px) {
+@media only screen and ( max-width: 600px ) {
 	.reader-recommended-follows-dialog__content {
 		width: 100%;
 	}
@@ -182,5 +190,5 @@
 
 .dialog__backdrop,
 .dialog__backdrop.card {
-	background-color: color-mix(in srgb, var(--color-neutral-70) 80%, transparent) !important;
+	background-color: color-mix( in srgb, var( --color-neutral-70 ) 80%, transparent ) !important;
 }

--- a/client/blocks/reader-suggested-follows/test/dialog.test.tsx
+++ b/client/blocks/reader-suggested-follows/test/dialog.test.tsx
@@ -117,6 +117,7 @@ describe( 'ReaderSuggestedFollowsDialog', () => {
 			/>
 		);
 
+		expect( screen.getByText( 'You’re now subscribed!' ) ).toBeVisible();
 		expect( screen.getByText( 'Recommended blogs' ) ).toBeVisible();
 		expect( screen.getByText( /Test Author/ ) ).toBeVisible();
 		expect( screen.getByText( 'Nice Recommended Blog' ) ).toBeVisible();
@@ -134,6 +135,7 @@ describe( 'ReaderSuggestedFollowsDialog', () => {
 			<ReaderSuggestedFollowsDialog onClose={ jest.fn() } siteId={ 1 } postId={ 2 } isVisible />
 		);
 
+		expect( screen.getByText( 'You’re now subscribed!' ) ).toBeVisible();
 		expect( screen.getByText( 'Suggested blogs' ) ).toBeVisible();
 		expect( screen.getByText( 'Related blog' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
Fixes DOTCOM-12454

## Proposed Changes

* Add a "You're now subscribed!" confirmation heading to the top of the Reader suggested follows dialog (`ReaderSuggestedFollowsDialog`).
* Demote the existing "Recommended blogs" / "Suggested blogs" heading from `<h2>` to `<h3>` with a smaller font, and center the dialog header.

## Why are these changes being made?

When subscribing to a site from a post details / full-post page, the only feedback was the suggested follows dialog listing "Recommended blogs". With no confirmation text, this read as "ads for random websites" and gave no indication the subscription succeeded. The dialog is shared across the feed header, post cards, related cards, and the post-options menu, and only ever opens after a successful subscribe — so adding the confirmation in the dialog itself fixes the feedback gap consistently across every surface.

## Testing Instructions

* Open a Reader post details page for a site you are not subscribed to (e.g. `/read/blogs/{blogId}/posts/{postId}`).
* Click **Subscribe**.
* Confirm the dialog now leads with "You're now subscribed!" and the "Recommended blogs" heading appears smaller and centered below it.
* Repeat from a feed/site header subscribe and a discover/search post card subscribe to confirm the shared restyle looks correct.
* Verify in dark mode.
* Run `yarn test-client client/blocks/reader-suggested-follows`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)