### PR TITLE
Remove lodash keys, values, and size in favor of native JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -601,6 +601,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-string': 'error',
 		'you-dont-need-lodash-underscore/is-undefined': 'error',
 		'you-dont-need-lodash-underscore/join': 'error',
+		'you-dont-need-lodash-underscore/keys': 'error',
 		'you-dont-need-lodash-underscore/last': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',
 		'you-dont-need-lodash-underscore/pad-end': 'error',
@@ -610,6 +611,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/replace': 'error',
 		'you-dont-need-lodash-underscore/reverse': 'error',
 		'you-dont-need-lodash-underscore/select': 'error',
+		'you-dont-need-lodash-underscore/size': 'error',
 		'you-dont-need-lodash-underscore/slice': 'error',
 		'you-dont-need-lodash-underscore/split': 'error',
 		'you-dont-need-lodash-underscore/starts-with': 'error',
@@ -619,6 +621,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/to-upper': 'error',
 		'you-dont-need-lodash-underscore/trim': 'error',
 		'you-dont-need-lodash-underscore/uniq': 'error',
+		'you-dont-need-lodash-underscore/values': 'error',
 
 		// @TODO remove these lines once we fixed the warnings so
 		// they'll become errors for new code added to the codebase

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -2,7 +2,7 @@ import { Button, Gridicon, SegmentedControl } from '@automattic/components';
 import { Icon, published } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { get, size, delay, pickBy } from 'lodash';
