### PR TITLE
Remove lodash keyBy and shuffle in favor of @automattic/js-utils

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -35,6 +35,12 @@ module.exports = {
 						importNames: [ 'flowRight' ],
 						message: "Please use `compose` from 'redux' instead.",
 					},
+					// Use the equivalents from `@automattic/js-utils` instead of lodash.
+					{
+						name: 'lodash',
+						importNames: [ 'keyBy', 'shuffle' ],
+						message: 'Please use the equivalent from `@automattic/js-utils` instead.',
+					},
 				],
 			},
 		],

--- a/client/blocks/conversation-caterpillar/docs/fixtures.js
+++ b/client/blocks/conversation-caterpillar/docs/fixtures.js
@@ -1,4 +1,5 @@
-import { keyBy, map } from 'lodash';
+import { keyBy } from '@automattic/js-utils';
+import { map } from 'lodash';
 
 export const comments = [
 	{

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,4 +1,5 @@
-import { map, size, filter, get, partition, pickBy, keyBy } from 'lodash';
+import { keyBy } from '@automattic/js-utils';
+import { map, size, filter, get, partition, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';

--- a/client/blocks/user-avatar/user-hovercard/recommended-blogs/index.tsx
+++ b/client/blocks/user-avatar/user-hovercard/recommended-blogs/index.tsx
@@ -1,7 +1,7 @@
 import './styles.scss';
+import { shuffle } from '@automattic/js-utils';
 import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { shuffle } from 'lodash';
 import { useMemo, type JSX } from 'react';
 import { useFeedRecommendationsQuery } from 'calypso/data/reader/use-feed-recommendations-query';
 import { ReaderSitesList } from 'calypso/reader/sites-list';

--- a/client/components/happiness-engineers-tray/index.tsx
+++ b/client/components/happiness-engineers-tray/index.tsx
@@ -1,6 +1,6 @@
 import { Gravatar } from '@automattic/components';
 import { useHappinessEngineersQuery } from '@automattic/data-stores';
-import { shuffle } from 'lodash';
+import { shuffle } from '@automattic/js-utils';
 import { useMemo } from 'react';
 
 import './style.scss';

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -1,7 +1,7 @@
 import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
+import { shuffle } from '@automattic/js-utils';
 import { Button, RadioControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -6,9 +6,9 @@ import {
 	isDomainRegistration,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import { shuffle } from '@automattic/js-utils';
 import { Button as GutenbergButton, Spinner } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -1,4 +1,5 @@
-import { memoize, pick, shuffle, values } from 'lodash';
+import { shuffle } from '@automattic/js-utils';
+import { memoize, pick, values } from 'lodash';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';

--- a/client/state/comments/selectors/get-hidden-comments-for-post.js
+++ b/client/state/comments/selectors/get-hidden-comments-for-post.js
@@ -1,5 +1,6 @@
+import { keyBy } from '@automattic/js-utils';
 import treeSelect from '@automattic/tree-select';
-import { keyBy, pickBy } from 'lodash';
+import { pickBy } from 'lodash';
 import { getExpansionsForPost } from 'calypso/state/comments/selectors/get-expansions-for-post';
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 

--- a/client/state/comments/selectors/get-post-comments-tree.js
+++ b/client/state/comments/selectors/get-post-comments-tree.js
@@ -1,5 +1,6 @@
+import { keyBy } from '@automattic/js-utils';
 import treeSelect from '@automattic/tree-select';
-import { filter, groupBy, keyBy, map, mapValues, partition } from 'lodash';
+import { filter, groupBy, map, mapValues, partition } from 'lodash';
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';
@@ -51,7 +52,7 @@ export const getPostCommentsTree = treeSelect(
 			children: parentToChildIdMap[ item.ID ] || [],
 		} );
 
-		const commentsByIdMap = keyBy( map( items, transformItemToNode ), 'data.ID' );
+		const commentsByIdMap = keyBy( map( items, transformItemToNode ), ( node ) => node.data.ID );
 
 		return {
 			...commentsByIdMap,

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -1,5 +1,5 @@
+import { keyBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
-import { keyBy } from 'lodash';
 import { POST_TYPES_RECEIVE } from 'calypso/state/action-types';
 import {
 	combineReducers,

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -1,4 +1,5 @@
-import { keyBy, omit, without } from 'lodash';
+import { keyBy } from '@automattic/js-utils';
+import { omit, without } from 'lodash';
 import {
 	KEYRING_CONNECTION_DELETE,
 	KEYRING_CONNECTIONS_RECEIVE,

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -1,4 +1,5 @@
-import { keyBy, omit, omitBy } from 'lodash';
+import { keyBy } from '@automattic/js-utils';
+import { omit, omitBy } from 'lodash';
 import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -1,5 +1,6 @@
+import { keyBy } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { keyBy, get, omit } from 'lodash';
+import { get, omit } from 'lodash';
 import stepsConfig from 'calypso/signup/config/steps-pure';
 import {
 	SIGNUP_COMPLETE_RESET,


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `keyBy` (8 files) and `shuffle` (5 files) with the equivalents from `@automattic/js-utils`, and add a `no-restricted-imports` rule (in `client/.eslintrc.js`) banning them from lodash to prevent reintroduction.

This continues the incremental removal of lodash, reusing helpers the codebase already maintains.

## Why are these changes being made?

* Shrinks the lodash surface using in-repo, already-tested utilities. `@automattic/js-utils` already houses this kind of helper (`keyBy`, `uniqueBy`, `shuffle`, case converters).

## Testing Instructions

* `@automattic/js-utils` `shuffle` is a Fisher-Yates shuffle returning a new array — equivalent to lodash for array inputs (every call site passes an array).
* `@automattic/js-utils` `keyBy` accepts a function or string property name, matching lodash for those forms. The one difference: it does a literal property lookup rather than lodash's deep-path resolution, so a `'data.ID'` iteratee was converted to a function `( node ) => node.data.ID`.
* `yarn lint:js` passes; the new rule reports no violations and is verified to fire in `client/`.
* `yarn typecheck-client` introduces no new errors vs. trunk.
* `yarn test-client --findRelatedTests` on the changed files passes (1614 related tests green).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
