### PR TITLE
Revert limiting escalation for Woo AI

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -152,8 +152,7 @@ export default function AgentDock( {
 	// some add a further requirement, noted below. Ordered to match the routes.
 	//
 	// `/zendesk` also needs the unified agent or using Woo AI.
-	const showZendeskChat =
-		( shouldUseUnifiedAgent || sectionName === 'wooai-admin' ) && ! isReaderChat;
+	const showZendeskChat = shouldUseUnifiedAgent && ! isReaderChat;
 	// `/support-guides` (the list) also needs the unified agent, and is only
 	// reachable from the AI chat entry button (WP admin bar or Calypso masterbar).
 	const showSupportGuides = shouldUseUnifiedAgent && ! isReaderChat && hasAiChatEntry;

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -151,9 +151,9 @@ export default function AgentDock( {
 	// Route visibility. All are hidden in reader chat (public blog frontends);
 	// some add a further requirement, noted below. Ordered to match the routes.
 	//
-	// `/zendesk` also needs the unified agent, and `wooai-admin` sites lack the
-	// HVM-tagged routing it relies on.
-	const showZendeskChat = shouldUseUnifiedAgent && ! isReaderChat && sectionName !== 'wooai-admin';
+	// `/zendesk` also needs the unified agent or using Woo AI.
+	const showZendeskChat =
+		( shouldUseUnifiedAgent || sectionName === 'wooai-admin' ) && ! isReaderChat;
 	// `/support-guides` (the list) also needs the unified agent, and is only
 	// reachable from the AI chat entry button (WP admin bar or Calypso masterbar).
 	const showSupportGuides = shouldUseUnifiedAgent && ! isReaderChat && hasAiChatEntry;


### PR DESCRIPTION
⚠️ Do not forget to do `install-plugin.sh am --release` on sandbox after Calypso is being merged

Linear: [WOOAI-608](https://linear.app/a8c/issue/WOOAI-608/)

## Proposed Changes

* Revert limiting having Zendesk Chat for WooCommerce AI plugin

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Recently we thought to limit escalation to Zendesk Chat for non-HVM merchants, but since we plan to pilot with small subset, it's fine to remove that limitation.

## Testing Instructions

* See the original https://github.com/Automattic/wp-calypso/pull/111102;
* Before and after should be the opposite: before should miss "New Zendesk Chat", after should have it.

## Mini demo

https://github.com/user-attachments/assets/3841d048-3bb8-4959-b044-4f5e8e2314c3

Even though the video shows Zendesk sandbox, it should work well for the production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
