### PR TITLE
Notifications: add prev/next navigation to mobile detail header

### DIFF
--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -14,7 +14,7 @@ import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
 import getKeyboardShortcutsEnabled from '../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { AppProvider } from './context';
 import Note from './note';
-import { useNoteNavigationViaKeyboardShortcuts } from './note/hooks';
+import { useNoteNavigation } from './note/hooks';
 import NotePanel from './note-panel';
 import type { FilterName } from './types';
 
@@ -80,7 +80,7 @@ const NotificationContent = ( { isDismissible }: { isDismissible: boolean } ) =>
 		}
 	};
 
-	useNoteNavigationViaKeyboardShortcuts( { filterName, selectedNoteId, setSelectedNoteId } );
+	const noteNavigation = useNoteNavigation( { filterName, selectedNoteId, setSelectedNoteId } );
 
 	return (
 		<HStack className="wpnc-app" spacing={ 0 } alignment="stretch">
@@ -100,6 +100,7 @@ const NotificationContent = ( { isDismissible }: { isDismissible: boolean } ) =>
 					isDismissible={ isDismissible }
 					noteId={ displayedNoteId }
 					setSelectedNoteId={ setSelectedNoteId }
+					noteNavigation={ noteNavigation }
 				/>
 			</div>
 			<div className="wpnc-app__list-pane">

--- a/apps/notifications/src/app/note/hooks.ts
+++ b/apps/notifications/src/app/note/hooks.ts
@@ -32,8 +32,14 @@ export function useNoteNavigation( {
 	const { client } = useAppContext();
 
 	const filter = getFilters()[ filterName ];
+	// Keep the selected note in the navigation list at its natural position even
+	// if it no longer matches the active filter. Opening a note marks it read,
+	// so on the "Unread" tab the selected note would otherwise drop out of the
+	// list — losing its index and disabling prev/next navigation.
 	const visibleNotes = notes.filter(
-		( note ) => filter.filter( note ) && hiddenNoteIds[ note.id ] !== true
+		( note ) =>
+			hiddenNoteIds[ note.id ] !== true &&
+			( filter.filter( note ) || String( note.id ) === selectedNoteId )
 	);
 	const selectedNote =
 		selectedNoteId !== undefined

--- a/apps/notifications/src/app/note/hooks.ts
+++ b/apps/notifications/src/app/note/hooks.ts
@@ -9,7 +9,14 @@ import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
 import type { FilterName, Note } from '../types';
 
-export function useNoteNavigationViaKeyboardShortcuts( {
+export type NoteNavigation = {
+	goToPreviousNote: () => void;
+	goToNextNote: () => void;
+	hasPreviousNote: boolean;
+	hasNextNote: boolean;
+};
+
+export function useNoteNavigation( {
 	filterName,
 	selectedNoteId,
 	setSelectedNoteId,
@@ -17,7 +24,7 @@ export function useNoteNavigationViaKeyboardShortcuts( {
 	filterName: FilterName;
 	selectedNoteId: string | undefined;
 	setSelectedNoteId: ( noteId: string | undefined ) => void;
-} ) {
+} ): NoteNavigation {
 	const areKeyboardShortcutsEnabled = useSelector( getKeyboardShortcutsEnabled );
 	const isLoading = useSelector( getIsLoading );
 	const notes = useSelector( ( state ) => ( getAllNotes( state ) || [] ) as Note[] );
@@ -43,18 +50,26 @@ export function useNoteNavigationViaKeyboardShortcuts( {
 		}
 	}, [ isLoading, visibleNotes, selectedNote, client ] );
 
+	const selectedIndex = selectedNote
+		? visibleNotes.findIndex( ( note ) => note.id === selectedNote.id )
+		: -1;
+	const hasPreviousNote = selectedIndex > 0;
+	const hasNextNote = selectedIndex >= 0 && selectedIndex < visibleNotes.length - 1;
+
 	const goToNoteByDirection = ( direction: number ) => {
-		if ( ! selectedNote ) {
+		if ( selectedIndex < 0 ) {
 			return;
 		}
 
-		const noteIndex = visibleNotes.findIndex( ( note ) => note.id === selectedNote.id );
-		const newIndex = noteIndex + direction;
+		const newIndex = selectedIndex + direction;
 
 		if ( newIndex >= 0 && newIndex < visibleNotes.length ) {
 			setSelectedNoteId( String( visibleNotes[ newIndex ].id ) );
 		}
 	};
+
+	const goToPreviousNote = () => goToNoteByDirection( -1 );
+	const goToNextNote = () => goToNoteByDirection( 1 );
 
 	useEffect( () => {
 		const stopEvent = ( event: KeyboardEvent ) => {
@@ -73,12 +88,12 @@ export function useNoteNavigationViaKeyboardShortcuts( {
 				case 'j':
 				case 'ArrowDown':
 					stopEvent( event );
-					goToNoteByDirection( 1 );
+					goToNextNote();
 					break;
 				case 'k':
 				case 'ArrowUp':
 					stopEvent( event );
-					goToNoteByDirection( -1 );
+					goToPreviousNote();
 					break;
 			}
 		};
@@ -88,4 +103,6 @@ export function useNoteNavigationViaKeyboardShortcuts( {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
 	}, [ areKeyboardShortcutsEnabled, selectedNote ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	return { goToPreviousNote, goToNextNote, hasPreviousNote, hasNextNote };
 }

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { chevronLeft, chevronRight, arrowUp, arrowDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -23,6 +23,7 @@ import { NoteBody, ActionBlock } from '../templates/body';
 import CloseButton from '../templates/close-button';
 import NoteSummary from '../templates/note-summary';
 import './style.scss';
+import type { NoteNavigation } from './hooks';
 import type { Note as NoteObject, Block } from '../types';
 
 const hasBadge = ( body: NoteObject[ 'body' ] ) =>
@@ -73,9 +74,10 @@ type NoteProps = {
 	// the exiting id during the slide-out animation.
 	noteId: string | undefined;
 	setSelectedNoteId: ( noteId: string | undefined ) => void;
+	noteNavigation: NoteNavigation;
 };
 
-const Note = ( { isDismissible, noteId, setSelectedNoteId }: NoteProps ) => {
+const Note = ( { isDismissible, noteId, setSelectedNoteId, noteNavigation }: NoteProps ) => {
 	const dispatch = useDispatch();
 	const isLargeScreen = useViewportMatch( 'large' );
 	const goBack = () => setSelectedNoteId( undefined );
@@ -121,8 +123,31 @@ const Note = ( { isDismissible, noteId, setSelectedNoteId }: NoteProps ) => {
 							{ note.title }
 						</Heading>
 					</HStack>
-					<HStack justify="flex-end" style={ { width: 'auto' } }>
+					<HStack justify="flex-end" style={ { width: 'auto', flexShrink: 0 } }>
+						{ /* Keep the optional action dropdown leftmost so that, when a note
+						   has no actions and it renders nothing, the navigation arrows and
+						   close button stay anchored to the right edge instead of shifting. */ }
 						<ActionDropdown note={ note } goBack={ goBack } />
+						{ ! isLargeScreen && (
+							<>
+								<Button
+									size="small"
+									icon={ arrowUp }
+									label={ __( 'Previous notification' ) }
+									onClick={ noteNavigation.goToPreviousNote }
+									disabled={ ! noteNavigation.hasPreviousNote }
+									accessibleWhenDisabled
+								/>
+								<Button
+									size="small"
+									icon={ arrowDown }
+									label={ __( 'Next notification' ) }
+									onClick={ noteNavigation.goToNextNote }
+									disabled={ ! noteNavigation.hasNextNote }
+									accessibleWhenDisabled
+								/>
+							</>
+						) }
 						{ isDismissible && <CloseButton /> }
 					</HStack>
 				</HStack>

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -124,10 +124,6 @@ const Note = ( { isDismissible, noteId, setSelectedNoteId, noteNavigation }: Not
 						</Heading>
 					</HStack>
 					<HStack justify="flex-end" style={ { width: 'auto', flexShrink: 0 } }>
-						{ /* Keep the optional action dropdown leftmost so that, when a note
-						   has no actions and it renders nothing, the navigation arrows and
-						   close button stay anchored to the right edge instead of shifting. */ }
-						<ActionDropdown note={ note } goBack={ goBack } />
 						{ ! isLargeScreen && (
 							<>
 								<Button
@@ -148,6 +144,7 @@ const Note = ( { isDismissible, noteId, setSelectedNoteId, noteNavigation }: Not
 								/>
 							</>
 						) }
+						<ActionDropdown note={ note } goBack={ goBack } />
 						{ isDismissible && <CloseButton /> }
 					</HStack>
 				</HStack>

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -8,6 +8,9 @@
 	margin: 0;
 	line-height: 20px;
 	text-wrap: balance;
+	// Break long unbroken strings (e.g. URLs) so they wrap instead of
+	// overflowing horizontally, which is especially visible on mobile.
+	overflow-wrap: break-word;
 
 	.has-text-align-center {
 		text-align: center;
@@ -214,12 +217,31 @@
 }
 
 .wpnc__text-summary {
+	// Allow this flex child to shrink below its content width so the snippet
+	// can truncate instead of overflowing horizontally, especially on mobile.
+	min-width: 0;
+
 	.components-external-link:not(:hover) {
 		color: inherit;
 	}
 
+	// Keep the snippet on a single line, truncating long unbroken strings
+	// (e.g. URLs) with an ellipsis while keeping the trailing link icon visible.
+	.components-external-link {
+		display: flex;
+		align-items: center;
+		max-width: 100%;
+	}
+
 	.components-external-link__contents {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 		text-decoration: none;
+	}
+
+	.components-external-link__icon {
+		flex-shrink: 0;
 	}
 }
 

--- a/apps/notifications/src/app/templates/action-dropdown.tsx
+++ b/apps/notifications/src/app/templates/action-dropdown.tsx
@@ -16,10 +16,6 @@ export default function ActionDropdown( { note, goBack }: { note: Note; goBack: 
 	const actions = getActions( note );
 	const hasDeleteAction = actions?.hasOwnProperty( 'trash-comment' );
 
-	if ( ! hasDeleteAction ) {
-		return null;
-	}
-
 	const handleDelete = async () => {
 		setIsDeleting( true );
 		await ( dispatch as any )( trashNote( note, true ) );
@@ -27,11 +23,18 @@ export default function ActionDropdown( { note, goBack }: { note: Note; goBack: 
 	};
 
 	return (
-		<HotkeyContainer shortcuts={ [ { hotkey: 't', action: handleDelete } ] }>
+		// Always render the dropdown — disabled when the note has no actions — so
+		// the header layout stays stable across notes instead of the toggle
+		// appearing and disappearing.
+		<HotkeyContainer shortcuts={ hasDeleteAction ? [ { hotkey: 't', action: handleDelete } ] : [] }>
 			<DropdownMenu
 				icon={ moreVertical }
 				label={ __( 'Actions' ) }
-				toggleProps={ { size: 'small' } }
+				toggleProps={ {
+					size: 'small',
+					disabled: ! hasDeleteAction,
+					accessibleWhenDisabled: true,
+				} }
 			>
 				{ ( { onClose } ) => {
 					return (


### PR DESCRIPTION
## Proposed Changes

* Add up/down arrow buttons to the notification **detail header on mobile**, so users can move to the next/previous notification without going back to the list.
* The buttons reuse the existing `j`/`k`/`ArrowUp`/`ArrowDown` keyboard-shortcut navigation, now extracted into a shared `useNoteNavigation` hook that exposes go-to-prev/next callbacks plus `hasPrevious`/`hasNext` boundary flags. The buttons are disabled (but stay focusable) at the list edges, and navigating to the last visible note still auto-loads more.
* Keep the currently-selected note in the navigation list even after it stops matching the active filter. Opening a note marks it read, so on the **Unread** tab the selected note used to drop out of the list, losing its index and disabling prev/next. (This also fixes the same long-standing issue for keyboard navigation on the Unread tab.)
* Always render the actions dropdown, disabled when a note has no actions, instead of hiding it — this keeps the header controls from shifting position as you move between notes.
* Fix detail-header layout issues surfaced on mobile:
  * Truncate the summary snippet link to a single line with an ellipsis (keeping the external-link icon visible) and wrap long URLs in the body so they no longer overflow horizontally.
  * Keep the right-hand control group from shrinking so the controls don't get squished.

| Before | After |
| - | - |
|<img width="447" height="73" alt="image" src="https://github.com/user-attachments/assets/3a81f072-1a4b-42c2-8ca6-44718cb9b2eb" />|<img width="445" height="70" alt="image" src="https://github.com/user-attachments/assets/c3188b03-2114-4b11-b10b-3b87d10dc940" />|

## Why are these changes being made?

* On mobile the detail view replaces the list, so reviewing notifications one by one previously required tapping Back and reopening each one. Prev/next arrows make triaging notifications much faster. Long URLs in notification bodies/snippets were also overflowing the viewport horizontally, and the header controls shifted around between notes depending on read state and available actions.

## Testing Instructions

* Open the notifications panel on a narrow/mobile viewport (redesign enabled).
* Open a notification to enter the detail view. Confirm `↑` / `↓` arrows appear in the header, before the actions dropdown and close button.
* Tap `↓` to go to the next notification and `↑` for the previous; confirm they're disabled at the first/last item and that reaching the end loads more.
* Switch to the **Unread** tab, open a note, and confirm you can still step through prev/next (the note stays navigable even though opening it marks it read). Verify the same on the Comments / Subscribers / Likes tabs.
* Open a notification whose body/snippet contains a long URL (e.g. a Grafana link) and confirm it no longer overflows horizontally — the snippet truncates with an ellipsis and the body wraps.
* Navigate between notes that do and don't have a trash action; confirm the actions dropdown is always present (disabled when there's nothing to do) and the arrows / close button don't shift.
* Verify keyboard shortcuts (`j`/`k`/arrow keys) still work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)