### PR TITLE
Achievements: link unlocked cards to their post or comment

### DIFF
--- a/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
@@ -2,6 +2,7 @@ import { siteByIdQuery } from '@automattic/api-queries';
 import { TimeSince } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
+import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 import { getOldestAchievement } from '../utils';
 import AchievementCard from './achievement-card';
 import type { Achievement } from '@automattic/api-core';
@@ -64,13 +65,19 @@ export default function GenericAchievement( {
 		if ( ! ( blog_id > 0 ) || ! ( post_id > 0 ) ) {
 			return undefined;
 		}
+		// `url` comes from an API payload — restrict it to http(s) so an unsafe
+		// protocol (e.g. `javascript:`) can't be used as the anchor href.
+		const safeUrl = safeProtocolUrl( url );
+		if ( ! safeUrl ) {
+			return undefined;
+		}
 		const isComment = !! comment_id && comment_id > 0;
 		return isComment
 			? translate( '{{a}}View comment{{/a}}', {
-					components: { a: <a href={ url } target="_blank" rel="noopener noreferrer" /> },
+					components: { a: <a href={ safeUrl } target="_blank" rel="noopener noreferrer" /> },
 			  } )
 			: translate( '{{a}}View post{{/a}}', {
-					components: { a: <a href={ url } target="_blank" rel="noopener noreferrer" /> },
+					components: { a: <a href={ safeUrl } target="_blank" rel="noopener noreferrer" /> },
 			  } );
 	};
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
@@ -9,9 +9,11 @@ import type { Achievement } from '@automattic/api-core';
 export default function GenericAchievement( {
 	achievement,
 	achievements,
+	isOwnProfile,
 }: {
 	achievement: Achievement;
 	achievements: Achievement[];
+	isOwnProfile: boolean;
 } ) {
 	const translate = useTranslate();
 	const hasMultiple = achievements.filter( ( a ) => a.slug === achievement.slug ).length > 1;
@@ -50,6 +52,41 @@ export default function GenericAchievement( {
 			  } );
 	};
 
+	// Only own-profile reads carry `context`, and only on achievements the
+	// backend can attribute to a specific post or comment. Link to the post or
+	// comment depending on which IDs are present.
+	const contextLink = () => {
+		const context = achievement.context;
+		if ( ! isOwnProfile || ! context?.url ) {
+			return undefined;
+		}
+		const { blog_id, post_id, comment_id, url } = context;
+		if ( ! ( blog_id > 0 ) || ! ( post_id > 0 ) ) {
+			return undefined;
+		}
+		const isComment = !! comment_id && comment_id > 0;
+		return isComment
+			? translate( '{{a}}View comment{{/a}}', {
+					components: { a: <a href={ url } target="_blank" rel="noopener noreferrer" /> },
+			  } )
+			: translate( '{{a}}View post{{/a}}', {
+					components: { a: <a href={ url } target="_blank" rel="noopener noreferrer" /> },
+			  } );
+	};
+
+	const renderCaption = () => {
+		const link = contextLink();
+		if ( ! link ) {
+			return caption();
+		}
+		return (
+			<>
+				{ caption() }
+				<span className="achievement-card__caption-context">{ link }</span>
+			</>
+		);
+	};
+
 	return (
 		<AchievementCard
 			image={ achievement.image }
@@ -63,7 +100,7 @@ export default function GenericAchievement( {
 			isRetired={ !! achievement.date_retired }
 			isA8cOnly={ achievement.is_a8c_only }
 			description={ achievement.description }
-			caption={ caption() }
+			caption={ renderCaption() }
 		/>
 	);
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -120,6 +120,7 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 								key={ a.achievement_id }
 								achievement={ a }
 								achievements={ earned }
+								isOwnProfile={ isOwnProfile }
 							/>
 						);
 					} ) }

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -108,6 +108,11 @@
 		}
 	}
 
