### PR TITLE
Legacy contact: add a printable contact view

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -881,7 +881,7 @@ export const securityLegacyContactPrintRoute = createRoute( {
 	} ),
 	getParentRoute: () => securityLegacyContactRoute,
 	path: '/print',
-	loader: () => queryClient.ensureQueryData( legacyContactsQuery() ),
+} ).lazy( () =>
 } ).lazy( () =>
 	import( '../../me/security-legacy-contact/print' ).then( ( d ) =>
 		createLazyRoute( 'security-legacy-contact-print' )( {

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -858,9 +858,33 @@ export const securityLegacyContactRoute = createRoute( {
 	getParentRoute: () => securityRoute,
 	path: '/legacy-contact',
 	loader: () => queryClient.ensureQueryData( legacyContactsQuery() ),
+} );
+
+export const securityLegacyContactIndexRoute = createRoute( {
+	getParentRoute: () => securityLegacyContactRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../me/security-legacy-contact' ).then( ( d ) =>
 		createLazyRoute( 'security-legacy-contact' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securityLegacyContactPrintRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Legacy contact' ),
+			},
+		],
+	} ),
+	getParentRoute: () => securityLegacyContactRoute,
+	path: '/print',
+	loader: () => queryClient.ensureQueryData( legacyContactsQuery() ),
+} ).lazy( () =>
+	import( '../../me/security-legacy-contact/print' ).then( ( d ) =>
+		createLazyRoute( 'security-legacy-contact-print' )( {
 			component: d.default,
 		} )
 	)
@@ -1348,7 +1372,14 @@ export const createMeRoutes = ( config: AppConfig ) => {
 				: [] ),
 			securityConnectedAppsRoute,
 			securitySocialLoginsRoute,
-			...( isEnabled( 'me/legacy-contact' ) ? [ securityLegacyContactRoute ] : [] ),
+			...( isEnabled( 'me/legacy-contact' )
+				? [
+						securityLegacyContactRoute.addChildren( [
+							securityLegacyContactIndexRoute,
+							securityLegacyContactPrintRoute,
+						] ),
+				  ]
+				: [] ),
 		] )
 	);
 

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -882,7 +882,6 @@ export const securityLegacyContactPrintRoute = createRoute( {
 	getParentRoute: () => securityLegacyContactRoute,
 	path: '/print',
 } ).lazy( () =>
-} ).lazy( () =>
 	import( '../../me/security-legacy-contact/print' ).then( ( d ) =>
 		createLazyRoute( 'security-legacy-contact-print' )( {
 			component: d.default,

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -8,6 +8,7 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
 
 export default function SecurityLegacyContact() {
@@ -30,12 +31,20 @@ export default function SecurityLegacyContact() {
 				<CardBody>
 					<VStack spacing={ 4 }>
 						{ contact ? (
-							<Text>
-								{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
-								{ createInterpolateElement( 'Your legacy contact is <contactEmail />.', {
-									contactEmail: <strong>{ contact.email }</strong>,
-								} ) }
-							</Text>
+							<>
+								<Text>
+									{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
+									{ createInterpolateElement( 'Your legacy contact is <contactEmail />.', {
+										contactEmail: <strong>{ contact.email }</strong>,
+									} ) }
+								</Text>
+								<ButtonStack justify="flex-start">
+									<RouterLinkButton variant="secondary" to="/me/security/legacy-contact/print">
+										{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
+										View printable details
+									</RouterLinkButton>
+								</ButtonStack>
+							</>
 						) : (
 							<ButtonStack justify="flex-start">
 								<Button

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -1,0 +1,74 @@
+import { legacyContactsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
+import { Text } from '../../components/text';
+import './style.scss';
+
+export default function SecurityLegacyContactPrint() {
+	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
+
+	const handlePrint = () => {
+		window.print();
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } title={ __( 'Legacy contact' ) } />
+			}
+		>
+			<Card>
+				<CardBody>
+					{ /* TODO: translate these strings once the legacy contact UI is finalized. */ }
+					{ contact ? (
+						<VStack spacing={ 6 }>
+							<VStack spacing={ 2 }>
+								<Text>
+									Keep this information somewhere safe. After your death, your legacy contact can
+									give this key to WordPress.com to request access to your account.
+								</Text>
+							</VStack>
+
+							<VStack spacing={ 1 } alignment="flex-start">
+								<Text upperCase variant="muted" size={ 11 }>
+									Legacy contact email
+								</Text>
+								<Text size={ 15 }>{ contact.email }</Text>
+							</VStack>
+
+							<VStack spacing={ 1 } alignment="flex-start">
+								<Text upperCase variant="muted" size={ 11 }>
+									Access key
+								</Text>
+								<div className="legacy-contact-print__key">{ contact.token }</div>
+							</VStack>
+
+							<ButtonStack justify="flex-start" className="legacy-contact-print__actions">
+								<Button variant="primary" onClick={ handlePrint }>
+									Print
+								</Button>
+							</ButtonStack>
+						</VStack>
+					) : (
+						<VStack spacing={ 4 } alignment="flex-start">
+							<Text>You don’t have a legacy contact set up yet.</Text>
+							<ButtonStack justify="flex-start">
+								<RouterLinkButton variant="primary" to="/me/security/legacy-contact">
+									Back to legacy contact
+								</RouterLinkButton>
+							</ButtonStack>
+						</VStack>
+					) }
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -1,0 +1,63 @@
+.legacy-contact-print__key {
+	font-family: monospace;
+	font-size: 1.5rem;
+	font-weight: 600;
+	line-height: 1.4;
+	word-break: break-all;
+	padding: 16px;
+	border: 1px solid var( --dashboard-surface__border-color );
+	border-radius: 4px;
+	background: var( --dashboard-background-color__elevated, var( --color-surface ) );
+}
+
+@media print {
+	// Scope the print rules to this page (the key block only exists here) so the
+	// shared layout/card components print normally on other pages.
+	body:has( .legacy-contact-print__key ) {
+		// The shared print reset for the body gutter/overflow loses to the
+		// higher-specificity `:has()` selectors that set them, so re-apply with
+		// enough specificity here. Also drop the viewport-height floor, which
+		// otherwise overflows the document onto a blank second page.
+		.dashboard-root__body {
+			padding-inline-start: 0;
+			overflow-x: visible;
+			min-height: 0;
+		}
+
+		// Hide the dev/staging environment badge (position: fixed, so it leaks
+		// into the printed output).
+		.environment-badge {
+			display: none;
+		}
+
+		// Use the full page width rather than the on-screen centered column.
+		.dashboard-page-layout {
+			max-width: none;
+		}
+
+		// Hide the action button — it's not useful on paper.
+		.legacy-contact-print__actions {
+			display: none;
+		}
+
+		// Hide the breadcrumbs; keep the page title as the document heading.
+		.dashboard-section-header__prefix {
+			display: none;
+		}
+
+		// Flatten the card into a plain document — no shadow or border.
+		.components-card {
+			box-shadow: none;
+			border: none;
+		}
+
+		.components-card-body {
+			padding: 0;
+		}
+
+		// Keep the key block's outline and background in the printed output.
+		.legacy-contact-print__key {
+			print-color-adjust: exact;
+		}
+	}
+}


### PR DESCRIPTION
Fixes RSM-4384.

## Proposed Changes

* Add a printable view of a user's legacy contact at `/me/security/legacy-contact/print`, linked from a **View printable details** button on the Legacy contact screen.
* It shows a title, intro text, the contact's email, and the access key, with a print stylesheet so "Save as PDF" produces a clean one-page document.
<img width="702" height="256" alt="Screenshot 2026-06-17 at 14 31 45" src="https://github.com/user-attachments/assets/5a72402b-c39f-4b4d-ad6a-07d557cf37c6" />
<img width="765" height="526" alt="Screenshot 2026-06-17 at 14 31 53" src="https://github.com/user-attachments/assets/b1ad6024-de8b-4b72-8947-10c3dd8630ec" />
<img width="711" height="436" alt="Screenshot 2026-06-17 at 14 31 50" src="https://github.com/user-attachments/assets/a6ec843a-2c01-45a9-8df1-880577bf9382" />



## Why are these changes being made?

A legacy contact needs the access key to request account access after the user's death. A printable record lets the user store it somewhere safe.

## Testing Instructions

The `/me/legacy-contacts` endpoint currently returns `[]`, so to preview the populated UI, temporarily mock the fetcher:

```diff
 export async function fetchLegacyContacts(): Promise< LegacyContact[] > {
+	// TEMPORARY: local preview only — do not commit.
+	return [ { email: 'legacy.contact@example.com', token: 'ABCD-1234-EFGH-5678-IJKL-9012' } ];
+
 	return wpcom.req.get( {
 		path: '/me/legacy-contacts',
 		apiNamespace: 'wpcom/v2',
 	} );
 }
```

(in `packages/api-core/src/me-legacy-contacts/fetchers.ts`)

1. Enable the `me/legacy-contact` flag and apply the mock above.
2. Go to **Me → Security → Legacy contact**, click **View printable details**, and open the browser print preview.
3. Confirm a clean single page with the email and key, and that "Save as PDF" works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
