### PR TITLE
Desktop: Sign and notarize macOS build on Buildkite

### DIFF
--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -4,10 +4,17 @@ set -euo pipefail
 
 export CONFIG_ENV=release
 export USE_HARD_LINKS=false
-export ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
 export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+# Build the real distributables (zip + dmg, both arches) rather than the
+# `-c.mac.target=dir` test tree, and notarize the result.
+export RELEASE_BUILD=true
+export NOTARIZE=true
+# We build on a PR branch with no `desktop-v*` tag, so tell electron-builder to
+# sign anyway instead of skipping signing as it does for untagged CI builds.
+export CSC_FOR_PULL_REQUEST=true
 
 # `desktop/.ruby-version` pins 3.3.0 but the a8c BK mac VM image only
 # ships 3.2.2 (default) and 3.3.4. Override here so `bundle` resolves.
@@ -18,16 +25,29 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export RBENV_VERSION=3.3.4
 
 cd desktop
+
+# Fetch and install the Developer ID signing certificate from fastlane match
+# (S3) into a temporary keychain. electron-builder auto-discovers the identity.
+bundle install
+bundle exec fastlane configure_code_signing
+
+# Materialize the App Store Connect API key (`.p8`) that `after_sign_hook.js`
+# hands to notarytool. `APP_STORE_CONNECT_API_KEY_KEY` holds the key content;
+# it may be raw PEM or base64-encoded.
+ASC_KEY_PATH="$(mktemp -t asc_api_key_XXXXXX).p8"
+trap 'rm -f "$ASC_KEY_PATH"' EXIT
+if [[ "$APP_STORE_CONNECT_API_KEY_KEY" == *"BEGIN PRIVATE KEY"* ]]; then
+  printf '%s' "$APP_STORE_CONNECT_API_KEY_KEY" > "$ASC_KEY_PATH"
+else
+  printf '%s' "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > "$ASC_KEY_PATH"
+fi
+export APP_STORE_CONNECT_API_KEY_PATH="$ASC_KEY_PATH"
+
 corepack enable
 yarn install --immutable --inline-builds
 yarn run ci:build-mac
 
-# `-c.mac.target=dir` produces an unpacked `Electron.app/` tree. Pack it
-# into a single archive so the artifact upload doesn't ferry thousands
-# of individual files. `ditto` preserves macOS resource forks.
-for arch_dir in release/mac release/mac-arm64; do
-  if [[ -d "$arch_dir" ]]; then
-    ditto -ck --rsrc --sequesterRsrc "$arch_dir" "${arch_dir}-unsigned.zip"
-    rm -rf "$arch_dir"
-  fi
-done
+# Drop the unpacked app trees electron-builder leaves behind so the artifact
+# upload ferries only the distributables (zip, dmg, blockmaps, update yml).
+rm -rf release/mac release/mac-arm64
+rm -f release/builder-debug.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,11 +30,11 @@ steps:
   # builds; we don't want to pay for it on every commit, especially
   # while the CircleCI -> Buildkite port is still in development.
   # Gate it on `ainfra-*` branches until the port is stabilized.
-  - label: ":desktop_computer: Build desktop (mac, unsigned)"
+  - label: ":desktop_computer: Build desktop (mac, signed)"
     branches: ainfra-*
     notify:
       - github_commit_status:
-          context: Desktop / Build (mac, unsigned)
+          context: Desktop / Build (mac, signed)
     agents:
       queue: mac
     env:
@@ -43,7 +43,10 @@ steps:
       - automattic/nvm#0.6.0
     command: .buildkite/commands/build-desktop-mac.sh
     artifact_paths:
