### PR TITLE
client/blocks: migrate function-component defaultProps to default params (React 19)

### DIFF
--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -8,7 +8,12 @@ import './comment-approve-action.scss';
 
 const noop = () => {};
 
-const CommentApproveAction = ( { translate, status, approveComment, unapproveComment } ) => {
+const CommentApproveAction = ( {
+	translate,
+	status,
+	approveComment = noop,
+	unapproveComment = noop,
+} ) => {
 	const isApproved = status === 'approved';
 	const buttonStyle = clsx( 'comments__comment-actions-approve', {
 		'is-approved': isApproved,
@@ -29,11 +34,6 @@ CommentApproveAction.propTypes = {
 	approveComment: PropTypes.func,
 	unapproveComment: PropTypes.func,
 	status: PropTypes.string.isRequired,
-};
-
-CommentApproveAction.defaultProps = {
-	approveComment: noop,
-	unapproveComment: noop,
 };
 
 export default localize( CommentApproveAction );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -69,7 +69,7 @@ export const EligibilityWarnings = ( {
 	isMarketplace,
 	isPlaceholder,
 	onDismiss,
-	onProceed,
+	onProceed = noop,
 	standaloneProceed,
 	recordUpgradeClick,
 	showDataCenterPicker,
@@ -306,10 +306,6 @@ function siteRequiresLaunch( holds: string[] ) {
 function siteRequiresGoingPublic( holds: string[] ) {
 	return holds.includes( 'SITE_NOT_PUBLIC' );
 }
-
-EligibilityWarnings.defaultProps = {
-	onProceed: noop,
-};
 
 /**
  * processMarketplaceExceptions: Remove 'NO_BUSINESS_PLAN' holds if the

--- a/client/blocks/like-button/icons.jsx
+++ b/client/blocks/like-button/icons.jsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import PropTypes from 'prop-types';
 
-const LikeIcons = ( { size } ) => (
+const LikeIcons = ( { size = 24 } ) => (
 	<span className="like-button__like-icons">
 		<Gridicon icon="star" size={ size } />
 		<Gridicon icon="star-outline" size={ size } />
@@ -10,10 +10,6 @@ const LikeIcons = ( { size } ) => (
 
 LikeIcons.propTypes = {
 	size: PropTypes.number,
-};
-
-LikeIcons.defaultProps = {
-	size: 24,
 };
 
 export default LikeIcons;

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -10,7 +10,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 
 const noop = () => {};
 
-const ReaderFullPostUnavailable = ( { post, onBackClick, translate, layout } ) => {
+const ReaderFullPostUnavailable = ( { post, onBackClick = noop, translate, layout } ) => {
 	const statusCode = get( post, [ 'error', 'statusCode' ] );
 	const isRecentLayout = layout === 'recent';
 	let errorTitle = translate( 'Post unavailable' );
@@ -71,11 +71,7 @@ const ReaderFullPostUnavailable = ( { post, onBackClick, translate, layout } ) =
 
 ReaderFullPostUnavailable.propTypes = {
 	post: PropTypes.object.isRequired,
-	onBackClick: PropTypes.func.isRequired,
-};
-
-ReaderFullPostUnavailable.defaultProps = {
-	onBackClick: noop,
+	onBackClick: PropTypes.func,
 };
 
 export default localize( ReaderFullPostUnavailable );

--- a/client/blocks/shortcode/index.jsx
+++ b/client/blocks/shortcode/index.jsx
@@ -53,8 +53,4 @@ Shortcode.propTypes = {
 	allowSameOrigin: PropTypes.bool,
 };
 
-Shortcode.defaultProps = {
-	allowSameOrigin: false,
-};
-
 export default Shortcode;

--- a/client/blocks/user-mentions/suggestion-list.jsx
+++ b/client/blocks/user-mentions/suggestion-list.jsx
@@ -6,13 +6,13 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import './suggestion-list.scss';
 
 const UserMentionsSuggestionList = ( {
-	onClick,
-	onClose,
-	popoverContext,
-	popoverPosition,
-	query,
-	selectedSuggestionId,
-	suggestions,
+	onClick = () => {},
+	onClose = () => {},
+	popoverContext = {},
+	popoverPosition = null,
+	query = '',
+	selectedSuggestionId = 0,
+	suggestions = [],
 } ) => (
 	<PopoverMenu
 		className="user-mentions__suggestions"
@@ -54,16 +54,6 @@ UserMentionsSuggestionList.propTypes = {
 	} ),
 	selectedSuggestionId: PropTypes.number,
 	suggestions: PropTypes.array,
-};
-
-UserMentionsSuggestionList.defaultProps = {
-	onClick: () => {},
-	onClose: () => {},
-	query: '',
-	popoverContext: {},
-	popoverPosition: null,
-	selectedSuggestionId: 0,
-	suggestions: [],
 };
 
 export default UserMentionsSuggestionList;

--- a/client/blocks/user-mentions/suggestion.jsx
+++ b/client/blocks/user-mentions/suggestion.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import './suggestion.scss';
 
-const UserMentionsSuggestion = ( { avatarUrl, fullName, query, username } ) => {
+const UserMentionsSuggestion = ( { avatarUrl = '', fullName = '', query = '', username = '' } ) => {
 	const highlight = ( content, type ) => {
 		const expressions = {
 			username: `(^${ query })(\\w*)\\s*`,
@@ -51,13 +51,6 @@ UserMentionsSuggestion.propTypes = {
 	fullName: PropTypes.string,
 	query: PropTypes.string,
 	username: PropTypes.string,
-};
-
-UserMentionsSuggestion.defaultProps = {
-	avatarUrl: '',
-	fullName: '',
-	query: '',
-	username: '',
 };
 
 export default UserMentionsSuggestion;


### PR DESCRIPTION
## Proposed Changes

Continues the React 19 forward-compatibility audit into `client/blocks`. React 19 ignores `defaultProps` on function components, so this migrates the 7 affected function components to destructuring default parameters:

* `comments/comment-approve-action`
* `like-button/icons`
* `reader-full-post/unavailable`
* `shortcode`
* `user-mentions/suggestion` and `user-mentions/suggestion-list`
* `eligibility-warnings` (`.tsx`)

Each default is copied verbatim from `defaultProps` to preserve behavior. Two notes:

* `reader-full-post/unavailable`: `onBackClick`'s PropType is relaxed from `.isRequired` to optional — it now has a default, so it's no longer required at the call site (without this, propTypes would warn now that the default applies inside the component rather than before the check).
* `shortcode`: the `allowSameOrigin` default is simply removed rather than moved — the child `ShortcodeFrame` is a **class** component whose own `defaultProps` still applies in React 19, so the default is already covered there.

Class-component `defaultProps` in `client/blocks` (`comments/form`, `reader-post-card/photo`) are left as-is — they remain supported in React 19.

## Why are these changes being made?

`defaultProps` on function components is a no-op in React 19, so these defaults would silently vanish on the upgrade.

## Testing Instructions

* `yarn test-client client/blocks/{eligibility-warnings,comments,user-mentions,shortcode,reader-full-post,like-button}` — 98 tests pass.
* `yarn typecheck-client` clean for the changed files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
