### PR TITLE
Help Center: fix broken bold in localized greeting

### DIFF
--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -264,7 +264,8 @@ export const getOdieInitialMessage = (
 			/* translators: %(name)s: the user's display name */
 			__( 'Howdy %(name)s', __i18n_text_domain__ ),
 			{
-				name: displayName || 'there',
+				/* translators: fallback used when the user's display name isn't available */
+				name: displayName || __( 'there', __i18n_text_domain__ ),
 			}
 		).trim() } 👋** \n\n ${ introMessage }`,
 		role: 'bot',

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -262,11 +262,11 @@ export const getOdieInitialMessage = (
 	return {
 		content: `**${ sprintf(
 			/* translators: %(name)s: the user's display name */
-			__( 'Howdy %(name)s 👋', __i18n_text_domain__ ),
+			__( 'Howdy %(name)s', __i18n_text_domain__ ),
 			{
 				name: displayName || 'there',
 			}
-		) }** \n\n ${ introMessage }`,
+		).trim() } 👋** \n\n ${ introMessage }`,
 		role: 'bot',
 		type: 'introduction',
 		context: getOdieInitialPromptContext( botNameSlug ),


### PR DESCRIPTION
## What

The Odie Help Center initial greeting renders literal `**` asterisks instead of bold in non-English locales.

<img width="462" height="473" alt="image" src="https://github.com/user-attachments/assets/586d57aa-65e8-4c10-bd90-212e5a5868ef" />

## Why

The greeting wraps the **translatable** string in bold markers:

```ts
`**${ __( 'Howdy %(name)s 👋' ) }** \n\n …`
```

Whether the bold renders depends on the **last character of the translation**, because CommonMark refuses a closing `**` that is preceded by whitespace (right-flanking delimiter rule). The English source ends in the 👋 emoji (non-whitespace), so `**Howdy Emanuele 👋**` renders bold. Translations that drop the emoji or add a trailing space — e.g. Italian `Ciao %(name)s ` — produce `**Ciao Emanuele Buccelli **`, which CommonMark renders as literal asterisks.

## Fix

Move the emoji **out** of the translatable string and `.trim()` the translated greeting, so the character immediately before the closing `**` is always non-whitespace, regardless of how any locale translates the string. This also means translators can no longer accidentally drop or move the emoji.

```ts
`**${ __( 'Howdy %(name)s' ).trim() } 👋** \n\n …`
```

## Notes

- Changing the source string `Howdy %(name)s 👋` → `Howdy %(name)s` invalidates existing GlotPress translations for this string (they'll need re-translation). Intentional tradeoff — the emoji is no longer part of the translatable unit.

## Testing

- [ ] Open the Help Center AI chat in a non-English locale (e.g. `it`) and confirm the greeting name renders **bold**, not `**literal**`.
- [ ] Confirm English still renders bold + emoji correctly.
