### PR TITLE
Domains: polish domain bundle cart displays

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -611,10 +611,6 @@ const BundleMemberList = styled.div`
 	font-size: 12px;
 	font-weight: 400;
 	gap: 2px;
-
-	& .cost-overrides-list-bundle-member {
-		display: flex;
-	}
 `;
 
 /**

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -614,8 +614,6 @@ const BundleMemberList = styled.div`
 
 	& .cost-overrides-list-bundle-member {
 		display: flex;
-		justify-content: space-between;
-		gap: 0 16px;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -619,15 +619,10 @@ const BundleMemberList = styled.div`
 	}
 `;
 
-const BundleRenewalNote = styled.div`
-	font-size: 12px;
-	font-weight: 400;
-`;
-
 /**
  * Render a domain bundle as a single compact row in the order summary, mirroring
- * the order-review surface's `BundleLineItem`: a "Domain bundle" title with the
- * summed bundle total, and each member domain listed beneath with its own price.
+ * the order-review surface's `BundleLineItem`: a "Domain Bundle" title with the
+ * summed bundle total, and each member domain listed beneath.
  * The presentation matches the summary's other product rows (green check icon,
  * label-and-price header) rather than reusing the heavier review component.
  */
@@ -650,48 +645,33 @@ export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBun
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
-	// Bundle members renew at full price (no plan credit at renewal —
-	// DOMAINS-2173), so the renewal aggregate is the pre-discount group total.
-	// item_original_subtotal_integer is the list price, so it needs no coupon
-	// exclusion (DOMAINS-2184).
 	const bundleOriginalInteger = products.reduce(
 		( total, product ) => total + product.item_original_subtotal_integer,
 		0
 	);
