### PR TITLE
api-queries: remove URLSearchParams from plansQuery queryKey

### DIFF
--- a/packages/api-queries/src/plans.ts
+++ b/packages/api-queries/src/plans.ts
@@ -2,11 +2,14 @@ import { fetchPlans } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
 export const plansQuery = ( coupon: string = '' ) => {
-	const params = new URLSearchParams();
-	coupon && params.append( 'coupon_code', coupon );
-
 	return queryOptions( {
-		queryKey: [ 'plans', coupon, params ],
-		queryFn: () => fetchPlans( params ),
+		queryKey: [ 'plans', coupon ],
+		queryFn: () => {
+			const params = new URLSearchParams();
+			if ( coupon ) {
+				params.append( 'coupon_code', coupon );
+			}
+			return fetchPlans( params );
+		},
 	} );
 };


### PR DESCRIPTION
Part of DOTCOM-17649

## Proposed Changes

- Build the `URLSearchParams` inside `plansQuery`'s `queryFn` instead of placing it in the query key. The key becomes `[ 'plans', coupon ]`.

## Why are these changes being made?

`plansQuery` put a raw `URLSearchParams` object in its query key. `URLSearchParams` is not structured-cloneable, so when Calypso persists the TanStack Query cache to IndexedDB (`client/state/query-client.ts` → `storePersistedStateItem` → IDB `put`) the whole write threw:

```
Uncaught (in promise) DataCloneError: Failed to execute 'put' on 'IDBObjectStore': URLSearchParams object could not be cloned.
```

By default every successful query is dehydrated (`client/state/should-dehydrate-query.ts` returns `true` unless `meta.persist` is explicitly `false`), so the offending key reached `put` and failed cache persistence.

The `coupon` string already uniquely identifies the request — `params` was derived solely from `coupon`, and `fetchPlans` uses only `params.toString()` — so the object in the key carried no distinguishing information. The new `[ 'plans', coupon ]` key captures every input and matches the existing convention in `packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts`.

The bug is pre-existing in `plansQuery`; it became visible when the modern logged-out Theme Showcase (`themes/showcase-modern`) mounted the plan-upgrade banner, which calls `useQuery( plansQuery() )`.

## Testing Instructions

- With `themes/showcase-modern` enabled, open the logged-out `/themes` showcase.
- Confirm the `DataCloneError: URLSearchParams object could not be cloned` console error no longer appears.
- Confirm plan data still loads (plan-upgrade banner, checkout upsell nudge) and the query cache persists to IndexedDB.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?