### PR TITLE
Notifications: enable redesign in the desktop app

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -53,9 +53,7 @@ const getIsVisible = () => {
 
 const isDesktop = config.isEnabled( 'desktop' );
 
-// Keep the legacy panel in the Electron desktop app for now; the redesign is
-// only enabled in the browser.
-const isRedesignEnabled = config.isEnabled( 'notifications/redesign' ) && ! isDesktop;
+const isRedesignEnabled = config.isEnabled( 'notifications/redesign' );
 
 let notificationAppModule;
 


### PR DESCRIPTION
## Proposed Changes

* Remove the `! isDesktop` check that gated the `notifications/redesign` feature flag in `client/notifications/index.jsx`. The redesigned notifications app now loads wherever the `notifications/redesign` flag is enabled, including the Electron desktop app.
* Drop the now-stale "keep the legacy panel in the desktop app" comment.

## Why are these changes being made?

The desktop app was previously pinned to the legacy notifications panel while the redesign was browser-only. That carve-out is no longer needed, so the redesign should be controlled solely by the `notifications/redesign` flag across all environments.

## Testing Instructions

* With `notifications/redesign` enabled, open the notifications panel in the browser — the redesigned app loads as before.
* Build/run the Electron desktop app with `notifications/redesign` enabled and confirm the redesigned notifications app loads (previously it fell back to the legacy panel).
* Confirm no TypeScript or console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
