### PR TITLE
Onboarding: A/B-gate a Help Center entry on the domain steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/use-onboarding-help-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/use-onboarding-help-experiment.ts
@@ -1,0 +1,31 @@
+import { isOnboardingFlow } from '@automattic/onboarding';
+import { useExperiment } from 'calypso/lib/explat';
+
+// Register the variation names ('control', 'treatment') in ExPlat alongside this slug.
+export const ONBOARDING_DOMAINS_HELP_EXPERIMENT_NAME = 'calypso_onboarding_domains_help_cta_202606';
+
+/**
+ * Whether to show the "Need help?" Help Center entry on the onboarding
+ * domain-selection steps (domains and use-my-domain).
+ *
+ * Gated by an A/B experiment: control hides the entry, treatment shows it.
+ * Both domain steps read the same assignment so a control user never sees the
+ * entry anywhere in the domain-selection sub-flow.
+ *
+ * Only eligible in the onboarding flow. While the assignment is loading we
+ * return false (the control shape) so the entry is the default-hidden state and
+ * never flashes in for users who ultimately resolve to control.
+ */
+export function useOnboardingHelpExperiment( flow: string ): {
+	isLoading: boolean;
+	showHelp: boolean;
+} {
+	const isEligible = isOnboardingFlow( flow );
+	const [ isLoading, assignment ] = useExperiment( ONBOARDING_DOMAINS_HELP_EXPERIMENT_NAME, {
+		isEligible,
+	} );
+
+	const showHelp = isEligible && ! isLoading && assignment?.variationName === 'treatment';
+
+	return { isLoading, showHelp };
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -105,7 +105,12 @@ const DomainSearchStep: StepType< {
 		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
 		[]
 	);
-	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
+	const toggleHelpCenter = () => {
+		if ( ! isHelpCenterShown ) {
+			recordTracksEvent( 'calypso_onboarding_help_center_click', { flow, step: 'domains' } );
+		}
+		setShowHelpCenter( ! isHelpCenterShown );
+	};
 
 	const isCiab = dashboard === 'ciab';
 	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -49,6 +49,7 @@ import { useOnboardingStepCounter } from '../../../flows/onboarding/use-onboardi
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { OnboardingProgress } from '../components/onboarding-progress';
 import { useShowOnboardingProgress } from '../components/onboarding-progress/use-show-onboarding-progress';
+import { useOnboardingHelpExperiment } from '../components/use-onboarding-help-experiment';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
@@ -111,6 +112,7 @@ const DomainSearchStep: StepType< {
 		}
 		setShowHelpCenter( ! isHelpCenterShown );
 	};
+	const { showHelp: showHelpCenter } = useOnboardingHelpExperiment( flow );
 
 	const isCiab = dashboard === 'ciab';
 	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
