### PR TITLE
Lodash: replace flatMap/flatten with native array methods

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -44,6 +44,11 @@ module.exports = {
 						],
 						message: 'Please use the equivalent from `@automattic/js-utils` instead.',
 					},
+					{
+						// Deep `lodash/<fn>` imports bypass the named-import guard below.
+						group: [ 'lodash/flatMap', 'lodash/flatten' ],
+						message: 'Please use native `array.flatMap()` / `array.flat()` instead.',
+					},
 				],
 				paths: [
 					// Use Redux's `compose` instead of lodash's `flowRight`.
@@ -75,6 +80,11 @@ module.exports = {
 						name: 'lodash',
 						importNames: [ 'compact' ],
 						message: 'Please use `array.filter( Boolean )` instead of lodash `compact`.',
+					},
+					{
+						name: 'lodash',
+						importNames: [ 'flatMap', 'flatten' ],
+						message: 'Please use native `array.flatMap()` / `array.flat()` instead.',
 					},
 				],
 			},

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -6,7 +6,7 @@ import { Icon, external } from '@wordpress/icons';
 import { isURL, getAuthority, getProtocol } from '@wordpress/url';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { get, some, flatMap } from 'lodash';
+import { get, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -177,7 +177,7 @@ class PostComment extends PureComponent {
 
 		const immediateChildren = get( commentsTree, [ id, 'children' ], [] );
 		return immediateChildren.concat(
-			flatMap( immediateChildren, ( childId ) => this.getAllChildrenIds( childId ) )
+			immediateChildren.flatMap( ( childId ) => this.getAllChildrenIds( childId ) )
 		);
 	};
 

--- a/client/lib/embed-frame-markup/index.jsx
+++ b/client/lib/embed-frame-markup/index.jsx
@@ -1,7 +1,7 @@
 // Here be dragons...
 /* eslint-disable react/no-danger */
 
-import { flatMap, map } from 'lodash';
+import { map } from 'lodash';
 import { renderToStaticMarkup } from 'react-dom/server.browser';
 
 /**
@@ -39,7 +39,7 @@ export default function generateEmbedFrameMarkup( { body, scripts, styles } = {}
 				`,
 					} }
 				/>
-				{ flatMap( scripts, ( { extra, src }, key ) => {
+				{ Object.entries( scripts || {} ).flatMap( ( [ key, { extra, src } ] ) => {
 					return [
 						extra ? (
 							<script

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -8,7 +8,6 @@ import {
 	difference,
 	filter,
 	find,
-	flatMap,
 	forEach,
 	includes,
 	isEmpty,
@@ -342,10 +341,12 @@ export default class SignupFlowController {
 	 * @returns {Array} a list of dependency names
 	 */
 	_getFlowProvidesDependencies() {
-		return flatMap(
-			this._getFlowSteps(),
-			( stepName ) => ( steps && steps[ stepName ] && steps[ stepName ].providesDependencies ) || []
-		).concat( this._flow.providesDependenciesInQuery || [] );
+		return this._getFlowSteps()
+			.flatMap(
+				( stepName ) =>
+					( steps && steps[ stepName ] && steps[ stepName ].providesDependencies ) || []
+			)
+			.concat( this._flow.providesDependenciesInQuery || [] );
 	}
 
 	_process() {
@@ -500,8 +501,7 @@ export default class SignupFlowController {
 	}
 
 	_getStoredDependencies() {
-		const requiredDependencies = flatMap(
-			this._getFlowSteps(),
+		const requiredDependencies = this._getFlowSteps().flatMap(
 			( stepName ) => ( steps && steps[ stepName ] && steps[ stepName ].providesDependencies ) || []
 		);
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { includes, find, flatMap } from 'lodash';
+import { includes, find } from 'lodash';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -312,7 +312,7 @@ class DnsAddNew extends React.Component {
 
 	render() {
 		const { recordToEdit, translate } = this.props;
-		const dnsRecordTypes = flatMap( this.dnsRecords, ( dnsRecord ) => dnsRecord.types );
+		const dnsRecordTypes = this.dnsRecords.flatMap( ( dnsRecord ) => dnsRecord.types );
 		const options = dnsRecordTypes.map( ( type ) => <option key={ type }>{ type }</option> );
 		const isSubmitDisabled =
 			formState.isSubmitButtonDisabled( this.state.fields ) ||

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -7,7 +7,6 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { flatMap } from 'lodash';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -146,16 +145,18 @@ class SearchStream extends React.Component {
 		const singleColumnResultsClasses = clsx( 'search-stream__single-column-results', {
 			'is-post-results': searchType === SEARCH_TYPES.POSTS && query,
 		} );
-		const suggestionList = flatMap( suggestions, ( suggestion ) => [
-			<Suggestion
-				suggestion={ suggestion.text }
-				source="search"
-				sort={ sortOrder === 'date' ? sortOrder : undefined }
-				railcar={ suggestion.railcar }
-				key={ 'suggestion-' + suggestion.text }
-			/>,
-			', ',
-		] ).slice( 0, -1 );
+		const suggestionList = ( suggestions || [] )
+			.flatMap( ( suggestion ) => [
+				<Suggestion
+					suggestion={ suggestion.text }
+					source="search"
+					sort={ sortOrder === 'date' ? sortOrder : undefined }
+					railcar={ suggestion.railcar }
+					key={ 'suggestion-' + suggestion.text }
+				/>,
+				', ',
+			] )
+			.slice( 0, -1 );
 
 		const fixedAreaHeight = this.fixedAreaRef && this.fixedAreaRef.clientHeight;
 

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,4 +1,3 @@
-import { flatMap } from 'lodash';
 import moment from 'moment';
 
 export const RECS_PER_BLOCK = 2;
@@ -48,7 +47,7 @@ export function injectRecommendations( posts, recs = [], itemsBetweenRecs ) {
 
 	let recIndex = 0;
 
-	return flatMap( posts, ( post, index ) => {
+	return posts.flatMap( ( post, index ) => {
 		if ( index && index % itemsBetweenRecs === 0 && recIndex < recs.length ) {
 			const recBlock = {
 				isRecommendationBlock: true,
@@ -116,7 +115,7 @@ export function injectPrompts( posts, itemsBetweenPrompts ) {
 
 	let promptIndex = 0;
 
-	return flatMap( posts, ( post, index ) => {
+	return posts.flatMap( ( post, index ) => {
 		if ( index && index % itemsBetweenPrompts === 0 ) {
 			const promptBlock = {
 				isPromptBlock: true,

--- a/client/state/analytics/actions/compose-analytics.js
+++ b/client/state/analytics/actions/compose-analytics.js
@@ -1,11 +1,10 @@
-import { flatMap, property } from 'lodash';
 import { ANALYTICS_MULTI_TRACK } from 'calypso/state/action-types';
 
 export function composeAnalytics( ...analytics ) {
 	return {
 		type: ANALYTICS_MULTI_TRACK,
 		meta: {
-			analytics: flatMap( analytics, property( 'meta.analytics' ) ),
+			analytics: analytics.flatMap( ( action ) => action.meta.analytics ),
 		},
 	};
 }

--- a/client/state/comments/selectors/get-comment-by-id.js
+++ b/client/state/comments/selectors/get-comment-by-id.js
@@ -1,4 +1,4 @@
-import { filter, find, flatMap } from 'lodash';
+import { filter, find } from 'lodash';
 import { deconstructStateKey, getErrorKey } from 'calypso/state/comments/utils';
 
 import 'calypso/state/comments/init';
@@ -9,10 +9,8 @@ export function getCommentById( { state, commentId, siteId } ) {
 		return state.comments.errors[ errorKey ];
 	}
 
-	const commentsForSite = flatMap(
-		filter( state.comments.items, ( comment, key ) => {
-			return deconstructStateKey( key ).siteId === siteId;
-		} )
-	);
+	const commentsForSite = filter( state.comments.items, ( comment, key ) => {
+		return deconstructStateKey( key ).siteId === siteId;
+	} ).flat();
 	return find( commentsForSite, ( comment ) => commentId === comment.ID );
 }

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -1,6 +1,7 @@
 import {
 	getPostOldestCommentDate,
 	getPostNewestCommentDate,
+	getCommentById,
 	getCommentLike,
 	getPostCommentsTree,
 	getPostCommentsCountAtDate,
@@ -299,6 +300,41 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCommentsApiDisabled( testState, 123 ) ).toBe( false );
+		} );
+	} );
+
+	describe( '#getCommentById()', () => {
+		const commentsState = {
+			comments: {
+				errors: {},
+				items: {
+					'1-10': [ { ID: 1 }, { ID: 2 } ],
+					'1-20': [ { ID: 3 } ],
+					'2-10': [ { ID: 4 } ],
+				},
+			},
+		};
+
+		test( 'finds a comment across the flattened posts of a site', () => {
+			expect( getCommentById( { state: commentsState, commentId: 3, siteId: 1 } ) ).toEqual( {
+				ID: 3,
+			} );
+		} );
+
+		test( 'ignores comments belonging to other sites', () => {
+			expect( getCommentById( { state: commentsState, commentId: 4, siteId: 1 } ) ).toBeUndefined();
+		} );
+
+		test( 'returns a stored error before looking up items', () => {
+			const errorState = {
+				comments: {
+					errors: { '1-99': { error: true } },
+					items: {},
+				},
+			};
+			expect( getCommentById( { state: errorState, commentId: 99, siteId: 1 } ) ).toEqual( {
+				error: true,
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Migrate client call sites from lodash `flatMap`/`flatten` to native `Array.prototype.flatMap()` / `.flat()`.
* Add a `no-restricted-imports` guard (named imports and deep `lodash/<fn>` imports) so lodash `flatMap`/`flatten` cannot be reintroduced in `client/`.

## Why are these changes being made?

* Part of the incremental removal of lodash. `flatMap`/`flatten` have exact native equivalents, so no helper is needed — call sites move straight to the platform methods, guarded by eslint to prevent regressions.

## Testing Instructions

* `yarn eslint client` — no `no-restricted-imports` violations remain for `flatMap`/`flatten`.
* Existing client tests for the migrated files pass; CI type-check is green (the only remaining errors are pre-existing, unrelated dashboard module-resolution errors).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