-      - desktop/release/*
+      - desktop/release/*.zip
+      - desktop/release/*.dmg
+      - desktop/release/*.blockmap
+      - desktop/release/*.yml
 
   - label: ":desktop_computer: Build desktop (linux, unsigned)"
     branches: ainfra-*

--- a/desktop/bin/after_sign_hook.js
+++ b/desktop/bin/after_sign_hook.js
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 
+const { execFileSync } = require( 'child_process' );
 const path = require( 'path' );
 const { notarize } = require( '@electron/notarize' );
 
 const APP_ID = 'com.automattic.wordpress';
-const NOTARIZATION_ID = process.env.WPDESKTOP_NOTARIZATION_ID;
-const NOTARIZATION_PWD = process.env.WPDESKTOP_NOTARIZATION_PWD;
-const NOTARIZATION_ASC_PROVIDER = process.env.APPLE_DEVELOPER_SHORT_NAME;
 
+// Notarize when explicitly requested (CI-agnostic, set by the Buildkite mac
+// build) or for a legacy CircleCI tagged release. The CircleCI branch — and
+// the Apple ID credentials it relies on — go away once the `wp-desktop-mac`
+// CircleCI job is decommissioned.
 const circleTag = process.env.CIRCLE_TAG;
+const isCircleRelease = !! circleTag && circleTag.startsWith( 'desktop-v' );
 const shouldNotarize =
-	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop-v' );
+	process.platform === 'darwin' && ( process.env.NOTARIZE === 'true' || isCircleRelease );
+
+// App Store Connect API key (notarytool). The standard a8c flow, sharing the
+// key fastlane match already uses. `*_PATH` points at a `.p8` materialized by
+// the CI build script.
+const ascApiKeyPath = process.env.APP_STORE_CONNECT_API_KEY_PATH;
+const ascApiKeyId = process.env.APP_STORE_CONNECT_API_KEY_KEY_ID;
+const ascApiIssuer = process.env.APP_STORE_CONNECT_API_KEY_ISSUER_ID;
 
 function elapsed( start ) {
 	const now = new Date();
@@ -32,13 +42,30 @@ module.exports = async function ( context ) {
 
 	const start = new Date();
 	console.log( `  • notarizing ${ appName } (${ arch })...` );
-	await notarize( {
-		appBundleId: APP_ID,
-		appPath: app,
-		appleId: NOTARIZATION_ID,
-		appleIdPassword: NOTARIZATION_PWD,
-		ascProvider: NOTARIZATION_ASC_PROVIDER,
-		teamId: NOTARIZATION_ASC_PROVIDER,
-	} );
+
+	if ( ascApiKeyPath ) {
+		await notarize( {
+			appPath: app,
+			appleApiKey: ascApiKeyPath,
+			appleApiKeyId: ascApiKeyId,
+			appleApiIssuer: ascApiIssuer,
+		} );
+	} else {
+		// Legacy CircleCI Apple ID flow. Removed with the CircleCI mac job.
+		await notarize( {
+			appBundleId: APP_ID,
+			appPath: app,
+			appleId: process.env.WPDESKTOP_NOTARIZATION_ID,
+			appleIdPassword: process.env.WPDESKTOP_NOTARIZATION_PWD,
+			teamId: process.env.APPLE_DEVELOPER_SHORT_NAME,
+		} );
+	}
+
+	// `@electron/notarize` submits and waits, but does not staple. Staple the
+	// ticket onto the `.app` so it verifies offline — and so the `.zip`/`.dmg`
+	// packaged from it carry the stapled app.
+	console.log( `  • stapling ${ appName } (${ arch })...` );
+	execFileSync( 'xcrun', [ 'stapler', 'staple', app ], { stdio: 'inherit' } );
+
 	console.log( `  • done notarizing ${ appName } ( ${ arch } ), took ${ elapsed( start ) }` );
 };


### PR DESCRIPTION
Part of AINFRA-2273. Step toward retiring the desktop app's CircleCI release path.

## Proposed Changes

* Buildkite mac build now produces the real distributables (zip + dmg, both arches), **signed** with the Developer ID cert from fastlane `match` and **notarized + stapled** — replacing the unsigned `-c.mac.target=dir` test tree.
* Notarization switches to the **App Store Connect API key** (notarytool), reusing the key `match` already needs, replacing the bespoke `WPDESKTOP_NOTARIZATION_*` / `APPLE_DEVELOPER_SHORT_NAME` Apple ID vars.
* The notarize gate in `after_sign_hook.js` generalizes from `CIRCLE_TAG` to a CI-agnostic `NOTARIZE` flag.

## Why are these changes being made?

The signed + notarized macOS release was the one desktop platform still produced only on CircleCI; the Buildkite build proved the toolchain but shipped nothing verifiable. This puts a signed, notarized, downloadable macOS artifact on Buildkite and standardizes the notarization credential, so CircleCI's `wp-desktop-mac` job can eventually be decommissioned.

The legacy Apple ID notarization path is **retained as a fallback** so CircleCI's tagged releases keep notarizing until that job is removed — this PR does not touch the CircleCI release.

## Testing Instructions

The mac step is gated to `ainfra-*` branches, so this branch's Buildkite run exercises it end-to-end (build → match sign → notarize → staple). Once green:

1. Download the `wordpress.com-macOS-app-*-arm64.zip` artifact from the Buildkite build.
2. `unzip` it, then verify it is signed and notarized **offline**:
   ```
   codesign --verify --deep --strict --verbose=2 WordPress.com.app
   spctl -a -t exec -vvv WordPress.com.app
   xcrun stapler validate WordPress.com.app
   ```
   `stapler validate` succeeding confirms the notarization ticket is stapled.

> [!NOTE]
> Requires `MATCH_S3_ACCESS_KEY` / `MATCH_S3_SECRET_ACCESS_KEY` / `MATCH_PASSWORD` and `APP_STORE_CONNECT_API_KEY_KEY` / `_KEY_ID` / `_ISSUER_ID` on the Buildkite `mac` queue. If signing/notarization fails on missing-secret errors, that provisioning is the gap.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? <!-- CI-only change; verification is the Buildkite run + artifact checks above -->
- [ ] Have you checked for TypeScript, React or other console errors?