### PR TITLE
ui: Use standard icons for Stepper indicators

### DIFF
--- a/packages/ui/src/stepper/indicator.tsx
+++ b/packages/ui/src/stepper/indicator.tsx
@@ -37,7 +37,7 @@ export const StepperIndicator = forwardRef< HTMLSpanElement, StepperIndicatorPro
 		// completed/error; upcoming/current keep the numbered circle.
 		const indicator: ReactNode =
 			indicatorVariant === 'bullet' || status ? (
-				<Icon icon={ STATE_ICONS[ state ] } className={ styles.icon } />
+				<Icon icon={ STATE_ICONS[ state ] } className={ styles.icon } fill="currentColor" />
 			) : (
 				<span aria-hidden="true" className={ styles.number }>
 					{ stepNumber }

--- a/packages/ui/src/stepper/indicator.tsx
+++ b/packages/ui/src/stepper/indicator.tsx
@@ -1,30 +1,21 @@
 // packages/ui/src/stepper/indicator.tsx
 import { forwardRef } from '@wordpress/element';
-import { check } from '@wordpress/icons';
-import { Path, SVG } from '@wordpress/primitives';
+import { border, caution, drafts, published } from '@wordpress/icons';
 import { Icon, VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useStepContext, useStepperContext } from './context';
 import styles from './style.module.scss';
 import type { ComponentProps, ReactNode } from 'react';
 
-// Half-circle (dome) icon for the bullet-variant current step.
-// 10×10 viewBox, dome in the bottom half: flat edge at vertical midpoint (y=5),
-// arc curving down to y=10. When centred inside the 18px indicator the flat
-// edge sits exactly on the horizontal centre line of the circle.
-const halfCircleIcon = (
-	<SVG
-		width="10"
-		height="10"
-		viewBox="0 0 10 10"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		aria-hidden="true"
-		style={ { transform: 'rotate(180deg)' } }
-	>
-		<Path d="M0 5a5 5 0 0 1 10 0H0z" fill="currentColor" />
-	</SVG>
-);
+// State → icon mapping, all standard @wordpress/icons:
+// border = dashed circle, drafts = half-filled circle,
+// published = circled check, caution = circled exclamation mark.
+const STATE_ICONS = {
+	upcoming: border,
+	current: drafts,
+	completed: published,
+	error: caution,
+} as const;
 
 type StepperIndicatorProps = ComponentProps< 'span' > & {
 	children?: ReactNode;
@@ -41,15 +32,15 @@ export const StepperIndicator = forwardRef< HTMLSpanElement, StepperIndicatorPro
 		const accessibleLabel =
 			totalSteps > 0 ? formatStepLabel( stepNumber, totalSteps, status ) : null;
 
-		let indicator: ReactNode =
-			indicatorVariant === 'number' ? <span aria-hidden="true">{ stepNumber }</span> : null;
-		if ( status === 'completed' ) {
-			indicator = <Icon icon={ check } size={ 14 } />;
-		} else if ( status === 'error' ) {
-			indicator = <span aria-hidden="true">!</span>;
-		} else if ( isCurrent && indicatorVariant === 'bullet' ) {
-			indicator = halfCircleIcon;
-		}
+		const state = status ?? ( isCurrent ? 'current' : 'upcoming' );
+		// Bullet variant: every state is an icon. Number variant: icons only for
+		// completed/error; upcoming/current keep the numbered circle.
+		const indicator: ReactNode =
+			indicatorVariant === 'bullet' || status ? (
+				<Icon icon={ STATE_ICONS[ state ] } />
+			) : (
+				<span aria-hidden="true">{ stepNumber }</span>
+			);
 
 		return (
 			<span

--- a/packages/ui/src/stepper/indicator.tsx
+++ b/packages/ui/src/stepper/indicator.tsx
@@ -37,7 +37,7 @@ export const StepperIndicator = forwardRef< HTMLSpanElement, StepperIndicatorPro
 		// completed/error; upcoming/current keep the numbered circle.
 		const indicator: ReactNode =
 			indicatorVariant === 'bullet' || status ? (
-				<Icon icon={ STATE_ICONS[ state ] } />
+				<Icon icon={ STATE_ICONS[ state ] } className={ styles.icon } />
 			) : (
 				<span aria-hidden="true" className={ styles.number }>
 					{ stepNumber }

--- a/packages/ui/src/stepper/indicator.tsx
+++ b/packages/ui/src/stepper/indicator.tsx
@@ -39,7 +39,9 @@ export const StepperIndicator = forwardRef< HTMLSpanElement, StepperIndicatorPro
 			indicatorVariant === 'bullet' || status ? (
 				<Icon icon={ STATE_ICONS[ state ] } />
 			) : (
-				<span aria-hidden="true">{ stepNumber }</span>
+				<span aria-hidden="true" className={ styles.number }>
+					{ stepNumber }
+				</span>
 			);
 
 		return (

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -34,8 +34,9 @@
 	background: var( --wpds-color-background-surface-neutral-strong );
 }
 
-// Current step (number variant): solid filled circle
-.indicator.is-current[data-indicator-variant='number'] {
+// Current step (number variant): solid filled circle. Completed/error render
+// icons even when current, so they are excluded from the circle fill.
+.indicator.is-current[data-indicator-variant='number']:not( .is-completed, .is-error ) {
 	border-color: var( --wpds-color-foreground-content-neutral );
 	background: var( --wpds-color-foreground-content-neutral );
 	color: var( --wpds-color-background-surface-neutral-strong );
@@ -104,9 +105,8 @@
 			color: var( --wpds-color-foreground-interactive-brand );
 		}
 
-		// Only number-variant non-current steps still draw a CSS circle;
-		// the current step keeps its solid fill on hover.
-		.indicator[data-indicator-variant='number']:not( .is-current ) {
+		// Only number-variant upcoming steps still draw a bordered CSS circle.
+		.indicator[data-indicator-variant='number']:not( .is-current, .is-completed, .is-error ) {
 			border-color: var( --wpds-color-foreground-interactive-brand );
 		}
 

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -7,10 +7,10 @@
 .root {
 	--a8c-ui-stepper-indicator-size: 24px;
 
-	// Matches the @wordpress/icons glyph geometry: the state icons draw a 16px
-	// circle inside the 24px viewBox, so the number-variant circle uses the
-	// same visual size within the same layout box.
-	--a8c-ui-stepper-indicator-circle-size: 16px;
+	// The @wordpress/icons state glyphs draw a 16px circle inside the 24px
+	// viewBox; they are scaled up to the 18px circle from Figma, and the
+	// number-variant circle uses the same 18px size within the same layout box.
+	--a8c-ui-stepper-indicator-circle-size: 18px;
 }
 
 // ---------------------------------------------------------------------------
@@ -28,6 +28,12 @@
 	height: var( --a8c-ui-stepper-indicator-size );
 	flex-shrink: 0;
 	color: var( --wpds-color-fg-interactive-neutral );
+
+	// Render the glyph circle at the Figma size (16 -> 18) without affecting
+	// the 24px layout box.
+	svg {
+		transform: scale( calc( 18 / 16 ) );
+	}
 }
 
 // The number span only renders for number-variant steps without a status

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -5,51 +5,46 @@
 // ---------------------------------------------------------------------------
 
 .root {
-	--a8c-ui-stepper-indicator-size: 18px;
-	--a8c-ui-stepper-indicator-size-sm: 16px;
-	// Centers the smaller current/completed bullets against upcoming ones.
-	--a8c-ui-stepper-indicator-offset: calc(
-		( var( --a8c-ui-stepper-indicator-size ) - var( --a8c-ui-stepper-indicator-size-sm ) ) * 0.5
-	);
+	--a8c-ui-stepper-indicator-size: 24px;
 }
 
 // ---------------------------------------------------------------------------
 // Indicator
 // ---------------------------------------------------------------------------
 
+// Icons draw their own circles and use currentColor, so state rules below
+// only set `color`. The CSS-drawn circle remains solely for number-variant
+// steps that display a number (completed/error render full icons).
 .indicator {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
+	flex-shrink: 0;
+	color: var( --wpds-color-fg-interactive-neutral );
+}
+
+.indicator[data-indicator-variant='number']:not( .is-completed ):not( .is-error ) {
 	border-radius: 50%;
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-foreground-interactive-neutral );
-	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
 	color: var( --wpds-color-foreground-interactive-neutral );
 	background: var( --wpds-color-background-surface-neutral-strong );
 }
 
-// Current step
-.indicator.is-current {
+// Current step (number variant): solid filled circle
+.indicator.is-current[data-indicator-variant='number'] {
 	border-color: var( --wpds-color-foreground-content-neutral );
 	background: var( --wpds-color-foreground-content-neutral );
 	color: var( --wpds-color-background-surface-neutral-strong );
 	font-weight: 600;
 }
 
-// Completed step
+// Completed step (both variants)
 .indicator.is-completed {
-	border-color: var( --wpds-color-foreground-content-neutral-weak );
-	background: transparent;
 	color: var( --wpds-color-foreground-content-neutral-weak );
-
-	svg {
-		stroke: currentColor;
-		stroke-width: 1.5px;
-	}
 }
 
 // Disabled step
@@ -58,37 +53,16 @@
 }
 
 // ---------------------------------------------------------------------------
-// Bullet indicator variant
+// Bullet indicator variant (icon colors only)
 // ---------------------------------------------------------------------------
 
-// Upcoming: dashed gray-700 circle, no icon
 .indicator[data-indicator-variant='bullet'] {
-	border-style: dashed;
-	border-color: var( --wpds-color-foreground-content-neutral-weak );
 	color: var( --wpds-color-foreground-content-neutral-weak );
 }
 
-// Current: 16px solid gray-900 ring, transparent background + half-circle dome
-// The margin compensates for the size reduction vs upcoming (size → size-sm)
-// so the indicator centres stay aligned vertically across states.
 .indicator.is-current[data-indicator-variant='bullet'] {
-	width: var( --a8c-ui-stepper-indicator-size-sm );
-	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: var( --a8c-ui-stepper-indicator-offset );
-	border-style: solid;
-	border-color: var( --wpds-color-foreground-content-neutral );
-	background: transparent;
 	color: var( --wpds-color-foreground-content-neutral );
 }
-
-// Completed: 16px, solid border (color inherited from .indicator.is-completed)
-.indicator.is-completed[data-indicator-variant='bullet'] {
-	width: var( --a8c-ui-stepper-indicator-size-sm );
-	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: var( --a8c-ui-stepper-indicator-offset );
-	border-style: solid;
-}
-
 // Upcoming step titles
 [data-indicator-variant] .title {
 	color: var( --wpds-color-foreground-interactive-neutral );

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -6,6 +6,11 @@
 
 .root {
 	--a8c-ui-stepper-indicator-size: 24px;
+
+	// Matches the @wordpress/icons glyph geometry: the state icons draw a 16px
+	// circle inside the 24px viewBox, so the number-variant circle uses the
+	// same visual size within the same layout box.
+	--a8c-ui-stepper-indicator-circle-size: 16px;
 }
 
 // ---------------------------------------------------------------------------
@@ -25,7 +30,14 @@
 	color: var( --wpds-color-fg-interactive-neutral );
 }
 
-.indicator[data-indicator-variant='number']:not( .is-completed, .is-error ) {
+// The number span only renders for number-variant steps without a status
+// (completed/error render icons instead), so no variant/state guards needed.
+.number {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var( --a8c-ui-stepper-indicator-circle-size );
+	height: var( --a8c-ui-stepper-indicator-circle-size );
 	border-radius: 50%;
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-foreground-interactive-neutral );
 	font-size: var( --wpds-typography-font-size-sm );
@@ -34,9 +46,8 @@
 	background: var( --wpds-color-background-surface-neutral-strong );
 }
 
-// Current step (number variant): solid filled circle. Completed/error render
-// icons even when current, so they are excluded from the circle fill.
-.indicator.is-current[data-indicator-variant='number']:not( .is-completed, .is-error ) {
+// Current step (number variant): solid filled circle.
+.indicator.is-current .number {
 	border-color: var( --wpds-color-foreground-content-neutral );
 	background: var( --wpds-color-foreground-content-neutral );
 	color: var( --wpds-color-background-surface-neutral-strong );
@@ -105,8 +116,8 @@
 			color: var( --wpds-color-foreground-interactive-brand );
 		}
 
-		// Only number-variant upcoming steps still draw a bordered CSS circle.
-		.indicator[data-indicator-variant='number']:not( .is-current, .is-completed, .is-error ) {
+		// Number circle: the current step keeps its solid fill on hover.
+		.indicator:not( .is-current ) .number {
 			border-color: var( --wpds-color-foreground-interactive-brand );
 		}
 

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -27,13 +27,11 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	flex-shrink: 0;
-	color: var( --wpds-color-fg-interactive-neutral );
+	color: var( --wpds-color-foreground-interactive-neutral );
+}
 
-	// Render the glyph circle at the Figma size (16 -> 18) without affecting
-	// the 24px layout box.
-	svg {
-		transform: scale( calc( 18 / 16 ) );
-	}
+.icon {
+	transform: scale( calc( 18 / 16 ) );
 }
 
 // The number span only renders for number-variant steps without a status

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -23,13 +23,6 @@
 	height: var( --a8c-ui-stepper-indicator-size );
 	flex-shrink: 0;
 	color: var( --wpds-color-fg-interactive-neutral );
-
-	// The icon glyphs draw a 16px circle inside the 24px viewBox; Figma specs
-	// an 18px circle. Scale the rendered SVG (16 -> 18) without affecting the
-	// 24px layout box.
-	svg {
-		transform: scale( calc( 18 / 16 ) );
-	}
 }
 
 .indicator[data-indicator-variant='number']:not( .is-completed, .is-error ) {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -25,7 +25,7 @@
 	color: var( --wpds-color-fg-interactive-neutral );
 }
 
-.indicator[data-indicator-variant='number']:not( .is-completed ):not( .is-error ) {
+.indicator[data-indicator-variant='number']:not( .is-completed, .is-error ) {
 	border-radius: 50%;
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-foreground-interactive-neutral );
 	font-size: var( --wpds-typography-font-size-sm );
@@ -104,16 +104,19 @@
 			color: var( --wpds-color-foreground-interactive-brand );
 		}
 
-		// Number-variant current step has a solid filled circle — skip border change
-		// to avoid an accent ring appearing against the dark background on hover.
-		.indicator:not( .is-current[data-indicator-variant='number'] ) {
+		// Only number-variant non-current steps still draw a CSS circle;
+		// the current step keeps its solid fill on hover.
+		.indicator[data-indicator-variant='number']:not( .is-current ) {
 			border-color: var( --wpds-color-foreground-interactive-brand );
 		}
 
-		// Pull icon color for completed and current steps (SVG/dome use currentColor).
-		// Number-variant current steps keep their original number color on hover.
+		// Pull icon color on hover. Icons use currentColor, so this covers every
+		// icon-rendered state (all bullet states, plus number-variant
+		// completed/error). Number-variant current steps keep their original
+		// number color on hover.
+		.indicator[data-indicator-variant='bullet'],
 		.indicator.is-completed,
-		.indicator.is-current:not( [data-indicator-variant='number'] ) {
+		.indicator.is-error {
 			color: var( --wpds-color-foreground-interactive-brand );
 		}
 	}

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -23,6 +23,13 @@
 	height: var( --a8c-ui-stepper-indicator-size );
 	flex-shrink: 0;
 	color: var( --wpds-color-fg-interactive-neutral );
+
+	// The icon glyphs draw a 16px circle inside the 24px viewBox; Figma specs
+	// an 18px circle. Scale the rendered SVG (16 -> 18) without affecting the
+	// 24px layout box.
+	svg {
+		transform: scale( calc( 18 / 16 ) );
+	}
 }
 
 .indicator[data-indicator-variant='number']:not( .is-completed, .is-error ) {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -6,6 +6,11 @@
 
 .root {
 	--a8c-ui-stepper-indicator-size: 24px;
+
+	// Matches the @wordpress/icons glyph geometry: the state icons draw a 16px
+	// circle inside the 24px viewBox, so the number-variant circle uses the
+	// same visual size within the same layout box.
+	--a8c-ui-stepper-indicator-circle-size: 16px;
 }
 
 // ---------------------------------------------------------------------------
@@ -25,7 +30,14 @@
 	color: var( --wpds-color-fg-interactive-neutral );
 }
 
-.indicator[data-indicator-variant='number']:not( .is-completed, .is-error ) {
+// The number span only renders for number-variant steps without a status
+// (completed/error render icons instead), so no variant/state guards needed.
+.number {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var( --a8c-ui-stepper-indicator-circle-size );
+	height: var( --a8c-ui-stepper-indicator-circle-size );
 	border-radius: 50%;
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
 	font-size: var( --wpds-typography-font-size-sm );
@@ -33,9 +45,8 @@
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
-// Current step (number variant): solid filled circle. Completed/error render
-// icons even when current, so they are excluded from the circle fill.
-.indicator.is-current[data-indicator-variant='number']:not( .is-completed, .is-error ) {
+// Current step (number variant): solid filled circle.
+.indicator.is-current .number {
 	border-color: var( --wpds-color-fg-content-neutral );
 	background: var( --wpds-color-fg-content-neutral );
 	color: var( --wpds-color-bg-surface-neutral-strong );
@@ -105,9 +116,8 @@
 			color: var( --wpds-color-fg-interactive-brand );
 		}
 
-		// Only number-variant non-current steps still draw a CSS circle;
-		// the current step keeps its solid fill on hover.
-		.indicator[data-indicator-variant='number']:not( .is-current, .is-completed, .is-error ) {
+		// Number circle: the current step keeps its solid fill on hover.
+		.indicator:not( .is-current ) .number {
 			border-color: var( --wpds-color-fg-interactive-brand );
 		}
 

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -33,8 +33,9 @@
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
-// Current step (number variant): solid filled circle
-.indicator.is-current[data-indicator-variant='number'] {
+// Current step (number variant): solid filled circle. Completed/error render
+// icons even when current, so they are excluded from the circle fill.
+.indicator.is-current[data-indicator-variant='number']:not( .is-completed, .is-error ) {
 	border-color: var( --wpds-color-fg-content-neutral );
 	background: var( --wpds-color-fg-content-neutral );
 	color: var( --wpds-color-bg-surface-neutral-strong );
@@ -106,7 +107,7 @@
 
 		// Only number-variant non-current steps still draw a CSS circle;
 		// the current step keeps its solid fill on hover.
-		.indicator[data-indicator-variant='number']:not( .is-current ) {
+		.indicator[data-indicator-variant='number']:not( .is-current, .is-completed, .is-error ) {
 			border-color: var( --wpds-color-fg-interactive-brand );
 		}
 

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -25,7 +25,7 @@
 	color: var( --wpds-color-fg-interactive-neutral );
 }
 
-.indicator[data-indicator-variant='number']:not( .is-completed ):not( .is-error ) {
+.indicator[data-indicator-variant='number']:not( .is-completed, .is-error ) {
 	border-radius: 50%;
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
 	font-size: var( --wpds-typography-font-size-sm );
@@ -104,16 +104,19 @@
 			color: var( --wpds-color-fg-interactive-brand );
 		}
 
-		// Number-variant current step has a solid filled circle — skip border change
-		// to avoid an accent ring appearing against the dark background on hover.
-		.indicator:not( .is-current[data-indicator-variant='number'] ) {
+		// Only number-variant non-current steps still draw a CSS circle;
+		// the current step keeps its solid fill on hover.
+		.indicator[data-indicator-variant='number']:not( .is-current ) {
 			border-color: var( --wpds-color-fg-interactive-brand );
 		}
 
-		// Pull icon color for completed and current steps (SVG/dome use currentColor).
-		// Number-variant current steps keep their original number color on hover.
+		// Pull icon color on hover. Icons use currentColor, so this covers every
+		// icon-rendered state (all bullet states, plus number-variant
+		// completed/error). Number-variant current steps keep their original
+		// number color on hover.
+		.indicator[data-indicator-variant='bullet'],
 		.indicator.is-completed,
-		.indicator.is-current:not( [data-indicator-variant='number'] ) {
+		.indicator.is-error {
 			color: var( --wpds-color-fg-interactive-brand );
 		}
 	}

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -5,47 +5,45 @@
 // ---------------------------------------------------------------------------
 
 .root {
-	--a8c-ui-stepper-indicator-size: 18px;
-	--a8c-ui-stepper-indicator-size-sm: 16px;
+	--a8c-ui-stepper-indicator-size: 24px;
 }
 
 // ---------------------------------------------------------------------------
 // Indicator
 // ---------------------------------------------------------------------------
 
+// Icons draw their own circles and use currentColor, so state rules below
+// only set `color`. The CSS-drawn circle remains solely for number-variant
+// steps that display a number (completed/error render full icons).
 .indicator {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
+	flex-shrink: 0;
+	color: var( --wpds-color-fg-interactive-neutral );
+}
+
+.indicator[data-indicator-variant='number']:not( .is-completed ):not( .is-error ) {
 	border-radius: 50%;
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
-	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-interactive-neutral );
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
-// Current step
-.indicator.is-current {
+// Current step (number variant): solid filled circle
+.indicator.is-current[data-indicator-variant='number'] {
 	border-color: var( --wpds-color-fg-content-neutral );
 	background: var( --wpds-color-fg-content-neutral );
 	color: var( --wpds-color-bg-surface-neutral-strong );
 	font-weight: 600;
 }
 
-// Completed step
+// Completed step (both variants)
 .indicator.is-completed {
-	border-color: var( --wpds-color-fg-content-neutral-weak );
-	background: transparent;
 	color: var( --wpds-color-fg-content-neutral-weak );
-
-	svg {
-		stroke: currentColor;
-		stroke-width: 1.5px;
-	}
 }
 
 // Disabled step
@@ -54,35 +52,15 @@
 }
 
 // ---------------------------------------------------------------------------
-// Bullet indicator variant
+// Bullet indicator variant (icon colors only)
 // ---------------------------------------------------------------------------
 
-// Upcoming: dashed gray-700 circle, no icon
 .indicator[data-indicator-variant='bullet'] {
-	border-style: dashed;
-	border-color: var( --wpds-color-fg-content-neutral-weak );
 	color: var( --wpds-color-fg-content-neutral-weak );
 }
 
-// Current: 16px solid gray-900 ring, transparent background + half-circle dome
-// margin: 1px compensates for the 2px size reduction vs upcoming (18px → 16px)
-// so the indicator centres stay aligned vertically across states.
 .indicator.is-current[data-indicator-variant='bullet'] {
-	width: var( --a8c-ui-stepper-indicator-size-sm );
-	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: 1px;
-	border-style: solid;
-	border-color: var( --wpds-color-fg-content-neutral );
-	background: transparent;
 	color: var( --wpds-color-fg-content-neutral );
-}
-
-// Completed: 16px, solid border (color inherited from .indicator.is-completed)
-.indicator.is-completed[data-indicator-variant='bullet'] {
-	width: var( --a8c-ui-stepper-indicator-size-sm );
-	height: var( --a8c-ui-stepper-indicator-size-sm );
-	margin: 1px;
-	border-style: solid;
 }
 
 // Upcoming step titles

--- a/packages/ui/src/stepper/test/index.tsx
+++ b/packages/ui/src/stepper/test/index.tsx
@@ -736,11 +736,20 @@ describe( 'Stepper indicatorVariant', () => {
 				<Stepper.Step value="a">
 					<Stepper.Indicator />
 				</Stepper.Step>
+				<Stepper.Step value="b" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
 			</Stepper.Root>
 		);
 		// The number variant renders <span aria-hidden="true">1</span> inside the indicator
 		const numericLabel = screen.getByText( '1' );
 		expect( numericLabel ).toHaveAttribute( 'aria-hidden', 'true' );
+		// Steps with a status render an icon instead of the number.
+		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
+		const completedIndicator = screen
+			.getByText( 'Step 2 of 2, completed' )
+			.closest( '[data-indicator-variant]' );
+		expect( completedIndicator?.querySelector( 'svg' ) ).not.toBeNull();
 	} );
 } );
 
@@ -817,89 +826,5 @@ describe( 'Stepper.Panel keepMounted horizontal', () => {
 			</Stepper.Root>
 		);
 		expect( screen.getByTestId( 'force-mounted-h' ) ).toBeInTheDocument();
-	} );
-} );
-
-describe( 'Stepper icon indicators', () => {
-	function getIndicator( label: string ): HTMLElement {
-		const indicator = screen.getByText( label ).closest( '[data-indicator-variant]' );
-		if ( ! indicator ) {
-			throw new Error( `No indicator found for label "${ label }"` );
-		}
-		return indicator as HTMLElement;
-	}
-
-	it( 'renders an SVG icon for every bullet-variant state', () => {
-		render(
-			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
-				<Stepper.Step value="a" status="completed">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="b">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="c">
-					<Stepper.Indicator />
-				</Stepper.Step>
-			</Stepper.Root>
-		);
-		const completed = getIndicator( 'Step 1 of 3, completed' );
-		const current = getIndicator( 'Step 2 of 3' );
-		const upcoming = getIndicator( 'Step 3 of 3' );
-		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
-		expect( current.querySelector( 'svg' ) ).not.toBeNull();
-		expect( upcoming.querySelector( 'svg' ) ).not.toBeNull();
-	} );
-
-	it( 'renders distinct icons for different bullet-variant states', () => {
-		render(
-			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
-				<Stepper.Step value="a" status="completed">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="b">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="c">
-					<Stepper.Indicator />
-				</Stepper.Step>
-			</Stepper.Root>
-		);
-		const dFor = ( label: string ) =>
-			getIndicator( label ).querySelector( 'path' )?.getAttribute( 'd' );
-		const completedD = dFor( 'Step 1 of 3, completed' );
-		const currentD = dFor( 'Step 2 of 3' );
-		const upcomingD = dFor( 'Step 3 of 3' );
-		expect( completedD ).toBeTruthy();
-		expect( currentD ).toBeTruthy();
-		expect( upcomingD ).toBeTruthy();
-		expect( new Set( [ completedD, currentD, upcomingD ] ).size ).toBe( 3 );
-	} );
-
-	it( 'renders icons instead of numbers for completed and error steps in the number variant', () => {
-		render(
-			<Stepper.Root orientation="vertical" value="c" indicatorVariant="number" aria-label="Test">
-				<Stepper.Step value="a" status="completed">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="b" status="error">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="c">
-					<Stepper.Indicator />
-				</Stepper.Step>
-			</Stepper.Root>
-		);
-		const completed = getIndicator( 'Step 1 of 3, completed' );
-		const error = getIndicator( 'Step 2 of 3, error' );
-		const current = getIndicator( 'Step 3 of 3' );
-		// Completed/error render icons, not the step number.
-		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
-		expect( screen.queryByText( '1' ) ).not.toBeInTheDocument();
-		expect( error.querySelector( 'svg' ) ).not.toBeNull();
-		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
-		// Current still renders the number, no icon.
-		expect( current.querySelector( 'svg' ) ).toBeNull();
-		expect( screen.getByText( '3' ) ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 } );

--- a/packages/ui/src/stepper/test/index.tsx
+++ b/packages/ui/src/stepper/test/index.tsx
@@ -531,7 +531,7 @@ describe( 'Stepper linear mode interaction', () => {
 } );
 
 describe( 'Stepper error status', () => {
-	it( 'shows "!" indicator and appends "error" to the accessible label', () => {
+	it( 'renders an icon indicator and appends "error" to the accessible label', () => {
 		render(
 			<Stepper.Root orientation="vertical" value="a" aria-label="Test">
 				<Stepper.Step value="a" status="error">
@@ -540,7 +540,11 @@ describe( 'Stepper error status', () => {
 			</Stepper.Root>
 		);
 		expect( screen.getByText( 'Step 1 of 1, error' ) ).toBeInTheDocument();
-		expect( screen.getByText( '!' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '!' ) ).not.toBeInTheDocument();
+		const indicator = screen
+			.getByText( 'Step 1 of 1, error' )
+			.closest( '[data-indicator-variant]' );
+		expect( indicator?.querySelector( 'svg' ) ).not.toBeNull();
 	} );
 } );
 
@@ -813,5 +817,89 @@ describe( 'Stepper.Panel keepMounted horizontal', () => {
 			</Stepper.Root>
 		);
 		expect( screen.getByTestId( 'force-mounted-h' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'Stepper icon indicators', () => {
+	function getIndicator( label: string ): HTMLElement {
+		const indicator = screen.getByText( label ).closest( '[data-indicator-variant]' );
+		if ( ! indicator ) {
+			throw new Error( `No indicator found for label "${ label }"` );
+		}
+		return indicator as HTMLElement;
+	}
+
+	it( 'renders an SVG icon for every bullet-variant state', () => {
+		render(
+			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
+				<Stepper.Step value="a" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="b">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="c">
+					<Stepper.Indicator />
+				</Stepper.Step>
+			</Stepper.Root>
+		);
+		const completed = getIndicator( 'Step 1 of 3, completed' );
+		const current = getIndicator( 'Step 2 of 3' );
+		const upcoming = getIndicator( 'Step 3 of 3' );
+		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
+		expect( current.querySelector( 'svg' ) ).not.toBeNull();
+		expect( upcoming.querySelector( 'svg' ) ).not.toBeNull();
+	} );
+
+	it( 'renders distinct icons for different bullet-variant states', () => {
+		render(
+			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
+				<Stepper.Step value="a" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="b">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="c">
+					<Stepper.Indicator />
+				</Stepper.Step>
+			</Stepper.Root>
+		);
+		const dFor = ( label: string ) =>
+			getIndicator( label ).querySelector( 'path' )?.getAttribute( 'd' );
+		const completedD = dFor( 'Step 1 of 3, completed' );
+		const currentD = dFor( 'Step 2 of 3' );
+		const upcomingD = dFor( 'Step 3 of 3' );
+		expect( completedD ).toBeTruthy();
+		expect( currentD ).toBeTruthy();
+		expect( upcomingD ).toBeTruthy();
+		expect( new Set( [ completedD, currentD, upcomingD ] ).size ).toBe( 3 );
+	} );
+
+	it( 'renders icons instead of numbers for completed and error steps in the number variant', () => {
+		render(
+			<Stepper.Root orientation="vertical" value="c" indicatorVariant="number" aria-label="Test">
+				<Stepper.Step value="a" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="b" status="error">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="c">
+					<Stepper.Indicator />
+				</Stepper.Step>
+			</Stepper.Root>
+		);
+		const completed = getIndicator( 'Step 1 of 3, completed' );
+		const error = getIndicator( 'Step 2 of 3, error' );
+		const current = getIndicator( 'Step 3 of 3' );
+		// Completed/error render icons, not the step number.
+		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
+		expect( screen.queryByText( '1' ) ).not.toBeInTheDocument();
+		expect( error.querySelector( 'svg' ) ).not.toBeNull();
+		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
+		// Current still renders the number, no icon.
+		expect( current.querySelector( 'svg' ) ).toBeNull();
+		expect( screen.getByText( '3' ) ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 } );

--- a/packages/ui/src/stepper/test/index.tsx
+++ b/packages/ui/src/stepper/test/index.tsx
@@ -540,8 +540,9 @@ describe( 'Stepper error status', () => {
 			</Stepper.Root>
 		);
 		const label = screen.getByText( 'Step 1 of 1, error' );
-		const indicator = label.closest( '[data-indicator-variant]' );
-		expect( indicator?.querySelector( 'svg' ) ).not.toBeNull();
+		const icon = label.closest( '[data-indicator-variant]' )?.querySelector( 'svg' );
+		expect( icon ).toHaveAttribute( 'fill', 'currentColor' );
+		expect( icon ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 } );
 
@@ -743,10 +744,11 @@ describe( 'Stepper indicatorVariant', () => {
 		expect( numericLabel ).toHaveAttribute( 'aria-hidden', 'true' );
 		// Steps with a status render an icon instead of the number.
 		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
-		const completedIndicator = screen
+		const completedIcon = screen
 			.getByText( 'Step 2 of 2, completed' )
-			.closest( '[data-indicator-variant]' );
-		expect( completedIndicator?.querySelector( 'svg' ) ).not.toBeNull();
+			.closest( '[data-indicator-variant]' )
+			?.querySelector( 'svg' );
+		expect( completedIcon ).toHaveAttribute( 'fill', 'currentColor' );
 	} );
 } );
 

--- a/packages/ui/src/stepper/test/index.tsx
+++ b/packages/ui/src/stepper/test/index.tsx
@@ -539,11 +539,8 @@ describe( 'Stepper error status', () => {
 				</Stepper.Step>
 			</Stepper.Root>
 		);
-		expect( screen.getByText( 'Step 1 of 1, error' ) ).toBeInTheDocument();
-		expect( screen.queryByText( '!' ) ).not.toBeInTheDocument();
-		const indicator = screen
-			.getByText( 'Step 1 of 1, error' )
-			.closest( '[data-indicator-variant]' );
+		const label = screen.getByText( 'Step 1 of 1, error' );
+		const indicator = label.closest( '[data-indicator-variant]' );
 		expect( indicator?.querySelector( 'svg' ) ).not.toBeNull();
 	} );
 } );

--- a/packages/ui/src/stepper/test/index.tsx
+++ b/packages/ui/src/stepper/test/index.tsx
@@ -531,7 +531,7 @@ describe( 'Stepper linear mode interaction', () => {
 } );
 
 describe( 'Stepper error status', () => {
-	it( 'shows "!" indicator and appends "error" to the accessible label', () => {
+	it( 'renders an icon indicator and appends "error" to the accessible label', () => {
 		render(
 			<Stepper.Root orientation="vertical" value="a" aria-label="Test">
 				<Stepper.Step value="a" status="error">
@@ -540,7 +540,11 @@ describe( 'Stepper error status', () => {
 			</Stepper.Root>
 		);
 		expect( screen.getByText( 'Step 1 of 1, error' ) ).toBeInTheDocument();
-		expect( screen.getByText( '!' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '!' ) ).not.toBeInTheDocument();
+		const indicator = screen
+			.getByText( 'Step 1 of 1, error' )
+			.closest( '[data-indicator-variant]' );
+		expect( indicator?.querySelector( 'svg' ) ).not.toBeNull();
 	} );
 } );
 
@@ -730,5 +734,89 @@ describe( 'Stepper.Panel keepMounted horizontal', () => {
 			</Stepper.Root>
 		);
 		expect( screen.getByTestId( 'force-mounted-h' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'Stepper icon indicators', () => {
+	function getIndicator( label: string ): HTMLElement {
+		const indicator = screen.getByText( label ).closest( '[data-indicator-variant]' );
+		if ( ! indicator ) {
+			throw new Error( `No indicator found for label "${ label }"` );
+		}
+		return indicator as HTMLElement;
+	}
+
+	it( 'renders an SVG icon for every bullet-variant state', () => {
+		render(
+			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
+				<Stepper.Step value="a" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="b">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="c">
+					<Stepper.Indicator />
+				</Stepper.Step>
+			</Stepper.Root>
+		);
+		const completed = getIndicator( 'Step 1 of 3, completed' );
+		const current = getIndicator( 'Step 2 of 3' );
+		const upcoming = getIndicator( 'Step 3 of 3' );
+		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
+		expect( current.querySelector( 'svg' ) ).not.toBeNull();
+		expect( upcoming.querySelector( 'svg' ) ).not.toBeNull();
+	} );
+
+	it( 'renders distinct icons for different bullet-variant states', () => {
+		render(
+			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
+				<Stepper.Step value="a" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="b">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="c">
+					<Stepper.Indicator />
+				</Stepper.Step>
+			</Stepper.Root>
+		);
+		const dFor = ( label: string ) =>
+			getIndicator( label ).querySelector( 'path' )?.getAttribute( 'd' );
+		const completedD = dFor( 'Step 1 of 3, completed' );
+		const currentD = dFor( 'Step 2 of 3' );
+		const upcomingD = dFor( 'Step 3 of 3' );
+		expect( completedD ).toBeTruthy();
+		expect( currentD ).toBeTruthy();
+		expect( upcomingD ).toBeTruthy();
+		expect( new Set( [ completedD, currentD, upcomingD ] ).size ).toBe( 3 );
+	} );
+
+	it( 'renders icons instead of numbers for completed and error steps in the number variant', () => {
+		render(
+			<Stepper.Root orientation="vertical" value="c" indicatorVariant="number" aria-label="Test">
+				<Stepper.Step value="a" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="b" status="error">
+					<Stepper.Indicator />
+				</Stepper.Step>
+				<Stepper.Step value="c">
+					<Stepper.Indicator />
+				</Stepper.Step>
+			</Stepper.Root>
+		);
+		const completed = getIndicator( 'Step 1 of 3, completed' );
+		const error = getIndicator( 'Step 2 of 3, error' );
+		const current = getIndicator( 'Step 3 of 3' );
+		// Completed/error render icons, not the step number.
+		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
+		expect( screen.queryByText( '1' ) ).not.toBeInTheDocument();
+		expect( error.querySelector( 'svg' ) ).not.toBeNull();
+		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
+		// Current still renders the number, no icon.
+		expect( current.querySelector( 'svg' ) ).toBeNull();
+		expect( screen.getByText( '3' ) ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 } );

--- a/packages/ui/src/stepper/test/index.tsx
+++ b/packages/ui/src/stepper/test/index.tsx
@@ -653,11 +653,20 @@ describe( 'Stepper indicatorVariant', () => {
 				<Stepper.Step value="a">
 					<Stepper.Indicator />
 				</Stepper.Step>
+				<Stepper.Step value="b" status="completed">
+					<Stepper.Indicator />
+				</Stepper.Step>
 			</Stepper.Root>
 		);
 		// The number variant renders <span aria-hidden="true">1</span> inside the indicator
 		const numericLabel = screen.getByText( '1' );
 		expect( numericLabel ).toHaveAttribute( 'aria-hidden', 'true' );
+		// Steps with a status render an icon instead of the number.
+		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
+		const completedIndicator = screen
+			.getByText( 'Step 2 of 2, completed' )
+			.closest( '[data-indicator-variant]' );
+		expect( completedIndicator?.querySelector( 'svg' ) ).not.toBeNull();
 	} );
 } );
 
@@ -734,89 +743,5 @@ describe( 'Stepper.Panel keepMounted horizontal', () => {
 			</Stepper.Root>
 		);
 		expect( screen.getByTestId( 'force-mounted-h' ) ).toBeInTheDocument();
-	} );
-} );
-
-describe( 'Stepper icon indicators', () => {
-	function getIndicator( label: string ): HTMLElement {
-		const indicator = screen.getByText( label ).closest( '[data-indicator-variant]' );
-		if ( ! indicator ) {
-			throw new Error( `No indicator found for label "${ label }"` );
-		}
-		return indicator as HTMLElement;
-	}
-
-	it( 'renders an SVG icon for every bullet-variant state', () => {
-		render(
-			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
-				<Stepper.Step value="a" status="completed">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="b">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="c">
-					<Stepper.Indicator />
-				</Stepper.Step>
-			</Stepper.Root>
-		);
-		const completed = getIndicator( 'Step 1 of 3, completed' );
-		const current = getIndicator( 'Step 2 of 3' );
-		const upcoming = getIndicator( 'Step 3 of 3' );
-		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
-		expect( current.querySelector( 'svg' ) ).not.toBeNull();
-		expect( upcoming.querySelector( 'svg' ) ).not.toBeNull();
-	} );
-
-	it( 'renders distinct icons for different bullet-variant states', () => {
-		render(
-			<Stepper.Root orientation="vertical" value="b" aria-label="Test">
-				<Stepper.Step value="a" status="completed">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="b">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="c">
-					<Stepper.Indicator />
-				</Stepper.Step>
-			</Stepper.Root>
-		);
-		const dFor = ( label: string ) =>
-			getIndicator( label ).querySelector( 'path' )?.getAttribute( 'd' );
-		const completedD = dFor( 'Step 1 of 3, completed' );
-		const currentD = dFor( 'Step 2 of 3' );
-		const upcomingD = dFor( 'Step 3 of 3' );
-		expect( completedD ).toBeTruthy();
-		expect( currentD ).toBeTruthy();
-		expect( upcomingD ).toBeTruthy();
-		expect( new Set( [ completedD, currentD, upcomingD ] ).size ).toBe( 3 );
-	} );
-
-	it( 'renders icons instead of numbers for completed and error steps in the number variant', () => {
-		render(
-			<Stepper.Root orientation="vertical" value="c" indicatorVariant="number" aria-label="Test">
-				<Stepper.Step value="a" status="completed">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="b" status="error">
-					<Stepper.Indicator />
-				</Stepper.Step>
-				<Stepper.Step value="c">
-					<Stepper.Indicator />
-				</Stepper.Step>
-			</Stepper.Root>
-		);
-		const completed = getIndicator( 'Step 1 of 3, completed' );
-		const error = getIndicator( 'Step 2 of 3, error' );
-		const current = getIndicator( 'Step 3 of 3' );
-		// Completed/error render icons, not the step number.
-		expect( completed.querySelector( 'svg' ) ).not.toBeNull();
-		expect( screen.queryByText( '1' ) ).not.toBeInTheDocument();
-		expect( error.querySelector( 'svg' ) ).not.toBeNull();
-		expect( screen.queryByText( '2' ) ).not.toBeInTheDocument();
-		// Current still renders the number, no icon.
-		expect( current.querySelector( 'svg' ) ).toBeNull();
-		expect( screen.getByText( '3' ) ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 } );


### PR DESCRIPTION
Part of the review feedback on #111036

## Proposed Changes

* Replace CSS-drawn bullet indicators with standard `@wordpress/icons` for upcoming, current, completed, and error states.
* Use a 24px indicator layout box with 18px visible icon and number circles.
* Keep number indicators for upcoming and current steps in the number variant. Completed and error steps still use icons.
* Use semantic WPDS colors for each state and hover.

<img width="1201" height="923" alt="Vertical Stepper variants" src="https://github.com/user-attachments/assets/41d1433b-148e-40f3-acde-d00aec21be43" />

<img width="1201" height="923" alt="Horizontal Stepper variants" src="https://github.com/user-attachments/assets/7c202730-084e-44b7-a51a-a51a86232ae6" />

## Why are these changes being made?

* The review on #111036 asked for standard WordPress icons and one indicator layout size.
* The stock icons keep the Stepper aligned across states and remove custom SVG and CSS indicator drawing. Their filled rings are slightly thicker than the 1px Figma ring; design accepted that tradeoff while stroke-based icons are unavailable.

## Testing Instructions

1. Run `yarn workspace @automattic/ui storybook:start`.
2. Open **UI/Stepper/Vertical → Step Variants** and confirm that upcoming, current, completed, error, and disabled states use the expected icon and color.
3. Open **UI/Stepper/Horizontal → Step Variants**, set `indicatorVariant` to `number`, and confirm that upcoming and current steps use 18px number circles while completed and error steps use 18px icons.
4. Hover enabled steps and confirm that the title and icon use the brand color.
5. Open **UI/Stepper/Horizontal → Mobile View** at 375px and confirm that indicators and connectors remain aligned.

## Pre-merge Checklist

- [x] Has the general [code quality](https://github.com/Automattic/wp-calypso/blob/trunk/docs/coding-guidelines/general.md) been checked?
- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you created or updated development documentation for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you checked the functionality in dark mode?
- [x] Have you checked the functionality for accessibility? (e.g. Keyboard, screen readers, etc.)
- [x] Have you checked the functionality on different browser sizes?
- [ ] Have you considered using `useCallback()` for event handlers passed to child components?
- [ ] Have you considered memoizing derived values that may be expensive to compute?
- [ ] Have you considered string freeze implications for new user-facing strings?
  - [ ] Have you considered localization implications for new user-facing strings?
- [ ] For changes affecting Jetpack: Have you added or updated privacy annotations where needed?
