### PR TITLE
A4A Amplify: Dashboard overview screen foundation

### DIFF
--- a/client/dashboard/agency/amplify/index.tsx
+++ b/client/dashboard/agency/amplify/index.tsx
@@ -1,0 +1,37 @@
+import {
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
+import './style.scss';
+
+export default function AgencyAmplify() {
+	const { recordTracksEvent } = useAnalytics();
+
+	return (
+		<PageLayout header={ <PageHeader title={ __( 'Amplify' ) } /> }>
+			<VStack className="amplify-overview-hero" spacing={ 6 } alignment="center">
+				<Heading level={ 1 } weight={ 500 }>
+					{ __( 'Your clients want more business. Find out what their site is doing about it.' ) }
+				</Heading>
+				<Text variant="muted" size={ 16 }>
+					{ __(
+						'Amplify scans your clients’ connected sites through two lenses: how their prospective clients perceive them on first visit, and how AI tools like ChatGPT and Perplexity read and rank them. Run a scan in minutes. Find what’s holding them back. Deliver fixes that prove your value and build trust.'
+					) }
+				</Text>
+				<RouterLinkButton
+					variant="primary"
+					to="/agency/amplify/reports"
+					onClick={ () => recordTracksEvent( 'calypso_a4a_amplify_overview_cta_click' ) }
+				>
+					{ __( 'Amplify a site' ) }
+				</RouterLinkButton>
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/amplify/style.scss
+++ b/client/dashboard/agency/amplify/style.scss
@@ -1,0 +1,5 @@
+.amplify-overview-hero {
+	max-inline-size: 640px;
+	margin-inline: auto;
+	text-align: center;
+}

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -21,7 +21,7 @@ boot( {
 	mainRoute: '/overview',
 	Logo,
 	supports: {
-		agency: { overview: true, tiers: true },
+		agency: { overview: true, tiers: true, amplify: true },
 		agencyClient: { subscriptions: true },
 		sites: true,
 		domains: false,

--- a/client/dashboard/app-a4a/section.ts
+++ b/client/dashboard/app-a4a/section.ts
@@ -9,6 +9,7 @@ export const A4A_DASHBOARD_SECTION_PATHS = [
 	'/oauth/token',
 	'/overview',
 	'/agency/tiers',
+	'/agency/amplify',
 	'/client',
 	'/client/subscriptions',
 ];

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -17,6 +17,7 @@ import type { PostHogOverrides } from '@automattic/posthog';
 export type AgencySupports = {
 	overview: boolean;
 	tiers: boolean;
+	amplify: boolean;
 };
 
 export type AgencyClientSupports = {

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -17,9 +17,18 @@ export default function AgencySidebar() {
 			<SidebarMenuItem icon={ home } to="/overview">
 				{ __( 'Home' ) }
 			</SidebarMenuItem>
-			{ supports.agency && supports.agency.tiers && (
-				<SidebarExpandableMenuItem label={ __( 'Agency' ) } icon={ globe } to="/agency/tiers">
-					<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
+			{ supports.agency && ( supports.agency.tiers || supports.agency.amplify ) && (
+				<SidebarExpandableMenuItem
+					label={ __( 'Agency' ) }
+					icon={ globe }
+					to={ supports.agency.tiers ? '/agency/tiers' : '/agency/amplify' }
+				>
+					{ supports.agency.tiers && (
+						<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
+					) }
+					{ supports.agency.amplify && (
+						<SidebarMenuItem to="/agency/amplify">{ __( 'Amplify' ) }</SidebarMenuItem>
+					) }
 				</SidebarExpandableMenuItem>
 			) }
 		</>

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -18,11 +18,7 @@ export default function AgencySidebar() {
 				{ __( 'Home' ) }
 			</SidebarMenuItem>
 			{ supports.agency && ( supports.agency.tiers || supports.agency.amplify ) && (
-				<SidebarExpandableMenuItem
-					label={ __( 'Agency' ) }
-					icon={ globe }
-					to={ supports.agency.tiers ? '/agency/tiers' : '/agency/amplify' }
-				>
+				<SidebarExpandableMenuItem label={ __( 'Agency' ) } icon={ globe } to="/agency">
 					{ supports.agency.tiers && (
 						<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
 					) }

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -59,6 +59,26 @@ const agencyTiersRoute = createRoute( {
 	)
 );
 
+// `/agency/amplify` – Amplify website analysis
+const agencyAmplifyRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Amplify' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyRoute,
+	path: 'agency/amplify',
+	loader: () => queryClient.ensureQueryData( activeAgencyQuery() ),
+} ).lazy( () =>
+	import( '../../agency/amplify' ).then( ( d ) =>
+		createLazyRoute( 'agency-amplify' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
-	agencyRoute.addChildren( [ agencyOverviewRoute, agencyTiersRoute ] ),
+	agencyRoute.addChildren( [ agencyOverviewRoute, agencyTiersRoute, agencyAmplifyRoute ] ),
 ];


### PR DESCRIPTION
Part of A4A-XXXX

Based on #111751 (Amplify data layer), which is itself based on #111342 (A4A agency Tiers).

## Proposed Changes

Adds a capability-gated Amplify overview screen to the Multi-site Dashboard at `/agency/amplify`, following the Tiers wiring pattern. This PR is the **foundation only** — routing, sidebar, the `supports.agency.amplify` flag, and a design-system hero. The richer marketing content lands in follow-ups (see below).

* **`client/dashboard/agency/amplify/index.tsx`**, **`style.scss`** — the overview screen: `PageLayout` + `PageHeader` with a centered hero (headline, subheadline, and an **Amplify a site** primary CTA). Built with `@wordpress/components` (`Heading`/`Text`/`VStack`) and `RouterLinkButton`; tracking via the dashboard `useAnalytics()` hook. Minimal custom CSS (hero centering only).
* **`client/dashboard/app/context.tsx`**, **`client/dashboard/app-a4a/index.tsx`** — adds `amplify` to `AgencySupports` and enables it for the A4A variant.
* **`client/dashboard/app/router/agency.tsx`** — registers the lazy `/agency/amplify` route under the agency route tree, with an `activeAgencyQuery` loader.
* **`client/dashboard/app-a4a/section.ts`** — serves `/agency/amplify` from the A4A dashboard section.
* **`client/dashboard/app/responsive-sidebar/agency.tsx`** — adds **Amplify** under the **Agency** sidebar menu, gated on `supports.agency.amplify`.

The hero CTA links to `/agency/amplify/reports`, which is added in the next PR; as a stacked PR this is the intended final behavior.

## Why are these changes being made?

Amplify is being built in the Dashboard following the Tiers pattern. The overview’s full marketing page (interactive demos + ~850 lines of styling on the original branch) is split into its own follow-up PRs so each change stays small and reviewable, and so the reports/analysis work can proceed in parallel on top of this foundation:

- a follow-up for the static content sections (human/AI criteria cards, FAQ);
- a follow-up for the interactive demos (score card, “how it works”, AI-workflow);
- the reports list and analysis flow at `/agency/amplify/reports`.

## Testing Instructions

1. Run `yarn start-dashboard` and open `my.a4a.localhost:3000/agency/amplify` logged in as an agency user (`a4a_administrator`/`a4a_developer`).
2. Confirm the page renders with the **Amplify** title, the hero headline/subheadline, and the **Amplify a site** primary button.
3. Confirm the sidebar shows **Agency → Tiers** and **Agency → Amplify**, and that clicking **Amplify** navigates to the screen.
4. Confirm there are no TypeScript/React console errors, and that client users are still redirected away from agency routes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
