### PR TITLE
A4A Marketplace: fix category menu header flicker on load

### DIFF
--- a/client/a8c-for-agencies/components/a4a-carousel/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-carousel/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 import './style.scss';
 
@@ -91,7 +91,11 @@ export default function A4ACarousel( { children, className }: Props ) {
 		setTouchStart( null );
 	}, [] );
 
-	useEffect( () => {
+	// Measure the carousel widths before the browser paints (rather than after, as
+	// useEffect would) so that `requiresNavigation` is correct on the very first
+	// painted frame. Otherwise the navigation buttons render absent on first paint
+	// and pop in a frame later, flickering the category menu on initial load.
+	useLayoutEffect( () => {
 		setContainerWidth( containerRef.current?.clientWidth ?? 0 );
 		setContentWidth( contentRef.current?.clientWidth ?? 0 );
 	}, [ containerRef, contentRef ] );


### PR DESCRIPTION

## Proposed Changes

A4ACarousel measured its widths in a useEffect, which runs after the browser paints. So the first painted frame rendered without the chevron navigation buttons, and they popped in a frame later — shifting the category items within the fixed-height menu and flickering the header.

Measure in useLayoutEffect instead so requiresNavigation is correct on the first painted frame, eliminating the flicker.


## Why are these changes being made?
* Makes our UI look more polished.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace/products` page.
* Confirm that you do not see the header specifically the Category menu flickering when during on page load.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
