### PR TITLE
Legacy contact: wire up the add contact form

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,6 +1,6 @@
 import { legacyContactsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -10,6 +10,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
+import LegacyContactForm from './legacy-contact-form';
 
 export default function SecurityLegacyContact() {
 	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
@@ -46,16 +47,7 @@ export default function SecurityLegacyContact() {
 								</ButtonStack>
 							</>
 						) : (
-							<ButtonStack justify="flex-start">
-								<Button
-									variant="primary"
-									onClick={ () => {
-										// TODO: open the legacy contact setup flow.
-									} }
-								>
-									{ __( 'Set up legacy contact' ) }
-								</Button>
-							</ButtonStack>
+							<LegacyContactForm />
 						) }
 					</VStack>
 				</CardBody>

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -1,15 +1,11 @@
 import { addLegacyContactMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import {
-	__experimentalInputControl as InputControl,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataForm } from '@wordpress/dataviews';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { Field } from '@wordpress/dataviews';
@@ -18,6 +14,22 @@ interface LegacyContactFormData {
 	email: string;
 }
 
+const fields: Field< LegacyContactFormData >[] = [
+	{
+		id: 'email',
+		label: __( 'Email address' ),
+		type: 'email' as const,
+		isValid: {
+			required: true,
+		},
+	},
+];
+
+const form = {
+	layout: { type: 'regular' as const },
+	fields: [ 'email' ],
+};
+
 export default function LegacyContactForm() {
 	const { recordTracksEvent } = useAnalytics();
 	const { mutate: addContact, isPending } = useMutation( addLegacyContactMutation() );
@@ -25,32 +37,13 @@ export default function LegacyContactForm() {
 
 	const [ formData, setFormData ] = useState< LegacyContactFormData >( { email: '' } );
 
-	const fields: Field< LegacyContactFormData >[] = useMemo(
-		() => [
-			{
-				id: 'email',
-				label: __( 'Email address' ),
-				type: 'email',
-				Edit: ( { field, data, onChange } ) => {
-					const { id, getValue } = field;
-					return (
-						<InputControl
-							__next40pxDefaultSize
-							type="email"
-							label={ field.label }
-							value={ getValue( { item: data } ) }
-							onChange={ ( value ) => onChange( { [ id ]: value ?? '' } ) }
-							disabled={ isPending }
-						/>
-					);
-				},
-			},
-		],
-		[ isPending ]
-	);
+	const { validity, isValid } = useFormValidity( formData, fields, form );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
+		if ( ! isValid ) {
+			return;
+		}
 		recordTracksEvent( 'calypso_dashboard_security_legacy_contact_add_click' );
 		addContact( formData.email, {
 			onSuccess: () => {
@@ -70,10 +63,8 @@ export default function LegacyContactForm() {
 				<DataForm< LegacyContactFormData >
 					data={ formData }
 					fields={ fields }
-					form={ {
-						layout: { type: 'regular' as const },
-						fields: fields.map( ( field ) => field.id ),
-					} }
+					form={ form }
+					validity={ validity }
 					onChange={ ( edits: Partial< LegacyContactFormData > ) =>
 						setFormData( ( data ) => ( { ...data, ...edits } ) )
 					}
@@ -83,7 +74,7 @@ export default function LegacyContactForm() {
 						variant="primary"
 						type="submit"
 						isBusy={ isPending }
-						disabled={ isPending || ! formData.email }
+						disabled={ isPending || ! isValid }
 					>
 						{ __( 'Set up legacy contact' ) }
 					</Button>

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -1,0 +1,94 @@
+import { addLegacyContactMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalInputControl as InputControl,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { ButtonStack } from '../../components/button-stack';
+import type { Field } from '@wordpress/dataviews';
+
+interface LegacyContactFormData {
+	email: string;
+}
+
+export default function LegacyContactForm() {
+	const { recordTracksEvent } = useAnalytics();
+	const { mutate: addContact, isPending } = useMutation( addLegacyContactMutation() );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< LegacyContactFormData >( { email: '' } );
+
+	const fields: Field< LegacyContactFormData >[] = useMemo(
+		() => [
+			{
+				id: 'email',
+				label: __( 'Email address' ),
+				type: 'email',
+				Edit: ( { field, data, onChange } ) => {
+					const { id, getValue } = field;
+					return (
+						<InputControl
+							__next40pxDefaultSize
+							type="email"
+							label={ field.label }
+							value={ getValue( { item: data } ) }
+							onChange={ ( value ) => onChange( { [ id ]: value ?? '' } ) }
+							disabled={ isPending }
+						/>
+					);
+				},
+			},
+		],
+		[ isPending ]
+	);
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		recordTracksEvent( 'calypso_dashboard_security_legacy_contact_add_click' );
+		addContact( formData.email, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Legacy contact saved.' ), { type: 'snackbar' } );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to save legacy contact.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 4 }>
+				<DataForm< LegacyContactFormData >
+					data={ formData }
+					fields={ fields }
+					form={ {
+						layout: { type: 'regular' as const },
+						fields: fields.map( ( field ) => field.id ),
+					} }
+					onChange={ ( edits: Partial< LegacyContactFormData > ) =>
+						setFormData( ( data ) => ( { ...data, ...edits } ) )
+					}
+				/>
+				<ButtonStack justify="flex-start">
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ isPending }
+						disabled={ isPending || ! formData.email }
+					>
+						{ __( 'Set up legacy contact' ) }
+					</Button>
+				</ButtonStack>
+			</VStack>
+		</form>
+	);
+}

--- a/packages/api-core/src/me-legacy-contacts/index.ts
+++ b/packages/api-core/src/me-legacy-contacts/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
+export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/me-legacy-contacts/mutators.ts
+++ b/packages/api-core/src/me-legacy-contacts/mutators.ts
@@ -1,0 +1,12 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { LegacyContact } from './types';
+
+export async function addLegacyContact( email: string ): Promise< LegacyContact > {
+	return wpcom.req.post(
+		{
+			path: '/me/legacy-contacts',
+			apiNamespace: 'wpcom/v2',
+		},
+		{ email }
+	);
+}

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -24,6 +24,6 @@ export const addLegacyContactMutation = () =>
 	mutationOptions( {
 		mutationFn: ( email: string ) => addLegacyContact( email ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'me', 'legacy-contacts' ] } );
+			queryClient.invalidateQueries( legacyContactsQuery() );
 		},
 	} );

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -1,5 +1,6 @@
-import { fetchLegacyContact, fetchLegacyContacts } from '@automattic/api-core';
-import { queryOptions } from '@tanstack/react-query';
+import { addLegacyContact, fetchLegacyContact, fetchLegacyContacts } from '@automattic/api-core';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
 
 export const legacyContactsQuery = () =>
 	queryOptions( {
@@ -17,4 +18,12 @@ export const legacyContactQuery = ( legacyContactId: number ) =>
 		// The response carries a sensitive `access_key`, so keep it out of the
 		// persisted (localStorage) query cache to limit its exposure.
 		meta: { persist: false },
+	} );
+
+export const addLegacyContactMutation = () =>
+	mutationOptions( {
+		mutationFn: ( email: string ) => addLegacyContact( email ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'me', 'legacy-contacts' ] } );
+		},
 	} );

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -5,7 +5,7 @@ export const legacyContactsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'legacy-contacts' ],
 		queryFn: fetchLegacyContacts,
-		// The response carries personal data (contact emails + ids), so keep it
+		// The response carries personal data (legacy contact email), so keep it
 		// out of the persisted (localStorage) query cache to limit its exposure.
 		meta: { persist: false },
 	} );

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -5,7 +5,7 @@ export const legacyContactsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'legacy-contacts' ],
 		queryFn: fetchLegacyContacts,
