### PR TITLE
Help Center: retry Zendesk conversation creation until Smooch is ready

### DIFF
--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import Smooch from 'smooch';
+import { useOdieAssistantContext } from '../../context';
+import { useCreateZendeskConversation } from '../use-create-zendesk-conversation';
+
+/**
+ * Mutable state backing the mocked dependencies. Each test mutates these in
+ * `beforeEach` (or inline) to drive the hook through the scenario under test.
+ */
+const mockTrackEvent = jest.fn();
+const mockSetChat = jest.fn();
+const mockSubmitUserFields = jest.fn();
+const mockAddEventToInteraction = jest.fn();
+const mockStartNewInteraction = jest.fn();
+let mockHasReachedLimit = false;
+
+jest.mock( 'smooch', () => ( {
+	__esModule: true,
+	default: {
+		createConversation: jest.fn(),
+		updateConversation: jest.fn(),
+		loadConversation: jest.fn(),
+	},
+} ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	useLocation: () => ( { search: '', pathname: '/' } ),
+	useNavigate: () => jest.fn(),
+} ) );
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useUpdateZendeskUserFields: () => ( {
+		isPending: false,
+		mutateAsync: mockSubmitUserFields,
+	} ),
+} ) );
+
+jest.mock( '../../context', () => ( {
+	useOdieAssistantContext: jest.fn(),
+} ) );
+
+jest.mock( '../../data', () => ( {
+	useManageSupportInteraction: () => ( {
+		addEventToInteraction: mockAddEventToInteraction,
+		startNewInteraction: mockStartNewInteraction,
+	} ),
+} ) );
+
+jest.mock( '../../data/use-current-support-interaction', () => ( {
+	useCurrentSupportInteraction: () => ( {
+		data: { uuid: 'int-1', bot_slug: 'wpcom-support-chat' },
+	} ),
+} ) );
+
+jest.mock( '../../utils/get-open-live-interactions', () => ( {
+	getOpenLiveInteractions: () => ( { hasReachedLimit: mockHasReachedLimit } ),
+} ) );
+
+jest.mock( '../use-open-interaction-status-map', () => ( {
+	useOpenInteractionStatusMap: () => ( {} ),
+} ) );
+
+jest.mock( '../../constants', () => ( {
+	getErrorTryAgainLaterMessage: () => ( { content: 'try-again', role: 'bot', type: 'message' } ),
+	getOdieTransferMessages: () => [],
+	getZendeskChatStartedMetaMessage: () => ( {
+		content: 'chat-started',
+		role: 'bot',
+		type: 'message',
+	} ),
+} ) );
+
+const smoochCreateConversation = Smooch.createConversation as jest.Mock;
+
+const notReadyError = () => new TypeError( 'i(...).createConversation is not a function' );
+
+// Returns the props object of the most recent trackEvent call for `name`.
+const lastTrackedProps = ( name: string ) =>
+	mockTrackEvent.mock.calls.filter( ( [ event ] ) => event === name ).at( -1 )?.[ 1 ];
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	jest.useFakeTimers();
+	mockHasReachedLimit = false;
+	mockSubmitUserFields.mockResolvedValue( undefined );
+	// activeInteractionId === interaction.uuid, so updateConversation is skipped.
+	mockAddEventToInteraction.mockResolvedValue( { uuid: 'int-1' } );
+	mockStartNewInteraction.mockResolvedValue( { uuid: 'int-1' } );
+	( useOdieAssistantContext as jest.Mock ).mockReturnValue( {
+		selectedSiteId: 1,
+		selectedSiteURL: 'https://example.com',
+		userFieldMessage: 'help',
+		userFieldFlowName: null,
+		setChat: mockSetChat,
+		chat: {
+			odieId: 'odie-1',
+			conversationId: null,
+			messages: [],
+			wpcomUserId: 99,
+			clientId: 'client-1',
+			provider: 'odie',
+			status: 'loaded',
+		},
+		trackEvent: mockTrackEvent,
+		isChatLoaded: true,
+	} );
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => {
+	it( 'retries the two transient "not ready" errors and succeeds once the SDK is ready', async () => {
+		smoochCreateConversation
+			.mockRejectedValueOnce( notReadyError() )
+			.mockRejectedValueOnce(
+				new Error( 'Must initialize the Web Messenger first using `init()`.' )
+			)
+			.mockResolvedValueOnce( { id: 'conv-1', metadata: {} } );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		const promise = result.current( { createdFrom: 'automatic_escalation' } );
+
+		// Two backoff intervals of 250ms drive the two retries.
+		await jest.advanceTimersByTimeAsync( 250 );
+		await jest.advanceTimersByTimeAsync( 250 );
+
+		await expect( promise ).resolves.toBe( 'conv-1' );
+		expect( smoochCreateConversation ).toHaveBeenCalledTimes( 3 );
+
+		const success = lastTrackedProps( 'new_zendesk_conversation' );
+		expect( success ).toMatchObject( { smooch_attempts: 3, smooch_waited_ms: 500 } );
+	} );
+
+	it( 'succeeds on the first attempt without waiting', async () => {
+		smoochCreateConversation.mockResolvedValueOnce( { id: 'conv-1', metadata: {} } );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		await expect( result.current( { createdFrom: 'automatic_escalation' } ) ).resolves.toBe(
+			'conv-1'
+		);
+
+		expect( smoochCreateConversation ).toHaveBeenCalledTimes( 1 );
+		const success = lastTrackedProps( 'new_zendesk_conversation' );
+		expect( success ).toMatchObject( { smooch_attempts: 1, smooch_waited_ms: 0 } );
+	} );
+
+	it( 'surfaces the error after the 10s deadline if the SDK never becomes ready', async () => {
+		smoochCreateConversation.mockRejectedValue( notReadyError() );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		const promise = result.current( { createdFrom: 'automatic_escalation' } );
+
+		// Past the 10s cap; the loop stops scheduling further retries.
+		await jest.advanceTimersByTimeAsync( 10_500 );
+
+		await expect( promise ).resolves.toBeUndefined();
+
+		const error = lastTrackedProps( 'error_creating_zendesk_conversation' );
+		expect( error ).toBeDefined();
+		// ~40 backoffs of 250ms fit inside the 10s window.
+		expect( error.smooch_attempts ).toBeGreaterThan( 1 );
+		expect( error.smooch_waited_ms ).toBeLessThanOrEqual( 10_000 );
+		// The user is shown the try-again message.
+		expect( mockSetChat ).toHaveBeenCalled();
+	} );
+
+	it( 'does not retry a non-transient error', async () => {
+		smoochCreateConversation.mockRejectedValueOnce( new Error( 'TypeError: Failed to fetch' ) );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		await expect(
+			result.current( { createdFrom: 'automatic_escalation' } )
+		).resolves.toBeUndefined();
+
+		expect( smoochCreateConversation ).toHaveBeenCalledTimes( 1 );
+		const error = lastTrackedProps( 'error_creating_zendesk_conversation' );
+		expect( error ).toMatchObject( { smooch_attempts: 1, smooch_waited_ms: 0 } );
+	} );
+} );

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -178,8 +178,11 @@ export const useCreateZendeskConversation = () => {
 				smoochWaitedMs = Date.now() - smoochWaitStart;
 				break;
 			} catch ( error ) {
-				if ( isSmoochNotReadyError( error ) && Date.now() < smoochReadyDeadline ) {
-					await new Promise( ( resolve ) => setTimeout( resolve, SMOOCH_RETRY_INTERVAL_MS ) );
+				const remainingMs = smoochReadyDeadline - Date.now();
+				if ( isSmoochNotReadyError( error ) && remainingMs > 0 ) {
+					// Cap the sleep to the time left so we never overshoot the deadline.
+					const sleepMs = Math.min( SMOOCH_RETRY_INTERVAL_MS, remainingMs );
+					await new Promise( ( resolve ) => setTimeout( resolve, sleepMs ) );
 					continue;
 				}
 				smoochWaitedMs = Date.now() - smoochWaitStart;

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -165,11 +165,9 @@ export const useCreateZendeskConversation = () => {
 
 		const SMOOCH_READY_TIMEOUT_MS = 10000;
 		const SMOOCH_RETRY_INTERVAL_MS = 250;
-		const smoochWaitStart = Date.now();
-		const smoochReadyDeadline = smoochWaitStart + SMOOCH_READY_TIMEOUT_MS;
+		const smoochReadyDeadline = Date.now() + SMOOCH_READY_TIMEOUT_MS;
 
-		// eslint-disable-next-line no-constant-condition
-		while ( true ) {
+		for (;;) {
 			try {
 				smoochAttempts++;
 				conversation = await Smooch.createConversation( {
@@ -179,17 +177,17 @@ export const useCreateZendeskConversation = () => {
 						...( chatId ? { odieChatId: chatId } : {} ),
 					},
 				} );
-				smoochWaitedMs = Date.now() - smoochWaitStart;
 				break;
 			} catch ( error ) {
 				const remainingMs = smoochReadyDeadline - Date.now();
 				if ( isSmoochNotReadyError( error ) && remainingMs > 0 ) {
 					// Cap the sleep to the time left so we never overshoot the deadline.
 					const sleepMs = Math.min( SMOOCH_RETRY_INTERVAL_MS, remainingMs );
+					// Only the backoff sleeps count as wait time, not the SDK call itself.
+					smoochWaitedMs += sleepMs;
 					await new Promise( ( resolve ) => setTimeout( resolve, sleepMs ) );
 					continue;
 				}
-				smoochWaitedMs = Date.now() - smoochWaitStart;
 				handleErrorCreatingZendeskConversation( 'error_creating_zendesk_conversation', error );
 				return;
 			}

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -102,9 +102,11 @@ export const useCreateZendeskConversation = () => {
 		const previousProvider = chat.provider;
 		const previousConversationId = chat.conversationId;
 
-		// Time spent waiting for the Smooch SDK to become ready before the
-		// conversation could be created (see the retry loop below).
+		// Time spent waiting for the Smooch SDK to become ready, and how many
+		// createConversation attempts it took (see the retry loop below).
+		// attempts > 1 means the retry rescued an otherwise-failed escalation.
 		let smoochWaitedMs = 0;
+		let smoochAttempts = 0;
 
 		const handleErrorCreatingZendeskConversation = ( errorType: string, error?: unknown ) => {
 			trackEvent( errorType, {
@@ -114,6 +116,7 @@ export const useCreateZendeskConversation = () => {
 				active_interaction_id: activeInteractionId || null,
 				is_chat_loaded: isChatLoaded,
 				smooch_waited_ms: smoochWaitedMs,
+				smooch_attempts: smoochAttempts,
 			} );
 
 			setChat( {
@@ -168,6 +171,7 @@ export const useCreateZendeskConversation = () => {
 		// eslint-disable-next-line no-constant-condition
 		while ( true ) {
 			try {
+				smoochAttempts++;
 				conversation = await Smooch.createConversation( {
 					metadata: {
 						createdAt: Date.now(),
@@ -251,6 +255,7 @@ export const useCreateZendeskConversation = () => {
 				messaging_site_id: selectedSiteId || null,
 				messaging_url: selectedSiteURL || null,
 				smooch_waited_ms: smoochWaitedMs,
+				smooch_attempts: smoochAttempts,
 			} );
 
 			// If the interaction id has changed, update the URL.

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -35,6 +35,18 @@ export const useCreateZendeskConversation = () => {
 	const getErrorMessage = ( error: unknown ) =>
 		error instanceof Error ? error.message : error?.toString?.() ?? 'Unknown error';
 
+	// The Smooch (Zendesk Web Messenger) SDK is initialized asynchronously elsewhere.
+	// When an escalation fires before init completes, `Smooch.createConversation` is
+	// either missing ("createConversation is not a function") or throws because the
+	// messenger isn't initialized yet. Both are transient — retry until it's ready.
+	const isSmoochNotReadyError = ( error: unknown ) => {
+		const message = getErrorMessage( error );
+		return (
+			message.includes( 'createConversation is not a function' ) ||
+			message.includes( 'Must initialize the Web Messenger' )
+		);
+	};
+
 	const createConversation = async ( {
 		createdFrom = '',
 		isFromError = false,
@@ -90,6 +102,10 @@ export const useCreateZendeskConversation = () => {
 		const previousProvider = chat.provider;
 		const previousConversationId = chat.conversationId;
 
+		// Time spent waiting for the Smooch SDK to become ready before the
+		// conversation could be created (see the retry loop below).
+		let smoochWaitedMs = 0;
+
 		const handleErrorCreatingZendeskConversation = ( errorType: string, error?: unknown ) => {
 			trackEvent( errorType, {
 				error_message: getErrorMessage( error ),
@@ -97,6 +113,7 @@ export const useCreateZendeskConversation = () => {
 				escalation_on_second_attempt: escalationOnSecondAttempt,
 				active_interaction_id: activeInteractionId || null,
 				is_chat_loaded: isChatLoaded,
+				smooch_waited_ms: smoochWaitedMs,
 			} );
 
 			setChat( {
@@ -143,17 +160,32 @@ export const useCreateZendeskConversation = () => {
 		let conversation: ZendeskConversation | null = null;
 		let interaction = null;
 
-		try {
-			conversation = await Smooch.createConversation( {
-				metadata: {
-					createdAt: Date.now(),
-					...( activeInteractionId ? { supportInteractionId: activeInteractionId } : {} ),
-					...( chatId ? { odieChatId: chatId } : {} ),
-				},
-			} );
-		} catch ( error ) {
-			handleErrorCreatingZendeskConversation( 'error_creating_zendesk_conversation', error );
-			return;
+		const SMOOCH_READY_TIMEOUT_MS = 10000;
+		const SMOOCH_RETRY_INTERVAL_MS = 250;
+		const smoochWaitStart = Date.now();
+		const smoochReadyDeadline = smoochWaitStart + SMOOCH_READY_TIMEOUT_MS;
+
+		// eslint-disable-next-line no-constant-condition
+		while ( true ) {
+			try {
+				conversation = await Smooch.createConversation( {
+					metadata: {
+						createdAt: Date.now(),
+						...( activeInteractionId ? { supportInteractionId: activeInteractionId } : {} ),
+						...( chatId ? { odieChatId: chatId } : {} ),
+					},
+				} );
+				smoochWaitedMs = Date.now() - smoochWaitStart;
+				break;
+			} catch ( error ) {
+				if ( isSmoochNotReadyError( error ) && Date.now() < smoochReadyDeadline ) {
+					await new Promise( ( resolve ) => setTimeout( resolve, SMOOCH_RETRY_INTERVAL_MS ) );
+					continue;
+				}
+				smoochWaitedMs = Date.now() - smoochWaitStart;
+				handleErrorCreatingZendeskConversation( 'error_creating_zendesk_conversation', error );
+				return;
+			}
 		}
 
 		if ( ! conversation ) {
@@ -215,6 +247,7 @@ export const useCreateZendeskConversation = () => {
 				created_from: createdFrom,
 				messaging_site_id: selectedSiteId || null,
 				messaging_url: selectedSiteURL || null,
+				smooch_waited_ms: smoochWaitedMs,
 			} );
 
 			// If the interaction id has changed, update the URL.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-456/help-center-error-on-creating-new-chat

## Proposed Changes

**Retry Zendesk conversation creation until the Smooch SDK is ready, instead of failing the first call.**

- Wrap `Smooch.createConversation()` in a bounded retry loop: 250ms interval, 10s cap.
- Retry **only** on the two transient not-ready errors (`createConversation is not a function`, `Must initialize the Web Messenger`); any other error — or a timeout — surfaces the existing try-again message, unchanged.
- Add a `smooch_waited_ms` Tracks prop to the success (`new_zendesk_conversation`) and error events, to measure how long the retry waited and whether it rescued or timed out.

## Why are these changes being made?

When a user asks to talk to a human, the Help Center escalates by opening a Zendesk live chat. That handoff sometimes fires before the Zendesk messaging SDK has finished loading, so the call to start the chat hits a method that isn’t there yet and throws.

**Over the last 30 days this broke ~1,260 escalations (~40/day),** nearly all from the automatic AI→human handoff ([DOTSUP-456](https://linear.app/a8c/issue/DOTSUP-456/help-center-error-on-creating-new-chat)). Every one is a person who asked for support and silently got nothing. Because the SDK is only a beat away from ready, briefly waiting and retrying turns those failures into a successful chat.

## Testing Instructions

1. Run `yarn start`.
2. Open the Help Center and start an Odie chat.
3. Ask to talk to a human so it escalates to live chat (automatic escalation).
4. Confirm the Zendesk chat opens and no error/try-again message appears.
5. In the Tracks/console events, confirm `new_zendesk_conversation` fires with a `smooch_waited_ms` prop.
