### PR TITLE
Masterbar help icon: sizing by tweaking the icon's internal padding

### DIFF
--- a/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
+++ b/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
@@ -1,4 +1,5 @@
 import { helpFilled } from '@wordpress/icons';
+import { cloneElement } from 'react';
 
 interface HelpCenterIconProps {
 	hasUnread: boolean;
@@ -7,9 +8,9 @@ export const HelpCenterIcon: React.FC< HelpCenterIconProps > = ( { hasUnread } )
 	if ( hasUnread ) {
 		return (
 			<svg
-				width="25"
+				width="24"
 				height="24"
-				viewBox="0 0 25 24"
+				viewBox="-1 -1 26 26"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 			>
@@ -21,6 +22,6 @@ export const HelpCenterIcon: React.FC< HelpCenterIconProps > = ( { hasUnread } )
 			</svg>
 		);
 	}
-	return helpFilled;
+	return cloneElement( helpFilled, { viewBox: '1.5 1.5 21 21' } );
 };
 export default HelpCenterIcon;

--- a/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
+++ b/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
@@ -1,4 +1,4 @@
-import { useBreakpoint } from '@automattic/viewport-react';
+import { useViewportMatch } from '@wordpress/compose';
 import { helpFilled } from '@wordpress/icons';
 import { cloneElement } from 'react';
 
@@ -8,7 +8,7 @@ interface HelpCenterIconProps {
 export const HelpCenterIcon: React.FC< HelpCenterIconProps > = ( { hasUnread } ) => {
 	// The help icon SVGs have some internal padding, and custom viewBox
 	// tweaks are needed to make sure they line up perfectly.
-	const isDesktop = useBreakpoint( '>782px' );
+	const isDesktop = useViewportMatch( 'medium' );
 
 	if ( hasUnread ) {
 		return (

--- a/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
+++ b/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import { helpFilled } from '@wordpress/icons';
 import { cloneElement } from 'react';
 
@@ -5,12 +6,16 @@ interface HelpCenterIconProps {
 	hasUnread: boolean;
 }
 export const HelpCenterIcon: React.FC< HelpCenterIconProps > = ( { hasUnread } ) => {
+	// The help icon SVGs have some internal padding, and custom viewBox
+	// tweaks are needed to make sure they line up perfectly.
+	const isDesktop = useBreakpoint( '>782px' );
+
 	if ( hasUnread ) {
 		return (
 			<svg
 				width="24"
 				height="24"
-				viewBox="-1 -1 26 26"
+				viewBox={ isDesktop ? '-1 -1 26 26' : '-3 -3 30 30' }
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 			>
@@ -22,6 +27,6 @@ export const HelpCenterIcon: React.FC< HelpCenterIconProps > = ( { hasUnread } )
 			</svg>
 		);
 	}
-	return cloneElement( helpFilled, { viewBox: '1.5 1.5 21 21' } );
+	return isDesktop ? cloneElement( helpFilled, { viewBox: '1.5 1.5 21 21' } ) : helpFilled;
 };
 export default HelpCenterIcon;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1248,15 +1248,8 @@ a.masterbar__quick-language-switcher {
 }
 
 .masterbar__item-help {
-	@media only screen and (min-width: 782px) {
-		padding-left: 8px;
-		padding-right: 9px;
-	}
-
 	svg {
 		fill: var(--color-masterbar-icon);
-		width: 27px;
-		height: 27px;
 
 		@media only screen and (max-width: 781px) {
 			width: 37px;


### PR DESCRIPTION
## Proposed Changes

* Tweak the masterbar Help Center icon's SVG `viewBox` so the glyph aligns correctly within the button.
* Remove the fixed `width`/`height` on desktop (27px) and the `padding-right: 9px` overrides on `.masterbar__item-help svg`, letting the icon size from its own SVG attributes.
  * I suspect the custom paddings and sizes were there as work arounds to the internal padding that made the icons look different sizes.

<img width="440" alt="CleanShot 2026-06-17 at 15 33 43@2x" src="https://github.com/user-attachments/assets/70ec9c77-82d4-457a-80e0-9177bacb7fcd" />

<img width="440" alt="CleanShot 2026-06-17 at 15 35 59@2x" src="https://github.com/user-attachments/assets/351855e3-bdc2-4792-a995-9899c75407dd" />

<img width="365" alt="CleanShot 2026-06-17 at 15 36 45@2x" src="https://github.com/user-attachments/assets/e2b44ef7-4c67-4a4f-8268-1406cde01c39" />

<img width="365" alt="CleanShot 2026-06-17 at 15 36 18@2x" src="https://github.com/user-attachments/assets/e42c020b-43ea-4cdf-b1c3-aea866373414" />

**And with hover**

<img width="365" alt="help hover" src="https://github.com/user-attachments/assets/912e00a3-444f-4ece-848f-2b4146f56833" />


<img width="365" alt="notification hover" src="https://github.com/user-attachments/assets/9d36ea41-d3a2-403b-b98a-eb134f099589" />


## Why are these changes being made?

* The help icon's hover/click target was visually larger in the masterbar; but we also want to make sure the horizontal padding between items is consistent too. And we want the size to appear consistent. I believe the underlying issue is the help icon's internal padding. Adjusting the `viewBox` allows us to adjust the icon's internal padding.

## Testing Instructions

* Load any logged-in Calypso page with the masterbar visible.
* Confirm the Help (question-mark) icon in the masterbar is correctly aligned/sized on desktop (>782px).
* Resize below 782px (mobile) and confirm the icon falls back to its original appearance.
* Optionally verify the unread (red-dot) variant by forcing `hasUnread` in `masterbar-help-center/index.jsx`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this changes what data or activity we track?