+import { get, delay, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
@@ -589,7 +589,7 @@ class PostCommentList extends Component {
 		// orphans (parent deleted/unapproved), that comment will become unreachable but still counted.
 		const showViewMoreComments =
 			! this.props.expandableView &&
-			( size( commentsTree.children ) > amountOfCommentsToTake ||
+			( commentsTree.children.length > amountOfCommentsToTake ||
 				haveEarlierCommentsToFetch ||
 				haveLaterCommentsToFetch ) &&
 			displayedCommentsCount > 0;

--- a/client/blocks/conversation-caterpillar/docs/example.jsx
+++ b/client/blocks/conversation-caterpillar/docs/example.jsx
@@ -1,5 +1,4 @@
 import { Card } from '@automattic/components';
-import { size } from 'lodash';
 import { ConversationCaterpillar } from 'calypso/blocks/conversation-caterpillar';
 import { comments, commentsTree } from 'calypso/blocks/conversation-caterpillar/docs/fixtures';
 
@@ -12,7 +11,7 @@ const ConversationCaterpillarExample = () => {
 					blogId={ 123 }
 					postId={ 12 }
 					commentsTree={ commentsTree }
-					commentCount={ size( comments ) }
+					commentCount={ comments.length }
 					commentsToShow={ {} }
 					expandComments={ () => {} }
 				/>

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,6 +1,6 @@
 import { uniqBy } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { map, get, size, filter } from 'lodash';
+import { map, get, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { isAncestor } from 'calypso/blocks/comments/utils';
@@ -70,14 +70,14 @@ class ConversationCaterpillarComponent extends Component {
 		const allExpandableComments = this.getExpandableComments();
 		const expandableComments = allExpandableComments.slice( -1 * NUMBER_TO_EXPAND );
 		const isRoot = ! parentCommentId;
-		const numberUnfetchedComments = this.props.commentCount - size( comments );
+		const numberUnfetchedComments = this.props.commentCount - comments.length;
 		const commentCount = isRoot
-			? numberUnfetchedComments + size( allExpandableComments )
-			: size( allExpandableComments );
+			? numberUnfetchedComments + allExpandableComments.length
+			: allExpandableComments.length;
 
 		// Only display each author once
 		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'avatar_URL' );
-		const uniqueAuthorsCount = size( uniqueAuthors );
+		const uniqueAuthorsCount = uniqueAuthors.length;
 		const lastAuthorName = get( uniqueAuthors.at( -1 ), 'name' );
 
 		return (

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,5 +1,5 @@
 import { keyBy } from '@automattic/js-utils';
-import { map, size, filter, get, partition, pickBy } from 'lodash';
+import { map, filter, get, partition, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
@@ -136,7 +136,7 @@ export class ConversationCommentList extends Component {
 		const hiddenComments = this.getHiddenComments( commentsToShow );
 
 		// if we are running low on comments to expand then fetch more
-		if ( size( hiddenComments ) < FETCH_NEW_COMMENTS_THRESHOLD ) {
+		if ( Object.keys( hiddenComments ).length < FETCH_NEW_COMMENTS_THRESHOLD ) {
 			this.reqMoreComments();
 		}
 
@@ -164,7 +164,7 @@ export class ConversationCommentList extends Component {
 
 	getInaccessibleParentsIds = ( commentsTree, commentIds ) => {
 		// base case
-		if ( size( commentIds ) === 0 ) {
+		if ( commentIds.length === 0 ) {
 			return [];
 		}
 
@@ -269,7 +269,8 @@ export class ConversationCommentList extends Component {
 			? filter( commentsTree, ( comment ) => get( comment, 'data.type' ) === 'comment' ).length // filter out pingbacks/trackbacks
 			: post.discussion.comment_count;
 
-		const showCaterpillar = enableCaterpillar && size( commentsToShow ) < commentCount;
+		const showCaterpillar =
+			enableCaterpillar && Object.keys( commentsToShow ).length < commentCount;
 
 		return (
 			<div className="conversations__comment-list">

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { values as objectValues } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -34,7 +33,7 @@ export class ImageEditorToolbar extends Component {
 		imageEditorRotateCounterclockwise: noop,
 		imageEditorFlip: noop,
 		setImageEditorAspectRatio: noop,
-		allowedAspectRatios: objectValues( AspectRatios ),
+		allowedAspectRatios: Object.values( AspectRatios ),
 		onShowNotice: noop,
 		isAspectRatioDisabled: false,
 		displayOnlyIcon: false,

--- a/client/blocks/reader-post-card/tags-list.jsx
+++ b/client/blocks/reader-post-card/tags-list.jsx
@@ -1,4 +1,3 @@
-import { values } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -31,7 +30,7 @@ class TagsList extends Component {
 
 	render() {
 		const tagsToShow = this.props.tagsToShow || 3;
-		const tagsInOccurrenceOrder = values( this.props.post.tags );
+		const tagsInOccurrenceOrder = Object.values( this.props.post.tags || {} );
 		tagsInOccurrenceOrder.sort( ( a, b ) => b.post_count - a.post_count );
 		const tags = tagsInOccurrenceOrder.map( ( tag ) => <TagLink tag={ tag } key={ tag.slug } /> );
 		const defaultTags = tags.slice( 0, tagsToShow );

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { pencil as edit, external, Icon, seen, published, unseen } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { size, map } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -173,7 +173,7 @@ class ReaderPostEllipsisMenu extends Component {
 		let feedItemIds = [ post.feed_item_ID ];
 		let globalIds = [ post.global_ID ];
 
-		if ( size( posts ) ) {
+		if ( posts.length ) {
 			postIds = map( posts, 'ID' );
 			feedItemIds = map( posts, 'feed_item_ID' );
 			globalIds = map( posts, 'global_ID' );
@@ -218,7 +218,7 @@ class ReaderPostEllipsisMenu extends Component {
 		let feedItemIds = [ post.feed_item_ID ];
 		let globalIds = [ post.global_ID ];
 
-		if ( size( posts ) ) {
+		if ( posts.length ) {
 			postIds = map( posts, 'ID' );
 			feedItemIds = map( posts, 'feed_item_ID' );
 			globalIds = map( posts, 'global_ID' );
@@ -328,8 +328,8 @@ class ReaderPostEllipsisMenu extends Component {
 							useWordPressIcon
 							iconSize={ 24 }
 						>
-							{ size( posts ) > 0 && translate( 'Mark all as unseen' ) }
-							{ size( posts ) === 0 && translate( 'Mark as unseen' ) }
+							{ posts.length > 0 && translate( 'Mark all as unseen' ) }
+							{ posts.length === 0 && translate( 'Mark as unseen' ) }
 						</PopoverMenuItem>
 					) }
 
@@ -342,8 +342,8 @@ class ReaderPostEllipsisMenu extends Component {
 							useWordPressIcon
 							iconSize={ 24 }
 						>
-							{ size( posts ) > 0 && translate( 'Mark all as seen' ) }
-							{ size( posts ) === 0 && translate( 'Mark as seen' ) }
+							{ posts.length > 0 && translate( 'Mark all as seen' ) }
+							{ posts.length === 0 && translate( 'Mark as seen' ) }
 						</PopoverMenuItem>
 					) }
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -11,7 +11,6 @@ import {
 	forEach,
 	get,
 	includes,
-	keys,
 	map,
 	mapKeys,
 	merge,
@@ -309,7 +308,7 @@ class SignupForm extends Component {
 
 					if ( field === 'username' && ! includes( usernamesSearched, fields.username ) ) {
 						recordTracksEvent( 'calypso_signup_username_validation_failed', {
-							error: keys( fieldError )[ 0 ],
+							error: Object.keys( fieldError )[ 0 ],
 							username: fields.username,
 						} );
 
@@ -318,7 +317,7 @@ class SignupForm extends Component {
 
 					if ( field === 'password' ) {
 						recordTracksEvent( 'calypso_signup_password_validation_failed', {
-							error: keys( fieldError )[ 0 ],
+							error: Object.keys( fieldError )[ 0 ],
 						} );
 
 						timesPasswordValidationFailed++;
@@ -326,7 +325,7 @@ class SignupForm extends Component {
 
 					if ( field === 'email' ) {
 						recordTracksEvent( 'calypso_signup_email_validation_failed', {
-							error: keys( fieldError )[ 0 ],
+							error: Object.keys( fieldError )[ 0 ],
 							email: fields.email,
 						} );
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -12,7 +12,6 @@ import { Button, Card, Gridicon, PlanPrice } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
-import { size } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, isValidElement } from 'react';
 import { connect } from 'react-redux';
@@ -275,7 +274,7 @@ export class Banner extends Component {
 				<div className="banner__info">
 					<h3 className="banner__title">{ title }</h3>
 					{ this.renderDescription( description ) }
-					{ size( list ) > 0 && (
+					{ ( list || [] ).length > 0 && (
 						<ul className="banner__list">
 							{ list.map( ( item, key ) => (
 								<li key={ key }>
@@ -293,8 +292,8 @@ export class Banner extends Component {
 				</div>
 				{ ( callToAction || price ) && (
 					<div className="banner__action">
-						{ size( prices ) === 1 && <PlanPrice rawPrice={ prices[ 0 ] } /> }
-						{ size( prices ) === 2 && (
+						{ prices.length === 1 && <PlanPrice rawPrice={ prices[ 0 ] } /> }
+						{ prices.length === 2 && (
 							<div className="banner__prices">
 								<PlanPrice rawPrice={ prices[ 0 ] } original />
 								<PlanPrice rawPrice={ prices[ 1 ] } discounted />

--- a/client/components/domains/registrant-extra-info/ca-form.tsx
+++ b/client/components/domains/registrant-extra-info/ca-form.tsx
@@ -1,6 +1,6 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { camelCase, difference, isEmpty, keys, map, pick } from 'lodash';
+import { camelCase, difference, isEmpty, map, pick } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -92,7 +92,7 @@ export class RegistrantExtraInfoCaForm extends PureComponent<
 		// Add defaults to redux state to make accepting default values work.
 		const neededRequiredDetails = difference(
 			[ 'lang', 'legalType', 'ciraAgreementAccepted' ],
-			keys( this.props.ccTldDetails )
+			Object.keys( this.props.ccTldDetails )
 		);
 
 		// Bail early as we already have the details from a previous purchase.

--- a/client/components/domains/registrant-extra-info/uk-form.tsx
+++ b/client/components/domains/registrant-extra-info/uk-form.tsx
@@ -2,7 +2,7 @@ import { FormInputValidation, FormLabel } from '@automattic/components';
 import { DomainContactDetails } from '@automattic/shopping-cart';
 import { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { camelCase, difference, get, isEmpty, keys, map, pick } from 'lodash';
+import { camelCase, difference, get, isEmpty, map, pick } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -60,7 +60,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 		// Add defaults to redux state to make accepting default values work.
 		const neededRequiredDetails = difference(
 			[ 'registrantType' ],
-			keys( this.props.ccTldDetails )
+			Object.keys( this.props.ccTldDetails )
 		);
 
 		// Bail early as we already have the details from a previous purchase.

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -1,5 +1,5 @@
 import { uniqBy } from '@automattic/js-utils';
-import { map, size, filter } from 'lodash';
+import { map, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Gravatar from 'calypso/components/gravatar';
@@ -16,7 +16,7 @@ class GravatarCaterpillar extends Component {
 	render() {
 		const { users, onClick, maxGravatarsToDisplay } = this.props;
 
-		if ( size( users ) < 1 ) {
+		if ( users.length < 1 ) {
 			return null;
 		}
 
@@ -26,7 +26,7 @@ class GravatarCaterpillar extends Component {
 		const displayedUsers = filter( uniqBy( users, 'avatar_URL' ), 'avatar_URL' ).slice(
 			-1 * maxGravatarsToDisplay
 		);
-		const displayedUsersCount = size( displayedUsers );
+		const displayedUsersCount = displayedUsers.length;
 
 		return (
 			<div className="gravatar-caterpillar" onClick={ onClick } aria-hidden="true">

--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -1,5 +1,5 @@
 import { shuffle } from '@automattic/js-utils';
-import { memoize, pick, values } from 'lodash';
+import { memoize, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -15,7 +15,7 @@ const shuffleAnswers = memoize(
 	},
 	( answers ) =>
 		answers
-			.map( ( answer ) => values( pick( answer, 'id', 'doNotShuffle' ) ).join( '_' ) )
+			.map( ( answer ) => Object.values( pick( answer, 'id', 'doNotShuffle' ) ).join( '_' ) )
 			.join( '-' )
 );
 

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -11,7 +11,6 @@ import {
 } from '@automattic/wpcom-checkout';
 import clsx from 'clsx';
 import i18n from 'i18n-calypso';
-import { keys } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -53,7 +52,7 @@ const ALT_TEXT = {
 	sofort: 'Sofort',
 };
 
-export const POSSIBLE_TYPES = keys( ALT_TEXT );
+export const POSSIBLE_TYPES = Object.keys( ALT_TEXT );
 
 class PaymentLogo extends Component {
 	static propTypes = {

--- a/client/components/share-button/docs/example.jsx
+++ b/client/components/share-button/docs/example.jsx
@@ -1,4 +1,3 @@
-import { keys } from 'lodash';
 import { PureComponent } from 'react';
 import ShareButton from '../';
 import services from '../services';
@@ -10,7 +9,7 @@ export default class ShareButtonExample extends PureComponent {
 		return (
 			<div>
 				<div>
-					{ keys( services ).map( ( service ) => (
+					{ Object.keys( services ).map( ( service ) => (
 						<ShareButton
 							key={ service }
 							size={ 48 }
@@ -21,7 +20,7 @@ export default class ShareButtonExample extends PureComponent {
 					) ) }
 				</div>
 				<div>
-					{ keys( services ).map( ( service ) => (
+					{ Object.keys( services ).map( ( service ) => (
 						<ShareButton
 							key={ service }
 							size={ 48 }

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,4 +1,4 @@
-import { get, keys, map, omit, reduce } from 'lodash';
+import { get, map, omit, reduce } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
@@ -52,7 +52,7 @@ class SortedGrid extends PureComponent {
 								text={ this.props.getGroupLabel( group ) }
 								itemsCount={ count }
 								itemsPerRow={ this.props.itemsPerRow }
-								lastInRow={ keys( row.groups ).at( -1 ) === group }
+								lastInRow={ Object.keys( row.groups ).at( -1 ) === group }
 								scale={ this.props.scale }
 							/>
 						)

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { TranslateResult, translate } from 'i18n-calypso';
-import { filter, orderBy, values } from 'lodash';
+import { filter, orderBy } from 'lodash';
 import { type ImporterOption } from 'calypso/blocks/import/list';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { appStates } from 'calypso/state/imports/constants';
@@ -407,7 +407,11 @@ export function getImporters( args: ImporterConfigArgs = { siteSlug: '', siteTit
 		delete importerConfig.substack;
 	}
 
-	const importers = orderBy( values( importerConfig ), [ 'weight', 'title' ], [ 'desc', 'asc' ] );
+	const importers = orderBy(
+		Object.values( importerConfig ),
+		[ 'weight', 'title' ],
+		[ 'desc', 'asc' ]
+	);
 
 	return importers;
 }

--- a/client/lib/post-normalizer/rule-pick-primary-tag.js
+++ b/client/lib/post-normalizer/rule-pick-primary-tag.js
@@ -1,8 +1,8 @@
-import { maxBy, values } from 'lodash';
+import { maxBy } from 'lodash';
 
 export default function pickPrimaryTag( post ) {
 	// if we hand max an invalid or empty array, it returns -Infinity
-	const primary_tag = maxBy( values( post.tags ), function ( tag ) {
+	const primary_tag = maxBy( Object.values( post.tags || {} ), function ( tag ) {
 		return tag.post_count;
 	} );
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,4 +1,4 @@
-import { clone, difference, get, isEqual, map, omit, reduce, values } from 'lodash';
+import { clone, difference, get, isEqual, map, omit, reduce } from 'lodash';
 import QueryKey from './key';
 
 /**
@@ -32,7 +32,7 @@ function getItemsForKeys( items, itemKeys ) {
 	if ( itemKeys == null ) {
 		let resultForAllKeys = cacheForItems.get( ALL_ITEMS_KEY );
 		if ( ! resultForAllKeys ) {
-			resultForAllKeys = values( items );
+			resultForAllKeys = Object.values( items );
 			cacheForItems.set( ALL_ITEMS_KEY, resultForAllKeys );
 		}
 		return resultForAllKeys;

--- a/client/lib/signup/asserts.js
+++ b/client/lib/signup/asserts.js
@@ -1,9 +1,12 @@
-import { get, keys, difference } from 'lodash';
+import { get, difference } from 'lodash';
 import steps from 'calypso/signup/config/steps-pure';
 
 export function assertValidDependencies( stepName, providedDependencies ) {
 	const providesDependencies = get( steps, [ stepName, 'providesDependencies' ], [] );
-	const extraDependencies = difference( keys( providedDependencies ), providesDependencies );
+	const extraDependencies = difference(
+		Object.keys( providedDependencies || {} ),
+		providesDependencies
+	);
 
 	if ( extraDependencies.length > 0 ) {
 		throw new Error(

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -11,7 +11,6 @@ import {
 	forEach,
 	includes,
 	isEmpty,
-	keys,
 	pick,
 	reject,
 	reduce,
@@ -222,7 +221,7 @@ export default class SignupFlowController {
 		const dependencyDiff = difference(
 			this._flow.providesDependenciesInQuery,
 			this._flow.optionalDependenciesInQuery || [],
-			keys( providedDependencies )
+			Object.keys( providedDependencies || {} )
 		);
 		if ( dependencyDiff.length > 0 ) {
 			throw new Error(
@@ -240,7 +239,7 @@ export default class SignupFlowController {
 				return;
 			}
 
-			const dependenciesFound = keys(
+			const dependenciesFound = Object.keys(
 				pick( getSignupDependencyStore( this._reduxStore.getState() ), step.dependencies )
 			);
 			const dependenciesNotProvided = difference(
@@ -265,7 +264,9 @@ export default class SignupFlowController {
 	}
 
 	_assertFlowProvidedRequiredDependencies() {
-		const storedDependencies = keys( getSignupDependencyStore( this._reduxStore.getState() ) );
+		const storedDependencies = Object.keys(
+			getSignupDependencyStore( this._reduxStore.getState() )
+		);
 
 		forEach( pick( steps, this._getFlowSteps() ), ( step ) => {
 			if ( ! step.providesDependencies ) {
@@ -380,7 +381,7 @@ export default class SignupFlowController {
 	_canProcessStep( step: Step ) {
 		const { dependencies = [], providesToken } = steps[ step.stepName ];
 		const dependenciesFound = this._findDependencies( step.stepName, 'dependencies' );
-		const dependenciesSatisfied = dependencies.length === keys( dependenciesFound ).length;
+		const dependenciesSatisfied = dependencies.length === Object.keys( dependenciesFound ).length;
 		const currentSteps = this._getFlowSteps();
 		const signupProgress = filter(
 			getSignupProgress( this._reduxStore.getState() ),
@@ -520,7 +521,7 @@ export default class SignupFlowController {
 	}
 
 	cleanup() {
-		this._unsubscribeStore && this._unsubscribeStore();
+		this._unsubscribeStore?.();
 	}
 
 	changeFlowName( flowName: string ) {

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { size } from 'lodash';
 import { createStore, applyMiddleware } from 'redux';
 import { thunk } from 'redux-thunk';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -185,7 +184,7 @@ describe( 'flow-controller', () => {
 						stepName: 'delayedStep',
 						stepCallback: function () {
 							const progress = getSignupProgress( store.getState() );
-							expect( size( progress ) ).toBe( 2 );
+							expect( Object.keys( progress ).length ).toBe( 2 );
 						},
 					} )
 				);

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -5,7 +5,7 @@ import languages from '@automattic/languages';
 import { ExternalLink } from '@wordpress/components';
 import debugFactory from 'debug';
 import { fixMe, localize } from 'i18n-calypso';
-import { debounce, get, map, size } from 'lodash';
+import { debounce, get, map } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -706,7 +706,7 @@ class Account extends Component {
 		 * If there are no actions or if there is only one action,
 		 * which we assume is the 'none' action, we ignore the actions.
 		 */
-		if ( size( actions ) <= 1 ) {
+		if ( Object.keys( actions ).length <= 1 ) {
 			return;
 		}
 

--- a/client/me/notification-settings/settings-form/stream.jsx
+++ b/client/me/notification-settings/settings-form/stream.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { find, size } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -21,7 +21,7 @@ class NotificationSettingsFormStream extends PureComponent {
 	getStreamSettings = () => {
 		let { stream, settings } = this.props;
 
-		if ( this.props.devices && size( this.props.devices ) > 0 ) {
+		if ( this.props.devices && this.props.devices.length > 0 ) {
 			stream = parseInt( this.state.selectedDeviceId || this.props.devices[ 0 ].id, 10 );
 			settings = find( this.props.settings, { device_id: stream } );
 		}

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -4,7 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { groupBy, isEmpty, map, size, values } from 'lodash';
+import { groupBy, isEmpty, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -424,9 +424,11 @@ export default withMobileBreakpoint(
 		( state, ownProps ) => {
 			const guidedTourState = getGuidedTourState( state );
 			const selectedSiteId = getSelectedSiteId( state );
-			const mediaValidationErrorTypes = values( ownProps.mediaValidationErrors ).map( first );
+			const mediaValidationErrorTypes = Object.values( ownProps.mediaValidationErrors || {} ).map(
+				first
+			);
 			const shouldPauseGuidedTour =
-				! isEmpty( guidedTourState.tour ) && 0 < size( mediaValidationErrorTypes );
+				! isEmpty( guidedTourState.tour ) && 0 < mediaValidationErrorTypes.length;
 			const googleConnection = getKeyringConnectionsByName( state, 'google_photos' );
 
 			return {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { get, isEqual, keys, omit, pick } from 'lodash';
+import { get, isEqual, omit, pick } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose, bindActionCreators } from 'redux';
@@ -390,7 +390,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			let saveInstantSearchRequest;
 			const siteSettingsSaveError = getSiteSettingsSaveError( state, siteId );
 			const settingsFields = {
-				site: keys( settings ),
+				site: Object.keys( settings || {} ),
 			};
 			const path = getCurrentRouteParameterized( state, siteId );
 
@@ -399,7 +399,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			if ( isJetpack ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
 				settings = { ...settings, ...jetpackSettings };
-				settingsFields.jetpack = keys( jetpackSettings );
+				settingsFields.jetpack = Object.keys( jetpackSettings || {} );
 				const fieldsToUpdate = /^error_/.test( fields.lang_id )
 					? omit( fields, 'lang_id' )
 					: fields;

--- a/client/my-sites/stats/sections/posting-activity-section/index.jsx
+++ b/client/my-sites/stats/sections/posting-activity-section/index.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { values } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -25,7 +24,7 @@ class PostingActivitySection extends Component {
 	getMonthComponents = () => {
 		const { streakData } = this.props;
 		// Compute maximum per-day post count from the streakData. It's used to scale the chart.
-		const maxPosts = Math.max( ...values( streakData ) );
+		const maxPosts = Math.max( ...Object.values( streakData || {} ) );
 		const months = [];
 
 		for ( let i = 11; i >= 0; i-- ) {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { flow, get, isEmpty, some, values } from 'lodash';
+import { flow, get, isEmpty, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -58,7 +58,7 @@ export class EditorMediaModal extends Component {
 		single: PropTypes.bool,
 		defaultFilter: PropTypes.string,
 		enabledFilters: PropTypes.arrayOf( PropTypes.string ),
-		view: PropTypes.oneOf( values( ModalViews ) ),
+		view: PropTypes.oneOf( Object.values( ModalViews ) ),
 		galleryViewEnabled: PropTypes.bool,
 		setView: PropTypes.func,
 		resetView: PropTypes.func,

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { values } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import SectionNav from 'calypso/components/section-nav';
@@ -14,7 +13,7 @@ class SearchStreamHeader extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
 		wideDisplay: PropTypes.bool,
-		selected: PropTypes.oneOf( values( SEARCH_TYPES ) ),
+		selected: PropTypes.oneOf( Object.values( SEARCH_TYPES ) ),
 		onSelection: PropTypes.func,
 		isLoggedIn: PropTypes.bool,
 	};

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -1,4 +1,4 @@
-import { intersection, isEmpty, keys } from 'lodash';
+import { intersection, isEmpty } from 'lodash';
 import flows from '../flows';
 import { generateFlows } from '../flows-pure';
 import { getStepModuleMap } from '../step-components';
@@ -19,7 +19,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 describe( 'index', () => {
 	// eslint-disable-next-line jest/expect-expect
 	test( 'should not have overlapping step/flow names', () => {
-		const overlappingNames = intersection( keys( steps ), keys( flows.getFlows() ) );
+		const overlappingNames = intersection( Object.keys( steps ), Object.keys( flows.getFlows() ) );
 
 		if ( ! isEmpty( overlappingNames ) ) {
 			throw new Error(

--- a/client/signup/validation-fieldset/index.jsx
+++ b/client/signup/validation-fieldset/index.jsx
@@ -1,7 +1,6 @@
 import { FormInputValidation } from '@automattic/components';
 import clsx from 'clsx';
 import debugFactory from 'debug';
-import { values } from 'lodash';
 import { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import './style.scss';
@@ -13,7 +12,7 @@ export default class ValidationFieldset extends Component {
 			<FormInputValidation
 				isError
 				isValid={ false }
-				text={ values( this.props.errorMessages )[ 0 ] }
+				text={ Object.values( this.props.errorMessages )[ 0 ] }
 			/>
 		);
 

--- a/client/sites/marketing/sharing/options.jsx
+++ b/client/sites/marketing/sharing/options.jsx
@@ -1,7 +1,7 @@
 import { FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { filter, get, some, values, xor } from 'lodash';
+import { filter, get, some, xor } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -288,7 +288,7 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const path = getCurrentRouteParameterized( state, siteId );
 
-		const postTypes = filter( values( getPostTypes( state, siteId ) ), 'public' );
+		const postTypes = filter( Object.values( getPostTypes( state, siteId ) || {} ), 'public' );
 
 		return {
 			initialized: !! postTypes || !! getSiteSettings( state, siteId ),

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -1,4 +1,4 @@
-import { get, keys } from 'lodash';
+import { get } from 'lodash';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import versionCompare from 'calypso/lib/version-compare';
 import wpcom from 'calypso/lib/wp';
@@ -24,7 +24,7 @@ const _fetching = {};
 
 const normalizePluginInstructions = ( data ) => {
 	const _plugins = data.keys;
-	return keys( _plugins ).map( ( slug ) => {
+	return Object.keys( _plugins || {} ).map( ( slug ) => {
 		const apiKey = _plugins[ slug ];
 		return {
 			slug: slug,

--- a/client/state/themes/selectors/get-theme-filter-terms-table.js
+++ b/client/state/themes/selectors/get-theme-filter-terms-table.js
@@ -1,5 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
-import { keys, mapValues } from 'lodash';
+import { mapValues } from 'lodash';
 import { getThemeFilters } from 'calypso/state/themes/selectors/get-theme-filters';
 import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors/is-ambiguous-theme-filter-term';
 
@@ -14,7 +14,7 @@ import 'calypso/state/themes/init';
 export const getThemeFilterTermsTable = createSelector(
 	( state ) => {
 		const termTable = {};
-		const taxonomies = mapValues( getThemeFilters( state ), keys );
+		const taxonomies = mapValues( getThemeFilters( state ), Object.keys );
 		Object.entries( taxonomies ).map( ( [ taxonomy, terms ] ) => {
 			terms.forEach( ( term ) => {
 				const key = isAmbiguousThemeFilterTerm( state, term ) ? `${ taxonomy }:${ term }` : term;

--- a/client/state/themes/selectors/get-theme-filter-to-term-table.js
+++ b/client/state/themes/selectors/get-theme-filter-to-term-table.js
@@ -1,5 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
-import { keys, mapValues } from 'lodash';
+import { mapValues } from 'lodash';
 import { getThemeFilterTermFromString } from 'calypso/state/themes/selectors/get-theme-filter-term-from-string';
 import { getThemeFilters } from 'calypso/state/themes/selectors/get-theme-filters';
 
@@ -14,7 +14,7 @@ import 'calypso/state/themes/init';
 export const getThemeFilterToTermTable = createSelector(
 	( state ) => {
 		const result = {};
-		const taxonomies = mapValues( getThemeFilters( state ), keys );
+		const taxonomies = mapValues( getThemeFilters( state ), Object.keys );
 		Object.entries( taxonomies ).map( ( [ taxonomy, terms ] ) => {
 			terms.forEach( ( term ) => {
 				const key = `${ taxonomy }:${ term }`;


### PR DESCRIPTION
## Proposed Changes

* Replace lodash's `keys` with `Object.keys` and `values` with `Object.values` across the client.
* Replace lodash's `size` with native length — `array.length` for arrays, `Object.keys( obj ).length` for objects.
* Enable the corresponding `you-dont-need-lodash-underscore` eslint rules (`keys`, `values`, `size`) to prevent reintroduction.

`keys`/`values`/`size` tolerate `null`/`undefined` (returning `[]`/`0`); the native forms throw, so nullable arguments are guarded (`Object.keys( x || {} )`, `( arr || [] ).length`). `size` is polymorphic, so each call is converted according to its argument type.

## Why are these changes being made?

Part of the incremental effort to remove lodash, replacing functions with native equivalents and guarding each removal against regression.

## Testing Instructions

* `yarn eslint` is clean and the guards reject `import { keys, values, size } from 'lodash'`.
* `yarn typecheck-client` shows no new errors.
* Related client unit tests pass.
* The affected surfaces render identically.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
