### PR TITLE
Domains: track bundle acceptance after cart add

### DIFF
--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -32,6 +32,10 @@ type AddBundleToCartVariables = {
 	query: string;
 };
 
+type AddBundleToCartResult = {
+	wasAdded: boolean;
+};
+
 type UnavailableBundle = {
 	groupId: string;
 	query: string;
@@ -88,11 +92,20 @@ export const ResultsPage = () => {
 		meta: {
 			mutationId,
 		},
-		mutationFn: async ( { bundle }: AddBundleToCartVariables ) => {
-			await cart.onAddBundle?.( bundle );
+		mutationFn: async ( {
+			bundle,
+		}: AddBundleToCartVariables ): Promise< AddBundleToCartResult > => {
+			if ( ! cart.onAddBundle ) {
+				return { wasAdded: false };
+			}
+
+			await cart.onAddBundle( bundle );
+			return { wasAdded: true };
 		},
-		onSuccess: ( _data, { bundle } ) => {
-			events.onBundleAddToCart( bundle );
+		onSuccess: ( { wasAdded }, { bundle } ) => {
+			if ( wasAdded ) {
+				events.onBundleAddToCart( bundle );
+			}
 		},
 		onError: async ( error, { bundle, query: failedQuery } ) => {
 			if ( ! isBundleUnavailableError( error ) ) {

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -91,6 +91,9 @@ export const ResultsPage = () => {
 		mutationFn: async ( { bundle }: AddBundleToCartVariables ) => {
 			await cart.onAddBundle?.( bundle );
 		},
+		onSuccess: ( _data, { bundle } ) => {
+			events.onBundleAddToCart( bundle );
+		},
 		onError: async ( error, { bundle, query: failedQuery } ) => {
 			if ( ! isBundleUnavailableError( error ) ) {
 				return;
@@ -201,7 +204,6 @@ export const ResultsPage = () => {
 					<BundleCard
 						suggestion={ visibleBundleSuggestion }
 						onAddToCart={ ( bundle ) => {
-							events.onBundleAddToCart( bundle );
 							addBundleToCart( { bundle, query } );
 						} }
 						isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1540,8 +1540,15 @@ describe( 'ResultsPage', () => {
 			expect( onBundleShown ).not.toHaveBeenCalled();
 		} );
 
-		it( 'fires the onBundleAddToCart event when the bundle CTA is clicked', async () => {
+		it( 'fires the onBundleAddToCart event after the bundle add succeeds', async () => {
 			const user = userEvent.setup();
+			let resolveAddBundle: () => void = () => {};
+			const onAddBundle = jest.fn(
+				() =>
+					new Promise< void >( ( resolve ) => {
+						resolveAddBundle = resolve;
+					} )
+			);
 			const onBundleAddToCart = jest.fn();
 
 			mockGetSuggestionsQuery( {
@@ -1555,6 +1562,7 @@ describe( 'ResultsPage', () => {
 
 			render(
 				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
 					events={ { onBundleAddToCart } }
 					config={ { showBundleSuggestions: true } }
 					query="bundle-accept"
@@ -1565,10 +1573,55 @@ describe( 'ResultsPage', () => {
 
 			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
 
-			expect( onBundleAddToCart ).toHaveBeenCalledTimes( 1 );
+			expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+			expect( onBundleAddToCart ).not.toHaveBeenCalled();
+
+			await act( async () => {
+				resolveAddBundle();
+			} );
+
+			await waitFor( () => {
+				expect( onBundleAddToCart ).toHaveBeenCalledTimes( 1 );
+			} );
 			expect( onBundleAddToCart ).toHaveBeenCalledWith(
 				expect.objectContaining( { bundle_group_id: 'mock-bundle-accept-group' } )
 			);
+		} );
+
+		it( 'does not fire the onBundleAddToCart event when the bundle add fails', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockRejectedValue( new Error( 'Bundle add failed' ) );
+			const onBundleAddToCart = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-reject' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-reject.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-reject' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-reject' ),
+			} );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					events={ { onBundleAddToCart } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-reject"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+			} );
+			await waitFor( () => {
+				expect( getByText( container, 'Bundle add failed' ) ).toBeInTheDocument();
+			} );
+			expect( onBundleAddToCart ).not.toHaveBeenCalled();
 		} );
 
 		it( 'fires the onQueryAvailabilityCheck event when the availability is checked', async () => {

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1624,6 +1624,38 @@ describe( 'ResultsPage', () => {
 			expect( onBundleAddToCart ).not.toHaveBeenCalled();
 		} );
 
+		it( 'does not fire the onBundleAddToCart event when no bundle add handler exists', async () => {
+			const user = userEvent.setup();
+			const onBundleAddToCart = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-no-handler' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-no-handler.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-no-handler' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-no-handler' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle: undefined } ) }
+					events={ { onBundleAddToCart } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-no-handler"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+			await act( async () => {
+				await Promise.resolve();
+			} );
+
+			expect( onBundleAddToCart ).not.toHaveBeenCalled();
+		} );
+
 		it( 'fires the onQueryAvailabilityCheck event when the availability is checked', async () => {
 			const onQueryAvailabilityCheck = jest.fn();
 


### PR DESCRIPTION
Fixes DOMAINS-2201

## Proposed Changes

* Fire bundle add-to-cart tracking only from the successful bundle add mutation path.
* Keep the bundle CTA click handler focused on starting the cart add mutation.
* Update ResultsPage regression coverage so accepted tracking does not fire while the add is pending or after an add failure.

## Why are these changes being made?

* `calypso_domain_bundle_accepted` previously represented a CTA click rather than a successful cart add.
* Failed bundle adds could be counted as accepted bundles, inflating the Phase 1 experiment funnel.

## Testing Instructions

* In a domain-search flow with bundle suggestions enabled, search for a query that shows a bundle card.
* Open the browser event inspector or Tracks debug tooling.
* Click **Get bundle** and wait for all bundle member domains to appear in the cart.
* Confirm `calypso_domain_bundle_accepted` is recorded once, after the bundle appears in the cart.
* Force the bundle add to fail, for example with a local cart stub or a network override that returns a bundle-add/cart error.
* Click **Get bundle** again and confirm the bundle error is shown.
* Confirm `calypso_domain_bundle_accepted` is not recorded for the failed add.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?