### PR TITLE
InfiniteList: remove transitional findDOMNode + string-ref fallback (React 19)

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -2,7 +2,6 @@ import page from '@automattic/calypso-router';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
-import ReactDom from 'react-dom';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import smartSetState from 'calypso/lib/react-smart-set-state';
 import scrollTo from 'calypso/lib/scroll-to';
@@ -378,14 +377,6 @@ export default class InfiniteList extends Component {
 		if ( node ) {
 			return node.getBoundingClientRect();
 		}
-		// Transitional fallback for consumers whose `renderItem` still attaches string
-		// refs instead of the `registerItemRef` callback. Remove with DOTCOM-17551 once
-		// all consumers are migrated (string refs and `findDOMNode` are gone in React 19).
-		/* eslint-disable react/no-string-refs */
-		if ( ReactDom.findDOMNode && ref in this.refs && ReactDom.findDOMNode( this.refs[ ref ] ) ) {
-			return ReactDom.findDOMNode( this.refs[ ref ] ).getBoundingClientRect();
-		}
-		/* eslint-enable react/no-string-refs */
 		return null;
 	};
 


### PR DESCRIPTION
Part of DOTCOM-17551

## Proposed Changes

* Remove the transitional `findDOMNode`/string-ref fallback that `InfiniteList` kept for consumers that had not yet migrated to its callback-ref measurement path. All consumers now use that path (the last one migrated in #111643), so the fallback and its `react-dom` import are dead code.

## Why are these changes being made?

* `findDOMNode` and string refs do not exist in React 19. The fallback was already inert under React 19 and is now unreachable, so removing it finishes moving this shared component fully onto React-19-compatible APIs.

## Testing Instructions

* Open a Reader stream and a media library grid, then scroll through several pages.
* Confirm scroll restoration and placeholder sizing behave as before — item measurement still works via the callback-ref path.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
