### PR TITLE
Lodash: make js-utils/native guards repo-wide and clear packages stragglers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 const path = require( 'path' );
-const { nodeConfig } = require( '@automattic/calypso-eslint-overrides' );
+const { nodeConfig, lodashRestrictedImports } = require( '@automattic/calypso-eslint-overrides' );
 const wpI18nConfig = require( '@wordpress/eslint-plugin/eslintrc' ).configs.i18n;
 const { merge } = require( 'lodash' );
 const reactVersion = require( './client/package.json' ).dependencies.react;
@@ -68,8 +68,16 @@ module.exports = {
 		{
 			files: [ 'packages/**/*' ],
 			rules: {
-				// These two rules are to ensure packages don't import from calypso by accident to avoid circular deps.
-				'no-restricted-imports': [ 'error', { patterns: [ 'calypso/*' ] } ],
+				// The `calypso/*` patterns ensure packages don't import from calypso by accident
+				// to avoid circular deps. The lodash entries keep the repo-wide guard in place
+				// here, since this override replaces the root `no-restricted-imports` rule.
+				'no-restricted-imports': [
+					'error',
+					{
+						paths: lodashRestrictedImports.paths,
+						patterns: [ { group: [ 'calypso/*' ] }, ...lodashRestrictedImports.patterns ],
+					},
+				],
 				'no-restricted-modules': [ 'error', { patterns: [ 'calypso/*' ] } ],
 			},
 		},
@@ -402,6 +410,7 @@ module.exports = {
 						message:
 							"Please use 'webp' files instead. You can convert using `brew install webp && cwebp -q 90 -alpha_q 85 -m 6 <input>.png -o <output>.webp`",
 					},
+					...lodashRestrictedImports.patterns,
 				],
 				paths: [
 					// Prevent naked import of gridicons module. Use 'components/gridicon' instead.
@@ -438,6 +447,7 @@ module.exports = {
 						importNames: [ 'flowRight' ],
 						message: "Please use `compose` from 'redux' instead.",
 					},
+					...lodashRestrictedImports.paths,
 				],
 			},
 		],

--- a/apps/notifications/.eslintrc.js
+++ b/apps/notifications/.eslintrc.js
@@ -1,4 +1,4 @@
-const { nodeConfig } = require( '@automattic/calypso-eslint-overrides' );
+const { nodeConfig, lodashRestrictedImports } = require( '@automattic/calypso-eslint-overrides' );
 
 module.exports = {
 	env: {
@@ -11,16 +11,12 @@ module.exports = {
 		},
 	],
 	rules: {
+		// This app imports `combineReducers` from redux directly, so the root
+		// restriction on it is intentionally not applied here. The shared lodash
+		// guard still applies.
 		'no-restricted-imports': [
-			0,
-			{
-				paths: [
-					{
-						name: 'redux',
-						importNames: [ 'combineReducers' ],
-					},
-				],
-			},
+			'error',
+			{ paths: lodashRestrictedImports.paths, patterns: lodashRestrictedImports.patterns },
 		],
 	},
 };

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,5 +1,5 @@
 const path = require( 'path' );
-const { nodeConfig } = require( '@automattic/calypso-eslint-overrides' );
+const { nodeConfig, lodashRestrictedImports } = require( '@automattic/calypso-eslint-overrides' );
 
 module.exports = {
 	// Allow fetch api function usage (and similar)
@@ -27,28 +27,7 @@ module.exports = {
 						message:
 							'@testing-library/jest-dom is already globally provided by our test setup framework.',
 					},
-					{
-						// Deep `lodash/<fn>` imports bypass the named-import guard below.
-						group: [
-							'lodash/keyBy',
-							'lodash/shuffle',
-							'lodash/uniqBy',
-							'lodash/times',
-							'lodash/pick',
-							'lodash/omit',
-							'lodash/mapValues',
-							'lodash/pickBy',
-							'lodash/omitBy',
-							'lodash/groupBy',
-							'lodash/mapKeys',
-						],
-						message: 'Please use the equivalent from `@automattic/js-utils` instead.',
-					},
-					{
-						// Deep `lodash/<fn>` imports bypass the named-import guard below.
-						group: [ 'lodash/flatMap', 'lodash/flatten' ],
-						message: 'Please use native `array.flatMap()` / `array.flat()` instead.',
-					},
+					...lodashRestrictedImports.patterns,
 				],
 				paths: [
 					// Use Redux's `compose` instead of lodash's `flowRight`.
@@ -57,35 +36,7 @@ module.exports = {
 						importNames: [ 'flowRight' ],
 						message: "Please use `compose` from 'redux' instead.",
 					},
-					// Use the equivalents from `@automattic/js-utils` instead of lodash.
-					{
-						name: 'lodash',
-						importNames: [
-							'keyBy',
-							'shuffle',
-							'uniqBy',
-							'times',
-							'pick',
-							'omit',
-							'mapValues',
-							'pickBy',
-							'omitBy',
-							'groupBy',
-							'mapKeys',
-						],
-						message: 'Please use the equivalent from `@automattic/js-utils` instead.',
-					},
-					// Use native equivalents instead of lodash.
-					{
-						name: 'lodash',
-						importNames: [ 'compact' ],
-						message: 'Please use `array.filter( Boolean )` instead of lodash `compact`.',
-					},
-					{
-						name: 'lodash',
-						importNames: [ 'flatMap', 'flatten' ],
-						message: 'Please use native `array.flatMap()` / `array.flat()` instead.',
-					},
+					...lodashRestrictedImports.paths,
 				],
 			},
 		],

