### PR TITLE
Domains: clear stale bundle suggestions after permanent add failures

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -1133,9 +1133,10 @@ describe( 'useWPCOMDomainSearchProps', () => {
 				} )
 			);
 
-			await expect( result.current.cart.onAddBundle?.( bundle ) ).rejects.toThrow(
-				'The domain bundle could not be added to the cart.'
-			);
+			await expect( result.current.cart.onAddBundle?.( bundle ) ).rejects.toMatchObject( {
+				message: 'The domain bundle could not be added to the cart.',
+				code: 'domain_bundle_unavailable',
+			} );
 
 			expect( onContinue ).not.toHaveBeenCalled();
 		} );

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -4,9 +4,10 @@ import {
 	isDomainMoveInternal,
 	isPlan,
 } from '@automattic/calypso-products';
-import { DomainSearch } from '@automattic/domain-search';
+import { DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE, DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
+	CartActionError,
 	type CartKey,
 	type MinimalRequestCartProduct,
 	type ResponseCartProduct,
@@ -236,7 +237,10 @@ export const useWPCOMDomainSearchCart = ( {
 				);
 
 				if ( bundleItemsInCart.length < bundle.domains.length ) {
-					throw new Error( 'The domain bundle could not be added to the cart.' );
+					throw new CartActionError(
+						'The domain bundle could not be added to the cart.',
+						DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE
+					);
 				}
 
 				if ( ! flowAllowsMultipleDomainsInCart ) {

--- a/packages/domain-search/src/page/constants.ts
+++ b/packages/domain-search/src/page/constants.ts
@@ -4,3 +4,5 @@ export const DEFAULT_FILTER: FilterState = {
 	exactSldMatchesOnly: false,
 	tlds: [],
 };
+
+export const DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE = 'domain_bundle_unavailable';

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -10,6 +10,8 @@ import { type DomainSearchProps } from './types';
 
 import './style.scss';
 
+export { DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE } from './constants';
+
 export const DomainSearch = ( props: DomainSearchProps ) => {
 	const contextValue = useDomainSearchContextValue( props );
 

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,4 +1,4 @@
-import { useIsMutating, useMutation } from '@tanstack/react-query';
+import { useIsMutating, useMutation, useQueryClient } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -14,8 +14,28 @@ import { UnavailableSearchResult } from '../components/unavailable-search-result
 import { useIsCurrentMutation } from '../hooks/use-is-current-mutation';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
+import { DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE } from './constants';
 import { useDomainSearch } from './context';
 import type { BundleSuggestion } from '@automattic/api-core';
+
+const hasErrorCode = ( error: unknown, code: string ) =>
+	typeof error === 'object' &&
+	error !== null &&
+	'code' in error &&
+	( error as { code?: unknown } ).code === code;
+
+const isBundleUnavailableError = ( error: unknown ) =>
+	hasErrorCode( error, DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE );
+
+type AddBundleToCartVariables = {
+	bundle: BundleSuggestion;
+	query: string;
+};
+
+type UnavailableBundle = {
+	groupId: string;
+	query: string;
+};
 
 const StickyCompactBanner = () => {
 	const { __ } = useI18n();
@@ -49,7 +69,9 @@ const StickyCompactBanner = () => {
 
 export const ResultsPage = () => {
 	const { __ } = useI18n();
-	const { slots, config, events, cart, query } = useDomainSearch();
+	const { slots, config, events, cart, query, queries } = useDomainSearch();
+	const queryClient = useQueryClient();
+	const [ unavailableBundle, setUnavailableBundle ] = useState< UnavailableBundle >();
 
 	const { mutationId, isCurrentMutation } = useIsCurrentMutation();
 
@@ -66,8 +88,18 @@ export const ResultsPage = () => {
 		meta: {
 			mutationId,
 		},
-		mutationFn: async ( bundle: BundleSuggestion ) => {
+		mutationFn: async ( { bundle }: AddBundleToCartVariables ) => {
 			await cart.onAddBundle?.( bundle );
+		},
+		onError: async ( error, { bundle, query: failedQuery } ) => {
+			if ( ! isBundleUnavailableError( error ) ) {
+				return;
+			}
+
+			setUnavailableBundle( { groupId: bundle.bundle_group_id, query: failedQuery } );
+			await queryClient.invalidateQueries( {
+				queryKey: queries.bundleSuggestion( failedQuery ).queryKey,
+			} );
 		},
 		networkMode: 'always',
 		retry: false,
@@ -79,13 +111,14 @@ export const ResultsPage = () => {
 	// query produces a new bundle suggestion, so drop the stale error.
 	useEffect( () => {
 		resetAddBundle();
+		setUnavailableBundle( undefined );
 	}, [ query, resetAddBundle ] );
 
 	// The cart rejects with the server's first cart message (a CartActionError),
 	// which is already user-facing copy. Fall back when it's missing. Clicking
 	// "Get bundle" again re-fires the mutation, which clears the error state.
 	const bundleErrorMessage =
-		isCurrentMutation && addBundleError
+		isCurrentMutation && addBundleError && ! isBundleUnavailableError( addBundleError )
 			? addBundleError.message ||
 			  __( 'Sorry, we couldn’t add the bundle to your cart. Please try again.' )
 			: undefined;
@@ -96,6 +129,12 @@ export const ResultsPage = () => {
 		regularSuggestions,
 		bundleSuggestion,
 	} = useSuggestionsList();
+	const visibleBundleSuggestion =
+		unavailableBundle &&
+		bundleSuggestion?.bundle_group_id === unavailableBundle.groupId &&
+		query === unavailableBundle.query
+			? undefined
+			: bundleSuggestion;
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
 
@@ -105,13 +144,13 @@ export const ResultsPage = () => {
 	// the group id so a new bundle (different query/experiment arm) re-fires, but
 	// re-renders of the same bundle do not.
 	const shownBundleGroupId =
-		! isLoadingSuggestions && bundleSuggestion && bundleSuggestion.domains.length > 0
-			? bundleSuggestion.bundle_group_id
+		! isLoadingSuggestions && visibleBundleSuggestion && visibleBundleSuggestion.domains.length > 0
+			? visibleBundleSuggestion.bundle_group_id
 			: undefined;
 
 	useEffect( () => {
-		if ( shownBundleGroupId && bundleSuggestion ) {
-			events.onBundleShown( bundleSuggestion );
+		if ( shownBundleGroupId && visibleBundleSuggestion ) {
+			events.onBundleShown( visibleBundleSuggestion );
 		}
 		// Intentionally keyed only on the group id: we want exactly one event per
 		// bundle that appears, not one per render or per `events`/object identity change.
@@ -158,14 +197,14 @@ export const ResultsPage = () => {
 				) : (
 					<FeaturedSearchResults suggestions={ featuredSuggestions } />
 				) }
-				{ ! isLoadingSuggestions && bundleSuggestion && (
+				{ ! isLoadingSuggestions && visibleBundleSuggestion && (
 					<BundleCard
-						suggestion={ bundleSuggestion }
+						suggestion={ visibleBundleSuggestion }
 						onAddToCart={ ( bundle ) => {
 							events.onBundleAddToCart( bundle );
-							addBundleToCart( bundle );
+							addBundleToCart( { bundle, query } );
 						} }
-						isAddedToCart={ bundleSuggestion.domains.every( ( { domain } ) =>
+						isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
 							cart.hasItem( domain )
 						) }
 						onContinue={ events.onContinue }

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -32,6 +32,10 @@ type AddBundleToCartVariables = {
 	query: string;
 };
 
+type AddBundleToCartResult = {
+	wasAdded: boolean;
+};
+
 type UnavailableBundle = {
 	groupId: string;
 	query: string;
@@ -88,8 +92,20 @@ export const ResultsPage = () => {
 		meta: {
 			mutationId,
 		},
-		mutationFn: async ( { bundle }: AddBundleToCartVariables ) => {
-			await cart.onAddBundle?.( bundle );
+		mutationFn: async ( {
+			bundle,
+		}: AddBundleToCartVariables ): Promise< AddBundleToCartResult > => {
+			if ( ! cart.onAddBundle ) {
+				return { wasAdded: false };
+			}
+
+			await cart.onAddBundle( bundle );
+			return { wasAdded: true };
+		},
+		onSuccess: ( { wasAdded }, { bundle } ) => {
+			if ( wasAdded ) {
+				events.onBundleAddToCart( bundle );
+			}
 		},
 		onError: async ( error, { bundle, query: failedQuery } ) => {
 			if ( ! isBundleUnavailableError( error ) ) {
@@ -201,7 +217,6 @@ export const ResultsPage = () => {
 					<BundleCard
 						suggestion={ visibleBundleSuggestion }
 						onAddToCart={ ( bundle ) => {
-							events.onBundleAddToCart( bundle );
 							addBundleToCart( { bundle, query } );
 						} }
 						isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1540,8 +1540,15 @@ describe( 'ResultsPage', () => {
 			expect( onBundleShown ).not.toHaveBeenCalled();
 		} );
 
-		it( 'fires the onBundleAddToCart event when the bundle CTA is clicked', async () => {
+		it( 'fires the onBundleAddToCart event after the bundle add succeeds', async () => {
 			const user = userEvent.setup();
+			let resolveAddBundle: () => void = () => {};
+			const onAddBundle = jest.fn(
+				() =>
+					new Promise< void >( ( resolve ) => {
+						resolveAddBundle = resolve;
+					} )
+			);
 			const onBundleAddToCart = jest.fn();
 
 			mockGetSuggestionsQuery( {
@@ -1555,6 +1562,7 @@ describe( 'ResultsPage', () => {
 
 			render(
 				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
 					events={ { onBundleAddToCart } }
 					config={ { showBundleSuggestions: true } }
 					query="bundle-accept"
@@ -1565,10 +1573,87 @@ describe( 'ResultsPage', () => {
 
 			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
 
-			expect( onBundleAddToCart ).toHaveBeenCalledTimes( 1 );
+			expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+			expect( onBundleAddToCart ).not.toHaveBeenCalled();
+
+			await act( async () => {
+				resolveAddBundle();
+			} );
+
+			await waitFor( () => {
+				expect( onBundleAddToCart ).toHaveBeenCalledTimes( 1 );
+			} );
 			expect( onBundleAddToCart ).toHaveBeenCalledWith(
 				expect.objectContaining( { bundle_group_id: 'mock-bundle-accept-group' } )
 			);
+		} );
+
+		it( 'does not fire the onBundleAddToCart event when the bundle add fails', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockRejectedValue( new Error( 'Bundle add failed' ) );
+			const onBundleAddToCart = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-reject' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-reject.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-reject' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-reject' ),
+			} );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					events={ { onBundleAddToCart } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-reject"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+			} );
+			await waitFor( () => {
+				expect( getByText( container, 'Bundle add failed' ) ).toBeInTheDocument();
+			} );
+			expect( onBundleAddToCart ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire the onBundleAddToCart event when no bundle add handler exists', async () => {
+			const user = userEvent.setup();
+			const onBundleAddToCart = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-no-handler' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-no-handler.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-no-handler' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-no-handler' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle: undefined } ) }
+					events={ { onBundleAddToCart } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-no-handler"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+			await act( async () => {
+				await Promise.resolve();
+			} );
+
+			expect( onBundleAddToCart ).not.toHaveBeenCalled();
 		} );
 
 		it( 'fires the onQueryAvailabilityCheck event when the availability is checked', async () => {

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1,5 +1,5 @@
 import { DomainAvailabilityStatus, type BundleSuggestion } from '@automattic/api-core';
-import { getByText, queryByText, render, screen, waitFor } from '@testing-library/react';
+import { act, getByText, queryByText, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { buildAvailability } from '../../test-helpers/factories/availability';
 import { buildCart, buildCartItem } from '../../test-helpers/factories/cart';
@@ -1006,6 +1006,173 @@ describe( 'ResultsPage', () => {
 					)
 				).toBeInTheDocument();
 			} );
+		} );
+
+		it( 'clears the bundle card and refetches the bundle suggestion when the bundle is permanently unavailable', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockRejectedValue(
+				Object.assign( new Error( 'The domain bundle could not be added to the cart.' ), {
+					code: 'domain_bundle_unavailable',
+				} )
+			);
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-permanent' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-permanent.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-permanent' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-permanent' ),
+			} );
+			const refetchRequest = mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-permanent' },
+				bundleSuggestion: null,
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-permanent"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'test-bundle-permanent.net' ) ).toBeInTheDocument();
+
+			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( refetchRequest.isDone() ).toBe( true );
+			} );
+
+			await waitFor( () => {
+				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+			} );
+			expect( screen.queryByText( 'test-bundle-permanent.net' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'keeps the stale bundle hidden when the permanent-failure refetch returns the same bundle group', async () => {
+			const user = userEvent.setup();
+			const unavailableBundle = buildBundleSuggestion( 'test-bundle-same-group' );
+			const onAddBundle = jest.fn().mockRejectedValue(
+				Object.assign( new Error( 'The domain bundle could not be added to the cart.' ), {
+					code: 'domain_bundle_unavailable',
+				} )
+			);
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-same-group' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-same-group.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-same-group' },
+				bundleSuggestion: unavailableBundle,
+			} );
+			const refetchRequest = mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-same-group' },
+				bundleSuggestion: unavailableBundle,
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-same-group"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'test-bundle-same-group.net' ) ).toBeInTheDocument();
+
+			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( refetchRequest.isDone() ).toBe( true );
+			} );
+
+			await waitFor( () => {
+				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+			} );
+			expect( screen.queryByText( 'test-bundle-same-group.net' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'does not hide or refetch the next query when an old bundle add fails permanently', async () => {
+			const user = userEvent.setup();
+			let rejectAddBundle: ( error: Error ) => void = () => {};
+			const staleBundle = buildBundleSuggestion( 'test-bundle-late-stale' );
+			const freshBundle = {
+				...buildBundleSuggestion( 'test-bundle-late-fresh' ),
+				bundle_group_id: staleBundle.bundle_group_id,
+			};
+			const onAddBundle = jest.fn(
+				() =>
+					new Promise< void >( ( _resolve, reject ) => {
+						rejectAddBundle = reject;
+					} )
+			);
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-late-stale' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-late-stale.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-late-stale' },
+				bundleSuggestion: staleBundle,
+			} );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-late-fresh' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-late-fresh.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-late-fresh' },
+				bundleSuggestion: freshBundle,
+			} );
+			const freshRefetchRequest = mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-late-fresh' },
+				bundleSuggestion: null,
+			} );
+
+			const { rerender } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-late-stale"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'test-bundle-late-stale.net' ) ).toBeInTheDocument();
+
+			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
+
+			rerender(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-late-fresh"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
+
+			await act( async () => {
+				rejectAddBundle(
+					Object.assign( new Error( 'The domain bundle could not be added to the cart.' ), {
+						code: 'domain_bundle_unavailable',
+					} )
+				);
+			} );
+
+			expect( freshRefetchRequest.isDone() ).toBe( false );
+			expect( screen.getByText( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
 		} );
 
 		it( 'clears the error when retrying succeeds', async () => {


### PR DESCRIPTION
Fixes DOMAINS-2193

## Proposed Changes

* Add a stable `domain_bundle_unavailable` error code for the app-layer case where the cart sync strips an incomplete bundle group.
* Clear and refetch bundle suggestions after that permanent failure, while keeping transient failures retryable on the bundle card.
* Keep same-group refetches hidden and guard against late failures from a previous search hiding the current query.

## Why are these changes being made?

* DOMAINS-2192 surfaced bundle add failures but left the failed bundle card retryable. That is correct for transient failures, but stale bundle groups should not keep inviting retries after the cart rejects them permanently.

## Testing Instructions

Use the Calypso Live build from this PR, then navigate to `/domains/add/<site-slug>?flags=domain-bundling` for a site that can buy domains.

Precondition: the WPCOM API backend must have the server-side bundle kill switch enabled (`WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED`). You can sanity-check this by loading `/rest/v1.1/domains/suggestions?query=thalasso.com&vendor=variation2_front&with_bundles=1` while logged in; the response needs a non-null `bundle_suggestion` for the bundle card to appear.

### Transient Cart Failure
1. Search for a bundle-producing domain, for example `thalasso.com` on a bundle-enabled backend.
2. Confirm the bundle card appears. Click **Get bundle** and verify the happy path adds all bundle members to the cart as a bundle.
3. Reload, search for a bundle-producing domain again, then simulate a transient cart failure by blocking the cart update request or toggling DevTools offline before clicking **Get bundle**. Expected: the bundle card remains visible, an error is shown, and retrying is possible after unblocking the request.

### Stale Bundle
1. Reload, search for a bundle-producing domain again, then simulate the permanent stale-bundle case with Requestly, Charles, or Chrome Local Overrides.
   - To use Chrome Local Overrides: open DevTools, go to **Sources → Overrides**, choose a local folder, grant Chrome access to it, and make sure overrides are enabled.
   - In **Network**, enable **Disable cache** and filter for `no-site`.
   - Click **Get bundle**, select the cart POST to `/me/shopping-cart/no-site` whose **Payload** includes the bundle members and their `domain_bundle_group_id`, then use **Override content** / **Save for overrides** to create the editable local response.
   - Edit the saved response under **Sources → Overrides** and keep DevTools open while testing. Chrome matches overrides by URL, so repeated `no-site?http_envelope=1` rows can all look overridden; use the Method and Payload columns to identify the cart-add POST rather than an empty cart reload.
2. Trigger the bundle add, then inspect the cart POST to `/me/shopping-cart/no-site`. The request payload should include the bundle members and their original `domain_bundle_group_id`; the response is what you are faking.
3. Let the cart update return HTTP 200, but edit the returned response so `body.products` does not contain the complete original bundle group. For example, change one returned product's `extra.domain_bundle_group_id` to a different value such as `force-bundle-test`, or return an empty `products: []` array. You do not need to edit `unmerged_products`.
4. Expected after the permanent failure: the current bundle card disappears, no retry/error state is shown for that card, `/domains/suggestions?...with_bundles=1` is refetched for the failed query, and the regular domain suggestions remain usable.
5. If a bundle card reappears after the refetch, compare its `bundle_group_id` with the failed bundle. A different `bundle_group_id` means this is a fresh bundle suggestion and is expected. The stale bundle should remain hidden only when the refetch returns the same failed `bundle_group_id`.
6. Search for a different bundle-producing query after the failed add. Expected: any old failed add response must not hide the new query's bundle card.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
