### PR TITLE
Nav 2026: raise the open nav above secondary navs and collapse the dropdown on close

### DIFF
--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -55,6 +55,8 @@ export interface ClickableItemProps extends MenuItemProps {
 	index?: number;
 	/** Fires when the pointer enters the item's `<li>` (2026 nav hover tracking). */
 	onItemMouseEnter?: () => void;
+	/** Fires when the item's link gains keyboard focus (2026 nav dropdown dismissal parity). */
+	onItemFocus?: () => void;
 }
 
 export type LanguageOptions = Record< string, string >;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -310,7 +310,13 @@ const UniversalNavbarHeader = ( {
 										className="x-nav-item"
 										role="none"
 										onMouseEnter={
-											nav2026 ? () => recordNavItemHover( isScrolled, 'logo', false ) : undefined
+											nav2026
+												? () => {
+														recordNavItemHover( isScrolled, 'logo', false );
+														// Hovering a non-dropdown item closes the open dropdown.
+														setActiveDropdown( null );
+												  }
+												: undefined
 										}
 									>
 										<a
@@ -364,9 +370,11 @@ const UniversalNavbarHeader = ( {
 														urlValue={ menu.href }
 														type="nav"
 														target="_self"
-														onItemMouseEnter={ () =>
-															recordNavItemHover( isScrolled, menu.name, false )
-														}
+														onItemMouseEnter={ () => {
+															recordNavItemHover( isScrolled, menu.name, false );
+															// Hovering a non-dropdown item closes the open dropdown.
+															setActiveDropdown( null );
+														} }
 													/>
 												)
 											) }
@@ -650,6 +658,7 @@ const UniversalNavbarHeader = ( {
 												localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true )
 											}
 											type="nav"
+											onItemMouseEnter={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 										/>
 									) }
 									{ ! hideGetStartedCta && (
@@ -664,6 +673,7 @@ const UniversalNavbarHeader = ( {
 											urlValue={ startUrl }
 											type="nav"
 											typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
+											onItemMouseEnter={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 										/>
 									) }
 									<li className="x-nav-item x-nav-item__narrow" role="none">

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -318,6 +318,8 @@ const UniversalNavbarHeader = ( {
 												  }
 												: undefined
 										}
+										// Keyboard parity: focusing into the logo also closes the open dropdown.
+										onFocusCapture={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 									>
 										<a
 											role="menuitem"
@@ -375,6 +377,8 @@ const UniversalNavbarHeader = ( {
 															// Hovering a non-dropdown item closes the open dropdown.
 															setActiveDropdown( null );
 														} }
+														// Keyboard parity: focusing the item also closes the open dropdown.
+														onItemFocus={ () => setActiveDropdown( null ) }
 													/>
 												)
 											) }
@@ -659,6 +663,7 @@ const UniversalNavbarHeader = ( {
 											}
 											type="nav"
 											onItemMouseEnter={ nav2026 ? () => setActiveDropdown( null ) : undefined }
+											onItemFocus={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 										/>
 									) }
 									{ ! hideGetStartedCta && (
@@ -674,6 +679,7 @@ const UniversalNavbarHeader = ( {
 											type="nav"
 											typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
 											onItemMouseEnter={ nav2026 ? () => setActiveDropdown( null ) : undefined }
+											onItemFocus={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 										/>
 									) }
 									<li className="x-nav-item x-nav-item__narrow" role="none">

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -76,6 +76,7 @@ export const ClickableItem = ( {
 	tabIndex,
 	index,
 	onItemMouseEnter,
+	onItemFocus,
 }: ClickableItemProps ) => {
 	let liClassName = '';
 	if ( type === 'menu' ) {
@@ -108,6 +109,7 @@ export const ClickableItem = ( {
 				title={ titleValue }
 				target={ target }
 				onClick={ onClick }
+				onFocus={ onItemFocus }
 				tabIndex={ tabIndex }
 			>
 				{ content }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -992,8 +992,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		// page content slides back under the bar.
 		transition: opacity $x-nav-2026-transition 0.22s;
 	}
-	// Exit (blur → none) eases out after a short delay so the surface lingers.
-	transition: backdrop-filter $x-nav-2026-transition 0.12s;
+	// Exit (blur → none) eases out after a short delay so the surface lingers; the z-index drop waits for the close fade.
+	transition: backdrop-filter $x-nav-2026-transition 0.12s, z-index 0s 0.22s;
 }
 
 // Scrolled (no dropdown): frosted tint + hairline shadow on the ::before.
@@ -1249,13 +1249,26 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	backdrop-filter: blur( 4px );
 	opacity: 0;
 	pointer-events: none;
-	transition: opacity $x-nav-2026-transition;
+	// The z-index drop on close waits for the fade-out.
+	transition: opacity $x-nav-2026-transition, z-index 0s 0.22s;
 }
 
 // Show the backdrop whenever a dropdown content block is active.
 .lpc-header-nav-container:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
 	.x-nav-backdrop {
 	opacity: 1;
+	// Above secondary navs (z-index up to 100000); the nav sits one higher.
+	z-index: 100001;
+	// Raise instantly; only the drop back is delayed.
+	transition-delay: 0s;
+}
+
+// Nav bar above secondary navs and the raised backdrop while the dropdown is open.
+.lpc-header-nav-container:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
+	.masterbar:has( .x-nav--2026-redesign ) {
+	z-index: 100002;
+	// Raise instantly, keeping the blur exit's own delay intact.
+	transition: backdrop-filter $x-nav-2026-transition 0.12s, z-index 0s;
 }
 
 // Desktop dropdown — one persistent panel easing its height between menus; active block (aria-hidden="false") sits in flow so the wrapper auto-sizes. `position: fixed` + high z escapes section stacking contexts; hidden at rest so it neither intercepts clicks nor paints until JS opens it.
@@ -1285,7 +1298,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	opacity: 1;
 	visibility: hidden;
 	pointer-events: none;
-	transition: visibility $x-nav-2026-transition;
+	// The z-index drop on close waits for the fade-out.
+	transition: visibility $x-nav-2026-transition, z-index 0s 0.22s;
 
 	// White surface that unrolls (scaleY) from the nav edge on first open, mirroring the reference's `.x-nav-dropdown-wrapper--2026::after`. `--x-dropdown-2026-unroll` is driven from `useDropdownFlip` so the open commit has a rendered `scaleY(0)` frame to ease from (a CSS-only version can't, since the panel is `visibility: hidden` at rest).
 	&::after {
@@ -1304,7 +1318,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	@media ( min-width: 1025px ) {
 		transition:
 			visibility $x-nav-2026-transition,
-			height var( --x-dropdown-2026-panel-duration ) var( --x-dropdown-2026-easing );
+			height var( --x-dropdown-2026-panel-duration ) var( --x-dropdown-2026-easing ),
+			z-index 0s 0.22s;
 
 		// JS sets the unroll duration only for the first-open ease; switches keep the surface up (no reroll).
 		&::after {
@@ -1318,6 +1333,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 .x-dropdown.x-dropdown--2026.is-dropdown-open {
 	visibility: visible;
 	pointer-events: auto;
+	// Above secondary navs (z-index up to 100000), level with the open nav bar.
+	z-index: 100002;
+	// Raise instantly; only the drop back is delayed.
+	transition-delay: 0s;
 }
 
 .x-dropdown--2026.x-dropdown-content {
@@ -1447,12 +1466,20 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	--x-menu-2026-title-pad-top: 16px; // drilled-in title's top padding
 	--x-menu-2026-navlink-pad-block: 4px; // each nav link's vertical padding
 
+	// Own stacking root, so the legacy billion z-indexes (overridden below) aren't load-bearing here.
+	position: relative;
+	z-index: $x-content-min-z-index;
+	// The z-index drop on close waits for the panel slide-out.
+	transition: z-index 0s var( --x-menu-2026-panel-duration, 0.34s );
+
 	/* Blurred overlay behind the menu (reference: blur(8px) over rgba(0,0,0,0.2)). */
 	.x-menu-overlay {
 		position: fixed;
 		inset: 0;
 		// Sit below the admin bar (real height logged-in, 0 logged-out); `body.admin-bar` consumers overridden further down.
 		top: var( --nav-2026-admin-offset, 0 );
+		// Stacks inside the menu root; replaces the legacy billion.
+		z-index: 1;
 		background: rgba( $studio-gray-100, 0.2 );
 		backdrop-filter: blur( 8px );
 		opacity: 0;
@@ -1473,6 +1500,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		inset: 0;
 		// Sit below the admin bar (real height logged-in, 0 logged-out); `body.admin-bar` consumers overridden further down.
 		top: var( --nav-2026-admin-offset, 0 );
+		// Above the overlay, inside the menu root; replaces the legacy billion.
+		z-index: 2;
 		display: flex;
 		flex-direction: column;
 		width: 100%;
@@ -2039,6 +2068,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 	/* Open: logo / close / footer-contents reveal immediately except during initial open, where they wait for the panel slide. */
 	&.x-menu__open {
+		// Sit above secondary navs (z-index up to 100000) while open; raise instantly.
+		z-index: 100001;
+		transition-delay: 0s;
+
 		.x-menu-mobile-logo:not( .is-hidden ),
 		.x-menu-button.x-menu-mobile-close,
 		.x-menu-mobile-footer > *:not( .x-menu-mobile-app-banner ) {

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1188,6 +1188,12 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	opacity: 1;
 	visibility: visible;
 	pointer-events: auto;
+	// Clip pinned off with `clip-path 0s` so opening never wipes; only the close does.
+	clip-path: inset( 0 0 0 0 );
+	transition:
+		opacity $x-nav-2026-transition,
+		visibility $x-nav-2026-transition,
+		clip-path 0s;
 
 	// Items slide in from the left, staggered by `--stagger-index`. Switch: short delay, no wait.
 	.x-dropdown-subcategory-title,
@@ -1280,6 +1286,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	--x-dropdown-2026-link-duration: 0.26s; // per-item fade + slide duration
 	--x-dropdown-2026-stagger-step: 0.02s; // added per --stagger-index (reading order)
 	--x-dropdown-2026-items-slide-overlap: 0.12s; // first-open: items start before unroll ends
+	--x-dropdown-2026-close-duration: 0.14s; // surface roll-up on close (half the open unroll)
+	--x-dropdown-2026-close-delay: 0.08s; // 0.22s close fade − roll, so the roll lands with the fades
 
 	position: fixed;
 	// Prefer host-provided `--nav-2026-height` (Calypso's single source of truth); fall back to the package constant standalone.
@@ -1337,6 +1345,26 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	z-index: 100002;
 	// Raise instantly; only the drop back is delayed.
 	transition-delay: 0s;
+}
+
+// Close: the white surface rolls back up (reverse of the open unroll, quicker), landing with the 0.22s close fades.
+.x-dropdown.x-dropdown--2026:not( .is-dropdown-open )::after {
+	opacity: 0;
+	transform: scaleY( 0 );
+	transition:
+		opacity 0s linear 0.22s,
+		transform var( --x-dropdown-2026-close-duration ) var( --x-dropdown-2026-easing )
+			var( --x-dropdown-2026-close-delay );
+}
+
+// Close: wipe the content at the rising edge so nothing trails below the roll. `:not()` keeps menu-to-menu switches (wrapper stays open) on the plain cross-fade.
+.x-dropdown.x-dropdown--2026:not( .is-dropdown-open ) .x-dropdown-content {
+	clip-path: inset( 0 0 100% 0 );
+	transition:
+		opacity $x-nav-2026-transition,
+		visibility $x-nav-2026-transition,
+		clip-path var( --x-dropdown-2026-close-duration ) var( --x-dropdown-2026-easing )
+			var( --x-dropdown-2026-close-delay );
 }
 
 .x-dropdown--2026.x-dropdown-content {
@@ -2139,6 +2167,11 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	// No unroll: the white surface is simply present when open, gone when not.
 	.x-dropdown.x-dropdown--2026::after {
 		transform: none !important;
+	}
+
+	// No close wipe: the close stays a plain fade.
+	.x-dropdown--2026.x-dropdown-content {
+		clip-path: none !important;
 	}
 }
 


### PR DESCRIPTION
Part of the Dotcom Global Nav Redesign 2026 effort.

## Proposed Changes

* While the desktop dropdown or the mobile menu is open, raise the nav bar, its blur backdrop, the dropdown panel and the menu above secondary navs (sticky sub-navs at z-index up to 100000) so they no longer paint over them. The raised stacking holds until the close fade/slide finishes; resting order is unchanged.
* Closing the dropdown now visibly collapses: the white surface rolls back up into the nav (the open unroll in reverse, about twice as fast) and the links are wiped at the rising edge, instead of the previous abrupt fade. Opening and menu-to-menu switching are unchanged.
* Moving the pointer onto — or tabbing the keyboard focus onto — a non-dropdown nav item (Pricing, Log In, Get Started, logo) now closes the open dropdown, matching the wpcom nav behavior.
* The 2026 mobile menu gets its own sane stacking root instead of inheriting the legacy menu's billion-scale z-indexes.

## Why are these changes being made?

* On surfaces with a pinned sub-nav, the sub-nav sat on top of the open desktop dropdown and stayed sharp above the blur backdrop.
* The dropdown close was abrupt; it now plays a faster reverse of the open animation.
* Mirrors the wpcom-side fix (wpcom PR 223053).

## Testing Instructions

* On a 2026-nav surface, open a nav dropdown at desktop width — it should cover any pinned sub-nav, and the page (including the sub-nav) should blur behind it.
* Move the pointer onto Pricing / Log In / Get Started, or tab onto them — the dropdown should close with a quick roll-up, and nothing should flash above it while it fades.
* At mobile width, open the hamburger menu — the drawer should cover the page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
