### PR TITLE
Blanket-disable Jetpack AI Sidebar provider

### DIFF
--- a/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
+++ b/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
@@ -19,6 +19,7 @@ const mockRegisterPlugin = jest.fn();
 jest.mock( '@wordpress/plugins', () => ( { registerPlugin: mockRegisterPlugin } ) );
 
 const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
+const BLOCK_NOTES_PROVIDER = 'block-notes/headless-agent-provider';
 
 const loadRender = () => {
 	let render;
@@ -65,17 +66,16 @@ describe( 'agents-manager-gutenberg entry', () => {
 		expect( render() ).toBeNull();
 	} );
 
-	it( 'renders the Agents Manager when the gate allows the mount', () => {
-		window._currentSiteType = 'simple';
+	it( 'renders the Agents Manager when another provider remains after filtering', () => {
 		globalThis.agentsManagerData = {
 			sectionName: 'gutenberg',
-			agentProviders: [ JETPACK_PROVIDER ],
+			agentProviders: [ BLOCK_NOTES_PROVIDER, JETPACK_PROVIDER ],
 			jetpackAiSidebarPreview: { enabled: true },
 		};
 
 		const render = loadRender();
 
-		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ JETPACK_PROVIDER ] );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ BLOCK_NOTES_PROVIDER ] );
 		const result = render();
 		expect( result ).not.toBeNull();
 		expect( result.type.name ).toBe( 'AgentsManagerWithProvider' );

--- a/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
+++ b/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
@@ -33,7 +33,7 @@ describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
 		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ BLOCK_NOTES_PROVIDER ] );
 	} );
 
-	it( 'does not suppress or filter on Simple sites', () => {
+	it( 'suppresses on Simple sites where the preview registered the only provider', () => {
 		window._currentSiteType = 'simple';
 		setAgentsManagerData( {
 			sectionName: 'gutenberg',
@@ -41,8 +41,20 @@ describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
 			jetpackAiSidebarPreview: { enabled: true },
 		} );
 
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
+	} );
+
+	it( 'keeps Simple sites mounted when Big Sky remains after filtering', () => {
+		window._currentSiteType = 'simple';
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ BIG_SKY_PROVIDER, JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
 		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( false );
-		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ JETPACK_PROVIDER ] );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ BIG_SKY_PROVIDER ] );
 	} );
 
 	it( 'suppresses on self-hosted sites where the preview registered the only provider', () => {

--- a/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
+++ b/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
@@ -3,12 +3,9 @@
 /**
  * Temporary kill switch for the Jetpack AI Sidebar preview.
  *
- * Jetpack can mount this post-editor surface on Atomic/self-hosted sites
- * before the server-side AI Assistant setting gate is available everywhere.
- * This widgets.wp.com entrypoint ships faster, so it filters the preview
- * provider client-side.
- *
- * Simple sites keep using wpcom's server-side gate and pass through untouched.
+ * Jetpack can mount this post-editor surface before the server-side AI
+ * Assistant setting gate is available everywhere. This widgets.wp.com
+ * entrypoint ships faster, so it filters the preview provider client-side.
  *
  * Remove once released Jetpack versions honor the AI Assistant setting.
  */
@@ -16,7 +13,7 @@
 const JETPACK_AI_SIDEBAR_PROVIDER_FILE = 'jetpack-ai-sidebar.provider.mjs';
 
 /**
- * Gate the Jetpack AI Sidebar preview on non-Simple sites.
+ * Gate the Jetpack AI Sidebar preview on all site types.
  *
  * Removes the Jetpack AI Sidebar provider from
  * `agentsManagerData.agentProviders`, which Agents Manager's
@@ -32,11 +29,6 @@ export function shouldSuppressJetpackAiSidebarPreview() {
 		return false;
 	}
 
-	// wpcom owns the Simple-site gating server-side.
-	if ( window._currentSiteType === 'simple' ) {
-		return false;
-	}
-
 	const providers = Array.isArray( data.agentProviders ) ? data.agentProviders : [];
 	const remaining = providers.filter(
 		( provider ) =>
@@ -44,6 +36,6 @@ export function shouldSuppressJetpackAiSidebarPreview() {
 	);
 	data.agentProviders = remaining;
 
-	// Mount only when another provider (Block Notes, Big Sky, …) still needs AM.
+	// Mount only when another provider (Block Notes, Big Sky, etc.) still needs AM.
 	return remaining.length === 0;
 }


### PR DESCRIPTION
## Proposed Changes

- Remove the Simple-site exemption from the Jetpack AI Sidebar preview gate.
- Continue filtering only the Jetpack AI Sidebar provider from Agents Manager provider data.
- Keep Agents Manager mounted when another provider, such as Big Sky or Block Notes, remains after filtering.
- Keep suppressing the mount when the Jetpack AI Sidebar provider was the only registered provider.

## Testing

- yarn jest apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js apps/agents-manager/__tests__/agents-manager-gutenberg.test.js --runInBand
- yarn eslint apps/agents-manager/jetpack-ai-sidebar-preview-gate.js apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
- yarn prettier --check apps/agents-manager/jetpack-ai-sidebar-preview-gate.js apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
- git diff --check HEAD^ HEAD