### PR TITLE
Onboarding: add mobile-only "Skip this step" button on domain search

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import { chevronRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -54,6 +55,10 @@ import type { OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const HUNDRED_YEAR_DOMAIN_TLDS = [ 'com', 'net', 'org', 'blog' ];
+
+// TODO: replace with useExperiment( 'calypso_onboarding_domain_skip_step' ) once the
+// experiment is ready. Forced on for now so the treatment can be verified in dev.
+const FORCE_SHOW_DOMAIN_SKIP_STEP = true;
 
 import './style.scss';
 
@@ -486,6 +491,32 @@ const DomainSearchStep: StepType< {
 			);
 		};
 
+		const showSkipStepButton =
+			FORCE_SHOW_DOMAIN_SKIP_STEP &&
+			isMobileViewport &&
+			isOnboardingFlow( flow ) &&
+			config.skippable;
+
+		const skipStepBottomBar = showSkipStepButton ? (
+			<Step.StickyBottomBar
+				fullWidth
+				hasTransparentBackground
+				noBoxShadow
+				centerElement={
+					<Step.SkipButton
+						appearance="secondary"
+						className="domain-search__skip-step-button"
+						icon={ chevronRight }
+						iconPosition="right"
+						iconSize={ 24 }
+						onClick={ () => events.onSkip() }
+					>
+						{ __( 'Skip this step' ) }
+					</Step.SkipButton>
+				}
+			/>
+		) : undefined;
+
 		return (
 			<Step.CenteredColumnLayout
 				topBar={
@@ -496,6 +527,7 @@ const DomainSearchStep: StepType< {
 				}
 				columnWidth={ 10 }
 				className="step-container-v2--domain-search"
+				stickyBottomBar={ skipStepBottomBar }
 				heading={
 					// On mobile, once the user has searched the persistent fixed
 					// search overlay (rendered by @automattic/domain-search) is the

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -49,16 +49,13 @@ import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-conta
 import { OnboardingProgress } from '../components/onboarding-progress';
 import { useShowOnboardingProgress } from '../components/onboarding-progress/use-show-onboarding-progress';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import { useShowDomainSkipStep } from './use-show-domain-skip-step';
 import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const HUNDRED_YEAR_DOMAIN_TLDS = [ 'com', 'net', 'org', 'blog' ];
-
-// TODO: replace with useExperiment( 'calypso_onboarding_domain_skip_step' ) once the
-// experiment is ready. Forced on for now so the treatment can be verified in dev.
-const FORCE_SHOW_DOMAIN_SKIP_STEP = true;
 
 import './style.scss';
 
@@ -164,6 +161,12 @@ const DomainSearchStep: StepType< {
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
 	}, [ flow, isCiab, isWooHostingSolutions, tldQuery, query ] );
+
+	const showSkipStepButton = useShowDomainSkipStep( {
+		flow,
+		isSkippable: config.skippable,
+		query,
+	} );
 
 	const { submit } = navigation;
 
@@ -490,12 +493,6 @@ const DomainSearchStep: StepType< {
 				</>
 			);
 		};
-
-		const showSkipStepButton =
-			FORCE_SHOW_DOMAIN_SKIP_STEP &&
-			isMobileViewport &&
-			isOnboardingFlow( flow ) &&
-			config.skippable;
 
 		const skipStepBottomBar = showSkipStepButton ? (
 			<Step.StickyBottomBar

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -53,11 +53,8 @@
 	width: 100%;
 	justify-content: center;
 	color: var( --color-text );
-	box-shadow: inset 0 0 0 1px var( --color-border-subtle );
-
-	&:hover:not( :disabled, [aria-disabled="true"] ) {
-		color: var( --color-text );
-		box-shadow: inset 0 0 0 1px var( --color-border );
+	&:not( :focus ) {
+		box-shadow: inset 0 0 0 1px var( --color-border-subtle );
 	}
 
 	svg {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -38,6 +38,33 @@
 	}
 }
 
+// The shared sticky bar gives the center element 32px inline margins; match
+// the 16px block margins so the skip button has even spacing on all sides.
+.step-container-v2__sticky-bottom-bar-center-element:has( .domain-search__skip-step-button ) {
+	margin-inline: 1rem;
+}
+
+// The flow's theme accent is blueberry blue, so a native secondary button
+// renders a blue border and blue text. Override to a neutral border (matching
+// the "Already have a domain?" CTA) and a text-colored label/chevron per Figma.
+.domain-search__skip-step-button.components-button.is-secondary {
+	// `fullWidth` on the sticky bar only stretches the centerElement wrapper;
+	// the button needs its own width to fill it edge-to-edge.
+	width: 100%;
+	justify-content: center;
+	color: var( --color-text );
+	box-shadow: inset 0 0 0 1px var( --color-border-subtle );
+
+	&:hover:not( :disabled, [aria-disabled="true"] ) {
+		color: var( --color-text );
+		box-shadow: inset 0 0 0 1px var( --color-border );
+	}
+
+	svg {
+		fill: currentColor;
+	}
+}
+
 .step-container-v2--domain-search {
 	flex: 1;
 	display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -44,22 +44,10 @@
 	margin-inline: 1rem;
 }
 
-// The flow's theme accent is blueberry blue, so a native secondary button
-// renders a blue border and blue text. Override to a neutral border (matching
-// the "Already have a domain?" CTA) and a text-colored label/chevron per Figma.
+// Make the skip button fill the full width of the sticky bar.
 .domain-search__skip-step-button.components-button.is-secondary {
-	// `fullWidth` on the sticky bar only stretches the centerElement wrapper;
-	// the button needs its own width to fill it edge-to-edge.
 	width: 100%;
 	justify-content: center;
-	color: var( --color-text );
-	&:not( :focus ) {
-		box-shadow: inset 0 0 0 1px var( --color-border-subtle );
-	}
-
-	svg {
-		fill: currentColor;
-	}
 }
 
 .step-container-v2--domain-search {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/use-show-domain-skip-step.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/use-show-domain-skip-step.ts
@@ -1,0 +1,33 @@
+import { isOnboardingFlow } from '@automattic/onboarding';
+import { useViewportMatch } from '@wordpress/compose';
+
+// TODO: replace with useExperiment( 'calypso_onboarding_domain_skip_step' ) once the
+// experiment is ready. Forced on for now so the treatment can be verified in dev.
+const FORCE_SHOW_DOMAIN_SKIP_STEP = true;
+
+/**
+ * Whether to show the "Skip this step" button on the domain search step.
+ *
+ * Gated to mobile viewports, the onboarding flow, and the empty/initial search
+ * screen (once the user has searched, results take over the limited vertical
+ * space). Eventually gated behind an A/B experiment — see the TODO above.
+ */
+export function useShowDomainSkipStep( {
+	flow,
+	isSkippable,
+	query,
+}: {
+	flow: string;
+	isSkippable: boolean;
+	query: string | undefined;
+} ): boolean {
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+
+	return (
+		FORCE_SHOW_DOMAIN_SKIP_STEP &&
+		isMobileViewport &&
+		isOnboardingFlow( flow ) &&
+		isSkippable &&
+		! query
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/use-show-domain-skip-step.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/use-show-domain-skip-step.ts
@@ -1,16 +1,16 @@
 import { isOnboardingFlow } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
+import { useExperiment } from 'calypso/lib/explat';
 
-// TODO: replace with useExperiment( 'calypso_onboarding_domain_skip_step' ) once the
-// experiment is ready. Forced on for now so the treatment can be verified in dev.
-const FORCE_SHOW_DOMAIN_SKIP_STEP = true;
+export const DOMAIN_SKIP_STEP_EXPERIMENT_NAME = 'calypso_onboarding_domain_skip_step_202606';
 
 /**
  * Whether to show the "Skip this step" button on the domain search step.
  *
- * Gated to mobile viewports, the onboarding flow, and the empty/initial search
- * screen (once the user has searched, results take over the limited vertical
- * space). Eventually gated behind an A/B experiment — see the TODO above.
+ * Eligibility (mobile viewport, onboarding flow) gates the A/B experiment so the
+ * population stays clean. The button then shows for the treatment variation, on a
+ * skippable step, and only on the empty/initial search screen — once the user has
+ * searched, results take over the limited mobile vertical space.
  */
 export function useShowDomainSkipStep( {
 	flow,
@@ -22,12 +22,15 @@ export function useShowDomainSkipStep( {
 	query: string | undefined;
 } ): boolean {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const isEligible = isMobileViewport && isOnboardingFlow( flow );
 
-	return (
-		FORCE_SHOW_DOMAIN_SKIP_STEP &&
-		isMobileViewport &&
-		isOnboardingFlow( flow ) &&
-		isSkippable &&
-		! query
-	);
+	const [ isLoading, assignment ] = useExperiment( DOMAIN_SKIP_STEP_EXPERIMENT_NAME, {
+		isEligible,
+	} );
+
+	if ( isLoading ) {
+		return false;
+	}
+
+	return isEligible && isSkippable && assignment?.variationName === 'treatment' && ! query;
 }

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
@@ -4,27 +4,39 @@ import { decorateButtonWithTracksEventRecording } from '../../../helpers/decorat
 import { normalizeButtonProps } from '../../../helpers/normalizeButtonProps';
 import { ButtonProps } from '../../../types';
 import { LinkButton } from '../LinkButton/LinkButton';
+import { SecondaryButton } from '../SecondaryButton/SecondaryButton';
+
+type SkipButtonProps = ButtonProps & {
+	/**
+	 * The visual style of the button. Defaults to a text link, matching
+	 * {@link LinkButton}. Use `'secondary'` to render a {@link SecondaryButton}.
+	 * @default 'link'
+	 */
+	appearance?: 'link' | 'secondary';
+};
 
 /**
  * Do NOT use this button if you don't intend to skip the step.
  *
- * This button is visually identical to {@link LinkButton}.
- * The difference between them is that this one fires a Tracks event when clicked.
+ * Fires the `calypso_signup_skip_step` Tracks event when clicked — this is the
+ * difference from the plain {@link LinkButton}/{@link SecondaryButton}. The
+ * `appearance` prop selects the visual style without changing that behavior.
  */
-export const SkipButton = ( originalProps: ButtonProps ) => {
+export const SkipButton = ( { appearance = 'link', ...originalProps }: SkipButtonProps ) => {
 	const { __ } = useI18n();
 	const stepContext = useStepContainerV2Context();
 
-	const skipButtonProps = normalizeButtonProps( originalProps, {
-		children: __( 'Skip', __i18n_text_domain__ ),
-	} );
-
-	return (
-		<LinkButton
-			{ ...decorateButtonWithTracksEventRecording( skipButtonProps, {
-				tracksEventName: 'calypso_signup_skip_step',
-				stepContext,
-			} ) }
-		/>
+	const skipButtonProps = decorateButtonWithTracksEventRecording(
+		normalizeButtonProps( originalProps, {
+			children: __( 'Skip', __i18n_text_domain__ ),
+		} ),
+		{
+			tracksEventName: 'calypso_signup_skip_step',
+			stepContext,
+		}
 	);
+
+	const Button = appearance === 'secondary' ? SecondaryButton : LinkButton;
+
+	return <Button { ...skipButtonProps } />;
 };

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
@@ -6,10 +6,13 @@ import { ButtonProps } from '../../../types';
 import { LinkButton } from '../LinkButton/LinkButton';
 import { SecondaryButton } from '../SecondaryButton/SecondaryButton';
 
+import './style.scss';
+
 type SkipButtonProps = ButtonProps & {
 	/**
 	 * The visual style of the button. Defaults to a text link, matching
-	 * {@link LinkButton}. Use `'secondary'` to render a {@link SecondaryButton}.
+	 * {@link LinkButton}. Use `'secondary'` to render a neutral-bordered
+	 * {@link SecondaryButton} (layout, e.g. width, is left to the consumer).
 	 * @default 'link'
 	 */
 	appearance?: 'link' | 'secondary';
@@ -29,6 +32,7 @@ export const SkipButton = ( { appearance = 'link', ...originalProps }: SkipButto
 	const skipButtonProps = decorateButtonWithTracksEventRecording(
 		normalizeButtonProps( originalProps, {
 			children: __( 'Skip', __i18n_text_domain__ ),
+			className: 'step-container-v2__skip-button',
 		} ),
 		{
 			tracksEventName: 'calypso_signup_skip_step',

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/style.scss
@@ -1,0 +1,10 @@
+// Render the skip button neutral (not the theme accent) per the onboarding design.
+.step-container-v2__skip-button.components-button.is-secondary {
+	color: var( --color-text );
+
+	// Scope the border to :not(:focus) so it doesn't override the focus ring,
+	// which @wordpress/components also draws with box-shadow.
+	&:not( :focus ) {
+		box-shadow: inset 0 0 0 1px var( --color-border-subtle );
+	}
+}


### PR DESCRIPTION
Fixes DOMAINS-2102

## Proposed Changes

* Add a full-width **"Skip this step"** button to the bottom of the domain search step in the `/setup/onboarding` flow. It's shown on **mobile viewports only**, on the **empty/initial search screen** (hidden once the user types a query, so results get the limited vertical space). Clicking it routes the user to the plans (select plan) step via the existing `onSkip` path.
* The button lives in the StepContainer V2 `CenteredColumnLayout`'s `stickyBottomBar` slot, using the bar's built-in `fullWidth` / `centerElement` / `hasTransparentBackground` / `noBoxShadow` props for layout. Custom CSS is minimal (full width, centered content, neutral border + text color, even 16px margins).
* Gated behind the ExPlat experiment **`calypso_onboarding_domain_skip_step_202606`**. Enrollment is limited to mobile + onboarding-flow users (the domain step is shared across ~13 flows, so this keeps the experiment population clean); the button renders for the `treatment` variation on a skippable, empty search screen.
* The show/hide decision lives in a dedicated **`useShowDomainSkipStep`** hook (colocated with the step), mirroring `useShowOnboardingProgress`. Called at the top level of the step component to avoid a conditional hook call.
* Extend the shared **`Step.SkipButton`** with an `appearance` prop (`'link' | 'secondary'`, default `'link'`) so the central skip component — which fires the `calypso_signup_skip_step` Tracks event — can render as a button without duplicating that wiring. Existing call sites are unaffected (default unchanged).

<img width="661" height="741" alt="Screenshot 2026-06-17 at 15 47 22" src="https://github.com/user-attachments/assets/03557837-d147-492d-8252-e47eb55e3bcb" />

## Why are these changes being made?

On mobile, users on the domain search step had no obvious way to proceed without choosing a domain. This adds a clear skip affordance that takes them to plan selection, measured via an A/B experiment.

## Testing Instructions

> **Note:** The "Skip this step" button is shown **only on the empty domain search screen** (no search query entered). As soon as the user types a query, the button is hidden so the results can use the limited mobile vertical space.

* Run the dev server (`yarn start`) and open `/setup/onboarding/domains`.
* Force the experiment `treatment` variation (e.g. via the ExPlat dev tooling / forced-variations query param) on a mobile viewport (< 600px).
* Confirm the full-width "Skip this step ›" button appears pinned at the bottom on the **empty** search screen, and **disappears once you type** a query.
* Resize to desktop (≥ 600px): confirm the button is hidden.
* Click the button: confirm navigation to the plans step (`/setup/onboarding/plans`) with no domain added to the cart, and that the `calypso_signup_skip_step` Tracks event fires.
* Confirm enrollment is limited to the onboarding flow (other flows reusing the domain step should not assign).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

