### PR TITLE
Add website setup tutorial to My Home "Need help?" recommended guides

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -80,8 +80,25 @@ function HelpSearchResults( {
 		sectionName
 	);
 
-	const searchResults = searchData ?? [];
+	const searchResults = useMemo( () => searchData ?? [], [ searchData ] );
 	const hasAPIResults = searchResults.length > 0;
+
+	// On the customer home "Need help?" card, surface our website setup
+	// tutorial as the first recommended guide.
+	const recommendedGuides = useMemo( () => {
+		if ( location !== 'customer-home' || searchQuery.length ) {
+			return searchResults;
+		}
+
+		return [
+			{
+				type: SUPPORT_TYPE_API_HELP,
+				link: localizeUrl( 'https://wordpress.com/support/five-step-website-setup/' ),
+				title: translate( 'Build your website in five steps' ),
+			},
+			...searchResults,
+		];
+	}, [ location, searchQuery, searchResults, translate ] );
 
 	useEffect( () => {
 		// Cancel all queued speak messages.
@@ -205,14 +222,14 @@ function HelpSearchResults( {
 			{
 				type: SUPPORT_TYPE_API_HELP,
 				title: translate( 'Recommended guides' ),
-				results: searchResults.slice( 0, 5 ),
-				condition: ! isSearching && searchResults.length > 0,
+				results: recommendedGuides.slice( 0, 5 ),
+				condition: ! isSearching && recommendedGuides.length > 0,
 			},
 			{
 				type: SUPPORT_TYPE_CONTEXTUAL_HELP,
 				title: ! searchQuery.length ? translate( 'Recommended guides' ) : '',
 				results: contextualResults.slice( 0, 6 ),
-				condition: ! isSearching && ! searchResults.length && contextualResults.length > 0,
+				condition: ! isSearching && ! recommendedGuides.length && contextualResults.length > 0,
 			},
 		];
 


### PR DESCRIPTION
## Proposed Changes

* Add the five-step website setup support guide as the first item in the "Recommended guides" list of the customer-home "Need help?" card.
* Scoped to the `customer-home` location so the Help Center popover and other inline-help surfaces are unaffected.

## Why are these changes being made?

We want new users on My Home to have a clear, prominent entry point to the "build your website in five steps" tutorial. Pinning it to the top of the recommended guides gives that tutorial consistent visibility regardless of what the help search API returns for the home section.

## Testing Instructions

1. Run `yarn start` and open `/home/<your-site>` (My Home).
2. Locate the "Need help?" card.
3. Verify the first item under "Recommended guides" is **Build your website in five steps**, and that clicking it opens the five-step website setup support guide in a new tab.
4. Type a query in the search box and confirm the pinned guide is replaced by search results (it only appears when not actively searching).
5. Open the Help Center popover elsewhere and confirm its recommended guides are unchanged (no pinned item).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)