### PR TITLE
Email forwarding: Improving form experience for email forwarding setup

### DIFF
--- a/client/my-sites/email/email-forwards-add/add-new-form/destination-input.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/destination-input.tsx
@@ -59,9 +59,7 @@ export function DestinationsInput( props: DestinationsInputProps ) {
 					}
 					return error;
 				} }
-				placeholder={ translate(
-					'These are the target email addresses where your emails will be forwarded.'
-				) }
+				placeholder={ translate( 'you@example.com' ) }
 			/>
 			{ values.map( ( value ) => (
 				<input key={ value } type="hidden" name="destinations" value={ value } />

--- a/client/my-sites/email/email-forwards-add/add-new-form/source-input.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/source-input.tsx
@@ -1,37 +1,30 @@
-import { TextControl } from '@wordpress/components';
-import clsx from 'clsx';
+import { FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import type { SourceInputProps } from './types';
 import './styles.scss';
 
 export function SourceInput( props: SourceInputProps ) {
-	const { onChange, suffix, ...rest } = props;
+	const { onChange, suffix, value, disabled } = props;
 	const translate = useTranslate();
-	const [ highlightSuffix, setHighlightSuffix ] = React.useState( 0 );
 
 	return (
-		<div className="email-forwarding__mailbox-input-wrapper">
-			<TextControl
-				label={ translate( 'Forward from' ) }
-				className="email-forwarding__mailbox-input"
+		<FormFieldset className="email-forwarding__mailbox-input">
+			<FormLabel htmlFor="email-forwarding-mailbox">{ translate( 'Forward from' ) }</FormLabel>
+			<FormTextInputWithAffixes
+				id="email-forwarding-mailbox"
 				name="mailbox"
 				maxLength={ 64 }
-				onChange={ ( value ) => onChange( value.replace( /@.*/gi, '' ) ) }
-				onKeyUp={ ( event ) => {
-					if ( event.key === '@' ) {
-						setHighlightSuffix( ( s ) => s + 1 );
-					}
-				} }
-				{ ...rest }
+				placeholder={ translate( 'e.g. contact' ) }
+				value={ value }
+				disabled={ disabled }
+				onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+					onChange( event.target.value.replace( /@.*/gi, '' ) )
+				}
+				suffix={ <span className="email-forwarding__mailbox-suffix">{ suffix }</span> }
 			/>
-			{ /* Blink the suffix when the user enters @ */ }
-			<p
-				key={ highlightSuffix }
-				className={ clsx( 'email-forwarding__mailbox-suffix', { animate: highlightSuffix } ) }
-			>
-				{ suffix }
-			</p>
-		</div>
+		</FormFieldset>
 	);
 }

--- a/client/my-sites/email/email-forwards-add/add-new-form/styles.scss
+++ b/client/my-sites/email/email-forwards-add/add-new-form/styles.scss
@@ -5,70 +5,30 @@
 	flex-direction: column;
 	gap: 24px;
 	padding-top: 24px;
+	max-width: 600px;
 
 	div.components-base-control__field {
 		margin-bottom: 0;
 	}
 }
 
-.email-forwarding__mailbox-input-wrapper {
-	position: relative;
+.email-forwarding__mailbox-input {
+	margin-bottom: 0;
 
-	// These margins mess our suffix.
-	div.components-base-control__field {
-		margin-bottom: 0;
-	}
-
-	& div.components-base-control.email-forwarding__mailbox-input {
-		margin-right: 0 !important;
-	}
-
-	& input {
-		// Make sure the suffix doesn't cross the input border.
-		background: transparent;
-		z-index: 2;
-		position: relative;
-	}
-
-
-	.email-forwarding__mailbox-suffix {
-		margin: 0;
-		position: absolute;
-		right: 1px;
-		bottom: 1px;
-		padding: 5px 10px;
-		background: var(--studio-gray-0);
-		border-top: 1px solid var(--studio-gray-0);
-		border-left: 1px solid var(--studio-gray-10);
-		color: var(--studio-gray-50);
-		font-size: $font-body-small;
-		z-index: 1;
-
-		&.animate {
-			animation: blink 3s forwards;
-
-			@keyframes blink {
-				5% {
-					opacity: 0;
-				}
-
-				10% {
-					opacity: 1;
-				}
-
-				15% {
-					opacity: 0;
-				}
-
-				20% {
-					opacity: 1;
-				}
-			}
+	.form-text-input-with-affixes {
+		// Match FormTokenField height when __next40pxDefaultSize is set.
+		.form-text-input,
+		.form-text-input-with-affixes__suffix {
+			min-height: 40px;
+			box-sizing: border-box;
 		}
 	}
 }
 
-
+.email-forwarding__mailbox-suffix {
+	color: var(--studio-gray-50);
+	font-size: $font-body-small;
+}
 
 /* If the user didn't add any tokens, show a shimmer effect, because they may not know to press Enter. */
 .components-form-token-field:not(:has(.components-form-token-field__token)):focus-within {

--- a/client/my-sites/email/email-forwards-add/add-new-form/test/index.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/test/index.tsx
@@ -8,6 +8,7 @@ import { NewForwardForm } from '../index';
 
 jest.mock( 'i18n-calypso', () => ( {
 	useTranslate: () => ( text: string ) => text,
+	localize: ( Component: React.ComponentType ) => Component,
 } ) );
 
 const defaultProps = {


### PR DESCRIPTION
## Summary

We have a somewhat hidden feature that allows users to create email addresses on their domain that forward to any external email address. The current form has a few issues:

Design inconsistencies: input fields are excessively wide and have inconsistent heights
**Unclear input expectations: it's not obvious what users should enter in each field**:
Specifically, the first field expects only the local part of the email (without the @Domain suffix), while the second field expects a complete email address — but nothing in the UI communicates this.
Also if you try to add an "@" symbol into the first form field, it would accept it - without any feedback to the user. 

This PR is an attempt to address these issues:
- Reworks the email forwarding add form's two inputs for a cleaner layout.
- Replaces the custom TextControl + absolutely-positioned suffix in the email forwarding source input with the shared FormTextInputWithAffixes component. 

_Note: This was a project by @hotslacks1  and me during the All Product Meetup in Porto - created with Build-on-WP.com_ 

## Changes

- Replace TextControl with FormTextInputWithAffixes + FormFieldset/FormLabel in source-input.tsx
- Remove highlight-suffix blink animation, wrapper div, and related positioning CSS
- Match FormTokenField height (min-height 40px) on the input and suffix for visual alignment
- Cap form width at 600px and drop trailing-newline / dead style blocks
- Change destinations placeholder to `you@example.com`
- Mock `localize` in the form test to satisfy the new component imports

## Before
<img width="1728" height="999" alt="image" src="https://github.com/user-attachments/assets/a4fa4712-0150-45ca-b345-d3d524565f53" />


## After
<img width="1727" height="995" alt="image" src="https://github.com/user-attachments/assets/50ca6944-5d5e-4c3d-bdf0-6392f091f831" />


## How to test

1. Go to `/email/:domain/forwarding/add/:site` for a site with a custom domain
2. Confirm the `Forward from` field renders with the domain shown as a right-aligned suffix and is vertically aligned with the destinations FormTokenField
3. Type a local part, then press `@` — verify the `@` is stripped from the input and no blink/animation fires on the suffix
4. Confirm the destinations field shows `you@example.com` as placeholder and accepts tokenized addresses on Enter
5. Resize the viewport and verify the form caps at 600px wide without layout shift
6. Toggle dark mode and verify suffix/label/input colors remain legible
7. Run `yarn test-client client/my-sites/email/email-forwards-add/add-new-form` and confirm the suite passes

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)

---
Created as a draft by Build on WP.com.

_Created with Build on WP.com — the author will mark this ready for review when they choose to._

---

## ⚠️ SecEx pre-PR review couldn't run

BoW's mandatory pre-PR SecEx review (via the wpcom `AI_Coder_Diff_Reviewer`) failed for this PR:

```
calypso: review: review_diff threw: Typed property AI_Coder_Diff_Reviewer::$logger must not be accessed before initialization
```

The PR was created anyway so the change isn't blocked. This is typically a sandbox-side issue (PHP class bug, library missing, network blip) that BoW can't fix client-side. **Please review this diff manually** before approving — the usual SecEx automated pass did not happen.
