### PR TITLE
Stats: link subscriber names to individual details page

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -74,6 +74,7 @@ const selectSubscribers = ( payload: {
 		email_subscription_id?: number;
 		subscription_id?: number;
 		wpcom_subscription_id?: number;
+		ID?: number;
 	}[];
 } ) => {
 	return {
@@ -100,11 +101,15 @@ const selectSubscribers = ( payload: {
 				date_subscribed: item.date_subscribed,
 				// Preserve the subscription id so the Subscribers module can link each
 				// name to its individual subscriber details page. Mirrors the precedence
-				// used by the Subscribers DataViews list.
+				// used by the Subscribers DataViews list, then falls back to `ID`, which is
+				// the field the `stats/followers` endpoint returns.
 				// Truthy fallback (not `??`) so a `0` placeholder id falls through to the
 				// next field, matching getSubscriptionIdFromSubscriber.
 				subscription_id:
-					item.email_subscription_id || item.subscription_id || item.wpcom_subscription_id,
+					item.email_subscription_id ||
+					item.subscription_id ||
+					item.wpcom_subscription_id ||
+					item.ID,
 			};
 		} ),
 	};

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -81,7 +81,7 @@ const selectSubscribers = ( payload: {
 		total_email: payload.total_email,
 		total_wpcom: payload.total_wpcom,
 		is_owner_subscribed: payload.is_owner_subscribed,
-		subscribers: payload.subscribers?.map( ( item ) => {
+		subscribers: ( payload.subscribers ?? [] ).map( ( item ) => {
 			return {
 				label: item.label ?? item.display_name,
 				iconClassName: 'avatar-user',

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -71,6 +71,9 @@ const selectSubscribers = ( payload: {
 		avatar: string;
 		url: string;
 		follow_data: { params: object }; //Empty object atm
+		email_subscription_id?: number;
+		subscription_id?: number;
+		wpcom_subscription_id?: number;
 	}[];
 } ) => {
 	return {
@@ -95,6 +98,13 @@ const selectSubscribers = ( payload: {
 					},
 				],
 				date_subscribed: item.date_subscribed,
+				// Preserve the subscription id so the Subscribers module can link each
+				// name to its individual subscriber details page. Mirrors the precedence
+				// used by the Subscribers DataViews list.
+				// Truthy fallback (not `??`) so a `0` placeholder id falls through to the
+				// next field, matching getSubscriptionIdFromSubscriber.
+				subscription_id:
+					item.email_subscription_id || item.subscription_id || item.wpcom_subscription_id,
 			};
 		} ),
 	};

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -59,6 +60,9 @@ const StatModuleFollowers = ( { className } ) => {
 
 	const noData = ! subTotals.subscribers.length;
 	const summaryPageSlug = siteSlug || '';
+	// The individual subscriber details route only exists in Calypso, so skip the
+	// name link in Odyssey Stats (wp-admin), where `page()` can't reach it.
+	const isOdysseyStats = config.isEnabled( 'is_odyssey' );
 	const useJetpackCloudLinks = isAtomic || isJetpack;
 	const subscriberManagementUrl = useJetpackCloudLinks
 		? `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`
@@ -70,6 +74,11 @@ const StatModuleFollowers = ( { className } ) => {
 			data={ subTotals.subscribers.map( ( dataPoint ) => ( {
 				...dataPoint,
 				value: calculateOffset( dataPoint.value?.value ),
+				// Link the subscriber name to its individual details page. `link` is kept
+				// for the right-side icon that opens the subscriber's own site.
+				...( ! isOdysseyStats && dataPoint.subscription_id
+					? { page: `/subscribers/${ summaryPageSlug }/${ dataPoint.subscription_id }` }
+					: {} ),
 			} ) ) }
 			usePlainCard
 			hasNoBackground

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -76,9 +76,10 @@ const StatModuleFollowers = ( { className } ) => {
 				value: calculateOffset( dataPoint.value?.value ),
 				// Link the subscriber name to its individual details page. `link` is kept
 				// for the right-side icon that opens the subscriber's own site.
-				...( ! isOdysseyStats && dataPoint.subscription_id
-					? { page: `/subscribers/${ summaryPageSlug }/${ dataPoint.subscription_id }` }
-					: {} ),
+				page:
+					! isOdysseyStats && dataPoint.subscription_id
+						? `/subscribers/${ summaryPageSlug }/${ dataPoint.subscription_id }`
+						: undefined,
 			} ) ) }
 			usePlainCard
 			hasNoBackground

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -60,8 +60,9 @@ const StatModuleFollowers = ( { className } ) => {
 
 	const noData = ! subTotals.subscribers.length;
 	const summaryPageSlug = siteSlug || '';
-	// The individual subscriber details route only exists in Calypso, so skip the
-	// name link in Odyssey Stats (wp-admin), where `page()` can't reach it.
+	// Odyssey Stats (wp-admin) can't route to the individual subscriber details
+	// page internally, so the name links out to the full wordpress.com /
+	// cloud.jetpack.com URL there and navigates in-app in Calypso.
 	const isOdysseyStats = config.isEnabled( 'is_odyssey' );
 	const useJetpackCloudLinks = isAtomic || isJetpack;
 	const subscriberManagementUrl = useJetpackCloudLinks
@@ -71,16 +72,23 @@ const StatModuleFollowers = ( { className } ) => {
 	return (
 		<StatsListCard
 			moduleType="followers"
-			data={ subTotals.subscribers.map( ( dataPoint ) => ( {
-				...dataPoint,
-				value: calculateOffset( dataPoint.value?.value ),
+			data={ subTotals.subscribers.map( ( dataPoint ) => {
 				// Link the subscriber name to its individual details page. `link` is kept
-				// for the right-side icon that opens the subscriber's own site.
-				page:
-					! isOdysseyStats && dataPoint.subscription_id
-						? `/subscribers/${ summaryPageSlug }/${ dataPoint.subscription_id }`
-						: undefined,
-			} ) ) }
+				// for the right-side icon that opens the subscriber's own site. Odyssey
+				// (wp-admin) can't route there internally, so use the full URL; Calypso
+				// navigates in-app.
+				let detailPage;
+				if ( dataPoint.subscription_id ) {
+					detailPage = isOdysseyStats
+						? `${ subscriberManagementUrl }/${ dataPoint.subscription_id }`
+						: `/subscribers/${ summaryPageSlug }/${ dataPoint.subscription_id }`;
+				}
+				return {
+					...dataPoint,
+					value: calculateOffset( dataPoint.value?.value ),
+					page: detailPage,
+				};
+			} ) }
 			usePlainCard
 			hasNoBackground
 			title={ translate( 'Subscribers' ) }

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -54,7 +54,14 @@ const StatsListCard = ( {
 
 		if ( listItemData?.page ) {
 			gaRecordEvent( 'Stats', ` Clicked ${ moduleNameTitle } Summary Link in List` );
-			page( listItemData.page );
+			// `page` is usually an in-app path, but it can be a full URL when the
+			// destination lives outside the current app (e.g. linking from Odyssey
+			// Stats in wp-admin out to the wordpress.com subscriber details page).
+			if ( /^https?:\/\//.test( listItemData.page ) ) {
+				window.location.href = listItemData.page;
+			} else {
+				page( listItemData.page );
+			}
 		} else if ( listItemData?.link ) {
 			// downloads component and some old search items (not all)
 			gaRecordEvent( 'Stats', ` Clicked ${ moduleNameTitle } External Link in List` );

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -57,9 +57,17 @@ const StatsListCard = ( {
 			// `page` is usually an in-app path, but it can be a full URL when the
 			// destination lives outside the current app (e.g. linking from Odyssey
 			// Stats in wp-admin out to the wordpress.com subscriber details page).
-			if ( /^https?:\/\//.test( listItemData.page ) ) {
-				window.location.href = listItemData.page;
-			} else {
+			// Use URL parsing to distinguish genuinely external destinations from
+			// same-origin absolute URLs, which can still use the in-app router.
+			try {
+				const parsedUrl = new URL( listItemData.page );
+				if ( parsedUrl.origin !== window.location.origin ) {
+					window.location.href = listItemData.page;
+				} else {
+					page( parsedUrl.pathname + parsedUrl.search + parsedUrl.hash );
+				}
+			} catch {
+				// Not an absolute URL; treat as an in-app path.
 				page( listItemData.page );
 			}
 		} else if ( listItemData?.link ) {


### PR DESCRIPTION
Fixes NL-266

## Proposed Changes

- On the Stats -> Subscribers page, the subscriber name currently links to the user's website. This doesn't make sense on this page.
- This PR updates the link for a subscriber's name in the Stats -> Subscribers to the existing subscriber's individual stats page.
- This works on both surfaces that render this module: Calypso (`/stats/subscribers/...`) navigates in-app to `/subscribers/{slug}/{id}`; Odyssey Stats in wp-admin links out to the full `https://wordpress.com/subscribers/{slug}/{id}` URL (`cloud.jetpack.com` for Atomic and Jetpack), matching the existing "Manage subscribers" link in the same module.
- The right-side icon still opens the subscriber's own site, unchanged.
- The subscribers totals query now preserves a subscription id per row, using the same field precedence the Subscribers list uses. The shared list-card click handler now accepts a full URL in `page`, not just an in-app path, so the same `page` value works on both surfaces.
- The link is added only when a row carries a subscription id, so the module renders unchanged when the id is absent.

### Screenshots

On the Stats -> Subscribers page
<img width="880" height="458" alt="CleanShot 2026-06-16 at 10 33 48@2x" src="https://github.com/user-attachments/assets/9ec6cc8b-2ce2-4d17-bf7d-0cb472c865f2" />

Instead of linking to the subscriber's website, it will link to their individual subscriber stats page.

<img width="1242" height="812" alt="image" src="https://github.com/user-attachments/assets/b344346e-4aa8-4b40-8a83-aa03a5a73553" />

## Why are these changes being made?

The Subscribers stats page has no path to that subscriber's insights. This adds a direct click-through from a name to its details page. 

## Testing Instructions

1. On a site with a few subscribers, open the Subscribers stats in wp-admin: `admin.php?page=stats#!/stats/subscribers/{your-site-slug}`.
2. Click a subscriber name. It opens that subscriber's details page on wordpress.com (cloud.jetpack.com for Atomic and Jetpack).
3. Confirm the right-side icon still opens the subscriber's own site.

Verified in wp-admin on a Simple site: the names link, which confirms the subscribers endpoint returns an id per row, and a row without an id stays plain text. The same code powers the Calypso view at `/stats/subscribers/{slug}` (in-app navigation) and the Atomic and Jetpack path (cloud.jetpack.com); those were not exercised here.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) (N/A: no expensive computation added)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (N/A: ci/i18n reports 0 new strings)
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. (N/A: no new strings)
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? (N/A: no tracking or data changes)



