### PR TITLE
Domain bundles: disclose the full-price renewal aggregate on grouped rows

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -619,6 +619,11 @@ const BundleMemberList = styled.div`
 	}
 `;
 
+const BundleRenewalNote = styled.div`
+	font-size: 12px;
+	font-weight: 400;
+`;
+
 /**
  * Render a domain bundle as a single compact row in the order summary, mirroring
  * the order-review surface's `BundleLineItem`: a "Domain bundle" title with the
@@ -645,6 +650,15 @@ export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBun
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
+	// Bundle members renew at full price (no plan credit at renewal —
+	// DOMAINS-2173), so the renewal aggregate is the pre-discount group total.
+	// item_original_subtotal_integer is the list price, so it needs no coupon
+	// exclusion (DOMAINS-2184).
+	const bundleOriginalInteger = products.reduce(
+		( total, product ) => total + product.item_original_subtotal_integer,
+		0
+	);
+	const isBundleDiscounted = bundleTotalInteger < bundleOriginalInteger;
 
 	return (
 		<SimplifiedSingleProductAndCostOverridesListWrapper className="cost-overrides-list-product-wrapper">
@@ -666,6 +680,18 @@ export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBun
 					</div>
 				) ) }
 			</BundleMemberList>
+			{ isBundleDiscounted && (
+				<BundleRenewalNote>
+					{ translate( 'Auto-renews at %(price)s/year.', {
+						args: {
+							price: formatCurrency( bundleOriginalInteger, currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ),
+						},
+					} ) }
+				</BundleRenewalNote>
+			) }
 		</SimplifiedSingleProductAndCostOverridesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
+++ b/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
@@ -151,6 +151,36 @@ describe( 'BundleProductAndCostOverridesList', () => {
 		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
 	} );
 
+	it( 'discloses the list-price aggregate even when a coupon also discounts a member', () => {
+		// Coupon and bundle discount together: the row total strips the coupon
+		// (shown on its dedicated line) while the disclosure uses the list
+		// price, which is pre-coupon by definition.
+		renderBundleRow( {
+			type: 'bundle',
+			groupId: 'bundle-coupon-and-discount',
+			products: [
+				buildDomainProduct( {
+					uuid: 'primary',
+					meta: 'example.com',
+					subtotal: 2200,
+					originalSubtotal: 6500,
+				} ),
+				buildDomainProduct( {
+					uuid: 'companion',
+					meta: 'example.net',
+					subtotal: 700,
+					originalSubtotal: 6400,
+					costOverrides: [ buildCouponOverride( 900, 700 ) ],
+				} ),
+			],
+		} );
+
+		// Row total: 2200 + pre-coupon 900 = 3100 smallest-unit => $31.
+		expect( screen.getByText( /\$31\b/ ) ).toBeVisible();
+		// Disclosure: list price 6500 + 6400 = 12900 => $129, unaffected by the coupon.
+		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
+	} );
+
 	it( 'shows no renewal disclosure when the bundle is not discounted', () => {
 		renderBundleRow();
 

--- a/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
+++ b/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
@@ -44,6 +44,7 @@ function buildDomainProduct( overrides: {
 	uuid: string;
 	meta: string;
 	subtotal: number;
+	originalSubtotal?: number;
 	costOverrides?: ResponseCartCostOverride[];
 	extra?: ResponseCartProduct[ 'extra' ];
 } ) {
@@ -54,6 +55,7 @@ function buildDomainProduct( overrides: {
 		uuid: overrides.uuid,
 		meta: overrides.meta,
 		item_subtotal_integer: overrides.subtotal,
+		item_original_subtotal_integer: overrides.originalSubtotal ?? overrides.subtotal,
 		cost_overrides: overrides.costOverrides ?? [],
 		extra: overrides.extra ?? {},
 	};
@@ -122,6 +124,37 @@ describe( 'BundleProductAndCostOverridesList', () => {
 		expect( screen.queryByText( /\$18\b/ ) ).not.toBeInTheDocument();
 		// 2200 + 2000 = 4200 smallest-unit => $42.
 		expect( screen.getByText( /\$42\b/ ) ).toBeVisible();
+	} );
+
+	it( 'discloses the full-price renewal aggregate when the bundle is discounted', () => {
+		// Bundle members renew at full (pre-discount) price, so the disclosure
+		// shows the summed item_original_subtotal_integer: 6500 + 6400 => $129.
+		renderBundleRow( {
+			type: 'bundle',
+			groupId: 'bundle-discounted',
+			products: [
+				buildDomainProduct( {
+					uuid: 'primary',
+					meta: 'example.com',
+					subtotal: 2200,
+					originalSubtotal: 6500,
+				} ),
+				buildDomainProduct( {
+					uuid: 'companion',
+					meta: 'example.net',
+					subtotal: 700,
+					originalSubtotal: 6400,
+				} ),
+			],
+		} );
+
+		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
+	} );
+
+	it( 'shows no renewal disclosure when the bundle is not discounted', () => {
+		renderBundleRow();
+
+		expect( screen.queryByText( /Auto-renews at/ ) ).not.toBeInTheDocument();
 	} );
 } );
 

--- a/packages/mini-cart/test/mini-cart-line-items.tsx
+++ b/packages/mini-cart/test/mini-cart-line-items.tsx
@@ -107,5 +107,11 @@ describe( 'MiniCartLineItems bundle grouping', () => {
 
 		// Only the discounted bundle shows a strikethrough.
 		expect( container.querySelectorAll( 's' ) ).toHaveLength( 1 );
+
+		// The mini-cart shares BundleLineItem with the order review, so the
+		// discounted bundle also discloses its renewal aggregate here — and
+		// only the discounted one (DOMAINS-2184).
+		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
+		expect( screen.getAllByText( /Auto-renews at/ ) ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/mini-cart/test/mini-cart-line-items.tsx
+++ b/packages/mini-cart/test/mini-cart-line-items.tsx
@@ -96,9 +96,12 @@ describe( 'MiniCartLineItems bundle grouping', () => {
 
 		const { container } = renderLineItems( true, cart );
 
-		const crossedOut = screen.getByText( /\$129\b/ );
+		// The $129 amount also appears in the renewal disclosure line
+		// (DOMAINS-2184), so match the crossed-out price on the tag.
+		const crossedOut = screen
+			.getAllByText( /\$129\b/ )
+			.find( ( element ) => element.tagName === 'S' );
 		expect( crossedOut ).toBeVisible();
-		expect( crossedOut.tagName ).toBe( 'S' );
 		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
 		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -503,6 +503,19 @@ export function BundleLineItem( {
 				</LineItemMeta>
 			) }
 
+			{ /* Bundle members renew at full price (no plan credit at renewal —
+			     DOMAINS-2173), so the renewal aggregate is the pre-discount group
+			     total already computed for the strikethrough (DOMAINS-2184). */ }
+			{ isBundleDiscounted && (
+				<LineItemMeta>
+					<span>
+						{ translate( 'Auto-renews at %(price)s/year.', {
+							args: { price: bundleOriginalDisplay },
+						} ) }
+					</span>
+				</LineItemMeta>
+			) }
+
 			{ products.map( ( product ) => (
 				<LineItemMeta key={ product.uuid }>
 					<span>{ product.meta }</span>

--- a/packages/wpcom-checkout/test/bundle-line-item.tsx
+++ b/packages/wpcom-checkout/test/bundle-line-item.tsx
@@ -90,11 +90,26 @@ describe( 'BundleLineItem', () => {
 
 		// 2200 + 700 = 2900 smallest-unit => $29.
 		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
-		// 6500 + 6400 = 12900 smallest-unit => $129, struck through.
-		const crossedOut = screen.getByText( /\$129\b/ );
+		// 6500 + 6400 = 12900 smallest-unit => $129, struck through. The same
+		// amount also appears in the renewal disclosure, so match on the tag.
+		const crossedOut = screen
+			.getAllByText( /\$129\b/ )
+			.find( ( element ) => element.tagName === 'S' );
 		expect( crossedOut ).toBeVisible();
-		expect( crossedOut.tagName ).toBe( 'S' );
 		expect( screen.getByText( 'Discount for first year' ) ).toBeVisible();
+	} );
+
+	test( 'discloses the full-price renewal aggregate when the bundle is discounted', () => {
+		renderBundle( { bundle: discountedBundle } );
+
+		// Bundle members renew at full (pre-discount) price: 6500 + 6400 => $129.
+		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
+	} );
+
+	test( 'shows no renewal disclosure when the bundle is not discounted', () => {
+		renderBundle();
+
+		expect( screen.queryByText( /Auto-renews at/ ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows no remove button without hasDeleteButton', () => {


### PR DESCRIPTION
Related to #DOMAINS-2184

## Proposed Changes

Bundle members are discounted in the first year and **renew at full price** — enforced server-side (bundle domains are excluded from plan credit at renewal, DOMAINS-2173). Neither grouped checkout surface disclosed that, which is the kind of gap legal/compliance flags on consumer money UI.

Per the decision recorded on DOMAINS-2184 (group-level aggregate, both grouped surfaces, launch blocker):

- **Order review** (`BundleLineItem`): an "Auto-renews at $129/year." line below the "Discount for first year" callout, reusing the existing checkout renewal copy. The renewal aggregate is the pre-discount group total already computed for the strikethrough — same number, no new math.
- **Order summary** (`BundleProductAndCostOverridesList`): the same line below the member list. `item_original_subtotal_integer` is the list price, so it needs no coupon exclusion on this surface (unlike the displayed totals, which strip coupon discounts to avoid double-counting against the dedicated coupon line).

The line only renders when the bundle is actually discounted — when it isn't, the renewal price equals the price already shown and the disclosure would be noise.

The search-page bundle card is unchanged: it already shows per-member full prices via the strikethrough.

The mini-cart also picks up the disclosure, intentionally: it renders bundles via the shared `BundleLineItem`, and accurate renewal disclosure there is a feature, not a leak — a mini-cart test pins it.

## Testing Instructions

```
yarn test-packages packages/wpcom-checkout
yarn test-client client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
```

New coverage: renewal disclosure shown with the summed pre-discount amount on both surfaces; no disclosure when the bundle isn't discounted. (The existing strikethrough test now disambiguates `$129` by tag since the amount appears twice.)

Manual: with a bundle in the cart (sandbox + `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` + `?flags=domain-bundling`, search a stub-catalogue TLD and click "Get bundle"), checkout shows "Auto-renews at $X/year." on the grouped bundle row in both the order review and the order summary, where $X is the crossed-out group total.

Co-Authored-By: Claude <noreply@anthropic.com>
