### PR TITLE
Agents Manager: only darken body backdrop while the sidebar is open

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -2,9 +2,18 @@
 @import '../../styles/mixins.scss';
 
 @mixin sidebar-base( $main-container-selector ) {
-	// Also set the background color for the sidebar chat to prevent transparency issues during transitions (e.g., site editor)
-	&,
+	// The docked chat panel keeps the dark background at all times to prevent
+	// transparency issues during dock/undock transitions (e.g., site editor).
 	.agents-manager-chat {
+		background-color: $gray-900 !important;
+	}
+
+	// The body is only the dark backdrop *behind* the chat, so only darken it
+	// while the sidebar is open (or animating closed). In the resting closed/FAB
+	// state the main container may not span the full viewport (e.g. the narrow
+	// domain-transfer step), and a dark body would bleed around it.
+	&.agents-manager-sidebar-container--sidebar-open,
+	&.agents-manager-sidebar-container--closing {
 		background-color: $gray-900 !important;
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Scope the Agents Manager docked-chat dark body backdrop (`#1e1e1e`) so it only applies while the sidebar is **open** or **closing**, instead of whenever the dock is mounted.
* The chat panel (`.agents-manager-chat`) keeps its dark background at all times, as before — only the `body` darkening changed.
* Single change in the shared `sidebar-base` mixin (`packages/agents-manager/src/components/agent-dock/style.scss`), so it applies uniformly to all six call sites (Calypso, MSD, Stepper, next-admin, site-editor, post-new).

## Why are these changes being made?

The `sidebar-base` mixin painted `body { background-color: #1e1e1e !important }` as soon as the dock mounted — including the resting **closed/FAB** state, before any `--sidebar-open` class is added by `use-agent-layout-manager`.

That dark body is harmless only while the section's main container spans the full viewport (it gets covered). On the `domain-transfer` "domains" stepper step the main container (`.step-route`) is constrained to `width: 754px`, so the light container is just a centered column and the dark body bled around it — leaving most of the page black while the chat was closed.

Darkening the body is only needed as the backdrop *behind* the chat, so it now only happens in the `--sidebar-open` / `--closing` states.

## Testing Instructions

1. `yarn start`, ensure the Agents Manager dock is enabled.
2. Log in and visit `/setup/domain-transfer/domains?dashboard=dotcom` (reach it via the domain-transfer intro step).
3. With the chat **closed** (FAB only): the page background should be the normal light stepper background — **not** black around the centered "Add your domains" column.
4. **Open** the chat: the dark backdrop behind/around the docked chat should appear as before; **close** it: it should animate back to light without flashing.
5. Sanity-check a full-width surface (e.g. a wp-admin / site-editor page or another stepper flow) still looks correct opening/closing the dock.

Before / after on the affected step:

| Before | After |
| --- | --- |
| Page black around the 754px column (chat closed) | Normal light page (chat closed) |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)