### PR TITLE
Notifications: enable notifications/redesign flag in horizon, stage, and production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -89,6 +89,7 @@
 		"migration/ssh-migration": false,
 		"nav-redesign/2026": false,
 		"nav-redesign/2026-variant-2": false,
+		"notifications/redesign": true,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/post-checkout-ai-step": true,

--- a/config/production.json
+++ b/config/production.json
@@ -106,6 +106,7 @@
 		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
+		"notifications/redesign": true,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,6 +104,7 @@
 		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
+		"notifications/redesign": true,
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,
 		"onboarding/import": true,


### PR DESCRIPTION
Related to DOTMSD-1294

## Proposed Changes

* Enable the `notifications/redesign` feature flag in the `horizon`, `stage`, and `production` environment configs.

The flag was already enabled in `development` and `wpcalypso`; this extends the redesigned notifications panel to the remaining environments.

## Why are these changes being made?

The notifications redesign is ready to roll out beyond local/wpcalypso testing. Enabling the flag in horizon, stage, and production makes the redesigned panel the active experience across all environments.

## Testing Instructions

* Open the notifications panel in each environment and confirm the redesigned panel renders.
* Confirm the existing panel behaviors (open, mark read, spam, trash) continue to work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
