### PR TITLE
Reader: show Automattician hire date on the automattician achievement card

### DIFF
--- a/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
@@ -2,8 +2,6 @@ import { siteByIdQuery } from '@automattic/api-queries';
 import { TimeSince } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
-import FormattedDate from 'calypso/components/formatted-date';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 import { getOldestAchievement } from '../utils';
 import AchievementCard from './achievement-card';
@@ -19,7 +17,6 @@ export default function GenericAchievement( {
 	isOwnProfile: boolean;
 } ) {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const hasMultiple = achievements.filter( ( a ) => a.slug === achievement.slug ).length > 1;
 	const oldest = hasMultiple ? getOldestAchievement( achievement.slug, achievements ) : undefined;
 	const unlockDate = oldest?.date_unlocked ?? achievement.date_unlocked;
@@ -92,11 +89,23 @@ export default function GenericAchievement( {
 			return undefined;
 		}
 		const dateHired = achievement.date_hired;
-		if ( ! dateHired || ! moment( dateHired ).isValid() ) {
+		if ( ! dateHired ) {
 			return undefined;
 		}
+		const parsed = new Date( dateHired );
+		if ( isNaN( parsed.getTime() ) ) {
+			return undefined;
+		}
+		// `date_hired` is an absolute hire date (the backend sends it as a
+		// UTC ISO 8601 timestamp), so format it in UTC — the displayed
+		// calendar day must not shift with the viewer's timezone. `medium`
+		// matches the short-month style TimeSince uses for the unlock date.
+		const formatted = new Intl.DateTimeFormat( translate.localeSlug, {
+			dateStyle: 'medium',
+			timeZone: 'UTC',
+		} ).format( parsed );
 		return translate( 'Started: {{date/}}', {
-			components: { date: <FormattedDate date={ dateHired } format="ll" /> },
+			components: { date: <time dateTime={ dateHired }>{ formatted }</time> },
 			comment: '{{date/}} is the date an Automattician was hired.',
 		} );
 	};

--- a/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
@@ -2,6 +2,8 @@ import { siteByIdQuery } from '@automattic/api-queries';
 import { TimeSince } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
+import FormattedDate from 'calypso/components/formatted-date';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 import { getOldestAchievement } from '../utils';
 import AchievementCard from './achievement-card';
@@ -17,6 +19,7 @@ export default function GenericAchievement( {
 	isOwnProfile: boolean;
 } ) {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 	const hasMultiple = achievements.filter( ( a ) => a.slug === achievement.slug ).length > 1;
 	const oldest = hasMultiple ? getOldestAchievement( achievement.slug, achievements ) : undefined;
 	const unlockDate = oldest?.date_unlocked ?? achievement.date_unlocked;
@@ -81,15 +84,34 @@ export default function GenericAchievement( {
 			  } );
 	};
 
+	// The `automattician` achievement pins its `date_unlocked` to the 2012
+	// launch, so old-timers all show the same legacy date. When the backend
+	// supplies the real hire date, surface it alongside the unlock date.
+	const hiredContext = () => {
+		if ( achievement.slug !== 'automattician' ) {
+			return undefined;
+		}
+		const dateHired = achievement.date_hired;
+		if ( ! dateHired || ! moment( dateHired ).isValid() ) {
+			return undefined;
+		}
+		return translate( 'Started: {{date/}}', {
+			components: { date: <FormattedDate date={ dateHired } format="ll" /> },
+			comment: '{{date/}} is the date an Automattician was hired.',
+		} );
+	};
+
 	const renderCaption = () => {
+		const hired = hiredContext();
 		const link = contextLink();
-		if ( ! link ) {
+		if ( ! hired && ! link ) {
 			return caption();
 		}
 		return (
 			<>
 				{ caption() }
-				<span className="achievement-card__caption-context">{ link }</span>
+				{ hired && <span className="achievement-card__caption-context">{ hired }</span> }
+				{ link && <span className="achievement-card__caption-context">{ link }</span> }
 			</>
 		);
 	};

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx
@@ -123,3 +123,51 @@ describe( 'GenericAchievement context link', () => {
 		expect( screen.queryByRole( 'link', { name: /View (post|comment)/ } ) ).not.toBeInTheDocument();
 	} );
 } );
+
+describe( 'GenericAchievement hire date', () => {
+	const automattician = ( overrides: Partial< Achievement > = {} ): Achievement =>
+		achievement( {
+			slug: 'automattician',
+			name: 'Automattician',
+			is_a8c_only: true,
+			date_unlocked: '2012-04-09T00:00:00+00:00',
+			...overrides,
+		} );
+
+	test( 'renders the hire date for the automattician achievement', () => {
+		const a = automattician( { date_hired: '2015-06-01T00:00:00+00:00' } );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: false } );
+
+		const hired = screen.getByText( /Started:/ );
+		expect( hired ).toBeVisible();
+		expect( hired ).toHaveTextContent( 'Started: Jun 1, 2015' );
+		// Inline within the existing caption, prefixed by the CSS middot.
+		expect( hired ).toHaveClass( 'achievement-card__caption-context' );
+		expect( hired.closest( '.achievement-card__caption' ) ).not.toBeNull();
+	} );
+
+	test( 'does not render a hire date on a non-automattician achievement', () => {
+		const a = achievement( { date_hired: '2015-06-01T00:00:00+00:00' } );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: false } );
+
+		expect( screen.queryByText( /Started:/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render a hire date when date_hired is absent', () => {
+		const a = automattician();
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: false } );
+
+		expect( screen.queryByText( /Started:/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render a hire date when date_hired is not a valid date', () => {
+		const a = automattician( { date_hired: 'not-a-date' } );
+
+		renderCard( { achievement: a, achievements: [ a ], isOwnProfile: false } );
+
+		expect( screen.queryByText( /Started:/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -28,6 +28,13 @@ export interface Achievement {
 	date_unlocked: string;
 	/** Y-m-d date the achievement was added to the registry. Used for sort order. */
 	date_created: string;
+	/**
+	 * ISO 8601 hire date, exposed only on the `automattician` achievement and
+	 * only to Automattic requesters. Its `date_unlocked` is pinned to the
+	 * achievement's 2012 launch, so for old-timers this carries the real hire
+	 * date instead. Omitted when no date is on record.
+	 */
+	date_hired?: string;
 	image: string;
 	/**
 	 * Y-m-d (or ISO 8601) date string when the achievement was retired, or


### PR DESCRIPTION
Closes RSM-4402

## Proposed Changes

* Surface an Automattician's real hire date on the `automattician` achievement card, shown in the caption next to the unlock date as `Started: <date>` (e.g. "Unlocked: Oct 21, 2016 · Started: Oct 21, 2016"), reusing the existing `caption-context` middot pattern.
* Add the optional `date_hired` field to the `Achievement` type in `@automattic/api-core`. It's exposed only on the `automattician` achievement and only to Automattic requesters (see backend PR Automattic/wpcom#223700).
* The hire date renders only when the slug is `automattician` and `date_hired` is a valid date. It uses `FormattedDate` with the `ll` format to match `TimeSince`'s short-month styling.

## Why are these changes being made?

The `automattician` achievement pins its `date_unlocked` to the achievement's 2012 launch, so every long-time Automattician shows the same legacy unlock date rather than when they actually started. The backend now exposes the real hire date separately as `date_hired`, leaving `date_unlocked` untouched, so the front end can display both.

## Testing Instructions

* As an Automattician, view another Automattician's Reader profile achievements (`/reader/users/<login>`).
* On the Automattician achievement card, confirm the caption reads `Unlocked: <date> · Started: <date>`, with the started date reflecting the real hire date in short-month format.
* Confirm the "Started:" line does not appear when there's no hire date on record, and never appears on any other achievement.
* Run the unit tests: `yarn test-client client/reader/user-profile/views/achievements/achievements-grid/test/generic-achievement.test.tsx`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
