### PR TITLE
Apps: React 19 forward-compatible codemod + odyssey-stats size limit

### DIFF
--- a/apps/notifications/src/app/note-icon/trophy-gridicon.tsx
+++ b/apps/notifications/src/app/note-icon/trophy-gridicon.tsx
@@ -1,4 +1,5 @@
 import { SVG, G, Path } from '@wordpress/primitives';
+import { type JSX } from 'react';
 
 const trophyGridicon: JSX.Element = (
 	<SVG version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 24 24">

--- a/apps/notifications/src/app/note-list/hooks.ts
+++ b/apps/notifications/src/app/note-list/hooks.ts
@@ -8,7 +8,7 @@ import type { Note } from '../types';
 
 import './style.scss';
 
-function focusToNote( noteListRef: React.RefObject< HTMLObjectElement >, note?: Note ) {
+function focusToNote( noteListRef: React.RefObject< HTMLObjectElement | null >, note?: Note ) {
 	const noteEl = noteListRef.current?.querySelector(
 		`.dataviews-view-list__item[id$="-${ note?.id }-item-wrapper"]`
 	) as HTMLElement;
@@ -22,7 +22,7 @@ export function useNoteListFocusToLastSelectedNote( {
 	noteListRef,
 	notes,
 }: {
-	noteListRef: React.RefObject< HTMLObjectElement >;
+	noteListRef: React.RefObject< HTMLObjectElement | null >;
 	notes: Note[];
 } ) {
 	const lastSelectedNoteId = useSelector( getLastSelectedNoteId );
@@ -78,7 +78,7 @@ export function useNoteListNavigationKeyboardShortcuts( {
 	noteListRef,
 	visibleNotes,
 }: {
-	noteListRef: React.RefObject< HTMLObjectElement >;
+	noteListRef: React.RefObject< HTMLObjectElement | null >;
 	visibleNotes: Note[];
 } ) {
 	const areKeyboardShortcutsEnabled = useSelector( getKeyboardShortcutsEnabled );

--- a/apps/notifications/src/shared/pending-approval-badge.tsx
+++ b/apps/notifications/src/shared/pending-approval-badge.tsx
@@ -1,5 +1,6 @@
 import { Icon, pending } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { type JSX } from 'react';
 import { getCommentsUrl, getReferenceId } from '../panel/helpers/notes';
 import type { Note } from '../app/types';
 

--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,10 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '495 KiB',
+		// Bumped for the React 19 / @wordpress/element 7 upgrade, which grows the
+		// gzipped bundle by ~33 KB (495 KiB -> ~528 KiB observed). Headroom added
+		// for CI/local build variance.
+		limit: '545 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),

--- a/apps/odyssey-stats/AGENTS.md
+++ b/apps/odyssey-stats/AGENTS.md
@@ -38,7 +38,7 @@ import './lib/init-app-config';
 
 ### Bundle Size Limits
 
-- `build.min.js`: 495 KiB max
+- `build.min.js`: 545 KiB max
 - `widget-loader.min.js`: 8 KiB max
 
 Run `yarn test:size` to verify.


### PR DESCRIPTION
Part of DOTCOM-17400

## Proposed Changes

Splits the `apps/` slice out of the React 19 validation spike (#111325) so it can land independently, ahead of the global `react`/`react-dom` version flip. All changes here are forward-compatible — they compile under both the React 18 types currently on trunk and React 19.

- **`apps/notifications`** — mechanical `types-react-codemod` output:
  - `scoped-jsx`: add `import { type JSX } from 'react'` where `JSX.Element` is used (`trophy-gridicon.tsx`, `pending-approval-badge.tsx`).
  - `useRef-required-initial`: widen `React.RefObject< HTMLObjectElement >` → `React.RefObject< HTMLObjectElement | null >` in `note-list/hooks.ts`.
- **`apps/odyssey-stats`** — raise the `build.min.js` `size-limit` from `495 KiB` → `545 KiB` (plus the matching note in `AGENTS.md`) to absorb the ~33 KB gzipped growth from React 19 + `@wordpress/element` 7.

## Why are these changes being made?

The "Migrate Calypso to React 19" project (DOTCOM-17400) lands forward-compatible codemod changes folder-by-folder before the version flip, to keep each PR small and reviewable. This is the `apps/` slice; `client/login` already landed in #111585. Both codemod patterns are already present on trunk with green CI, so they are safe under React 18 today.

## Testing Instructions

- The `apps/notifications` changes are type-only; verify with `yarn typecheck-apps`.
- For odyssey-stats: `yarn workspace @automattic/odyssey-stats run build && yarn workspace @automattic/odyssey-stats run test:size` — the size check passes against the new 545 KiB limit. (The bundle only actually grows once the React 19 version flip lands; this PR raises the ceiling ahead of it.)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
