### PR TITLE
A4A Plugins: standardize description text size in update modal

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/variables";
+
 .is-section-a8c-for-agencies-plugins {
 	.wpcom-site {
 		.main.hosting-dashboard-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
@@ -35,13 +37,8 @@
 		}
 	}
 
-	// Standardize the description text in the plugin action confirmation modal
-	// (e.g. "Update to version X") so it matches our normal body text size. The
-	// modal is shared Calypso code portaled to <body>, so we scope this override
-	// to the A4A plugins section to avoid affecting other clients.
 	.plugins__confirmation-modal .components-modal__content p {
-		font-size: 0.875rem;
-		line-height: 1.5;
+		font-size: $font-size-medium;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -34,6 +34,15 @@
 			}
 		}
 	}
+
+	// Standardize the description text in the plugin action confirmation modal
+	// (e.g. "Update to version X") so it matches our normal body text size. The
+	// modal is shared Calypso code portaled to <body>, so we scope this override
+	// to the A4A plugins section to avoid affecting other clients.
+	.plugins__confirmation-modal .components-modal__content p {
+		font-size: 0.875rem;
+		line-height: 1.5;
+	}
 }
 
 .a4a-plugins-jetpack-banner-container {

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -1,4 +1,4 @@
-@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
 
 .is-section-a8c-for-agencies-plugins {
 	.wpcom-site {
@@ -38,7 +38,7 @@
 	}
 
 	.plugins__confirmation-modal .components-modal__content p {
-		font-size: $font-size-medium;
+		@include body-medium;
 	}
 }
 


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2741/a4a-plugins-reduce-description-text-size-in-update-modal

## Proposed Changes

* Scope a font-size override to the A4A plugins section so the description text in the plugin action confirmation modal (e.g. “Update to version X”) matches our normal body text size instead of rendering larger.

<img width="590" height="234" alt="Screenshot 2026-06-15 at 6 09 54 PM" src="https://github.com/user-attachments/assets/c6426a78-1934-44db-8201-186443535963" />


## Why are these changes being made?

The confirmation modal is shared Calypso code (`useShowPluginActionDialog`), which renders its description as a bare `<p>` inside a `@wordpress/components` Modal with no font-size rule, so the text inherited an oversized default. Because the modal is shared with classic Calypso and Jetpack Cloud, the fix is scoped to the A4A plugins section only.

The modal portals to `<body>`, which carries the `is-section-a8c-for-agencies-plugins` class (set by `body-section-css-class.js`) only while on A4A's plugins section, so nesting the override under that class limits it to A4A — the same scoping pattern already used in `client/lib/accept/dialog.scss`.

## Testing Instructions

* In the A4A dashboard, go to Plugins → Manage and open a site with a plugin that has an available update.
* Click the “Update to version X” CTA to open the confirmation modal.
* Confirm the description text now matches standard body text size (not enlarged).
* Verify the equivalent modal in classic Calypso (`/plugins`) and Jetpack Cloud is unaffected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

