### PR TITLE
Downgrades: Adjustments for downgrade buttons

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -4,6 +4,7 @@ import {
 	WPCOM_DIFM_LITE,
 	OFFSITE_REDIRECT,
 	DomainTransferStatus,
+	SubscriptionBillPeriod,
 } from '@automattic/api-core';
 import {
 	domainQuery,
@@ -138,16 +139,37 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	}
 
 	if ( purchase.is_plan ) {
-		return getWpcomPlanGridUrl( purchase.site_slug );
+		return getWpcomPlanGridUrl( purchase );
 	}
 
 	return wpcomLink( `/plans/${ purchase.site_slug }` );
 }
 
-function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
+// Map the purchase's billing term to the plans grid's `intervalType` param so the
+// grid opens on the same term as the current plan. Downgrades only work within the
+// same term, and the grid hides the term selector in the downgrade flow.
+function getPlanGridIntervalType( purchase: Purchase ): string | undefined {
+	switch ( purchase.bill_period_days ) {
+		case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
+			return 'monthly';
+		case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
+			return 'yearly';
+		case SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD:
+			return '2yearly';
+		case SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD:
+			return '3yearly';
+		default:
+			return undefined;
+	}
+}
+
+function getWpcomPlanGridUrl( purchase: Purchase ): string {
 	const backUrl = redirectToDashboardLink();
+	const siteSlug = purchase.site_slug;
+	const intervalType = getPlanGridIntervalType( purchase );
 	return addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
 		...( siteSlug && { siteSlug } ),
+		...( intervalType && { intervalType } ),
 		cancel_to: backUrl,
 		dashboard: getCurrentDashboard(),
 		redirect_to: getChangedPlanRedirectUrl(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -204,6 +204,10 @@ const PlansStepAdaptor: StepType< {
 	const isUsingStepContainerV2 =
 		shouldUseStepContainerV2( props.flow ) || props.flow === DOMAIN_FLOW;
 
+	// The downgrade flow only lets users move between paid plans, so hide the free
+	// and enterprise plans that aren't valid downgrade targets.
+	const isDowngradeFlow = defaultPlansIntent === 'plans-upgrade-or-downgrade';
+
 	if ( isLoadingSelectedTheme ) {
 		return isUsingStepContainerV2 ? <Step.Loading /> : <Loading />;
 	}
@@ -211,7 +215,8 @@ const PlansStepAdaptor: StepType< {
 	return (
 		<UnifiedPlansStep
 			{ ...getHidePlanPropsBasedOnThemeType( selectedThemeType || '' ) }
-			hideFreePlan={ hideFreePlan }
+			hideFreePlan={ hideFreePlan || isDowngradeFlow }
+			hideEnterprisePlan={ isDowngradeFlow }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } as ProvidedDependencies ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -204,8 +204,9 @@ const PlansStepAdaptor: StepType< {
 	const isUsingStepContainerV2 =
 		shouldUseStepContainerV2( props.flow ) || props.flow === DOMAIN_FLOW;
 
-	// The downgrade flow only lets users move between paid plans, so hide the free
-	// and enterprise plans that aren't valid downgrade targets.
+	// The downgrade flow only lets users move between paid plans on the same billing
+	// term, so hide the free and enterprise plans (not valid downgrade targets) and
+	// the billing term selector.
 	const isDowngradeFlow = defaultPlansIntent === 'plans-upgrade-or-downgrade';
 
 	if ( isLoadingSelectedTheme ) {
@@ -217,6 +218,7 @@ const PlansStepAdaptor: StepType< {
 			{ ...getHidePlanPropsBasedOnThemeType( selectedThemeType || '' ) }
 			hideFreePlan={ hideFreePlan || isDowngradeFlow }
 			hideEnterprisePlan={ isDowngradeFlow }
+			hidePlanTypeSelector={ isDowngradeFlow }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } as ProvidedDependencies ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -72,6 +72,7 @@ export interface UnifiedPlansStepProps {
 	hidePremiumPlan?: boolean;
 	hideEnterprisePlan?: boolean;
 	hideEcommercePlan?: boolean;
+	hidePlanTypeSelector?: boolean;
 
 	flowName: string;
 	stepName: string;
@@ -220,6 +221,7 @@ function UnifiedPlansStep( {
 	hidePersonalPlan,
 	hidePremiumPlan,
 	hideEnterprisePlan,
+	hidePlanTypeSelector,
 	saveSignupStep: saveSignupStepFromProps,
 	submitSignupStep: submitSignupStepFromProps,
 	customerType: customerTypeFromProps,
@@ -671,6 +673,7 @@ function UnifiedPlansStep( {
 				hidePremiumPlan={ hidePremiumPlan }
 				hideEcommercePlan={ shouldHideEcommercePlan() }
 				hideEnterprisePlan={ hideEnterprisePlan }
+				hidePlanTypeSelector={ hidePlanTypeSelector }
 				removePaidDomain={ handleRemovePaidDomain }
 				setSiteUrlAsFreeDomainSuggestion={ handleSetSiteUrlAsFreeDomainSuggestion }
 				coupon={ coupon ?? undefined }

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -174,7 +174,7 @@ function useGenerateActionCallback( {
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
 	flowName?: string | null;
 	intent?: PlansIntent | null;
-	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
+	showModalAndExit?: ( planSlug: PlanSlug ) => boolean | Promise< boolean >;
 	sitePlanSlug?: PlanSlug | null;
 	siteId?: number | null;
 	coupon?: string;
@@ -212,7 +212,7 @@ function useGenerateActionCallback( {
 			const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 			const freeTrialPlanSlug = freeTrialPlanSlugs?.[ planConstantObj.type ];
 
-			const earlyReturn = showModalAndExit?.( planSlug );
+			const earlyReturn = await showModalAndExit?.( planSlug );
 			if ( earlyReturn ) {
 				return;
 			}

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -82,7 +82,7 @@ export default function useGenerateActionHook( {
 	plansIntent?: PlansIntent | null;
 	isInSignup: boolean;
 	isLaunchPage: boolean | null;
-	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
+	showModalAndExit?: ( planSlug: PlanSlug ) => boolean | Promise< boolean >;
 	coupon?: string;
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 	enableCategorisedFeatures?: boolean;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1,5 +1,6 @@
 import {
 	cancelAndRefundPurchaseMutation,
+	purchaseCancelFeaturesQuery,
 	purchaseQuery,
 	userPurchasesQuery,
 } from '@automattic/api-queries';
@@ -584,8 +585,25 @@ const PlansFeaturesMain = ( {
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
+	// Prefetch the list of features lost in the downgrade before opening the
+	// confirmation modal. The downgrade button stays in its busy state (the action
+	// callback awaits this) until the data is ready, so the modal opens already
+	// populated instead of revealing a spinner.
+	const openDowngradeModal = async ( planSlug: PlanSlug ) => {
+		if ( currentPlanPurchaseId ) {
+			try {
+				await queryClient.ensureQueryData(
+					purchaseCancelFeaturesQuery( currentPlanPurchaseId, 'control', planSlug )
+				);
+			} catch {
+				// Open the modal regardless; its own query will retry and show a spinner.
+			}
+		}
+		setPendingDowngradePlanSlug( planSlug );
+	};
+
 	// TODO: We should move the modal logic into a data store
-	const showModalAndExit = ( planSlug: PlanSlug ): boolean => {
+	const showModalAndExit = async ( planSlug: PlanSlug ): Promise< boolean > => {
 		if (
 			sitePlanSlug &&
 			isFreePlan( sitePlanSlug ) &&
@@ -604,7 +622,7 @@ const PlansFeaturesMain = ( {
 			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
 		) {
-			setPendingDowngradePlanSlug( planSlug );
+			await openDowngradeModal( planSlug );
 			return true;
 		}
 
@@ -616,7 +634,7 @@ const PlansFeaturesMain = ( {
 			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
 		) {
-			setPendingDowngradePlanSlug( planSlug );
+			await openDowngradeModal( planSlug );
 			return true;
 		}
 


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-2156/

## Proposed changes

This smooths out the plan downgrade flow reached via the **View plans** button on the Dashboard purchase settings page (`/setup/plan-upgrade/plans?…&allow_downgrade=true`), so the grid only offers valid downgrade targets, opens on the right billing term, and gives clearer feedback when confirming.

* Prefetch the lost-features list on Downgrade click and show a busy state on the button until it's ready, then open the confirmation dialog already populated (instead of opening immediately and spinning inside the dialog).
* Hide the free and enterprise plans in the downgrade flow — neither is a valid downgrade target.
* Hide the billing term selector in the downgrade flow, since downgrades only work within the same term.
* Pass the purchase's billing term as `intervalType` when building the View plans URL, so the grid opens on the same term as the current plan.

Before             |  After
:-------------------------:|:-------------------------:
<img width="691" height="377" alt="Screenshot 2026-06-16 at 4 16 12 PM" src="https://github.com/user-attachments/assets/7ad428d3-76b0-45ec-9fe2-6a708fd9ba0a" /> | <img width="695" height="327" alt="Screenshot 2026-06-16 at 4 08 44 PM" src="https://github.com/user-attachments/assets/0f401424-ae87-41bb-ad35-f73a69597454" />


## Why are these changes being made?

A monthly-plan owner clicking **View plans** landed on the *yearly* grid because the URL carried no `intervalType` and the unified-plans flow defaults to `yearly`. On the wrong term, the downgrade buttons don't function — they fall back to "Contact support" — because the current plan isn't matched against the displayed term. Passing the current plan's term as `intervalType` and hiding the term selector keeps the term fixed and matching, so the downgrade buttons work seamlessly.

The remaining changes tighten the same flow: the free and enterprise plans were rendered even though you can't downgrade *to* them, and the confirmation dialog previously popped open empty and then revealed a spinner while fetching the features-to-be-lost. Moving that fetch ahead of the dialog (with the button in a busy state) makes the interaction feel deliberate and avoids a flash of empty modal.

## Testing instructions

Manual testing:
* Have a site on a **monthly** paid plan (and separately, test a yearly plan).
* Go to the Dashboard purchase settings page for that plan: `/me/billing/purchases/<purchaseId>`.
* Click **View plans** and confirm the grid opens on the **same billing term** as the current plan (monthly stays monthly), with **no term selector** shown.
* Confirm the **free** and **enterprise** plans are **not** displayed.
* Click **Downgrade** on a lower paid plan and confirm the button shows a **busy/spinner state** until the confirmation dialog opens, and that the dialog appears **already populated** with the list of features that will be lost (no in-dialog spinner flash).
* Confirm the downgrade button actually proceeds (does not fall back to "Contact support").

