### PR TITLE
Scan: fix threat header layout wrapping

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -244,41 +244,45 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 	return (
 		<>
 			<Card className="scan-threats__card-header">
-				<SecurityIcon icon={ securityIcon } className="scan-threats security-icon" />
-				<h1 className="scan-threats scan__header">{ headerMessage }</h1>
-				<p className="scan-threats__header-message">
-					{ headerSummary }{ ' ' }
-					{ maxSeverity < 3 && (
-						<InfoPopover position="top" screenReaderText={ translate( 'Learn more' ) }>
-							{ translate(
-								'Low risk items could have a negative impact on your site and should either be fixed or ignored at your convenience.'
-							) }
-						</InfoPopover>
+				<div className="scan__header">
+					<SecurityIcon icon={ securityIcon } className="scan-threats security-icon" />
+				</div>
+				<div className="scan__card-body scan-threats__card-body">
+					<h1 className="scan-threats scan__header">{ headerMessage }</h1>
+					<p className="scan-threats__header-message">
+						{ headerSummary }{ ' ' }
+						{ maxSeverity < 3 && (
+							<InfoPopover position="top" screenReaderText={ translate( 'Learn more' ) }>
+								{ translate(
+									'Low risk items could have a negative impact on your site and should either be fixed or ignored at your convenience.'
+								) }
+							</InfoPopover>
+						) }
+					</p>
+					{ hasFixableThreats && (
+						<>
+							<div className="scan-threats__buttons">
+								<p>{ fixSummary }</p>
+								<Button
+									primary
+									className="scan-threats__fix-all-threats-button"
+									onClick={ openFixAllThreatsDialog }
+									disabled={ ! hasFixableThreats || updatingThreats.length > 0 }
+								>
+									{ translate( 'Show auto fixers' ) }
+								</Button>
+								<Button className="scan-threats__scan-secondary-button" onClick={ dispatchScanRun }>
+									{ translate( 'Scan now' ) }
+								</Button>
+							</div>
+						</>
 					) }
-				</p>
-				{ hasFixableThreats && (
-					<>
-						<div className="scan-threats__buttons">
-							<p>{ fixSummary }</p>
-							<Button
-								primary
-								className="scan-threats__fix-all-threats-button"
-								onClick={ openFixAllThreatsDialog }
-								disabled={ ! hasFixableThreats || updatingThreats.length > 0 }
-							>
-								{ translate( 'Show auto fixers' ) }
-							</Button>
-							<Button className="scan-threats__scan-secondary-button" onClick={ dispatchScanRun }>
-								{ translate( 'Scan now' ) }
-							</Button>
-						</div>
-					</>
-				) }
-				{ ! hasFixableThreats && (
-					<Button primary className="scan-threats__button" onClick={ dispatchScanRun }>
-						{ translate( 'Scan now' ) }
-					</Button>
-				) }
+					{ ! hasFixableThreats && (
+						<Button primary className="scan-threats__button" onClick={ dispatchScanRun }>
+							{ translate( 'Scan now' ) }
+						</Button>
+					) }
+				</div>
 			</Card>
 			<ThreatListHeader />
 			<div className="scan-threats__threats">

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -14,6 +14,11 @@
 		padding: 32px;
 	}
 
+	&__card-body {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
 	&__header-message {
 		display: flex;
 		padding-bottom: 8px;
@@ -124,13 +129,9 @@
 		display: flex;
 		border-top: 1px solid var(--studio-gray-5);
 		padding-top: 32px;
-		flex-direction: space-between;
 		flex-wrap: wrap;
 		align-items: center;
-
-		@include breakpoint-deprecated( ">800px" ) {
-			flex-direction: row;
-		}
+		gap: 10px;
 
 		> p {
 			font-size: $font-body;
@@ -155,14 +156,13 @@
 		border-radius: 2px;
 		font-weight: 600;
 		@include breakpoint-deprecated( "<960px" ) {
-			flex-grow: 1;
+			flex: 1 1 180px;
 		}
 	}
 
 	&__scan-secondary-button {
-		margin-left: 10px;
 		@include breakpoint-deprecated( "<960px" ) {
-			flex-grow: 1;
+			flex: 1 1 180px;
 		}
 	}
 

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -151,6 +151,7 @@
 		}
 	}
 
+	// 180px keeps action button labels readable before wrapping.
 	&__fix-all-threats-button {
 		height: 40px;
 		border-radius: 2px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes PROTECT-175

This fixes a regression introduced in #109625, when the Scanner pages were migrated to the admin-ui `Page` layout and Scan cards gained a broad flex-row layout.

## Proposed Changes

* Update the Scanner threats header card so it matches the migrated Scan card structure: one `.scan__header` icon column and one `.scan__card-body` content column.
* Keep the threat count, auto-fix summary, and action buttons grouped inside the content column instead of letting them become separate card-level flex children.
* Let the content column shrink with `min-width: 0`, and make the auto-fix action row wrap with `gap` spacing so the buttons do not overlap at narrow widths.

| Before | After |
|---|---|
| <img width="2188" height="782" alt="CleanShot 2026-06-16 at 09 41 09@2x" src="https://github.com/user-attachments/assets/5b459385-74f2-4d0a-9fd6-a4e3cf1f45db" /> | <img width="2188" height="788" alt="CleanShot 2026-06-16 at 10 00 26@2x" src="https://github.com/user-attachments/assets/6e9ad6d6-f453-46f9-9915-dd8e219a2033" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Scan admin-ui migration added a broad `body.is-section-scan .scan__content > .card` flex layout for Scan cards. Most Scan card states were updated to render as an icon wrapper plus `.scan__card-body`, but the threat-results header still rendered the icon, heading, threat summary, and actions as direct children of the `Card`.

Once that card became a flex row, those children competed for horizontal space. That caused the reported layout breakage: summary text wrapping one word per line, the auto-fix divider appearing in the wrong place, and the action buttons colliding at narrow widths.

This change fixes the threat-results header locally without changing the shared Jetpack page layout mixin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a vulnerable plugin to one of your test sites, for example `formgent` 1.5.5 or `12-step-meeting-list` 3.16.6. An exhaustive list could be found on https://wpscan.com/plugins/
* Purchase/add a Jetpack plan that includes Scan (like Jetpack Security)
* Spin up a Jetpack Cloud Live branch
* Navigate to `/scan/:site`
* Ensure the header now looks correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