-		// The response carries personal data (legacy contact email), so keep it
+		// The response carries personal data (contact emails + ids), so keep it
 		// out of the persisted (localStorage) query cache to limit its exposure.
 		meta: { persist: false },
 	} );


### PR DESCRIPTION
## Proposed Changes

* Wire up the placeholder "Set up legacy contact" button in the Dashboard `/me/security/legacy-contact` view, replacing it with an email `DataForm`.
* `@automattic/api-core`: add `addLegacyContact( email )` (`POST /wpcom/v2/me/legacy-contacts`).
* `@automattic/api-queries`: add `addLegacyContactMutation()`, which invalidates the legacy-contacts query on success.

<img width="717" height="317" alt="Screenshot 2026-06-25 at 14 36 03" src="https://github.com/user-attachments/assets/eb0f5c5a-e642-42b7-abbc-59bedef3bbb8" />

## Why are these changes being made?

The read layer already surfaces an existing legacy contact, but the "Set up" button was a no-op. This connects it to the backend so a user can add one.

## Testing Instructions

* Run `yarn start-dashboard` with the `me/legacy-contact` flag enabled and visit `/me/security/legacy-contact`.
* With no contact set, submit an email — a success snackbar appears and the view shows the saved contact.
* Confirm a failed request shows an error snackbar.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
