### PR TITLE
ExPlat: surface variation custom value on the assignment client

### DIFF
--- a/packages/explat-client/src/internal/requests.ts
+++ b/packages/explat-client/src/internal/requests.ts
@@ -6,6 +6,13 @@ import type { Config, ExperimentAssignment } from '../types';
 
 interface FetchExperimentAssignmentResponse {
 	variations: Record< string, unknown >;
+	/**
+	 * Additive structured sibling to `variations`, keyed by the same experiment
+	 * names. Each entry carries the assigned variation's decoded custom `value`
+	 * (any JSON type, or `null` for no payload). Optional: older servers omit it
+	 * entirely, in which case consumers fall back to `variations` alone.
+	 */
+	assignments?: Record< string, { value?: unknown } >;
 	ttl: number;
 }
 
@@ -19,6 +26,9 @@ export function isFetchExperimentAssignmentResponse(
 	return (
 		isObject( response ) &&
 		isObject( response.variations ) &&
+		// `assignments` is additive and optional — accept its absence, but if it
+		// is present it must be an object so we can safely index it.
+		( response.assignments === undefined || isObject( response.assignments ) ) &&
 		typeof response.ttl === 'number' &&
 		0 < response.ttl
 	);
@@ -83,7 +93,11 @@ export async function fetchExperimentAssignment(
 ): Promise< ExperimentAssignment > {
 	const retrievedTimestamp = monotonicNow();
 
-	const { variations, ttl: responseTtl } = validateFetchExperimentAssignmentResponse(
+	const {
+		variations,
+		assignments,
+		ttl: responseTtl,
+	} = validateFetchExperimentAssignmentResponse(
 		await config.fetchExperimentAssignment( {
 			anonId: await localStorageCachedGetAnonId( config.getAnonId ),
 			experimentName,
@@ -93,12 +107,21 @@ export async function fetchExperimentAssignment(
 	const ttl = Math.max( ExperimentAssignments.minimumTtl, responseTtl );
 
 	const fetchedExperimentAssignments = Object.entries( variations )
-		.map( ( [ experimentName, variationName ] ) => ( {
-			experimentName,
-			variationName,
-			retrievedTimestamp,
-			ttl,
-		} ) )
+		.map( ( [ experimentName, variationName ] ) => {
+			// Surface the decoded custom value from the additive `assignments` key
+			// when the server provides it. When the key is absent (older server)
+			// we leave `variationValue` off entirely so existing consumers and
+			// cached assignments are unaffected. A present entry whose `value` is
+			// missing collapses to `null` ("no usable value").
+			const assignmentEntry = assignments?.[ experimentName ];
+			return {
+				experimentName,
+				variationName,
+				retrievedTimestamp,
+				ttl,
+				...( assignmentEntry ? { variationValue: assignmentEntry.value ?? null } : {} ),
+			};
+		} )
 		.map( validateExperimentAssignment );
 
 	if ( fetchedExperimentAssignments.length > 1 ) {

--- a/packages/explat-client/src/internal/test/requests.ts
+++ b/packages/explat-client/src/internal/test/requests.ts
@@ -78,6 +78,42 @@ describe( 'fetchExperimentAssignment', () => {
 		] );
 	} );
 
+	it.each( [
+		[ 'an object value', { color: 'blue', count: 3 } ],
+		[ 'a scalar value', 'hello' ],
+		// A valueless variation, a stored JSON `null`, all collapse to `null`.
+		[ 'a null value when the variation has no payload', null ],
+	] )( 'should surface %s from the additive assignments key', async ( _label, value ) => {
+		mockedGetAnonId.mockImplementationOnce( () => delayedValue( null, ONE_DELAY ) );
+		spiedMonotonicNow.mockImplementationOnce( () => validExperimentAssignment.retrievedTimestamp );
+		mockedFetchExperimentAssignment.mockImplementationOnce( () =>
+			delayedValue(
+				{
+					ttl: validExperimentAssignment.ttl,
+					variations: {
+						[ validExperimentAssignment.experimentName ]: validExperimentAssignment.variationName,
+					},
+					assignments: { [ validExperimentAssignment.experimentName ]: { value } },
+				},
+				ONE_DELAY
+			)
+		);
+		await expect(
+			Requests.fetchExperimentAssignment( mockedConfig, validExperimentAssignment.experimentName )
+		).resolves.toEqual( { ...validExperimentAssignment, variationValue: value } );
+	} );
+
+	it( 'should omit variationValue for an older server response without the assignments key (backwards compatible)', async () => {
+		mockedGetAnonId.mockImplementationOnce( () => delayedValue( null, ONE_DELAY ) );
+		mockFetchExperimentAssignmentToMatchExperimentAssignment( validExperimentAssignment );
+		const result = await Requests.fetchExperimentAssignment(
+			mockedConfig,
+			validExperimentAssignment.experimentName
+		);
+		expect( result ).toEqual( validExperimentAssignment );
+		expect( 'variationValue' in result ).toBe( false );
+	} );
+
 	it( 'should return an experiment assignment with a ttl as the maximum of the ttl provided from the server and the set minimum ttl', async () => {
 		const outputTtl = async ( inputTtl: number ) => {
 			mockedFetchExperimentAssignment.mockReset();
@@ -212,6 +248,40 @@ describe( 'isFetchExperimentAssignmentResponse', () => {
 				},
 			} )
 		).toBe( true );
+	} );
+
+	it( 'should return true when the additive assignments key is present and an object', () => {
+		expect(
+			Requests.isFetchExperimentAssignmentResponse( {
+				ttl: 60,
+				variations: { experiment_a: 'variation_name_a' },
+				assignments: { experiment_a: { value: 'blue' } },
+			} )
+		).toBe( true );
+		expect(
+			Requests.isFetchExperimentAssignmentResponse( {
+				ttl: 60,
+				variations: {},
+				assignments: {},
+			} )
+		).toBe( true );
+	} );
+
+	it( 'should return false when assignments is present but not an object', () => {
+		expect(
+			Requests.isFetchExperimentAssignmentResponse( {
+				ttl: 60,
+				variations: {},
+				assignments: 'string',
+			} )
+		).toBe( false );
+		expect(
+			Requests.isFetchExperimentAssignmentResponse( {
+				ttl: 60,
+				variations: {},
+				assignments: null,
+			} )
+		).toBe( false );
 	} );
 
 	it( 'should return false for responses with 0 ttl', () => {

--- a/packages/explat-client/src/types.ts
+++ b/packages/explat-client/src/types.ts
@@ -10,6 +10,19 @@ export interface ExperimentAssignment {
 	 */
 	variationName: string | null;
 	/**
+	 * The decoded custom value attached to the assigned variation, when the
+	 * server provides one.
+	 *
+	 * Sourced from the additive `assignments[ experimentName ].value` key on the
+	 * `GET /assignments` wire. It can be any JSON type, or `null` when the
+	 * variation has no payload. It is `undefined` when the value is unavailable —
+	 * e.g. an older server that predates the `assignments` key, a fallback
+	 * assignment, or an assignment cached before this field existed. Consumers
+	 * should treat both `null` and `undefined` as "no usable value, use your
+	 * default".
+	 */
+	variationValue?: unknown;
+	/**
 	 * The timestamp of when this assignment was retrieved.
 	 */
 	retrievedTimestamp: number;


### PR DESCRIPTION
## Proposed Changes

* Add an optional `variationValue` field to `ExperimentAssignment`, sourced from the new additive `assignments[ experimentName ].value` key on the `GET /assignments` wire.
* Parse the `assignments` key when present and attach the decoded value; a valueless variation or stored JSON `null` collapses to `null`.
* Leave the field off entirely when the server omits the `assignments` key, so older servers, fallback assignments, and previously cached assignments are unaffected.
* Accept the additive `assignments` key in the response guard (must be an object when present).

## Why are these changes being made?

* Part of the no-code experiments effort: a variation now carries a typed custom `value`, and wpcom serves it on the assignments wire (Automattic/wpcom#222948). This adapts Calypso's ExPlat client to read it so behaviour can change without a deploy.
* The change is fully additive and backwards compatible — consumers reading only `variationName` keep working, and consumers can now read `assignment.variationValue` (treat both `null` and `undefined` as "no usable value, use your default").

## Testing Instructions

* `yarn test-packages packages/explat-client` — all suites pass, including new cases covering object, scalar, and null payloads plus the backwards-compatible no-`assignments` path.
* `yarn typecheck-packages` — passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
