### PR TITLE
Plans: hide the upgrade-credit notice in the downgrade flow

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -41,7 +41,7 @@ export type PlanNoticeTypes =
 	| typeof CURRENT_PLAN_IN_APP_PURCHASE_NOTICE;
 
 function useResolveNoticeType(
-	{ siteId, isInSignup, visiblePlans = [], discountInformation }: PlanNoticeProps,
+	{ siteId, isInSignup, visiblePlans = [], discountInformation, intent }: PlanNoticeProps,
 	isNoticeDismissed: boolean
 ): PlanNoticeTypes {
 	const canUserPurchasePlan = useSelector(
@@ -70,7 +70,9 @@ function useResolveNoticeType(
 		return CURRENT_PLAN_IN_APP_PURCHASE_NOTICE;
 	} else if ( activeDiscount ) {
 		return ACTIVE_DISCOUNT_NOTICE;
-	} else if ( upgradeCreditsNoticeData ) {
+	} else if ( upgradeCreditsNoticeData && intent !== 'plans-upgrade-or-downgrade' ) {
+		// In the downgrade flow the user isn't upgrading, so the "credit applied at
+		// checkout if you upgrade today" message is misleading — skip it.
 		return UPGRADE_CREDIT_NOTICE;
 	}
 	return MARKETING_NOTICE;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2156/

## Proposed changes

This hides the "upgrade credits available" notice on the plans page when the page is shown for a downgrade, since that message only makes sense when upgrading.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1385" height="668" alt="Screenshot 2026-06-16 at 4 29 46 PM" src="https://github.com/user-attachments/assets/4451d8e5-d70f-4fcc-8136-380e2981414d" /> | <img width="1405" height="600" alt="Screenshot 2026-06-16 at 4 30 03 PM" src="https://github.com/user-attachments/assets/3598f393-1e92-4054-99cf-b7303330b156" />


## Why are these changes being made?

In the downgrade flow (`/setup/plan-upgrade/plans?…&allow_downgrade=true`), the plans page reused the standard notice resolution and showed a notice like *"You have €96.00 in upgrade credits available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!"* That message is misleading here — the user is downgrading, not upgrading today, and the credit won't be applied to a lower-tier plan. Gating the credit notice on the intent suppresses just that one notice while leaving the other notices (cannot-purchase, plan retirement, in-app purchase, active discount) and their priority order intact; when the credit notice is skipped, the resolver falls through to the same marketing-message fallback used for any site without upgrade credits.

## Testing instructions

* Use a site whose current plan has upgrade credits available (so the credit notice would normally show).
* From the Dashboard purchase settings page for that plan (`/me/billing/purchases/<purchaseId>`), click **View plans** to enter the downgrade flow, and confirm the "…in upgrade credits available…" notice is **not** shown.
* For comparison, open the normal upgrade flow (`/setup/plan-upgrade/plans` without `allow_downgrade=true`, or any standard plans page) and confirm the upgrade-credit notice **still appears** as before.

