### PR TITLE
E2E: stabilise openSettings selector and auth-cookie writes

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -322,10 +322,13 @@ export class EditorToolbarComponent {
 		if ( target !== 'Settings' ) {
 			await this.openMoreOptionsMenu();
 
-			button = editorParent.getByRole( 'menuitemcheckbox', {
-				name: translatedTargetName,
-				exact: true,
-			} );
+			// Match the sidebar's stable `aria-controls` id, not the visible
+			// label: "Jetpack" is a prefix of "Jetpack Newsletter" and the menu
+			// entries reorder as plugin sidebars register, so a name match can
+			// land on the sibling and open the wrong sidebar.
+			button = editorParent.locator(
+				'[role="menuitemcheckbox"][aria-controls="jetpack-sidebar:jetpack"]'
+			);
 		}
 
 		if ( await this.targetIsOpen( button ) ) {

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -191,14 +191,17 @@ export class TestAccount {
 	async saveAuthCookies( browserContext: BrowserContext ): Promise< void > {
 		const cookiesPath = this.getAuthCookiesPath();
 
-		// Force remove existing cookies to prevent complaints if they don't exist.
-		// We need the remove step because otherwise, existing files will only be
-		// modified and the "created" date will stay the same, failing the freshness
-		// check.
-		await fs.rm( cookiesPath, { force: true } );
+		// Parallel workers share one cookie file per account. Writing in place
+		// lets a concurrent reader (getAuthCookies) observe a half-written file
+		// and throw a JSON parse error. Write to a per-process temp file and
+		// rename it into place: rename is atomic, so a reader always sees a
+		// complete file (old or new), never a torn one. The renamed file also
+		// gets a fresh birthtime, which the freshness check relies on.
+		const tempPath = `${ cookiesPath }.${ process.pid }.tmp`;
 
 		this.log( `Saving auth cookies to ${ cookiesPath }` );
-		await browserContext.storageState( { path: cookiesPath } );
+		await browserContext.storageState( { path: tempPath } );
+		await fs.rename( tempPath, cookiesPath );
 	}
 
 	/**


### PR DESCRIPTION
Two E2E reliability fixes in `@automattic/calypso-e2e`, both surfaced while triaging Jetpack Atomic Smoke failures.

## Changes

- **`openSettings('Jetpack')` matches the sidebar by `aria-controls`, not its label.** "Jetpack" is a prefix of "Jetpack Newsletter" and the more-options entries reorder as plugin sidebars register, so a name match could click the sibling and open the wrong sidebar (then `expandSection('Share to social media')` timed out). The `jetpack-sidebar:jetpack` id is unique and position-independent. Fixes the recurring `social__editor-features` failures ([build 18117073](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_atomic_build_smoke_e2e_desktop/18117073)).
- **The auth-cookie file is written atomically.** Parallel workers share one cookie file per account; the in-place write (`rm` + `storageState`) let a concurrent reader observe a half-written file and throw `Unexpected non-whitespace character after JSON`. It now writes a temp file and renames it into place ([build 18150392](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/18150392)).

## Testing

Both bugs are races that only reproduce under parallel/slow CI, so local runs confirm no regression and the verification evidence; the race elimination rests on a stable selector and `rename(2)` atomicity respectively.

**Sidebar selector (`openSettings`)**

```bash
cd test/e2e
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn jest specs/jetpack/social__editor-features.ts
```

- Expect 6/6 passing (Free + Personal Simple-site cases).
- Selector uniqueness was confirmed by instrumenting the open more-options menu and counting matches for `[role="menuitemcheckbox"][aria-controls="jetpack-sidebar:jetpack"]`: exactly one on every sample, both locally (Simple) and on a personal Atomic Smoke build ([18148746](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_atomic_build_smoke_e2e_desktop/18148746)) across the php-new and wp-beta variations, with no other element carrying the id. WooCommerce (the ecomm-plan plugin) registers no post-editor more-options entry, so it cannot collide.

**Atomic auth-cookie write**

```bash
cd test/e2e
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test:pw -- specs/me/me__smoke.spec.ts --reporter=list
```

- First run logs in and writes `cookies/<account>.json`: valid JSON, directory auto-created, and no leftover `.tmp` file (the rename consumes it).
- A second run logs "Found fresh cookies, skipping log in" and reuses the file via the previously-crashing read path (`getAuthCookies`). 3/3 both runs.
