### PR TITLE
Checkout: Localize the start/end/renewal dates in terms and conditions

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -1,4 +1,9 @@
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import {
+	localizeUrl,
+	useIsEnglishLocale,
+	useLocale,
+	getShortDateString,
+} from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
 	TermsOfServiceRecord,
@@ -47,19 +52,12 @@ export default function AdditionalTermsOfServiceInCart() {
 	);
 }
 
-export function formatDate( isoDate: string ): string {
-	// This somewhat mimics `moment.format('ll')` (used here formerly) without
-	// needing the deprecated `moment` package.
+export function formatDate( isoDate: string, locale: string ): string {
 	// Parse only the date portion (YYYY-MM-DD) and construct via the local-time
 	// Date constructor to avoid the UTC-midnight-to-local-time shift that causes
 	// dates to appear one day off for users behind UTC.
 	const [ year, month, day ] = isoDate.slice( 0, 10 ).split( '-' ).map( Number );
-	return new Date( year, month - 1, day ).toLocaleDateString( 'en-US', {
-		weekday: undefined,
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-	} );
+	return getShortDateString( new Date( year, month - 1, day ).getTime(), locale );
 }
 
 function MessageForTermsOfServiceRecordUnknown( {
@@ -73,6 +71,7 @@ function MessageForTermsOfServiceRecordUnknown( {
 } ): ReactNode {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
+	const locale = useLocale();
 	const args = termsOfServiceRecord.args;
 	if ( ! args ) {
 		return null;
@@ -87,7 +86,7 @@ function MessageForTermsOfServiceRecordUnknown( {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
-	const startDate = formatDate( args.subscription_start_date );
+	const startDate = formatDate( args.subscription_start_date, locale );
 	const maybeProratedRegularPrice = formatCurrency(
 		args.maybe_prorated_regular_renewal_price_integer,
 		currency,
@@ -99,12 +98,13 @@ function MessageForTermsOfServiceRecordUnknown( {
 	const manageSubscriptionLink = `/purchases/subscriptions/${ siteSlug }`;
 
 	if ( doesTermsOfServiceRecordHaveDates( args ) ) {
-		const promotionEndDate = formatDate( args.subscription_end_of_promotion_date );
-		const subscriptionEndDate = formatDate( args.subscription_expiry_date );
+		const promotionEndDate = formatDate( args.subscription_end_of_promotion_date, locale );
+		const subscriptionEndDate = formatDate( args.subscription_expiry_date, locale );
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
-		const renewalDate = formatDate( args.subscription_auto_renew_date );
+		const renewalDate = formatDate( args.subscription_auto_renew_date, locale );
 		const proratedRenewalDate = formatDate(
-			args.subscription_maybe_prorated_regular_auto_renew_date
+			args.subscription_maybe_prorated_regular_auto_renew_date,
+			locale
 		);
 
 		const termLengthText = translate(

--- a/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
+++ b/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
@@ -11,7 +11,11 @@ describe( 'formatDate', () => {
 	} );
 
 	afterAll( () => {
-		process.env.TZ = originalTZ;
+		if ( originalTZ === undefined ) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = originalTZ;
+		}
 	} );
 
 	it( 'formats a bare date string to the correct calendar date', () => {

--- a/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
+++ b/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
@@ -33,6 +33,6 @@ describe( 'formatDate', () => {
 	} );
 
 	it( 'respects the locale when formatting', () => {
-		expect( formatDate( '2026-06-17', 'fr' ) ).toBe( '17 juin 2027' );
+		expect( formatDate( '2026-06-17', 'fr' ) ).toBe( '17 juin 2026' );
 	} );
 } );

--- a/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
+++ b/client/my-sites/checkout/src/components/test/additional-terms-of-service-in-cart.test.ts
@@ -11,28 +11,28 @@ describe( 'formatDate', () => {
 	} );
 
 	afterAll( () => {
-		if ( originalTZ === undefined ) {
-			delete process.env.TZ;
-		} else {
-			process.env.TZ = originalTZ;
-		}
+		process.env.TZ = originalTZ;
 	} );
 
 	it( 'formats a bare date string to the correct calendar date', () => {
-		expect( formatDate( '2026-06-17' ) ).toBe( 'Jun 17, 2026' );
+		expect( formatDate( '2026-06-17', 'en' ) ).toBe( 'Jun 17, 2026' );
 	} );
 
 	it( 'formats a date at the start of a month correctly', () => {
-		expect( formatDate( '2026-01-01' ) ).toBe( 'Jan 1, 2026' );
+		expect( formatDate( '2026-01-01', 'en-US' ) ).toBe( 'Jan 1, 2026' );
 	} );
 
 	it( 'formats a date at the end of a month correctly', () => {
-		expect( formatDate( '2026-12-31' ) ).toBe( 'Dec 31, 2026' );
+		expect( formatDate( '2026-12-31', 'en' ) ).toBe( 'Dec 31, 2026' );
 	} );
 
 	it( 'does not shift the date when the string includes a UTC midnight timestamp', () => {
 		// API responses may include a time component; UTC midnight is the worst
 		// case for UTC- timezones.
-		expect( formatDate( '2026-06-17T00:00:00.000Z' ) ).toBe( 'Jun 17, 2026' );
+		expect( formatDate( '2026-06-17T00:00:00.000Z', 'en' ) ).toBe( 'Jun 17, 2026' );
+	} );
+
+	it( 'respects the locale when formatting', () => {
+		expect( formatDate( '2026-06-17', 'fr' ) ).toBe( '17 juin 2027' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17653

## Proposed Changes

* Localize the dates to user language.

**Before**
<img width="537" height="83" alt="Screenshot 2026-06-17 at 15 42 56" src="https://github.com/user-attachments/assets/f97b7269-c85b-4c72-bda4-1b4108a4fa43" />

**After**
<img width="537" height="83" alt="Screenshot 2026-06-17 at 15 43 07" src="https://github.com/user-attachments/assets/4abbd6ce-1ac2-4dc3-857b-d7e49f7cf02b" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The start/end/renewal dates in terms and conditions popup are using the US English format by default, which results in a bad UX for non-US-English users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-English locale, add a plan to the cart, navigate to checkout, click on 'Read more' link and confirm that the dates are using the locale format.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
