### PR TITLE
Domains: add breadcrumbs to the Transfer page

### DIFF
--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -3,6 +3,7 @@ import { domainQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -23,6 +24,7 @@ export default function DomainTransfer() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Transfer' ) }
 					description={
 						! isNewInboundTransferExperience


### PR DESCRIPTION
Fixes DOTMSD-1292

## Proposed Changes

* Add the standard `<Breadcrumbs length={ 2 } />` prefix to the `PageHeader` of the Dashboard domain **Transfer** page.

## Why are these changes being made?

The Transfer page was the only domain management sub-page without breadcrumbs. Every other sub-page (DNS, Security, Forwarding, Glue records, Contact details, Name servers, etc.) renders breadcrumbs that let the user navigate back to the main domain management screen. On the Transfer page the user had no in-app way back short of the browser Back button.

The transfer route already defines a `Transfer` meta title, so adding the breadcrumb prefix is all that's needed for the crumb to render correctly.

## Testing Instructions

* Open the Dashboard for a domain and go to its **Transfer** page.
* Confirm breadcrumbs now appear in the header (e.g. `<domain name> / Transfer`) and that clicking the domain name navigates back to the main domain management screen.
* Confirm the other domain sub-pages are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
