### PR TITLE
Dashboard Emails: Fix cold-load 500 on the add-mailbox page

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -111,12 +111,17 @@ export const chooseEmailSolutionRoute = createRoute( {
 		await redirectIfInvalidDomain( domainName );
 	},
 	loader: async ( { params: { domain: domainName } } ) => {
-		const products = queryClient.ensureQueryData( productsQuery() );
-
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+
+		// Warm the same products query useEmailProduct reads (site-specific when
+		// the domain has a site) so prices render on the first load instead of
+		// flashing a $0 fallback.
+		const products = domain.blog_id
+			? queryClient.ensureQueryData( siteProductsQuery( domain.blog_id ) )
+			: queryClient.ensureQueryData( productsQuery() );
 		const site = queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
 
-		await Promise.all( [ products, site, domain ] );
+		await Promise.all( [ products, site ] );
 	},
 } ).lazy( () =>
 	import( '../../emails/choose-email-solution' ).then( ( d ) =>

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -6,6 +6,7 @@ import {
 	queryClient,
 	rawUserPreferencesQuery,
 	siteByIdQuery,
+	siteProductsQuery,
 	userMailboxesQuery,
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, Outlet } from '@tanstack/react-router';
@@ -154,15 +155,20 @@ export const addMailboxRoute = createRoute( {
 		}
 	},
 	loader: async ( { params: { domain: domainName } } ) => {
-		const products = queryClient.ensureQueryData( productsQuery() );
-
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+
+		// useEmailProduct reads site-specific products when the domain has a
+		// blog_id and only falls back to the global products list otherwise, so
+		// warm the same query the component will read to avoid a cold-load crash.
+		const products = domain.blog_id
+			? queryClient.ensureQueryData( siteProductsQuery( domain.blog_id ) )
+			: queryClient.ensureQueryData( productsQuery() );
 		const site = queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
-		const mailboxAccounts = await queryClient.ensureQueryData(
+		const mailboxAccounts = queryClient.ensureQueryData(
 			mailboxAccountsQuery( domain.blog_id, domainName )
 		);
 
-		await Promise.all( [ products, site, domain, mailboxAccounts ] );
+		await Promise.all( [ products, site, mailboxAccounts ] );
 	},
 } ).lazy( () =>
 	import( '../../emails/add-mailbox' ).then( ( d ) =>

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -144,7 +144,7 @@ const AddProfessionalEmail = () => {
 	let mailboxCost;
 	const totalItems = mailboxEntities.length;
 	let totalPrice = '0';
-	if ( isAddMailboxRoute ) {
+	if ( isAddMailboxRoute && product ) {
 		mailboxCost = getMailboxCost( {
 			domain,
 			product,


### PR DESCRIPTION
## What

The Emails → "Add mailbox" page crashes with a 500 the **first time** you open it. Reloading makes it work, so it looks random.

## Why

The page reads the per-site product list, but the page's data loader was fetching the *global* product list instead. So on the first load that data isn't there yet, the price is `undefined`, and the page crashes trying to read it. After one load the data is cached, so it stops crashing.

Error in the console: `Cannot read properties of undefined (reading 'product_slug')`

## Fix

- Load the **same** product list the page actually uses (per-site).
- Add a small guard so a missing product can never crash the page again.

2 files changed.

## How to test

1. Open a brand-new tab (so nothing is cached).
2. Go straight to an add-mailbox URL, e.g. `/emails/add-mailbox/<your-domain>/titan/annually`.
3. **Before:** 500 error on first load. **After:** the form loads fine the first time.
