### PR TITLE
MCP: add 'Learn more' link to /me/mcp subheader

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -247,8 +247,7 @@ const contextLinks = {
 		post_id: 219751,
 	},
 	mcp: {
-		link: 'https://wordpress.com/support/model-context-protocol-mcp-settings/',
-		post_id: 418160,
+		link: 'https://wordpress.com/support/mcp/',
 	},
 	media: {
 		link: 'https://wordpress.com/support/media/',

--- a/client/me/mcp/mcp-page-header.jsx
+++ b/client/me/mcp/mcp-page-header.jsx
@@ -1,4 +1,6 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 /**
  * Shared top-of-page chrome for `/me/mcp*` routes (Figma: AI & MCP settings — primary nav header).
@@ -12,7 +14,17 @@ export function useMcpPageChrome() {
 			navigationItems: [],
 			title: translate( 'AI and MCP' ),
 			subtitle: translate(
-				'Control how AI assistants interact with your WordPress.com account and sites.'
+				'Control how AI assistants interact with your WordPress.com account and sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: (
+							<InlineSupportLink
+								supportLink={ localizeUrl( 'https://wordpress.com/support/mcp/' ) }
+								showIcon={ false }
+							/>
+						),
+					},
+				}
 			),
 		},
 	};

--- a/client/me/mcp/mcp-page-header.jsx
+++ b/client/me/mcp/mcp-page-header.jsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
@@ -17,12 +16,7 @@ export function useMcpPageChrome() {
 				'Control how AI assistants interact with your WordPress.com account and sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 				{
 					components: {
-						learnMoreLink: (
-							<InlineSupportLink
-								supportLink={ localizeUrl( 'https://wordpress.com/support/mcp/' ) }
-								showIcon={ false }
-							/>
-						),
+						learnMoreLink: <InlineSupportLink supportContext="mcp" showIcon={ false } />,
 					},
 				}
 			),


### PR DESCRIPTION
Fixes [AIINT-453](https://linear.app/a8c/issue/AIINT-453/add-learn-more-link-to-memcp-subheader)

## Proposed Changes

* Add a "Learn more" link to the `/me/mcp` page subheader, matching the pattern used by the profile and account settings pages.

## Why are these changes being made?

The other `/me/` screens (profile, account, purchases) all have a "Learn more" link in their subheader, but the MCP page was missing one. This adds a link to `https://wordpress.com/support/mcp/` so users who are curious about AI agents and MCP but not confident about diving in can learn what MCP is and how to use it.

## Testing Instructions

* Navigate to `/me/mcp`
* Verify the subheader now reads: "Control how AI assistants interact with your WordPress.com account and sites. Learn more."
* Verify "Learn more" is a link that opens `https://wordpress.com/support/mcp/` in a new tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?