### PR TITLE
Agents Manager: keep Jetpack admin pages inside the docked sidebar frame

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
+++ b/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
@@ -13,6 +13,17 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		#wpbody {
 			padding-left: 0;
 		}
+
+		// Fill and clip the framed `#wpbody` so app-like pages (e.g. Jetpack
+		// Social) stay inside the frame instead of scrolling the whole admin body.
+		#wpbody-content {
+			position: absolute;
+			inset: 0;
+			display: flex;
+			flex-direction: column;
+			overflow: hidden;
+			border-radius: 0 0 $main-border-radius $main-border-radius;
+		}
 	}
 
 	&.plugins_page_wpcom-install-plugin {

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -51,7 +51,7 @@
 @mixin notice-panel-open( $notice-panel-selector ) {
 	#{$notice-panel-selector} {
 		right: $sidebar-width !important;
-		top: $layout-spacing + $admin-bar-height + 1px !important;
+		top: calc( $admin-content-top + 1px ) !important;
 		bottom: $layout-spacing !important;
 		border-bottom-right-radius: $main-border-radius !important;
 		border: 1px solid $admin-border-color;
@@ -242,7 +242,7 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 		}
 
 		#secondary {
-			top: calc( $layout-spacing + $admin-bar-height );
+			top: $admin-content-top;
 			left: $layout-spacing;
 			bottom: $layout-spacing;
 			overflow: hidden;
@@ -338,20 +338,19 @@ body.is-section-stepper.agents-manager-sidebar-container {
 /* Calypso: Fix sticky headers on marketplace pages when the sidebar is open */
 .agents-manager-sidebar-container--sidebar-open .layout__secondary ~ .layout__primary {
 	.plugins-browser--site-view .search-categories.fixed-top {
-		top: calc( $admin-bar-height + $layout-spacing + 1px );
+		top: calc( $admin-content-top + 1px );
 		right: calc( $sidebar-width + 1px );
 		left: calc( var( --sidebar-width-max, #{$admin-menu-width-unified} ) + 17px );
 
 		&::after {
 			width: calc(
-				100vw - var( --sidebar-width-max, #{$admin-menu-width-unified} ) - $sidebar-width -
-					18px
+				100vw - var( --sidebar-width-max, #{$admin-menu-width-unified} ) - $sidebar-width - 18px
 			);
 		}
 	}
 
 	.themes__content .themes__controls.is-sticky:not( .is-global-sidebar-visible ) {
-		top: calc( $admin-bar-height + $layout-spacing + 1px );
+		top: calc( $admin-content-top + 1px );
 		left: calc( var( --sidebar-width-max, #{$admin-menu-width-unified} ) + 17px );
 		width: calc(
 			100vw - var( --sidebar-width-max, #{$admin-menu-width-unified} ) - $sidebar-width - 18px


### PR DESCRIPTION
AI-998

## Proposed Changes

- On app-like Jetpack admin pages (`jetpack_page_*`, `plugins_page_wpcom-*`, `toplevel_page_jetpack`, `tools_page_advertising`), make `#wpbody-content` fill and clip the framed `#wpbody` via `position: absolute; inset: 0` so the page stays inside the rounded sidebar frame instead of scrolling the whole admin body. Scoped to these pages only.
- Replace hand-rolled `$admin-bar-height + $layout-spacing` top offsets with the existing `$admin-content-top` variable.

## Why are these changes being made?

When the Agents Manager sidebar is docked, the wp-admin layout is reframed. On normal admin pages `#wpbody` is the fixed, scrollable frame and content flows inside it. App-like Jetpack pages render their own full-height UI that wasn't being constrained to that frame, so it bled past the rounded corners and scrolled the whole admin body. Filling the fixed `#wpbody` parent constrains the app to the frame in every menu state (classic / nav-unified / folded) without repeating the menu-width math, and scoping it to those pages leaves normal admin pages (which need `#wpbody` to scroll) untouched.

## Testing Instructions

- Sandbox this PR
- Now the sidebar layout should work as expected on the related pages. For example:
  - `/wp-admin/admin.php?page=jetpack-social`
  - `/wp-admin/admin.php?page=jetpack-newsletter`
  - `/wp-admin/admin.php?page=jetpack-podcast`

https://github.com/user-attachments/assets/c1416be6-7f73-4325-9db9-c5398be97f85

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)