### PR TITLE
Domains: prevent default DNS record warnings from flashing while loading

### DIFF
--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -89,7 +89,7 @@ export default function DomainDns() {
 	} );
 
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: dnsData, isLoading } = useQuery( domainDnsQuery( domainName ) );
+	const { data: dnsData, isLoading, isFetching } = useQuery( domainDnsQuery( domainName ) );
 	const [ isRestoreDefaultARecordsDialogOpen, setIsRestoreDefaultARecordsDialogOpen ] =
 		useState( false );
 	const [ isRestoreDefaultCnameRecordDialogOpen, setIsRestoreDefaultCnameRecordDialogOpen ] =
@@ -220,11 +220,14 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultARecordsNotice = () => {
-		// While the DNS query is still doing its initial load, `dnsData` is undefined
-		// and the "has default record" checks run against an empty array, which would
-		// momentarily render the warning even when the record actually exists. Wait
-		// until the records have loaded before deciding whether to show it.
-		if ( isLoading || ! domain.has_wpcom_nameservers || hasDefaultARecordsValue ) {
+		// Only judge whether the default records are missing once we have records we
+		// trust. The route loader prefetches the DNS query, so by the time this
+		// component mounts the cache often already holds (possibly stale) records and
+		// `isLoading` is false; a background refetch then runs because of `staleTime: 0`.
+		// Gating on `isFetching` — which is true during both the initial load and any
+		// background revalidation — prevents the warning from flashing against stale or
+		// not-yet-loaded data, matching the legacy "hide while requesting" behavior.
+		if ( isFetching || ! domain.has_wpcom_nameservers || hasDefaultARecordsValue ) {
 			return null;
 		}
 
@@ -257,7 +260,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultCnameRecordNotice = () => {
-		if ( isLoading || ! domain.has_wpcom_nameservers || hasDefaultCnameRecordValue ) {
+		if ( isFetching || ! domain.has_wpcom_nameservers || hasDefaultCnameRecordValue ) {
 			return null;
 		}
 

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -220,7 +220,11 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultARecordsNotice = () => {
-		if ( ! domain.has_wpcom_nameservers || hasDefaultARecordsValue ) {
+		// While the DNS query is still doing its initial load, `dnsData` is undefined
+		// and the "has default record" checks run against an empty array, which would
+		// momentarily render the warning even when the record actually exists. Wait
+		// until the records have loaded before deciding whether to show it.
+		if ( isLoading || ! domain.has_wpcom_nameservers || hasDefaultARecordsValue ) {
 			return null;
 		}
 
@@ -253,7 +257,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultCnameRecordNotice = () => {
-		if ( ! domain.has_wpcom_nameservers || hasDefaultCnameRecordValue ) {
+		if ( isLoading || ! domain.has_wpcom_nameservers || hasDefaultCnameRecordValue ) {
 			return null;
 		}
 

--- a/client/dashboard/domains/domain-dns/test/index.test.tsx
+++ b/client/dashboard/domains/domain-dns/test/index.test.tsx
@@ -2,12 +2,15 @@
  * @jest-environment jsdom
  */
 import { DomainSubtype, type Domain, type DnsRecord } from '@automattic/api-core';
+import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainDns from '../index';
 
 const domainName = 'example.com';
+
+const dnsQueryKey = [ 'domains', domainName, 'dns' ];
 
 const CNAME_WARNING = 'Your domain is not using the default WWW CNAME record';
 
@@ -77,6 +80,32 @@ describe( 'DomainDns', () => {
 		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
 
 		// Once the DNS records load, the warning still must not appear.
+		expect( await screen.findByText( 'CNAME' ) ).toBeInTheDocument();
+		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not flash the WWW CNAME warning when the route loader seeded stale records', async () => {
+		mockDomainApiRequest( getDefaultDomainData( { has_wpcom_nameservers: true } ) );
+
+		// In production the route loader prefetches the DNS query via
+		// `ensureQueryData`, so the cache already holds records (possibly stale) when
+		// the component mounts and `isLoading` is false. With `staleTime: 0` a
+		// background refetch then runs. Seed the cache with stale records that lack
+		// the default WWW CNAME record to mirror that scenario.
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false, staleTime: 0 } },
+		} );
+		queryClient.setQueryData( dnsQueryKey, { records: [] } );
+
+		// The server actually has the default WWW CNAME record, so the warning must
+		// never appear — not even while the background refetch is in flight.
+		mockDnsApiRequest( [ defaultCnameRecord ], { delayMs: 200 } );
+
+		render( <DomainDns />, { queryClient } );
+
+		await screen.findByText( 'Add record' );
+		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
+
 		expect( await screen.findByText( 'CNAME' ) ).toBeInTheDocument();
 		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
 	} );

--- a/client/dashboard/domains/domain-dns/test/index.test.tsx
+++ b/client/dashboard/domains/domain-dns/test/index.test.tsx
@@ -40,13 +40,24 @@ const mockDomainApiRequest = ( domainData: Domain ) =>
 		.get( `/rest/v1.2/domain-details/${ domainName }` )
 		.reply( 200, domainData );
 
-const mockDnsApiRequest = ( records: DnsRecord[], { delayMs = 0 }: { delayMs?: number } = {} ) =>
+const mockDnsApiRequest = ( records: DnsRecord[] ) =>
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/domains/${ domainName }/dns` )
-		.delay( delayMs )
 		.reply( 200, { records } );
 
-afterEach( () => nock.cleanAll() );
+// Mocks the DNS request but holds the response pending until the returned
+// `release` callback is invoked, letting tests assert on the in-flight state
+// without relying on `nock.delay()` (which leaves open handles).
+const mockDnsApiRequestPending = ( records: DnsRecord[] ) => {
+	let release!: () => void;
+	const pending = new Promise< void >( ( resolve ) => {
+		release = resolve;
+	} );
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/domains/${ domainName }/dns` )
+		.reply( 200, () => pending.then( () => ( { records } ) ) );
+	return release;
+};
 
 describe( 'DomainDns', () => {
 	test( 'shows EmailSetup when domain has WordPress.com nameservers', async () => {
@@ -54,7 +65,7 @@ describe( 'DomainDns', () => {
 
 		render( <DomainDns /> );
 
-		expect( await screen.findByText( 'Email setup' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Email setup' ) ).toBeVisible();
 	} );
 
 	test( 'hides EmailSetup when domain does not have WordPress.com nameservers', async () => {
@@ -62,7 +73,7 @@ describe( 'DomainDns', () => {
 
 		render( <DomainDns /> );
 
-		expect( await screen.findByText( 'Add record' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Add record' ) ).toBeVisible();
 		expect( screen.queryByText( 'Email setup' ) ).not.toBeInTheDocument();
 	} );
 
@@ -70,7 +81,7 @@ describe( 'DomainDns', () => {
 		mockDomainApiRequest( getDefaultDomainData( { has_wpcom_nameservers: true } ) );
 		// The domain already has the default WWW CNAME record, so the warning must
 		// never appear — not even during the window where the DNS query is loading.
-		mockDnsApiRequest( [ defaultCnameRecord ], { delayMs: 200 } );
+		const release = mockDnsApiRequestPending( [ defaultCnameRecord ] );
 
 		render( <DomainDns /> );
 
@@ -80,7 +91,8 @@ describe( 'DomainDns', () => {
 		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
 
 		// Once the DNS records load, the warning still must not appear.
-		expect( await screen.findByText( 'CNAME' ) ).toBeInTheDocument();
+		release();
+		expect( await screen.findByText( 'CNAME' ) ).toBeVisible();
 		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
 	} );
 
@@ -98,15 +110,17 @@ describe( 'DomainDns', () => {
 		queryClient.setQueryData( dnsQueryKey, { records: [] } );
 
 		// The server actually has the default WWW CNAME record, so the warning must
-		// never appear — not even while the background refetch is in flight.
-		mockDnsApiRequest( [ defaultCnameRecord ], { delayMs: 200 } );
+		// never appear — not even while the background refetch is in flight over the
+		// stale records.
+		const release = mockDnsApiRequestPending( [ defaultCnameRecord ] );
 
 		render( <DomainDns />, { queryClient } );
 
 		await screen.findByText( 'Add record' );
 		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
 
-		expect( await screen.findByText( 'CNAME' ) ).toBeInTheDocument();
+		release();
+		expect( await screen.findByText( 'CNAME' ) ).toBeVisible();
 		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
 	} );
 
@@ -117,6 +131,6 @@ describe( 'DomainDns', () => {
 
 		render( <DomainDns /> );
 
-		expect( await screen.findByText( CNAME_WARNING ) ).toBeInTheDocument();
+		expect( await screen.findByText( CNAME_WARNING ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/domains/domain-dns/test/index.test.tsx
+++ b/client/dashboard/domains/domain-dns/test/index.test.tsx
@@ -1,13 +1,21 @@
 /**
  * @jest-environment jsdom
  */
-import { DomainSubtype, type Domain } from '@automattic/api-core';
+import { DomainSubtype, type Domain, type DnsRecord } from '@automattic/api-core';
 import { screen } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainDns from '../index';
 
 const domainName = 'example.com';
+
+const CNAME_WARNING = 'Your domain is not using the default WWW CNAME record';
+
+const defaultCnameRecord: DnsRecord = {
+	type: 'CNAME',
+	name: 'www',
+	data: `${ domainName }.`,
+};
 
 jest.mock( '../../../app/router/domains', () => ( {
 	...jest.requireActual( '../../../app/router/domains' ),
@@ -29,6 +37,12 @@ const mockDomainApiRequest = ( domainData: Domain ) =>
 		.get( `/rest/v1.2/domain-details/${ domainName }` )
 		.reply( 200, domainData );
 
+const mockDnsApiRequest = ( records: DnsRecord[], { delayMs = 0 }: { delayMs?: number } = {} ) =>
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/domains/${ domainName }/dns` )
+		.delay( delayMs )
+		.reply( 200, { records } );
+
 afterEach( () => nock.cleanAll() );
 
 describe( 'DomainDns', () => {
@@ -47,5 +61,33 @@ describe( 'DomainDns', () => {
 
 		expect( await screen.findByText( 'Add record' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Email setup' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not flash the WWW CNAME warning while DNS records are still loading', async () => {
+		mockDomainApiRequest( getDefaultDomainData( { has_wpcom_nameservers: true } ) );
+		// The domain already has the default WWW CNAME record, so the warning must
+		// never appear — not even during the window where the DNS query is loading.
+		mockDnsApiRequest( [ defaultCnameRecord ], { delayMs: 200 } );
+
+		render( <DomainDns /> );
+
+		// The page chrome renders once the domain (suspense) query resolves, but the
+		// DNS query is still in flight at this point.
+		await screen.findByText( 'Add record' );
+		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
+
+		// Once the DNS records load, the warning still must not appear.
+		expect( await screen.findByText( 'CNAME' ) ).toBeInTheDocument();
+		expect( screen.queryByText( CNAME_WARNING ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the WWW CNAME warning when the default record is missing', async () => {
+		mockDomainApiRequest( getDefaultDomainData( { has_wpcom_nameservers: true } ) );
+		// No default WWW CNAME record present, so the warning is expected after load.
+		mockDnsApiRequest( [ { type: 'A', name: domainName, data: '192.0.2.1' } ] );
+
+		render( <DomainDns /> );
+
+		expect( await screen.findByText( CNAME_WARNING ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes DOTMSD-1293

## Proposed Changes

* On the Dashboard DNS management page, gate the "default A records" and "default WWW CNAME record" warning notices on the DNS query's `isFetching` state so they only render once the records have actually loaded and are not being revalidated.

## Why are these changes being made?

The notices decide whether the default records are missing by checking `dnsData?.records ?? []`. When that data is empty or stale, the checks conclude the records are missing and render the warning — causing it to flash abruptly (e.g. when returning to the page or after editing a record), as reported in DOTMSD-1293.

The first attempt gated on `isLoading`, but that never engages on the Dashboard. The DNS route loader prefetches the query via `ensureQueryData` (and `defaultPreload: 'intent'` warms it on hover), so by the time the component mounts the cache already holds records and `isLoading` is `false`. With `staleTime: 0` a background refetch then runs, and while it is in flight the component renders the previously cached (possibly stale) records and briefly shows the warning before the fresh records arrive.

`isFetching` is `true` during both the initial load and any background revalidation, so gating on it suppresses the warning until we have records we trust. This mirrors the legacy `my-sites` behavior, which hid the notices while a request was in flight (`!hasLoadedFromServer || isRequestingDomains`). `isLoading` is kept for the DataViews skeleton, which should only appear on the initial load.

## Testing Instructions

* Have a domain that uses WordPress.com nameservers and **has** the default WWW CNAME record.
* Go to the Dashboard domain DNS management page.
* Edit a DNS record and cancel (or reload the page) and confirm the "Your domain is not using the default WWW CNAME record" warning no longer flashes.
* Confirm that for a domain genuinely missing the default record, the warning still appears after the records load.
* Automated coverage in `client/dashboard/domains/domain-dns/test/index.test.tsx`, including a regression test that seeds the query cache before rendering (as the route loader does) and asserts the warning never flashes during the background refetch.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