+	const bundleOriginalDisplay = formatCurrency( bundleOriginalInteger, currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
 	const isBundleDiscounted = bundleTotalInteger < bundleOriginalInteger;
 
 	return (
 		<SimplifiedSingleProductAndCostOverridesListWrapper className="cost-overrides-list-product-wrapper">
 			<WPCheckoutCheckIcon />
 			<ProductTitleAreaForCostOverridesList>
-				<span className="cost-overrides-list-product__title">{ translate( 'Domain bundle' ) }</span>
-				<SimplifiedLineItemPrice actualAmount={ bundleTotalDisplay } />
+				<span className="cost-overrides-list-product__title">{ translate( 'Domain Bundle' ) }</span>
+				<SimplifiedLineItemPrice
+					actualAmount={ bundleTotalDisplay }
+					crossedOutAmount={ isBundleDiscounted ? bundleOriginalDisplay : undefined }
+				/>
 			</ProductTitleAreaForCostOverridesList>
 			<BundleMemberList>
 				{ products.map( ( product ) => (
 					<div className="cost-overrides-list-bundle-member" key={ product.uuid }>
 						<span>{ product.meta }</span>
-						<span>
-							{ formatCurrency( getItemSubtotalExcludingCoupon( product ), product.currency, {
-								isSmallestUnit: true,
-								stripZeros: true,
-							} ) }
-						</span>
 					</div>
 				) ) }
 			</BundleMemberList>
-			{ isBundleDiscounted && (
-				<BundleRenewalNote>
-					{ translate( 'Auto-renews at %(price)s/year.', {
-						args: {
-							price: formatCurrency( bundleOriginalInteger, currency, {
-								isSmallestUnit: true,
-								stripZeros: true,
-							} ),
-						},
-					} ) }
-				</BundleRenewalNote>
-			) }
 		</SimplifiedSingleProductAndCostOverridesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
+++ b/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
@@ -94,11 +94,13 @@ describe( 'BundleProductAndCostOverridesList', () => {
 	it( 'renders the bundle label, each member domain, and the summed total', () => {
 		renderBundleRow();
 
-		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'Domain Bundle' ) ).toBeVisible();
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 		// 2200 + 1800 = 4000 smallest-unit => $40.
 		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+		expect( screen.queryByText( /\$22\b/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /\$18\b/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows pre-coupon prices so the dedicated coupon line is not double-counted', () => {
@@ -119,16 +121,13 @@ describe( 'BundleProductAndCostOverridesList', () => {
 			],
 		} );
 
-		// Companion shows the pre-coupon $20, not the $18 post-coupon subtotal.
-		expect( screen.getByText( /\$20\b/ ) ).toBeVisible();
+		// Companion price is included in the grouped total, not shown as a separate row.
+		expect( screen.queryByText( /\$20\b/ ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( /\$18\b/ ) ).not.toBeInTheDocument();
 		// 2200 + 2000 = 4200 smallest-unit => $42.
 		expect( screen.getByText( /\$42\b/ ) ).toBeVisible();
 	} );
-
-	it( 'discloses the full-price renewal aggregate when the bundle is discounted', () => {
-		// Bundle members renew at full (pre-discount) price, so the disclosure
-		// shows the summed item_original_subtotal_integer: 6500 + 6400 => $129.
+	it( 'shows the summed original price crossed out when the bundle is discounted', () => {
 		renderBundleRow( {
 			type: 'bundle',
 			groupId: 'bundle-discounted',
@@ -148,43 +147,10 @@ describe( 'BundleProductAndCostOverridesList', () => {
 			],
 		} );
 
-		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
-	} );
-
-	it( 'discloses the list-price aggregate even when a coupon also discounts a member', () => {
-		// Coupon and bundle discount together: the row total strips the coupon
-		// (shown on its dedicated line) while the disclosure uses the list
-		// price, which is pre-coupon by definition.
-		renderBundleRow( {
-			type: 'bundle',
-			groupId: 'bundle-coupon-and-discount',
-			products: [
-				buildDomainProduct( {
-					uuid: 'primary',
-					meta: 'example.com',
-					subtotal: 2200,
-					originalSubtotal: 6500,
-				} ),
-				buildDomainProduct( {
-					uuid: 'companion',
-					meta: 'example.net',
-					subtotal: 700,
-					originalSubtotal: 6400,
-					costOverrides: [ buildCouponOverride( 900, 700 ) ],
-				} ),
-			],
-		} );
-
-		// Row total: 2200 + pre-coupon 900 = 3100 smallest-unit => $31.
-		expect( screen.getByText( /\$31\b/ ) ).toBeVisible();
-		// Disclosure: list price 6500 + 6400 = 12900 => $129, unaffected by the coupon.
-		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
-	} );
-
-	it( 'shows no renewal disclosure when the bundle is not discounted', () => {
-		renderBundleRow();
-
-		expect( screen.queryByText( /Auto-renews at/ ) ).not.toBeInTheDocument();
+		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
+		const crossedOut = screen.getByText( /\$129\b/ );
+		expect( crossedOut ).toBeVisible();
+		expect( crossedOut.tagName ).toBe( 'S' );
 	} );
 } );
 
@@ -251,7 +217,7 @@ describe( 'ProductsAndCostOverridesList', () => {
 			</TestWrapper>
 		);
 
-		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'Domain Bundle' ) ).toBeVisible();
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 	} );
@@ -266,7 +232,7 @@ describe( 'ProductsAndCostOverridesList', () => {
 			</TestWrapper>
 		);
 
-		expect( screen.queryByText( 'Domain bundle' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Domain Bundle' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 	} );

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -268,10 +268,22 @@ export interface BundleSuggestion {
 	bundle_price: number;
 
 	/**
+	 * Formatted total bundle price
+	 * @example "$60"
+	 */
+	bundle_cost?: string;
+
+	/**
 	 * Combined original price before bundle discount (raw numeric)
 	 * @example 75
 	 */
 	original_price: number;
+
+	/**
+	 * Formatted combined original price before bundle discount
+	 * @example "$75"
+	 */
+	original_cost?: string;
 
 	/**
 	 * Bundle discount as a whole-number percent

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -41,9 +41,19 @@ export const BundleCard = ( {
 		);
 	}
 
-	const { sld, domains, bundle_price, original_price, discount_percent } = suggestion;
+	const {
+		sld,
+		domains,
+		bundle_price,
+		bundle_cost,
+		original_price,
+		original_cost,
+		discount_percent,
+	} = suggestion;
 
 	const hasPremiumDomain = domains.some( ( domain ) => domain.is_premium );
+	const displayBundlePrice = bundle_cost ?? bundle_price;
+	const displayOriginalPrice = original_cost ?? original_price;
 
 	return (
 		<div className="bundle-card">
@@ -71,10 +81,10 @@ export const BundleCard = ( {
 				<div className="bundle-card__pricing">
 					<HStack alignment="center" justify="flex-start" spacing={ 2 } expanded={ false }>
 						<Text size={ 20 } weight={ 500 } className="bundle-card__bundle-price">
-							{ bundle_price }
+							{ displayBundlePrice }
 						</Text>
 						<Text className="bundle-card__original-price">
-							<s>{ original_price }</s>
+							<s>{ displayOriginalPrice }</s>
 						</Text>
 					</HStack>
 					<Text className="bundle-card__discount">

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -80,6 +80,26 @@ describe( 'BundleCard', () => {
 		expect( original.closest( 's' ) ).not.toBeNull();
 	} );
 
+	it( 'renders formatted bundle totals when provided', () => {
+		render(
+			<BundleCard
+				suggestion={ buildSuggestion( twoDomains, {
+					bundle_price: 29.9,
+					bundle_cost: '$29.90',
+					original_price: 39,
+					original_cost: '$39',
+				} ) }
+			/>
+		);
+
+		expect( screen.getByText( '$29.90' ) ).toBeInTheDocument();
+
+		const original = screen.getByText( '$39' );
+		expect( original.closest( 's' ) ).not.toBeNull();
+
+		expect( screen.queryByText( '29.9' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders the discount percent text', () => {
 		render( <BundleCard suggestion={ buildSuggestion( twoDomains, { discount_percent: 20 } ) } /> );
 

--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -360,7 +360,10 @@ describe( 'FullCart', () => {
 				expect( screen.getByText( 'Cart' ) ).toBeVisible();
 			} );
 
-			const bundleRow = await screen.findByTitle( 'Domain bundle' );
+			const bundleRow = await screen.findByTitle( 'Domain Bundle' );
+
+			expect( getByText( bundleRow, 'Protect your brand' ) ).toBeInTheDocument();
+			expect( getByText( bundleRow, 'Includes' ) ).toBeInTheDocument();
 
 			expect( getByLabelText( bundleRow, 'example.com' ) ).toBeInTheDocument();
 			expect( getByLabelText( bundleRow, 'example.net' ) ).toBeInTheDocument();
@@ -395,7 +398,7 @@ describe( 'FullCart', () => {
 				expect( screen.getByText( 'Cart' ) ).toBeVisible();
 			} );
 
-			expect( await screen.findByTitle( 'Domain bundle' ) ).toBeInTheDocument();
+			expect( await screen.findByTitle( 'Domain Bundle' ) ).toBeInTheDocument();
 
 			const standaloneRow = await screen.findByTitle( 'standalone.org' );
 			expect( getByLabelText( standaloneRow, 'Price: $10' ) ).toBeInTheDocument();
@@ -437,7 +440,7 @@ describe( 'FullCart', () => {
 				expect( screen.getByText( 'Cart' ) ).toBeVisible();
 			} );
 
-			const bundleRows = await screen.findAllByTitle( 'Domain bundle' );
+			const bundleRows = await screen.findAllByTitle( 'Domain Bundle' );
 			expect( bundleRows ).toHaveLength( 2 );
 
 			const [ firstBundle, secondBundle ] = bundleRows;
@@ -473,12 +476,12 @@ describe( 'FullCart', () => {
 				expect( screen.getByText( 'Cart' ) ).toBeVisible();
 			} );
 
-			const bundleRow = await screen.findByTitle( 'Domain bundle' );
+			const bundleRow = await screen.findByTitle( 'Domain Bundle' );
 
 			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove bundle' } ) );
 
 			await waitFor( () => {
-				expect( screen.queryByTitle( 'Domain bundle' ) ).not.toBeInTheDocument();
+				expect( screen.queryByTitle( 'Domain Bundle' ) ).not.toBeInTheDocument();
 			} );
 
 			expect( screen.queryByLabelText( 'example.com' ) ).not.toBeInTheDocument();
@@ -507,7 +510,7 @@ describe( 'FullCart', () => {
 				expect( screen.getByText( 'Cart' ) ).toBeVisible();
 			} );
 
-			const bundleRow = await screen.findByTitle( 'Domain bundle' );
+			const bundleRow = await screen.findByTitle( 'Domain Bundle' );
 
 			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove bundle' } ) );
 
@@ -539,7 +542,7 @@ describe( 'FullCart', () => {
 			);
 
 			expect( await screen.findByTitle( 'example.com' ) ).toBeInTheDocument();
-			expect( screen.queryByTitle( 'Domain bundle' ) ).not.toBeInTheDocument();
+			expect( screen.queryByTitle( 'Domain Bundle' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -363,16 +363,19 @@ describe( 'FullCart', () => {
 			const bundleRow = await screen.findByTitle( 'Domain Bundle' );
 
 			expect( getByText( bundleRow, 'Protect your brand' ) ).toBeInTheDocument();
-			expect( getByText( bundleRow, 'Includes' ) ).toBeInTheDocument();
+			expect(
+				bundleRow.querySelector( '.domains-full-cart-items__bundle-protect-icon' )
+			).toBeInTheDocument();
+			expect( queryByText( bundleRow, 'Includes' ) ).not.toBeInTheDocument();
 
 			expect( getByLabelText( bundleRow, 'example.com' ) ).toBeInTheDocument();
 			expect( getByLabelText( bundleRow, 'example.net' ) ).toBeInTheDocument();
 
-			expect( getByLabelText( bundleRow, 'Price: $40' ) ).toBeInTheDocument();
+			expect( getByLabelText( bundleRow, 'Price: $40 /year' ) ).toBeInTheDocument();
 			expect( queryByText( bundleRow, '$22' ) ).not.toBeInTheDocument();
 			expect( queryByText( bundleRow, '$18' ) ).not.toBeInTheDocument();
 
-			expect( getAllByRole( bundleRow, 'button', { name: 'Remove bundle' } ) ).toHaveLength( 1 );
+			expect( getAllByRole( bundleRow, 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
 		} );
 
 		it( 'renders standalone items on their own rows next to a bundle', async () => {
@@ -404,8 +407,7 @@ describe( 'FullCart', () => {
 			expect( getByLabelText( standaloneRow, 'Price: $10' ) ).toBeInTheDocument();
 
 			// One remove action for the bundle, one for the standalone item.
-			expect( await screen.findAllByRole( 'button', { name: 'Remove bundle' } ) ).toHaveLength( 1 );
-			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
+			expect( await screen.findAllByRole( 'button', { name: 'Remove' } ) ).toHaveLength( 2 );
 		} );
 
 		it( 'renders two bundles as two separate grouped rows', async () => {
@@ -447,14 +449,15 @@ describe( 'FullCart', () => {
 
 			expect( getByLabelText( firstBundle, 'example.com' ) ).toBeInTheDocument();
 			expect( getByLabelText( firstBundle, 'example.net' ) ).toBeInTheDocument();
-			expect( getByLabelText( firstBundle, 'Price: $40' ) ).toBeInTheDocument();
+			expect( getByLabelText( firstBundle, 'Price: $40 /year' ) ).toBeInTheDocument();
 
 			expect( getByLabelText( secondBundle, 'other.com' ) ).toBeInTheDocument();
 			expect( getByLabelText( secondBundle, 'other.net' ) ).toBeInTheDocument();
-			expect( getByLabelText( secondBundle, 'Price: $25' ) ).toBeInTheDocument();
+			expect( getByLabelText( secondBundle, 'Price: $25 /year' ) ).toBeInTheDocument();
 
 			// One remove action per bundle.
-			expect( await screen.findAllByRole( 'button', { name: 'Remove bundle' } ) ).toHaveLength( 2 );
+			expect( getAllByRole( firstBundle, 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
+			expect( getAllByRole( secondBundle, 'button', { name: 'Remove' } ) ).toHaveLength( 1 );
 		} );
 
 		it( 'removes the whole bundle, and only the bundle, with a single remove action', async () => {
@@ -478,7 +481,7 @@ describe( 'FullCart', () => {
 
 			const bundleRow = await screen.findByTitle( 'Domain Bundle' );
 
-			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove bundle' } ) );
+			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove' } ) );
 
 			await waitFor( () => {
 				expect( screen.queryByTitle( 'Domain Bundle' ) ).not.toBeInTheDocument();
@@ -512,7 +515,7 @@ describe( 'FullCart', () => {
 
 			const bundleRow = await screen.findByTitle( 'Domain Bundle' );
 
-			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove bundle' } ) );
+			await fireEvent.click( getByRole( bundleRow, 'button', { name: 'Remove' } ) );
 
 			await waitFor( () => {
 				expect( onRemoveItem ).toHaveBeenCalledTimes( 2 );

--- a/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import type { DomainInCart } from './types';
 
 /**
- * Render a domain bundle as a single grouped cart row: a "Domain bundle"
+ * Render a domain bundle as a single grouped cart row: a "Domain Bundle"
  * label, the member domains listed beneath it, one summed price, and a single
  * remove action that clears every member from the cart at once (matching the
  * backend's all-or-nothing rule).
@@ -36,7 +36,7 @@ export const DomainsFullCartBundleItem = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	const bundleLabel = __( 'Domain bundle' );
+	const bundleLabel = __( 'Domain Bundle' );
 
 	return (
 		<Card title={ bundleLabel }>
@@ -47,32 +47,9 @@ export const DomainsFullCartBundleItem = ( {
 							<Text size="medium" weight={ 500 }>
 								{ bundleLabel }
 							</Text>
-							{ members.map( ( member ) => {
-								const domainName = `${ member.domain }.${ member.tld }`;
-
-								return (
-									<Text
-										key={ member.uuid }
-										size="medium"
-										aria-label={ domainName }
-										style={ { wordBreak: 'break-all' } }
-									>
-										{ member.domain }
-										<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
-											.{ member.tld }
-										</Text>
-									</Text>
-								);
-							} ) }
-							<Button
-								disabled={ disabled }
-								isBusy={ isBusy }
-								variant="link"
-								className="domains-full-cart-items__remove"
-								onClick={ onRemove }
-							>
-								{ __( 'Remove bundle' ) }
-							</Button>
+							<Text size="small" variant="muted">
+								{ __( 'Protect your brand' ) }
+							</Text>
 						</VStack>
 						<VStack className="domains-full-cart-items__price">
 							<HStack alignment="right" spacing={ 2 }>
@@ -89,6 +66,41 @@ export const DomainsFullCartBundleItem = ( {
 							</HStack>
 						</VStack>
 					</HStack>
+					<VStack
+						spacing={ 2 }
+						alignment="left"
+						className="domains-full-cart-items__bundle-members"
+					>
+						<Text size="small" variant="muted" className="domains-full-cart-items__bundle-includes">
+							{ __( 'Includes' ) }
+						</Text>
+						{ members.map( ( member ) => {
+							const domainName = `${ member.domain }.${ member.tld }`;
+
+							return (
+								<Text
+									key={ member.uuid }
+									size="medium"
+									aria-label={ domainName }
+									style={ { wordBreak: 'break-all' } }
+								>
+									{ member.domain }
+									<Text size="inherit" weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
+										.{ member.tld }
+									</Text>
+								</Text>
+							);
+						} ) }
+					</VStack>
+					<Button
+						disabled={ disabled }
+						isBusy={ isBusy }
+						variant="link"
+						className="domains-full-cart-items__remove"
+						onClick={ onRemove }
+					>
+						{ __( 'Remove bundle' ) }
+					</Button>
 					{ errorMessage && (
 						<Notice status="error" onRemove={ removeErrorMessage }>
 							{ errorMessage }

--- a/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/bundle.tsx
@@ -8,6 +8,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
+import { Icon, lock } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import type { DomainInCart } from './types';
 
@@ -37,6 +38,11 @@ export const DomainsFullCartBundleItem = ( {
 	const { __ } = useI18n();
 
 	const bundleLabel = __( 'Domain Bundle' );
+	const priceWithInterval = sprintf(
+		// translators: %(price)s is the total price of the domain bundle.
+		__( '%(price)s /year' ),
+		{ price }
+	);
 
 	return (
 		<Card title={ bundleLabel }>
@@ -47,9 +53,14 @@ export const DomainsFullCartBundleItem = ( {
 							<Text size="medium" weight={ 500 }>
 								{ bundleLabel }
 							</Text>
-							<Text size="small" variant="muted">
-								{ __( 'Protect your brand' ) }
-							</Text>
+							<HStack alignment="center" justify="flex-start" spacing={ 2 }>
+								<Icon
+									icon={ lock }
+									size={ 16 }
+									className="domains-full-cart-items__bundle-protect-icon"
+								/>
+								<Text size="small">{ __( 'Protect your brand' ) }</Text>
+							</HStack>
 						</VStack>
 						<VStack className="domains-full-cart-items__price">
 							<HStack alignment="right" spacing={ 2 }>
@@ -58,10 +69,10 @@ export const DomainsFullCartBundleItem = ( {
 									aria-label={ sprintf(
 										// translators: %(price)s is the total price of the domain bundle.
 										__( 'Price: %(price)s' ),
-										{ price }
+										{ price: priceWithInterval }
 									) }
 								>
-									{ price }
+									{ priceWithInterval }
 								</Text>
 							</HStack>
 						</VStack>
@@ -71,9 +82,6 @@ export const DomainsFullCartBundleItem = ( {
 						alignment="left"
 						className="domains-full-cart-items__bundle-members"
 					>
-						<Text size="small" variant="muted" className="domains-full-cart-items__bundle-includes">
-							{ __( 'Includes' ) }
-						</Text>
 						{ members.map( ( member ) => {
 							const domainName = `${ member.domain }.${ member.tld }`;
 
@@ -91,16 +99,16 @@ export const DomainsFullCartBundleItem = ( {
 								</Text>
 							);
 						} ) }
+						<Button
+							disabled={ disabled }
+							isBusy={ isBusy }
+							variant="link"
+							className="domains-full-cart-items__remove"
+							onClick={ onRemove }
+						>
+							{ __( 'Remove' ) }
+						</Button>
 					</VStack>
-					<Button
-						disabled={ disabled }
-						isBusy={ isBusy }
-						variant="link"
-						className="domains-full-cart-items__remove"
-						onClick={ onRemove }
-					>
-						{ __( 'Remove bundle' ) }
-					</Button>
 					{ errorMessage && (
 						<Notice status="error" onRemove={ removeErrorMessage }>
 							{ errorMessage }

--- a/packages/domain-search/src/ui/domains-full-cart-items/style.scss
+++ b/packages/domain-search/src/ui/domains-full-cart-items/style.scss
@@ -7,6 +7,16 @@
 	flex-shrink: 0;
 }
 
+.domains-full-cart-items__bundle-members {
+	border-top: 1px solid rgba( 0, 0, 0, 0.05 );
+	border-bottom: 1px solid rgba( 0, 0, 0, 0.05 );
+	padding: 16px 0;
+}
+
+.domains-full-cart-items__bundle-includes {
+	text-transform: uppercase;
+}
+
 .domains-full-cart-items__original-price {
 	text-decoration: line-through;
 }

--- a/packages/domain-search/src/ui/domains-full-cart-items/style.scss
+++ b/packages/domain-search/src/ui/domains-full-cart-items/style.scss
@@ -7,14 +7,14 @@
 	flex-shrink: 0;
 }
 
-.domains-full-cart-items__bundle-members {
-	border-top: 1px solid rgba( 0, 0, 0, 0.05 );
-	border-bottom: 1px solid rgba( 0, 0, 0, 0.05 );
-	padding: 16px 0;
+.domains-full-cart-items__bundle-protect-icon {
+	fill: currentColor;
+	flex: 0 0 auto;
 }
 
-.domains-full-cart-items__bundle-includes {
-	text-transform: uppercase;
+.domains-full-cart-items__bundle-members {
+	border-top: 1px solid rgba( 0, 0, 0, 0.05 );
+	padding: 16px 0;
 }
 
 .domains-full-cart-items__original-price {

--- a/packages/mini-cart/test/mini-cart-line-items.tsx
+++ b/packages/mini-cart/test/mini-cart-line-items.tsx
@@ -59,7 +59,7 @@ describe( 'MiniCartLineItems bundle grouping', () => {
 	test( 'folds bundle members into one grouped line item when grouping is enabled', () => {
 		renderLineItems( true );
 
-		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'Domain Bundle' ) ).toBeVisible();
 		// Both members show inside the group; the standalone domain stays on its own line.
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
@@ -69,7 +69,7 @@ describe( 'MiniCartLineItems bundle grouping', () => {
 	test( 'renders every product on its own line when grouping is disabled', () => {
 		renderLineItems( false );
 
-		expect( screen.queryByText( 'Domain bundle' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Domain Bundle' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 		expect( screen.getByText( 'standalone.com' ) ).toBeVisible();
@@ -96,22 +96,14 @@ describe( 'MiniCartLineItems bundle grouping', () => {
 
 		const { container } = renderLineItems( true, cart );
 
-		// The $129 amount also appears in the renewal disclosure line
-		// (DOMAINS-2184), so match the crossed-out price on the tag.
 		const crossedOut = screen
 			.getAllByText( /\$129\b/ )
 			.find( ( element ) => element.tagName === 'S' );
 		expect( crossedOut ).toBeVisible();
-		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
-		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+		expect( screen.getAllByText( /\$29\b/ ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( /\$40\b/ ) ).toHaveLength( 2 );
 
 		// Only the discounted bundle shows a strikethrough.
 		expect( container.querySelectorAll( 's' ) ).toHaveLength( 1 );
-
-		// The mini-cart shares BundleLineItem with the order review, so the
-		// discounted bundle also discloses its renewal aggregate here — and
-		// only the discounted one (DOMAINS-2184).
-		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
-		expect( screen.getAllByText( /Auto-renews at/ ) ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -207,6 +207,53 @@ const DeleteButtonWrapper = styled.div`
 	justify-content: inherit;
 `;
 
+const BundleLineItemWrapper = styled.div< { theme?: Theme } >`
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	padding: 16px 0;
+	font-weight: ${ ( props ) => props.theme.weights.normal };
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-size: 1.1em;
+	position: relative;
+
+	.checkout-line-item__price {
+		position: relative;
+	}
+`;
+
+const BundleMemberList = styled.div< { theme?: Theme } >`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin-top: 8px;
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-size: 14px;
+	line-height: 1.4;
+`;
+
+const BundleTermRow = styled.div< { theme?: Theme } >`
+	box-sizing: border-box;
+	width: 100%;
+	border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin-top: 16px;
+	padding: 16px;
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-size: 14px;
+`;
+
+const BundleTermPrice = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+`;
+
 const DeleteButton = styled( Button )< { theme?: Theme } >`
 	width: auto;
 	font-size: 0.75rem;
@@ -472,7 +519,7 @@ export function BundleLineItem( {
 		stripZeros: true,
 	} );
 	const isBundleDiscounted = bundleTotalInteger < bundleOriginalInteger;
-	const bundleLabel = String( translate( 'Domain bundle' ) );
+	const bundleLabel = String( translate( 'Domain Bundle' ) );
 
 	const removeBundleFromCart = () => {
 		products.forEach( ( product ) => {
@@ -483,7 +530,7 @@ export function BundleLineItem( {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div
+		<BundleLineItemWrapper
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
 			data-e2e-product-slug="domain-bundle"
 			data-product-type="domain-bundle"
@@ -497,36 +544,28 @@ export function BundleLineItem( {
 				/>
 			</span>
 
-			{ isBundleDiscounted && (
-				<LineItemMeta>
+			<LineItemMeta>
+				<LineItemSublabelTitle>
+					{ translate( 'Domain Bundle Registration: billed annually' ) }
+				</LineItemSublabelTitle>
+				{ isBundleDiscounted && (
 					<DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>
-				</LineItemMeta>
-			) }
+				) }
+			</LineItemMeta>
 
-			{ /* Bundle members renew at full price (no plan credit at renewal —
-			     DOMAINS-2173), so the renewal aggregate is the pre-discount group
-			     total already computed for the strikethrough (DOMAINS-2184). */ }
-			{ isBundleDiscounted && (
-				<LineItemMeta>
-					<span>
-						{ translate( 'Auto-renews at %(price)s/year.', {
-							args: { price: bundleOriginalDisplay },
-						} ) }
-					</span>
-				</LineItemMeta>
-			) }
+			<BundleMemberList>
+				{ products.map( ( product ) => (
+					<span key={ product.uuid }>{ product.meta }</span>
+				) ) }
+			</BundleMemberList>
 
-			{ products.map( ( product ) => (
-				<LineItemMeta key={ product.uuid }>
-					<span>{ product.meta }</span>
-					<span>
-						{ formatCurrency( product.item_subtotal_integer, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ) }
-					</span>
-				</LineItemMeta>
-			) ) }
+			<BundleTermRow>
+				<span>{ translate( 'One year' ) }</span>
+				<BundleTermPrice>
+					<span>{ bundleTotalDisplay }</span>
+					<Gridicon icon="chevron-down" size={ 16 } />
+				</BundleTermPrice>
+			</BundleTermRow>
 
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
@@ -572,7 +611,7 @@ export function BundleLineItem( {
 					/>
 				</>
 			) }
-		</div>
+		</BundleLineItemWrapper>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -563,7 +563,7 @@ export function BundleLineItem( {
 				<span>{ translate( 'One year' ) }</span>
 				<BundleTermPrice>
 					<span>{ bundleTotalDisplay }</span>
-					<Gridicon icon="chevron-down" size={ 16 } />
+					<Gridicon icon="chevron-down" size={ 16 } aria-hidden="true" />
 				</BundleTermPrice>
 			</BundleTermRow>
 

--- a/packages/wpcom-checkout/test/bundle-line-item.tsx
+++ b/packages/wpcom-checkout/test/bundle-line-item.tsx
@@ -1,10 +1,13 @@
 import { CheckoutProvider } from '@automattic/composite-checkout';
+import { matchers } from '@emotion/jest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BundleLineItem } from '../src/checkout-line-items';
 import { buildDomainProduct } from './fixtures/bundle-cart';
 import type { CartBundleLineItem } from '../src/group-bundle-line-items';
+
+expect.extend( matchers );
 
 const bundle: CartBundleLineItem = {
 	type: 'bundle',
@@ -68,14 +71,41 @@ function renderBundle( props: Partial< React.ComponentProps< typeof BundleLineIt
 }
 
 describe( 'BundleLineItem', () => {
-	test( 'renders the bundle label, member domains, and the summed total', () => {
+	test( 'renders the bundle label, billing copy, member domains, and the summed total', () => {
 		renderBundle();
 
-		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'Domain Bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'Domain Bundle Registration: billed annually' ) ).toBeVisible();
+		expect(
+			screen.queryByText( 'First year discounted; domains renew at standard rates.' )
+		).not.toBeInTheDocument();
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 		// 2200 + 1800 = 4000 smallest-unit => $40.
-		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+		expect( screen.getAllByText( /\$40\b/ ) ).toHaveLength( 2 );
+	} );
+
+	test( 'uses the checkout product-row layout', () => {
+		const { container } = renderBundle();
+
+		const root = container.querySelector( '[data-product-type="domain-bundle"]' );
+		expect( root ).toHaveStyleRule( 'display', 'flex' );
+		expect( root ).toHaveStyleRule( 'flex-wrap', 'wrap' );
+		expect( root ).toHaveStyleRule( 'justify-content', 'space-between' );
+	} );
+
+	test( 'does not show individual member prices', () => {
+		renderBundle();
+
+		expect( screen.queryByText( /\$22\b/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /\$18\b/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a one-year term row with the bundle total', () => {
+		renderBundle();
+
+		expect( screen.getByText( 'One year' ) ).toBeVisible();
+		expect( screen.getAllByText( /\$40\b/ ) ).toHaveLength( 2 );
 	} );
 
 	test( 'shows no crossed-out price or discount callout when the bundle is not discounted', () => {
@@ -89,27 +119,12 @@ describe( 'BundleLineItem', () => {
 		renderBundle( { bundle: discountedBundle } );
 
 		// 2200 + 700 = 2900 smallest-unit => $29.
-		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
-		// 6500 + 6400 = 12900 smallest-unit => $129, struck through. The same
-		// amount also appears in the renewal disclosure, so match on the tag.
-		const crossedOut = screen
-			.getAllByText( /\$129\b/ )
-			.find( ( element ) => element.tagName === 'S' );
+		expect( screen.getAllByText( /\$29\b/ ) ).toHaveLength( 2 );
+		// 6500 + 6400 = 12900 smallest-unit => $129, struck through.
+		const crossedOut = screen.getByText( /\$129\b/ );
 		expect( crossedOut ).toBeVisible();
+		expect( crossedOut.tagName ).toBe( 'S' );
 		expect( screen.getByText( 'Discount for first year' ) ).toBeVisible();
-	} );
-
-	test( 'discloses the full-price renewal aggregate when the bundle is discounted', () => {
-		renderBundle( { bundle: discountedBundle } );
-
-		// Bundle members renew at full (pre-discount) price: 6500 + 6400 => $129.
-		expect( screen.getByText( 'Auto-renews at $129/year.' ) ).toBeVisible();
-	} );
-
-	test( 'shows no renewal disclosure when the bundle is not discounted', () => {
-		renderBundle();
-
-		expect( screen.queryByText( /Auto-renews at/ ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows no remove button without hasDeleteButton', () => {
@@ -124,7 +139,7 @@ describe( 'BundleLineItem', () => {
 
 		renderBundle( { hasDeleteButton: true, removeProductFromCart } );
 
-		await user.click( screen.getByRole( 'button', { name: /Remove Domain bundle from cart/ } ) );
+		await user.click( screen.getByRole( 'button', { name: /Remove Domain Bundle from cart/ } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 
 		expect( removeProductFromCart ).toHaveBeenCalledTimes( 2 );
@@ -142,7 +157,7 @@ describe( 'BundleLineItem', () => {
 			onRemoveBundle,
 		} );
 
-		await user.click( screen.getByRole( 'button', { name: /Remove Domain bundle from cart/ } ) );
+		await user.click( screen.getByRole( 'button', { name: /Remove Domain Bundle from cart/ } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 
 		expect( onRemoveBundle ).toHaveBeenCalledTimes( 1 );
@@ -159,7 +174,7 @@ describe( 'BundleLineItem', () => {
 			onRemoveBundle,
 		} );
 
-		await user.click( screen.getByRole( 'button', { name: /Remove Domain bundle from cart/ } ) );
+		await user.click( screen.getByRole( 'button', { name: /Remove Domain Bundle from cart/ } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
 		expect( onRemoveBundle ).not.toHaveBeenCalled();


### PR DESCRIPTION
Part of DOMAINS-2191

## Proposed Changes

* Format domain bundle totals in the search result card using the API-provided formatted prices.
* Refine the domain-search cart sidebar bundle grouping so bundled domains are presented as one grouped card with members listed underneath.
* Align the domain-search cart sidebar bundle card with design feedback: `/year` pricing, lock + “Protect your brand” row, no “Includes” label, no one-year selector, and a left-aligned `Remove` action.
* Refine the checkout and order-summary bundle rows to match the approved design: grouped title/price, compact member list, and one-year selector row.

<img width="2422" height="1610" alt="CleanShot 2026-06-15 at 15 36 09@2x" src="https://github.com/user-attachments/assets/bca0ef2b-757e-4fef-b06e-8d54b2d8ac4a" />

<img width="832" height="690" alt="CleanShot 2026-06-16 at 10 56 15@2x" src="https://github.com/user-attachments/assets/f24115da-49eb-49bf-a29f-f38276b86c58" />


<img width="2330" height="696" alt="image" src="https://github.com/user-attachments/assets/1c4e597b-a593-4ad6-b4d7-7b6a5e2d5367" />


## Why are these changes being made?

* The domain bundle upsell needs consistent pricing and grouping across search results, mini-cart, and checkout before broader testing.
* The checkout bundle row previously used the generic line-item layout, which put pricing and copy in the wrong places compared with the design.

## Testing Instructions

* Load the domain search flow with the domain bundling flag enabled.
* Search for an eligible domain bundle and confirm the bundle card shows formatted bundle pricing.
* Add the bundle to cart and confirm the domain-search cart sidebar groups the bundle domains into one card with `/year` pricing, the lock/protect row, member domains, and a `Remove` link.
* Continue to checkout and confirm the checkout row and order summary show the bundle title, struck original price when discounted, discounted total, member domains, and one-year selector.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

