### PR TITLE
Global Nav 2026: hide logged-in nav while assignment loads

### DIFF
--- a/client/landing/subscriptions/components/subscription-manager-page/styles.scss
+++ b/client/landing/subscriptions/components/subscription-manager-page/styles.scss
@@ -2,6 +2,12 @@
 @import "@automattic/typography/styles/variables";
 @import "@automattic/color-studio/dist/color-variables";
 
+// TODO: Remove this loading hide once the Nav 2026 experiment is retired.
+.is-nav-2026-assignment-loading {
+	visibility: hidden;
+	pointer-events: none;
+}
+
 .subscription-manager__container {
 	max-width: 1440px;
 	padding: 48px 62px;

--- a/client/landing/subscriptions/components/subscription-manager-page/styles.scss
+++ b/client/landing/subscriptions/components/subscription-manager-page/styles.scss
@@ -2,12 +2,6 @@
 @import "@automattic/typography/styles/variables";
 @import "@automattic/color-studio/dist/color-variables";
 
-// TODO: Remove this loading hide once the Nav 2026 experiment is retired.
-.is-nav-2026-assignment-loading {
-	visibility: hidden;
-	pointer-events: none;
-}
-
 .subscription-manager__container {
 	max-width: 1440px;
 	padding: 48px 62px;
@@ -50,4 +44,3 @@
 
 	}
 }
-

