### PR TITLE
Reader connections: fix featured card gradient in dark mode

### DIFF
--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -1,3 +1,5 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+
 .connections-view {
 	max-width: 760px;
 }
@@ -82,6 +84,17 @@
 			var( --studio-pink-0 ) 0%,
 			var( --color-surface ) 60%
 		);
+
+		// --studio-pink-0 keeps its light pale-pink value in dark mode (the dark
+		// palette only regenerates blue/gray), so the gradient would start on a
+		// bright patch. Tint the dark surface with the brand pink instead.
+		@include ui-mixins.when-dark-theme {
+			background: linear-gradient(
+				135deg,
+				color-mix( in srgb, var( --color-surface ) 88%, var( --studio-pink-50 ) ) 0%,
+				var( --color-surface ) 60%
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR.
-->

Fixes READ-546

## Proposed Changes

* Add a dark-mode override for the featured card gradient on `/reader/connections/new` (`.connections-new__card.is-featured`), tinting the dark surface with the brand pink via the shared `when-dark-theme` mixin.

## Why are these changes being made?

* The gradient started from `--studio-pink-0`, which the dark palette does not regenerate (only blue/gray are), so in dark mode the gradient began on a bright pale-pink patch against the dark surface — looking off once `--color-surface` maps to `--dashboard-surface__background-color`. The override replaces that stale light stop with a subtle pink-tinted dark surface so the card still reads as featured.

## Testing Instructions

* Enable dark mode at `/me/preferences/appearance`, then visit `/reader/connections/new` and confirm the featured (Fediverse) card's gradient blends smoothly into the dark surface with no bright pink patch. Toggle back to light mode and confirm the original gradient is unchanged. Before/after dark-mode screenshots welcome.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
