### PR TITLE
Remove lodash compact and times

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -38,8 +38,14 @@ module.exports = {
 					// Use the equivalents from `@automattic/js-utils` instead of lodash.
 					{
 						name: 'lodash',
-						importNames: [ 'keyBy', 'shuffle', 'uniqBy' ],
+						importNames: [ 'keyBy', 'shuffle', 'uniqBy', 'times' ],
 						message: 'Please use the equivalent from `@automattic/js-utils` instead.',
+					},
+					// Use native equivalents instead of lodash.
+					{
+						name: 'lodash',
+						importNames: [ 'compact' ],
+						message: 'Please use `array.filter( Boolean )` instead of lodash `compact`.',
 					},
 				],
 			},

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,6 +1,6 @@
 import { uniqBy } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { map, get, size, filter, compact } from 'lodash';
+import { map, get, size, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { isAncestor } from 'calypso/blocks/comments/utils';
@@ -54,7 +54,7 @@ class ConversationCaterpillarComponent extends Component {
 		this.props.expandComments( {
 			siteId: blogId,
 			postId,
-			commentIds: compact( map( commentsToExpand, ( c ) => get( c, 'parent.ID', null ) ) ),
+			commentIds: map( commentsToExpand, ( c ) => get( c, 'parent.ID', null ) ).filter( Boolean ),
 			displayType: POST_COMMENT_DISPLAY_TYPES.excerpt,
 		} );
 		recordAction( 'comment_caterpillar_click' );

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -1,4 +1,4 @@
-import { map, compact } from 'lodash';
+import { map } from 'lodash';
 import { commentsTree } from 'calypso/blocks/conversations/docs/fixtures';
 import { ConversationCommentList } from 'calypso/blocks/conversations/list';
 import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
@@ -16,7 +16,7 @@ const ConversationCommentListExample = () => {
 				blogId={ 123 }
 				postId={ 12 }
 				commentIds={ [ 1, 2, 3 ] }
-				sortedComments={ compact( map( commentsTree, 'data' ) ) }
+				sortedComments={ map( commentsTree, 'data' ).filter( Boolean ) }
 				post={ post }
 				enableCaterpillar={ false }
 				shouldRequestComments={ false }

--- a/client/components/checklist/checklist.jsx
+++ b/client/components/checklist/checklist.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
+import { times } from '@automattic/js-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Children, PureComponent, cloneElement } from 'react';
 import { useSelector } from 'react-redux';

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
+import { times } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 

--- a/client/components/related-posts/index.jsx
+++ b/client/components/related-posts/index.jsx
@@ -1,6 +1,6 @@
 import { SCOPE_OTHER, SCOPE_SAME } from '@automattic/api-core';
+import { times } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { times } from 'lodash';
 import RelatedPostCard from 'calypso/blocks/reader-related-card';
 import { useRelatedPosts } from 'calypso/components/data/with-reader-related-posts';
 

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -8,7 +8,7 @@ import {
 	TYPE_ARTICLE,
 } from '@automattic/social-previews';
 import { localize } from 'i18n-calypso';
-import { compact, find, get } from 'lodash';
+import { find, get } from 'lodash';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import SeoPreviewUpgradeNudge from 'calypso/components/seo/preview-upgrade-nudge';
@@ -200,7 +200,7 @@ export class SeoPreviewPane extends PureComponent {
 
 		const { selectedService } = this.state;
 
-		const services = compact( [ post && 'wordpress', 'google', 'facebook', 'x' ] );
+		const services = [ post && 'wordpress', 'google', 'facebook', 'x' ].filter( Boolean );
 
 		if ( showNudge ) {
 			return <SeoPreviewUpgradeNudge { ...{ site } } />;

--- a/client/components/theme-collection/theme-collection-placeholder.tsx
+++ b/client/components/theme-collection/theme-collection-placeholder.tsx
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from '@automattic/js-utils';
 import Theme from 'calypso/components/theme';
 import ThemeCollectionItem from 'calypso/components/theme-collection/theme-collection-item';
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,8 +1,9 @@
 import { FEATURE_INSTALL_THEMES, PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { times } from '@automattic/js-utils';
 import { Icon, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { isEmpty, times } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
@@ -454,7 +455,7 @@ function Empty( props ) {
 }
 
 function LoadingPlaceholders( { placeholderCount } ) {
-	return times( placeholderCount, function ( i ) {
+	return times( placeholderCount, ( i ) => {
 		return (
 			<Theme
 				key={ 'placeholder-' + i }

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -1,5 +1,5 @@
 import { convertFromRaw, convertToRaw } from 'draft-js';
-import { compact, get, map, matchesProperty, reduce } from 'lodash';
+import { get, map, matchesProperty, reduce } from 'lodash';
 import { compose } from 'redux';
 
 /*
@@ -97,7 +97,7 @@ export const fromEditor = ( content ) => {
 	);
 
 	// add final remaining text not captured by any entity ranges
-	return compact( [ ...o, i < t.length && { type: 'string', value: t.slice( i ) } ] );
+	return [ ...o, i < t.length && { type: 'string', value: t.slice( i ) } ].filter( Boolean );
 };
 
 const isTextPiece = matchesProperty( 'type', 'string' );

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -1,4 +1,4 @@
-import { compact, get } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { cloneElement, Component } from 'react';
 import NavigationLink from './navigation-link';
@@ -46,7 +46,7 @@ class Wizard extends Component {
 			return;
 		}
 
-		return compact( [ basePath, previousStepName, baseSuffix ] ).join( '/' );
+		return [ basePath, previousStepName, baseSuffix ].filter( Boolean ).join( '/' );
 	};
 
 	getForwardUrl = () => {
@@ -63,7 +63,7 @@ class Wizard extends Component {
 			return;
 		}
 
-		return compact( [ basePath, nextStepName, baseSuffix ] ).join( '/' );
+		return [ basePath, nextStepName, baseSuffix ].filter( Boolean ).join( '/' );
 	};
 
 	render() {

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -5,7 +5,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import creditcards from 'creditcards';
 import i18n from 'i18n-calypso';
-import { capitalize, compact, isEmpty, mergeWith } from 'lodash';
+import { capitalize, isEmpty, mergeWith } from 'lodash';
 
 /**
  * Returns the credit card validation rule set
@@ -320,15 +320,15 @@ export function getCreditCardType( number ) {
  * @returns {Array} array of errors found, if any
  */
 function getErrors( field, value, paymentDetails ) {
-	return compact(
-		field.rules.map( function ( rule ) {
+	return field.rules
+		.map( function ( rule ) {
 			const validator = getValidator( rule );
 
 			if ( ! validator.isValid( value, paymentDetails ) ) {
 				return validator.error( field.description );
 			}
 		} )
-	);
+		.filter( Boolean );
 }
 
 function getEbanxCreditCardRules( { country } ) {

--- a/client/lib/highlight/index.js
+++ b/client/lib/highlight/index.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { compact } from 'lodash';
 const debug = debugFactory( 'calypso:highlight' );
 
 /**
@@ -55,7 +54,7 @@ function highlightNode( node, term, wrapperNode ) {
 	}
 	nodes.push( document.createTextNode( remainingText ) );
 
-	nodes = compact( nodes );
+	nodes = nodes.filter( Boolean );
 	if ( nodes.length && found ) {
 		replaceChildNodesWithGroup( node.parentElement, nodes, node );
 	}

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,6 +1,6 @@
 /* eslint-disable jsdoc/no-undefined-types */
 
-import { map, compact, includes, some, filter } from 'lodash';
+import { map, includes, some, filter } from 'lodash';
 import getEmbedMetadata from 'calypso/lib/get-video-id';
 import { READER_CONTENT_WIDTH } from 'calypso/reader/data/post/sizes';
 import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
@@ -158,7 +158,7 @@ export default function detectMedia( post, dom ) {
 		return false;
 	} );
 
-	post.content_media = compact( contentMedia );
+	post.content_media = contentMedia.filter( Boolean );
 	post.content_embeds = filter( post.content_media, ( m ) => m.mediaType === 'video' );
 	post.content_images = filter( post.content_media, ( m ) => m.mediaType === 'image' );
 

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
+import { times } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { times } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { times } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -16,7 +16,6 @@ import { getCalypsoUrl } from '@automattic/calypso-url';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { compact } from 'lodash';
 import { useState, useEffect } from 'react';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
@@ -537,7 +536,7 @@ const Home = () => {
 	};
 
 	const promos: PromoSectionProps = {
-		promos: compact( [
+		promos: [
 			getRecurringPaymentsCard(),
 			getDonationsCard(),
 			getPremiumContentCard(),
@@ -545,7 +544,7 @@ const Home = () => {
 			getSimplePaymentsCard(),
 			getAdsCard(),
 			getPeerReferralsCard(),
-		] ),
+		].filter( ( card ): card is PromoSectionCardProps => Boolean( card ) ),
 	};
 
 	if ( ! isUserAdmin ) {

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,5 +1,5 @@
 import { Card, DotPager } from '@automattic/components';
-import { times } from 'lodash';
+import { times } from '@automattic/js-utils';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -4,7 +4,7 @@ import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { compact, pickBy } from 'lodash';
+import { pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { InView } from 'react-intersection-observer';
@@ -329,7 +329,7 @@ class ThemeShowcase extends Component {
 		const filters = searchString.match( filterRegex ) || [];
 
 		const validFilters = filters.map( ( filter ) => filterToTermTable[ filter ] );
-		const filterString = compact( validFilters ).join( '+' );
+		const filterString = validFilters.filter( Boolean ).join( '+' );
 
 		const search = searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim();
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,6 +1,5 @@
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import pageRouter from '@automattic/calypso-router';
-import { compact } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import * as React from 'react';
@@ -334,7 +333,7 @@ export function buildThemesSelectionQuery( {
 		search,
 		page,
 		tier: premiumThemesEnabled ? tier : 'free',
-		filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
+		filter: [ filter, vertical ].filter( Boolean ).concat( hiddenFilters ).join( ',' ),
 		number,
 		...( tabFilter === 'recommended' && { collection: 'recommended' } ),
 		...( tabFilter === 'all' && { sort: 'date' } ),

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -1,6 +1,7 @@
 import { SelectDropdown } from '@automattic/components';
+import { times } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { includes, times } from 'lodash';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -1,4 +1,5 @@
-import { map, sampleSize, times } from 'lodash';
+import { times } from '@automattic/js-utils';
+import { map, sampleSize } from 'lodash';
 import { Component } from 'react';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { useFollowedTags } from 'calypso/reader/data/tags';

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,8 +1,8 @@
 import './style.scss';
 import { isDefaultLocale } from '@automattic/i18n-utils';
+import { times } from '@automattic/js-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import * as React from 'react';

--- a/client/sites/marketing/connections/services-group.jsx
+++ b/client/sites/marketing/connections/services-group.jsx
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from '@automattic/js-utils';
 import PropTypes from 'prop-types';
 import { Fragment, useEffect } from 'react';
 import { connect } from 'react-redux';

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -3,5 +3,6 @@ export { default as keyBy } from './key-by';
 export { default as mapRecordKeysRecursively } from './map-record-keys-recursively';
 export { default as shuffle } from './shuffle';
 export { default as snakeToCamelCase } from './snake-to-camel-case';
+export { default as times } from './times';
 export { default as uniqBy } from './uniq-by';
 export { default as uniqueBy } from './unique-by';

--- a/packages/js-utils/src/test/times.ts
+++ b/packages/js-utils/src/test/times.ts
@@ -1,0 +1,16 @@
+import times from '../times';
+
+describe( 'times', () => {
+	it( 'should invoke the iteratee `n` times with the index', () => {
+		expect( times( 3, ( i ) => i * 2 ) ).toEqual( [ 0, 2, 4 ] );
+	} );
+
+	it( 'should return an empty array for `n` <= 0', () => {
+		expect( times( 0, ( i ) => i ) ).toEqual( [] );
+		expect( times( -2, ( i ) => i ) ).toEqual( [] );
+	} );
+
+	it( 'should floor a non-integer `n`', () => {
+		expect( times( 3.9, ( i ) => i ) ).toEqual( [ 0, 1, 2 ] );
+	} );
+} );

--- a/packages/js-utils/src/times.ts
+++ b/packages/js-utils/src/times.ts
@@ -1,0 +1,4 @@
+const times = < T >( n: number, iteratee: ( index: number ) => T ): T[] =>
+	Array.from( { length: n }, ( _, index ) => iteratee( index ) );
+
+export default times;


### PR DESCRIPTION
## Proposed Changes

* Replace lodash's `compact` with native `array.filter( Boolean )` across the client.
* Add a `times` helper to `@automattic/js-utils` and migrate the client's lodash `times` call sites to it.
* Add `no-restricted-imports` eslint guards for both: `compact` → native, `times` → js-utils.

`compact`'s native form is idiomatic, so it stays inline. `times`'s native form (`Array.from( { length: n }, ( _, i ) => … )`) is clunky boilerplate, so a small drop-in keeps call sites readable.

## Why are these changes being made?

Part of the incremental effort to remove lodash, replacing functions with native equivalents (or well-typed first-party helpers) and guarding each removal against regression. Every `compact` call site operates on a known array and every `times` site uses an integer count, so the replacements are exact behavioral equivalents.

## Testing Instructions

* New unit tests cover the `times` helper (iteratee invocation, empty/negative `n`, non-integer `n`).
* `yarn eslint` is clean and the guards reject `import { compact, times } from 'lodash'`.
* `yarn typecheck-client` and `yarn typecheck-packages` show no new errors.
* Related client unit tests pass.
* The affected UI (placeholders, star ratings, reader/theme/plugin lists, SEO preview, checkout validation) renders identically.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
