### PR TITLE
Show renewal price on the current plan card outside the renewal-pricing experiment

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -702,6 +702,7 @@ const PlansFeaturesMain = ( {
 		showPricingDifferentiationFeaturePills,
 		useFocusedNewCopyTaglines,
 		isExperimentVariant,
+		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
 	} );
 
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
@@ -730,6 +731,7 @@ const PlansFeaturesMain = ( {
 		showPricingDifferentiationFeaturePills,
 		useFocusedNewCopyTaglines,
 		isExperimentVariant,
+		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
 	} );
 
 	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.

--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -147,6 +147,87 @@ describe( 'usePricingMetaForGridPlans', () => {
 		expect( pricingMeta ).toEqual( expectedPricingMeta );
 	} );
 
+	describe( 'current plan with an active introductory offer', () => {
+		beforeEach( () => {
+			Plans.useCurrentPlan.mockImplementation( () => ( {
+				productSlug: PLAN_BUSINESS,
+				planSlug: PLAN_BUSINESS,
+				purchaseId: 1234,
+			} ) );
+			// Yearly purchase: renewal 600/yr, active intro 120/yr.
+			Purchases.useSitePurchaseById.mockImplementation( () => ( {
+				priceInteger: 600,
+				currencyCode: 'USD',
+				billPeriodDays: 365,
+				introductoryOffer: {
+					isWithinPeriod: true,
+					costPerIntervalInteger: 120,
+				},
+			} ) );
+		} );
+
+		it( 'should return the intro price as the headline plus a renewal price for the experiment treatment', () => {
+			const pricingMeta = usePricingMetaForGridPlans( {
+				planSlugs: [ PLAN_BUSINESS ],
+				siteId,
+				coupon: undefined,
+				useCheckPlanAvailabilityForPurchase,
+				showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+			} );
+
+			const expectedPricingMeta = {
+				[ PLAN_BUSINESS ]: {
+					originalPrice: {
+						full: 120,
+						monthly: 10,
+					},
+					discountedPrice: {
+						full: null,
+						monthly: null,
+					},
+					billingPeriod: 365,
+					currencyCode: 'USD',
+					expiry: null,
+					introOffer: undefined,
+					renewalPrice: {
+						full: 600,
+						monthly: 50,
+					},
+				},
+			};
+
+			expect( pricingMeta ).toEqual( expectedPricingMeta );
+		} );
+
+		it( 'should return the renewal price as the headline for non-treatment users', () => {
+			const pricingMeta = usePricingMetaForGridPlans( {
+				planSlugs: [ PLAN_BUSINESS ],
+				siteId,
+				coupon: undefined,
+				useCheckPlanAvailabilityForPurchase,
+			} );
+
+			const expectedPricingMeta = {
+				[ PLAN_BUSINESS ]: {
+					originalPrice: {
+						full: 600,
+						monthly: 50,
+					},
+					discountedPrice: {
+						full: null,
+						monthly: null,
+					},
+					billingPeriod: 365,
+					currencyCode: 'USD',
+					expiry: null,
+					introOffer: undefined,
+				},
+			};
+
+			expect( pricingMeta ).toEqual( expectedPricingMeta );
+		} );
+	} );
+
 	it( 'should return the original price as the site plan price and discounted price as Null for plans not available for purchase', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
 			productSlug: PLAN_BUSINESS,

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -58,6 +58,12 @@ interface Props {
 	 * from the final price.
 	 */
 	reflectStorageSelectionInPlanPrices?: boolean;
+
+	/**
+	 * Renewal-pricing experiment flag. When falsy (non-treatment), the current plan's
+	 * headline uses the renewal price, not an active intro price.
+	 */
+	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 }
 
 function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): number | null {
@@ -81,6 +87,7 @@ const usePricingMetaForGridPlans = ( {
 	useCheckPlanAvailabilityForPurchase,
 	withProratedDiscounts,
 	reflectStorageSelectionInPlanPrices = false,
+	showBillingDescriptionForIncreasedRenewalPrice,
 }: Props ): { [ planSlug: string ]: Plans.PricingMetaForGridPlan } | null => {
 	// plans - should have a definition for all plans, being the main source of API data
 	const plans = Plans.usePlans( { coupon } );
@@ -186,15 +193,17 @@ const usePricingMetaForGridPlans = ( {
 					let fullPrice = sitePlan?.pricing.originalPrice.full;
 
 					/**
-					 * Ensure the spotlight (current) plan shows the price with which the plan was purchased.
-					 * When the purchase has an active intro offer, use the intro offer price (what the
-					 * user is actually paying this billing term) instead of the renewal price.
+					 * Spotlight (current) plan headline. Only the renewal-pricing experiment treatment shows
+					 * the active intro price (with a separate "renews at" line); everyone else sees the renewal
+					 * price, so the headline is never lower than what they'll actually pay.
 					 */
 					let renewalPrice: Plans.PlanPricing[ 'originalPrice' ] | undefined;
 
 					if ( purchasedPlan ) {
-						const hasActiveIntroOffer = purchasedPlan.introductoryOffer?.isWithinPeriod;
-						const currentTermPrice = hasActiveIntroOffer
+						const showIntroOfferHeadline =
+							!! showBillingDescriptionForIncreasedRenewalPrice &&
+							purchasedPlan.introductoryOffer?.isWithinPeriod;
+						const currentTermPrice = showIntroOfferHeadline
 							? purchasedPlan.introductoryOffer!.costPerIntervalInteger
 							: purchasedPlan.priceInteger;
 						const isMonthly = purchasedPlan.billPeriodDays === PLAN_MONTHLY_PERIOD;
@@ -208,7 +217,7 @@ const usePricingMetaForGridPlans = ( {
 							fullPrice = currentTermPrice;
 						}
 
-						if ( hasActiveIntroOffer ) {
+						if ( showIntroOfferHeadline ) {
 							const renewalTerm = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
 							renewalPrice = {
 								monthly: isMonthly

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -51,6 +51,11 @@ export interface UseGridPlansParams {
 	 * When true, use cohort feature lists and comparison grid copy.
 	 */
 	isExperimentVariant?: boolean;
+	/**
+	 * Renewal-pricing experiment flag, threaded to the pricing hook so the current
+	 * plan's headline matches the renewal-vs-intro treatment.
+	 */
+	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 }
 
 export type UseGridPlansType = (

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -32,6 +32,7 @@ const useGridPlansForComparisonGrid = ( {
 	showPricingDifferentiationFeaturePills,
 	useFocusedNewCopyTaglines,
 	isExperimentVariant,
+	showBillingDescriptionForIncreasedRenewalPrice,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -51,6 +52,7 @@ const useGridPlansForComparisonGrid = ( {
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
 		useFocusedNewCopyTaglines,
+		showBillingDescriptionForIncreasedRenewalPrice,
 	} );
 
 	const planFeaturesForComparisonGrid = useRestructuredPlanFeaturesForComparisonGrid( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -29,6 +29,7 @@ const useGridPlansForFeaturesGrid = ( {
 	showPricingDifferentiationFeaturePills,
 	useFocusedNewCopyTaglines,
 	isExperimentVariant,
+	showBillingDescriptionForIncreasedRenewalPrice,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -50,6 +51,7 @@ const useGridPlansForFeaturesGrid = ( {
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
 		useFocusedNewCopyTaglines,
+		showBillingDescriptionForIncreasedRenewalPrice,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -326,6 +326,7 @@ const useGridPlans: UseGridPlansType = ( {
 	isDomainOnlySite,
 	reflectStorageSelectionInPlanPrices,
 	useFocusedNewCopyTaglines,
+	showBillingDescriptionForIncreasedRenewalPrice,
 } ) => {
 	const translate = useTranslate();
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
@@ -388,6 +389,7 @@ const useGridPlans: UseGridPlansType = ( {
 		siteId,
 		useCheckPlanAvailabilityForPurchase,
 		reflectStorageSelectionInPlanPrices,
+		showBillingDescriptionForIncreasedRenewalPrice,
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.


### PR DESCRIPTION
Resolves SHILL-1938
Related to MARTECH-1665

## Proposed Changes

* Gate the current-plan ("Your plan") headline price on the renewal-pricing experiment flag (`showBillingDescriptionForIncreasedRenewalPrice`) in `usePricingMetaForGridPlans`. Only experiment-treatment users see an active intro price as the headline; everyone else sees the renewal price.
* Thread that flag from `plans-features-main` down through `useGridPlansForFeaturesGrid` / `useGridPlansForComparisonGrid` → `useGridPlans` → `usePricingMetaForGridPlans`. The param is optional and defaults to falsy, so the ~20 other callers of the hook are unaffected (they get the renewal-price headline, the pre-#109529 behavior).
* The hook's separate `renewalPrice` field is now produced on the same condition as the intro headline, so the headline and the "Auto-renews at X" line always agree.
* Add unit tests for the current-plan-with-active-intro-offer branch covering both experiment states.

## Why are these changes being made?

#109529 changed the current-plan card to show the active intro price as the headline for everyone, and relied on an "Auto-renews at X" line to carry the renewal price. But that line only renders for users in the renewal-pricing experiment treatment. So users outside the experiment saw the low intro price with no renewal context, then a higher price at checkout - the price mismatch reported in this issue.

This gates the headline choice on the same experiment flag the renewal line already uses, so the intro headline and the renewal line stay together. Non-experiment users go back to seeing the renewal price as the headline.

| User | Before | After |
|------|--------|-------|
| In renewal-pricing experiment (treatment) | Intro headline + "Auto-renews at X" line | Same (unchanged) |
| Not in experiment | Intro headline, no renewal info | Renewal price as the headline |

## Testing Instructions

The bug needs a current plan with an **active** introductory offer (e.g. a non-USD plan whose intro term is still running, where the renewal price is higher than the intro price).

**Don't have a plan in that state?** It's quick to set one up: switch your currency to JPY and buy a Personal plan. JPY Personal comes with an active intro offer (¥4,800/yr intro, ¥6,960/yr renewal), which is exactly the case this fix targets.

**Steps:**
1. Log in as a user whose current plan has an active intro offer and visit `/plans/{your-site}`. Find the "Your plan" (current plan) spotlight card.
2. Force the experiment OFF (non-treatment). In the browser console:
   ```js
   Object.keys(localStorage).filter(k => k.startsWith('explat-experiment-')).forEach(k => localStorage.removeItem(k));
   location.reload();
   ```
   Verify the current-plan card headline shows the **renewal** price (not the lower intro price).
3. Force the experiment ON (treatment). Use the matching experiment for the currency - `wpcom_renewal_pricing_increase_v2_usd_202604_v1` (USD) or `..._non_usd_...` (everything else):
   ```js
   const exp = 'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1';
   localStorage.setItem('explat-experiment--' + exp, JSON.stringify({ experimentName: exp, variationName: 'crossed_price', retrievedTimestamp: Date.now(), ttl: 31536000 }));
   location.reload();
   ```
   Verify the headline shows the intro price **plus** an "Auto-renews at X" line (the existing treatment behavior, unchanged).


**Before this change:** non-experiment users see the intro price as the headline with no renewal info.
**After this change:** non-experiment users see the renewal price as the headline.

**Automated tests:**
```bash
yarn test-packages packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
```
Covers both experiment states for a current plan with an active intro offer: treatment gets the intro headline plus a renewal price, non-treatment gets the renewal headline.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