--- a/client/server/.eslintrc.js
+++ b/client/server/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
 			newRestrictedImports[ 0 ],
 			{
 				paths: filteredRestrictedPaths,
+				patterns: newRestrictedImports[ 1 ].patterns,
 			},
 		],
 	},

--- a/packages/calypso-eslint-overrides/index.js
+++ b/packages/calypso-eslint-overrides/index.js
@@ -1,1 +1,2 @@
 module.exports.nodeConfig = require( './node' );
+module.exports.lodashRestrictedImports = require( './lodash-restricted-imports' );

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -1,0 +1,41 @@
+/**
+ * Shared `no-restricted-imports` entries for the incremental lodash removal.
+ *
+ * Imported by every config that declares a `no-restricted-imports` rule (the
+ * root config and the overrides that replace, rather than merge with, it) so the
+ * guard stays identical everywhere. Replacements live in `@automattic/js-utils`,
+ * or are native array methods.
+ */
+
+const JS_UTILS_NAMES = [
+	'keyBy',
+	'shuffle',
+	'uniqBy',
+	'times',
+	'pick',
+	'omit',
+	'mapValues',
+	'pickBy',
+	'omitBy',
+	'groupBy',
+	'mapKeys',
+];
+
+const JS_UTILS_MESSAGE = 'Please use the equivalent from `@automattic/js-utils` instead.';
+const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash `compact`.';
+const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
+
+const paths = [
+	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
+	{ name: 'lodash', importNames: [ 'compact' ], message: COMPACT_MESSAGE },
+	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
+];
+
+// Deep `lodash/<fn>` imports bypass the named-import paths above.
+const patterns = [
+	{ group: JS_UTILS_NAMES.map( ( name ) => `lodash/${ name }` ), message: JS_UTILS_MESSAGE },
+	{ group: [ 'lodash/compact' ], message: COMPACT_MESSAGE },
+	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
+];
+
+module.exports = { paths, patterns };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,6 +47,7 @@
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/js-utils": "workspace:^",
 		"@automattic/load-script": "workspace:^",
 		"@automattic/material-design-icons": "workspace:^",
 		"@automattic/number-formatters": "^1.2.0",

--- a/packages/components/src/dot-pager/index.tsx
+++ b/packages/components/src/dot-pager/index.tsx
@@ -1,8 +1,8 @@
+import { times } from '@automattic/js-utils';
 import { Button } from '@wordpress/components';
 import { Icon, arrowRight, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate, useRtl } from 'i18n-calypso';
-import { times } from 'lodash';
 import { Children, useState, useEffect, ReactNode } from 'react';
 import { Swipeable } from '../swipeable';
 

--- a/packages/components/src/suggestions/index.tsx
+++ b/packages/components/src/suggestions/index.tsx
@@ -1,5 +1,6 @@
+import { groupBy } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { find, groupBy, isEqual, partition, property } from 'lodash';
+import { find, isEqual, partition } from 'lodash';
 import { Fragment, Component } from 'react';
 import ReactDOM from 'react-dom';
 import Item from './item';
@@ -121,8 +122,9 @@ class Suggestions extends Component< Props, State > {
 				break;
 
 			case 'Enter':
-				this.state.suggestionPosition >= 0 &&
+				if ( this.state.suggestionPosition >= 0 ) {
 					this.suggest( this.getOriginalIndexFromPosition( this.state.suggestionPosition ) );
+				}
 				break;
 		}
 	};
