### PR TITLE
Spike: ExpressCheckoutElement for Link/Apple Pay/Google Pay + upgrade @stripe/stripe-js to v4

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -57,6 +57,7 @@ import payPalProcessor from '../lib/paypal-express-processor';
 import { payPalJsProcessor } from '../lib/paypal-js-processor';
 import { pixAutomaticoProcessor } from '../lib/pix-automatico-processor';
 import { pixProcessor } from '../lib/pix-processor';
+import stripeLinkProcessor from '../lib/stripe-link-processor';
 import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
 import upiProcessor from '../lib/upi-processor';
 import weChatProcessor from '../lib/we-chat-processor';
@@ -590,6 +591,8 @@ export default function CheckoutMain( {
 				),
 			'stripe-blik': ( transactionData: unknown ) =>
 				blikProcessor( transactionData, dataForProcessor, translate ),
+			'stripe-link': ( transactionData: unknown ) =>
+				stripeLinkProcessor( transactionData, dataForProcessor ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			'existing-card-ebanx': ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -33,6 +33,7 @@ import {
 import { createWeChatMethod } from '../../payment-methods/wechat';
 import useCreateExistingCards from './use-create-existing-cards';
 import useCreateExistingPayPalPPCP from './use-create-existing-paypal-ppcp';
+import useCreateStripeLink from './use-create-stripe-link';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -505,6 +506,12 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 	} );
 
+	const stripeLinkMethod = useCreateStripeLink( {
+		isStripeLoading,
+		stripeLoadingError,
+		stripe,
+	} );
+
 	// The order of this array is the order that Payment Methods will be
 	// displayed in Checkout, although not all payment methods here will be
 	// listed; the list of allowed payment methods is returned by the shopping
@@ -515,6 +522,7 @@ export default function useCreatePaymentMethods( {
 		...existingPayPalPPCPMethods,
 		applePayMethod,
 		googlePayMethod,
+		stripeLinkMethod,
 		stripeMethod,
 		freePaymentMethod,
 		paypalExpressMethod,
@@ -540,6 +548,7 @@ export default function useCreatePaymentMethods( {
 			...existingPayPalPPCPMethods,
 			applePayMethod,
 			googlePayMethod,
+			stripeLinkMethod,
 			paypalExpressMethod,
 			paypalPPCPMethod,
 			stripeMethod,

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-stripe-link.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-stripe-link.ts
@@ -1,0 +1,28 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { createStripeLinkMethod } from '@automattic/wpcom-checkout';
+import { useMemo } from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import type { StripeLoadingError } from '@automattic/calypso-stripe';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { Stripe } from '@stripe/stripe-js';
+
+export default function useCreateStripeLink( {
+	isStripeLoading,
+	stripeLoadingError,
+	stripe,
+}: {
+	isStripeLoading: boolean;
+	stripeLoadingError: StripeLoadingError;
+	stripe: Stripe | null;
+} ): PaymentMethod | null {
+	const cartKey = useCartKey();
+	const shouldLoad =
+		! isStripeLoading && ! stripeLoadingError && !! stripe && isEnabled( 'checkout/stripe-link' );
+
+	return useMemo( () => {
+		if ( ! shouldLoad || ! stripe || ! cartKey ) {
+			return null;
+		}
+		return createStripeLinkMethod( stripe, cartKey );
+	}, [ shouldLoad, stripe, cartKey ] );
+}

--- a/client/my-sites/checkout/src/lib/stripe-link-processor.ts
+++ b/client/my-sites/checkout/src/lib/stripe-link-processor.ts
@@ -1,0 +1,21 @@
+import { makeErrorResponse } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+const debug = debugFactory( 'wpcom-checkout:stripe-link-processor' );
+
+// Spike stub. The ECE's onConfirm handler calls event.paymentFailed() before
+// invoking the processor, so this is never reached during the spike. In the
+// real implementation this would:
+//   1. POST to /me/transactions to create the PI and get clientSecret
+//   2. Return the clientSecret to the ECE onConfirm handler
+//   3. That handler calls stripe.confirmPayment({ elements, clientSecret })
+//   4. Webhook completes the order; client polls via fetchPurchaseOrder
+export default async function stripeLinkProcessor(
+	submitData: unknown,
+	options: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	debug( '[spike] stripeLinkProcessor called with', submitData, options );
+	return makeErrorResponse( 'Stripe Link processor is not yet implemented (spike)' );
+}

--- a/client/my-sites/checkout/src/lib/translate-cart.ts
+++ b/client/my-sites/checkout/src/lib/translate-cart.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	isGoogleWorkspaceExtraLicence,
 	isGSuiteOrGoogleWorkspaceProductSlug,
@@ -37,6 +38,12 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		.map( readWPCOMPaymentMethodClass )
 		.filter( isValueTruthy )
 		.map( translateWpcomPaymentMethodToCheckoutPaymentMethod );
+
+	// Spike: inject stripe-link directly since there is no backend class yet.
+	// Remove this when SHILL-2100 adds WPCOM_Billing_Stripe_Link.
+	if ( isEnabled( 'checkout/stripe-link' ) ) {
+		allowedPaymentMethods.push( 'stripe-link' );
+	}
 
 	return {
 		allowedPaymentMethods,

--- a/config/development.json
+++ b/config/development.json
@@ -61,6 +61,7 @@
 		"calypso/write-on-flow": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
+		"checkout/stripe-link": true,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,6 +22,7 @@
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,
+		"checkout/stripe-link": true,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -17,6 +17,7 @@ export * from './payment-methods/sofort';
 export * from './payment-methods/p24';
 export * from './payment-methods/eps';
 export * from './payment-methods/alipay';
+export * from './payment-methods/stripe-link';
 export * from './payment-methods/stripe-upi';
 export * from './payment-methods/web-pay-utils';
 export * from './payment-methods/google-pay';

--- a/packages/wpcom-checkout/src/payment-methods/stripe-link.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/stripe-link.tsx
@@ -1,0 +1,120 @@
+import {
+	useTogglePaymentMethod,
+	useRegisterPaymentMethodLoading,
+} from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import debugFactory from 'debug';
+import { useEffect, useRef, useState } from 'react';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { CartKey } from '@automattic/shopping-cart';
+import type { Stripe, StripeElements, StripeExpressCheckoutElement } from '@stripe/stripe-js';
+
+const debug = debugFactory( 'wpcom-checkout:stripe-link' );
+
+export function createStripeLinkMethod( stripe: Stripe, cartKey: CartKey ): PaymentMethod {
+	return {
+		id: 'stripe-link',
+		paymentProcessorId: 'stripe-link',
+		label: <StripeLinkLabel />,
+		submitButton: <StripeLinkSubmitButton stripe={ stripe } cartKey={ cartKey } />,
+		inactiveContent: <StripeLinkSummary />,
+		getAriaLabel: ( __ ) => __( 'Link by Stripe' ),
+		isInitiallyDisabled: true,
+	};
+}
+
+function StripeLinkLabel() {
+	return <span>Link by Stripe</span>;
+}
+
+function StripeLinkSummary() {
+	return <span>Link by Stripe</span>;
+}
+
+export function StripeLinkSubmitButton( {
+	stripe,
+	cartKey,
+}: {
+	stripe: Stripe;
+	cartKey: CartKey;
+} ) {
+	const { responseCart } = useShoppingCart( cartKey );
+	const amount = responseCart.total_cost_integer;
+	const currency = responseCart.currency.toLowerCase();
+
+	const togglePaymentMethod = useTogglePaymentMethod();
+	const [ isReady, setIsReady ] = useState( false );
+
+	const elementsRef = useRef< StripeElements | null >( null );
+	const eceRef = useRef< StripeExpressCheckoutElement | null >( null );
+	const mountTargetRef = useRef< HTMLDivElement | null >( null );
+
+	// Mount the ECE once on first render. Uses deferred-intent mode so amount
+	// can be updated without remounting. This group is separate from the
+	// StripeHookProvider's Elements group (which has no mode/amount).
+	useEffect( () => {
+		if ( ! stripe || ! mountTargetRef.current || elementsRef.current ) {
+			return;
+		}
+
+		debug( 'Creating elements group: amount=%d currency=%s', amount, currency );
+		const elements = stripe.elements( { mode: 'payment', amount, currency } );
+		elementsRef.current = elements;
+
+		// paymentMethods: hide Apple Pay and Google Pay, show only Link.
+		const ece = elements.create( 'expressCheckout', {
+			paymentMethods: { applePay: 'auto', googlePay: 'auto', link: 'auto' },
+		} );
+		eceRef.current = ece;
+
+		ece.on( 'ready', ( { availablePaymentMethods } ) => {
+			// AvailablePaymentMethods in @stripe/stripe-js v4 only tracks
+			// applePay/googlePay — link is not yet in the typed shape. The ECE
+			// itself is the source of truth for whether Link actually renders.
+			debug( '[spike] ECE ready — availablePaymentMethods=%o', availablePaymentMethods );
+			setIsReady( true );
+			togglePaymentMethod( 'stripe-link', true );
+		} );
+
+		ece.on( 'confirm', ( event ) => {
+			debug(
+				'[spike] ECE confirm — expressPaymentType=%s',
+				( event as { expressPaymentType?: string } ).expressPaymentType
+			);
+			debug( '[spike] elements group at confirm: %o', elements );
+
+			// Spike step 3: real processor would:
+			//   1. POST to /me/transactions → clientSecret
+			//   2. stripe.confirmPayment({ elements, clientSecret, confirmParams: {...} })
+			//   3. poll fetchPurchaseOrder until success/error
+			debug( '[spike] Would call stripe.confirmPayment({ elements, clientSecret }) here' );
+			event.paymentFailed( { reason: 'fail' } );
+		} );
+
+		ece.mount( mountTargetRef.current );
+		debug( 'ECE mounted' );
+
+		return () => {
+			ece.unmount();
+			elementsRef.current = null;
+			eceRef.current = null;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ stripe ] );
+
+	// SPIKE STEP 1: Call elements.update({ amount }) on cart total changes.
+	// This is the mechanism that replaces the whole-paymentRequest-rebuild
+	// workaround in web-pay-utils.tsx:107. What we're validating: does the ECE
+	// stay mounted and reflect the new amount, or does it remount/error?
+	useEffect( () => {
+		if ( ! elementsRef.current ) {
+			return;
+		}
+		debug( '[spike] elements.update({ amount: %d })', amount );
+		elementsRef.current.update( { amount } );
+	}, [ amount ] );
+
+	useRegisterPaymentMethodLoading( 'stripe-link', ! isReady );
+
+	return <div ref={ mountTargetRef } />;
+}

--- a/packages/wpcom-checkout/src/translate-payment-method-names.ts
+++ b/packages/wpcom-checkout/src/translate-payment-method-names.ts
@@ -169,6 +169,8 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'apple-pay':
 		case 'google-pay':
 			return 'web-pay';
+		case 'stripe-link':
+			return 'stripe-link';
 	}
 	return null;
 }

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -343,7 +343,8 @@ export type CheckoutPaymentMethodSlug =
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay' // a synonym for 'web-pay'
 	| 'stripe-upi'
-	| 'stripe-blik';
+	| 'stripe-blik'
+	| 'stripe-link'; // synonym for 'web-pay' during spike; will get its own backend class
 
 /**
  * Payment method slugs as returned by the WPCOM backend.


### PR DESCRIPTION
Part of SHILL-2098 DO NOT MERGE!

## Proposed Changes

* Upgrades `@stripe/stripe-js` from v1.54.2 to v4.10.0 and `@stripe/react-stripe-js` from v2.1.0 to v3.10.0. v4 adds proper TypeScript types for the `paymentMethods.link` option on `ExpressCheckoutElementOptions`, which v1 lacked.
* Wires Stripe's ExpressCheckoutElement (ECE) into composite-checkout as a `stripe-link` payment method behind the `checkout/stripe-link` feature flag. Currently shows Apple Pay, Google Pay, and Link (all `auto`).

## Why are these changes being made?

Spike to validate ECE as the path for adding Link (and eventually migrating Apple Pay / Google Pay away from the legacy PaymentRequestButton). Key questions being tested in staging:

- Does `elements.update({ amount })` correctly update the mounted ECE when the cart total changes? (Confirmed locally — no remount required.)
- Does ECE mount correctly inside composite-checkout? (Confirmed locally.)
- Are Apple Pay / Google Pay available via ECE in staging? (To be validated — domain verification and HTTPS requirements blocked local testing.)
- Is Link available via ECE on the Stripe accounts used in staging? (Blocked locally by account-level surface restriction on stripe-ie; see SHILL-2098 for details.)

## Testing Instructions

* Enable the feature flag `checkout/stripe-link` in `config/development.json` (already set in this branch).
* Go to checkout. A "Link by Stripe" row should appear in the payment methods list.
* In Safari on an Apple device: Apple Pay button should appear in the ECE widget.
* In Chrome: Google Pay button should appear.
* Change the cart total (add/remove a product) and confirm the ECE stays mounted and updates in place — no flicker or remount.
* If Link is enabled on the Stripe account in use, a Link button should also appear.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?