### PR TITLE
Desktop: Staple mac app before packaging zip/dmg

### DIFF
--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -32,8 +32,26 @@ yarn install --immutable --inline-builds
 bundle install
 bundle exec fastlane configure_code_signing
 
+# Notarize and staple the `.app` inside electron-builder's afterSign hook
+# (`bin/after_sign_hook.js`), before the `.zip`/`.dmg` are packaged from it, so
+# both distributables carry a stapled, offline-verifiable app. `NOTARIZE`
+# triggers the hook; the hook hands `notarytool` the App Store Connect API key,
+# which it reads from this `.p8`. `APP_STORE_CONNECT_API_KEY_KEY` holds the key
+# content (raw PEM or base64).
+export NOTARIZE=true
+ASC_KEY_PATH="$(mktemp -t asc_api_key_XXXXXX).p8"
+trap 'rm -f "$ASC_KEY_PATH"' EXIT
+if [[ "$APP_STORE_CONNECT_API_KEY_KEY" == *"BEGIN PRIVATE KEY"* ]]; then
+  printf '%s' "$APP_STORE_CONNECT_API_KEY_KEY" > "$ASC_KEY_PATH"
+else
+  printf '%s' "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > "$ASC_KEY_PATH"
+fi
+export APP_STORE_CONNECT_API_KEY_PATH="$ASC_KEY_PATH"
+
 yarn run ci:build-mac
 
+# The afterSign hook already notarized and stapled the app; this notarizes and
+# staples the `.dmg` wrapper for offline Gatekeeper checks on first mount.
 bundle exec fastlane notarize_app
 
 # Drop the unpacked app trees electron-builder leaves behind so the artifact

--- a/desktop/bin/after_sign_hook.js
+++ b/desktop/bin/after_sign_hook.js
@@ -1,16 +1,32 @@
 #!/usr/bin/env node
 
+const { execFileSync } = require( 'child_process' );
 const path = require( 'path' );
 const { notarize } = require( '@electron/notarize' );
 
 const APP_ID = 'com.automattic.wordpress';
-const NOTARIZATION_ID = process.env.WPDESKTOP_NOTARIZATION_ID;
-const NOTARIZATION_PWD = process.env.WPDESKTOP_NOTARIZATION_PWD;
-const NOTARIZATION_ASC_PROVIDER = process.env.APPLE_DEVELOPER_SHORT_NAME;
 
+// Notarize when explicitly requested (CI-agnostic, set by the Buildkite mac
+// build) or for a legacy CircleCI tagged release. The CircleCI branch — and
+// the Apple ID credentials it relies on — go away once the `wp-desktop-mac`
+// CircleCI job is decommissioned.
+//
+// Running here, in electron-builder's afterSign hook, is deliberate: the app
+// is notarized and stapled *before* the `.zip` and `.dmg` are packaged from
+// it, so both distributables carry a stapled, offline-verifiable app. (The
+// fastlane `notarize_app` lane runs post-build and can only staple the `.dmg`
+// wrapper, not the already-zipped app.)
 const circleTag = process.env.CIRCLE_TAG;
+const isCircleRelease = !! circleTag && circleTag.startsWith( 'desktop-v' );
 const shouldNotarize =
