### PR TITLE
React 19 forward-compat: function-component defaultProps → default params

### DIFF
--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -3,7 +3,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } ) => {
+const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick = () => {} } ) => {
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 		<div className="example-components__main" onClick={ onClick }>
@@ -59,10 +59,6 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 
 JetpackConnectExampleActivate.propTypes = {
 	onClick: PropTypes.func,
-};
-
-JetpackConnectExampleActivate.defaultProps = {
-	onClick: () => {},
 };
 
 export default localize( JetpackConnectExampleActivate );

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -3,7 +3,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-const JetpackConnectExampleConnect = ( { url, translate, onClick } ) => {
+const JetpackConnectExampleConnect = ( { url = '', translate, onClick = () => {} } ) => {
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 		<div className="example-components__main" onClick={ onClick }>
@@ -43,11 +43,6 @@ const JetpackConnectExampleConnect = ( { url, translate, onClick } ) => {
 JetpackConnectExampleConnect.propTypes = {
 	onClick: PropTypes.func,
 	url: PropTypes.string,
-};
-
-JetpackConnectExampleConnect.defaultProps = {
-	onClick: () => {},
-	url: '',
 };
 
 export default localize( JetpackConnectExampleConnect );

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -3,7 +3,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
+const JetpackConnectExampleInstall = ( { url, translate, onClick = () => {} } ) => {
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 		<div className="example-components__main" onClick={ onClick }>
@@ -39,10 +39,6 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 
 JetpackConnectExampleInstall.propTypes = {
 	onClick: PropTypes.func,
-};
-
-JetpackConnectExampleInstall.defaultProps = {
-	onClick: () => {},
 };
 
 export default localize( JetpackConnectExampleInstall );

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -147,14 +146,6 @@ class EditorMediaModalDetailFields extends Component {
 	getItemValue( attribute ) {
 		return this.state.modifiedChanges?.[ attribute ] ?? this.props.item?.[ attribute ];
 	}
-
-	scrollToShowVisibleDropdown = ( event ) => {
-		if ( ! event.open || ! ( 'scrollIntoView' in window.Element.prototype ) ) {
-			return;
-		}
-
-		ReactDom.findDOMNode( event.target ).scrollIntoView();
-	};
 
 	renderImageAltText() {
 		if ( ! this.isMimePrefix( 'image' ) ) {

--- a/client/signup/recaptcha/index.jsx
+++ b/client/signup/recaptcha/index.jsx
@@ -6,7 +6,7 @@ import { initGoogleRecaptcha } from 'calypso/lib/analytics/recaptcha';
 import './style.scss';
 import { CHECKOUT_STORE } from 'calypso/my-sites/checkout/src/lib/wpcom-store';
 
-function Recaptcha( { badgePosition } ) {
+function Recaptcha( { badgePosition = 'bottomright' } ) {
 	const { setRecaptchaClientId } = useDispatch( CHECKOUT_STORE ) ?? {};
 	useEffect( () => {
 		initGoogleRecaptcha( 'g-recaptcha', config( 'google_recaptcha_site_key' ) ).then(
@@ -25,10 +25,6 @@ function Recaptcha( { badgePosition } ) {
 
 Recaptcha.propTypes = {
 	badgePosition: PropTypes.string,
-};
-
-Recaptcha.defaultProps = {
-	badgePosition: 'bottomright',
 };
 
 export default memo( Recaptcha );

--- a/client/sites-dashboard/components/sites-site-name.ts
+++ b/client/sites-dashboard/components/sites-site-name.ts
@@ -6,7 +6,7 @@ export const SiteName = styled.a< { fontSize?: number } >`
 	white-space: nowrap;
 	margin-inline-end: 8px;
 	font-weight: 500;
-	font-size: ${ ( props ) => `${ props.fontSize }px` };
+	font-size: ${ ( props ) => `${ props.fontSize ?? 14 }px` };
 	letter-spacing: -0.4px;
 	color: var( --studio-gray-100 );
 	line-height: 18px;
@@ -15,7 +15,3 @@ export const SiteName = styled.a< { fontSize?: number } >`
 		text-decoration: underline;
 	}
 `;
-
-SiteName.defaultProps = {
-	fontSize: 14,
-};

--- a/client/sites/marketing/connections/account-dialog-account.jsx
+++ b/client/sites/marketing/connections/account-dialog-account.jsx
@@ -6,7 +6,13 @@ import Image from 'calypso/components/image';
 
 import './account-dialog-account.scss';
 
-const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {
+const AccountDialogAccount = ( {
+	account,
+	conflicting = false,
+	onChange = () => {},
+	selected = false,
+	defaultIcon,
+} ) => {
 	const classes = clsx( 'account-dialog-account', {
 		'is-connected': account.isConnected,
 		'is-conflict': conflicting,
@@ -55,13 +61,6 @@ AccountDialogAccount.propTypes = {
 	selected: PropTypes.bool,
 	conflicting: PropTypes.bool,
 	onChange: PropTypes.func,
-};
-
-AccountDialogAccount.defaultProps = {
-	conflicting: false,
-	connected: false,
-	onChange: () => {},
-	selected: false,
 };
 
 export default AccountDialogAccount;

--- a/client/sites/marketing/connections/service-action.jsx
+++ b/client/sites/marketing/connections/service-action.jsx
@@ -8,13 +8,13 @@ import getRemovableConnections from 'calypso/state/selectors/get-removable-conne
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const SharingServiceAction = ( {
-	isConnecting,
-	isDisconnecting,
-	isRefreshing,
-	onAction,
-	removableConnections,
+	isConnecting = false,
+	isDisconnecting = false,
+	isRefreshing = false,
+	onAction = () => {},
+	removableConnections = [],
 	service,
-	status,
+	status = 'unknown',
 	translate,
 	recordTracksEvent,
 	path,
@@ -150,15 +150,6 @@ SharingServiceAction.propTypes = {
 	translate: PropTypes.func,
 	recordTracksEvent: PropTypes.func,
 	isExpanded: PropTypes.bool,
-};
-
-SharingServiceAction.defaultProps = {
-	isConnecting: false,
-	isDisconnecting: false,
-	isRefreshing: false,
-	onAction: () => {},
-	removableConnections: [],
-	status: 'unknown',
 };
 
 export default connect(

--- a/client/sites/marketing/connections/service-connected-accounts.jsx
+++ b/client/sites/marketing/connections/service-connected-accounts.jsx
@@ -2,7 +2,12 @@ import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
-const SharingServiceConnectedAccounts = ( { children, connect, service, translate } ) => {
+const SharingServiceConnectedAccounts = ( {
+	children,
+	connect = () => {},
+	service,
+	translate,
+} ) => {
 	const allowMultipleAccounts = [ 'instagram-basic-display', 'p2_github' ];
 	const doesNotAllowMultipleAccounts = [ 'google_plus', 'mastodon', 'bluesky' ];
 	const shouldShowConnectButton =
@@ -27,10 +32,6 @@ SharingServiceConnectedAccounts.propTypes = {
 	connect: PropTypes.func, // Handler to invoke when adding a new connection
 	service: PropTypes.object.isRequired, // The service object
 	translate: PropTypes.func,
-};
-
-SharingServiceConnectedAccounts.defaultProps = {
-	connect: () => {},
 };
 
 export default localize( SharingServiceConnectedAccounts );

--- a/client/sites/marketing/connections/service-example.jsx
+++ b/client/sites/marketing/connections/service-example.jsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
-const SharingServiceExample = ( { image, label, single } ) => (
+const SharingServiceExample = ( { image, label, single = false } ) => (
 	<div className={ clsx( 'sharing-service-example', { 'is-single': single } ) }>
 		{ image ? (
 			<div className="service-example__screenshot">
@@ -19,10 +19,6 @@ SharingServiceExample.propTypes = {
 	} ),
 	label: PropTypes.node,
 	single: PropTypes.bool,
-};
-
-SharingServiceExample.defaultProps = {
-	single: false,
 };
 
 export default SharingServiceExample;

--- a/client/sites/marketing/connections/services-group.jsx
+++ b/client/sites/marketing/connections/services-group.jsx
@@ -34,10 +34,10 @@ const serviceWarningLevelToNoticeStatus = ( level ) => {
 };
 
 const SharingServicesGroup = ( {
-	isFetching,
-	services,
+	isFetching = false,
+	services = [],
 	title,
-	expandedService,
+	expandedService = '',
 	numberOfPlaceholders = NUMBER_OF_PLACEHOLDERS,
 } ) => {
 	useEffect( () => {
@@ -113,12 +113,6 @@ SharingServicesGroup.propTypes = {
 	title: PropTypes.node.isRequired,
 	type: PropTypes.string.isRequired,
 	expandedService: PropTypes.string,
-};
-
-SharingServicesGroup.defaultProps = {
-	isFetching: false,
-	services: [],
-	expandedService: '',
 };
 
 const mapStateToProps = ( state, { type } ) => {

--- a/client/sites/marketing/sharing/preview-action.jsx
+++ b/client/sites/marketing/sharing/preview-action.jsx
@@ -1,10 +1,16 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { omit, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 
-const SharingButtonsPreviewAction = ( props ) => {
-	const { active, position, icon, children } = props;
+const SharingButtonsPreviewAction = ( {
+	active = true,
+	position = 'top-left',
+	icon,
+	onClick = () => {},
+	children,
+	...props
+} ) => {
 	const classes = clsx( 'sharing-buttons-preview-action', {
 		'is-active': active,
 		'is-top': startsWith( position, 'top' ),
@@ -14,11 +20,7 @@ const SharingButtonsPreviewAction = ( props ) => {
 	} );
 
 	return (
-		<button
-			type="button"
-			className={ classes }
-			{ ...omit( props, [ 'active', 'position', 'icon' ] ) }
-		>
+		<button type="button" className={ classes } onClick={ onClick } { ...props }>
 			{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 			{ children }
 		</button>
@@ -30,12 +32,6 @@ SharingButtonsPreviewAction.propTypes = {
 	position: PropTypes.oneOf( [ 'top-left', 'top-right', 'bottom-left', 'bottom-right' ] ),
 	icon: PropTypes.string,
 	onClick: PropTypes.func,
-};
-
-SharingButtonsPreviewAction.defaultProps = {
-	active: true,
-	position: 'top-left',
-	onClick: () => {},
 };
 
 export default SharingButtonsPreviewAction;

--- a/client/sites/settings/site/toolbar.jsx
+++ b/client/sites/settings/site/toolbar.jsx
@@ -14,8 +14,8 @@ import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const Masterbar = ( {
-	isRequestingSettings,
-	isSavingSettings,
+	isRequestingSettings = true,
+	isSavingSettings = false,
 	selectedSiteId,
 	masterbarModuleUnavailable,
 	translate,
@@ -64,11 +64,6 @@ const Masterbar = ( {
 			{ renderForm() }
 		</PanelCard>
 	);
-};
-
-Masterbar.defaultProps = {
-	isSavingSettings: false,
-	isRequestingSettings: true,
 };
 
 Masterbar.propTypes = {


### PR DESCRIPTION
Part of DOTCOM-17400

## Proposed Changes

Forward-compatible React 19 source changes for several of the still-unowned catch-all `client/` areas (`jetpack-connect`, `signup`, `sites`, `sites-dashboard`, `post-editor`). Everything here compiles unchanged under React 18 and is ready for React 19, with **no runtime behavior change**:

- Migrate function-component (and one styled-component) `defaultProps` to destructured default params / inline fallbacks. React 19 drops `defaultProps` support for function components; class-component `defaultProps` is still supported and is intentionally left untouched.
- Remove a dead method in the media-modal detail fields that held the only live `findDOMNode` call in these areas. It was defined but never wired up, so this is pure dead-code removal (and drops a now-unused `react-dom` import).

This is part of the broader effort to land forward-compatible changes on trunk ahead of the single React 19 version bump.

## Why are these changes being made?

`@wordpress/*` packages bundled by Calypso are moving to React 19, and staying on React 18 would pin Calypso to stale versions. Landing these mechanical, behavior-neutral changes per-area now keeps the eventual version bump small and low-risk.

## Testing Instructions

- `yarn test-client --findRelatedTests <changed files>` — all related suites pass (498 tests / 68 suites).
- `yarn typecheck-client` — no new errors introduced by these files.
- Smoke-test the affected UI under React 18 (current trunk): Jetpack Connect example screens, the signup reCAPTCHA badge, the Marketing → Connections/Sharing screens, and the media-modal detail panel. Behavior should be identical.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