+	.achievement-card__caption-context::before {
+		content: "·";
+		margin-inline: 4px;
+	}
+
 	.achievement-card__progress {
 		align-items: center;
 		display: flex;

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import GenericAchievement from '../generic-achievement';
+import type { Achievement } from '@automattic/api-core';
+
+const achievement = ( overrides: Partial< Achievement > = {} ): Achievement => ( {
+	achievement_id: 1,
+	slug: 'ship_it',
+	name: 'Ship It',
+	description: 'You published a post.',
+	badge_prefix: 'p',
+	level: 0,
+	date_unlocked: '2026-01-15T00:00:00Z',
+	date_created: '2025-01-01',
+	image: 'https://example.com/ship.png',
+	is_secret: false,
+	...overrides,
+} );
+
+function renderCard( props: React.ComponentProps< typeof GenericAchievement > ) {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return render(
+		<QueryClientProvider client={ client }>
+			<GenericAchievement { ...props } />
+		</QueryClientProvider>
+	);
+}
+
+describe( 'GenericAchievement context link', () => {
+	test( 'renders a "View post" link when blog_id and post_id are set but no comment_id', () => {
+		const a = achievement( {
+			context: { blog_id: 123, post_id: 45, url: 'https://example.com/post' },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		const link = screen.getByRole( 'link', { name: 'View post' } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/post' );
+		expect( screen.queryByRole( 'link', { name: 'View comment' } ) ).not.toBeInTheDocument();
+		// Inline within the existing caption, not a separate line.
+		expect( link.closest( '.achievement-card__caption' ) ).not.toBeNull();
+	} );
+
+	test( 'renders a "View comment" link when blog_id, post_id, and comment_id are set', () => {
+		const a = achievement( {
+			slug: 'got_carried_away',
+			context: { blog_id: 123, post_id: 45, comment_id: 67, url: 'https://example.com/comment' },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		const link = screen.getByRole( 'link', { name: 'View comment' } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/comment' );
+		expect( screen.queryByRole( 'link', { name: 'View post' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders no context link on a cross-user profile', () => {
+		const a = achievement( {
+			context: { blog_id: 123, post_id: 45, url: 'https://example.com/post' },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: false } );
+
+		expect( screen.queryByRole( 'link', { name: /View (post|comment)/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders no context link when there is no context', () => {
+		const a = achievement();
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		expect( screen.queryByRole( 'link', { name: /View (post|comment)/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders no context link when blog_id or post_id is not a positive value', () => {
+		const a = achievement( {
+			context: { blog_id: 0, post_id: 45, url: 'https://example.com/post' },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		expect( screen.queryByRole( 'link', { name: /View (post|comment)/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'falls back to "View post" when comment_id is 0', () => {
+		const a = achievement( {
+			context: { blog_id: 123, post_id: 45, comment_id: 0, url: 'https://example.com/post' },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		expect( screen.getByRole( 'link', { name: 'View post' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'View comment' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders no context link when the url is missing', () => {
+		const a = achievement( {
+			// @ts-expect-error - exercising a malformed payload missing the url.
+			context: { blog_id: 123, post_id: 45 },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		expect( screen.queryByRole( 'link', { name: /View (post|comment)/ } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx
@@ -99,6 +99,19 @@ describe( 'GenericAchievement context link', () => {
 		expect( screen.queryByRole( 'link', { name: 'View comment' } ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'neutralizes an unsafe javascript: url so it never reaches the href', () => {
+		const a = achievement( {
+			// eslint-disable-next-line no-script-url
+			context: { blog_id: 123, post_id: 45, url: 'javascript:alert(1)' },
+		} );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: true } );
+
+		const link = screen.queryByRole( 'link', { name: 'View post' } );
+		// The link may still render, but the dangerous protocol must be stripped.
+		expect( link?.getAttribute( 'href' ) ?? '' ).not.toMatch( /^javascript:/i );
+	} );
+
 	test( 'renders no context link when the url is missing', () => {
 		const a = achievement( {
 			// @ts-expect-error - exercising a malformed payload missing the url.

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -1,4 +1,18 @@
 /**
+ * The post or comment an achievement was unlocked on. Only present when viewing
+ * your own achievements, and only on achievements the backend can attribute to a
+ * specific post or comment.
+ */
+export interface AchievementContext {
+	blog_id: number;
+	post_id: number;
+	/** Present (and `> 0`) when the achievement was unlocked on a comment. */
+	comment_id?: number;
+	/** Permalink to the post or comment. */
+	url: string;
+}
+
+/**
  * Earned, fully-visible achievement. The shape returned for own-profile reads
  * and for non-secret entries on cross-user reads. A self-read of an earned
  * secret achievement also uses this shape — `is_secret` then reflects the
@@ -34,6 +48,11 @@ export interface Achievement {
 	site_ID?: number;
 	/** Only present when viewing your own achievements. */
 	url?: string;
+	/**
+	 * The post or comment that unlocked the achievement. Only present when viewing
+	 * your own achievements, and only on achievements the backend can attribute.
+	 */
+	context?: AchievementContext;
 }
 
 /**


### PR DESCRIPTION
Fixes RSM-4355

## Proposed Changes

<img width="419" height="157" alt="Screenshot 2026-06-15 at 16 33 33" src="https://github.com/user-attachments/assets/0b008d00-ae8d-4977-ac3c-7fa6bd270fe0" />

* Add an optional `context` object (`blog_id`, `post_id`, optional `comment_id`, `url`) to the achievements endpoint `Achievement` type. The endpoint returns it only on self-reads, on newly-unlocked achievements it can attribute to a specific post or comment. It flows through the existing query untouched.
* On **own-profile unlocked** achievement cards, append a link to the caption (separated by a mid-dot):
  * **View post** → `context.url` when `blog_id > 0` and `post_id > 0` and there's no positive `comment_id`.
  * **View comment** → `context.url` when `blog_id`, `post_id`, and `comment_id` are all positive.
  * Nothing otherwise (cross-user views, no context, missing/zero IDs, missing url).
* Thread `isOwnProfile` into `GenericAchievement` so the link is gated to self-views.

## Why are these changes being made?

The backend now attributes certain achievements (e.g. `ship_it`, `got_carried_away`) to the post or comment that earned them. Surfacing a direct link lets users jump straight to the content that unlocked the achievement.

## Testing Instructions

* View your own Reader user profile achievements (`/reader/users/...`).
* For a newly-unlocked achievement whose `context` has a `blog_id` + `post_id` (no `comment_id`), confirm the card caption shows `… · View post` linking to `context.url` (opens in a new tab).
* For one whose `context` also has a `comment_id`, confirm it shows `… · View comment`.
* Confirm no link appears on another user's profile, or on achievements without a valid post context.
* `yarn test-client client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx` passes (7 tests).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?