### PR TITLE
Logs: vertically center Auto-refresh toggle with sibling header buttons

### DIFF
--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -64,3 +64,9 @@
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.3 );
 	cursor: pointer;
 }
+
+/* Center the Auto-refresh toggle with the sibling view-config and download icon buttons. */
+.site-logs-card .dataviews__view-actions .components-toggle-control {
+	display: flex;
+	align-items: center;
+}


### PR DESCRIPTION
## Proposed Changes

* On the site Logs page (PHP errors / Server logs), vertically center the **Auto-refresh** toggle so it lines up with the sibling header buttons (the view-config gear and the download button).

The DataViews header renders the gear and download as compact icon buttons, while Auto-refresh is a `ToggleControl`. The `ToggleControl` root (`BaseControl`) doesn't share a vertical center with those icon buttons, so the toggle sat slightly off. A `style`/inline-prop approach doesn't work here — `ToggleControl` forwards extra props to its inner `FormToggle` (the switch), not its root — so the fix is a small scoped CSS rule that centers the control's actual root:

```scss
.site-logs-card .dataviews__view-actions .components-toggle-control {
	display: flex;
	align-items: center;
}
```

## Why are these changes being made?

* The Auto-refresh toggle appeared vertically misaligned relative to the gear and download buttons in the Logs toolbar, which looked visually inconsistent.

## Testing Instructions

* Go to a site's **Logs → PHP errors** (and **Server logs**) page in the dashboard.
* Confirm the Auto-refresh toggle is vertically centered in line with the settings gear and download icon buttons.
* Toggle Auto-refresh on/off and resize the viewport to confirm alignment holds.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)