### PR TITLE
Speed Test: fix results-page header for the 2026 Global Nav

### DIFF
--- a/client/performance-profiler/style.scss
+++ b/client/performance-profiler/style.scss
@@ -14,26 +14,63 @@
 		}
 	}
 
-	.has-no-sidebar {
-		.masterbar-menu {
-			.masterbar {
-				background: var(--studio-gray-100);
-				border-bottom: 1px solid var(--studio-gray-100);
-			}
+	// The results page sits on a dark hero, so the nav needs light contents in
+	// both nav designs.
+
+	// Legacy nav: dark masterbar overriding the package's light-blue one. Compound
+	// `&.has-no-sidebar` (both classes are on the same element) plus the
+	// `.lpc-header-nav-wrapper` ancestor to outrank the package rule.
+	&.has-no-sidebar {
+		.lpc-header-nav-wrapper .masterbar-menu .masterbar:not( :has( .x-nav--2026-redesign ) ) {
+			background: var(--studio-gray-100);
+			border-bottom: 1px solid var(--studio-gray-100);
 		}
 	}
 
-	.x-nav-link__logo svg path {
-		fill: var(--studio-white);
+	.masterbar:not( :has( .x-nav--2026-redesign ) ) {
+		.x-nav-link__logo svg path {
+			fill: var(--studio-white);
+		}
+
+		.x-nav-item,
+		.x-nav-link-chevron::before {
+			color: var(--studio-white);
+		}
+
+		.x-nav-item .cta-btn-nav {
+			background: var(--studio-white) !important;
+			color: var(--studio-black) !important;
+		}
 	}
 
-	.x-nav-item,
-	.x-nav-link-chevron::before {
-		color: var(--studio-white);
+	// 2026 nav: white ink over the dark hero while the bar rests transparent.
+	// Scoped to the resting bar so the ink reverts to the package's dark default
+	// once the bar turns white on scroll/dropdown-open. CTA hover pair inverted to
+	// suit the dark hero.
+	.lpc-header-nav-container:not(
+			:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
+		):not( .is-scrolled )
+		.x-nav--2026-redesign
+		.x-nav-item {
+		--x-nav-2026-cta-hover-fill: var(--studio-white);
+		--x-nav-2026-cta-hover-ink: var(--studio-gray-100);
+
+		color: var(--studio-white) !important;
+
+		.x-nav-link-chevron::before {
+			border-color: var(--studio-white);
+		}
 	}
 
-	.x-nav-item .cta-btn-nav {
-		background: var(--studio-white) !important;
-		color: var(--studio-black) !important;
+	// The 2026 bar floats over the page: drop the legacy clearance so the dark hero
+	// sits behind it, and pad the hero by the bar's height so the heading clears it.
+	&:has( .x-nav--2026-redesign ) {
+		.is-logged-in .lpc-header-nav-wrapper {
+			padding-top: 0;
+		}
+
+		.profiler-header {
+			padding-top: calc(40px + var(--nav-2026-height));
+		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Give the Speed Test results page (performance-profiler) proper header styling for the 2026 Global Nav, so its navigation bar renders correctly over the dark results hero.

## Why are these changes being made?

The results page sits on a dark hero, but the section had no styling for the 2026 Global Nav it opts into — so the floating nav rendered with the wrong background and ink over the hero. Its only prior header styling was a legacy masterbar override whose selector never actually matched (both classes sit on the same layout element).

This ports the dark-hero treatment the patterns section already uses, adapted to the profiler hero: a dark legacy masterbar with white contents, white nav ink for the 2026 bar at rest that reverts to dark once the bar's white surface fades in on scroll or dropdown-open, and a layout tweak so the dark hero sits under the floating bar with the heading still clearing it. The landing page is a separate section and is unaffected.

## Testing Instructions

* Run the dev server, log in, and open a Speed Test results page (submit a URL from `/speed-test/`, or open `/speed-test-tool/?url=example.com`).
* With the 2026 Global Nav enabled: confirm the nav bar reads correctly over the dark hero (light ink at rest), and that the ink flips to dark when you scroll down or open a nav dropdown (the bar turns white).
* With the legacy nav: confirm the masterbar is dark with white contents.
* Confirm the `/speed-test/` landing page header is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