@@ -150,7 +152,9 @@ class Suggestions extends Component< Props, State > {
 
 		// For all intents and purposes `groupBy` keeps the order stable
 		// https://github.com/lodash/lodash/issues/2212
-		const byCategory = groupBy( withCategory, property( 'category' ) );
+		// `withCategory` is the truthy-category half of the partition above, so
+		// `category` is always present here.
+		const byCategory = groupBy( withCategory, ( suggestion ) => suggestion.category! );
 
 		const categories: CategorizedSuggestions = Object.entries( byCategory ).map(
 			( [ category, suggestions ] ) => ( {

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -13,6 +13,7 @@
 		{ "path": "../calypso-analytics" },
 		{ "path": "../calypso-url" },
 		{ "path": "../i18n-utils" },
+		{ "path": "../js-utils" },
 		{ "path": "../ui" }
 	]
 }

--- a/packages/domain-search/.eslintrc.js
+++ b/packages/domain-search/.eslintrc.js
@@ -1,13 +1,17 @@
+const { lodashRestrictedImports } = require( '@automattic/calypso-eslint-overrides' );
+
 module.exports = {
 	rules: {
 		'no-restricted-imports': [
 			'error',
 			{
+				paths: lodashRestrictedImports.paths,
 				patterns: [
 					{
 						group: [ 'client/**/*', 'calypso/**/*' ],
 						message: 'Calypso imports are not allowed in this package',
 					},
+					...lodashRestrictedImports.patterns,
 				],
 			},
 		],

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -60,6 +60,7 @@
 		"qs": "^6.15.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/addon-a11y": "^9.1.20",

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -44,6 +44,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/js-utils": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@automattic/urls": "workspace:^",

--- a/packages/domains-table/src/utils/assembler.ts
+++ b/packages/domains-table/src/utils/assembler.ts
@@ -1,5 +1,6 @@
 import { DomainData } from '@automattic/data-stores';
-import { camelCase, mapKeys } from 'lodash';
+import { mapKeys } from '@automattic/js-utils';
+import { camelCase } from 'lodash';
 import { getDomainType } from './get-domain-type';
 import { getGdprConsentStatus } from './get-gdpr-consent-status';
 import { getTransferStatus } from './get-transfer-status';

--- a/packages/domains-table/tsconfig.json
+++ b/packages/domains-table/tsconfig.json
@@ -14,6 +14,7 @@
 		{ "path": "../data-stores" },
 		{ "path": "../viewport" },
 		{ "path": "../i18n-utils" },
+		{ "path": "../js-utils" },
 		{ "path": "../search" }
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,6 +857,7 @@ __metadata:
     "@automattic/calypso-url": "workspace:^"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/i18n-utils": "workspace:^"
+    "@automattic/js-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
     "@automattic/material-design-icons": "workspace:^"
     "@automattic/number-formatters": "npm:^1.2.0"
@@ -1187,6 +1188,7 @@ __metadata:
   resolution: "@automattic/domain-search@workspace:packages/domain-search"
   dependencies:
     "@automattic/api-core": "workspace:^"
+    "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -1229,6 +1231,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
+    "@automattic/js-utils": "workspace:^"
     "@automattic/search": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@automattic/urls": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Extract the lodash `no-restricted-imports` entries (the `@automattic/js-utils` replacements plus native `compact`/`flatMap`/`flatten`) into a shared module in `@automattic/calypso-eslint-overrides`, consumed by every config that declares the rule — the root config, the `client/`, `client/server/`, `packages/**`, and `packages/domain-search/` overrides. Each declaration replaces rather than merges with the ones above it, so this gives a single source of truth and applies the guard repo-wide instead of only in `client/`.
* Migrate the remaining `packages/` stragglers for functions already guarded in `client/`: `times` (dot-pager), `groupBy` (suggestions), `mapKeys` (domains-table) — all to `@automattic/js-utils`.

## Why are these changes being made?

* Part of the incremental lodash removal. Earlier PRs guarded these functions only in `client/`, leaving `packages/`/`apps/` able to reintroduce them and a few stragglers behind. This finishes those functions repo-wide and removes the guard duplication so future additions touch one file.

## Testing Instructions

* `yarn install` completes (the new `@automattic/js-utils` workspace deps resolve and the postinstall build passes).
* A throwaway `import { groupBy } from 'lodash'` (and a deep `import omit from 'lodash/omit'`) is now flagged in `client/`, `client/server/`, `packages/`, `packages/domain-search/`, and `apps/` scopes with the appropriate message.
* `yarn typecheck-packages` is green; package tests for the migrated files pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
