### PR TITLE
Checkout: align contact-info focus indicator with VAT field

### DIFF
--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -30,6 +30,16 @@ const BillingFormFields = styled.div< BillingFormFieldsProps >`
 		color: ${ ( props ) => props.theme.colors.textColorDark };
 	}
 
+	/* Align focus indicator with the VAT field — single solid outline,
+	   instead of the default form-field border-color change + halo. */
+	& input:focus:not( .is-valid ):not( .is-error ),
+	& .form-select:focus,
+	& select:focus {
+		border-color: var( --color-neutral-10 );
+		box-shadow: none;
+		outline: 2px solid var( --studio-wordpress-blue-30 );
+	}
+
 	& .form-input-validation {
 		padding: 6px 6px 11px 0;
 	}


### PR DESCRIPTION
  Attempts to fix [DOTCOM-12354](https://github.com/Automattic/wp-calypso/issues/95818)

  ## Proposed Changes

  * Add a scoped focus-state override inside the `BillingFormFields` styled-component in `client/my-sites/checkout/src/components/wp-contact-form.tsx` so that contact information fields use the same focus indicator as the VAT field — a single 2px solid blue outline —
  instead of inheriting the classic `.form-text-input` border-color change + light box-shadow halo.

  ## Why are these changes being made?

  The fields in the contact information section at checkout used a different focus treatment from the VAT field. Contact info fields inherited the `%form-field:focus` styles from `client/assets/stylesheets/shared/_extends-forms.scss` (border-color turns blue and a light
  blue halo via `box-shadow`), while the VAT field's wrapper applies a single solid 2px outline via its `:focus-within` rule. Side-by-side this read as two different shades of blue when tabbing between fields.

  The override aligns contact info fields with the VAT focus style — same color, same width, same single-element treatment — while leaving the shared `%form-field` placeholder untouched so other Calypso forms keep their existing focus indicator. Validation states
  (`.is-valid` / `.is-error`) are excluded from the override so the existing red and green halos still surface as expected.

  ## Testing Instructions

  1. Open checkout (any product in the cart).
  2. With the keyboard, focus a contact information field such as **First Name** or **Email**.
  3. Now focus the **VAT number** field.
  4. Confirm:
     * Both fields show a 2px solid outline in the same shade of blue.
     * No light-blue halo around the contact info field.
     * The gray border on the contact info field stays gray on focus (no border-color change).

  ### Before / After

  Before: Two different focus treatments

<img width="3394" height="2286" alt="CleanShot 2026-06-19 at 17 38 31@2x" src="https://github.com/user-attachments/assets/c120eafb-1237-4bc3-95a3-3174ee7dcde9" />


  After: Same focus treatments 


<img width="3338" height="2012" alt="CleanShot 2026-06-19 at 17 40 28@2x" src="https://github.com/user-attachments/assets/1633fe53-9a75-4b01-ac39-e6eb150a77d5" />



  ## Pre-merge Checklist

  - [ ] Has the general commit checklist been followed?
  - [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
  - [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
  - [ ] Have you checked for TypeScript, React or other console errors?
  - [ ] For UI changes, have you tested the affected components in dark mode?
  - [ ] Have you tested accessibility for your changes?
  - [ ] Have you used memoizing on expensive computations?
  - [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
  - [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
