### PR TITLE
media-library: migrate InfiniteList measurement off findDOMNode + string refs (React 19)

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -53,6 +53,8 @@ export default class InfiniteList extends Component {
 	// renders. An unstable ref would re-run on every render and, when forwarded as
 	// a prop, would defeat consumers' own-props memoization (e.g. the Reader stream).
 	itemRefCallbacks = new Map();
+	// Item keys rendered in the latest render, used to prune the maps above.
+	renderedItemKeys = new Set();
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
@@ -160,6 +162,15 @@ export default class InfiniteList extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		// Prune cached refs for items no longer rendered; consumers that ignore the ref arg
+		// never fire the callback's own cleanup.
+		for ( const key of this.itemRefCallbacks.keys() ) {
+			if ( ! this.renderedItemKeys.has( key ) ) {
+				this.itemRefCallbacks.delete( key );
+				this.itemRefs.delete( key );
+			}
+		}
+
 		if ( ! this._contextLoaded() ) {
 			return;
 		}
@@ -457,9 +468,12 @@ export default class InfiniteList extends Component {
 
 		debug( 'rendering %d to %d', this.state.firstRenderedIndex, lastRenderedIndex );
 
+		this.renderedItemKeys.clear();
 		for ( i = this.state.firstRenderedIndex; i <= lastRenderedIndex; i++ ) {
 			const item = items[ i ];
-			itemsToRender.push( renderItem( item, i, this.setItemRef( this.props.getItemRef( item ) ) ) );
+			const itemKey = this.props.getItemRef( item );
+			this.renderedItemKeys.add( itemKey );
+			itemsToRender.push( renderItem( item, i, this.setItemRef( itemKey ) ) );
 		}
 
 		if ( fetchingNextPage ) {

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,6 +1,6 @@
 import { get, keys, last, map, omit, reduce } from 'lodash';
 import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
+import { createRef, PureComponent } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
 import Label from './label';
 
@@ -14,6 +14,11 @@ class SortedGrid extends PureComponent {
 		itemsPerRow: PropTypes.number.isRequired,
 		scale: PropTypes.number.isRequired,
 	};
+
+	infiniteListRef = createRef();
+
+	// Exposes the underlying list's container DOM node (replaces the removed `findDOMNode`).
+	getDOMNode = () => this.infiniteListRef.current?.getDOMNode() ?? null;
 
 	getItems() {
 		const items = [];
@@ -57,12 +62,12 @@ class SortedGrid extends PureComponent {
 		);
 	}
 
-	renderItem = ( item ) => {
+	renderItem = ( item, index, itemRef ) => {
 		if ( item.isGridLabel ) {
 			return this.renderLabels( item );
 		}
 
-		return this.props.renderItem( item );
+		return this.props.renderItem( item, index, itemRef );
 	};
 
 	render() {
@@ -75,7 +80,14 @@ class SortedGrid extends PureComponent {
 			'scale'
 		);
 
-		return <InfiniteList items={ this.getItems() } renderItem={ this.renderItem } { ...props } />;
+		return (
+			<InfiniteList
+				ref={ this.infiniteListRef }
+				items={ this.getItems() }
+				renderItem={ this.renderItem }
+				{ ...props }
+			/>
+		);
 	}
 }
 

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -25,6 +25,7 @@ interface Props {
 	selectedIndex?: number;
 	onToggle?: ( media: Media | undefined, shiftKey: boolean ) => void;
 	style?: React.CSSProperties;
+	forwardedRef?: React.Ref< HTMLButtonElement >;
 }
 
 interface State {
@@ -112,6 +113,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 			selectedIndex,
 			onToggle,
 			style,
+			forwardedRef,
 			...otherProps
 		} = this.props;
 
@@ -138,6 +140,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 
 		return (
 			<button
+				ref={ forwardedRef }
 				className={ classes }
 				style={ styleWithDefaults }
 				onClick={ this.clickItem }

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -2,7 +2,6 @@ import { withRtl } from 'i18n-calypso';
 import { clone, filter, findIndex } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, Component } from 'react';
-import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import SortedGrid from 'calypso/components/sorted-grid';
@@ -55,7 +54,7 @@ export class MediaLibraryList extends Component {
 		}
 
 		this.setState( {
-			listContext: ReactDom.findDOMNode( component ),
+			listContext: component.getDOMNode(),
 		} );
 	};
 
@@ -147,7 +146,7 @@ export class MediaLibraryList extends Component {
 		return this.props.moment( minDate ).format( 'YYYY-MM-DD' );
 	};
 
-	renderItem = ( item ) => {
+	renderItem = ( item, listIndex, itemRef ) => {
 		const index = findIndex( this.props.media, { ID: item.ID } );
 		const selectedItems = this.props.selectedItems;
 		const selectedIndex = findIndex( selectedItems, { ID: item.ID } );
@@ -155,7 +154,7 @@ export class MediaLibraryList extends Component {
 
 		return (
 			<ListItem
-				ref={ ref }
+				forwardedRef={ itemRef }
 				key={ ref }
 				style={ this.getMediaItemStyle( index ) }
 				media={ item }


### PR DESCRIPTION
## Proposed Changes

Follow-up to #111508 ("Reader: forward-compatible React 19 changes"), which migrated `InfiniteList` and the Reader stream to the callback-ref API but left **media-library** on the transitional `findDOMNode`/string-ref fallback (the `DOTCOM-17551` TODO in `boundsForRef`). media-library was the last string-ref consumer; this completes its migration and adds a robustness improvement to the shared `InfiniteList`.

**Gap fill — media-library measurement:**
* `sorted-grid` forwards the `(item, index, itemRef)` callback through to its consumer's `renderItem`.
* `media-library` attaches that callback to `MediaLibraryListItem`'s root `<button>` via a `forwardedRef` prop (was a removed-in-React-19 string ref), restoring precise item-height measurement.
* `media-library`'s `setListContext` uses `SortedGrid`'s new `getDOMNode()` (which delegates to `InfiniteList.getDOMNode()`) instead of `ReactDom.findDOMNode`, removing the `react-dom` import.

**Improvement — bound the ref caches:**
* `InfiniteList.componentDidUpdate` prunes `itemRefs`/`itemRefCallbacks` for keys no longer rendered. Consumers that ignore the ref arg never trigger the callback's own (`node === null`) cleanup, so without this the maps grow as a long list scrolls through many items. A reused `renderedItemKeys` Set tracks the current window with no per-render allocation.

With media-library migrated, no remaining consumer relies on the string-ref fallback, so `DOTCOM-17551` can remove it.

## Why are these changes being made?

`findDOMNode` and string refs are removed in React 19. #111508 covered the Reader path; this covers the remaining media-library consumer and tightens the shared cache.

## Testing Instructions

* `yarn test-client client/components/infinite-list client/components/sorted-grid client/my-sites/media-library` — passes.
* Media library (`/media/:site`): the grid scrolls, paginates, and items size correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
