### PR TITLE
Notifications: dark mode support for the redesigned panel

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -13,7 +13,7 @@
 		}
 
 		.dataviews-view-list__item-wrapper {
-			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 16%, var(--color-surface));
+			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 10%, var(--color-surface));
 			box-shadow: inset 3px 0 0
 				color-mix(in srgb, var(--wp-admin-theme-color) 72%, transparent);
 		}
@@ -22,7 +22,7 @@
 	div[role="article"]:where(.is-hovered):has(.is-unread),
 	div[role="article"]:where(.is-hovered):has(.is-unread):focus-within {
 		.dataviews-view-list__item-wrapper {
-			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 22%, var(--color-surface));
+			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 16%, var(--color-surface));
 		}
 	}
 }
@@ -41,7 +41,7 @@
 		}
 
 		.dataviews-view-list__item-wrapper {
-			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 20%, var(--color-surface));
+			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 24%, var(--color-surface));
 			box-shadow: inset 3px 0 0 var(--wp-admin-theme-color);
 		}
 	}
@@ -96,6 +96,13 @@
 	@include ui-mixins.when-dark-theme {
 		@include dark-unread-note-list-item;
 		@include dark-selected-note-list-item;
+
+		// $gray-700 (#757575) is a light-mode literal — it fails WCAG AA on the
+		// dark surface and the accent tints (~1.8–2.7:1). Use a light muted that
+		// clears 4.5:1 on every row state, including the stronger selected tint.
+		div[role="article"] .dataviews-view-list__item-wrapper .dataviews-view-list__fields {
+			color: #c2c5cc;
+		}
 	}
 
 	// We override the media field

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -1,3 +1,4 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/mixins';
@@ -101,7 +102,7 @@
 		&:has(.wpnc__button) {
 			margin: 0 -#{$grid-unit-20};
 			padding: 16px;
-			border-top: 1px solid $gray-100;
+			border-top: 1px solid var( --wpnc-divider__color, #{$gray-100} );
 		}
 	}
 
@@ -134,7 +135,7 @@
 
 	.wpnc__hr-separator {
 		border: none;
-		border-top: 1px solid $gray-100;
+		border-top: 1px solid var( --wpnc-divider__color, #{$gray-100} );
 	}
 
 	// Links
@@ -166,10 +167,10 @@
 	blockquote {
 		padding: 0 $grid-unit-20;
 		margin: 0 0 $grid-unit-20 0;
-		box-shadow: inset 3px 0 0 #f0f0f0;
+		box-shadow: inset 3px 0 0 var( --wpnc-quote__border-color, #f0f0f0 );
 		font-weight: 400;
 		font-style: italic;
-		color: #646970;
+		color: var( --wpnc-quote__text-color, #646970 );
 		background: transparent;
 	}
 
@@ -260,7 +261,7 @@
  */
 .wpnc__note.wpnc__comment .wpnc__body .wpnc__body-content {
 	padding: 0 0 0 $grid-unit-20;
-	box-shadow: inset 3px 0 0 #f0f0f0;
+	box-shadow: inset 3px 0 0 var( --wpnc-quote__border-color, #f0f0f0 );
 
 	.wpnc__user {
 		padding: 0 0 $grid-unit-20 0;
@@ -275,7 +276,7 @@
 .wpnc__note.wpnc__follow .wpnc__body .wpnc__body-content {
 	.wpnc__user {
 		padding: 12px 0;
-		border-bottom: 1px solid $gray-100;
+		border-bottom: 1px solid var( --wpnc-divider__color, #{$gray-100} );
 
 		&:first-child {
 			padding-top: 0;
@@ -301,7 +302,7 @@
  * Reply
  */
 .wpnc__reply {
-	color: #646970;
+	color: var( --wpnc-quote__text-color, #646970 );
 
 	.wpnc__gridicon {
 		fill: currentColor;
@@ -310,5 +311,32 @@
 	a {
 		font-weight: 600;
 		color: inherit;
+	}
+}
+
+// Dark mode: the detail-pane literals above (quote bars/text, dividers) ship
+// light-mode values that don't adapt. Point their tokens at dashboard colors —
+// readable muted quote text (passes AA on the overlay panel), a neutral quote
+// bar, and the gray-400 divider used across the dark overlays (Help Center).
+.wpnc-app {
+	@include ui-mixins.when-dark-theme {
+		--wpnc-quote__border-color: var( --wp-components-color-gray-600, #758095 );
+		--wpnc-quote__text-color: var( --wp-components-color-gray-700, #9aa2b1 );
+		--wpnc-divider__color: var( --wp-components-color-gray-400, #424855 );
+
+		// Two frame-level dividers miss the dashboard's border handling:
+		//   - the action-block CardFooter (above Like/Reply) — the dark card
+		//     mixin themes card header/divider but not the footer, so its
+		//     border falls back to a near-invisible rgba(0,0,0,0.1).
+		//   - the list/detail pane separator — $wpnc-pane-border.
+		// Route both to the same gray-400 divider as the rest of the panel.
+		.components-card__footer {
+			border-top-color: var( --wpnc-divider__color );
+		}
+
+		.wpnc-app__list-pane,
+		.wpnc-app__detail-pane {
+			border-color: var( --wpnc-divider__color );
+		}
 	}
 }

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -92,6 +92,11 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 	flex-direction: column;
 	overflow: hidden;
 	background: var(--color-surface, #fff);
+	// DataViews paints its wrapper with --wp-dataviews-color-background, which
+	// falls back to a --wpds surface token (the dark canvas in the dashboard).
+	// That shows through the transparent rows as a darker block. Track the pane
+	// surface so the list sits flush with the panel.
+	--wp-dataviews-color-background: var(--color-surface, #fff);
 	transition: transform 300ms $wpnc-slide-easing;
 }
 


### PR DESCRIPTION
Part of the MSD dark mode follow-up. Linear: DOTMSD-1296. Pairs with #111689 (dashboard dark mode), but stands alone.

## Proposed Changes

Fix dark-mode rendering in the new `apps/notifications` panel (the redesign app). It hardcoded light-mode color literals and missed a few surfaces.

- Detail pane: quote text is now readable (WCAG AA) with a visible quote bar. The action-block (`CardFooter`), the `hr` separator, and the list/detail pane separator all use one divider color.
- List: rows track the panel surface instead of the dark canvas — the DataViews wrapper fell back to a `--wpds` surface token.
- List items: clearer separation between unread and selected (unread tint reduced, selected increased), and the excerpt/meta text now clears AA contrast on every row state.

## Why are these changes being made?

The redesigned notifications panel ships hardcoded light-mode values (`#757575`, `#f0f0f0`, `$gray-100`) that do not adapt to dark mode, so text failed contrast and dividers/backgrounds read wrong on a dark panel. This makes the panel render correctly in dark mode.

## Testing Instructions

1. Open the dashboard at `/sites`, set the color scheme to Dark, and open the notifications bell.
2. List: read rows sit flush with the panel (no dark blocks). Unread and selected rows are clearly different. Excerpt/meta text is readable.
3. Open a notification: quote text is readable, the quote bar is visible, and the divider above Like and the list/detail separator are consistent.

## Pre-merge Checklist

- [x] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? (Excerpt/meta text now clears WCAG AA 4.5:1 on read, unread, and selected rows.)
- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
