### PR TITLE
Remove lodash uniqBy in favor of @automattic/js-utils

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
 					// Use the equivalents from `@automattic/js-utils` instead of lodash.
 					{
 						name: 'lodash',
-						importNames: [ 'keyBy', 'shuffle' ],
+						importNames: [ 'keyBy', 'shuffle', 'uniqBy' ],
 						message: 'Please use the equivalent from `@automattic/js-utils` instead.',
 					},
 				],

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,5 +1,6 @@
+import { uniqBy } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { map, get, uniqBy, size, filter, compact } from 'lodash';
+import { map, get, size, filter, compact } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { isAncestor } from 'calypso/blocks/comments/utils';

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -1,4 +1,5 @@
-import { map, size, filter, uniqBy } from 'lodash';
+import { uniqBy } from '@automattic/js-utils';
+import { map, size, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Gravatar from 'calypso/components/gravatar';

--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -1,6 +1,6 @@
+import { uniqBy } from '@automattic/js-utils';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { localize } from 'i18n-calypso';
-import { uniqBy } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -1,7 +1,7 @@
 import { CompactCard, Count } from '@automattic/components';
+import { uniqBy } from '@automattic/js-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { uniqBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -57,9 +57,7 @@ class PluginItem extends Component {
 	doing() {
 		const { translate, progress } = this.props;
 		const log = progress[ 0 ];
-		const uniqLogs = uniqBy( progress, function ( uniqLog ) {
-			return uniqLog.siteId;
-		} );
+		const uniqLogs = uniqBy( progress, 'siteId' );
 		const translationArgs = {
 			args: { count: uniqLogs.length },
 			count: uniqLogs.length,

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -1,9 +1,10 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { Card } from '@automattic/components';
+import { uniqBy } from '@automattic/js-utils';
 import clsx from 'clsx';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
-import { forEach, uniqBy } from 'lodash';
+import { forEach } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -3,4 +3,5 @@ export { default as keyBy } from './key-by';
 export { default as mapRecordKeysRecursively } from './map-record-keys-recursively';
 export { default as shuffle } from './shuffle';
 export { default as snakeToCamelCase } from './snake-to-camel-case';
+export { default as uniqBy } from './uniq-by';
 export { default as uniqueBy } from './unique-by';

--- a/packages/js-utils/src/test/uniq-by.ts
+++ b/packages/js-utils/src/test/uniq-by.ts
@@ -1,0 +1,51 @@
+import uniqBy from '../uniq-by';
+
+describe( 'uniqBy', () => {
+	it( 'should keep the first occurrence per `iteratee` result', () => {
+		const array = [
+			{ id: 1, label: 'a' },
+			{ id: 2, label: 'b' },
+			{ id: 1, label: 'c' },
+		];
+
+		expect( uniqBy( array, ( object ) => object.id ) ).toEqual( [
+			{ id: 1, label: 'a' },
+			{ id: 2, label: 'b' },
+		] );
+	} );
+
+	it( 'should work with `_.property` shorthands', () => {
+		const array = [ { dir: 'left' }, { dir: 'right' }, { dir: 'left' } ];
+
+		expect( uniqBy( array, 'dir' ) ).toEqual( [ { dir: 'left' }, { dir: 'right' } ] );
+	} );
+
+	it( 'should work with a number for `iteratee`', () => {
+		const array = [
+			[ 1, 'a' ],
+			[ 2, 'a' ],
+			[ 1, 'b' ],
+		];
+
+		expect( uniqBy( array, 0 ) ).toEqual( [
+			[ 1, 'a' ],
+			[ 2, 'a' ],
+		] );
+	} );
+
+	it( 'should treat duplicate `undefined` keys as equal', () => {
+		const array = [ { id: undefined }, { id: undefined }, { id: 1 } ];
+
+		expect( uniqBy( array, 'id' ) ).toEqual( [ { id: undefined }, { id: 1 } ] );
+	} );
+
+	it( 'should resolve the property shorthand off nullish elements without throwing', () => {
+		const array = [ undefined, { avatar: 'a' }, undefined, { avatar: 'a' }, { avatar: 'b' } ];
+
+		expect( uniqBy( array, 'avatar' ) ).toEqual( [ undefined, { avatar: 'a' }, { avatar: 'b' } ] );
+	} );
+
+	it( 'should return an empty array for a nullish collection', () => {
+		expect( uniqBy( undefined as any, 'id' ) ).toEqual( [] );
+	} );
+} );

--- a/packages/js-utils/src/uniq-by.ts
+++ b/packages/js-utils/src/uniq-by.ts
@@ -1,0 +1,20 @@
+type Iteratee< T, TResult > = TResult | ( ( value: T ) => TResult );
+
+const uniqBy = < T >( array: T[], iteratee: Iteratee< T, PropertyKey > ): T[] => {
+	const seen = new Set< unknown >();
+
+	return ( array || [] ).filter( ( value ) => {
+		// `?.` keeps the property shorthand null-safe: nullish elements dedupe to
+		// a single `undefined` key instead of throwing.
+		const key: unknown =
+			typeof iteratee === 'function' ? iteratee( value ) : ( value as any )?.[ iteratee ];
+
+		if ( seen.has( key ) ) {
+			return false;
+		}
+		seen.add( key );
+		return true;
+	} );
+};
+
+export default uniqBy;


### PR DESCRIPTION
## Proposed Changes

* Add an iteratee-based `uniqBy` to `@automattic/js-utils`, mirroring the existing `keyBy`: it accepts a function or property-shorthand iteratee, keeps the first occurrence, and runs in O(n).
* Migrate the client's lodash `uniqBy` call sites (5) to it — drop-in swaps that leave each iteratee unchanged.
* Add a `no-restricted-imports` eslint guard for `uniqBy` (alongside `keyBy`/`shuffle`) so it can't be reintroduced.

The helper keeps lodash's null-safe property lookup, so nullish elements collapse to a single deduped value instead of throwing — preserving behavior at sites that map over possibly-authorless data.

## Why are these changes being made?

Part of the incremental effort to remove lodash, replacing functions with well-typed first-party equivalents and guarding each removal against regression. Providing a true drop-in in `js-utils` keeps call sites readable and makes future `uniqBy` removals a one-line import swap.

## Testing Instructions

* New unit tests cover the iteratee forms, first-occurrence ordering, and the null-safe shorthand path.
* `yarn eslint` is clean and the guard rejects `import { uniqBy } from 'lodash'`.
* `yarn typecheck-client` and `yarn typecheck-packages` show no new errors.
* Related client unit tests pass.
* The affected UI (Reader x-posts, conversation/gravatar caterpillars, plugin notices) renders the same deduplicated lists as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
