### PR TITLE
Agents Manager: toggle chat from entry points, preserve minimize view, store cleanups

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -56,7 +56,7 @@ import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import { getSectionGroup } from 'calypso/state/ui/selectors';
+import { getSectionGroup, getSectionName } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
 import BigSkyIcon from './masterbar-agents-manager/big-sky-icon';
@@ -94,6 +94,7 @@ class MasterbarLoggedIn extends Component {
 		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		sectionName: PropTypes.string,
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -908,10 +909,14 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	clickAgentsManagerAiChat = () => {
-		this.props.recordTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked' );
 		// Toggle: close the chat if it's already showing, otherwise resume the active
 		// conversation and open it.
-		if ( isAgentsManagerChatVisible() ) {
+		const isVisible = isAgentsManagerChatVisible();
+		this.props.recordTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
+			section: this.props.sectionName,
+			action: isVisible ? 'close' : 'open',
+		} );
+		if ( isVisible ) {
 			closeAgentsManagerChat();
 		} else {
 			openAgentsManagerChat();
@@ -1002,6 +1007,7 @@ const ConnectedMasterbarLoggedIn = connect(
 			siteHomeUrl: getSiteHomeUrl( state, siteId ),
 			adminMenu: getAdminMenu( state, siteId ),
 			sectionGroup,
+			sectionName: getSectionName( state ),
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasNoSites: siteCount === 0,
 			user: getCurrentUser( state ),

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -60,7 +60,11 @@ import { getSectionGroup } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
 import BigSkyIcon from './masterbar-agents-manager/big-sky-icon';
-import { openAgentsManagerChat } from './masterbar-agents-manager/chat-actions';
+import {
+	closeAgentsManagerChat,
+	isAgentsManagerChatVisible,
+	openAgentsManagerChat,
+} from './masterbar-agents-manager/chat-actions';
 import HelpIcon from './masterbar-agents-manager/help-icon';
 import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
 import { MasterbarLaunchButton } from './masterbar-launch-button';
@@ -905,8 +909,13 @@ class MasterbarLoggedIn extends Component {
 
 	clickAgentsManagerAiChat = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked' );
-		// Reopen and resume the active conversation rather than start a new one.
-		openAgentsManagerChat();
+		// Toggle: close the chat if it's already showing, otherwise resume the active
+		// conversation and open it.
+		if ( isAgentsManagerChatVisible() ) {
+			closeAgentsManagerChat();
+		} else {
+			openAgentsManagerChat();
+		}
 	};
 
 	renderAgentsManagerAiChat() {

--- a/client/layout/masterbar/masterbar-agents-manager/chat-actions.ts
+++ b/client/layout/masterbar/masterbar-agents-manager/chat-actions.ts
@@ -7,6 +7,8 @@ interface AgentsManagerActions {
 	chatNavigate: NavigateFunction;
 	resumeChat: () => void;
 	setChatOpen: ( isOpen: boolean ) => void;
+	isChatVisible: () => boolean;
+	getCurrentRoute: () => string;
 	isReady?: boolean;
 }
 
@@ -43,3 +45,18 @@ export const openAgentsManagerChat = ( path?: string ): void => {
 
 // No readiness wait needed: the chat can only be closed once it is already open.
 export const closeAgentsManagerChat = (): void => getAgentsManagerActions()?.setChatOpen( false );
+
+/**
+ * Whether the chat is visible (open and not minimized). Entry points use this to
+ * toggle: re-clicking while visible closes it; otherwise it opens (which also
+ * expands a minimized chat).
+ */
+export const isAgentsManagerChatVisible = (): boolean =>
+	!! getAgentsManagerActions()?.isChatVisible?.();
+
+/**
+ * The chat's current route (e.g. `/chat`), or `undefined` if the bundle isn't loaded.
+ * The Help menu uses it to detect a same-route re-click, which closes the chat.
+ */
+export const getAgentsManagerChatRoute = (): string | undefined =>
+	getAgentsManagerActions()?.getCurrentRoute?.();

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -41,18 +41,21 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 	};
 
 	const handleMenuClick = ( destination, isExternal = false ) => {
+		// Re-clicking the current route closes the chat; external links never do.
+		const isClosing =
+			! isExternal && isAgentsManagerChatVisible() && getAgentsManagerChatRoute() === destination;
+
 		recordTracksEvent( 'calypso_dashboard_help_center_menu_panel_click', {
 			section: sectionName,
 			destination,
+			action: isClosing ? 'close' : 'open',
 		} );
 
 		if ( isExternal ) {
 			return window.open( destination, '_blank', 'noopener,noreferrer' );
 		}
 
-		// Re-clicking the item for the current route closes the chat; a different
-		// route switches view (and opens/expands) without closing.
-		if ( isAgentsManagerChatVisible() && getAgentsManagerChatRoute() === destination ) {
+		if ( isClosing ) {
 			recordTracksEvent( 'calypso_inlinehelp_close', {
 				force_site_id: true,
 				location: 'help-center',

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -11,7 +11,12 @@ import { useSelector } from 'react-redux';
 import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import Item from '../item';
-import { closeAgentsManagerChat, openAgentsManagerChat } from './chat-actions';
+import {
+	closeAgentsManagerChat,
+	getAgentsManagerChatRoute,
+	isAgentsManagerChatVisible,
+	openAgentsManagerChat,
+} from './chat-actions';
 import HelpIcon from './help-icon';
 import './style.scss';
 
@@ -43,6 +48,17 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 
 		if ( isExternal ) {
 			return window.open( destination, '_blank', 'noopener,noreferrer' );
+		}
+
+		// Re-clicking the item for the current route closes the chat; a different
+		// route switches view (and opens/expands) without closing.
+		if ( isAgentsManagerChatVisible() && getAgentsManagerChatRoute() === destination ) {
+			recordTracksEvent( 'calypso_inlinehelp_close', {
+				force_site_id: true,
+				location: 'help-center',
+				section: sectionName,
+			} );
+			return closeAgentsManagerChat();
 		}
 
 		// `/chat` resumes the active conversation (no path), matching the AI

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -78,7 +78,7 @@ function MyComponent() {
 
 The Agents Manager exposes a `window.__agentsManagerActions` API for controlling the UI from outside the React tree (e.g., from a host app, legacy code, or a separate bundle).
 
-See `src/hooks/use-setup-custom-actions/README.md` for details.
+See `src/hooks/custom-actions/README.md` for details.
 
 ## API Reference
 
@@ -123,6 +123,8 @@ import type {
 	BaseContextEntry,
 	ContextEntry,
 	Suggestion,
+	UseFeedbackActionConfig,
+	UseFeedbackActionReturn,
 } from '@automattic/agents-manager';
 ```
 

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -219,7 +219,7 @@ describe( 'AgentDock', () => {
 		expect( screen.getByTestId( 'orchestrator-chat' ).dataset.chatOpen ).toBe( 'true' );
 	} );
 
-	it( 'resumes the active session when expanding from the minimized state', () => {
+	it( 'keeps the chat history view when expanding from the minimized state', () => {
 		useWpAdminAgent();
 		mockHasAdminBar = true;
 		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
@@ -227,7 +227,9 @@ describe( 'AgentDock', () => {
 		renderAgentDock( '/history' );
 		fireEvent.click( screen.getByText( 'Expand history' ) );
 
-		expect( mockResumeActiveChat ).toHaveBeenCalled();
+		// Expanding restores the last view instead of jumping back to the chat.
+		expect( mockResumeActiveChat ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/history' );
 	} );
 
 	it( 'keeps the current route when opening the docked sidebar', () => {
@@ -242,7 +244,7 @@ describe( 'AgentDock', () => {
 		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/history' );
 	} );
 
-	it( 'resumes the active session when expanding from the support guides view', () => {
+	it( 'keeps the support guides view when expanding from the minimized state', () => {
 		useWpAdminAgent();
 		mockShouldUseUnifiedAgent = true;
 		mockHasAdminBar = true;
@@ -251,7 +253,8 @@ describe( 'AgentDock', () => {
 		renderAgentDock( '/support-guides' );
 		fireEvent.click( screen.getByText( 'Expand guides' ) );
 
-		expect( mockResumeActiveChat ).toHaveBeenCalled();
+		expect( mockResumeActiveChat ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/support-guides' );
 	} );
 
 	it( 'hides the support guides list without the WP admin bar trigger', () => {

--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -5,7 +5,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-let mockIsDocked = false;
 const mockSetIsMinimized = jest.fn();
 
 jest.mock( '@wordpress/components', () => ( {
@@ -38,8 +37,6 @@ jest.mock( '@wordpress/icons', () => ( {
 } ) );
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { setIsMinimized: mockSetIsMinimized } ),
-	useSelect: ( mapSelect: ( select: () => unknown ) => unknown ) =>
-		mapSelect( () => ( { getIsDocked: () => mockIsDocked } ) ),
 } ) );
 jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
 jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
@@ -70,17 +67,16 @@ function installMasterbarTrigger() {
 	document.body.appendChild( el );
 }
 
-function renderChatHeader( title?: string ) {
+function renderChatHeader( title?: string, isDocked = false ) {
 	return render(
 		<MemoryRouter>
-			<ChatHeader onClose={ jest.fn() } options={ [] } title={ title } />
+			<ChatHeader onClose={ jest.fn() } options={ [] } title={ title } isDocked={ isDocked } />
 		</MemoryRouter>
 	);
 }
 
 describe( 'ChatHeader', () => {
 	afterEach( () => {
-		mockIsDocked = false;
 		mockSetIsMinimized.mockClear();
 		document.getElementById( 'wp-admin-bar-agents-manager-ai-chat' )?.remove();
 		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
@@ -139,10 +135,19 @@ describe( 'ChatHeader', () => {
 
 	it( 'hides the Minimize button when docked', () => {
 		installAdminBarTrigger();
-		mockIsDocked = true;
 
-		renderChatHeader();
+		renderChatHeader( undefined, true );
 
 		expect( screen.queryByText( 'Minimize' ) ).toBeNull();
+	} );
+
+	it( 'shows the Minimize button when floating even if the docked preference is set', () => {
+		// `isDocked` is the effective state: a docked preference that can't
+		// dock (e.g. a too-narrow viewport) arrives here as `false`, so minimize shows.
+		installAdminBarTrigger();
+
+		renderChatHeader( undefined, false );
+
+		expect( screen.getByText( 'Minimize' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -261,7 +261,7 @@ export default function AgentChat( {
 			}
 		>
 			<AgentUI.ConversationView ref={ conversationViewRef }>
-				<ChatHeader onClose={ onClose } options={ chatHeaderOptions } />
+				<ChatHeader onClose={ onClose } options={ chatHeaderOptions } isDocked={ isDocked } />
 				{ isLoadingConversation ? <ChatMessageSkeleton count={ 3 } /> : <AgentUI.Messages /> }
 				{ ( onContextCardAction || onContextCardDismiss ) && (
 					<ContextCards onAction={ onContextCardAction } onDismiss={ onContextCardDismiss } />

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -76,7 +76,7 @@ export default function AgentDock( {
 	useCheckpoint,
 	capabilities,
 }: Props ) {
-	const { siteKey, sectionName, agentConfig, resumeActiveChat } = useAgentsManagerContext();
+	const { siteKey, sectionName, agentConfig } = useAgentsManagerContext();
 
 	const [ isCompactMode, setIsCompactMode ] = useState(
 		window.__agentsManagerActions?.isCompactMode ?? false
@@ -91,10 +91,10 @@ export default function AgentDock( {
 	const { setIsOpen, setIsDocked, setIsMinimized, setIsSplitScreen } =
 		useDispatch( AGENTS_MANAGER_STORE );
 	const {
-		isOpen: isPersistedOpen = false,
-		isDocked: isPersistedDocked = false,
-		isMinimized = false,
-		isSplitScreen = false,
+		isOpen: isPersistedOpen,
+		isDocked: isPersistedDocked,
+		isMinimized,
+		isSplitScreen,
 	} = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
@@ -128,10 +128,11 @@ export default function AgentDock( {
 			isSplitScreen,
 		} );
 
+	const handleClose = isDocked ? closeSidebar : () => setOpenState( false );
+
 	// WP admin bar integration. Returns whether the AI chat entry button is present.
 	const hasAiChatEntry = useAdminBarIntegration( {
-		isOpen: isPersistedOpen,
-		sectionName,
+		closeChat: handleClose,
 		// Open/un-minimize the chat panel, leaving the route unchanged.
 		maybeOpenChat: () => {
 			if ( isMinimized ) {
@@ -189,8 +190,6 @@ export default function AgentDock( {
 		[]
 	);
 
-	const handleClose = isDocked ? closeSidebar : () => setOpenState( false );
-
 	const handleExpand = () => {
 		if ( isMinimized ) {
 			setIsMinimized( false );
@@ -199,12 +198,6 @@ export default function AgentDock( {
 		// from the minimized bar).
 		if ( ! isPersistedOpen ) {
 			setOpenState( true );
-		}
-
-		// Return to the active chat, resuming its session — unless already on the
-		// `/chat` or `/zendesk` view.
-		if ( pathname !== '/chat' && pathname !== '/zendesk' ) {
-			resumeActiveChat();
 		}
 	};
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -76,7 +76,7 @@ export default function AgentDock( {
 	useCheckpoint,
 	capabilities,
 }: Props ) {
-	const { siteKey, sectionName, agentConfig } = useAgentsManagerContext();
+	const { siteKey, agentConfig } = useAgentsManagerContext();
 
 	const [ isCompactMode, setIsCompactMode ] = useState(
 		window.__agentsManagerActions?.isCompactMode ?? false

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -46,6 +46,7 @@ export default function AgentHistory( {
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
 	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
+	const title = __( 'Past chats', '__i18n_text_domain__' );
 
 	const handleBack = () => resumeActiveChat();
 
@@ -60,6 +61,7 @@ export default function AgentHistory( {
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
+			triggerTitle={ title }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }
@@ -70,7 +72,8 @@ export default function AgentHistory( {
 					onClose={ onClose }
 					onBack={ handleBack }
 					options={ chatHeaderOptions }
-					title={ __( 'Past chats', '__i18n_text_domain__' ) }
+					title={ title }
+					isDocked={ isDocked }
 				/>
 				<ConversationHistoryView onSelectConversation={ onSelectConversation } />
 			</AgentUI.ConversationView>

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -1,5 +1,5 @@
 import { Button, DropdownMenu } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close, lineSolid, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
@@ -7,7 +7,6 @@ import { useNavigate } from 'react-router-dom';
 import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
-import type { AgentsManagerSelect } from '@automattic/data-stores';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
@@ -18,15 +17,13 @@ interface Props {
 	onClose: () => void;
 	options: Options;
 	onBack?: () => void;
+	/** Effective docked state (`canDock && isDocked`), not the stored preference. */
+	isDocked: boolean;
 }
 
-export default function ChatHeader( { onClose, options, title, onBack }: Props ) {
+export default function ChatHeader( { onClose, options, title, onBack, isDocked }: Props ) {
 	const navigate = useNavigate();
 	const { setIsMinimized } = useDispatch( AGENTS_MANAGER_STORE );
-	const isDocked = useSelect(
-		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getIsDocked(),
-		[]
-	);
 	const [ hasAiChatEntry ] = useState( hasAiChatEntryButton );
 
 	// Minimize only applies to the floating chat reachable from the AI chat button

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -47,6 +47,7 @@ export default function SupportGuide( {
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
 	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
 	const isFromChat = !! ( state?.sessionId || state?.conversationId );
+	const title = __( 'Support Guides', '__i18n_text_domain__' );
 
 	// Navigate back to the source route, preserving relevant state.
 	const handleBack = () => {
@@ -70,6 +71,7 @@ export default function SupportGuide( {
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
+			triggerTitle={ title }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }
@@ -80,7 +82,8 @@ export default function SupportGuide( {
 					onClose={ onClose }
 					onBack={ handleBack }
 					options={ chatHeaderOptions }
-					title={ __( 'Support Guides', '__i18n_text_domain__' ) }
+					title={ title }
+					isDocked={ isDocked }
 				/>
 				<div className="agent-manager-support-guide-wrapper">
 					<div className="agent-manager-support-guide-content help-center__container-content">

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -128,6 +128,7 @@ export default function SupportGuides( {
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
 	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
+	const title = __( 'Support Guides', '__i18n_text_domain__' );
 
 	return (
 		<AgentUI.Container
@@ -140,6 +141,7 @@ export default function SupportGuides( {
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
+			triggerTitle={ title }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }
@@ -149,7 +151,8 @@ export default function SupportGuides( {
 				<ChatHeader
 					onClose={ onClose }
 					options={ chatHeaderOptions }
-					title={ __( 'Support Guides', '__i18n_text_domain__' ) }
+					title={ title }
+					isDocked={ isDocked }
 				/>
 				<VStack
 					className="agent-manager-support-guides-wrapper"

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -105,6 +105,8 @@ interface AgentsManagerActions {
 	setSiteEditorAction: ( name: string, value: string | number | boolean | null ) => void;
 	chatNavigate: import('react-router-dom').NavigateFunction;
 	resumeChat: () => void;
+	isChatVisible: () => boolean;
+	getCurrentRoute: () => string;
 	isCompactMode?: boolean;
 	isChatEnabled?: boolean;
 	desktopMediaQuery?: string;

--- a/packages/agents-manager/src/hooks/__tests__/custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/custom-actions.test.ts
@@ -25,6 +25,7 @@ let mockSelectState: {
 	isDocked: false,
 	floatingPosition: '',
 };
+let mockLocation = { pathname: '/chat' };
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn( () => mockSelectState ),
@@ -37,6 +38,7 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( 'react-router-dom', () => ( {
 	useNavigate: jest.fn( () => jest.fn() ),
+	useLocation: jest.fn( () => mockLocation ),
 } ) );
 
 jest.mock( '../../contexts', () => ( {
@@ -69,6 +71,7 @@ describe( 'useSetupCustomActions', () => {
 			agentConfig: { agentId: 'reader-chat' },
 		};
 		mockSelectState = { hasLoaded: true, isOpen: false, isDocked: false, floatingPosition: '' };
+		mockLocation = { pathname: '/chat' };
 	} );
 
 	it( 'sets `isReady` on the global after mount', () => {
@@ -233,6 +236,29 @@ describe( 'useSetupCustomActions', () => {
 		expect( getSiteEditorActions() ).toEqual( {
 			colorPickerItemSelected: 'Ruby',
 		} );
+	} );
+
+	it( '`isChatVisible` is true only when open and not minimized', () => {
+		mockSelectState = {
+			hasLoaded: true,
+			isOpen: true,
+			isDocked: false,
+			isMinimized: false,
+			floatingPosition: '',
+		};
+		const { rerender } = renderHook( () => useSetupCustomActions( baseProps ) );
+		expect( window.__agentsManagerActions?.isChatVisible?.() ).toBe( true );
+
+		mockSelectState = { ...mockSelectState, isMinimized: true };
+		rerender();
+		expect( window.__agentsManagerActions?.isChatVisible?.() ).toBe( false );
+	} );
+
+	it( 'reports the current route via `getCurrentRoute`', () => {
+		mockLocation = { pathname: '/history' };
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		expect( window.__agentsManagerActions?.getCurrentRoute?.() ).toBe( '/history' );
 	} );
 } );
 

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
@@ -24,260 +24,249 @@ const CLOSING_CLASS = 'agents-manager-sidebar-container--closing';
 const OPEN_CLASS = 'agents-manager-sidebar-container--sidebar-open';
 const SPLIT_SCREEN_CLASS = 'is-split-screen';
 const TRANSITION_MS = 200;
+const DOCK_OPEN_DELAY_MS = 100;
 
 const FULLSCREEN_BODY_CLASS = 'is-fullscreen-mode';
 const EDITOR_BODY_CLASSES = [ 'post-php', 'post-new-php', 'site-editor-php' ] as const;
 
-function renderLayoutManager( container: HTMLElement ) {
-	return renderHook( () =>
-		useAgentLayoutManager( {
-			sidebarContainer: container,
-			defaultDocked: true,
-			defaultOpen: true,
-		} )
+type Options = NonNullable< Parameters< typeof useAgentLayoutManager >[ 0 ] >;
+
+let container: HTMLElement;
+
+// Render the hook against the shared `container`. Defaults to a docked-open
+// sidebar (the common case); pass overrides here or to the returned `rerender`.
+function render( options: Options = {} ) {
+	return renderHook(
+		( props: Options ) =>
+			useAgentLayoutManager( {
+				sidebarContainer: container,
+				defaultDocked: true,
+				defaultOpen: true,
+				...props,
+			} ),
+		{ initialProps: options }
 	);
 }
 
-describe( 'useAgentLayoutManager — closing class suppression', () => {
-	let container: HTMLElement;
-
-	beforeEach( () => {
-		jest.useFakeTimers();
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
+// Toggle a body class and flush the `MutationObserver` microtask so the
+// resulting `useSyncExternalStore` re-render settles inside `act()`.
+async function setBodyClass( className: string, on: boolean ) {
+	await act( async () => {
+		document.body.classList.toggle( className, on );
+		await Promise.resolve();
 	} );
+}
 
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
-		container.remove();
-	} );
-
-	it( 'adds --closing class when closeSidebar() is called while sidebar is open', () => {
-		const { result } = renderLayoutManager( container );
-
-		act( () => {
-			result.current.closeSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
-	} );
-
-	it( 'does not add --closing class when sidebar was already closed', () => {
-		const { result } = renderLayoutManager( container );
-
-		// Close once to get to closed state
-		act( () => {
-			result.current.closeSidebar();
-		} );
-		act( () => {
-			jest.runAllTimers();
-		} );
-
-		// Close again from already-closed state
-		act( () => {
-			result.current.closeSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-	} );
-
-	it( 'removes --closing class after the transition timeout', () => {
-		const { result } = renderLayoutManager( container );
-
-		act( () => {
-			result.current.closeSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
-
-		act( () => {
-			jest.advanceTimersByTime( TRANSITION_MS );
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-	} );
-
-	it( 'clears the timeout and removes --closing class when openSidebar() is called during transition', () => {
-		const { result } = renderLayoutManager( container );
-
-		act( () => {
-			result.current.closeSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
-
-		// Re-open before timeout fires
-		act( () => {
-			result.current.openSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
-
-		// Advance past where the timeout would have fired — class should still be absent
-		act( () => {
-			jest.advanceTimersByTime( TRANSITION_MS );
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-	} );
-
-	it( 'removes --closing class and cancels the timeout when undocking during a close transition', () => {
-		const { result } = renderLayoutManager( container );
-
-		act( () => {
-			result.current.closeSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
-
-		act( () => {
-			result.current.undock();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-
-		// Advance past where the timeout would have fired — class should still be absent
-		act( () => {
-			jest.advanceTimersByTime( TRANSITION_MS );
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-	} );
-
-	it( 'removes --closing class on unmount', () => {
-		const { result, unmount } = renderLayoutManager( container );
-
-		act( () => {
-			result.current.closeSidebar();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
-
-		act( () => {
-			unmount();
-		} );
-
-		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
-	} );
+beforeEach( () => {
+	// Reset before each test (not after) so RTL's auto-cleanup disconnects the
+	// observer first — otherwise this body mutation re-renders outside `act()`.
+	document.body.className = '';
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
 } );
 
-describe( 'useAgentLayoutManager — fullscreen gate', () => {
-	let container: HTMLElement;
+afterEach( () => {
+	container.remove();
+} );
 
-	beforeEach( () => {
-		// Reset in `beforeEach` (not `afterEach`) so RTL's auto-cleanup
-		// disconnects the observer first — otherwise the next test's
-		// `body` mutation triggers a re-render outside `act()`.
-		document.body.className = '';
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
-	} );
-
-	afterEach( () => {
-		container.remove();
-	} );
-
+describe( 'useAgentLayoutManager — docking gate', () => {
 	it( 'allows docking on non-editor screens (no gated body class)', () => {
-		const { result } = renderLayoutManager( container );
-		expect( result.current.canDock ).toBe( true );
+		expect( render().result.current.canDock ).toBe( true );
 	} );
 
-	it.each( EDITOR_BODY_CLASSES )(
-		'blocks docking on `%s` when fullscreen mode is off',
-		( editorClass ) => {
-			document.body.classList.add( editorClass );
-			const { result } = renderLayoutManager( container );
-			expect( result.current.canDock ).toBe( false );
-		}
-	);
+	it.each( EDITOR_BODY_CLASSES )( 'blocks docking on `%s` when fullscreen mode is off', ( cls ) => {
+		document.body.classList.add( cls );
+		expect( render().result.current.canDock ).toBe( false );
+	} );
 
-	it.each( EDITOR_BODY_CLASSES )(
-		'allows docking on `%s` when fullscreen mode is on',
-		( editorClass ) => {
-			document.body.classList.add( editorClass, FULLSCREEN_BODY_CLASS );
-			const { result } = renderLayoutManager( container );
-			expect( result.current.canDock ).toBe( true );
-		}
-	);
+	it.each( EDITOR_BODY_CLASSES )( 'allows docking on `%s` when fullscreen mode is on', ( cls ) => {
+		document.body.classList.add( cls, FULLSCREEN_BODY_CLASS );
+		expect( render().result.current.canDock ).toBe( true );
+	} );
 
 	it( 'reacts to runtime fullscreen-mode toggles', async () => {
 		document.body.classList.add( 'post-php' );
-		const { result } = renderLayoutManager( container );
-
+		const { result } = render();
 		expect( result.current.canDock ).toBe( false );
 
-		// `MutationObserver` callbacks fire on a microtask — flush one tick
-		// inside `act()` so the resulting re-render lands within it.
-		await act( async () => {
-			document.body.classList.add( FULLSCREEN_BODY_CLASS );
-			await Promise.resolve();
-		} );
+		await setBodyClass( FULLSCREEN_BODY_CLASS, true );
 		expect( result.current.canDock ).toBe( true );
 
-		await act( async () => {
-			document.body.classList.remove( FULLSCREEN_BODY_CLASS );
-			await Promise.resolve();
-		} );
+		await setBodyClass( FULLSCREEN_BODY_CLASS, false );
 		expect( result.current.canDock ).toBe( false );
+	} );
+} );
+
+describe( 'useAgentLayoutManager — open / close', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
+	it( 'toggles the sidebar-open class via open/close', () => {
+		const { result } = render();
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+
+		act( () => result.current.closeSidebar() );
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( false );
+
+		act( () => result.current.openSidebar() );
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+	} );
+
+	it( 'adds --closing when closing an open sidebar, and removes it after the transition', () => {
+		const { result } = render();
+
+		act( () => result.current.closeSidebar() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
+
+		act( () => jest.advanceTimersByTime( TRANSITION_MS ) );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+	} );
+
+	it( 'does not add --closing when the sidebar was already closed', () => {
+		const { result } = render();
+
+		act( () => result.current.closeSidebar() );
+		act( () => jest.runAllTimers() );
+
+		act( () => result.current.closeSidebar() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+	} );
+
+	it( 'cancels the --closing transition when openSidebar() interrupts it', () => {
+		const { result } = render();
+
+		act( () => result.current.closeSidebar() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
+
+		act( () => result.current.openSidebar() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+
+		// The pending removal must not fire after the class is already gone.
+		act( () => jest.advanceTimersByTime( TRANSITION_MS ) );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+	} );
+
+	it( 'cancels the --closing transition when undocking interrupts it', () => {
+		const { result } = render();
+
+		act( () => result.current.closeSidebar() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
+
+		act( () => result.current.undock() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+
+		act( () => jest.advanceTimersByTime( TRANSITION_MS ) );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+	} );
+
+	it( 'removes --closing on unmount', () => {
+		const { result, unmount } = render();
+
+		act( () => result.current.closeSidebar() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( true );
+
+		act( () => unmount() );
+		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+	} );
+
+	it( 'cancels the pending dock-open when the layout undocks before it fires', async () => {
+		document.body.classList.add( 'post-php', FULLSCREEN_BODY_CLASS );
+		const onOpenSidebar = jest.fn();
+		const { result } = render( { defaultDocked: false, defaultOpen: false, onOpenSidebar } );
+
+		// dock() schedules the open ~100ms later (its captured `canDock` is true).
+		act( () => result.current.dock() );
+
+		// Dockability is lost via the layout path — not undock() — before it fires.
+		await setBodyClass( FULLSCREEN_BODY_CLASS, false );
+
+		act( () => jest.advanceTimersByTime( DOCK_OPEN_DELAY_MS ) );
+		expect( onOpenSidebar ).not.toHaveBeenCalled();
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( false );
+	} );
+} );
+
+describe( 'useAgentLayoutManager — open-state sync on dock transition', () => {
+	it( 'opens the docked sidebar when the shared open state is true as it becomes dockable', async () => {
+		// Editor screen without fullscreen → not dockable yet (floating).
+		document.body.classList.add( 'post-php' );
+		const { result, rerender } = render( { defaultOpen: false } );
+		expect( result.current.isDocked ).toBe( false );
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( false );
+
+		// The floating chat is opened — the shared open state flips to true.
+		rerender( { defaultOpen: true } );
+
+		await setBodyClass( FULLSCREEN_BODY_CLASS, true );
+		expect( result.current.isDocked ).toBe( true );
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+	} );
+
+	it( 'keeps the docked sidebar closed when the shared open state is false as it becomes dockable', async () => {
+		document.body.classList.add( 'post-php' );
+		const { result } = render( { defaultOpen: false } );
+		expect( result.current.isDocked ).toBe( false );
+
+		await setBodyClass( FULLSCREEN_BODY_CLASS, true );
+		expect( result.current.isDocked ).toBe( true );
+		expect( container.classList.contains( OPEN_CLASS ) ).toBe( false );
+	} );
+} );
+
+describe( 'useAgentLayoutManager — lifecycle callbacks', () => {
+	it( 'fires onDock when the layout docks and onUndock when it undocks', async () => {
+		document.body.classList.add( 'post-php' ); // not dockable yet
+		const onDock = jest.fn();
+		const onUndock = jest.fn();
+		render( { onDock, onUndock } );
+
+		await setBodyClass( FULLSCREEN_BODY_CLASS, true );
+		expect( onDock ).toHaveBeenCalledTimes( 1 );
+		expect( onUndock ).not.toHaveBeenCalled();
+
+		await setBodyClass( FULLSCREEN_BODY_CLASS, false );
+		expect( onUndock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'fires onOpenSidebar and onCloseSidebar when the docked sidebar is toggled', () => {
+		const onOpenSidebar = jest.fn();
+		const onCloseSidebar = jest.fn();
+		const { result } = render( { onOpenSidebar, onCloseSidebar } );
+
+		act( () => result.current.closeSidebar() );
+		expect( onCloseSidebar ).toHaveBeenCalledTimes( 1 );
+
+		act( () => result.current.openSidebar() );
+		expect( onOpenSidebar ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 
 describe( 'useAgentLayoutManager — split-screen class', () => {
-	let container: HTMLElement;
-
-	beforeEach( () => {
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
-	} );
-
-	afterEach( () => {
-		container.remove();
-	} );
-
-	function renderWithSplitScreen( isSplitScreen: boolean ) {
-		return renderHook(
-			( props: { isSplitScreen: boolean } ) =>
-				useAgentLayoutManager( {
-					sidebarContainer: container,
-					defaultDocked: true,
-					defaultOpen: true,
-					isSplitScreen: props.isSplitScreen,
-				} ),
-			{ initialProps: { isSplitScreen } }
-		);
-	}
-
 	it( 'adds the class when `isSplitScreen` flips from `false` to `true`', () => {
-		const { rerender } = renderWithSplitScreen( false );
-
+		const { rerender } = render( { isSplitScreen: false } );
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
 
 		rerender( { isSplitScreen: true } );
-
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( true );
 	} );
 
 	it( 'removes the class when `isSplitScreen` flips from `true` to `false`', () => {
-		const { rerender } = renderWithSplitScreen( true );
-
+		const { rerender } = render( { isSplitScreen: true } );
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( true );
 
 		rerender( { isSplitScreen: false } );
-
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
 	} );
 
 	it( 'removes the class on unmount', () => {
-		const { unmount } = renderWithSplitScreen( true );
-
+		const { unmount } = render( { isSplitScreen: true } );
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( true );
 
-		act( () => {
-			unmount();
-		} );
-
+		act( () => unmount() );
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/custom-actions/README.md
+++ b/packages/agents-manager/src/hooks/custom-actions/README.md
@@ -17,6 +17,8 @@ Consuming the API? See [Public API](#public-api). Adding a new action? See [Addi
 | -------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `getChatState`             | `() => Promise<{ isOpen, isDocked, floatingPosition }>` | Current chat state. Waits for the store to load before resolving.         |
 | `getSessionId`             | `() => string`                                          | Active session ID.                                                        |
+| `isChatVisible`            | `() => boolean`                                         | Whether the chat is visible (open and not minimized).                     |
+| `getCurrentRoute`          | `() => string`                                          | The chat's current route, e.g. `/chat`, `/history`, `/support-guides`.    |
 | `setChatOpen`              | `(isOpen: boolean) => void`                             | Open or close the chat. Opening also expands it from the minimized bar.   |
 | `setChatDocked`            | `(isDocked: boolean) => void`                           | Dock or undock the chat.                                                  |
 | `setChatEnabled`           | `(isEnabled: boolean) => void`                          | Enable or disable chat rendering.                                         |
@@ -28,6 +30,7 @@ Consuming the API? See [Public API](#public-api). Adding a new action? See [Addi
 | `removeContextEntry`       | `(id: string) => void`                                  | Remove a context entry. Linked cards (`contextEntryIds`) are removed too. |
 | `setContextCard`           | `(card) => void`                                        | Add or replace a card shown inside the chat.                              |
 | `removeContextCard`        | `(id: string) => void`                                  | Remove a card.                                                            |
+| `setSiteEditorAction`      | `(name, value) => void`                                 | Record a Site Editor action (name → value) for the chat to read.          |
 | `chatNavigate`             | `NavigateFunction`                                      | The `react-router-dom` navigate function (path with options, or delta).   |
 | `resumeChat`               | `() => void`                                            | Reopen the chat, resuming the active conversation (not a new one).        |
 | `isReady`                  | `boolean`                                               | `true` once the API is fully populated and safe to call.                  |

--- a/packages/agents-manager/src/hooks/custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/custom-actions/index.ts
@@ -1,6 +1,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import {
@@ -74,6 +74,11 @@ export function useSetupCustomActions( {
 	const { setIsOpen, setIsDocked, setIsMinimized } = useDispatch( AGENTS_MANAGER_STORE );
 	const { agentConfig, getActiveSessionId, resumeActiveChat } = useAgentsManagerContext();
 	const navigate = useNavigate();
+	const location = useLocation();
+	// Keep the latest location in a ref so `getCurrentRoute` stays a stable
+	// reference while always reporting the chat's current route.
+	const locationRef = useRef( location );
+	locationRef.current = location;
 	const resolveRef = useRef< ( ( state: AgentsManagerChatState ) => void ) | null >( null );
 	const shouldPersistOpenState = ! isReaderChatAgent( agentConfig?.agentId );
 
@@ -170,9 +175,9 @@ export function useSetupCustomActions( {
 	const getChatState = useCallback( (): Promise< AgentsManagerChatState > => {
 		if ( hasLoaded ) {
 			return Promise.resolve( {
-				isOpen: !! isOpen,
-				isDocked: !! isDocked,
-				floatingPosition: floatingPosition || '',
+				isOpen,
+				isDocked,
+				floatingPosition,
 			} );
 		}
 
@@ -185,16 +190,25 @@ export function useSetupCustomActions( {
 	useEffect( () => {
 		if ( hasLoaded && resolveRef.current ) {
 			resolveRef.current( {
-				isOpen: !! isOpen,
-				isDocked: !! isDocked,
-				floatingPosition: floatingPosition || '',
+				isOpen,
+				isDocked,
+				floatingPosition,
 			} );
 			resolveRef.current = null;
 		}
 	}, [ hasLoaded, isOpen, isDocked, floatingPosition ] );
 
+	// Whether the chat is visible (open and not minimized). Entry points outside
+	// the bundle (e.g. the Calypso masterbar) read this to toggle.
+	const isChatVisible = useCallback( () => isOpen && ! isMinimized, [ isOpen, isMinimized ] );
+
+	// The chat's current route (e.g. `/chat`), so callers can detect a same-route re-click.
+	const getCurrentRoute = useCallback( () => locationRef.current.pathname, [] );
+
 	useRegisterCustomActions( {
 		getChatState,
+		isChatVisible,
+		getCurrentRoute,
 		getSessionId: getActiveSessionId,
 		setChatOpen,
 		setChatDocked,

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -1,7 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { AGENTS_MANAGER_STORE } from '../../stores';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
 import './style.scss';
 
 // Admin bar element selectors
@@ -35,9 +38,8 @@ const DESTINATION_HISTORY = 'agents-manager-history';
 const DESTINATION_GUIDES = 'agents-manager-support-guides';
 
 interface UseAdminBarIntegrationOptions {
-	isOpen: boolean;
-	sectionName: string;
 	maybeOpenChat: () => void;
+	closeChat: () => void;
 }
 
 /**
@@ -51,21 +53,37 @@ interface UseAdminBarIntegrationOptions {
  * Returns whether the AI chat entry button is present on the page.
  */
 export default function useAdminBarIntegration( {
-	isOpen,
-	sectionName,
 	maybeOpenChat,
+	closeChat,
 }: UseAdminBarIntegrationOptions ): boolean {
 	const navigate = useNavigate();
-	const { resumeActiveChat } = useAgentsManagerContext();
+	const { pathname } = useLocation();
+	const { resumeActiveChat, sectionName } = useAgentsManagerContext();
+	const { isOpen, isMinimized } = useSelect(
+		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getAgentsManagerState(),
+		[]
+	);
 
 	// Refs keep the latest callbacks without re-attaching DOM listeners each render.
 	const maybeOpenChatRef = useRef( maybeOpenChat );
 	maybeOpenChatRef.current = maybeOpenChat;
+	const closeChatRef = useRef( closeChat );
+	closeChatRef.current = closeChat;
 	const resumeActiveChatRef = useRef( resumeActiveChat );
 	resumeActiveChatRef.current = resumeActiveChat;
 
 	// Whether the AI chat entry button is present (captured once on mount).
 	const [ hasAiChatEntry ] = useState( hasAiChatEntryButton );
+
+	// Whether the chat is visible (open and not minimized), read inside the
+	// one-time DOM click handlers below to decide whether a click opens or closes.
+	const isChatVisibleRef = useRef( false );
+	isChatVisibleRef.current = isOpen && ! isMinimized;
+
+	// The chat's current route, read inside those same handlers so a Help menu item
+	// only closes the chat when it targets the route already showing.
+	const currentRouteRef = useRef( pathname );
+	currentRouteRef.current = pathname;
 
 	// Toggle the Help button's dropdown menu when it is clicked.
 	useEffect( () => {
@@ -112,7 +130,8 @@ export default function useAdminBarIntegration( {
 		};
 	}, [] );
 
-	// The standalone AI button reopens the chat, resuming the active conversation.
+	// The standalone AI button toggles the chat: close it if it's already showing,
+	// otherwise resume the active conversation and open it.
 	useEffect( () => {
 		const aiChatButton = document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID );
 		if ( ! aiChatButton ) {
@@ -123,6 +142,10 @@ export default function useAdminBarIntegration( {
 			recordTracksEvent( 'calypso_admin_bar_agents_manager_ai_chat_clicked', {
 				section: sectionName || 'wp-admin',
 			} );
+			if ( isChatVisibleRef.current ) {
+				closeChatRef.current();
+				return;
+			}
 			resumeActiveChatRef.current();
 			maybeOpenChatRef.current();
 		};
@@ -131,28 +154,31 @@ export default function useAdminBarIntegration( {
 		return () => aiChatButton.removeEventListener( 'click', handleClick );
 	}, [ sectionName ] );
 
-	// Wire each Help menu item's click: track it, go to its view, then open the chat.
+	// Wire each Help menu item's click: track it, then open or close the chat.
 	useEffect( () => {
 		const menuItems = [
 			// Chat Support resumes the active conversation, matching the AI button.
 			{
 				id: ADMIN_BAR_CHAT_ITEM_ID,
 				destination: DESTINATION_CHAT,
+				route: '/chat',
 				action: () => resumeActiveChatRef.current(),
 			},
 			{
 				id: ADMIN_BAR_HISTORY_ITEM_ID,
 				destination: DESTINATION_HISTORY,
+				route: '/history',
 				action: () => navigate( '/history' ),
 			},
 			{
 				id: ADMIN_BAR_GUIDES_ITEM_ID,
 				destination: DESTINATION_GUIDES,
+				route: '/support-guides',
 				action: () => navigate( '/support-guides' ),
 			},
 		];
 
-		const listeners = menuItems.map( ( { id, destination, action } ) => {
+		const listeners = menuItems.map( ( { id, destination, route, action } ) => {
 			const element = document.getElementById( id );
 
 			const handleClick = () => {
@@ -160,6 +186,12 @@ export default function useAdminBarIntegration( {
 					section: sectionName || 'wp-admin',
 					destination,
 				} );
+				// Re-clicking the item for the current route closes the chat; a
+				// different route switches view (and opens/expands) without closing.
+				if ( isChatVisibleRef.current && currentRouteRef.current === route ) {
+					closeChatRef.current();
+					return;
+				}
 				action();
 				maybeOpenChatRef.current();
 			};

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -141,6 +141,7 @@ export default function useAdminBarIntegration( {
 		const handleClick = () => {
 			recordTracksEvent( 'calypso_admin_bar_agents_manager_ai_chat_clicked', {
 				section: sectionName || 'wp-admin',
+				action: isChatVisibleRef.current ? 'close' : 'open',
 			} );
 			if ( isChatVisibleRef.current ) {
 				closeChatRef.current();
@@ -178,21 +179,23 @@ export default function useAdminBarIntegration( {
 			},
 		];
 
-		const listeners = menuItems.map( ( { id, destination, route, action } ) => {
+		const listeners = menuItems.map( ( { id, destination, route, action: onSelect } ) => {
 			const element = document.getElementById( id );
 
 			const handleClick = () => {
+				// Re-clicking the item for the current route closes the chat; a
+				// different route switches view (and opens/expands) without closing.
+				const isClosing = isChatVisibleRef.current && currentRouteRef.current === route;
 				recordTracksEvent( 'calypso_dashboard_help_center_menu_panel_click', {
 					section: sectionName || 'wp-admin',
 					destination,
+					action: isClosing ? 'close' : 'open',
 				} );
-				// Re-clicking the item for the current route closes the chat; a
-				// different route switches view (and opens/expands) without closing.
-				if ( isChatVisibleRef.current && currentRouteRef.current === route ) {
+				if ( isClosing ) {
 					closeChatRef.current();
 					return;
 				}
-				action();
+				onSelect();
 				maybeOpenChatRef.current();
 			};
 

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -107,7 +107,6 @@ export default function useAgentLayoutManager( {
 	isSplitScreen = false,
 }: Options = {} ): ReturnValue {
 	const portalRef = useRef< HTMLDivElement >();
-	const wasOpenRef = useRef( defaultOpen );
 	const [ isPortalReady, setIsPortalReady ] = useState( false );
 	const [ isDocked, setIsDocked ] = useState< boolean | null >( null );
 	const { canDock, calculateAdminMenuHeight } = useCanDock( { desktopMediaQuery } );
@@ -182,12 +181,15 @@ export default function useAgentLayoutManager( {
 			portalRef.current.classList.add( 'agents-manager-chat--docked' );
 			portalRef.current.classList.remove( 'agents-manager-chat--undocked' );
 
-			if ( wasOpenRef.current ) {
+			if ( defaultOpenRef.current ) {
 				container.classList.add( 'agents-manager-sidebar-container--sidebar-open' );
 			}
 
 			onDockRef.current();
 		} else {
+			// Cancel the sidebar-open `dock()` scheduled — its closure captured
+			// `canDock` as true, so it would otherwise open the just-undocked sidebar.
+			clearTimeout( openSidebarTimeoutRef.current );
 			clearTimeout( closeSidebarTimeoutRef.current );
 			container.classList.remove(
 				'agents-manager-sidebar-container',
@@ -241,7 +243,6 @@ export default function useAgentLayoutManager( {
 			return;
 		}
 
-		wasOpenRef.current = true;
 		clearTimeout( closeSidebarTimeoutRef.current );
 		container.classList.remove( 'agents-manager-sidebar-container--closing' );
 		container.classList.add( 'agents-manager-sidebar-container--sidebar-open' );
@@ -258,7 +259,6 @@ export default function useAgentLayoutManager( {
 			'agents-manager-sidebar-container--sidebar-open'
 		);
 
-		wasOpenRef.current = false;
 		container.classList.remove( 'agents-manager-sidebar-container--sidebar-open' );
 
 		// Only suppress admin bar pointer events during an actual sidebar-close transition.

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -3,7 +3,7 @@ import { PerSiteLastActivity, PerSiteRouterHistory } from './types';
 import type { AgentsManagerAction } from './actions';
 import type { Reducer } from 'redux';
 
-const isOpen: Reducer< boolean | undefined, AgentsManagerAction > = ( state, action ) => {
+const isOpen: Reducer< boolean, AgentsManagerAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_OPEN':
 			return action.isOpen;
@@ -11,7 +11,7 @@ const isOpen: Reducer< boolean | undefined, AgentsManagerAction > = ( state, act
 	return state;
 };
 
-const isDocked: Reducer< boolean | undefined, AgentsManagerAction > = ( state, action ) => {
+const isDocked: Reducer< boolean, AgentsManagerAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_DOCKED':
 			return action.isDocked;
@@ -19,10 +19,7 @@ const isDocked: Reducer< boolean | undefined, AgentsManagerAction > = ( state, a
 	return state;
 };
 
-export const isMinimized: Reducer< boolean | undefined, AgentsManagerAction > = (
-	state,
-	action
-) => {
+export const isMinimized: Reducer< boolean, AgentsManagerAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_MINIMIZED':
 			return action.isMinimized;

--- a/packages/data-stores/src/agents-manager/test/reducer.test.ts
+++ b/packages/data-stores/src/agents-manager/test/reducer.test.ts
@@ -45,8 +45,8 @@ describe( 'getIsSplitScreen selector', () => {
 } );
 
 describe( 'isMinimized reducer slice', () => {
-	it( 'defaults to undefined', () => {
-		expect( isMinimized( undefined, { type: '@@INIT' } as never ) ).toBeUndefined();
+	it( 'defaults to false', () => {
+		expect( isMinimized( undefined, { type: '@@INIT' } as never ) ).toBe( false );
 	} );
 
 	it( 'returns the action value on `AGENTS_MANAGER_SET_MINIMIZED`', () => {


### PR DESCRIPTION
Part of AI-1002, AI-1003

## Proposed Changes

- **Entry points now toggle the chat.** The standalone AI button (Calypso masterbar + wp-admin admin bar) closes the chat when it's visibly open and otherwise opens/resumes it. Help-menu items close the chat only when you re-click the item for the route already showing; clicking a different item just switches view.
- **Preserve the view when expanding a minimized chat.** Expanding restores whatever route was showing instead of jumping back to `/chat`, and the minimized bar shows a per-route title.
- **Fix the minimize button disappearing** when the docked preference is set but the chat can't actually dock (narrow viewport, fullscreen gate). `ChatHeader` now uses the effective docked state (`canDock && isDocked`).
- **Track toggle direction in analytics.** The AI-button and wp-admin Help-menu events now carry an `action: 'open' | 'close'` property.
- **Store cleanups.** Default `isOpen`/`isDocked`/`isMinimized` to `false` (typed `boolean`), sync the docked sidebar open state in `useAgentLayoutManager`, and expose `isChatVisible()`/`getCurrentRoute()` on `window.__agentsManagerActions` so out-of-bundle hosts can make the toggle decision.

## Why are these changes being made?

The chat's entry points only ever opened it, so there was no way to dismiss it from the same control. Expanding a minimized chat discarded the user's current view, and the minimize affordance vanished where the chat couldn't dock. These changes make the entry points behave as toggles, preserve context across minimize/expand, and make docked-state handling consistent across the Calypso masterbar and wp-admin.

## Testing Instructions

- Check out this PR and run `yarn start`.
- Open `http://calypso.localhost:3000/me`.

**Responsive (docking) behavior**

- Dock the chat into the sidebar, then narrow the viewport — the chat pops out to floating and its header now shows the **Minimize** option.
- Close the chat, then widen the viewport again — the docked sidebar stays closed (no empty sidebar is shown).

https://github.com/user-attachments/assets/bf3099df-4cb9-49b8-ad65-34253bf52f6a

**Masterbar / admin-bar entry points**

- The standalone AI button now toggles the chat open and closed, matching the other masterbar buttons' UX (e.g. Notifications).
- Re-clicking the same Help Center menu item for the view you're already on closes the chat — the same toggle behavior.

https://github.com/user-attachments/assets/10627a11-328e-470e-842c-3bc82bdd477c

**Minimized bar**

- Expanding the minimized bar now restores the last view instead of jumping back to the chat.

https://github.com/user-attachments/assets/3f5fee1d-7fef-47e1-91e8-7834ecc3436b

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


