### PR TITLE
A4A: Support yearly alternative product IDs in referral commissions CSV

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/use-download-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-download-commissions-csv.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { generateCommissionsCsv } from '../lib/generate-commissions-csv';
 import type { Referral, ReferralCommissionPayoutResponse } from '../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 export function useDownloadCommissionsCsv( isSingleClient?: boolean ) {
 	const dispatch = useDispatch();

--- a/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
@@ -1,4 +1,3 @@
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductCommissionPercentage } from './commissions';
 import type {
 	Referral,
@@ -6,6 +5,7 @@ import type {
 	ReferralCommissionPayoutResponse,
 	ReferralPurchase,
 } from '../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 /** CSV line ending per RFC 4180; CRLF ensures Excel and Windows tools parse rows correctly. */
 const CSV_LINE_ENDING = '\r\n';
@@ -97,9 +97,14 @@ function findMatchingPurchase(
 		return null;
 	}
 	const product = products.find( ( p ) =>
-		[ p.product_id, p.monthly_product_id, p.yearly_product_id, p.alternative_product_id ].includes(
-			productId
-		)
+		[
+			p.product_id,
+			p.monthly_product_id,
+			p.yearly_product_id,
+			p.alternative_product_id,
+			p.monthly_alternative_product_id,
+			p.yearly_alternative_product_id,
+		].includes( productId )
 	);
 	if ( ! product ) {
 		return null;
@@ -110,6 +115,8 @@ function findMatchingPurchase(
 			product.monthly_product_id,
 			product.yearly_product_id,
 			product.alternative_product_id,
+			product.monthly_alternative_product_id,
+			product.yearly_alternative_product_id,
 		].includes( p.product_id )
 	);
 	if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {

--- a/client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts
@@ -1,5 +1,6 @@
 import { generateCommissionsCsv } from '../generate-commissions-csv';
-import type { ReferralCommissionPayoutResponse } from '../../types';
+import type { Referral, ReferralCommissionPayoutResponse } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 function payoutWithProductName( productName: string ): ReferralCommissionPayoutResponse {
 	return {
@@ -52,5 +53,84 @@ describe( 'generateCommissionsCsv', () => {
 	it( 'still quotes and escapes fields containing commas and quotes', () => {
 		const csv = generateCommissionsCsv( [], [], payoutWithProductName( 'Plan "A", annual' ) );
 		expect( csv ).toContain( '"Plan ""A"", annual"' );
+	} );
+
+	// The payout endpoint can report an alternative product id while the referrals endpoint
+	// reports the canonical one, so matching must bridge every id variant.
+	const catalogProduct = {
+		name: 'WordPress.com Business',
+		slug: 'wpcom-hosting',
+		family_slug: 'wpcom-hosting',
+		product_id: 1018,
+		alternative_product_id: 9999,
+		monthly_alternative_product_id: 3301,
+		yearly_alternative_product_id: 3300,
+	} as unknown as APIProductFamilyProduct;
+
+	const referral = {
+		id: 12345,
+		client: { id: 12345, email: 'client@example.com' },
+		purchases: [ { product_id: 1018, status: 'active', quantity: 2 } ],
+		purchaseStatuses: [ 'active' ],
+		referralStatuses: [ 'active' ],
+		referrals: [],
+	} as unknown as Referral;
+
+	function payoutForProductId( productId: number ): ReferralCommissionPayoutResponse {
+		return {
+			total_amount: 100,
+			total_commission: 20,
+			start_date: '2024-01-01',
+			end_date: '2024-01-31',
+			next_payout_date: '2024-03-02',
+			client_data: [
+				{
+					client_user_id: 12345,
+					email: 'client@example.com',
+					total_amount: 100,
+					total_commission: 20,
+					products: [
+						{
+							product_id: productId,
+							product_name: 'WordPress.com Business',
+							total_amount: 100,
+							total_commission: 20,
+							invoices: [ { payment_date: '2024-01-15', paid_amount: 100, commission_amount: 20 } ],
+						},
+					],
+				},
+			],
+		};
+	}
+
+	it.each( [
+		[ 'monthly alternative', 3301 ],
+		[ 'yearly alternative', 3300 ],
+		[ 'legacy alternative', 9999 ],
+	] )(
+		'matches a purchase when the payout reports the %s product id',
+		( _label, payoutProductId ) => {
+			const csv = generateCommissionsCsv(
+				[ referral ],
+				[ catalogProduct ],
+				payoutForProductId( payoutProductId as number ),
+				true
+			);
+			expect( csv ).toContain( 'WordPress.com Business' );
+			// 20% (from the matched product's hosting slug) and quantity 2 (from the matched purchase)
+			// only appear when the row came from a successful match rather than being dropped.
+			expect( csv ).toContain( '20%' );
+			expect( csv ).toContain( 'WordPress.com Business,2,' );
+		}
+	);
+
+	it( 'drops the row in the single-client view when no product matches', () => {
+		const csv = generateCommissionsCsv(
+			[ referral ],
+			[ catalogProduct ],
+			payoutForProductId( 4242 ),
+			true
+		);
+		expect( csv ).not.toContain( 'WordPress.com Business' );
 	} );
 } );


### PR DESCRIPTION
Context p1771839085042399-slack-C091P0A65U5

Resolves A4A-2837

## Proposed Changes

* When matching client purchases for the referral commissions CSV, match on the full set of product id variants — canonical, monthly, yearly, and all alternative ids — in both the catalog and purchase lookups. Previously only the **monthly** alternative product id was matched, so this **adds support for yearly** (and the legacy `alternative_product_id`) as well.
* Import `APIProductFamilyProduct` from `calypso/a8c-for-agencies/types/products` (which declares the monthly/yearly alternative fields) instead of the older `calypso/state/partner-portal/types` copy that only has the collapsed `alternative_product_id`.
* Add unit tests covering matching via the monthly, yearly, and legacy alternative product ids, plus the no-match (row dropped) case.

## Why are these changes being made?

* The `/referrals` and `/referrals/commission-payout` endpoints can report different product ids for the same purchase — the payout endpoint may return an alternative product id (e.g. the A4A alternative for WordPress.com Business) while `/referrals` returns the canonical one. The CSV matching only bridged the monthly alternative, so purchases whose payout used the **yearly** alternative id were silently dropped from the export, even though the commission total displayed correctly.
* The CSV code imported a product type that doesn't declare the monthly/yearly alternative fields, so those ids weren't available to match against (and accessing them failed type checking).

## Testing Instructions

Reproduce using: https://linear.app/a8c/issue/A4A-2837 > Comment

* Find (or set up) a referral whose payout reports a **yearly** alternative product id that differs from the canonical id on `/referrals`.
* Open the client's detailed view, click **Download CSV**, and confirm the purchase now appears as a row (it was previously missing) and the total matches.
* Repeat for a product reported under the monthly alternative id to confirm no regression.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?