### PR TITLE
Fix: theme showcase "More" menu renders on the wrong side (DOTTHEM-370)

### DIFF
--- a/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
@@ -123,7 +123,6 @@ export default function DropdownGroup( {
 				<SlotFillProvider>
 					<Popover.Slot />
 					<Dropdown
-						popoverProps={ { className: classes } }
 						renderToggle={ ( { onToggle } ) => (
 							<ToolbarButton
 								className={ clsx(


### PR DESCRIPTION
Fixes [DOTTHEM-370](https://linear.app/a8c/issue/DOTTHEM-370/more-menu-on-theme-showcase-renders-on-the-wrong-side-of-the-screen)

## Proposed Changes

* Remove `popoverProps={ { className: classes } }` from the "More" overflow `Dropdown` in `ResponsiveToolbarGroup`'s `DropdownGroup`.

## Why are these changes being made?

On the logged-in theme showcase, clicking **More** in the category filter opened the hidden-categories menu on the *opposite side of the screen* from the button.

The menu is a `@wordpress/components` `Dropdown`/`Popover`. The `popoverProps` className applied the toolbar **container** classes (`responsive-toolbar-group__dropdown` etc.) directly onto the floating popover, which made it lay out at the **full container width** (~1440px in a 1800px viewport) instead of sizing to its menu content. A full-width popover with the default `bottom-start` placement overflows the viewport to the right, so floating-ui's `shift` middleware slides it all the way across to keep it on screen — landing it on the far side, away from the toggle.

Dropping that className lets the popover size to its content and anchor correctly under the **More** button. The popover renders *inside* the toolbar container (its offset parent is the container), so the existing menu-item styling continues to apply through descendant selectors — no theming is lost.

This className was introduced in #110552; this change effectively reverts that one line, which was the regression source.

## Testing Instructions

1. Log in and open the theme showcase (`/themes` or `/themes/sitename.wordpress.com` )
2. Narrow the browser window until the category row overflows and a **More** button appears at the end.
3. Click **More**.
4. Before: the menu appears on the opposite side of the screen. After: the menu opens directly under the **More** button, sized to its content.

Verified live on a local Calypso dev server (logged-in showcase, 1800px viewport): the popover width dropped from ~1439px to its content width and it now renders under the toggle.

> Reviewer input requested: please confirm in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md) and on a site-specific showcase. Reasoning suggests theming is unaffected (popover stays inside the themed container), but I verified light mode only.

## Screenshots

Before:

<img width="1795" height="905" alt="image" src="https://github.com/user-attachments/assets/1b5f3258-4efc-424c-907b-f85432bfc8db" />


After: 

<img width="1800" height="935" alt="image" src="https://github.com/user-attachments/assets/e35ce242-257a-4026-b883-f003cc63a108" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? (Keyboard/popover behaviour is unchanged; only the popover's width/placement is affected.)

---

Note: Opening this PR auto-flips DOTTHEM-370 to "In Progress" in Linear. This is a Bug Blitz contribution that is **review-ready**, not actively being worked by the owning team.