### PR TITLE
Desktop: Document mac lanes with YARD instead of desc

### DIFF
--- a/desktop/fastlane/Fastfile
+++ b/desktop/fastlane/Fastfile
@@ -75,7 +75,11 @@ before_all do
 end
 
 platform :mac do
-  desc 'Download and configure code signing certificates and provisioning profiles .'
+  # Download and configure code signing certificates and provisioning profiles.
+  #
+  # @param readonly [Boolean] Use `true` to only fetch existing certificates and profiles from
+  #   our S3 bucket via `match`. Use `false` to create or update them on App Store Connect.
+  #
   lane :configure_code_signing do |readonly: true|
     EnvManager.require_env_vars!(*CODE_SIGNING_ENV_VARS)
 
@@ -97,11 +101,13 @@ platform :mac do
     )
   end
 
-  desc 'Notarize and staple the .dmg artifacts produced by electron-builder.'
+  # Notarize and staple the .dmg artifacts produced by electron-builder.
+  #
   # The `.app` is notarized and stapled earlier, in electron-builder's
   # afterSign hook (`bin/after_sign_hook.js`), so that the `.zip` packaged from
   # it carries a stapled app. This lane handles the `.dmg` wrapper, which only
   # exists after the build completes.
+  #
   lane :notarize_app do
     EnvManager.require_env_vars!(*ASC_API_KEY_ENV_VARS)
 


### PR DESCRIPTION
Switch fastlane lanes from `desc '...'` to using YARD doc-comments.

Follow up to @iangmaia suggestion at https://github.com/Automattic/wp-calypso/pull/110331#discussion_r3417420168

<details>
<summary>AI-generated details</summary>

## Proposed Changes

* Replace `desc` with a YARD doc-comment block above each `desktop/fastlane` mac lane, documenting keyword arguments via name-first `@param` lines.

## Why are these changes being made?

Addresses a review nit on #110331: sibling Fastlane setups (`studio`, `wpios`, `wcios`, `pcios`) have been moving away from `desc` toward YARD docs, which — unlike `desc` — can document a lane's parameters. This aligns the desktop Fastfile with that convention.

Note: `desc` feeds the `fastlane lanes`/`list` summaries; YARD comments don't. Dropping it trades that listing blurb for inline parameter docs, matching the sibling repos.

## Testing Instructions

* Comment-only change. `ruby -c desktop/fastlane/Fastfile` passes; lane behaviour is unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


</details>