### PR TITLE
[codex] Fix Google Consent Mode signals

### DIFF
--- a/client/blocks/cookie-banner/index.tsx
+++ b/client/blocks/cookie-banner/index.tsx
@@ -2,6 +2,7 @@ import { getTrackingPrefs, setTrackingPrefs } from '@automattic/calypso-analytic
 import { CookieBanner } from '@automattic/privacy-toolset';
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
+import { updateGoogleConsentMode } from 'calypso/lib/analytics/ad-tracking/consent-mode';
 import { loadTrackingScripts } from 'calypso/lib/analytics/ad-tracking/load-tracking-scripts';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -35,6 +36,8 @@ const CookieBannerInner = ( { onClose }: { onClose: () => void } ) => {
 			} );
 
 			setTrackingPrefs( { ok: true, buckets } );
+			updateGoogleConsentMode();
+
 			// If the user is logged in, update their advertising opt-out setting
 			if ( isLoggedIn ) {
 				setUserAdvertisingOptOut( ! buckets.advertising );

--- a/client/dashboard/app/analytics/tracking-preferences.ts
+++ b/client/dashboard/app/analytics/tracking-preferences.ts
@@ -1,5 +1,10 @@
 // eslint-disable-next-line no-restricted-imports -- Helper functions for tracking preferences
-import { isCountryInGdprZone, isRegionInCcpaZone } from '@automattic/calypso-analytics';
+import {
+	DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS,
+	getGoogleConsentModeSignals,
+	isCountryInGdprZone,
+	isRegionInCcpaZone,
+} from '@automattic/calypso-analytics';
 import cookie from 'cookie';
 
 type TrackingPrefs = {
@@ -14,6 +19,15 @@ type TrackingPrefs = {
 type TrackingPrefsData = Partial<
 	Omit< TrackingPrefs, 'buckets' > & { buckets: Partial< TrackingPrefs[ 'buckets' ] > }
 >;
+
+type GoogleTagWindow = typeof window & {
+	gtag?: (
+		command: 'consent',
+		consentArg: 'default' | 'update',
+		consentParams: Gtag.ConsentParams
+	) => void;
+	__calypsoGoogleConsentModeDefaultSet?: boolean;
+};
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * ( 365.25 / 2 ); // 365.25 is the average number of days in a year.
 const TRACKING_PREFS_COOKIE_V1 = 'sensitive_pixel_option';
@@ -88,6 +102,25 @@ export function setTrackingPrefs( newPrefs: TrackingPrefsData ): TrackingPrefs {
 	} );
 
 	return newOptions;
+}
+
+export function updateGoogleConsentModeIfInitialized(): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	const googleWindow = window as GoogleTagWindow;
+
+	if ( ! googleWindow.gtag ) {
+		return;
+	}
+
+	if ( ! googleWindow.__calypsoGoogleConsentModeDefaultSet ) {
+		googleWindow.gtag( 'consent', 'default', DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS );
+		googleWindow.__calypsoGoogleConsentModeDefaultSet = true;
+	}
+
+	googleWindow.gtag( 'consent', 'update', getGoogleConsentModeSignals() );
 }
 
 /**

--- a/client/dashboard/me/privacy/do-not-sell-card.tsx
+++ b/client/dashboard/me/privacy/do-not-sell-card.tsx
@@ -6,7 +6,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { useIsRegionInCcpaZone } from '../../app/analytics/country-code-cookie-gdpr';
-import { getTrackingPrefs, setTrackingPrefs } from '../../app/analytics/tracking-preferences';
+import {
+	getTrackingPrefs,
+	setTrackingPrefs,
+	updateGoogleConsentModeIfInitialized,
+} from '../../app/analytics/tracking-preferences';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
@@ -27,6 +31,7 @@ export default function DoNotSellCard() {
 	} ) => {
 		// Update the preferences in the cookie.
 		setTrackingPrefs( { ok: true, buckets: { advertising: ! advertising_targeting_opt_out } } );
+		updateGoogleConsentModeIfInitialized();
 
 		// Should fail quietly in the event they have an expired 2FA token
 		// and a success notification is not standard when accepting or denying cookies.

--- a/client/lib/analytics/ad-tracking/consent-mode.ts
+++ b/client/lib/analytics/ad-tracking/consent-mode.ts
@@ -1,0 +1,83 @@
+import {
+	DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS,
+	getGoogleConsentModeSignals,
+} from '@automattic/calypso-analytics';
+
+type GoogleTagFunction = ( command: string, ...args: unknown[] ) => void;
+
+type GoogleTagWindow = typeof window & {
+	dataLayer?: unknown[];
+	gtag?: GoogleTagFunction;
+	__calypsoGoogleConsentModeDefaultSet?: boolean;
+	__calypsoGoogleTagInitialized?: boolean;
+};
+
+export { DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS, getGoogleConsentModeSignals };
+
+const getGoogleTagWindow = (): GoogleTagWindow | null => {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	return window as GoogleTagWindow;
+};
+
+const setupGoogleTagGlobal = (): GoogleTagWindow | null => {
+	const googleWindow = getGoogleTagWindow();
+
+	if ( ! googleWindow ) {
+		return null;
+	}
+
+	googleWindow.dataLayer = googleWindow.dataLayer || [];
+
+	if ( ! googleWindow.gtag ) {
+		googleWindow.gtag = function ( ...args: unknown[] ) {
+			googleWindow.dataLayer?.push( args );
+		};
+	}
+
+	return googleWindow;
+};
+
+export function ensureGoogleConsentModeDefault(): void {
+	const googleWindow = setupGoogleTagGlobal();
+
+	if ( ! googleWindow || googleWindow.__calypsoGoogleConsentModeDefaultSet ) {
+		return;
+	}
+
+	googleWindow.gtag?.( 'consent', 'default', DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS );
+	googleWindow.__calypsoGoogleConsentModeDefaultSet = true;
+}
+
+export function updateGoogleConsentMode( {
+	onlyIfInitialized = false,
+}: { onlyIfInitialized?: boolean } = {} ): void {
+	const googleWindow = getGoogleTagWindow();
+
+	if ( onlyIfInitialized && ! googleWindow?.gtag ) {
+		return;
+	}
+
+	ensureGoogleConsentModeDefault();
+	setupGoogleTagGlobal()?.gtag?.( 'consent', 'update', getGoogleConsentModeSignals() );
+}
+
+export function initializeGoogleTag(): void {
+	const googleWindow = setupGoogleTagGlobal();
+
+	if ( ! googleWindow ) {
+		return;
+	}
+
+	ensureGoogleConsentModeDefault();
+	updateGoogleConsentMode();
+
+	if ( googleWindow.__calypsoGoogleTagInitialized ) {
+		return;
+	}
+
+	googleWindow.gtag?.( 'js', new Date() );
+	googleWindow.__calypsoGoogleTagInitialized = true;
+}

--- a/client/lib/analytics/ad-tracking/gtm-container.ts
+++ b/client/lib/analytics/ad-tracking/gtm-container.ts
@@ -1,5 +1,6 @@
 import { loadScript } from '@automattic/load-script';
 import { mayWeInitTracker } from '../tracker-buckets';
+import { updateGoogleConsentMode } from './consent-mode';
 import { GOOGLE_GTM_SCRIPT_URL } from './constants';
 
 /**
@@ -25,6 +26,8 @@ export const loadGTMContainer = async ( gtmTag: string ): Promise< void > => {
 		throw new Error( 'Tracking is not allowed' );
 	}
 
+	updateGoogleConsentMode();
+
 	// Load the Google Tag Manager script
 	await loadScript( GOOGLE_GTM_SCRIPT_URL + gtmTag );
 };
@@ -34,6 +37,8 @@ export const loadGTMContainer = async ( gtmTag: string ): Promise< void > => {
  * @returns Promise<void>
  */
 export const initGTMContainer = async (): Promise< void > => {
+	updateGoogleConsentMode();
+
 	// Note: window.dataLayer is prop required by Google. Not to be confused with Calypso Data Layer (see: /client/state/data-layer/README.md)
 	window.dataLayer = window.dataLayer || [];
 	window.dataLayer.push( { 'gtm.start': new Date().getTime(), event: 'gtm.js' } );

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -3,6 +3,7 @@ import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { mayWeInitTracker, mayWeTrackByTracker } from '../tracker-buckets';
+import { initializeGoogleTag, updateGoogleConsentMode } from './consent-mode';
 import {
 	ADROLL_PAGEVIEW_PIXEL_URL_1,
 	ADROLL_PAGEVIEW_PIXEL_URL_2,
@@ -317,20 +318,7 @@ function setupOpenAIGlobal() {
 	window.oaiq = q;
 }
 function setupGtag() {
-	if ( window.dataLayer && window.gtag ) {
-		return;
-	}
-	window.dataLayer = window.dataLayer || [];
-	window.gtag = function () {
-		window.dataLayer.push( arguments );
-	};
-	window.gtag( 'js', new Date() );
-	window.gtag( 'consent', 'default', {
-		ad_storage: 'granted',
-		analytics_storage: 'granted',
-		ad_user_data: 'granted',
-		ad_personalization: 'granted',
-	} );
+	initializeGoogleTag();
 }
 
 function setupWpcomGoogleAdsGtag() {
@@ -350,6 +338,8 @@ function setupWpcomFloodlightGtag() {
 }
 
 function setupGtmGtag() {
+	updateGoogleConsentMode();
+
 	if ( isAkismetCheckout() ) {
 		window.dataLayer = window.dataLayer || [];
 		window.dataLayer.push( { 'gtm.start': new Date().getTime(), event: 'gtm.js' } );

--- a/client/lib/analytics/test/consent-mode.js
+++ b/client/lib/analytics/test/consent-mode.js
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { loadScript } from '@automattic/load-script';
+import { mayWeInitTracker } from 'calypso/lib/analytics/tracker-buckets';
+import {
+	DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS,
+	ensureGoogleConsentModeDefault,
+	getGoogleConsentModeSignals,
+	initializeGoogleTag,
+	updateGoogleConsentMode,
+} from '../ad-tracking/consent-mode';
+import { GOOGLE_GTM_SCRIPT_URL } from '../ad-tracking/constants';
+import { initGTMContainer, loadGTMContainer } from '../ad-tracking/gtm-container';
+
+jest.mock( '@automattic/load-script', () => ( {
+	loadScript: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracker-buckets', () => ( {
+	mayWeInitTracker: jest.fn(),
+} ) );
+
+const mockLoadScript = loadScript;
+const mockMayWeInitTracker = mayWeInitTracker;
+
+const trackingPrefs = ( { analytics, advertising, ok = true } ) => ( {
+	ok,
+	buckets: {
+		essential: true,
+		analytics,
+		advertising,
+	},
+} );
+
+const setCookie = ( name, value ) => {
+	document.cookie = `${ name }=${ encodeURIComponent( value ) }; path=/`;
+};
+
+const deleteCookie = ( name ) => {
+	document.cookie = `${ name }=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+};
+
+const resetTrackingCookies = () => {
+	[ 'sensitive_pixel_options', 'sensitive_pixel_option', 'country_code', 'region' ].forEach(
+		deleteCookie
+	);
+};
+
+const setGeoCookies = ( countryCode = 'US', region = 'utah' ) => {
+	setCookie( 'country_code', countryCode );
+	setCookie( 'region', region );
+};
+
+const setTrackingPrefsCookie = ( prefs ) => {
+	setCookie( 'sensitive_pixel_options', JSON.stringify( prefs ) );
+};
+
+const setGlobalPrivacyControl = ( value ) => {
+	Object.defineProperty( window.navigator, 'globalPrivacyControl', {
+		configurable: true,
+		value,
+	} );
+};
+
+const dataLayerCalls = () =>
+	window.dataLayer.map( ( call ) =>
+		'function' === typeof call?.[ Symbol.iterator ] ? Array.from( call ) : [ call ]
+	);
+
+const resetGoogleWindow = () => {
+	delete window.dataLayer;
+	delete window.gtag;
+	delete window.__calypsoGoogleConsentModeDefaultSet;
+	delete window.__calypsoGoogleTagInitialized;
+};
+
+describe( 'Google Consent Mode', () => {
+	beforeEach( () => {
+		resetGoogleWindow();
+		resetTrackingCookies();
+		setGeoCookies();
+		setTrackingPrefsCookie( trackingPrefs( { analytics: true, advertising: true } ) );
+		setGlobalPrivacyControl( false );
+		mockMayWeInitTracker.mockReturnValue( true );
+		mockLoadScript.mockResolvedValue();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		resetGoogleWindow();
+		resetTrackingCookies();
+	} );
+
+	describe( 'getGoogleConsentModeSignals', () => {
+		test( 'denies all signals for GDPR visitors before consent is saved', () => {
+			resetTrackingCookies();
+			setGeoCookies( 'DE', 'berlin' );
+
+			expect( getGoogleConsentModeSignals() ).toEqual( DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS );
+		} );
+
+		test( 'maps analytics-only consent to analytics granted and ads denied', () => {
+			setGeoCookies( 'DE', 'berlin' );
+			setTrackingPrefsCookie( trackingPrefs( { analytics: true, advertising: false } ) );
+
+			expect( getGoogleConsentModeSignals() ).toEqual( {
+				analytics_storage: 'granted',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			} );
+		} );
+
+		test( 'maps accept-all consent to all granted', () => {
+			expect( getGoogleConsentModeSignals() ).toEqual( {
+				analytics_storage: 'granted',
+				ad_storage: 'granted',
+				ad_user_data: 'granted',
+				ad_personalization: 'granted',
+			} );
+		} );
+
+		test( 'maps declined non-essential consent to all denied', () => {
+			setGeoCookies( 'DE', 'berlin' );
+			setTrackingPrefsCookie( trackingPrefs( { analytics: false, advertising: false } ) );
+
+			expect( getGoogleConsentModeSignals() ).toEqual( {
+				analytics_storage: 'denied',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			} );
+		} );
+
+		test( 'maps CCPA advertising opt-out to advertising denied', () => {
+			setGeoCookies( 'US', 'california' );
+			setTrackingPrefsCookie( trackingPrefs( { analytics: true, advertising: false } ) );
+
+			expect( getGoogleConsentModeSignals() ).toEqual( {
+				analytics_storage: 'granted',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			} );
+		} );
+
+		test( 'denies advertising signals when CCPA GPC blocks advertising tracking', () => {
+			setGeoCookies( 'US', 'california' );
+			setTrackingPrefsCookie( trackingPrefs( { analytics: true, advertising: true } ) );
+			setGlobalPrivacyControl( true );
+
+			expect( getGoogleConsentModeSignals() ).toEqual( {
+				analytics_storage: 'granted',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			} );
+		} );
+
+		test( 'fails closed when tracking preferences cannot be read', () => {
+			setCookie( 'sensitive_pixel_options', '{' );
+
+			expect( getGoogleConsentModeSignals() ).toEqual( DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS );
+		} );
+	} );
+
+	test( 'initializes gtag with default denied then current consent before js', () => {
+		setTrackingPrefsCookie( trackingPrefs( { analytics: true, advertising: false } ) );
+
+		initializeGoogleTag();
+
+		const calls = dataLayerCalls();
+		expect( calls[ 0 ] ).toEqual( [ 'consent', 'default', DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS ] );
+		expect( calls[ 1 ] ).toEqual( [
+			'consent',
+			'update',
+			{
+				analytics_storage: 'granted',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			},
+		] );
+		expect( calls[ 2 ][ 0 ] ).toBe( 'js' );
+		expect( calls[ 2 ][ 1 ] ).toBeInstanceOf( Date );
+	} );
+
+	test( 'does not initialize gtag when update is limited to an existing tag', () => {
+		updateGoogleConsentMode( { onlyIfInitialized: true } );
+
+		expect( window.gtag ).toBeUndefined();
+		expect( window.dataLayer ).toBeUndefined();
+	} );
+
+	test( 'sets the default consent state only once', () => {
+		ensureGoogleConsentModeDefault();
+		ensureGoogleConsentModeDefault();
+
+		expect( dataLayerCalls() ).toEqual( [
+			[ 'consent', 'default', DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS ],
+		] );
+	} );
+
+	test( 'loads GTM only after Consent Mode commands are queued', async () => {
+		await loadGTMContainer( 'GTM-TEST' );
+
+		const calls = dataLayerCalls();
+		expect( calls[ 0 ] ).toEqual( [ 'consent', 'default', DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS ] );
+		expect( calls[ 1 ][ 0 ] ).toBe( 'consent' );
+		expect( calls[ 1 ][ 1 ] ).toBe( 'update' );
+		expect( mockLoadScript ).toHaveBeenCalledWith( GOOGLE_GTM_SCRIPT_URL + 'GTM-TEST' );
+	} );
+
+	test( 'pushes GTM start only after Consent Mode commands are queued', async () => {
+		await initGTMContainer();
+
+		const calls = dataLayerCalls();
+		expect( calls[ 0 ][ 0 ] ).toBe( 'consent' );
+		expect( calls[ 1 ][ 0 ] ).toBe( 'consent' );
+		expect( calls[ 2 ] ).toEqual( [
+			expect.objectContaining( {
+				event: 'gtm.js',
+			} ),
+		] );
+	} );
+} );

--- a/client/lib/analytics/utils/use-do-not-sell.ts
+++ b/client/lib/analytics/utils/use-do-not-sell.ts
@@ -7,6 +7,7 @@ import {
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { updateGoogleConsentMode } from 'calypso/lib/analytics/ad-tracking/consent-mode';
 import { saveUserSettings } from 'calypso/state/user-settings/actions';
 import { refreshCountryCodeCookieGdpr } from '.';
 
@@ -49,6 +50,7 @@ export default () => {
 			// Update the preferences in the cookie
 			// isActive = true means user has opted out of "advertising" tracking
 			const prefs = setTrackingPrefs( { ok: true, buckets: { advertising: ! isActive } } );
+			updateGoogleConsentMode();
 
 			if ( isActive ) {
 				recordTracksEvent( 'a8c_ccpa_optout', {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -252,7 +252,7 @@ export class CheckoutThankYou extends Component<
 				const params = [ 'trackCustom', 'BulkDomainTransfer', {} ];
 
 				debug( 'recordOrderInFacebookAds: WPCom Bulk Domain Transfer Purchase', params );
-				window.fbq && window.fbq( ...params );
+				window.fbq?.( ...params );
 			}
 
 			// Custom conversion for Twitter Ads.

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -12,6 +12,11 @@ export {
 } from './utils/get-tracking-prefs';
 export type { TrackingPrefs } from './utils/get-tracking-prefs';
 export { default as setTrackingPrefs } from './utils/set-tracking-prefs';
+export {
+	DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS,
+	getGoogleConsentModeSignals,
+} from './utils/google-consent-mode';
+export type { GoogleConsentModeSignals, GoogleConsentModeValue } from './utils/google-consent-mode';
 export { default as isRegionInStsZone } from './utils/is-region-in-sts-zone';
 export { isRegionInCcpaZone, isCountryInGdprZone } from './utils/geo-privacy';
 export {

--- a/packages/calypso-analytics/src/utils/google-consent-mode.ts
+++ b/packages/calypso-analytics/src/utils/google-consent-mode.ts
@@ -1,0 +1,93 @@
+import cookie from 'cookie';
+import { isCountryInGdprZone, isRegionInCcpaZone } from './geo-privacy';
+import getTrackingPrefs, { type TrackingPrefs } from './get-tracking-prefs';
+
+export type GoogleConsentModeValue = 'granted' | 'denied';
+
+export type GoogleConsentModeSignals = {
+	ad_storage: GoogleConsentModeValue;
+	analytics_storage: GoogleConsentModeValue;
+	ad_user_data: GoogleConsentModeValue;
+	ad_personalization: GoogleConsentModeValue;
+};
+
+type NavigatorWithGlobalPrivacyControl = Navigator & {
+	globalPrivacyControl?: boolean;
+};
+
+type GeoCookies = {
+	country_code?: string;
+	region?: string;
+};
+
+export const DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS: GoogleConsentModeSignals = {
+	ad_storage: 'denied',
+	analytics_storage: 'denied',
+	ad_user_data: 'denied',
+	ad_personalization: 'denied',
+};
+
+const toConsentValue = ( isGranted: boolean ): GoogleConsentModeValue =>
+	isGranted ? 'granted' : 'denied';
+
+const getGeoCookies = (): GeoCookies => {
+	if ( typeof document === 'undefined' ) {
+		return {};
+	}
+
+	return cookie.parse( document.cookie );
+};
+
+const isGpcFlagSetOptOut = (): boolean => {
+	if ( typeof navigator === 'undefined' ) {
+		return false;
+	}
+
+	return ( navigator as NavigatorWithGlobalPrivacyControl ).globalPrivacyControl === true;
+};
+
+const mayGrantAdvertisingConsent = (
+	hasAdvertisingConsent: boolean,
+	{ country_code, region }: GeoCookies
+): boolean => {
+	if ( ! hasAdvertisingConsent ) {
+		return false;
+	}
+
+	if ( isRegionInCcpaZone( country_code, region ) && isGpcFlagSetOptOut() ) {
+		return false;
+	}
+
+	return true;
+};
+
+const isGdprPreConsent = ( prefs: TrackingPrefs, { country_code }: GeoCookies ): boolean => {
+	return isCountryInGdprZone( country_code ) && prefs.ok !== true;
+};
+
+export function getGoogleConsentModeSignals(
+	trackingPrefs?: TrackingPrefs
+): GoogleConsentModeSignals {
+	try {
+		const prefs = trackingPrefs ?? getTrackingPrefs();
+		const geoCookies = getGeoCookies();
+
+		if ( isGdprPreConsent( prefs, geoCookies ) ) {
+			return { ...DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS };
+		}
+
+		const advertisingConsent = mayGrantAdvertisingConsent(
+			Boolean( prefs.buckets.advertising ),
+			geoCookies
+		);
+
+		return {
+			analytics_storage: toConsentValue( Boolean( prefs.buckets.analytics ) ),
+			ad_storage: toConsentValue( advertisingConsent ),
+			ad_user_data: toConsentValue( advertisingConsent ),
+			ad_personalization: toConsentValue( advertisingConsent ),
+		};
+	} catch {
+		return { ...DEFAULT_GOOGLE_CONSENT_MODE_SIGNALS };
+	}
+}


### PR DESCRIPTION
Part of MARTECH-1968

## Proposed Changes

* Replace Calypso’s hardcoded all-granted Google Consent Mode default with a central gtag helper that defaults all four Consent Mode v2 signals to denied, then updates them before Google config/event calls.
* Hoist the Consent Mode signal mapper into `@automattic/calypso-analytics` so classic Calypso and Dashboard use the same source of truth.
* Map `analytics_storage` from the analytics bucket and `ad_storage`, `ad_user_data`, and `ad_personalization` from the advertising bucket.
* Mirror the wpcom GDPR pre-consent behavior: GDPR visitors with no saved consent get all four signals denied. CCPA + GPC forces advertising signals denied while preserving CCPA analytics behavior.
* Emit Consent Mode updates after cookie banner and Do Not Sell preference changes, and before Google tag initialization for gtag/GA4/Google Ads/Floodlight/GTM paths.
* Keep existing tracker gating unchanged. GA4 remains in the existing advertising bucket for this deadline fix.

## Why are these changes being made?

* Google Consent Mode becomes the sole gate for the GA to Ads path on 2026-06-15, so Calypso must stop telling Google that analytics and advertising consent are granted when the visitor has not granted them.
* The previous Calypso gtag bootstrap always sent `ad_storage`, `analytics_storage`, `ad_user_data`, and `ad_personalization` as `granted`, and never sent consent updates after preference changes.
* This keeps Calypso on the existing basic gated model while making the Consent Mode signal truthful for Google tags that do run.

## Testing Instructions

* `yarn workspace @automattic/calypso-analytics run build`
* `yarn test-client client/lib/analytics/test/consent-mode.js client/lib/analytics/test/google-analytics-4.js client/lib/analytics/test/gpc-opt-out.js`
* `yarn eslint --ext .js,.jsx,.ts,.tsx client/lib/analytics/ad-tracking/consent-mode.ts client/lib/analytics/test/consent-mode.js client/dashboard/app/analytics/tracking-preferences.ts client/lib/analytics/ad-tracking/record-migration-events.js client/my-sites/checkout/checkout-thank-you/index.tsx packages/calypso-analytics/src/index.ts packages/calypso-analytics/src/utils/google-consent-mode.ts`
* `yarn typecheck-client` currently fails before this change surface because `@automattic/omnibar` and `@automattic/date-range-picker` type declarations are missing in Dashboard files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?