### PR TITLE
Agents Manager: merge provider context and markdown exports

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -6,7 +6,22 @@ import {
 	mergeCapabilitiesInto,
 	mergeUseSuggestionsHooks,
 } from '../load-external-providers';
+import type { Ability } from '../../extension-types';
 import type { ProviderCapabilities, UseSuggestionsHook } from '../load-external-providers';
+
+function setAgentsManagerData( data: Record< string, unknown > ) {
+	( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData = data;
+	( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData = data;
+}
+
+function createAbility( name: string ): Ability {
+	return {
+		name,
+		label: name,
+		description: `${ name } description`,
+		category: 'test',
+	};
+}
 
 describe( 'mergeCapabilitiesInto', () => {
 	it( 'is a no-op when capabilities is undefined', () => {
@@ -79,16 +94,185 @@ describe( 'loadExternalProviders', () => {
 			agentId: 'reader-chat',
 			agentProviders: [ 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs' ],
 		};
-		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
-			agentsManagerData;
-		( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData =
-			agentsManagerData;
+		setAgentsManagerData( agentsManagerData );
 
 		const providers = await loadExternalProviders();
 
 		expect( providers.toolProvider ).toBeUndefined();
 		expect( providers.contextProvider ).toBeUndefined();
 		expect( providers.useSuggestions ).toEqual( expect.any( Function ) );
+	} );
+
+	it( 'merges abilities from multiple tool providers and dispatches execution to the owner', async () => {
+		const firstProvider = {
+			getAbilities: jest.fn( () => Promise.resolve( [ createAbility( 'host/navigate' ) ] ) ),
+			executeAbility: jest.fn( () => Promise.resolve( { handledBy: 'host' } ) ),
+		};
+		const secondProvider = {
+			getAbilities: jest.fn( () =>
+				Promise.resolve( [ createAbility( 'woocommerce/get-products' ) ] )
+			),
+			executeAbility: jest.fn( () => Promise.resolve( { handledBy: 'woo' } ) ),
+		};
+		setAgentsManagerData( {
+			agentProviders: [ { toolProvider: firstProvider }, { toolProvider: secondProvider } ],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
+			createAbility( 'host/navigate' ),
+			createAbility( 'woocommerce/get-products' ),
+		] );
+		await expect(
+			providers.toolProvider?.executeAbility( 'woocommerce__get_products', { limit: 5 } )
+		).resolves.toEqual( { handledBy: 'woo' } );
+		expect( firstProvider.executeAbility ).not.toHaveBeenCalled();
+		expect( secondProvider.executeAbility ).toHaveBeenCalledWith( 'woocommerce__get_products', {
+			limit: 5,
+		} );
+	} );
+
+	it( 'keeps the earlier tool provider on duplicate ability names', async () => {
+		const firstProvider = {
+			getAbilities: jest.fn( () => Promise.resolve( [ createAbility( 'shared/action' ) ] ) ),
+			executeAbility: jest.fn( () => Promise.resolve( { handledBy: 'first' } ) ),
+		};
+		const secondProvider = {
+			getAbilities: jest.fn( () => Promise.resolve( [ createAbility( 'shared/action' ) ] ) ),
+			executeAbility: jest.fn( () => Promise.resolve( { handledBy: 'second' } ) ),
+		};
+		setAgentsManagerData( {
+			agentProviders: [ { toolProvider: firstProvider }, { toolProvider: secondProvider } ],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
+			createAbility( 'shared/action' ),
+		] );
+		await expect( providers.toolProvider?.executeAbility( 'shared/action', {} ) ).resolves.toEqual(
+			{
+				handledBy: 'first',
+			}
+		);
+		expect( firstProvider.executeAbility ).toHaveBeenCalled();
+		expect( secondProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'merges context from multiple context providers', async () => {
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					contextProvider: {
+						getClientContext: () => ( {
+							url: 'https://example.com/wp-admin/site-editor.php',
+							pathname: '/wp-admin/site-editor.php',
+							search: '',
+							environment: 'wp-admin',
+							currentScreen: { url: 'https://example.com/wp-admin/site-editor.php' },
+							contextEntries: [
+								{ id: 'site-structure', type: 'site-structure', data: { pages: 3 } },
+							],
+							constructorArguments: { client: 'site-editor' },
+						} ),
+					},
+				},
+				{
+					contextProvider: {
+						getClientContext: () => ( {
+							url: 'https://example.com/wp-admin/admin.php?page=wc-admin',
+							pathname: '/wp-admin/admin.php?page=wc-admin',
+							search: '?page=wc-admin',
+							environment: 'woocommerce-ai',
+							page: { type: 'dashboard' },
+							store: { currency: 'USD' },
+							contextEntries: [
+								{ id: 'woocommerce-ai', type: 'woocommerce-ai', data: { enabled: true } },
+							],
+							constructorArguments: { model: 'gpt-5.2', client: 'woocommerce-ai' },
+						} ),
+					},
+				},
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.contextProvider?.getClientContext() ).toEqual( {
+			url: 'https://example.com/wp-admin/site-editor.php',
+			pathname: '/wp-admin/site-editor.php',
+			search: '',
+			environment: 'wp-admin',
+			currentScreen: { url: 'https://example.com/wp-admin/site-editor.php' },
+			page: { type: 'dashboard' },
+			store: { currency: 'USD' },
+			contextEntries: [
+				{ id: 'site-structure', type: 'site-structure', data: { pages: 3 } },
+				{ id: 'woocommerce-ai', type: 'woocommerce-ai', data: { enabled: true } },
+			],
+			constructorArguments: {
+				client: 'site-editor',
+				model: 'gpt-5.2',
+			},
+		} );
+	} );
+
+	it( 'merges markdown components and extensions from multiple providers', async () => {
+		const hostStrong = jest.fn( () => ( { type: 'strong', props: { provider: 'host' } } ) );
+		const wooTable = jest.fn( () => ( { type: 'table', props: { provider: 'woo' } } ) );
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					markdownComponents: { strong: hostStrong },
+					markdownExtensions: { gfm: { enabled: true } },
+				},
+				{
+					markdownComponents: { table: wooTable },
+					markdownExtensions: { charts: { enabled: true } },
+				},
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.markdownComponents?.strong ).toBe( hostStrong );
+		expect( providers.markdownComponents?.table ).toBe( wooTable );
+		expect( providers.markdownExtensions ).toEqual( {
+			gfm: { enabled: true },
+			charts: { enabled: true },
+		} );
+	} );
+
+	it( 'chains markdown code renderers so later providers can handle structured blocks', async () => {
+		const hostCode = jest.fn( ( props ) => ( {
+			type: 'code',
+			props: { ...props, provider: 'host-fallback' },
+		} ) );
+		const wooCode = jest.fn( ( props: { className?: string } ) =>
+			props.className === 'language-product'
+				? { type: 'ProductCard', props: { provider: 'woo' } }
+				: { type: 'code', props: { ...props, provider: 'woo-fallback' } }
+		);
+		setAgentsManagerData( {
+			agentProviders: [
+				{ markdownComponents: { code: hostCode } },
+				{ markdownComponents: { code: wooCode } },
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+		const CodeComponent = providers.markdownComponents?.code as ( props: {
+			className?: string;
+			children?: string;
+		} ) => unknown;
+
+		expect( CodeComponent( { className: 'language-product', children: '{"id":1}' } ) ).toEqual( {
+			type: 'ProductCard',
+			props: { provider: 'woo' },
+		} );
+		expect( hostCode ).toHaveBeenCalled();
+		expect( wooCode ).toHaveBeenCalled();
 	} );
 } );
 

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -218,6 +218,92 @@ describe( 'loadExternalProviders', () => {
 		} );
 	} );
 
+	it( 'skips failed context providers when merging context from multiple providers', async () => {
+		const consoleWarn = jest.spyOn( console, 'warn' ).mockImplementation();
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					contextProvider: {
+						getClientContext: () => ( {
+							url: 'https://example.com/wp-admin/site-editor.php',
+							pathname: '/wp-admin/site-editor.php',
+							search: '',
+							environment: 'wp-admin',
+							currentScreen: { url: 'https://example.com/wp-admin/site-editor.php' },
+						} ),
+					},
+				},
+				{
+					contextProvider: {
+						getClientContext: () => {
+							throw new Error( 'Provider is not ready on this surface.' );
+						},
+					},
+				},
+				{
+					contextProvider: {
+						getClientContext: () => ( {
+							url: 'https://example.com/wp-admin/admin.php?page=wc-admin',
+							pathname: '/wp-admin/admin.php?page=wc-admin',
+							search: '?page=wc-admin',
+							environment: 'woocommerce-ai',
+							store: { currency: 'USD' },
+						} ),
+					},
+				},
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.contextProvider?.getClientContext() ).toEqual( {
+			url: 'https://example.com/wp-admin/site-editor.php',
+			pathname: '/wp-admin/site-editor.php',
+			search: '',
+			environment: 'wp-admin',
+			currentScreen: { url: 'https://example.com/wp-admin/site-editor.php' },
+			store: { currency: 'USD' },
+		} );
+		expect( consoleWarn ).toHaveBeenCalledWith(
+			'[AgentsManager] Failed to load context from provider:',
+			expect.any( Error )
+		);
+		consoleWarn.mockRestore();
+	} );
+
+	it( 'returns a minimal browser context when every merged context provider fails', async () => {
+		const consoleWarn = jest.spyOn( console, 'warn' ).mockImplementation();
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					contextProvider: {
+						getClientContext: () => {
+							throw new Error( 'First provider failed.' );
+						},
+					},
+				},
+				{
+					contextProvider: {
+						getClientContext: () => {
+							throw new Error( 'Second provider failed.' );
+						},
+					},
+				},
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.contextProvider?.getClientContext() ).toEqual( {
+			url: window.location.href,
+			pathname: window.location.pathname,
+			search: window.location.search,
+			environment: 'wp-admin',
+		} );
+		expect( consoleWarn ).toHaveBeenCalledTimes( 2 );
+		consoleWarn.mockRestore();
+	} );
+
 	it( 'merges markdown components and extensions from multiple providers', async () => {
 		const hostStrong = jest.fn( () => ( { type: 'strong', props: { provider: 'host' } } ) );
 		const wooTable = jest.fn( () => ( { type: 'table', props: { provider: 'woo' } } ) );

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -15,9 +15,17 @@ import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
 import { isReaderChatAgent } from './is-reader-chat-agent';
 import { useReaderFollowupSuggestions } from './reader-followup-hook';
 import type { ImageUploadHook } from '../hooks/use-image-upload';
-import type { ToolProvider, ContextProvider, Suggestion, BigSkyMessage } from '../types';
+import type {
+	ToolProvider,
+	ContextProvider,
+	ClientContextType,
+	ContextEntry,
+	Suggestion,
+	BigSkyMessage,
+} from '../types';
 import type { UseAgentChatReturn } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
+import type { ReactNode } from 'react';
 
 /**
  * Check if the unified experience flag is set via agentsManagerData.
@@ -192,6 +200,159 @@ export function mergeUseSuggestionsHooks(
 	};
 }
 
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return typeof value === 'object' && value !== null;
+}
+
+function mergeContextEntries(
+	firstEntries: ContextEntry[] | undefined,
+	nextEntries: ContextEntry[] | undefined
+): ContextEntry[] | undefined {
+	const entries = [ ...( firstEntries || [] ) ];
+	const seenIds = new Set( entries.map( ( entry ) => entry.id ) );
+
+	for ( const entry of nextEntries || [] ) {
+		if ( seenIds.has( entry.id ) ) {
+			continue;
+		}
+		seenIds.add( entry.id );
+		entries.push( entry );
+	}
+
+	return entries.length ? entries : undefined;
+}
+
+function getConstructorArguments(
+	context: ClientContextType
+): Record< string, unknown > | undefined {
+	const constructorArguments = context.constructorArguments;
+	return isRecord( constructorArguments ) ? constructorArguments : undefined;
+}
+
+function mergeClientContexts( contexts: ClientContextType[] ): ClientContextType {
+	const [ firstContext, ...remainingContexts ] = contexts;
+	let mergedContext = { ...firstContext };
+
+	for ( const context of remainingContexts ) {
+		const contextEntries = mergeContextEntries(
+			mergedContext.contextEntries,
+			context.contextEntries
+		);
+		const constructorArguments = {
+			...( getConstructorArguments( context ) || {} ),
+			...( getConstructorArguments( mergedContext ) || {} ),
+		};
+
+		mergedContext = {
+			...context,
+			...mergedContext,
+			...( contextEntries && { contextEntries } ),
+			...( Object.keys( constructorArguments ).length > 0 && { constructorArguments } ),
+		};
+	}
+
+	return mergedContext;
+}
+
+export function mergeContextProviders(
+	contextProviders: ContextProvider[]
+): ContextProvider | undefined {
+	if ( contextProviders.length === 0 ) {
+		return undefined;
+	}
+
+	if ( contextProviders.length === 1 ) {
+		return contextProviders[ 0 ];
+	}
+
+	return {
+		getClientContext: () =>
+			mergeClientContexts(
+				contextProviders.map( ( contextProvider ) => contextProvider.getClientContext() )
+			),
+	};
+}
+
+function isPlainMarkdownFallback( value: unknown, componentName: string ): boolean {
+	return isRecord( value ) && value.type === componentName;
+}
+
+function composeMarkdownCodeComponents( components: unknown[] ): unknown {
+	const callableComponents = components.filter(
+		( component ): component is ( props: Record< string, unknown > ) => ReactNode =>
+			typeof component === 'function'
+	);
+
+	if ( callableComponents.length !== components.length ) {
+		return components[ 0 ];
+	}
+
+	return ( props: Record< string, unknown > ) => {
+		let firstFallback: ReactNode | undefined;
+
+		for ( const component of callableComponents ) {
+			const result = component( props );
+			if ( ! isPlainMarkdownFallback( result, 'code' ) ) {
+				return result;
+			}
+
+			if ( firstFallback === undefined ) {
+				firstFallback = result;
+			}
+		}
+
+		return firstFallback ?? null;
+	};
+}
+
+export function mergeMarkdownComponentsFromProviders(
+	componentGroups: MarkdownComponents[]
+): MarkdownComponents | undefined {
+	if ( componentGroups.length === 0 ) {
+		return undefined;
+	}
+
+	if ( componentGroups.length === 1 ) {
+		return componentGroups[ 0 ];
+	}
+
+	const componentsByName = new Map< string, unknown[] >();
+	for ( const components of componentGroups ) {
+		for ( const [ name, component ] of Object.entries( components ) ) {
+			const existing = componentsByName.get( name ) || [];
+			existing.push( component );
+			componentsByName.set( name, existing );
+		}
+	}
+
+	const mergedComponents: Record< string, unknown > = {};
+	for ( const [ name, components ] of componentsByName ) {
+		mergedComponents[ name ] =
+			name === 'code' && components.length > 1
+				? composeMarkdownCodeComponents( components )
+				: components[ 0 ];
+	}
+
+	return mergedComponents as MarkdownComponents;
+}
+
+export function mergeMarkdownExtensionsFromProviders(
+	extensionGroups: MarkdownExtensions[]
+): MarkdownExtensions | undefined {
+	if ( extensionGroups.length === 0 ) {
+		return undefined;
+	}
+
+	if ( extensionGroups.length === 1 ) {
+		return extensionGroups[ 0 ];
+	}
+
+	return extensionGroups.reduce< MarkdownExtensions >(
+		( merged, extensions ) => ( { ...extensions, ...merged } ),
+		{}
+	);
+}
+
 /**
  * Load external agent providers from agentsManagerData.agentProviders.
  *
@@ -231,10 +392,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	}
 
 	let mergedToolProvider: ToolProvider | undefined;
-	let mergedContextProvider: ContextProvider | undefined;
 	let mergedGetEmptyViewSuggestions: ( () => Suggestion[] ) | undefined;
-	let mergedMarkdownComponents: MarkdownComponents | undefined;
-	let mergedMarkdownExtensions: MarkdownExtensions | undefined;
 	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
 	let mergedAbilitiesSetup: AbilitiesSetupHook | undefined;
 	let mergedGetChatComponent: GetChatComponent | undefined;
@@ -246,6 +404,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 
 	// Collect exports that need to be merged across all providers.
 	const allToolProviders: ToolProvider[] = [];
+	const allContextProviders: ContextProvider[] = [];
+	const allMarkdownComponents: MarkdownComponents[] = [];
+	const allMarkdownExtensions: MarkdownExtensions[] = [];
 	const allGetChatComponents: GetChatComponent[] = [];
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
@@ -295,17 +456,17 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		if ( module.getEmptyViewSuggestions ) {
 			allGetEmptyViewSuggestions.push( module.getEmptyViewSuggestions );
 		}
+		if ( module.contextProvider ) {
+			allContextProviders.push( module.contextProvider );
+		}
+		if ( module.markdownComponents ) {
+			allMarkdownComponents.push( module.markdownComponents );
+		}
+		if ( module.markdownExtensions ) {
+			allMarkdownExtensions.push( module.markdownExtensions );
+		}
 
 		// First-write-wins for singleton exports.
-		if ( module.contextProvider && ! mergedContextProvider ) {
-			mergedContextProvider = module.contextProvider;
-		}
-		if ( module.markdownComponents && ! mergedMarkdownComponents ) {
-			mergedMarkdownComponents = module.markdownComponents;
-		}
-		if ( module.markdownExtensions && ! mergedMarkdownExtensions ) {
-			mergedMarkdownExtensions = module.markdownExtensions;
-		}
 		if ( module.useNavigationContinuation && ! mergedNavigationContinuation ) {
 			mergedNavigationContinuation = module.useNavigationContinuation;
 		}
@@ -322,11 +483,13 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		mergeCapabilitiesInto( mergedCapabilities, module.capabilities );
 	}
 
+	const mergedContextProvider = mergeContextProviders( allContextProviders );
+	const mergedMarkdownComponents = mergeMarkdownComponentsFromProviders( allMarkdownComponents );
+	const mergedMarkdownExtensions = mergeMarkdownExtensionsFromProviders( allMarkdownExtensions );
+
 	// Merge toolProviders: first-write-wins by ability name, matching the
-	// resolution order of every other merged provider export (contextProvider,
-	// getChatComponent, useSuggestions, etc). Providers are processed in the
-	// order they were registered; earlier providers win on ability-name
-	// collisions.
+	// resolution order of colliding provider exports. Providers are processed
+	// in the order they were registered; earlier providers win on collisions.
 	if ( allToolProviders.length === 1 ) {
 		mergedToolProvider = allToolProviders[ 0 ];
 	} else if ( allToolProviders.length > 1 ) {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -254,6 +254,18 @@ function mergeClientContexts( contexts: ClientContextType[] ): ClientContextType
 	return mergedContext;
 }
 
+function getFallbackClientContext(): ClientContextType {
+	const location =
+		typeof window !== 'undefined' ? window.location : { href: '', pathname: '', search: '' };
+
+	return {
+		url: location.href,
+		pathname: location.pathname,
+		search: location.search,
+		environment: 'wp-admin',
+	};
+}
+
 export function mergeContextProviders(
 	contextProviders: ContextProvider[]
 ): ContextProvider | undefined {
@@ -266,10 +278,20 @@ export function mergeContextProviders(
 	}
 
 	return {
-		getClientContext: () =>
-			mergeClientContexts(
-				contextProviders.map( ( contextProvider ) => contextProvider.getClientContext() )
-			),
+		getClientContext: () => {
+			const contexts: ClientContextType[] = [];
+
+			for ( const contextProvider of contextProviders ) {
+				try {
+					contexts.push( contextProvider.getClientContext() );
+				} catch ( error ) {
+					// eslint-disable-next-line no-console
+					console.warn( '[AgentsManager] Failed to load context from provider:', error );
+				}
+			}
+
+			return contexts.length ? mergeClientContexts( contexts ) : getFallbackClientContext();
+		},
 	};
 }
 


### PR DESCRIPTION
Relates to WOOAI-441

## Proposed Changes

* Compose multiple external `contextProvider` exports in Agents Manager instead of keeping only the first provider.
* Merge additive context shapes: append/dedupe `contextEntries` by `id` and shallow-merge `constructorArguments` while keeping earlier-provider precedence for collisions.
* Merge `markdownComponents` and `markdownExtensions` across providers.
* Chain colliding `markdownComponents.code` renderers so a plain `<code>` fallback from one provider does not block a later provider from rendering structured cards.
* Add regression coverage for multi-provider tool, context, markdown component, markdown extension, and duplicate ability behavior.

## Why are these changes being made?

WOOAI-441 is the Agents Manager dependency for WooCommerce AI on WPCOM additive mode. WooCommerce AI can be installed alongside an existing WPCOM/Jetpack provider. In that case, AM must preserve host context and rendering behavior while still adding Woo-specific tools, context, and structured response cards.

Tools were already mostly composed, but context and markdown exports still behaved like singleton exports. That made provider order too important:

* If the WPCOM/host provider won, Woo context and Woo structured cards could be dropped.
* If the Woo provider won, WPCOM context such as `environment`, current page/editor context, and host renderers could be dropped.

This PR keeps provider order deterministic for collisions, while making known additive shapes compose.

## Relationship to the provider composition RFC

This is intended as an initial step toward the multiple-provider support direction described in the [Agents Manager provider merge contract RFC](https://fornop2.wordpress.com/2026/06/12/rfc-merge-contract-for-agents-manager-providers/). The RFC goes further by proposing an explicit host/guest composition manifest with claimed ability namespaces, component types, context keys, supported agent IDs, conflict handling, and fail-soft fallback behavior. This PR keeps the current legacy/provider-order contract and only makes known additive exports compose safely: tools, context entries, constructor arguments, markdown components, and markdown extensions. A follow-up should add the explicit composition policy from the RFC so ownership no longer depends on PHP/provider registration order, and so guest providers can contribute only the namespaces and context keys they claim.

## Example: two providers after this change

Assume AM receives providers in this order:

```ts
agentsManagerData.agentProviders = [ hostProvider, wooProvider ];
```

The host/WPCOM-style provider owns the base environment and page context:

```ts
const hostProvider = {
	toolProvider: {
		getAbilities: async () => [
			{ name: 'wp-admin/navigate' },
			{ name: 'shared/report' },
		],
		executeAbility: async ( name ) => ( { handledBy: 'host', name } ),
	},

	contextProvider: {
		getClientContext: () => ( {
			url: 'https://example.com/wp-admin/site-editor.php',
			pathname: '/wp-admin/site-editor.php',
			search: '',
			environment: 'wp-admin',
			currentScreen: { url: 'https://example.com/wp-admin/site-editor.php' },
			contextEntries: [ { id: 'site-structure', type: 'site-structure' } ],
			constructorArguments: { client: 'site-editor' },
		} ),
	},

	markdownComponents: {
		code: HostCode,
		strong: HostStrong,
	},
	markdownExtensions: {
		gfm: { enabled: true },
	},
};
```

The Woo provider contributes Woo abilities, Woo context, and Woo structured card renderers:

```ts
const wooProvider = {
	toolProvider: {
		getAbilities: async () => [
			{ name: 'woocommerce/get-products' },
			{ name: 'shared/report' }, // duplicate
		],
		executeAbility: async ( name ) => ( { handledBy: 'woo', name } ),
	},

	contextProvider: {
		getClientContext: () => ( {
			url: 'https://example.com/wp-admin/admin.php?page=wc-admin',
			pathname: '/wp-admin/admin.php?page=wc-admin',
			search: '?page=wc-admin',
			environment: 'woocommerce-ai',
			page: { type: 'dashboard' },
			store: { currency: 'USD' },
			contextEntries: [ { id: 'woocommerce-ai', type: 'woocommerce-ai' } ],
			constructorArguments: { model: 'gpt-5.2', client: 'woocommerce-ai' },
		} ),
	},

	markdownComponents: {
		code: WooCode,
		table: WooTable,
	},
	markdownExtensions: {
		charts: { enabled: true },
	},
};
```

The merged tool provider exposes abilities from both providers, with earlier-provider-wins on duplicate ability names:

```ts
await merged.toolProvider.getAbilities();
// [
//   { name: 'wp-admin/navigate' },
//   { name: 'shared/report' },
//   { name: 'woocommerce/get-products' },
// ]
```

`shared/report` appears only once from `hostProvider`. A Woo ability still routes to Woo, including when AM calls it by its normalized tool name:

```ts
await merged.toolProvider.executeAbility( 'woocommerce__get_products', args );
// calls wooProvider.toolProvider.executeAbility(...)
```

The merged context preserves host-owned scalar fields and adds Woo-only fields:

```ts
merged.contextProvider.getClientContext();
// {
//   url: 'https://example.com/wp-admin/site-editor.php',
//   pathname: '/wp-admin/site-editor.php',
//   search: '',
//   environment: 'wp-admin',
//   currentScreen: { url: 'https://example.com/wp-admin/site-editor.php' },
//
//   page: { type: 'dashboard' },
//   store: { currency: 'USD' },
//
//   contextEntries: [
//     { id: 'site-structure', type: 'site-structure' },
//     { id: 'woocommerce-ai', type: 'woocommerce-ai' },
//   ],
//
//   constructorArguments: {
//     client: 'site-editor',
//     model: 'gpt-5.2',
//   },
// }
```

That means Woo can add context without switching the final request from `environment: 'wp-admin'` to standalone `environment: 'woocommerce-ai'` just because both providers are present.

The merged markdown config also contains keys from both providers:

```ts
merged.markdownComponents;
// {
//   code: ChainedCodeRenderer,
//   strong: HostStrong,
//   table: WooTable,
// }

merged.markdownExtensions;
// {
//   gfm: { enabled: true },
//   charts: { enabled: true },
// }
```

## Why `markdownComponents.code` gets special handling

`markdownComponents.code` is the React Markdown override for inline code and fenced code blocks. Providers use it to turn structured fenced code blocks into richer UI.

For example, Woo can render this response:

````md
```product
{ "id": 123, "name": "Hoodie" }
```
````

as a Woo product card instead of raw JSON.

The issue is that most `code` renderers are written as “handle what I know, otherwise return a normal `<code>` fallback”:

```tsx
function HostCode( props ) {
	if ( props.className === 'language-host-card' ) {
		return <HostCard />;
	}

	return <code>{ props.children }</code>;
}

function WooCode( props ) {
	if ( props.className === 'language-product' ) {
		return <ProductCard />;
	}

	return <code>{ props.children }</code>;
}
```

Without the special case, first-provider-wins means `HostCode` handles every code block. For a Woo product block, `HostCode` does not understand `language-product`, so it returns plain `<code>` and Woo never gets a chance to render `<ProductCard />`.

With this PR, colliding `code` renderers are tried in provider order. A plain `<code>` result is treated as “not handled yet”, so the next provider gets a chance:

```ts
ChainedCodeRenderer( { className: 'language-product', children: json } );
// HostCode returns plain <code> fallback, so AM tries WooCode.
// WooCode returns <ProductCard />.
// Final render: <ProductCard />.
```

If every provider returns a plain `<code>` fallback, AM keeps the first fallback. That preserves provider-order precedence for ordinary code blocks while allowing structured card renderers from multiple providers to coexist.

Other markdown component collisions, such as two providers defining `table`, still use earlier-provider-wins because they are normal element renderers, not structured-code dispatchers.

## Testing Instructions

* `yarn jest -c test/packages/jest.config.js packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts --runInBand`
* `yarn eslint --ext .ts packages/agents-manager/src/utils/load-external-providers.ts packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts`
* `yarn typecheck-packages`
* `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager --runInBand`
* `git diff --check`

The full Agents Manager Jest subset emits existing unrelated console warnings from React Router future flags and feedback-input tests, but all suites pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
