### PR TITLE
Image Studio: fix post editor crash when the Jetpack Social store is unregistered

### DIFF
--- a/packages/image-studio/src/hooks/use-reel-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.test.ts
@@ -45,6 +45,11 @@ let mockState: {
 
 let mockReelSharePath: string | null;
 
+// When false, simulate the Jetpack Social plugin's editor data store not being
+// registered (e.g. Atomic sites without Jetpack Social active). `@wordpress/data`
+// then returns null from both select() and dispatch() for that store.
+let mockSocialStoreRegistered: boolean;
+
 jest.mock( '@wordpress/data', () => {
 	const select = ( storeName: string ) => {
 		if ( storeName === 'video-studio' ) {
@@ -68,10 +73,12 @@ jest.mock( '@wordpress/data', () => {
 			};
 		}
 		if ( storeName === 'jetpack-social-plugin' ) {
-			return {
-				getConnections: () => mockState.connections,
-				isSharingCurrentPost: () => mockState.isSharingCurrentPost,
-			};
+			return mockSocialStoreRegistered
+				? {
+						getConnections: () => mockState.connections,
+						isSharingCurrentPost: () => mockState.isSharingCurrentPost,
+				  }
+				: null;
 		}
 		return {};
 	};
@@ -83,7 +90,8 @@ jest.mock( '@wordpress/data', () => {
 				return { editPost: mockEditPost };
 			}
 			if ( storeName === 'jetpack-social-plugin' ) {
-				return { shareCurrentPost: mockShareCurrentPost };
+				// Registry.dispatch() returns null for an unregistered store.
+				return mockSocialStoreRegistered ? { shareCurrentPost: mockShareCurrentPost } : null;
 			}
 			if ( storeName === 'image-studio' ) {
 				return { addNotice: mockAddNotice };
@@ -158,6 +166,7 @@ describe( 'useReelShare', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockReelSharePath = '/wpcom/v2/publicize/share-post/{postId}';
+		mockSocialStoreRegistered = true;
 		mockState = {
 			currentVideoUrl: 'https://example.com/clip.mp4',
 			currentAttachmentId: 555,
@@ -541,6 +550,59 @@ describe( 'useReelShare', () => {
 			} );
 
 			expect( mockTrackNotPublished ).toHaveBeenCalledWith( { surface: 'modal' } );
+			expect( result.current.isConfirming ).toBe( false );
+			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'social store not registered (Atomic site regression)', () => {
+		it( 'renders without throwing when useDispatch( jetpack-social-plugin ) returns null', () => {
+			mockSocialStoreRegistered = false;
+
+			expect( () =>
+				renderHook( () =>
+					useReelShare( 'sidebar', {
+						url: 'https://example.com/clip.mp4',
+						attachmentId: 555,
+						durationSeconds: 12,
+					} )
+				)
+			).not.toThrow();
+		} );
+
+		it( 'keeps the share entry point visible so a late store registration can still hydrate', () => {
+			mockSocialStoreRegistered = false;
+
+			const { result } = renderHook( () =>
+				useReelShare( 'sidebar', {
+					url: 'https://example.com/clip.mp4',
+					attachmentId: 555,
+					durationSeconds: 12,
+				} )
+			);
+
+			expect( result.current.isVisible ).toBe( true );
+			expect( result.current.isConfirming ).toBe( false );
+		} );
+
+		it( 'does not dispatch a share when the social store is absent', async () => {
+			mockSocialStoreRegistered = false;
+
+			const { result } = renderHook( () =>
+				useReelShare( 'sidebar', {
+					url: 'https://example.com/clip.mp4',
+					attachmentId: 555,
+					durationSeconds: 12,
+				} )
+			);
+
+			// requestShare reads the social store fresh; with no IG connection it
+			// routes to the "connect Instagram" notice rather than opening the
+			// confirmation, so confirmShare can't dispatch a half-formed share.
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+
 			expect( result.current.isConfirming ).toBe( false );
 			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
 		} );

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -97,12 +97,19 @@ export function useReelShare(
 	const { editPost } = useDispatch( EDITOR_STORE ) as {
 		editPost: ( edits: { meta: Record< string, unknown > } ) => void;
 	};
-	const { shareCurrentPost } = useDispatch( SOCIAL_STORE ) as {
-		shareCurrentPost: (
+	// `jetpack-social-plugin` is registered by the Jetpack Social editor bundle,
+	// which isn't always present (e.g. Atomic sites without Jetpack Social
+	// active). `useDispatch` returns null for an unregistered store, so read the
+	// action off the result instead of destructuring it — destructuring null
+	// throws at render and takes down the whole editor. Mirrors the `?.`-guarded
+	// `useSelect( SOCIAL_STORE )` above.
+	const socialActions = useDispatch( SOCIAL_STORE ) as {
+		shareCurrentPost?: (
 			params: { message: string; skipped_connections: string[] },
 			config: { apiPath: string; savePost?: boolean }
 		) => Promise< boolean >;
-	};
+	} | null;
+	const shareCurrentPost = socialActions?.shareCurrentPost;
 	const { addNotice: addModalNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
 	const { createNotice: createCoreNotice } = useDispatch( 'core/notices' ) as {
 		createNotice?: (
@@ -292,10 +299,11 @@ export function useReelShare(
 			return;
 		}
 
-		if ( ! currentVideoUrl || ! currentAttachmentId || ! sharePath ) {
+		if ( ! currentVideoUrl || ! currentAttachmentId || ! sharePath || ! shareCurrentPost ) {
 			// requestShare gated these already; if we somehow lost state between
-			// open and confirm, fall back to closing the dialog rather than
-			// dispatching a half-formed share.
+			// open and confirm — or the social store never registered, leaving
+			// `shareCurrentPost` undefined — fall back to closing the dialog
+			// rather than dispatching a half-formed share.
 			setPendingShare( null );
 			return;
 		}

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -104,11 +104,14 @@ export function useReelShare(
 	// throws at render and takes down the whole editor. Mirrors the `?.`-guarded
 	// `useSelect( SOCIAL_STORE )` above.
 	const socialActions = useDispatch( SOCIAL_STORE ) as {
-		shareCurrentPost?: (
+		shareCurrentPost: (
 			params: { message: string; skipped_connections: string[] },
 			config: { apiPath: string; savePost?: boolean }
 		) => Promise< boolean >;
 	} | null;
+	// `socialActions` is null when the store isn't registered; optional chaining
+	// yields `undefined` for `shareCurrentPost` in that case. The action itself
+	// is required on a registered store, so it stays non-optional above.
 	const shareCurrentPost = socialActions?.shareCurrentPost;
 	const { addNotice: addModalNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
 	const { createNotice: createCoreNotice } = useDispatch( 'core/notices' ) as {


### PR DESCRIPTION
Fixes the Feature Clip Reel-share editor crash on sites without Jetpack Social.

## Proposed Changes

* `useReelShare` no longer destructures `shareCurrentPost` directly off `useDispatch( 'jetpack-social-plugin' )`. It now reads the action off the (possibly `null`) dispatch result and guards the single call site in `confirmShare`.
* Adds regression tests that simulate the `jetpack-social-plugin` store being unregistered (`useDispatch`/`select` return `null`) and assert the hook renders without throwing, keeps the share entry point visible, and never dispatches a half-formed share.

## Why are these changes being made?

On sites where the Jetpack Social editor data store isn't registered (e.g. Atomic sites without Jetpack Social active), the WordPress data registry's `dispatch()` returns `null` for that store. The hook destructured `shareCurrentPost` straight off that `null`, throwing at **render time** and taking down the entire post editor with “The editor has encountered an unexpected error”.

The crash surfaced specifically **after generating a Feature Clip**: once the post carries the clip meta, the sidebar mounts the clip preview, which calls `useReelShare`. The reported error was:

> TypeError: Cannot destructure property 'shareCurrentPost' of '(0 , r.useDispatch)(...)' as it is null.

The same store's `useSelect`, `select`, and `freshSelect` reads were already `?.`-guarded — only the `useDispatch` was not. This change brings it in line. The Instagram share button stays visible and clicking it falls back to the existing “Connect Instagram” notice rather than crashing.

## Testing Instructions

* On a site **without** Jetpack Social registered in the editor (e.g. an Atomic site without Jetpack Social active): generate a Feature Clip (cinematic or highlights) for a `post`, then reload/edit the post. Before this change the editor crashes; after it, the Feature Clip panel renders normally (preview, Add to post, Regenerate, generic Share). Clicking “Share on Instagram” shows the “Connect Instagram…” notice instead of crashing.
* On a site **with** Jetpack Social active, the full Reel share flow is unchanged.
* Automated: `yarn test-packages packages/image-studio/src/hooks/use-reel-share` — 29 passing, including the new "social store not registered (Atomic site regression)" cases.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)