### PR TITLE
Signup: use accurate copy for Reader flow processing screen

### DIFF
--- a/client/signup/processing-screen/index.tsx
+++ b/client/signup/processing-screen/index.tsx
@@ -50,6 +50,7 @@ const useSteps = ( {
 		case ACCOUNT_FLOW:
 		case HOSTING_LP_FLOW:
 		case ENTREPRENEUR_FLOW:
+		case 'reader':
 			steps = [ { title: __( 'Creating your account' ) } ];
 			break;
 		case 'do-it-for-me':
@@ -122,7 +123,7 @@ export default function ProcessingScreen( props: ProcessingScreenProps ) {
 				progress={ progressValue }
 				subtitle={
 					totalSteps > 1 &&
-					// translators: these are progress steps. Eg: step 1 of 4.
+					// translators: %(currentStep)d is the current step number; %(totalSteps)d is the total number of steps. Eg: step 1 of 4.
 					sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
 						currentStep: currentStep + 1,
 						totalSteps,

--- a/client/signup/processing-screen/index.tsx
+++ b/client/signup/processing-screen/index.tsx
@@ -1,4 +1,9 @@
-import { ACCOUNT_FLOW, HOSTING_LP_FLOW, ENTREPRENEUR_FLOW } from '@automattic/onboarding';
+import {
+	ACCOUNT_FLOW,
+	HOSTING_LP_FLOW,
+	ENTREPRENEUR_FLOW,
+	READER_FLOW,
+} from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -50,7 +55,7 @@ const useSteps = ( {
 		case ACCOUNT_FLOW:
 		case HOSTING_LP_FLOW:
 		case ENTREPRENEUR_FLOW:
-		case 'reader':
+		case READER_FLOW:
 			steps = [ { title: __( 'Creating your account' ) } ];
 			break;
 		case 'do-it-for-me':

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -28,6 +28,7 @@ export const HUNDRED_YEAR_DOMAIN_FLOW = 'hundred-year-domain';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const BLOG_FLOW = 'blog';
 export const REBLOGGING_FLOW = 'reblogging';
+export const READER_FLOW = 'reader';
 export const DOMAIN_FOR_GRAVATAR_FLOW = 'domain-for-gravatar';
 export const ONBOARDING_FLOW = 'onboarding';
 export const EXAMPLE_FLOW = 'example';


### PR DESCRIPTION
Fixes READ-270

## Proposed Changes

* Add `'reader'` alongside `ACCOUNT_FLOW`/`HOSTING_LP_FLOW`/`ENTREPRENEUR_FLOW` in `processing-screen/index.tsx`'s `useSteps`, so the post-signup loader shows "Creating your account" instead of falling through to the default "Building your site / Applying design / …" steps.
* Tighten the translator comment on the "Step X of Y" subtitle to describe each placeholder, unblocking the pre-commit lint hook.

## Why are these changes being made?

The Reader signup flow at `/start/reader` is a single-step account-only flow — there is no site to build, no design to apply, no domain to provision. Today, after the signup step submits, the post-signup processing screen briefly flashes "Building your site", which is misleading for users who only wanted to read.

The loader cannot simply be hidden for this flow: it doubles as a timing window for the `WpcomLoginForm` POST that converts the bearer token into a session cookie before `handleDestination` redirects to `/reader`. Skipping the loader entirely causes the redirect to outrun the auth handshake and bounces users to `/log-in`. Reusing the existing one-line "Creating your account" copy that other simple account-only flows already use is the minimal, safe fix.

## Testing Instructions

1. Sign out of WordPress.com (use a private/incognito window).
2. Open `/start/reader`.
3. Create a new account.
4. **Expected:** the processing screen flashes briefly with "Creating your account" (not "Building your site"), then you land on `/reader` already logged in.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?