-	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop-v' );
+	process.platform === 'darwin' && ( process.env.NOTARIZE === 'true' || isCircleRelease );
+
+// App Store Connect API key (notarytool). The standard a8c flow, sharing the
+// key fastlane match already uses. `*_PATH` points at a `.p8` materialized by
+// the CI build script.
+const ascApiKeyPath = process.env.APP_STORE_CONNECT_API_KEY_PATH;
+const ascApiKeyId = process.env.APP_STORE_CONNECT_API_KEY_KEY_ID;
+const ascApiIssuer = process.env.APP_STORE_CONNECT_API_KEY_ISSUER_ID;
 
 function elapsed( start ) {
 	const now = new Date();
@@ -32,13 +48,30 @@ module.exports = async function ( context ) {
 
 	const start = new Date();
 	console.log( `  • notarizing ${ appName } (${ arch })...` );
-	await notarize( {
-		appBundleId: APP_ID,
-		appPath: app,
-		appleId: NOTARIZATION_ID,
-		appleIdPassword: NOTARIZATION_PWD,
-		ascProvider: NOTARIZATION_ASC_PROVIDER,
-		teamId: NOTARIZATION_ASC_PROVIDER,
-	} );
+
+	if ( ascApiKeyPath ) {
+		await notarize( {
+			appPath: app,
+			appleApiKey: ascApiKeyPath,
+			appleApiKeyId: ascApiKeyId,
+			appleApiIssuer: ascApiIssuer,
+		} );
+	} else {
+		// Legacy CircleCI Apple ID flow. Removed with the CircleCI mac job.
+		await notarize( {
+			appBundleId: APP_ID,
+			appPath: app,
+			appleId: process.env.WPDESKTOP_NOTARIZATION_ID,
+			appleIdPassword: process.env.WPDESKTOP_NOTARIZATION_PWD,
+			teamId: process.env.APPLE_DEVELOPER_SHORT_NAME,
+		} );
+	}
+
+	// `@electron/notarize` submits and waits, but does not staple. Staple the
+	// ticket onto the `.app` so it verifies offline — and so the `.zip`/`.dmg`
+	// packaged from it carry the stapled app.
+	console.log( `  • stapling ${ appName } (${ arch })...` );
+	execFileSync( 'xcrun', [ 'stapler', 'staple', app ], { stdio: 'inherit' } );
+
 	console.log( `  • done notarizing ${ appName } ( ${ arch } ), took ${ elapsed( start ) }` );
 };

--- a/desktop/fastlane/Fastfile
+++ b/desktop/fastlane/Fastfile
@@ -97,19 +97,15 @@ platform :mac do
     )
   end
 
-  desc 'Notarize the .app and .dmg artifacts produced by electron-builder.'
+  desc 'Notarize and staple the .dmg artifacts produced by electron-builder.'
+  # The `.app` is notarized and stapled earlier, in electron-builder's
+  # afterSign hook (`bin/after_sign_hook.js`), so that the `.zip` packaged from
+  # it carries a stapled app. This lane handles the `.dmg` wrapper, which only
+  # exists after the build completes.
   lane :notarize_app do
     EnvManager.require_env_vars!(*ASC_API_KEY_ENV_VARS)
 
     api_key = app_store_connect_api_key
-
-    Dir[File.join(PROJECT_ROOT_FOLDER, 'release', '*', '*.app')].each do |path|
-      notarize(
-        package: path,
-        api_key: api_key,
-        print_log: true
-      )
-    end
 
     Dir[File.join(PROJECT_ROOT_FOLDER, 'release', '**', '*.dmg')].each do |path|
       notarize(


### PR DESCRIPTION
Stacked on #110331. Iterating on the zip-stapling gap found while reviewing that PR; once green and verified, these commits fold into #110331 and this PR closes.

## Proposed Changes

* Notarize + staple the macOS `.app` in electron-builder's `afterSign` hook (before the `.zip`/`.dmg` are packaged) instead of post-build, so the auto-update **zip** carries a stapled, offline-verifiable app — not just the dmg.
* Hook uses the App Store Connect API key (notarytool), the same key `match`/`notarize_app` already use; legacy CircleCI Apple ID flow kept as a fallback.
* `notarize_app` now handles only the `.dmg` wrapper.

## Why

On #110331, `notarize_app` runs after `ci:build-mac`, so it staples the dmg but not the app already sealed in the zip. Verified against build 7371 artifacts: dmg `stapler validate` passed, zip app reported \"no ticket stapled\" (accepted online via `spctl`, but no offline ticket).

## Testing / verification

The mac step is gated to `ainfra-*`, so this branch's Buildkite run exercises it. Verified by downloading the artifacts and confirming **both** the zip's app and the dmg pass \`xcrun stapler validate\` and \`spctl\` (codesign chain intact). Results posted in-thread.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes? <!-- CI-only; verification is the Buildkite run + artifact stapler/spctl checks -->
- [ ] Have you checked for TypeScript, React or other console errors?