### PR TITLE
Remove lodash startsWith/trim/last/flatten in favor of native JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -580,6 +580,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/extend-own': 'error',
 		'you-dont-need-lodash-underscore/fill': 'error',
 		'you-dont-need-lodash-underscore/first': 'error',
+		'you-dont-need-lodash-underscore/flatten': 'error',
 		'you-dont-need-lodash-underscore/foldl': 'error',
 		'you-dont-need-lodash-underscore/foldr': 'error',
 		'you-dont-need-lodash-underscore/index-of': 'error',
@@ -594,6 +595,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-string': 'error',
 		'you-dont-need-lodash-underscore/is-undefined': 'error',
 		'you-dont-need-lodash-underscore/join': 'error',
+		'you-dont-need-lodash-underscore/last': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',
 		'you-dont-need-lodash-underscore/pad-end': 'error',
 		'you-dont-need-lodash-underscore/pad-start': 'error',
@@ -604,10 +606,12 @@ module.exports = {
 		'you-dont-need-lodash-underscore/select': 'error',
 		'you-dont-need-lodash-underscore/slice': 'error',
 		'you-dont-need-lodash-underscore/split': 'error',
+		'you-dont-need-lodash-underscore/starts-with': 'error',
 		'you-dont-need-lodash-underscore/take-right': 'error',
 		'you-dont-need-lodash-underscore/to-lower': 'error',
 		'you-dont-need-lodash-underscore/to-pairs': 'error',
 		'you-dont-need-lodash-underscore/to-upper': 'error',
+		'you-dont-need-lodash-underscore/trim': 'error',
 		'you-dont-need-lodash-underscore/uniq': 'error',
 
 		// @TODO remove these lines once we fixed the warnings so

--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -157,7 +157,7 @@ function processNumberFormat( format ) {
 		match: format[ numberFormatIndexes.PATTERN ],
 		replace: format[ numberFormatIndexes.FORMAT ],
 		nationalFormat: format[ numberFormatIndexes.NATIONAL_CALLING_FORMAT ] || undefined,
-		leadingDigitPattern: _.last( format[ numberFormatIndexes.LEADING_DIGIT_PATTERN ] || [] ),
+		leadingDigitPattern: ( format[ numberFormatIndexes.LEADING_DIGIT_PATTERN ] || [] ).at( -1 ),
 	};
 }
 

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -47,7 +47,7 @@ function getPathForCommand( command ) {
 	 * @see printPhpcsDocs
 	 */
 	const path_to_command = path.join( __dirname, '..', 'vendor', 'bin', command );
-	return _.trim( path_to_command );
+	return path_to_command.trim();
 }
 function linterFailure() {
 	console.log(

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { map, get, last, uniqBy, size, filter, compact } from 'lodash';
+import { map, get, uniqBy, size, filter, compact } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { isAncestor } from 'calypso/blocks/comments/utils';
@@ -77,7 +77,7 @@ class ConversationCaterpillarComponent extends Component {
 		// Only display each author once
 		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'avatar_URL' );
 		const uniqueAuthorsCount = size( uniqueAuthors );
-		const lastAuthorName = get( last( uniqueAuthors ), 'name' );
+		const lastAuthorName = get( uniqueAuthors.at( -1 ), 'name' );
 
 		return (
 			<div className="conversation-caterpillar">

--- a/client/blocks/get-apps/apps-badge.tsx
+++ b/client/blocks/get-apps/apps-badge.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { startsWith } from 'lodash';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
@@ -83,7 +82,7 @@ export class AppsBadge extends PureComponent< AppsBadgeProps, AppsBadgeState > {
 		super( props );
 
 		const localeSlug = APP_STORE_BADGE_URLS[ props.storeName ].getLocaleSlug().toLowerCase();
-		const shouldLoadExternalImage = ! startsWith( localeSlug, 'en' );
+		const shouldLoadExternalImage = ! localeSlug.startsWith( 'en' );
 
 		this.state = {
 			imageSrc: shouldLoadExternalImage
@@ -94,7 +93,7 @@ export class AppsBadge extends PureComponent< AppsBadgeProps, AppsBadgeState > {
 
 	componentDidMount(): void {
 		const localeSlug = APP_STORE_BADGE_URLS[ this.props.storeName ].getLocaleSlug().toLowerCase();
-		const shouldLoadExternalImage = ! startsWith( localeSlug, 'en' );
+		const shouldLoadExternalImage = ! localeSlug.startsWith( 'en' );
 
 		// Kick off the external image load in the commit phase rather than the
 		// constructor, which React can run multiple times (or discard) before a

--- a/client/blocks/keyring-connect-button/index.jsx
+++ b/client/blocks/keyring-connect-button/index.jsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import requestExternalAccess from '@automattic/request-external-access';
 import { localize } from 'i18n-calypso';
-import { find, last, some } from 'lodash';
+import { find, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -85,7 +85,7 @@ class KeyringConnectButton extends Component {
 		// Depending on current status, perform an action when user clicks the
 		// service action button
 		if ( 'connected' === connectionStatus && ! forceReconnect ) {
-			this.props.onConnect( last( keyringConnections ) );
+			this.props.onConnect( keyringConnections.at( -1 ) );
 		} else {
 			this.addConnection();
 		}

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { trim, escapeRegExp } from 'lodash';
+import { escapeRegExp } from 'lodash';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -89,10 +89,11 @@ const chooseExcerpt = ( post ) => {
 		// Remove … from short_excerpt
 		const short_excerpt = post.short_excerpt.replaceAll( '…', '' );
 		// Remove any non-alphanumeric chars to avoid string comparison issues, then trim
-		const short_excerpt_chars = trim( short_excerpt.replace( /\W/g, '' ) );
-		const custom_excerpt_chars = trim(
-			post.excerpt.substring( 0, short_excerpt.length ).replace( /\W/g, '' )
-		);
+		const short_excerpt_chars = short_excerpt.replace( /\W/g, '' ).trim();
+		const custom_excerpt_chars = post.excerpt
+			.substring( 0, short_excerpt.length )
+			.replace( /\W/g, '' )
+			.trim();
 
 		if ( short_excerpt_chars !== custom_excerpt_chars ) {
 			// In this case, the post excerpt is different to the short excerpt (which is a shortened version of the better_excerpt)

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -4,7 +4,7 @@ import { Gridicon, EmbedContainer } from '@automattic/components';
 import { isDefaultLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { get, startsWith, pickBy } from 'lodash';
+import { get, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component, useMemo } from 'react';
 import { connect } from 'react-redux';
@@ -502,7 +502,7 @@ export class FullPostView extends Component {
 	 * @returns {number} - the commentId in the url of the form #comment-${id}
 	 */
 	getCommentIdFromUrl = () =>
-		startsWith( window.location.hash, '#comment-' )
+		window.location.hash.startsWith( '#comment-' )
 			? +window.location.hash.split( '-' )[ 1 ]
 			: undefined;
 

--- a/client/components/line-chart/index.jsx
+++ b/client/components/line-chart/index.jsx
@@ -4,7 +4,7 @@ import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
 import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } from 'd3-shape';
-import { concat, last, throttle } from 'lodash';
+import { concat, throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import D3Base from 'calypso/components/d3-base';
@@ -183,7 +183,7 @@ class LineChart extends Component {
 			const drawFullSeries = dataSeries.length < POINTS_MAX;
 			const colorNum = dataSeriesIndex % NUM_SERIES;
 
-			( drawFullSeries ? dataSeries : [ dataSeries[ 0 ], last( dataSeries ) ] ).forEach(
+			( drawFullSeries ? dataSeries : [ dataSeries[ 0 ], dataSeries.at( -1 ) ] ).forEach(
 				( datum ) => {
 					svg
 						.append( 'circle' )

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -1,6 +1,5 @@
 import { getLanguage, addLocaleToPath } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
-import startsWith from 'lodash/startsWith';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -75,7 +74,7 @@ export class LocaleSuggestions extends Component {
 		}
 
 		const usersOtherLocales = localeSuggestions.filter( function ( locale ) {
-			return ! startsWith( getLocaleSlug(), locale.locale );
+			return ! ( getLocaleSlug() ?? '' ).startsWith( locale.locale );
 		} );
 
 		if ( usersOtherLocales.length === 0 ) {

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -33,7 +33,6 @@ import {
 	camelCase,
 	flowRight as compose,
 	get,
-	last,
 	map,
 	mapKeys,
 	mapValues,
@@ -71,7 +70,7 @@ export const nativeToRaw = compose(
 		reduce(
 			list,
 			( format, piece ) => {
-				const lastPiece = last( format );
+				const lastPiece = format.at( -1 );
 
 				if ( lastPiece && 'string' === lastPiece.type && 'string' === piece.type ) {
 					return [ ...format.slice( 0, -1 ), mergeStringPieces( lastPiece, piece ) ];

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,4 +1,4 @@
-import { get, keys, last, map, omit, reduce } from 'lodash';
+import { get, keys, map, omit, reduce } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
@@ -52,7 +52,7 @@ class SortedGrid extends PureComponent {
 								text={ this.props.getGroupLabel( group ) }
 								itemsCount={ count }
 								itemsPerRow={ this.props.itemsPerRow }
-								lastInRow={ last( keys( row.groups ) ) === group }
+								lastInRow={ keys( row.groups ).at( -1 ) === group }
 								scale={ this.props.scale }
 							/>
 						)

--- a/client/components/translator-invite/utils.js
+++ b/client/components/translator-invite/utils.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { getLanguage, getLocaleFromPath } from '@automattic/i18n-utils';
-import { startsWith } from 'lodash';
 
 /**
  * Module variables
@@ -15,7 +14,7 @@ const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
  * @returns {boolean} The locale slug of the language, if any found.
  */
 export function isDefaultLocale( locale ) {
-	return startsWith( locale, defaultLanguageSlug );
+	return ( locale ?? '' ).startsWith( defaultLanguageSlug );
 }
 
 /**

--- a/client/jetpack-connect/authorize.jsx
+++ b/client/jetpack-connect/authorize.jsx
@@ -11,7 +11,7 @@ import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { flowRight, get, includes, startsWith } from 'lodash';
+import { flowRight, get, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -387,12 +387,12 @@ export class JetpackAuthorize extends Component {
 
 	isFromJpo( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jpo' );
+		return ( from ?? '' ).startsWith( 'jpo' );
 	}
 
 	isFromJetpackBoost( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-boost' );
+		return ( from ?? '' ).startsWith( 'jetpack-boost' );
 	}
 
 	isFromBlockEditor( props = this.props ) {
@@ -427,32 +427,32 @@ export class JetpackAuthorize extends Component {
 
 	isFromJetpackConnectionManager( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'connection-ui' );
+		return ( from ?? '' ).startsWith( 'connection-ui' );
 	}
 
 	isFromJetpackBackupPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-backup' );
+		return ( from ?? '' ).startsWith( 'jetpack-backup' );
 	}
 
 	isFromJetpackSearchPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-search' );
+		return ( from ?? '' ).startsWith( 'jetpack-search' );
 	}
 
 	isFromJetpackSocialPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-social' );
+		return ( from ?? '' ).startsWith( 'jetpack-social' );
 	}
 
 	isFromJetpackVideoPressPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-videopress' );
+		return ( from ?? '' ).startsWith( 'jetpack-videopress' );
 	}
 
 	isFromMyJetpack( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'my-jetpack' );
+		return ( from ?? '' ).startsWith( 'my-jetpack' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {
@@ -487,22 +487,22 @@ export class JetpackAuthorize extends Component {
 
 	isJetpackPartnerCoupon( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-partner-coupon' );
+		return ( from ?? '' ).startsWith( 'jetpack-partner-coupon' );
 	}
 
 	isFromMigrationPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'wpcom-migration' );
+		return ( from ?? '' ).startsWith( 'wpcom-migration' );
 	}
 
 	isFromAutomatticForAgenciesPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'automattic-for-agencies-client' );
+		return ( from ?? '' ).startsWith( 'automattic-for-agencies-client' );
 	}
 
 	isFromBlazeAdsPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'blaze-ads' );
+		return ( from ?? '' ).startsWith( 'blaze-ads' );
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {
@@ -513,7 +513,7 @@ export class JetpackAuthorize extends Component {
 
 	isFromMyJetpackConnectAfterCheckout( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'connect-after-checkout' );
+		return ( from ?? '' ).startsWith( 'connect-after-checkout' );
 	}
 
 	isFromJetpackOnboarding( props = this.props ) {

--- a/client/jetpack-connect/controller.jsx
+++ b/client/jetpack-connect/controller.jsx
@@ -25,7 +25,7 @@ import page from '@automattic/calypso-router';
 import { getLocaleFromPath, removeLocaleFromPath } from '@automattic/i18n-utils';
 import { JETPACK_PRICING_PAGE } from '@automattic/urls';
 import Debug from 'debug';
-import { get, some, startsWith } from 'lodash';
+import { get, some } from 'lodash';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { navigate } from 'calypso/lib/navigate';
 import { login } from 'calypso/lib/paths';
@@ -390,7 +390,7 @@ export function signupForm( context, next ) {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 	const { query } = context;
 	const from = query.from;
-	if ( from && startsWith( from, 'wpcom-migration' ) ) {
+	if ( from && from.startsWith( 'wpcom-migration' ) ) {
 		const urlQueryArgs = {
 			redirect_to: context.path,
 			from,

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -3,7 +3,6 @@ import {
 	camelCase,
 	debounce,
 	filter,
-	flatten,
 	isEmpty,
 	map,
 	mapValues,
@@ -315,7 +314,7 @@ function getInvalidFields( formState ) {
 function getErrorMessages( formState ) {
 	const invalidFields = getInvalidFields( formState );
 
-	return flatten( map( invalidFields, 'errors' ) );
+	return map( invalidFields, 'errors' ).flat();
 }
 
 function isSubmitButtonDisabled( formState ) {

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { startsWith } from 'lodash';
 import {
 	getLanguageFilePathUrl,
 	getLanguageFileUrl,
@@ -39,7 +38,7 @@ describe( 'getLanguageFileUrl()', () => {
 			hasMockedWindow = true;
 		}
 
-		expect( startsWith( getLanguageFileUrl( 'ja' ), '//' ) ).toBe( true );
+		expect( getLanguageFileUrl( 'ja' ).startsWith( '//' ) ).toBe( true );
 
 		if ( hasMockedWindow ) {
 			global.window = null;

--- a/client/lib/importer/url-validation.js
+++ b/client/lib/importer/url-validation.js
@@ -1,8 +1,7 @@
 import { translate } from 'i18n-calypso';
-import { trim } from 'lodash';
 
 export const parseUrl = function ( value = '' ) {
-	const rawUrl = trim( value );
+	const rawUrl = value.trim();
 	const hasProtocol = value.startsWith( 'https://' ) || value.startsWith( 'http://' );
 
 	return new URL( hasProtocol ? rawUrl : 'https://' + rawUrl );

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { addLocaleToPath, isDefaultLocale } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
-import { get, includes, startsWith } from 'lodash';
+import { get, includes } from 'lodash';
 import {
 	isAkismetOAuth2Client,
 	isCrowdsignalOAuth2Client,
@@ -56,7 +56,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 
 	if (
 		// Match locales like `/log-in/jetpack/es`
-		startsWith( currentRoute, '/log-in/jetpack' )
+		( currentRoute ?? '' ).startsWith( '/log-in/jetpack' )
 	) {
 		// Basic validation that we're in a valid Jetpack Authorization flow
 		if (

--- a/client/lib/media/utils/is-exceeding-site-max-upload-size.js
+++ b/client/lib/media/utils/is-exceeding-site-max-upload-size.js
@@ -1,4 +1,4 @@
-import { includes, startsWith, get } from 'lodash';
+import { includes, get } from 'lodash';
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
 
 /**
@@ -24,7 +24,7 @@ export function isExceedingSiteMaxUploadSize( item, site ) {
 	if (
 		site.jetpack &&
 		includes( get( site, 'options.active_modules' ), 'videopress' ) &&
-		startsWith( getMimeType( item ), 'video/' )
+		( getMimeType( item ) ?? '' ).startsWith( 'video/' )
 	) {
 		return null;
 	}

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -1,4 +1,4 @@
-import { filter, get, maxBy, startsWith } from 'lodash';
+import { filter, get, maxBy } from 'lodash';
 import { getSections } from 'calypso/sections-helper';
 
 export default function pathToSection( path ) {
@@ -6,20 +6,20 @@ export default function pathToSection( path ) {
 	const bestMatch = maxBy( getSections(), ( section ) =>
 		Math.max(
 			...section.paths.map( ( sectionPath ) =>
-				startsWith( path, sectionPath ) ? sectionPath.length : 0
+				( path ?? '' ).startsWith( sectionPath ) ? sectionPath.length : 0
 			)
 		)
 	);
 
 	// sort out special case we don't want to match: matching on '/' but path isn't exactly '/'
 	const matchingPaths = filter( bestMatch.paths, ( sectionPath ) =>
-		startsWith( path, sectionPath )
+		( path ?? '' ).startsWith( sectionPath )
 	);
 	if ( matchingPaths.length === 1 && matchingPaths[ 0 ] === '/' && path !== '/' ) {
 		return null;
 	}
 	// make sure the best match is actually a match (in case nothing matches)
-	if ( bestMatch.paths.some( ( sectionPath ) => startsWith( path, sectionPath ) ) ) {
+	if ( bestMatch.paths.some( ( sectionPath ) => ( path ?? '' ).startsWith( sectionPath ) ) ) {
 		return get( bestMatch, 'name' );
 	}
 	return null;

--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -1,5 +1,5 @@
 import { getUrlParts } from '@automattic/calypso-url';
-import { some, forEach, startsWith } from 'lodash';
+import { some, forEach } from 'lodash';
 import { iframeIsAllowed } from './utils';
 
 /**
@@ -30,7 +30,7 @@ export default function makeEmbedsSafe( post, dom ) {
 	const iframes = dom.querySelectorAll( 'iframe' );
 
 	forEach( iframes, function ( iframe ) {
-		if ( ! startsWith( iframe.src, 'http' ) ) {
+		if ( ! ( iframe.src ?? '' ).startsWith( 'http' ) ) {
 			iframe.parentNode.removeChild( iframe );
 			return;
 		}

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -1,5 +1,5 @@
 import { getUrlParts, getUrlFromParts, safeImageUrl } from '@automattic/calypso-url';
-import { forEach, startsWith, some, includes, filter } from 'lodash';
+import { forEach, some, includes, filter } from 'lodash';
 import { resolveRelativePath } from 'calypso/lib/url';
 import { maxWidthPhotonishURL } from './utils';
 
@@ -15,7 +15,7 @@ const removeUnwantedAttributes = ( node ) => {
 	}
 
 	const inlineEventHandlerAttributes = filter( node.attributes, ( attr ) =>
-		startsWith( attr.name, 'on' )
+		attr.name.startsWith( 'on' )
 	);
 	inlineEventHandlerAttributes.forEach( ( a ) => node.removeAttribute( a.name ) );
 
@@ -84,7 +84,7 @@ function makeImageSafe( post, image, maxWidth ) {
 
 	// allow https sources through even if we can't make them 'safe'
 	// helps images that use querystring params and are from secure sources
-	if ( ! safeSource && startsWith( imgSource, 'https://' ) ) {
+	if ( ! safeSource && ( imgSource ?? '' ).startsWith( 'https://' ) ) {
 		safeSource = imgSource;
 	}
 

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -1,4 +1,4 @@
-import { trim, forEach } from 'lodash';
+import { forEach } from 'lodash';
 import striptags from 'striptags';
 import { domForHtml } from './utils';
 
@@ -60,7 +60,7 @@ export function formatExcerpt( content ) {
 
 	// strip any p's that are empty
 	Array.from( dom.querySelectorAll( 'p' ) )
-		.filter( ( element ) => trim( element.textContent ).length === 0 )
+		.filter( ( element ) => ( element.textContent ?? '' ).trim().length === 0 )
 		.forEach( removeElement );
 
 	// remove styles for all p's that remain
@@ -82,7 +82,7 @@ export function formatExcerpt( content ) {
 	);
 
 	// trim and replace &nbsp; entities
-	const betterExcerpt = trim( dom.innerHTML.replace( /&nbsp;/g, ' ' ) );
+	const betterExcerpt = dom.innerHTML.replace( /&nbsp;/g, ' ' ).trim();
 	dom.innerHTML = '';
 	return betterExcerpt;
 }
@@ -94,10 +94,10 @@ export default function createBetterExcerpt( post ) {
 
 	const strippedDom = buildStrippedDom( post.content );
 
-	post.content_no_html = trim( striptags( strippedDom ) );
+	post.content_no_html = striptags( strippedDom ).trim();
 
 	post.better_excerpt = formatExcerpt( strippedDom );
-	post.better_excerpt_no_html = trim( striptags( post.better_excerpt ) );
+	post.better_excerpt_no_html = striptags( post.better_excerpt ).trim();
 
 	// also make a shorter excerpt...
 	if ( post.better_excerpt_no_html ) {

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -1,4 +1,3 @@
-import { startsWith } from 'lodash';
 import { makeImageURLSafe } from './utils';
 
 export default function safeImagePropertiesForWidth( maxWidth ) {
@@ -16,7 +15,7 @@ export default function safeImagePropertiesForWidth( maxWidth ) {
 		}
 		if ( post.attachments ) {
 			Object.values( post.attachments ).forEach( function ( attachment ) {
-				if ( startsWith( attachment.mime_type, 'image/' ) ) {
+				if ( ( attachment.mime_type ?? '' ).startsWith( 'image/' ) ) {
 					makeImageURLSafe( attachment, 'URL', maxWidth, post.URL );
 				}
 			} );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { safeImageUrl as safeImageUrlFake } from '@automattic/calypso-url';
-import { flow, trim } from 'lodash';
+import { flow } from 'lodash';
 import detectMedia from '../rule-content-detect-media';
 import detectPolls from '../rule-content-detect-polls';
 import detectSurveys from '../rule-content-detect-surveys';
@@ -905,7 +905,7 @@ describe( 'index', () => {
 					`,
 			};
 			const normalized = withContentDOM( [ removeElementsBySelector ] )( post );
-			expect( trim( normalized.content ) ).toBe( '' );
+			expect( normalized.content.trim() ).toBe( '' );
 		} );
 	} );
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -8,7 +8,7 @@ import { getAddOn } from '@automattic/data-stores/src/add-ons/add-ons-list';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
-import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
+import { defer, difference, get, includes, isEmpty, pick } from 'lodash';
 import { buildUpgradeFunction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import {
@@ -256,7 +256,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			? [ ...Object.values( domainCart ), googleAppsCartItem, themeItem ].filter( ( item ) => item )
 			: [ domainItem, googleAppsCartItem, themeItem ].filter( ( item ) => item );
 
-	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' ) && ! themeItem;
+	const isFreeThemePreselected = ( themeSlugWithRepo ?? '' ).startsWith( 'pub' ) && ! themeItem;
 	const state = reduxStore.getState();
 	const bearerToken = get( getSignupDependencyStore( state ), 'bearer_token', null );
 

--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -3,7 +3,7 @@ import { PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
-import { some, startsWith } from 'lodash';
+import { some } from 'lodash';
 import { createElement } from 'react';
 import EmptyContentComponent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
@@ -297,7 +297,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		domainUseMyDomain( slug ),
 	];
 
-	if ( some( startsWithPaths, ( startsWithPath ) => startsWith( path, startsWithPath ) ) ) {
+	if ( some( startsWithPaths, ( startsWithPath ) => path.startsWith( startsWithPath ) ) ) {
 		return true;
 	}
 
@@ -373,7 +373,7 @@ function onSelectedSiteAvailable( context ) {
 	} else {
 		// If migration is in progress, only /migrate paths should be loaded for the site
 		const isMigrationInProgress = isSiteMigrationInProgress( state, selectedSite.ID );
-		if ( isMigrationInProgress && ! startsWith( context.pathname, '/migrate/' ) ) {
+		if ( isMigrationInProgress && ! context.pathname.startsWith( '/migrate/' ) ) {
 			page.redirect( `/migrate/${ selectedSite.slug }` );
 			return false;
 		}

--- a/client/my-sites/domains/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/domains/domain-management/dns/email-provider.jsx
@@ -1,6 +1,6 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { isEmpty, trim } from 'lodash';
+import { isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
@@ -18,7 +18,7 @@ class EmailProvider extends Component {
 	onChange = ( event ) => {
 		const { value } = event.target;
 
-		this.setState( { token: trim( value ) } );
+		this.setState( { token: value.trim() } );
 	};
 
 	onAddDnsRecords = ( event ) => {

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -1,7 +1,7 @@
 import { Card, Dialog, Suggestions } from '@automattic/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { find, isEmpty, startsWith } from 'lodash';
+import { find, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
@@ -68,7 +68,8 @@ class SelectIpsTag extends Component {
 		return this.state.ipsTagList
 			.filter(
 				( hint ) =>
-					this.state.currentQuery && startsWith( hint.tag, this.state.currentQuery.toUpperCase() )
+					this.state.currentQuery &&
+					( hint.tag ?? '' ).startsWith( this.state.currentQuery.toUpperCase() )
 			)
 			.map( ( hint ) => ( { label: hint.tag + '  (' + hint.registrarName + ')' } ) );
 	}

--- a/client/my-sites/google-my-business/stats/chart.jsx
+++ b/client/my-sites/google-my-business/stats/chart.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { flatten } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -231,7 +230,7 @@ class GoogleMyBusinessStatsChart extends Component {
 			return false;
 		}
 
-		return flatten( transformedData ).reduce( ( sum, { value } ) => sum + value, 0 ) === 0;
+		return transformedData.flat().reduce( ( sum, { value } ) => sum + value, 0 ) === 0;
 	}
 
 	renderChartNotice() {

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { isEmpty, flowRight, trim, sortBy } from 'lodash';
+import { isEmpty, flowRight, sortBy } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -141,7 +141,7 @@ class SiteImporterInputPane extends Component {
 	};
 
 	validateSite = () => {
-		const siteURL = trim( this.state.siteURLInput );
+		const siteURL = this.state.siteURLInput.trim();
 
 		if ( ! siteURL ) {
 			return;

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get, startsWith } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -55,11 +55,11 @@ class PeopleListSectionHeader extends Component {
 	getPopoverText() {
 		const { currentRoute, translate } = this.props;
 
-		if ( startsWith( currentRoute, '/people/followers' ) ) {
+		if ( ( currentRoute ?? '' ).startsWith( '/people/followers' ) ) {
 			return translate( 'A list of people currently following your site.' );
 		}
 
-		if ( startsWith( currentRoute, '/people/email-followers' ) ) {
+		if ( ( currentRoute ?? '' ).startsWith( '/people/email-followers' ) ) {
 			return translate( 'A list of people who are subscribed to your blog via email only.' );
 		}
 
@@ -69,13 +69,13 @@ class PeopleListSectionHeader extends Component {
 	isSubscribersTab() {
 		const { currentRoute } = this.props;
 
-		return startsWith( currentRoute, '/people/email-followers' );
+		return ( currentRoute ?? '' ).startsWith( '/people/email-followers' );
 	}
 
 	isFollowersTab() {
 		const { currentRoute } = this.props;
 
-		return startsWith( currentRoute, '/people/followers' );
+		return ( currentRoute ?? '' ).startsWith( '/people/followers' );
 	}
 
 	render() {

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -1,4 +1,3 @@
-import { startsWith } from 'lodash';
 import moment from 'moment-timezone';
 
 /**
@@ -13,7 +12,7 @@ import moment from 'moment-timezone';
  * @returns {Object} The timezone-adjusted Moment.js object of the current date and time.
  */
 export function getLocalizedDate( timezoneString ) {
-	return startsWith( timezoneString, 'UTC' )
+	return ( timezoneString ?? '' ).startsWith( 'UTC' )
 		? moment().utcOffset( timezoneString.substring( 3 ) * 60 ) // E.g. "UTC+5" -> "+5" * 60 -> 300
 		: moment.tz( timezoneString );
 }

--- a/client/my-sites/store/lib/analytics/tracks-utils.js
+++ b/client/my-sites/store/lib/analytics/tracks-utils.js
@@ -1,8 +1,7 @@
-import { startsWith } from 'lodash';
 import { bumpStat } from 'calypso/state/analytics/actions';
 
 export const recordTrack = ( tracks, debug ) => ( eventName, eventProperties ) => {
-	if ( ! startsWith( eventName, 'calypso_woocommerce_' ) ) {
+	if ( ! ( eventName ?? '' ).startsWith( 'calypso_woocommerce_' ) ) {
 		debug( `invalid store track name: '${ eventName }', must start with 'calypso_woocommerce_'` );
 		return;
 	}

--- a/client/reader/get-helpers.ts
+++ b/client/reader/get-helpers.ts
@@ -1,6 +1,5 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { translate } from 'i18n-calypso';
-import { trim } from 'lodash';
 import { ReactNode } from 'react';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
@@ -181,7 +180,7 @@ export const getSiteAuthorName = ( site: ReaderSite ): string => {
 	const authorFullName =
 		siteAuthor &&
 		( siteAuthor.name ||
-			trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` ) );
+			`${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }`.trim() );
 
 	return decodeEntities( authorFullName || '' );
 };

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { trim, flatMap } from 'lodash';
+import { flatMap } from 'lodash';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -69,7 +69,7 @@ class SearchStream extends React.Component {
 	updateQuery = ( newValue ) => {
 		this.scrollToTop();
 		// Remove whitespace from newValue and limit to 1024 characters
-		const trimmedValue = trim( newValue ).substring( 0, 1024 );
+		const trimmedValue = ( newValue ?? '' ).trim().substring( 0, 1024 );
 		if (
 			( trimmedValue !== '' && trimmedValue.length > 1 && trimmedValue !== this.props.query ) ||
 			newValue === ''

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { some, startsWith } from 'lodash';
+import { some } from 'lodash';
 
 const exported = {
 	itemLinkClass: function ( path, currentPath, additionalClasses ) {
@@ -39,7 +39,7 @@ const exported = {
 
 	pathStartsWithOneOf: function ( paths, currentPath ) {
 		return some( paths, function ( path ) {
-			return startsWith( currentPath.toLowerCase(), path.toLowerCase() );
+			return currentPath.toLowerCase().startsWith( path.toLowerCase() );
 		} );
 	},
 };

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -8,7 +8,7 @@ import { Icon, commentAuthorAvatar, plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import closest from 'component-closest';
 import i18n, { localize } from 'i18n-calypso';
-import { defer, startsWith } from 'lodash';
+import { defer } from 'lodash';
 import { Component, useMemo } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { withReaderOrganizations } from 'calypso/components/data/with-reader-organizations';
@@ -118,7 +118,7 @@ export class ReaderSidebar extends Component {
 	openExpandableMenuForCurrentTagOrList = () => {
 		const pathParts = this.props.path.split( '/' );
 
-		if ( startsWith( this.props.path, '/tag/' ) ) {
+		if ( this.props.path.startsWith( '/tag/' ) ) {
 			const tagSlug = pathParts[ 2 ];
 			if ( tagSlug ) {
 				// Open the sidebar
@@ -129,7 +129,7 @@ export class ReaderSidebar extends Component {
 			}
 		}
 
-		if ( startsWith( this.props.path, '/reader/list/' ) ) {
+		if ( this.props.path.startsWith( '/reader/list/' ) ) {
 			const listOwner = pathParts[ 3 ];
 			const listSlug = pathParts[ 4 ];
 			if ( listOwner && listSlug ) {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -2,7 +2,6 @@ import { followReadTagMutation } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { localize, translate as i18nTranslate } from 'i18n-calypso';
-import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect, useDispatch } from 'react-redux';
@@ -31,7 +30,7 @@ export class ReaderSidebarTags extends Component {
 	};
 
 	followTag = ( tag ) => {
-		if ( startsWith( tag, '#' ) ) {
+		if ( ( tag ?? '' ).startsWith( '#' ) ) {
 			tag = tag.substring( 1 );
 		}
 

--- a/client/reader/tag-stream/controller.jsx
+++ b/client/reader/tag-stream/controller.jsx
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { trim } from 'lodash';
 import titlecase from 'to-title-case';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -27,11 +26,15 @@ export const tagListing = ( context, next ) => {
 	const basePath = '/tag/:slug';
 	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag;
 	const tagSlug = decodeURIComponent(
-		trim( context.params.tag ).toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' )
+		( context.params.tag ?? '' )
+			.trim()
+			.toLowerCase()
+			.replace( /\s+/g, '-' )
+			.replace( /-{2,}/g, '-' )
 	);
 	const state = context.store.getState();
 	const tagTitle = capitalPDangit(
-		titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' )
+		titlecase( ( context.params.tag ?? '' ).trim() ).replace( /[-_]/g, ' ' )
 	);
 
 	const encodedTag = encodeURIComponent( tagSlug ).toLowerCase();

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { getLanguageRouteParam, getAnyLanguageRouteParam } from '@automattic/i18n-utils';
-import { startsWith } from 'lodash';
 import {
 	makeLayout,
 	redirectInvalidLanguage,
@@ -13,7 +12,7 @@ import { sidebar, setBeforePrimary } from 'calypso/reader/controller';
 import { tagListing } from './controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
-	if ( context.hashstring && startsWith( context.pathname, '/tag/#' ) ) {
+	if ( context.hashstring && ( context.pathname ?? '' ).startsWith( '/tag/#' ) ) {
 		page.redirect( `/tag/${ context.hashstring }` );
 	}
 	next();

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -12,19 +12,7 @@ import { camelToSnakeCase } from '@automattic/js-utils';
 import * as oauthToken from '@automattic/oauth-token';
 import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
-import {
-	clone,
-	defer,
-	find,
-	get,
-	includes,
-	isEmpty,
-	isEqual,
-	kebabCase,
-	map,
-	omit,
-	startsWith,
-} from 'lodash';
+import { clone, defer, find, get, includes, isEmpty, isEqual, kebabCase, map, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -736,7 +724,7 @@ class Signup extends Component {
 	}
 
 	loginRedirectTo = ( path ) => {
-		if ( startsWith( path, 'https://' ) || startsWith( path, 'http://' ) ) {
+		if ( ( path ?? '' ).startsWith( 'https://' ) || ( path ?? '' ).startsWith( 'http://' ) ) {
 			return path;
 		}
 

--- a/client/sites/marketing/connections/services/google-drive.jsx
+++ b/client/sites/marketing/connections/services/google-drive.jsx
@@ -1,4 +1,3 @@
-import { last } from 'lodash';
 import googleDriveLogo from 'calypso/assets/images/connections/google-drive-logo.svg';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import { SharingService, connectFor } from '../service';
@@ -22,7 +21,7 @@ export class GoogleDrive extends SharingService {
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
-		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
+		this.props.deleteStoredKeyringConnection( this.props.keyringConnections?.at( -1 ) );
 	};
 
 	didKeyringConnectionSucceed( availableExternalAccounts ) {

--- a/client/sites/marketing/connections/services/google-photos.jsx
+++ b/client/sites/marketing/connections/services/google-photos.jsx
@@ -1,4 +1,4 @@
-import { last, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import { SharingService, connectFor } from '../service';
@@ -23,7 +23,7 @@ export class GooglePhotos extends SharingService {
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
-		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
+		this.props.deleteStoredKeyringConnection( this.props.keyringConnections?.at( -1 ) );
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!

--- a/client/sites/marketing/connections/services/mailchimp.js
+++ b/client/sites/marketing/connections/services/mailchimp.js
@@ -1,4 +1,4 @@
-import { last, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import { SharingService, connectFor } from '../service';
@@ -23,7 +23,7 @@ export class Mailchimp extends SharingService {
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
-		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
+		this.props.deleteStoredKeyringConnection( this.props.keyringConnections?.at( -1 ) );
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!

--- a/client/sites/marketing/connections/services/p2-slack.jsx
+++ b/client/sites/marketing/connections/services/p2-slack.jsx
@@ -1,4 +1,4 @@
-import { last, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { deleteP2KeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -25,7 +25,7 @@ export class P2Slack extends SharingService {
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
 		this.props.deleteStoredKeyringConnection(
-			last( this.props.keyringConnections ),
+			this.props.keyringConnections?.at( -1 ),
 			this.props.siteId
 		);
 	};

--- a/client/sites/marketing/sharing/preview-action.jsx
+++ b/client/sites/marketing/sharing/preview-action.jsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 
 const SharingButtonsPreviewAction = ( {
@@ -13,9 +12,9 @@ const SharingButtonsPreviewAction = ( {
 } ) => {
 	const classes = clsx( 'sharing-buttons-preview-action', {
 		'is-active': active,
-		'is-top': startsWith( position, 'top' ),
+		'is-top': position.startsWith( 'top' ),
 		'is-right': position.endsWith( '-right' ),
-		'is-bottom': startsWith( position, 'bottom' ),
+		'is-bottom': position.startsWith( 'bottom' ),
 		'is-left': position.endsWith( '-left' ),
 	} );
 

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,16 +1,5 @@
 import { withStorageKey } from '@automattic/state-utils';
-import {
-	filter,
-	orderBy,
-	has,
-	map,
-	reject,
-	isEqual,
-	get,
-	includes,
-	omit,
-	startsWith,
-} from 'lodash';
+import { filter, orderBy, has, map, reject, isEqual, get, includes, omit } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,
@@ -482,7 +471,7 @@ export const counts = ( state = {}, action ) => {
 		}
 		case COMMENTS_DELETE: {
 			const { siteId, postId = -1, commentId } = action;
-			if ( commentId && startsWith( commentId, 'placeholder' ) ) {
+			if ( commentId && String( commentId ).startsWith( 'placeholder' ) ) {
 				return state;
 			}
 			const previousStatus = get( action, 'meta.comment.previousStatus' );

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import { get, startsWith, pickBy, map } from 'lodash';
+import { get, pickBy, map } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import {
 	COMMENTS_REQUEST,
@@ -148,7 +148,7 @@ export const announceFailure =
 export const deleteComment = ( action ) => ( dispatch, getState ) => {
 	const { siteId, commentId } = action;
 
-	if ( startsWith( commentId, 'placeholder' ) ) {
+	if ( String( commentId ).startsWith( 'placeholder' ) ) {
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -1,5 +1,5 @@
 import { translate } from 'i18n-calypso';
-import { get, omit, startsWith } from 'lodash';
+import { get, omit } from 'lodash';
 import { trailingslashit } from 'calypso/lib/route';
 import { JETPACK_SETTINGS_REQUEST, JETPACK_SETTINGS_SAVE } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
@@ -132,7 +132,7 @@ export const retryOrAnnounceSaveFailure = ( action, { message: errorMessage } ) 
 	// properly, in which case a subsequent request will return 'success'.
 	if (
 		get( settings, [ 'onboarding', 'installWooCommerce' ] ) !== true ||
-		! startsWith( errorMessage, 'cURL error 28' ) || // cURL timeout
+		! ( errorMessage ?? '' ).startsWith( 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {
 		return handleSaveFailure( { siteId }, action );

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -1,5 +1,5 @@
 import update from 'immutability-helper';
-import { filter, find, findIndex, matches, pick, reject, some, startsWith, without } from 'lodash';
+import { filter, find, findIndex, matches, pick, reject, some, without } from 'lodash';
 import {
 	DOMAINS_DNS_ADD,
 	DOMAINS_DNS_ADD_COMPLETED,
@@ -17,7 +17,7 @@ import {
 } from 'calypso/state/action-types';
 
 function isWpcomRecord( record ) {
-	return startsWith( record.id, 'wpcom:' );
+	return ( record.id ?? '' ).startsWith( 'wpcom:' );
 }
 
 function isRootARecord( domain ) {

--- a/client/state/immediate-login/test/selectors.js
+++ b/client/state/immediate-login/test/selectors.js
@@ -1,4 +1,3 @@
-import { last } from 'lodash';
 import { REASONS_FOR_MANUAL_RENEWAL } from '../constants';
 import {
 	wasImmediateLoginAttempted,
@@ -49,7 +48,7 @@ describe( 'immediate-login/selectors', () => {
 		test( 'should return correct value from state [4]', () => {
 			expect(
 				wasManualRenewalImmediateLoginAttempted( {
-					immediateLogin: { reason: last( REASONS_FOR_MANUAL_RENEWAL ) },
+					immediateLogin: { reason: REASONS_FOR_MANUAL_RENEWAL.at( -1 ) },
 				} )
 			).toEqual( true );
 		} );

--- a/client/state/immediate-login/test/utils.js
+++ b/client/state/immediate-login/test/utils.js
@@ -1,4 +1,3 @@
-import { last } from 'lodash';
 import { REASONS_FOR_MANUAL_RENEWAL } from '../constants';
 import { createPathWithoutImmediateLoginInformation, createImmediateLoginMessage } from '../utils';
 
@@ -114,7 +113,7 @@ describe( 'immediate-login/utils', () => {
 		const messages = [
 			createImmediateLoginMessage( '', 'test@wordpress.com' ),
 			createImmediateLoginMessage( REASONS_FOR_MANUAL_RENEWAL[ 0 ], 'test@wordpress.com' ),
-			createImmediateLoginMessage( last( REASONS_FOR_MANUAL_RENEWAL ), 'test@wordpress.com' ),
+			createImmediateLoginMessage( REASONS_FOR_MANUAL_RENEWAL.at( -1 ), 'test@wordpress.com' ),
 		];
 		test( 'should put an email in every message', () => {
 			for ( const m of messages ) {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -1,5 +1,5 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { get, isEmpty, pick, startsWith } from 'lodash';
+import { get, isEmpty, pick } from 'lodash';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
 import {
@@ -72,9 +72,9 @@ export const redirectTo = combineReducers( {
 		switch ( action.type ) {
 			case ROUTE_SET: {
 				const { path, query } = action;
-				if ( startsWith( path, '/log-in' ) ) {
+				if ( path.startsWith( '/log-in' ) ) {
 					return query.redirect_to || state;
-				} else if ( startsWith( path, '/start/account' ) ) {
+				} else if ( path.startsWith( '/start/account' ) ) {
 					return query.redirect_to || state;
 				} else if ( '/jetpack/connect/authorize' === path ) {
 					return addQueryArgs( query, path );

--- a/client/state/oauth2-clients/ui/reducer.js
+++ b/client/state/oauth2-clients/ui/reducer.js
@@ -1,4 +1,3 @@
-import { startsWith } from 'lodash';
 import { ROUTE_SET } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
 
@@ -7,16 +6,16 @@ export const currentClientId = ( state = null, action ) => {
 		case ROUTE_SET: {
 			const { path, query } = action;
 			if (
-				( startsWith( path, '/log-in' ) || startsWith( path, '/oauth2/authorize' ) ) &&
+				( path.startsWith( '/log-in' ) || path.startsWith( '/oauth2/authorize' ) ) &&
 				query.client_id
 			) {
 				return Number( query.client_id );
 			}
 
 			if (
-				startsWith( path, '/log-in/apple/callback' ) ||
-				startsWith( path, '/start/wpcc' ) ||
-				startsWith( path, '/start/crowdsignal' )
+				path.startsWith( '/log-in/apple/callback' ) ||
+				path.startsWith( '/start/wpcc' ) ||
+				path.startsWith( '/start/crowdsignal' )
 			) {
 				return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
 			}

--- a/client/state/partner-portal/selectors.js
+++ b/client/state/partner-portal/selectors.js
@@ -1,8 +1,7 @@
-import startsWith from 'lodash/startsWith';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
 
 export const isPartnerPortal = ( state ) =>
-	startsWith( getCurrentRoute( state ), '/partner-portal' );
+	( getCurrentRoute( state ) ?? '' ).startsWith( '/partner-portal' );

--- a/client/state/posts/utils/append-to-post-edits-log.js
+++ b/client/state/posts/utils/append-to-post-edits-log.js
@@ -1,4 +1,4 @@
-import { isEmpty, last } from 'lodash';
+import { isEmpty } from 'lodash';
 import { mergePostEdits } from 'calypso/state/posts/utils/merge-post-edits';
 
 /**
@@ -15,7 +15,7 @@ export function appendToPostEditsLog( postEditsLog, newPostEdits ) {
 		return [ newPostEdits ];
 	}
 
-	const lastEdits = last( postEditsLog );
+	const lastEdits = postEditsLog.at( -1 );
 
 	if ( typeof lastEdits === 'string' ) {
 		return [ ...postEditsLog, newPostEdits ];

--- a/client/state/selectors/get-google-my-business-connected-location.js
+++ b/client/state/selectors/get-google-my-business-connected-location.js
@@ -1,4 +1,4 @@
-import { filter, last } from 'lodash';
+import { filter } from 'lodash';
 import getGoogleMyBusinessLocations from 'calypso/state/selectors/get-google-my-business-locations';
 
 /**
@@ -9,9 +9,7 @@ import getGoogleMyBusinessLocations from 'calypso/state/selectors/get-google-my-
  * @returns {Object[]}        A connected GMB location
  */
 export default function getGoogleMyBusinessConnectedLocation( state, siteId ) {
-	return last(
-		filter( getGoogleMyBusinessLocations( state, siteId ), {
-			isConnected: true,
-		} )
-	);
+	return filter( getGoogleMyBusinessLocations( state, siteId ), {
+		isConnected: true,
+	} ).at( -1 );
 }

--- a/client/state/selectors/get-google-my-business-locations.js
+++ b/client/state/selectors/get-google-my-business-locations.js
@@ -1,11 +1,13 @@
-import { filter, last } from 'lodash';
+import { filter } from 'lodash';
 import { getAvailableExternalAccounts } from 'calypso/state/sharing/selectors';
 import { getSiteKeyringsForService } from 'calypso/state/site-keyrings/selectors';
 
 export default function getGoogleMyBusinessLocations( state, siteId ) {
-	const googleMyBusinessSiteKeyring = last(
-		getSiteKeyringsForService( state, siteId, 'google_my_business' )
-	);
+	const googleMyBusinessSiteKeyring = getSiteKeyringsForService(
+		state,
+		siteId,
+		'google_my_business'
+	)?.at( -1 );
 
 	if ( ! googleMyBusinessSiteKeyring ) {
 		return [];

--- a/client/state/selectors/get-site-user-connections-for-google-my-business.js
+++ b/client/state/selectors/get-site-user-connections-for-google-my-business.js
@@ -1,4 +1,4 @@
-import { filter, last } from 'lodash';
+import { filter } from 'lodash';
 import { getKeyringConnectionsByName } from 'calypso/state/sharing/keyring/selectors';
 import { getSiteKeyringsForService } from 'calypso/state/site-keyrings/selectors';
 
@@ -21,9 +21,11 @@ function isConnected( keyringConnection, externalUser, siteKeyring ) {
  */
 export default function getSiteUserConnectionsForGoogleMyBusiness( state, siteId ) {
 	// Google Business Profile can only have one location connected at a time
-	const googleMyBusinessSiteKeyring = last(
-		getSiteKeyringsForService( state, siteId, 'google_my_business' )
-	);
+	const googleMyBusinessSiteKeyring = getSiteKeyringsForService(
+		state,
+		siteId,
+		'google_my_business'
+	)?.at( -1 );
 
 	if ( ! googleMyBusinessSiteKeyring ) {
 		return [];

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from '@automattic/state-utils';
 import treeSelect from '@automattic/tree-select';
-import { get, map, flatten } from 'lodash';
+import { get, map } from 'lodash';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSerializedStatsQuery, normalizers, buildExportArray } from './utils';
@@ -175,11 +175,9 @@ export function getSiteStatsCSVData( state, siteId, statType, query, modifierFn 
 		return [];
 	}
 
-	return flatten(
-		map( data, ( item ) => {
-			return buildExportArray( item, null, modifierFn );
-		} )
-	);
+	return map( data, ( item ) => {
+		return buildExportArray( item, null, modifierFn );
+	} ).flat();
 }
 
 /**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,5 +1,5 @@
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { sortBy, camelCase, get, filter, map, flatten, capitalize } from 'lodash';
+import { sortBy, camelCase, get, filter, map, capitalize } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
@@ -140,7 +140,7 @@ export function buildExportArray( data, parent = null, modifierFn = null ) {
 			return buildExportArray( child, label, modifierFn );
 		} );
 
-		exportData = exportData.concat( flatten( childData ) );
+		exportData = exportData.concat( childData.flat() );
 	}
 
 	return exportData;

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -1,4 +1,4 @@
-import { get, includes, map, omit, omitBy, some, startsWith } from 'lodash';
+import { get, includes, map, omit, omitBy, some } from 'lodash';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -32,7 +32,7 @@ const DELISTED_WPORG_THEMES = [ 'shopline', 'store-shopline' ];
  */
 export function isPremium( theme ) {
 	const themeStylesheet = get( theme, 'stylesheet', false );
-	return themeStylesheet && startsWith( themeStylesheet, 'premium/' );
+	return themeStylesheet && themeStylesheet.startsWith( 'premium/' );
 }
 
 /**

--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { last } from 'lodash';
 
 import 'calypso/state/ui/init';
 
@@ -23,6 +22,6 @@ export function getActionLog( state ) {
  * @returns {Object}              The matching dispatched action
  */
 export const getLastAction = createSelector(
-	( state ) => last( state.ui.actionLog ) || false,
+	( state ) => state.ui.actionLog?.at( -1 ) || false,
 	( state ) => [ state.ui.actionLog ]
 );


### PR DESCRIPTION
## Proposed Changes

* Replace four `lodash` helpers — `startsWith`, `trim`, `last`, and `flatten` — with native JavaScript across the client (and a couple of build scripts).
* Enable the matching `you-dont-need-lodash-underscore` lint rules so these helpers can't be reintroduced.

This is the first tier of an incremental effort to remove `lodash` from the codebase, scoped to the functions with safe, near-mechanical native replacements that the existing lint plugin already supports.

## Why are these changes being made?

* `lodash` is imported in ~1,000 files; removing it shrinks the dependency surface and bundle, and these helpers have direct native equivalents. Pairing each sweep with a lint rule prevents regressions and lets the migration proceed tier by tier.

## Testing Instructions

* These are behavior-preserving substitutions; nullish receivers are guarded to keep `lodash`'s coercion/null-safety behavior.
* `yarn lint:js` reports no violations of the newly enabled rules anywhere in the repo.
* `yarn typecheck-client` and `yarn typecheck-packages` show no new type errors introduced by this change.
* Smoke-test a few affected surfaces (Reader sidebar/tag streams, signup, stats charts, marketing connections) and confirm no console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