@@ -468,7 +470,6 @@ const DomainSearchStep: StepType< {
 			// On desktop empty state, the link stays hidden and the
 			// in-body card carries the same CTA.
 			const showUseMyDomain = ( !! query || isMobileViewport ) && config.allowsUsingOwnDomain;
-			const showHelpCenter = isOnboardingFlow( flow );
 
 			if ( ! stepCounter && ! showUseMyDomain && ! showHelpCenter ) {
 				return;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -1,3 +1,4 @@
+import { HelpCenter } from '@automattic/data-stores';
 import {
 	isAIBuilderFlow,
 	isCopySiteFlow,
@@ -13,7 +14,8 @@ import {
 } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { help } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -50,10 +52,12 @@ import { useShowOnboardingProgress } from '../components/onboarding-progress/use
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
-import type { OnboardSelect } from '@automattic/data-stores';
+import type { HelpCenterSelect, OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const HUNDRED_YEAR_DOMAIN_TLDS = [ 'com', 'net', 'org', 'blog' ];
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 import './style.scss';
 
@@ -95,6 +99,13 @@ const DomainSearchStep: StepType< {
 	const sourceSlug = queryParams.get( 'sourceSlug' );
 	const dashboard = queryParams.get( 'dashboard' );
 	const { __ } = useI18n();
+
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const isHelpCenterShown = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
 
 	const isCiab = dashboard === 'ciab';
 	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
@@ -452,8 +463,9 @@ const DomainSearchStep: StepType< {
 			// On desktop empty state, the link stays hidden and the
 			// in-body card carries the same CTA.
 			const showUseMyDomain = ( !! query || isMobileViewport ) && config.allowsUsingOwnDomain;
+			const showHelpCenter = isOnboardingFlow( flow );
 
-			if ( ! stepCounter && ! showUseMyDomain ) {
+			if ( ! stepCounter && ! showUseMyDomain && ! showHelpCenter ) {
 				return;
 			}
 
@@ -481,6 +493,16 @@ const DomainSearchStep: StepType< {
 						>
 							{ __( 'Use a domain I own' ) }
 						</Step.LinkButton>
+					) }
+					{ showHelpCenter && (
+						<>
+							{ showUseMyDomain && (
+								<span className="domain-search--top-bar-divider" aria-hidden="true" />
+							) }
+							<Step.LinkButton icon={ help } iconSize={ 20 } onClick={ toggleHelpCenter }>
+								{ __( 'Need help?' ) }
+							</Step.LinkButton>
+						</>
 					) }
 				</>
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -1,6 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.domain-search--top-bar-divider {
+	inline-size: 1px;
+	block-size: 1.25rem;
+	background-color: var( --color-border-subtle );
+}
+
 .domain-search--step-container {
 	--domain-search-content-max-width: 1040px;
 	--domain-search-mini-cart-inline-padding: 16px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,6 +1,9 @@
-import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
+import { HelpCenter } from '@automattic/data-stores';
+import { StepContainer, isOnboardingFlow, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { help } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
@@ -25,8 +28,11 @@ import { useQuery } from '../../../../hooks/use-query';
 import { useOnboardingStepCounter } from '../../../flows/onboarding/use-onboarding-step-counter';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
+import type { HelpCenterSelect } from '@automattic/data-stores';
 
 import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 type OwnershipVerificationData = {
 	ownership_verification_data: {
@@ -65,6 +71,13 @@ const UseMyDomain: StepType< {
 		inputMode.domainInput
 	);
 	const stepCounter = useOnboardingStepCounter( flow, 'use-my-domain' );
+
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const isHelpCenterShown = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
 
 	const handleGoBack = () => {
 		if ( String( getQueryArg( window.location.search, 'step' ) ?? '' ) === 'transfer-or-connect' ) {
@@ -183,6 +196,8 @@ const UseMyDomain: StepType< {
 		let headingText;
 		let subText;
 
+		const showHelpCenter = isOnboardingFlow( flow );
+
 		if ( useMyDomainMode === 'domain-input' ) {
 			columnWidth = 4 as const;
 			headingText = __( 'Your domain name' );
@@ -229,8 +244,20 @@ const UseMyDomain: StepType< {
 						<Step.TopBar
 							leftElement={ getTopBarLeftElement() }
 							rightElement={
-								stepCounter && (
-									<Step.StepCounter current={ stepCounter.current } total={ stepCounter.total } />
+								( stepCounter || showHelpCenter ) && (
+									<>
+										{ stepCounter && (
+											<Step.StepCounter
+												current={ stepCounter.current }
+												total={ stepCounter.total }
+											/>
+										) }
+										{ showHelpCenter && (
+											<Step.LinkButton icon={ help } iconSize={ 20 } onClick={ toggleHelpCenter }>
+												{ __( 'Need help?' ) }
+											</Step.LinkButton>
+										) }
+									</>
 								)
 							}
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -77,7 +77,12 @@ const UseMyDomain: StepType< {
 		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
 		[]
 	);
-	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
+	const toggleHelpCenter = () => {
+		if ( ! isHelpCenterShown ) {
+			recordTracksEvent( 'calypso_onboarding_help_center_click', { flow, step: 'use-my-domain' } );
+		}
+		setShowHelpCenter( ! isHelpCenterShown );
+	};
 
 	const handleGoBack = () => {
 		if ( String( getQueryArg( window.location.search, 'step' ) ?? '' ) === 'transfer-or-connect' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,5 +1,5 @@
 import { HelpCenter } from '@automattic/data-stores';
-import { StepContainer, isOnboardingFlow, isStartWritingFlow, Step } from '@automattic/onboarding';
+import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -27,6 +27,7 @@ import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { useQuery } from '../../../../hooks/use-query';
 import { useOnboardingStepCounter } from '../../../flows/onboarding/use-onboarding-step-counter';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { useOnboardingHelpExperiment } from '../components/use-onboarding-help-experiment';
 import type { Step as StepType } from '../../types';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -83,6 +84,7 @@ const UseMyDomain: StepType< {
 		}
 		setShowHelpCenter( ! isHelpCenterShown );
 	};
+	const { showHelp: showHelpCenter } = useOnboardingHelpExperiment( flow );
 
 	const handleGoBack = () => {
 		if ( String( getQueryArg( window.location.search, 'step' ) ?? '' ) === 'transfer-or-connect' ) {
@@ -200,8 +202,6 @@ const UseMyDomain: StepType< {
 		let columnWidth;
 		let headingText;
 		let subText;
-
-		const showHelpCenter = isOnboardingFlow( flow );
 
 		if ( useMyDomainMode === 'domain-input' ) {
 			columnWidth = 4 as const;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-432/domains-closing-help-center-cant-open-it-again

## Proposed Changes

**A/B-gates a “Need help?” Help Center entry on the onboarding domains and use-my-domain steps, so we can measure its effect on purchases before standardizing it.**

- New shared hook `useOnboardingHelpExperiment` reads one ExPlat assignment (`calypso_onboarding_domains_help_cta_202606`) and renders the entry only for the `treatment` arm. Both domain steps share the assignment, so a control user never sees the entry anywhere in domain selection.
- The entry is the help icon + “Need help?” in the step top bar; on the domains step it sits beside “Use a domain I own” with a divider after a search.
- Defaults to hidden while the assignment loads (no flicker bias). `control` is current production — no help entry on these steps — so this is inert until the experiment is started.
- Opening the Help Center from the entry fires `calypso_onboarding_help_center_click` (props `flow`, `step`) to measure adoption.

## Why are these changes being made?

The Help Center entry shipped piecemeal across onboarding: the plans and checkout steps have a “Need help?” link, but the domain steps never did — so a user who closed the Help Center there had no way to reopen it ([DOTSUP-432](https://linear.app/a8c/issue/DOTSUP-432)). Before standardizing the entry everywhere, we want to know whether one-click help at the domain-selection stage actually increases onboarding completion and purchases, instead of assuming it — so this wires it as a clean A/B test ([DOTSUP-431](https://linear.app/a8c/issue/DOTSUP-431)). For reference, ~0.8% of domain-step visitors currently go on to purchase.

## Testing Instructions

1. Run `yarn start` and open `/setup/onboarding/domains` while logged in.
2. With no experiment override you are in `control`: there is no “Need help?” on the domains or use-my-domain steps.
3. Force the `treatment` assignment for `calypso_onboarding_domains_help_cta_202606` (ExPlat dev override) and reload. The “Need help?” entry appears on both domain steps; clicking it opens the Help Center, and the `calypso_onboarding_help_center_click` event fires with the step name.
4. Search a domain on the domains step and confirm the top right reads `Use a domain I own │ ⊘ Need help?` (divider + help icon) in treatment.
