### PR TITLE
Checkout: add card to submit label and add change payment method button

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -365,7 +365,11 @@ function PortaledCheckoutFormSubmit( {
 		return null;
 	}
 	return createPortal(
-		<CheckoutFormSubmit validateForm={ validateForm } continueToNextIncompleteStep />,
+		<CheckoutFormSubmit
+			validateForm={ validateForm }
+			continueToNextIncompleteStep
+			changePaymentMethodStepId="payment-method-step"
+		/>,
 		slotEl
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -361,6 +361,7 @@ function PortaledCheckoutFormSubmit( {
 	validateForm?: () => Promise< boolean >;
 } ) {
 	const { slotEl } = useSubmitButtonSlot();
+	const reduxDispatch = useReduxDispatch();
 	if ( ! slotEl ) {
 		return null;
 	}
@@ -369,6 +370,11 @@ function PortaledCheckoutFormSubmit( {
 			validateForm={ validateForm }
 			continueToNextIncompleteStep
 			changePaymentMethodStepId="payment-method-step"
+			onChangePaymentMethodClick={ () =>
+				reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_change_payment_method_click' )
+				)
+			}
 		/>,
 		slotEl
 	);

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -22,6 +22,9 @@ import {
 	usePaymentMethod,
 	useTransactionStatus,
 	TransactionStatus,
+	useAvailablePaymentMethodIds,
+	useMakeStepActive,
+	useNextIncompleteStepId,
 } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
 import { ONBOARDING_FLOW, Step } from '@automattic/onboarding';
@@ -351,6 +354,57 @@ function CheckoutSidebarNudge( {
 	);
 }
 
+const ChangePaymentMethodButton = styled.button`
+	display: block;
+	margin: 12px auto 0;
+	padding: 0;
+	border: none;
+	background: none;
+	color: ${ ( props ) => props.theme.colors.highlight };
+	font-size: 14px;
+	text-align: center;
+	text-decoration: underline;
+	cursor: pointer;
+
+	&:hover {
+		text-decoration: none;
+	}
+`;
+
+// A "Use a different payment method" link rendered below the submit button via
+// CheckoutFormSubmit's generic `submitButtonFooter` slot. This is WP.com-specific
+// UX (the concept of a "payment method step", the count heuristic, the analytics
+// event), so it lives here rather than in the generic composite-checkout package.
+export function ChangePaymentMethodFooter( { stepId }: { stepId: string } ) {
+	const translate = useTranslate();
+	const reduxDispatch = useReduxDispatch();
+	const makeStepActive = useMakeStepActive();
+	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
+	// Hide the link while the submit area is showing "Continue" (i.e. there is an
+	// earlier incomplete step) so it only appears alongside the final Pay button.
+	const nextIncompleteStepId = useNextIncompleteStepId();
+
+	if ( availablePaymentMethodIds.length <= 1 || nextIncompleteStepId ) {
+		return null;
+	}
+
+	const goToChangePaymentMethod = async () => {
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_change_payment_method_click' ) );
+		await makeStepActive( stepId );
+		document.getElementById( stepId )?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
+	};
+
+	return (
+		<ChangePaymentMethodButton
+			type="button"
+			className="checkout-steps__change-payment-method-button"
+			onClick={ goToChangePaymentMethod }
+		>
+			{ translate( 'Use a different payment method' ) }
+		</ChangePaymentMethodButton>
+	);
+}
+
 // Renders CheckoutFormSubmit inside CheckoutStepGroup (so it keeps full step-state
 // awareness) while portaling its output into the sidebar slot registered via
 // SubmitButtonSlotContext. The sidebar button IS the active payment-method submit
@@ -361,7 +415,6 @@ function PortaledCheckoutFormSubmit( {
 	validateForm?: () => Promise< boolean >;
 } ) {
 	const { slotEl } = useSubmitButtonSlot();
-	const reduxDispatch = useReduxDispatch();
 	if ( ! slotEl ) {
 		return null;
 	}
@@ -369,12 +422,7 @@ function PortaledCheckoutFormSubmit( {
 		<CheckoutFormSubmit
 			validateForm={ validateForm }
 			continueToNextIncompleteStep
-			changePaymentMethodStepId="payment-method-step"
-			onChangePaymentMethodClick={ () =>
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_change_payment_method_click' )
-				)
-			}
+			submitButtonFooter={ <ChangePaymentMethodFooter stepId="payment-method-step" /> }
 		/>,
 		slotEl
 	);

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -2,6 +2,7 @@ import { MaterialIcon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import useCartKey from '../../use-cart-key';
 
@@ -28,8 +29,8 @@ const StyledMaterialIcon = styled( MaterialIcon )`
  * There are also checkout-like forms (eg: "add credit card") which do not use
  * this because they want their submit button to render something different.
  */
-export function CheckoutSubmitButtonContent() {
-	const { __ } = useI18n();
+export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} ) {
+	const { __, _x } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
@@ -50,7 +51,14 @@ export function CheckoutSubmitButtonContent() {
 	return (
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
-			{ __( 'Pay now' ) }
+			{ last4
+				? sprintf(
+						/* translators: %s is the masked saved card number, e.g. "**** 3220" */
+						__( 'Pay with %s' ),
+						/* translators: %s is the last 4 digits of the credit card number */
+						sprintf( _x( '**** %s', 'Masked credit card number' ), last4 )
+				  )
+				: __( 'Pay now' ) }
 		</CreditCardPayButtonWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -710,13 +710,15 @@ const CheckoutSummaryPayButtonSlot = styled.div`
 	 * Each payment method provides its own button element, and a "Continue" button
 	 * renders here while steps are incomplete, so normalize every button in the slot
 	 * to a consistent full-width, 50px-tall look in the sidebar regardless of which
-	 * one is showing (Pay, Continue, PayPal, etc.).
+	 * one is showing (Pay, Continue, PayPal, etc.). The "Use a different payment
+	 * method" link is also a <button> but is a text link, so it is excluded from
+	 * the 50px submit-button sizing below.
 	 */
 	.checkout-submit-button {
 		width: 100%;
 	}
 
-	button {
+	button:not( .checkout-steps__change-payment-method-button ) {
 		width: 100%;
 		height: 50px;
 		box-sizing: border-box;

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -448,7 +448,7 @@ export default function useCreatePaymentMethods( {
 		isStripeLoading,
 		stripeLoadingError,
 		storedCards,
-		submitButtonContent: <CheckoutSubmitButtonContent />,
+		submitButtonContent: ( card ) => <CheckoutSubmitButtonContent last4={ card.card_last_4 } />,
 	} );
 
 	const existingPayPalPPCPMethods = useCreateExistingPayPalPPCP( {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -18,7 +18,7 @@ export default function useCreateExistingCards( {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredPaymentMethod[];
-	submitButtonContent: ReactNode;
+	submitButtonContent: ReactNode | ( ( card: StoredPaymentMethodCard ) => ReactNode );
 	allowEditingTaxInfo?: boolean;
 	isTaxInfoRequired?: boolean;
 } ): PaymentMethod[] {
@@ -53,7 +53,10 @@ export default function useCreateExistingCards( {
 					storedDetailsId: storedDetails.stored_details_id,
 					paymentMethodToken: storedDetails.mp_ref,
 					paymentPartnerProcessorId: storedDetails.payment_partner,
-					submitButtonContent,
+					submitButtonContent:
+						typeof submitButtonContent === 'function'
+							? submitButtonContent( storedDetails )
+							: submitButtonContent,
 					allowEditingTaxInfo,
 					isTaxInfoRequired,
 				} )

--- a/client/my-sites/checkout/src/test/change-payment-method-footer.tsx
+++ b/client/my-sites/checkout/src/test/change-payment-method-footer.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	CheckoutProvider,
+	CheckoutStepGroup,
+	CheckoutFormSubmit,
+	PaymentMethodStep,
+	makeSuccessResponse,
+} from '@automattic/composite-checkout';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useMemo } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { ChangePaymentMethodFooter } from 'calypso/my-sites/checkout/src/components/checkout-main-content';
+import { createReduxStore } from 'calypso/state';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+
+function createMockPaymentMethod( id: string ): PaymentMethod {
+	return {
+		id,
+		paymentProcessorId: id,
+		label: <span>{ id }</span>,
+		activeContent: <span>{ `${ id } active` }</span>,
+		submitButton: <button>{ `Pay with ${ id }` }</button>,
+		getAriaLabel: () => id,
+	};
+}
+
+function TestWrapper( { paymentMethods }: { paymentMethods: PaymentMethod[] } ) {
+	const store = createReduxStore( {} );
+	const queryClient = useMemo( () => new QueryClient(), [] );
+	return (
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<CheckoutProvider
+					paymentMethods={ paymentMethods }
+					selectFirstAvailablePaymentMethod
+					paymentProcessors={ Object.fromEntries(
+						paymentMethods.map( ( method ) => [
+							method.paymentProcessorId,
+							() => Promise.resolve( makeSuccessResponse( 'ok' ) ),
+						] )
+					) }
+				>
+					<CheckoutStepGroup>
+						<PaymentMethodStep />
+						<CheckoutFormSubmit
+							submitButtonFooter={ <ChangePaymentMethodFooter stepId="payment-method-step" /> }
+						/>
+					</CheckoutStepGroup>
+				</CheckoutProvider>
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+describe( 'ChangePaymentMethodFooter', () => {
+	it( 'renders the "Use a different payment method" link when more than one payment method is available', async () => {
+		render(
+			<TestWrapper
+				paymentMethods={ [
+					createMockPaymentMethod( 'method-a' ),
+					createMockPaymentMethod( 'method-b' ),
+				] }
+			/>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( 'Use a different payment method' ) ).toBeVisible();
+		} );
+	} );
+
+	it( 'does not render the link when only one payment method is available', async () => {
+		render( <TestWrapper paymentMethods={ [ createMockPaymentMethod( 'method-a' ) ] } /> );
+		// Wait for the single submit button to confirm the form has rendered.
+		await waitFor( () => {
+			expect( screen.getByText( 'Pay with method-a' ) ).toBeVisible();
+		} );
+		expect( screen.queryByText( 'Use a different payment method' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'scrolls to the payment method step when the link is clicked', async () => {
+		const scrollIntoView = jest.fn();
+		window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+		render(
+			<TestWrapper
+				paymentMethods={ [
+					createMockPaymentMethod( 'method-a' ),
+					createMockPaymentMethod( 'method-b' ),
+				] }
+			/>
+		);
+		const link = await screen.findByText( 'Use a different payment method' );
+		await userEvent.click( link );
+		await waitFor( () => {
+			expect( scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'start' } );
+		} );
+		expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+			'payment-method-step'
+		);
+	} );
+} );

--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -9,14 +9,39 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
+import { CheckoutSubmitButtonContent } from 'calypso/my-sites/checkout/src/components/checkout-submit-button-content';
 import { createExistingCardMethod } from 'calypso/my-sites/checkout/src/payment-methods/existing-credit-card';
 import { createReduxStore } from 'calypso/state';
+
+const mockResponseCart = {
+	...getEmptyResponseCart(),
+	total_cost_integer: 15600,
+	sub_total_integer: 15600,
+	currency: 'USD',
+};
+
+jest.mock( 'calypso/my-sites/checkout/use-cart-key', () => ( {
+	__esModule: true,
+	default: () => 'no-site',
+} ) );
+
+jest.mock( '@automattic/shopping-cart', () => {
+	const actual = jest.requireActual( '@automattic/shopping-cart' );
+	return {
+		...actual,
+		useShoppingCart: () => ( {
+			...actual.emptyCart,
+			responseCart: mockResponseCart,
+		} ),
+	};
+} );
 
 function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 	const store = createReduxStore();
@@ -176,6 +201,25 @@ describe( 'Existing credit card payment methods', () => {
 		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'renders "Pay with <last4>" on the submit button when CheckoutSubmitButtonContent is given a last4 prop', async () => {
+		mockTaxLocationEndpoint();
+		const last4 = '4242';
+		const existingCard = getExistingCardPaymentMethod( {
+			submitButtonContent: <CheckoutSubmitButtonContent last4={ last4 } />,
+		} );
+		render(
+			<TestWrapper
+				paymentMethods={ [ existingCard ] }
+				paymentProcessors={ {
+					[ existingCard.paymentProcessorId ]: () => makeSuccessResponse( 'ok' ),
+				} }
+			></TestWrapper>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( `Pay with **** ${ last4 }` ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -356,7 +356,9 @@ export class CartCheckoutPage {
 	async purchase( { timeout }: { timeout: number } = { timeout: 60000 } ): Promise< void > {
 		await Promise.all( [
 			this.page.waitForResponse( /.*me\/transactions.*/, { timeout: timeout } ),
-			this.page.getByRole( 'button', { name: 'Pay now' } ).click(),
+			// The submit button reads "Pay now" by default, but "Pay with **** 1234"
+			// when a saved card is selected, so match either label.
+			this.page.getByRole( 'button', { name: /Pay (now|with)/ } ).click(),
 		] );
 	}
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -16,7 +16,7 @@ import {
 import { getDefaultPaymentMethodStep } from '../components/default-steps';
 import { useFormStatus } from '../lib/form-status';
 import joinClasses from '../lib/join-classes';
-import { usePaymentMethod } from '../lib/payment-methods';
+import { useAvailablePaymentMethodIds, usePaymentMethod } from '../lib/payment-methods';
 import { SubscriptionManager } from '../lib/subscription-manager';
 import { CheckoutStepGroupActions, FormStatus } from '../types';
 import Button from './button';
@@ -658,6 +658,23 @@ export const SubmitButtonWrapper = styled.div`
 	}
 `;
 
+const ChangePaymentMethodButton = styled.button`
+	display: block;
+	margin: 12px auto 0;
+	padding: 0;
+	border: none;
+	background: none;
+	color: ${ ( props ) => props.theme.colors.highlight };
+	font-size: 14px;
+	text-align: center;
+	text-decoration: underline;
+	cursor: pointer;
+
+	&:hover {
+		text-decoration: none;
+	}
+`;
+
 function CheckoutStepArea( {
 	children,
 	className,
@@ -685,6 +702,7 @@ export function CheckoutFormSubmit( {
 	submitButton,
 	onPageLoadError,
 	continueToNextIncompleteStep,
+	changePaymentMethodStepId,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
@@ -693,6 +711,7 @@ export function CheckoutFormSubmit( {
 	submitButton?: ReactNode;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	continueToNextIncompleteStep?: boolean;
+	changePaymentMethodStepId?: string;
 } ) {
 	const { __ } = useI18n();
 	const { state, actions } = useContext( CheckoutStepGroupContext );
@@ -806,6 +825,22 @@ export function CheckoutFormSubmit( {
 		isThereAnotherNumberedStep &&
 		!! nextIncompleteStepId;
 
+	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
+	const showChangePaymentMethodLink =
+		!! changePaymentMethodStepId &&
+		! showContinueToNextIncompleteStep &&
+		availablePaymentMethodIds.length > 1;
+
+	const goToChangePaymentMethod = async () => {
+		if ( ! changePaymentMethodStepId ) {
+			return;
+		}
+		await makeStepActive( changePaymentMethodStepId );
+		document
+			.getElementById( changePaymentMethodStepId )
+			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
+	};
+
 	const goToNextIncompleteStep = async () => {
 		// Prefer the next incomplete step; otherwise just advance one step so the
 		// user always moves forward (covers the rare all-complete-but-not-last case).
@@ -852,6 +887,15 @@ export function CheckoutFormSubmit( {
 						onLoadError={ onSubmitButtonLoadError }
 					/>
 				)
+			) }
+			{ showChangePaymentMethodLink && (
+				<ChangePaymentMethodButton
+					type="button"
+					className="checkout-steps__change-payment-method-button"
+					onClick={ goToChangePaymentMethod }
+				>
+					{ __( 'Use a different payment method' ) }
+				</ChangePaymentMethodButton>
 			) }
 			<div className="checkout-steps__submit-footer-wrapper">{ submitButtonFooter || null }</div>
 		</SubmitButtonWrapper>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -16,7 +16,7 @@ import {
 import { getDefaultPaymentMethodStep } from '../components/default-steps';
 import { useFormStatus } from '../lib/form-status';
 import joinClasses from '../lib/join-classes';
-import { useAvailablePaymentMethodIds, usePaymentMethod } from '../lib/payment-methods';
+import { usePaymentMethod } from '../lib/payment-methods';
 import { SubscriptionManager } from '../lib/subscription-manager';
 import { CheckoutStepGroupActions, FormStatus } from '../types';
 import Button from './button';
@@ -658,23 +658,6 @@ export const SubmitButtonWrapper = styled.div`
 	}
 `;
 
-const ChangePaymentMethodButton = styled.button`
-	display: block;
-	margin: 12px auto 0;
-	padding: 0;
-	border: none;
-	background: none;
-	color: ${ ( props ) => props.theme.colors.highlight };
-	font-size: 14px;
-	text-align: center;
-	text-decoration: underline;
-	cursor: pointer;
-
-	&:hover {
-		text-decoration: none;
-	}
-`;
-
 function CheckoutStepArea( {
 	children,
 	className,
@@ -702,8 +685,6 @@ export function CheckoutFormSubmit( {
 	submitButton,
 	onPageLoadError,
 	continueToNextIncompleteStep,
-	changePaymentMethodStepId,
-	onChangePaymentMethodClick,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
@@ -712,8 +693,6 @@ export function CheckoutFormSubmit( {
 	submitButton?: ReactNode;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	continueToNextIncompleteStep?: boolean;
-	changePaymentMethodStepId?: string;
-	onChangePaymentMethodClick?: () => void;
 } ) {
 	const { __ } = useI18n();
 	const { state, actions } = useContext( CheckoutStepGroupContext );
@@ -827,23 +806,6 @@ export function CheckoutFormSubmit( {
 		isThereAnotherNumberedStep &&
 		!! nextIncompleteStepId;
 
-	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
-	const showChangePaymentMethodLink =
-		!! changePaymentMethodStepId &&
-		! showContinueToNextIncompleteStep &&
-		availablePaymentMethodIds.length > 1;
-
-	const goToChangePaymentMethod = async () => {
-		if ( ! changePaymentMethodStepId ) {
-			return;
-		}
-		onChangePaymentMethodClick?.();
-		await makeStepActive( changePaymentMethodStepId );
-		document
-			.getElementById( changePaymentMethodStepId )
-			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
-	};
-
 	const goToNextIncompleteStep = async () => {
 		// Prefer the next incomplete step; otherwise just advance one step so the
 		// user always moves forward (covers the rare all-complete-but-not-last case).
@@ -890,15 +852,6 @@ export function CheckoutFormSubmit( {
 						onLoadError={ onSubmitButtonLoadError }
 					/>
 				)
-			) }
-			{ showChangePaymentMethodLink && (
-				<ChangePaymentMethodButton
-					type="button"
-					className="checkout-steps__change-payment-method-button"
-					onClick={ goToChangePaymentMethod }
-				>
-					{ __( 'Use a different payment method' ) }
-				</ChangePaymentMethodButton>
 			) }
 			<div className="checkout-steps__submit-footer-wrapper">{ submitButtonFooter || null }</div>
 		</SubmitButtonWrapper>
@@ -1121,6 +1074,38 @@ export function useCompleteAllSteps(): CompleteAllSteps {
 export function useMakeStepActive(): MakeStepActive {
 	const store = useContext( CheckoutStepGroupContext );
 	return store.actions.makeStepActive;
+}
+
+/**
+ * Returns the id of the step the "Continue" submit button would advance to (the
+ * first incomplete numbered step at or after the active step, falling back to
+ * the lowest incomplete step overall), or undefined when there is no such step
+ * to continue to (all steps complete, or the active step is the last one).
+ *
+ * Consumers can use this to tell whether the submit area is showing "Continue"
+ * versus the final submit button — e.g. to gate UI rendered via
+ * `submitButtonFooter` so it only appears on the final step.
+ */
+export function useNextIncompleteStepId(): string | undefined {
+	const { state } = useContext( CheckoutStepGroupContext );
+	const { activeStepNumber, totalSteps, stepCompleteStatus, stepIdMap } = state;
+	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
+	if ( ! isThereAnotherNumberedStep ) {
+		return undefined;
+	}
+	const getStepIdFromNumber = ( stepNumber: number ): string | undefined =>
+		Object.entries( stepIdMap ).find( ( [ , num ] ) => num === stepNumber )?.[ 0 ];
+	for ( let step = Math.max( activeStepNumber, 1 ); step <= totalSteps; step++ ) {
+		if ( ! stepCompleteStatus[ step ] ) {
+			return getStepIdFromNumber( step );
+		}
+	}
+	for ( let step = 1; step <= totalSteps; step++ ) {
+		if ( ! stepCompleteStatus[ step ] ) {
+			return getStepIdFromNumber( step );
+		}
+	}
+	return undefined;
 }
 
 const StepTitle = styled.span< StepTitleProps & HTMLAttributes< HTMLSpanElement > >`

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -703,6 +703,7 @@ export function CheckoutFormSubmit( {
 	onPageLoadError,
 	continueToNextIncompleteStep,
 	changePaymentMethodStepId,
+	onChangePaymentMethodClick,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
@@ -712,6 +713,7 @@ export function CheckoutFormSubmit( {
 	onPageLoadError?: CheckoutPageErrorCallback;
 	continueToNextIncompleteStep?: boolean;
 	changePaymentMethodStepId?: string;
+	onChangePaymentMethodClick?: () => void;
 } ) {
 	const { __ } = useI18n();
 	const { state, actions } = useContext( CheckoutStepGroupContext );
@@ -835,6 +837,7 @@ export function CheckoutFormSubmit( {
 		if ( ! changePaymentMethodStepId ) {
 			return;
 		}
+		onChangePaymentMethodClick?.();
 		await makeStepActive( changePaymentMethodStepId );
 		document
 			.getElementById( changePaymentMethodStepId )

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -14,6 +14,7 @@ import {
 	useSetStepComplete,
 	useCompleteAllSteps,
 	useMakeStepActive,
+	useNextIncompleteStepId,
 	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
 import RadioButton from './components/radio-button';
@@ -76,6 +77,7 @@ export {
 	useTogglePaymentMethod,
 	useTransactionStatus,
 	useMakeStepActive,
+	useNextIncompleteStepId,
 	useRegisterPaymentMethodLoading,
 	useArePaymentMethodsLoading,
 };

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -991,6 +991,109 @@ describe( 'Checkout', () => {
 		} );
 	} );
 
+	describe( 'with changePaymentMethodStepId', function () {
+		const mockMethod = createMockMethod();
+		const mockMethod2 = createMockMethod( {
+			submitButton: <MockSubmitButton content="Pay Second Method" />,
+			activeContent: <div />,
+		} );
+		const steps = createMockStepObjects();
+
+		// steps[0] = 'custom-summary-step'   (no step number)
+		// steps[1] = 'custom-contact-step'   (numbered, isCompleteCallback () => true)
+		// steps[3] = 'custom-incomplete-step' (numbered, isCompleteCallback () => false)
+
+		function ChangePaymentCheckout( props ) {
+			const [ paymentData, setPaymentData ] = useState( {} );
+			const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
+				createStepsFromStepObjects( props.steps || steps );
+			const createStepFromStepObject = createStepObjectConverter( paymentData );
+			return (
+				<myContext.Provider value={ [ paymentData, setPaymentData ] }>
+					<CheckoutProvider
+						paymentMethods={ props.paymentMethods || [ mockMethod, mockMethod2 ] }
+						paymentProcessors={ getMockPaymentProcessors() }
+						selectFirstAvailablePaymentMethod
+					>
+						<CheckoutStepGroup>
+							{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
+							{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
+							<CheckoutFormSubmit
+								continueToNextIncompleteStep
+								changePaymentMethodStepId={ props.changePaymentMethodStepId }
+							/>
+						</CheckoutStepGroup>
+					</CheckoutProvider>
+				</myContext.Provider>
+			);
+		}
+
+		const getSubmitArea = ( container ) =>
+			container.querySelector( '.checkout-steps__submit-button-wrapper' );
+
+		it( 'shows the "Use a different payment method" link when Pay button is shown and there is more than one payment method', () => {
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect(
+				queryByTextInNode( submitArea, 'Use a different payment method' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'clicking the link scrolls to the target step', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Use a different payment method' ) );
+
+			await waitFor( () => {
+				expect( scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'start' } );
+			} );
+			expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+				'custom-contact-step'
+			);
+		} );
+
+		it( 'hides the link when there is only one available payment method', () => {
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+					paymentMethods={ [ mockMethod ] }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect(
+				queryByTextInNode( submitArea, 'Use a different payment method' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'hides the link while a step is incomplete (Continue button is showing)', () => {
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
+			expect(
+				queryByTextInNode( submitArea, 'Use a different payment method' )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'submitting the form', function () {
 		let MyCheckout;
 		const submitButtonComponent = <MockSubmitButtonSimple />;

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -1021,6 +1021,7 @@ describe( 'Checkout', () => {
 							<CheckoutFormSubmit
 								continueToNextIncompleteStep
 								changePaymentMethodStepId={ props.changePaymentMethodStepId }
+								onChangePaymentMethodClick={ props.onChangePaymentMethodClick }
 							/>
 						</CheckoutStepGroup>
 					</CheckoutProvider>
@@ -1063,6 +1064,25 @@ describe( 'Checkout', () => {
 			expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
 				'custom-contact-step'
 			);
+		} );
+
+		it( 'calls onChangePaymentMethodClick when the link is clicked', async () => {
+			window.HTMLElement.prototype.scrollIntoView = jest.fn();
+			const onChangePaymentMethodClick = jest.fn();
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+					onChangePaymentMethodClick={ onChangePaymentMethodClick }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Use a different payment method' ) );
+
+			await waitFor( () => {
+				expect( onChangePaymentMethodClick ).toHaveBeenCalledTimes( 1 );
+			} );
 		} );
 
 		it( 'hides the link when there is only one available payment method', () => {

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -22,6 +22,7 @@ import {
 	useTogglePaymentMethod,
 	makeErrorResponse,
 	useMakeStepActive,
+	useNextIncompleteStepId,
 } from '../src/public-api';
 import { PaymentProcessorFunction, PaymentProcessorResponseType } from '../src/types';
 import { DefaultCheckoutSteps } from './utils/default-checkout-steps';
@@ -991,19 +992,23 @@ describe( 'Checkout', () => {
 		} );
 	} );
 
-	describe( 'with changePaymentMethodStepId', function () {
+	describe( 'useNextIncompleteStepId', function () {
 		const mockMethod = createMockMethod();
-		const mockMethod2 = createMockMethod( {
-			submitButton: <MockSubmitButton content="Pay Second Method" />,
-			activeContent: <div />,
-		} );
 		const steps = createMockStepObjects();
 
 		// steps[0] = 'custom-summary-step'   (no step number)
 		// steps[1] = 'custom-contact-step'   (numbered, isCompleteCallback () => true)
 		// steps[3] = 'custom-incomplete-step' (numbered, isCompleteCallback () => false)
 
-		function ChangePaymentCheckout( props ) {
+		// Renders the hook's value (or the string 'none' when undefined) so tests can
+		// assert on it. This is the generic primitive consumers use to tell whether the
+		// submit area is showing "Continue" (a step remains) versus the final Pay button.
+		function NextIncompleteStepIdProbe() {
+			const nextIncompleteStepId = useNextIncompleteStepId();
+			return <div data-testid="next-incomplete-step-id">{ nextIncompleteStepId ?? 'none' }</div>;
+		}
+
+		function ProbeCheckout( props ) {
 			const [ paymentData, setPaymentData ] = useState( {} );
 			const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
 				createStepsFromStepObjects( props.steps || steps );
@@ -1011,106 +1016,30 @@ describe( 'Checkout', () => {
 			return (
 				<myContext.Provider value={ [ paymentData, setPaymentData ] }>
 					<CheckoutProvider
-						paymentMethods={ props.paymentMethods || [ mockMethod, mockMethod2 ] }
+						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
 						selectFirstAvailablePaymentMethod
 					>
 						<CheckoutStepGroup>
 							{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
 							{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
-							<CheckoutFormSubmit
-								continueToNextIncompleteStep
-								changePaymentMethodStepId={ props.changePaymentMethodStepId }
-								onChangePaymentMethodClick={ props.onChangePaymentMethodClick }
-							/>
+							<NextIncompleteStepIdProbe />
 						</CheckoutStepGroup>
 					</CheckoutProvider>
 				</myContext.Provider>
 			);
 		}
 
-		const getSubmitArea = ( container ) =>
-			container.querySelector( '.checkout-steps__submit-button-wrapper' );
-
-		it( 'shows the "Use a different payment method" link when Pay button is shown and there is more than one payment method', () => {
-			const { container } = render(
-				<ChangePaymentCheckout
-					steps={ [ steps[ 0 ], steps[ 1 ] ] }
-					changePaymentMethodStepId="custom-contact-step"
-				/>
-			);
-			const submitArea = getSubmitArea( container );
-			expect(
-				queryByTextInNode( submitArea, 'Use a different payment method' )
-			).toBeInTheDocument();
+		it( 'returns undefined when the active step is the last numbered step (Pay button state)', () => {
+			render( <ProbeCheckout steps={ [ steps[ 0 ], steps[ 1 ] ] } /> );
+			expect( screen.getByTestId( 'next-incomplete-step-id' ) ).toHaveTextContent( 'none' );
 		} );
 
-		it( 'clicking the link scrolls to the target step', async () => {
-			const scrollIntoView = jest.fn();
-			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
-			const { container } = render(
-				<ChangePaymentCheckout
-					steps={ [ steps[ 0 ], steps[ 1 ] ] }
-					changePaymentMethodStepId="custom-contact-step"
-				/>
-			);
-			const submitArea = getSubmitArea( container );
-			const user = userEvent.setup();
-			await user.click( getByTextInNode( submitArea, 'Use a different payment method' ) );
-
-			await waitFor( () => {
-				expect( scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'start' } );
-			} );
-			expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+		it( 'returns the next incomplete step id when there is a later numbered step (Continue state)', () => {
+			render( <ProbeCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] } /> );
+			expect( screen.getByTestId( 'next-incomplete-step-id' ) ).toHaveTextContent(
 				'custom-contact-step'
 			);
-		} );
-
-		it( 'calls onChangePaymentMethodClick when the link is clicked', async () => {
-			window.HTMLElement.prototype.scrollIntoView = jest.fn();
-			const onChangePaymentMethodClick = jest.fn();
-			const { container } = render(
-				<ChangePaymentCheckout
-					steps={ [ steps[ 0 ], steps[ 1 ] ] }
-					changePaymentMethodStepId="custom-contact-step"
-					onChangePaymentMethodClick={ onChangePaymentMethodClick }
-				/>
-			);
-			const submitArea = getSubmitArea( container );
-			const user = userEvent.setup();
-			await user.click( getByTextInNode( submitArea, 'Use a different payment method' ) );
-
-			await waitFor( () => {
-				expect( onChangePaymentMethodClick ).toHaveBeenCalledTimes( 1 );
-			} );
-		} );
-
-		it( 'hides the link when there is only one available payment method', () => {
-			const { container } = render(
-				<ChangePaymentCheckout
-					steps={ [ steps[ 0 ], steps[ 1 ] ] }
-					changePaymentMethodStepId="custom-contact-step"
-					paymentMethods={ [ mockMethod ] }
-				/>
-			);
-			const submitArea = getSubmitArea( container );
-			expect(
-				queryByTextInNode( submitArea, 'Use a different payment method' )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'hides the link while a step is incomplete (Continue button is showing)', () => {
-			const { container } = render(
-				<ChangePaymentCheckout
-					steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] }
-					changePaymentMethodStepId="custom-contact-step"
-				/>
-			);
-			const submitArea = getSubmitArea( container );
-			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
-			expect(
-				queryByTextInNode( submitArea, 'Use a different payment method' )
-			).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
Closes SHILL-2104

Re-lands #111346, which was reverted in #111728 because it broke pre-release E2E purchase specs. This PR restores the original change and fixes the E2E locator that depended on the old button label.

## Proposed Changes

Checkout now has a persistent "Pay Now" submit button in the sidebar, which when active, represents the current selected payment method. When the button represents a stored card, this PR updates the label to say "Pay with **** 1234" to help clarify which payment method is being used. It also adds a link to "Use a different payment method" under the button that links to the payment method step.

<img width="3516" height="2356" alt="CleanShot 2026-06-04 at 15 29 07@2x" src="https://github.com/user-attachments/assets/a939e07e-25f7-457e-97da-ccdce667f783" />

**1. Saved-card pay button label**
* Add an optional `last4` prop to `CheckoutSubmitButtonContent`. In the ready-to-pay state, when a last 4 is provided the button reads **"Pay with **** 3220"** (masked, reusing the existing `_x( '**** %s', 'Masked credit card number' )` translation) with the card icon, instead of the generic "Pay now". Other states (Processing…, Please wait…, free → "Complete Checkout") are unchanged; omitting `last4` is byte-identical to today.
* Wire the **checkout** `useCreateExistingCards` to supply per-card content via a render-prop, so each saved card's button shows its own last 4.

**2. "Use a different payment method" link**
* Add an optional `changePaymentMethodStepId` prop to `CheckoutFormSubmit` (`@automattic/composite-checkout`). When set, it renders a centered "Use a different payment method" link below the submit button that expands and smooth-scrolls to the Payment Method step (reusing the existing `makeStepActive` + `scrollIntoView` pattern).
* The link shows only when (a) the real Pay button is shown (not the "Continue" state) and (b) there is more than one available payment method (`useAvailablePaymentMethodIds().length > 1`).

**3. Analytics for the "Use a different payment method" link**
* The "Pay with **** 1234" button is already tracked on click via `recordTransactionBeginAnalytics` (`calypso_checkout_form_submit`, `calypso_checkout_composite_form_submit`, and `calypso_checkout_composite_existing_card_submit_clicked`), so no new event is needed there.
* The new link had no analytics. Add an optional `onChangePaymentMethodClick` callback to `CheckoutFormSubmit` (keeping `@automattic/composite-checkout` analytics-agnostic) and wire it Calypso-side in `PortaledCheckoutFormSubmit` to record `calypso_checkout_composite_change_payment_method_click`.

**E2E fix (the reason for the original revert)**
* `CartCheckoutPage.purchase()` clicked `getByRole( 'button', { name: 'Pay now' } )`. Playwright matches the accessible name as a substring, so the new saved-card label "Pay with **** 1234" no longer matched and the click timed out. The locator now matches either label via `{ name: /Pay (now|with)/ }`.

## Why are these changes being made?

When a shopper has saved cards, a generic "Pay now" doesn't say which card will be charged; "Pay with **** 3220" makes the active card explicit — especially with the pay button pinned in the sidebar and multiple cards on file. The "Use a different payment method" link gives a one-tap way to jump back to the Payment Method step to switch methods, without scrolling to find it.

## Testing Instructions

* `yarn test-client client/my-sites/checkout/src/test/existing-credit-card.tsx` — includes a test asserting the masked "Pay with **** <last 4>" label; existing tests confirm the static-content path is unchanged.
* `yarn test-packages packages/composite-checkout/test/checkout.tsx -t "changePaymentMethodStepId"` — 5 tests: link shows with the Pay button + >1 method; click scrolls to the target step; click fires `onChangePaymentMethodClick`; hidden with a single method; hidden while the Continue button shows.
* Manual (desktop): in checkout with a saved card selected and more than one payment method available, confirm the sidebar button reads "Pay with **** <last 4>" and a "Use a different payment method" link appears below it that scrolls to and expands the Payment Method step. Confirm the link is absent when only one method is available, and that a free cart still shows "Complete Checkout".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
