### PR TITLE
Checkout: align "Secure checkout" baseline with WordPress.com wordmark

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1141,7 +1141,7 @@ a.masterbar__quick-language-switcher {
 		}
 
 		.masterbar--is-wpcom & {
-			transform: translateY(1px);
+			transform: translateY(0.5px);
 			margin-left: 16px;
 		}
 


### PR DESCRIPTION
## Proposed Changes

* In `client/layout/masterbar/style.scss`, change the `.masterbar__secure-checkout-text` `translateY` for `.masterbar--is-wpcom` from `1px` to `0.5px` so the "Secure checkout" text baseline aligns with the "WordPress.com" wordmark baseline.

## Why are these changes being made?

The legacy checkout masterbar places the WordPress.com wordmark SVG (viewBox `0 0 134 18`) and the "Secure checkout" span in a flex container with `align-items: center`. That geometrically centers the two boxes, but the wordmark's alphabetic baseline sits at ~82% of its viewBox height - below the SVG box's geometric center, while the text baseline sits much closer to its line-box center. The existing `translateY(1px)` nudged the text further down rather than up.

Measured offset on production: "Secure checkout" sat ~0.56px below the wordmark baseline. `translateY(0.5px)` brings the residual to ~0.06px - sub-pixel and effectively invisible.

## Testing Instructions

1. Load a wpcom checkout URL (e.g. `/checkout/<your-site>`).
2. Confirm visually that "Secure checkout" sits on the same baseline as "WordPress.com".


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
