### PR TITLE
A4A: clarify launch permissions for team members without site access

### DIFF
--- a/client/a8c-for-agencies/components/launch-permission-modal/index.tsx
+++ b/client/a8c-for-agencies/components/launch-permission-modal/index.tsx
@@ -1,0 +1,60 @@
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+const LEARN_MORE_URL =
+	'https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#allowing-team-members-to-access-wp-admin';
+
+interface Props {
+	onClose: () => void;
+	source: 'sites' | 'licenses';
+}
+
+/**
+ * Explains why a team member without site admin access can't launch a site.
+ *
+ * Rendered as the body of a modal on both the Sites Dashboard and the Licenses
+ * area. The modal chrome (and title) is supplied by the surface that mounts it.
+ */
+export default function LaunchPermissionModal( { onClose, source }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_prepare_for_launch_no_permission', { source } ) );
+	}, [ dispatch, source ] );
+
+	const onLearnMoreClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_prepare_for_launch_no_permission_learn_more', { source } )
+		);
+		showSupportGuide( LEARN_MORE_URL );
+	};
+
+	return (
+		<VStack spacing={ 6 }>
+			<Text as="p">
+				{ translate(
+					'To launch this site, sign in with the agency owner account, or ask the owner to add you as an administrator. The account must also be connected to WordPress.com to manage the site there.'
+				) }
+			</Text>
+			<HStack justify="space-between">
+				<Button variant="link" onClick={ onLearnMoreClick }>
+					{ translate( 'Learn more about team member permissions' ) }
+				</Button>
+				<Button __next40pxDefaultSize variant="primary" onClick={ onClose }>
+					{ translate( 'Got it' ) }
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/components/launch-permission-modal/index.tsx
+++ b/client/a8c-for-agencies/components/launch-permission-modal/index.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { useDispatch } from 'calypso/state';
@@ -25,7 +25,6 @@ interface Props {
  * area. The modal chrome (and title) is supplied by the surface that mounts it.
  */
 export default function LaunchPermissionModal( { onClose, source }: Props ) {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { showSupportGuide } = useHelpCenter();
 
@@ -43,16 +42,16 @@ export default function LaunchPermissionModal( { onClose, source }: Props ) {
 	return (
 		<VStack spacing={ 6 }>
 			<Text as="p">
-				{ translate(
+				{ __(
 					'To launch this site, sign in with the agency owner account, or ask the owner to add you as an administrator. The account must also be connected to WordPress.com to manage the site there.'
 				) }
 			</Text>
 			<HStack justify="space-between">
 				<Button variant="link" onClick={ onLearnMoreClick }>
-					{ translate( 'Learn more about team member permissions' ) }
+					{ __( 'Learn more about team member permissions' ) }
 				</Button>
 				<Button __next40pxDefaultSize variant="primary" onClick={ onClose }>
-					{ translate( 'Got it' ) }
+					{ __( 'Got it' ) }
 				</Button>
 			</HStack>
 		</VStack>

--- a/client/a8c-for-agencies/components/launch-permission-modal/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/launch-permission-modal/test/index.test.tsx
@@ -9,10 +9,6 @@ import LaunchPermissionModal from '..';
 const mockDispatch = jest.fn();
 const mockShowSupportGuide = jest.fn();
 
-jest.mock( 'i18n-calypso', () => ( {
-	useTranslate: () => ( text: string ) => text,
-} ) );
-
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => mockDispatch,
 } ) );

--- a/client/a8c-for-agencies/components/launch-permission-modal/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/launch-permission-modal/test/index.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import LaunchPermissionModal from '..';
+
+const mockDispatch = jest.fn();
+const mockShowSupportGuide = jest.fn();
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( ( name, properties ) => ( {
+		type: 'RECORD_TRACKS_EVENT',
+		name,
+		properties,
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/a8c-for-agencies/hooks/use-help-center', () => ( {
+	__esModule: true,
+	default: () => ( { showSupportGuide: mockShowSupportGuide } ),
+} ) );
+
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
+
+describe( 'LaunchPermissionModal', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'records a Tracks event with the source when shown', () => {
+		render( <LaunchPermissionModal source="sites" onClose={ jest.fn() } /> );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_a4a_prepare_for_launch_no_permission',
+			{ source: 'sites' }
+		);
+	} );
+
+	it( 'calls onClose when "Got it" is clicked', async () => {
+		const onClose = jest.fn();
+		render( <LaunchPermissionModal source="licenses" onClose={ onClose } /> );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Got it' } ) );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'opens the support guide from the learn more link', async () => {
+		render( <LaunchPermissionModal source="sites" onClose={ jest.fn() } /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Learn more about team member permissions' } )
+		);
+
+		expect( mockShowSupportGuide ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/a8c-for-agencies/hooks/test/use-wp-admin-access-control.ts
+++ b/client/a8c-for-agencies/hooks/test/use-wp-admin-access-control.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment node
+ */
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import { hasNoWPAdminAccess } from '../use-wp-admin-access-control';
+
+jest.mock( 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies' );
+
+const mockedIsA8CForAgencies = isA8CForAgencies as jest.MockedFunction< typeof isA8CForAgencies >;
+
+describe( 'hasNoWPAdminAccess', () => {
+	beforeEach( () => {
+		mockedIsA8CForAgencies.mockReturnValue( true );
+	} );
+
+	it( 'returns true for a team member without manage_options on the site', () => {
+		expect(
+			hasNoWPAdminAccess( { role: 'a4a_manager', capabilities: { manage_options: false } } )
+		).toBe( true );
+	} );
+
+	it( 'returns true for a team member with no capabilities for the site', () => {
+		expect( hasNoWPAdminAccess( { role: 'a4a_manager', capabilities: undefined } ) ).toBe( true );
+	} );
+
+	it( 'returns false for a team member who has manage_options on the site', () => {
+		expect(
+			hasNoWPAdminAccess( { role: 'a4a_manager', capabilities: { manage_options: true } } )
+		).toBe( false );
+	} );
+
+	it( 'returns false for an agency owner regardless of capabilities', () => {
+		expect( hasNoWPAdminAccess( { role: 'a4a_administrator', capabilities: undefined } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'returns false when not in the A4A context', () => {
+		mockedIsA8CForAgencies.mockReturnValue( false );
+		expect(
+			hasNoWPAdminAccess( { role: 'a4a_manager', capabilities: { manage_options: false } } )
+		).toBe( false );
+	} );
+
+	it( 'returns false when the role is undefined', () => {
+		expect( hasNoWPAdminAccess( { role: undefined, capabilities: undefined } ) ).toBe( false );
+	} );
+} );

--- a/client/a8c-for-agencies/hooks/use-wp-admin-access-control.ts
+++ b/client/a8c-for-agencies/hooks/use-wp-admin-access-control.ts
@@ -3,18 +3,35 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import type { AppState } from 'calypso/types';
 
+type SiteCapabilities = Record< string, boolean > | undefined;
+
+/**
+ * Whether the current user lacks WP Admin access on a given site.
+ *
+ * This is true for A4A team members (`a4a_manager`) who have not been added to
+ * the underlying WordPress.com site, so they don't have the `manage_options`
+ * capability there. Agency owners (`a4a_administrator`) always have access.
+ */
+export function hasNoWPAdminAccess( {
+	role,
+	capabilities,
+}: {
+	role: string | undefined;
+	capabilities: SiteCapabilities;
+} ): boolean {
+	return isA8CForAgencies() && role === 'a4a_manager' && ! capabilities?.[ 'manage_options' ];
+}
+
 export default function useWPAdminAccessControl( { siteId }: { siteId: number } ) {
 	const agency = useSelector( getActiveAgency );
 
 	const role = agency?.user?.role;
 
-	const userCapabilities = useSelector( ( state: AppState ) =>
-		siteId ? state?.currentUser?.capabilities?.[ siteId ] : []
+	const capabilities = useSelector( ( state: AppState ) =>
+		siteId ? state?.currentUser?.capabilities?.[ siteId ] : undefined
 	);
 
-	const hasCapability = userCapabilities?.[ 'manage_options' ];
-
 	return {
-		noWPAdminAccess: isA8CForAgencies() && role === 'a4a_manager' && ! hasCapability,
+		noWPAdminAccess: hasNoWPAdminAccess( { role, capabilities } ),
 	};
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -394,6 +394,7 @@ export default function LicensePreview( {
 					{ isWPCOMLicense && isSiteAtomic ? (
 						<LicenseActions
 							siteUrl={ siteUrl }
+							blogId={ blogId }
 							isDevSite={ isDevelopmentSite }
 							attachedAt={ attachedAt }
 							revokedAt={ revokedAt }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -99,6 +99,7 @@ export default function LicenseActions( {
 			{ showLaunchPermissionModal && (
 				<Modal
 					title={ translate( 'Launching requires site admin access' ) }
+					size="medium"
 					onRequestClose={ () => setShowLaunchPermissionModal( false ) }
 				>
 					<LaunchPermissionModal

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -1,6 +1,10 @@
 import { Button, Gridicon } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import CancelLicenseFeedbackModal from 'calypso/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal';
+import LaunchPermissionModal from 'calypso/a8c-for-agencies/components/launch-permission-modal';
+import useWPAdminAccessControl from 'calypso/a8c-for-agencies/hooks/use-wp-admin-access-control';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { LicenseAction, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
@@ -8,6 +12,7 @@ import useLicenseActions from './use-license-actions';
 
 interface Props {
 	siteUrl: string | null;
+	blogId?: number | null;
 	isDevSite: boolean;
 	attachedAt: string | null;
 	revokedAt: string | null;
@@ -21,6 +26,7 @@ interface Props {
 
 export default function LicenseActions( {
 	siteUrl,
+	blogId,
 	isDevSite,
 	attachedAt,
 	revokedAt,
@@ -31,10 +37,17 @@ export default function LicenseActions( {
 	licenseKey,
 	productId,
 }: Props ) {
+	const translate = useTranslate();
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
+	const [ showLaunchPermissionModal, setShowLaunchPermissionModal ] = useState( false );
+
+	const { noWPAdminAccess } = useWPAdminAccessControl( { siteId: blogId ?? 0 } );
+	// Only block launching when we have a valid site to check access against.
+	const cannotLaunch = !! blogId && noWPAdminAccess;
+
 	const licenseActions = useLicenseActions(
 		siteUrl,
 		isDevSite,
@@ -42,13 +55,17 @@ export default function LicenseActions( {
 		revokedAt,
 		licenseType,
 		isChildLicense,
-		isClientLicense
+		isClientLicense,
+		cannotLaunch
 	);
 
 	const handleActionClick = ( action: LicenseAction ) => {
 		action.onClick();
 		if ( action.type === 'revoke' ) {
 			setShowRevokeDialog( true );
+		}
+		if ( action.type === 'launch_permission' ) {
+			setShowLaunchPermissionModal( true );
 		}
 	};
 
@@ -79,6 +96,17 @@ export default function LicenseActions( {
 						</PopoverMenuItem>
 					) ) }
 			</PopoverMenu>
+			{ showLaunchPermissionModal && (
+				<Modal
+					title={ translate( 'Launching requires site admin access' ) }
+					onRequestClose={ () => setShowLaunchPermissionModal( false ) }
+				>
+					<LaunchPermissionModal
+						source="licenses"
+						onClose={ () => setShowLaunchPermissionModal( false ) }
+					/>
+				</Modal>
+			) }
 			{ showRevokeDialog && (
 				<CancelLicenseFeedbackModal
 					isAtomicSite

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -20,7 +20,8 @@ export default function useLicenseActions(
 	revokedAt: string | null,
 	licenseType: LicenseType,
 	isChildLicense?: boolean,
-	isClientLicense?: boolean
+	isClientLicense?: boolean,
+	cannotLaunch?: boolean
 ): LicenseAction[] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -44,9 +45,15 @@ export default function useLicenseActions(
 		return [
 			{
 				name: translate( 'Prepare for launch' ),
-				href: `https://wordpress.com/sites/${ siteSlug }/settings/site-visibility`,
+				// A4A team members without admin access on the site can't launch it. Instead of
+				// opening a page where it would fail, flag the action so the click shows an
+				// explanatory modal (handled in license-actions.tsx).
+				href: cannotLaunch
+					? undefined
+					: `https://wordpress.com/sites/${ siteSlug }/settings/site-visibility`,
 				onClick: () => handleClickMenuItem( 'prepare_for_launch' ),
-				isExternalLink: true,
+				type: cannotLaunch ? 'launch_permission' : undefined,
+				isExternalLink: ! cannotLaunch,
 				isEnabled: isDevSite,
 			},
 			{
@@ -107,6 +114,7 @@ export default function useLicenseActions(
 	}, [
 		attachedAt,
 		canRevoke,
+		cannotLaunch,
 		dispatch,
 		isChildLicense,
 		isClientLicense,

--- a/client/a8c-for-agencies/sections/sites/site-actions/launch-permission-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/launch-permission-action-modal.tsx
@@ -1,0 +1,22 @@
+import LaunchPermissionModal from 'calypso/a8c-for-agencies/components/launch-permission-modal';
+import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+type ModalProps = {
+	items: SiteData[];
+	closeModal?: () => void;
+	onActionPerformed?: () => void;
+};
+
+function LaunchPermissionActionModal( { closeModal }: ModalProps ) {
+	return <LaunchPermissionModal source="sites" onClose={ () => closeModal?.() } />;
+}
+
+export default function createLaunchPermissionModal() {
+	const LaunchPermissionActionModalWrapper = ( modalProps: ModalProps ) => {
+		return <LaunchPermissionActionModal { ...modalProps } />;
+	};
+
+	LaunchPermissionActionModalWrapper.displayName = 'LaunchPermissionActionModalWrapper';
+
+	return LaunchPermissionActionModalWrapper;
+}

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -6,9 +6,13 @@ import { useContext, useMemo } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { hasNoWPAdminAccess } from 'calypso/a8c-for-agencies/hooks/use-wp-admin-access-control';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
-import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import {
+	getActiveAgency,
+	hasAgencyCapability,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -18,9 +22,11 @@ import { JETPACK_ACTIVITY_ID, JETPACK_BACKUP_ID } from '../features/features';
 import SitesDashboardContext from '../sites-dashboard-context';
 import createDeleteSiteActionModal from './delete-site-action-modal';
 import getActionEventName from './get-action-event-name';
+import createLaunchPermissionModal from './launch-permission-action-modal';
 import createRemoveSiteActionModal from './remove-site-action-modal';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import type { SiteNode, AllowedActionTypes } from '../types';
+import type { AppState } from 'calypso/types';
 
 type Props = {
 	site: SiteNode;
@@ -230,6 +236,9 @@ export function useSiteActionsDataViews( {
 		hasAgencyCapability( state, 'a4a_remove_managed_sites' )
 	);
 
+	const agencyRole = useSelector( getActiveAgency )?.user?.role;
+	const capabilities = useSelector( ( state: AppState ) => state?.currentUser?.capabilities );
+
 	return useMemo( () => {
 		const isUrlOnly = ( item: SiteData ) =>
 			item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
@@ -267,12 +276,20 @@ export function useSiteActionsDataViews( {
 		const recordTracksEventDeleteSite = () =>
 			dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
 
+		// A4A team members who haven't been added to the site can't launch it.
+		const cannotLaunch = ( item: SiteData ) =>
+			hasNoWPAdminAccess( {
+				role: agencyRole,
+				capabilities: capabilities?.[ getBlogId( item ) ],
+			} );
+
 		return [
 			{
+				id: 'prepare_for_launch',
 				label: translate( 'Prepare for launch' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isDevSite( item );
+					return canHaveActions( item ) && isDevSite( item ) && ! cannotLaunch( item );
 				},
 				callback( items: SiteData[] ) {
 					window.open(
@@ -282,6 +299,19 @@ export function useSiteActionsDataViews( {
 						recordTracksEvent( getActionEventName( 'prepare_for_launch', isLargeScreen ) )
 					);
 				},
+			},
+			{
+				// Same label as the action above. Shown instead of it when the current user is an
+				// A4A team member without admin access on the site, so clicking explains why
+				// launching is unavailable rather than opening a page where it would fail.
+				id: 'prepare_for_launch_no_permission',
+				label: translate( 'Prepare for launch' ),
+				icon: external,
+				modalHeader: translate( 'Launching requires site admin access' ),
+				isEligible( item: SiteData ) {
+					return canHaveActions( item ) && isDevSite( item ) && cannotLaunch( item );
+				},
+				RenderModal: createLaunchPermissionModal(),
 			},
 			{
 				id: 'set_up_site',
@@ -468,5 +498,7 @@ export function useSiteActionsDataViews( {
 		setDataViewsState,
 		setSelectedSiteFeature,
 		hasRemoveManagedSitesCapability,
+		agencyRole,
+		capabilities,
 	] );
 }


### PR DESCRIPTION
Part of A4A-2553
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

<img width="578" height="237" alt="Screenshot 2026-06-12 at 16 14 26" src="https://github.com/user-attachments/assets/1c409d38-cea1-4cfe-8ed7-5ffcf6d7cea8" />

* **`client/a8c-for-agencies/components/launch-permission-modal/`** *(new)* — the modal body shown to a team member who can't launch a site. It explains that launching needs the agency owner account or being added to the site as an administrator, links to the team-member permissions doc, and fires a `calypso_a4a_prepare_for_launch_no_permission` Tracks event on display.
* **`client/a8c-for-agencies/hooks/use-wp-admin-access-control.ts`** — extracted the access check into a pure `hasNoWPAdminAccess( { role, capabilities } )` helper (the existing hook now wraps it), so the same "team member without `manage_options` on the site" rule drives both surfaces.
* **`client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts`** (+ `launch-permission-action-modal.tsx`) — in the Sites Dashboard `⋯` menu, **Prepare for launch** now resolves per row: a user with access keeps the existing navigate behavior; a team member without access gets the modal, rendered through the DataViews `RenderModal` slot.
* **`client/a8c-for-agencies/sections/purchases/licenses/license-preview/`** — same treatment in the Licenses `⋯` menu: when the current user can't launch the site, **Prepare for launch** opens the modal instead of linking out to wordpress.com.

## Why are these changes being made?

A4A team members who are on the underlying WordPress.com site with a role below administrator (e.g. editor) still saw **Prepare for launch** in the Sites Dashboard and Licenses menus, but clicking it dropped them on the wordpress.com site-visibility page where launching fails — they don't have `manage_options` on the site. Nothing in A4A explained the limitation. The action now stays visible but, for those users, opens a short modal telling them launching requires the agency owner account or being added to the site as an administrator — so the constraint is clear instead of a dead-end round trip.

## Testing Instructions

The launch action is the `⋯` menu on a **development** site in **A4A → Sites** (the dashboard row) and **A4A → Purchases → Licenses** (the WordPress.com license row, which shows a **Development** badge).

On licenses, to reach the modal you need a team member whose WordPress.com role on the site is below administrator — e.g. an **editor** — so they can see the action but lack `manage_options`. (In Licenses, the `⋯` menu only appears when you're a user on that site at all.)

1. **Agency owner / administrator on the site** — `⋯` → **Prepare for launch** opens the wordpress.com site-visibility page in a new tab. No modal.
2. **Team member who is an editor (non-admin) on the site** — `⋯` → **Prepare for launch** opens the modal (no navigation), with **Learn more about team member permissions** and **Got it**. Check both the Sites Dashboard and Licenses.
3. Run the unit tests: `yarn test-client client/a8c-for-agencies/components/launch-permission-modal client/a8c-for-agencies/hooks/test/use-wp-admin-access-control.ts`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