--- a/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
@@ -1,6 +1,5 @@
 import { SubscriptionManager } from '@automattic/data-stores';
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
-import { UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -8,7 +7,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import { TabsSwitcher } from 'calypso/landing/subscriptions/components/tabs-switcher';
 import { useSubheaderText } from 'calypso/landing/subscriptions/hooks';
-import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
+import { Nav2026UniversalHeader } from 'calypso/layout/nav-2026-universal-header';
 import {
 	SubscriptionManagerContextProvider,
 	SubscriptionsPortal,
@@ -21,7 +20,6 @@ const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const emailAddress = SubscriptionManager.useSubscriberEmailAddress();
-	const nav2026Props = useNav2026Props();
 
 	const startUrl = addQueryArgs(
 		localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn ),
@@ -41,19 +39,14 @@ const SubscriptionManagementPage = () => {
 
 	return (
 		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions }>
-			<UniversalNavbarHeader
+			<Nav2026UniversalHeader
 				variant="minimal"
 				isLoggedIn={ isLoggedIn }
 				startUrl={ startUrl }
 				loginUrl={ loginUrl }
-				{ ...nav2026Props }
-				className={ clsx(
-					'subscription-manager-header',
-					{
-						'is-logged-in': isLoggedIn,
-					},
-					nav2026Props.className
-				) }
+				className={ clsx( 'subscription-manager-header', {
+					'is-logged-in': isLoggedIn,
+				} ) }
 			/>
 			<Main className="subscription-manager__container">
 				<FormattedHeader

--- a/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
@@ -42,14 +42,18 @@ const SubscriptionManagementPage = () => {
 	return (
 		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions }>
 			<UniversalNavbarHeader
-				className={ clsx( 'subscription-manager-header', {
-					'is-logged-in': isLoggedIn,
-				} ) }
 				variant="minimal"
 				isLoggedIn={ isLoggedIn }
 				startUrl={ startUrl }
 				loginUrl={ loginUrl }
 				{ ...nav2026Props }
+				className={ clsx(
+					'subscription-manager-header',
+					{
+						'is-logged-in': isLoggedIn,
+					},
+					nav2026Props.className
+				) }
 			/>
 			<Main className="subscription-manager__container">
 				<FormattedHeader

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Component, useEffect } from 'react';
@@ -22,7 +21,7 @@ import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-util
 import { installKonamiListener } from 'calypso/layout/arcade-mode/detect';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
-import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
+import { Nav2026UniversalHeader } from 'calypso/layout/nav-2026-universal-header';
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { ClassicColorSchemeProvider, withColorScheme } from 'calypso/lib/color-scheme';
@@ -468,19 +467,6 @@ class Layout extends Component {
 			</div>
 		);
 	}
-}
-
-// Resolves the 2026 nav experiment only where the universal header renders,
-// so non-universal-header routes don't fetch an unused ExPlat assignment.
-function Nav2026UniversalHeader( { isLoggedIn, sectionName } ) {
-	const nav2026Props = useNav2026Props();
-	return (
-		<UniversalNavbarHeader
-			isLoggedIn={ isLoggedIn }
-			sectionName={ sectionName }
-			{ ...nav2026Props }
-		/>
-	);
 }
 
 export default withCurrentRoute(

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -285,8 +285,8 @@ const LayoutLoggedOut = ( {
 			<UniversalNavbarHeader
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
-				className={ className }
 				{ ...nav2026Props }
+				className={ clsx( className, nav2026Props.className ) }
 				{ ...( isEnabled( 'site-profiler/metrics' ) &&
 					! nonMonochromeSections.includes( sectionName ) && {
 						logoColor: 'white',

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,7 +1,7 @@
 import config, { isEnabled } from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Step } from '@automattic/onboarding';
-import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
+import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -17,7 +17,7 @@ import { getDashboardFromHostname } from 'calypso/dashboard/app/routing';
 import { getDashboardStepperLogo } from 'calypso/dashboard/app/stepper-logo';
 import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
-import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
+import { Nav2026UniversalHeader } from 'calypso/layout/nav-2026-universal-header';
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -132,7 +132,6 @@ const LayoutLoggedOut = ( {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentRoute = useSelector( getCurrentRoute );
 	const loggedInAction = useSelector( getLastActionRequiresLogin );
-	const nav2026Props = useNav2026Props();
 	const { partnerConfig } = usePartnerBranding();
 
 	const dashboard =
@@ -282,11 +281,10 @@ const LayoutLoggedOut = ( {
 		} );
 
 		masterbar = (
-			<UniversalNavbarHeader
+			<Nav2026UniversalHeader
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
-				{ ...nav2026Props }
-				className={ clsx( className, nav2026Props.className ) }
+				className={ className }
 				{ ...( isEnabled( 'site-profiler/metrics' ) &&
 					! nonMonochromeSections.includes( sectionName ) && {
 						logoColor: 'white',

--- a/client/layout/nav-2026-universal-header.tsx
+++ b/client/layout/nav-2026-universal-header.tsx
@@ -1,0 +1,16 @@
+import { UniversalNavbarHeader, type HeaderProps } from '@automattic/wpcom-template-parts';
+import clsx from 'clsx';
+import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
+
+export function Nav2026UniversalHeader( { className, variant, ...headerProps }: HeaderProps ) {
+	const nav2026Props = useNav2026Props( { variant } );
+
+	return (
+		<UniversalNavbarHeader
+			{ ...headerProps }
+			{ ...nav2026Props }
+			variant={ variant }
+			className={ clsx( className, nav2026Props.className ) }
+		/>
+	);
+}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -573,6 +573,11 @@ body.is-mobile-app-view {
 	padding-top: var( --masterbar-height );
 }
 
+.is-nav-2026-assignment-loading {
+	visibility: hidden;
+	pointer-events: none;
+}
+
 // Source of truth for the fixed 2026 nav's geometry; everything that clears or sticks
 // to the nav derives from these vars.
 .layout:has( .x-nav--2026-redesign ) {

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -45,8 +45,8 @@ const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
 
 /**
  * Props to spread onto `UniversalNavbarHeader` to opt into the 2026 Global Nav.
- * Returns `{}` when the nav stays on the old design, so `{ ...useNav2026Props() }`
- * is a no-op then.
+ * Returns a temporary loading class while a logged-in assignment is pending,
+ * otherwise returns `{}` when the nav stays on the old design.
  *
  * Resolution order:
  * 1. Minimal universal headers are not eligible for Nav 2026.
@@ -80,7 +80,6 @@ export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
 		variant = VARIATION_TO_VARIANT[ experimentAssignment.variationName ];
 	}
 
-	// TODO: Remove this loading hide once the Nav 2026 experiment is retired.
 	if ( isLoggedIn && isLoadingExperiment && ! forcedOn ) {
 		return { className: 'is-nav-2026-assignment-loading' };
 	}

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -5,17 +5,26 @@ import {
 	getCurrentUser,
 	getCurrentUserDisplayName,
 	getCurrentUserEmail,
+	isUserLoggedIn,
 } from 'calypso/state/current-user/selectors';
 
 type Nav2026Props =
 	| {
+			className?: string;
 			nav2026: true;
 			nav2026Variant: 1 | 2;
 			userAvatar?: string;
 			userName?: string;
 			userEmail?: string;
 	  }
-	| Record< string, never >;
+	| {
+			className?: string;
+			nav2026?: never;
+			nav2026Variant?: never;
+			userAvatar?: never;
+			userName?: never;
+			userEmail?: never;
+	  };
 
 // ExPlat experiment driving the 2026 Global Nav A/B test. It's a single
 // `wpcom`-platform experiment (also serving the LOHP + Landpack PHP surfaces);
@@ -38,10 +47,13 @@ const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
  * 1. `nav-redesign/2026` config flag — manual force-on for staff/dev. Variant
  *    follows the existing `nav-redesign/2026-variant-2` flag.
  * 2. The NAV_2026_EXPERIMENT assignment — `treatment_1`/`treatment_2` map to
- *    variants 1/2; everything else (control, null, still loading) → old nav.
+ *    variants 1/2; everything else (control, null) → old nav.
+ *    While the assignment is still loading for logged-in users, return a
+ *    temporary className that hides the old nav until the assignment resolves.
  */
 export function useNav2026Props(): Nav2026Props {
 	const forcedOn = config.isEnabled( 'nav-redesign/2026' );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const userAvatar = useSelector( ( state ) => getCurrentUser( state )?.avatar_URL );
 	const userName = useSelector( getCurrentUserDisplayName );
 	const userEmail = useSelector( getCurrentUserEmail );
@@ -52,13 +64,18 @@ export function useNav2026Props(): Nav2026Props {
 	} );
 
 	// Resolve the variant: the config flag forces it on for staff/dev, otherwise
-	// the experiment assignment decides. Anything else (control, null, loading,
-	// unknown variation) leaves it undefined → old nav.
+	// the experiment assignment decides. Anything else (control, null, unknown
+	// variation) leaves it undefined → old nav.
 	let variant: 1 | 2 | undefined;
 	if ( forcedOn ) {
 		variant = config.isEnabled( 'nav-redesign/2026-variant-2' ) ? 2 : 1;
 	} else if ( ! isLoadingExperiment && experimentAssignment?.variationName ) {
 		variant = VARIATION_TO_VARIANT[ experimentAssignment.variationName ];
+	}
+
+	// TODO: Remove this loading hide once the Nav 2026 experiment is retired.
+	if ( isLoggedIn && isLoadingExperiment && ! forcedOn ) {
+		return { className: 'is-nav-2026-assignment-loading' };
 	}
 
 	if ( ! variant ) {

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -7,6 +7,7 @@ import {
 	getCurrentUserEmail,
 	isUserLoggedIn,
 } from 'calypso/state/current-user/selectors';
+import type { HeaderProps } from '@automattic/wpcom-template-parts';
 
 type Nav2026Props =
 	| {
@@ -26,6 +27,10 @@ type Nav2026Props =
 			userEmail?: never;
 	  };
 
+type Nav2026Options = {
+	variant?: HeaderProps[ 'variant' ];
+};
+
 // ExPlat experiment driving the 2026 Global Nav A/B test. It's a single
 // `wpcom`-platform experiment (also serving the LOHP + Landpack PHP surfaces);
 // the wpcom assignments controller allowlists it so the /assignments/calypso
@@ -44,15 +49,17 @@ const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
  * is a no-op then.
  *
  * Resolution order:
- * 1. `nav-redesign/2026` config flag — manual force-on for staff/dev. Variant
+ * 1. Minimal universal headers are not eligible for Nav 2026.
+ * 2. `nav-redesign/2026` config flag — manual force-on for staff/dev. Variant
  *    follows the existing `nav-redesign/2026-variant-2` flag.
- * 2. The NAV_2026_EXPERIMENT assignment — `treatment_1`/`treatment_2` map to
+ * 3. The NAV_2026_EXPERIMENT assignment — `treatment_1`/`treatment_2` map to
  *    variants 1/2; everything else (control, null) → old nav.
  *    While the assignment is still loading for logged-in users, return a
  *    temporary className that hides the old nav until the assignment resolves.
  */
-export function useNav2026Props(): Nav2026Props {
-	const forcedOn = config.isEnabled( 'nav-redesign/2026' );
+export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
+	const isHeaderEligible = options.variant !== 'minimal';
+	const forcedOn = isHeaderEligible && config.isEnabled( 'nav-redesign/2026' );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const userAvatar = useSelector( ( state ) => getCurrentUser( state )?.avatar_URL );
 	const userName = useSelector( getCurrentUserDisplayName );
@@ -60,7 +67,7 @@ export function useNav2026Props(): Nav2026Props {
 
 	// SSR is ineligible (no assignment server-side); the browser refetches on hydration.
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( NAV_2026_EXPERIMENT, {
-		isEligible: ! forcedOn && typeof window !== 'undefined',
+		isEligible: isHeaderEligible && ! forcedOn && typeof window !== 'undefined',
 	} );
 
 	// Resolve the variant: the config flag forces it on for staff/dev, otherwise

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -1,7 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
+import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import Main from 'calypso/components/main';
-import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
+import { Nav2026UniversalHeader } from 'calypso/layout/nav-2026-universal-header';
 import { getOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -16,16 +16,14 @@ export const PatternsWrapper = ( {
 }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const locale = useLocale();
-	const nav2026Props = useNav2026Props();
 
 	return (
 		<>
 			{ isLoggedIn && (
-				<UniversalNavbarHeader
+				<Nav2026UniversalHeader
 					hideGetStartedCta={ hideGetStartedCta }
 					isLoggedIn
 					startUrl={ getOnboardingUrl( locale, isLoggedIn ) }
-					{ ...nav2026Props }
 				/>
 			) }
 

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -1,10 +1,10 @@
 import { Context } from '@automattic/calypso-router';
-import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
+import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import { translate, fixMe } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { getLoginUrl } from 'calypso/landing/stepper/utils/path';
-import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
+import { Nav2026UniversalHeader } from 'calypso/layout/nav-2026-universal-header';
 import { WeeklyReportUnsubscribe } from 'calypso/performance-profiler/pages/weekly-report/unsubscribe';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
@@ -22,11 +22,9 @@ export function PerformanceProfilerWrapper( {
 	children: React.ReactNode;
 	isLoggedIn: boolean;
 } ): JSX.Element {
-	const nav2026Props = useNav2026Props();
-
 	return (
 		<>
-			{ isLoggedIn && <UniversalNavbarHeader isLoggedIn { ...nav2026Props } /> }
+			{ isLoggedIn && <Nav2026UniversalHeader isLoggedIn /> }
 			<Main fullWidthLayout>{ children }</Main>
 			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />
 		</>

--- a/client/performance-profiler/style.scss
+++ b/client/performance-profiler/style.scss
@@ -62,15 +62,20 @@
 		}
 	}
 
-	// The 2026 bar floats over the page: drop the legacy clearance so the dark hero
-	// sits behind it, and pad the hero by the bar's height so the heading clears it.
+	// The 2026 bar floats over the page: drop the legacy clearance and let the hero
+	// clear the fixed nav with a smaller, consistent top gap.
 	&:has( .x-nav--2026-redesign ) {
-		.is-logged-in .lpc-header-nav-wrapper {
+		.layout__header-section {
+			min-height: 0;
+		}
+
+		.lpc-header-nav-wrapper {
 			padding-top: 0;
+			z-index: auto;
 		}
 
 		.profiler-header {
-			padding-top: calc(40px + var(--nav-2026-height));
+			padding-top: calc(24px + var(--nav-2026-sticky-offset));
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [WPBRAND-402](https://linear.app/a8c/issue/WPBRAND-402/create-the-infrastructure-for-ab-testing)

## Proposed Changes

* Hide the universal nav for logged-in users while the Nav 2026 experiment assignment is still loading.
* Keep logged-out SSR behavior unchanged so public SEO pages continue rendering visible navigation in the initial HTML.
* Preserve existing header classes when the temporary loading class is applied.
* Flyby: keep the Performance Profiler results header aligned with its dark hero treatment when Nav 2026 is enabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Treatment users can briefly see the old nav before the Nav 2026 assignment resolves.
* This avoids the logged-in flash without changing SSR caching behavior or hiding logged-out navigation from crawlers.
* Avoiding logged-out visits means we don't affect SEO by hiding the nav before assignment.
* Performance Profiler uses a dark hero, so the 2026 nav should keep white text, logo, and borders there without leaving an oversized gap, overlapping the report header, or letting page controls sit above the open dropdown.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in and visit a public SSR surface such as `/patterns` with the Nav 2026 experiment not yet cached; confirm the old nav is hidden while the assignment loads, then the assigned nav appears.
* Visit `/patterns?flags=nav-redesign/2026` while logged in; confirm the Nav 2026 header renders immediately.
* Visit `/speed-test-tool?url=wordpress.com&flags=nav-redesign/2026`; confirm the nav text, logo, and button border are white over the dark hero, the hero starts close to the nav without overlapping it, and the open dropdown/backdrop sits above the report controls.
* Visit logged-out `/themes`, `/plugins`, and `/patterns`; confirm the SSR nav remains visible before hydration.
* Run `git diff --check origin/trunk...HEAD`.
* Run focused lint/style checks for the touched files.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
