### PR TITLE
Checkout: fix off-by-one issue with dates in renewal terms

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -49,7 +49,7 @@ export default function AdditionalTermsOfServiceInCart() {
 
 export function formatDate( isoDate: string ): string {
 	// This somewhat mimics `moment.format('ll')` (used here formerly) without
-	// needing the depdecated `moment` package.
+	// needing the deprecated `moment` package.
 	// Parse only the date portion (YYYY-MM-DD) and construct via the local-time
 	// Date constructor to avoid the UTC-midnight-to-local-time shift that causes
 	// dates to appear one day off for users behind UTC.

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -47,10 +47,14 @@ export default function AdditionalTermsOfServiceInCart() {
 	);
 }
 
-function formatDate( isoDate: string ): string {
+export function formatDate( isoDate: string ): string {
 	// This somewhat mimics `moment.format('ll')` (used here formerly) without
 	// needing the depdecated `moment` package.
-	return new Date( Date.parse( isoDate ) ).toLocaleDateString( 'en-US', {
+	// Parse only the date portion (YYYY-MM-DD) and construct via the local-time
+	// Date constructor to avoid the UTC-midnight-to-local-time shift that causes
+	// dates to appear one day off for users behind UTC.
+	const [ year, month, day ] = isoDate.slice( 0, 10 ).split( '-' ).map( Number );
+	return new Date( year, month - 1, day ).toLocaleDateString( 'en-US', {
 		weekday: undefined,
 		month: 'short',
 		day: 'numeric',

--- a/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
+++ b/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
@@ -11,7 +11,11 @@ describe( 'formatDate', () => {
 	} );
 
 	afterAll( () => {
-		process.env.TZ = originalTZ;
+		if ( originalTZ === undefined ) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = originalTZ;
+		}
 	} );
 
 	it( 'formats a bare date string to the correct calendar date', () => {

--- a/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
+++ b/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
@@ -1,0 +1,34 @@
+import { formatDate } from '../additional-terms-of-service-in-cart';
+
+describe( 'formatDate', () => {
+	const originalTZ = process.env.TZ;
+
+	beforeAll( () => {
+		// Simulate a UTC-5 timezone so tests catch the off-by-one that affects
+		// users behind UTC: Date.parse("2026-06-17") returns UTC midnight, which
+		// toLocaleDateString() would render as June 16 here.
+		process.env.TZ = 'America/New_York';
+	} );
+
+	afterAll( () => {
+		process.env.TZ = originalTZ;
+	} );
+
+	it( 'formats a bare date string to the correct calendar date', () => {
+		expect( formatDate( '2026-06-17' ) ).toBe( 'Jun 17, 2026' );
+	} );
+
+	it( 'formats a date at the start of a month correctly', () => {
+		expect( formatDate( '2026-01-01' ) ).toBe( 'Jan 1, 2026' );
+	} );
+
+	it( 'formats a date at the end of a month correctly', () => {
+		expect( formatDate( '2026-12-31' ) ).toBe( 'Dec 31, 2026' );
+	} );
+
+	it( 'does not shift the date when the string includes a UTC midnight timestamp', () => {
+		// API responses may include a time component; UTC midnight is the worst
+		// case for UTC- timezones.
+		expect( formatDate( '2026-06-17T00:00:00.000Z' ) ).toBe( 'Jun 17, 2026' );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17653

## Proposed Changes

* In checkout, the Read More link shows the renewal terms for the plan which include the start/end date and a renewal date. For timezones like UTC-5, the dates are off by one day due to them being parsed as UTC midnight. This fix makes sure to only keep the date part.

**Before**
<img width="537" height="84" alt="before" src="https://github.com/user-attachments/assets/782685b0-c8f5-4c0b-a276-0423b59662eb" />


**After**
<img width="537" height="84" alt="after" src="https://github.com/user-attachments/assets/6bd72d24-5f96-4eb2-8860-807e9462f22b" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To display the correct dates to our users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your timezone to UTC-5 or a similar one, add a product to cart, navigate to checkout, click on 'Read more' link and confirm that the dates shown are not correct.
* Re-test with the fix applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
