### PR TITLE
MSD: hide opt-in welcome banner when the Preferences toggle is unavailable

### DIFF
--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -6,12 +6,15 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
+import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import Notice from '../../components/notice';
+import { isOptInToggleVisible } from '../../utils/hosting-dashboard-enrollment';
 import ComponentViewTracker from '../component-view-tracker';
 
 export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 	const { optIn } = useAppContext();
+	const { user } = useAuth();
 	const { data: dashboardOptIn } = useSuspenseQuery(
 		userPreferenceQuery( 'hosting-dashboard-opt-in' )
 	);
@@ -30,7 +33,9 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 		} );
 	};
 
-	if ( ! optIn || dashboardOptIn?.value === 'forced-opt-in' ) {
+	// The banner's CTA points users to the Preferences toggle to switch back, so
+	// only show it when that toggle is actually available to them.
+	if ( ! optIn || ! isOptInToggleVisible( dashboardOptIn, user.ID ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Part of DOTMSD-1173

## Proposed Changes

Align the dashboard opt-in **welcome banner** (`OptInWelcome`) with the percentage-rollout mechanism introduced in #111604.

- Replace the ad-hoc `dashboardOptIn?.value === 'forced-opt-in'` suppression check with `isOptInToggleVisible( dashboardOptIn, user.ID )`.
- The banner's CTA tells users to *"switch back to the previous version, go to Preferences"* — but that toggle is hidden for percentage-rollout cohort members and `forced-opt-out` users. Gating on `isOptInToggleVisible()` means the banner only renders when its switch-back instruction is actually actionable.

| Before | After |
| - | - |
| <img width="1363" height="71" alt="image" src="https://github.com/user-attachments/assets/4835d057-f58b-4158-80e1-701f1b3a73e9" />| - |

## Why are these changes being made?

#111604 introduced the forced percentage rollout and the shared `isOptInToggleVisible()` / `getHostingDashboardEnrollment()` helpers, and updated the welcome **modal** to suppress itself for force-enrolled users. The welcome **banner** was left on its old manual check, which only handled `forced-opt-in` and missed:

- **Rollout cohort users** (`user_id % 100 < 50` when the flag is on) — they have the Preferences toggle hidden, so the "go to Preferences to switch back" pitch points at a control that doesn't exist for them.
- **`forced-opt-out` users** — same problem.

Routing the banner through `isOptInToggleVisible()` keeps it consistent with the rest of the rollout logic and avoids drift, since both clients now derive visibility from the same helper.

Note: this slightly diverges from the modal — an *old* `forced-opt-in` user now sees the banner (their toggle is visible), which is intended: the switch-back instruction is genuinely valid for them.

## Testing Instructions

- With `dashboard/enable-percentage-rollout` **off** (default), behavior is unchanged for voluntary opt-in users: the banner still shows.
- Locally enable `dashboard/enable-percentage-rollout`:
  - A cohort user (ID ending `00`–`49`) does **not** see the welcome banner.
  - A non-cohort opt-in user (ID ending `50`–`99`) still sees it.
- Set `hosting-dashboard-opt-in` to `forced-opt-out`: the banner is hidden.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
