### PR TITLE
A4A Marketplace: load Products first for Pressable owners

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -33,7 +33,6 @@ import {
 	A4A_PURCHASES_LINK,
 	A4A_REFERRALS_LINK,
 	A4A_SITES_LINK,
-	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MIGRATIONS_LINK,
 	A4A_SETTINGS_LINK,
 	A4A_PLUGINS_LINK,
@@ -170,7 +169,7 @@ const useMainMenuItems = ( path: string ) => {
 			{
 				icon: tag,
 				path: A4A_MARKETPLACE_LINK,
-				link: A4A_MARKETPLACE_HOSTING_LINK,
+				link: A4A_MARKETPLACE_LINK,
 				title: translate( 'Marketplace' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Marketplace',

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -5,6 +5,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
@@ -14,6 +15,7 @@ import Checkout from './checkout';
 import { MARKETPLACE_TYPE_SESSION_STORAGE_KEY } from './hoc/with-marketplace-type';
 import { TERM_PRICING_PREFERENCE_KEY, TERM_PRICING_YEARLY } from './hoc/with-term-pricing';
 import HostingOverview from './hosting-overview';
+import { getPressableOwnershipType } from './lib/get-pressable-ownership-type';
 import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
 import { PLAN_CATEGORY_ENTERPRISE, PLAN_CATEGORY_PREMIUM } from './pressable-overview/constants';
@@ -58,7 +60,15 @@ export const marketplaceContext: Callback = ( context ) => {
 		purchaseType = purchase_type === 'referral' ? 'referral' : 'regular';
 	}
 	const purchaseTypeURLQuery = purchaseType ? `?purchase_type=${ purchaseType }` : '';
-	page.redirect( A4A_MARKETPLACE_HOSTING_LINK + purchaseTypeURLQuery );
+
+	// Pressable owners primarily use the marketplace to buy products, so default them to Products.
+	const agency = getActiveAgency( context.store.getState() );
+	const ownsPressable = getPressableOwnershipType( agency ) !== 'none';
+
+	page.redirect(
+		( ownsPressable ? A4A_MARKETPLACE_PRODUCTS_LINK : A4A_MARKETPLACE_HOSTING_LINK ) +
+			purchaseTypeURLQuery
+	);
 };
 
 export const marketplaceProductsContext: Callback = ( context, next ) => {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
@@ -1,24 +1,10 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getPressableOwnershipType } from '../../lib/get-pressable-ownership-type';
 
 export default function usePressableOwnershipType() {
 	const activeAgency = useSelector( getActiveAgency );
 
-	const pressableOwnership = useMemo( () => {
-		// Agencies can have pressable through A4A Licenses or via Pressable itself
-		const hasPressablePlan = !! activeAgency?.third_party?.pressable?.pressable_id;
-
-		if ( ! hasPressablePlan ) {
-			return 'none';
-		}
-
-		// If the agency has a regular Pressable plan (not brought through A4A marketplace), A4A id is null.
-		const hasRegularPressablePlan =
-			hasPressablePlan && activeAgency?.third_party?.pressable?.a4a_id === null;
-
-		return hasRegularPressablePlan ? 'regular' : 'agency';
-	}, [ activeAgency ] );
-
-	return pressableOwnership;
+	return useMemo( () => getPressableOwnershipType( activeAgency ), [ activeAgency ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/lib/get-pressable-ownership-type.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/get-pressable-ownership-type.ts
@@ -1,0 +1,16 @@
+import type { Agency } from 'calypso/state/a8c-for-agencies/types';
+
+export type PressableOwnershipType = 'none' | 'regular' | 'agency';
+
+export function getPressableOwnershipType( agency: Agency | null ): PressableOwnershipType {
+	const hasPressablePlan = !! agency?.third_party?.pressable?.pressable_id;
+
+	if ( ! hasPressablePlan ) {
+		return 'none';
+	}
+
+	// A regular Pressable plan (not bought through the A4A marketplace) has a null A4A id.
+	const hasRegularPressablePlan = agency?.third_party?.pressable?.a4a_id === null;
+
+	return hasRegularPressablePlan ? 'regular' : 'agency';
+}

--- a/client/a8c-for-agencies/sections/marketplace/lib/test/get-pressable-ownership-type.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/test/get-pressable-ownership-type.test.ts
@@ -1,0 +1,31 @@
+import { getPressableOwnershipType } from '../get-pressable-ownership-type';
+import type { Agency } from 'calypso/state/a8c-for-agencies/types';
+
+function createAgency(
+	pressable: { pressable_id?: string; a4a_id?: string | null } | null
+): Agency {
+	return {
+		third_party: pressable ? { pressable } : {},
+	} as unknown as Agency;
+}
+
+describe( 'getPressableOwnershipType', () => {
+	it( 'returns "none" when the agency is null', () => {
+		expect( getPressableOwnershipType( null ) ).toBe( 'none' );
+	} );
+
+	it( 'returns "none" when the agency has no Pressable plan', () => {
+		expect( getPressableOwnershipType( createAgency( null ) ) ).toBe( 'none' );
+		expect( getPressableOwnershipType( createAgency( {} ) ) ).toBe( 'none' );
+	} );
+
+	it( 'returns "regular" for a Pressable plan not bought through the A4A marketplace', () => {
+		const agency = createAgency( { pressable_id: '123', a4a_id: null } );
+		expect( getPressableOwnershipType( agency ) ).toBe( 'regular' );
+	} );
+
+	it( 'returns "agency" for a Pressable plan bought through the A4A marketplace', () => {
+		const agency = createAgency( { pressable_id: '123', a4a_id: '456' } );
+		expect( getPressableOwnershipType( agency ) ).toBe( 'agency' );
+	} );
+} );


### PR DESCRIPTION

Closes https://linear.app/a8c/issue/A4A-2711/load-products-first-for-pressable-owners

## Proposed Changes
Default the marketplace landing tab to Products for agencies that already own a Pressable plan, since they primarily use the marketplace to buy products rather than manage hosting. Extract the ownership rule into a shared getPressableOwnershipType helper reused by the controller redirect and the existing usePressableOwnershipType hook, and route the top-level Marketplace nav through the redirect so the decision lives in one place.


## Why are these changes being made?
For users who already own Pressable and do not need to manage it often, the Products page should load first.


## Testing Instructions

* Use the A4A live link to navigate to the `/overview` page.
* Click the **Marketplace** sidebar menu button.
* For Agencies with a Pressable plan, the default page should be the Products page.
* For Agencies without a Pressable plan, the default page should be the Hosting page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
