### PR TITLE
A4A Amplify: Dashboard reports table (read-only)

### DIFF
--- a/client/dashboard/agency/amplify/reports/fields.tsx
+++ b/client/dashboard/agency/amplify/reports/fields.tsx
@@ -1,0 +1,86 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import { MODE_LABELS, STATUS_LABELS } from './types';
+import type { AmplifyReportRow, AmplifyRowStatus } from './types';
+import type { Field, Operator } from '@wordpress/dataviews';
+
+function scoreLabel( row: AmplifyReportRow ): string {
+	if ( row.status !== 'completed' || ! row.score ) {
+		return '—';
+	}
+	const parts: string[] = [];
+	if ( row.score.human !== null ) {
+		parts.push( `${ __( 'Human' ) } ${ row.score.human }` );
+	}
+	if ( row.score.ai !== null ) {
+		parts.push( `${ __( 'AI' ) } ${ row.score.ai }` );
+	}
+	return parts.length ? parts.join( ' · ' ) : '—';
+}
+
+export function useReportFields(): Field< AmplifyReportRow >[] {
+	return [
+		{
+			id: 'site',
+			label: __( 'Site' ),
+			enableHiding: false,
+			enableSorting: true,
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => `${ item.agencyName ?? '' } ${ item.url }`.trim(),
+			render: ( { item } ) => (
+				<VStack spacing={ 0 }>
+					{ item.agencyName && <Text weight={ 500 }>{ item.agencyName }</Text> }
+					<Text variant="muted" size={ 12 }>
+						{ item.url }
+					</Text>
+				</VStack>
+			),
+		},
+		{
+			id: 'mode',
+			label: __( 'Analysis type' ),
+			enableSorting: true,
+			elements: ( Object.keys( MODE_LABELS ) as Array< keyof typeof MODE_LABELS > ).map(
+				( value ) => ( { value, label: MODE_LABELS[ value ] } )
+			),
+			filterBy: { operators: [ 'isAny' as Operator ] },
+			getValue: ( { item } ) => item.mode,
+			render: ( { item } ) => <Text>{ MODE_LABELS[ item.mode ] }</Text>,
+		},
+		{
+			id: 'status',
+			label: __( 'Status' ),
+			enableSorting: true,
+			elements: ( Object.keys( STATUS_LABELS ) as AmplifyRowStatus[] ).map( ( value ) => ( {
+				value,
+				label: STATUS_LABELS[ value ],
+			} ) ),
+			filterBy: { operators: [ 'isAny' as Operator ] },
+			getValue: ( { item } ) => item.status,
+			render: ( { item } ) => (
+				<Text>
+					{ item.status === 'failed' && item.failureReason
+						? item.failureReason
+						: STATUS_LABELS[ item.status ] }
+				</Text>
+			),
+		},
+		{
+			id: 'score',
+			label: __( 'Scores' ),
+			enableSorting: false,
+			enableGlobalSearch: false,
+			getValue: ( { item } ) => scoreLabel( item ),
+			render: ( { item } ) => <Text>{ scoreLabel( item ) }</Text>,
+		},
+		{
+			id: 'timestamp',
+			label: __( 'Date' ),
+			enableSorting: true,
+			enableGlobalSearch: false,
+			getValue: ( { item } ) => item.timestamp,
+			render: ( { item } ) => <Text>{ dateI18n( 'F j, Y, g:i a', item.timestamp ) }</Text>,
+		},
+	];
+}

--- a/client/dashboard/agency/amplify/reports/index.tsx
+++ b/client/dashboard/agency/amplify/reports/index.tsx
@@ -1,0 +1,91 @@
+import { activeAgencyQuery, amplifyReportsQuery, amplifyJobsQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+import { DataViews, DataViewsCard, DataViewsEmptyStateLayout } from '../../../components/dataviews';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { useReportFields } from './fields';
+import { toRows } from './to-rows';
+import { DEFAULT_LAYOUTS, DEFAULT_VIEW } from './views';
+import type { AmplifyReportRow } from './types';
+import type { Action, View } from '@wordpress/dataviews';
+
+function AmplifyReportsList( { agencyId }: { agencyId: number } ) {
+	const { recordTracksEvent } = useAnalytics();
+	const fields = useReportFields();
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	const { data: reports } = useSuspenseQuery( amplifyReportsQuery( agencyId ) );
+	const { data: jobs } = useSuspenseQuery( amplifyJobsQuery( agencyId ) );
+
+	const rows = toRows( reports, jobs );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( rows, view, fields );
+
+	const actions: Action< AmplifyReportRow >[] = [
+		{
+			id: 'download-pdf',
+			label: __( 'Download PDF' ),
+			isPrimary: true,
+			isEligible: ( item ) => item.status === 'completed' && !! item.pdfUrl,
+			callback: ( items ) => {
+				const item = items[ 0 ];
+				if ( ! item.pdfUrl ) {
+					return;
+				}
+				recordTracksEvent( 'calypso_a4a_amplify_report_download', {
+					report_id: item.id,
+					site_url: item.url,
+					analysis_type: item.mode,
+				} );
+				window.open( item.pdfUrl, '_blank', 'noreferrer' );
+			},
+		},
+	];
+
+	const hasRows = rows.length > 0;
+
+	return (
+		<PageLayout header={ <PageHeader title={ __( 'Amplify reports' ) } /> }>
+			{ ! hasRows ? (
+				<DataViewsEmptyStateLayout
+					title={ __( 'No reports yet' ) }
+					description={ __( 'Run an analysis from the Amplify overview to see reports here.' ) }
+				/>
+			) : (
+				<DataViewsCard>
+					<DataViews< AmplifyReportRow >
+						data={ filteredData || [] }
+						fields={ fields }
+						view={ view }
+						onChangeView={ setView }
+						actions={ actions }
+						search
+						paginationInfo={ paginationInfo }
+						getItemId={ ( item ) => item.id }
+						defaultLayouts={ DEFAULT_LAYOUTS }
+						empty={
+							<DataViewsEmptyStateLayout
+								title={ __( 'No reports match your search' ) }
+								description={ __( 'Try a different search or filter.' ) }
+								isBorderless
+							/>
+						}
+					/>
+				</DataViewsCard>
+			) }
+		</PageLayout>
+	);
+}
+
+export default function AgencyAmplifyReports() {
+	const { data: agency } = useQuery( activeAgencyQuery() );
+
+	if ( ! agency ) {
+		return <PageLayout header={ <PageHeader title={ __( 'Amplify reports' ) } /> } />;
+	}
+
+	return <AmplifyReportsList agencyId={ agency.id } />;
+}

--- a/client/dashboard/agency/amplify/reports/to-rows.ts
+++ b/client/dashboard/agency/amplify/reports/to-rows.ts
@@ -1,0 +1,35 @@
+import type { AmplifyReportRow } from './types';
+import type { AmplifyReport, AmplifyJob } from '@automattic/api-core';
+
+/**
+ * Combine finished reports and in-flight/failed jobs into a single row list.
+ * Jobs (pending/failed) and reports (completed) are disjoint sets server-side,
+ * so no de-duplication is needed.
+ */
+export function toRows( reports: AmplifyReport[], jobs: AmplifyJob[] ): AmplifyReportRow[] {
+	const reportRows: AmplifyReportRow[] = reports.map( ( report ) => ( {
+		id: report.id,
+		url: report.url,
+		agencyName: report.agency_name,
+		mode: report.mode,
+		timestamp: report.timestamp,
+		status: 'completed',
+		score: report.score,
+		pdfUrl: report.pdf_url,
+		failureReason: null,
+	} ) );
+
+	const jobRows: AmplifyReportRow[] = jobs.map( ( job ) => ( {
+		id: job.id,
+		url: job.url,
+		agencyName: null,
+		mode: job.mode,
+		timestamp: job.timestamp,
+		status: job.status,
+		score: null,
+		pdfUrl: null,
+		failureReason: job.failure_reason ?? null,
+	} ) );
+
+	return [ ...jobRows, ...reportRows ];
+}

--- a/client/dashboard/agency/amplify/reports/types.ts
+++ b/client/dashboard/agency/amplify/reports/types.ts
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+import type { AmplifyMode, AmplifyScore } from '@automattic/api-core';
+
+export type AmplifyRowStatus = 'completed' | 'pending' | 'failed';
+
+/** One table row, normalized from a finished report or an in-flight/failed job. */
+export interface AmplifyReportRow {
+	id: string;
+	url: string;
+	agencyName: string | null;
+	mode: AmplifyMode;
+	timestamp: string;
+	status: AmplifyRowStatus;
+	score: AmplifyScore | null;
+	pdfUrl: string | null;
+	failureReason: string | null;
+}
+
+export const MODE_LABELS: Record< AmplifyMode, string > = {
+	human: __( 'Human' ),
+	ai: __( 'AI' ),
+	fullanalysis: __( 'Full' ),
+};
+
+export const STATUS_LABELS: Record< AmplifyRowStatus, string > = {
+	completed: __( 'Completed' ),
+	pending: __( 'In progress' ),
+	failed: __( 'Failed' ),
+};

--- a/client/dashboard/agency/amplify/reports/views.ts
+++ b/client/dashboard/agency/amplify/reports/views.ts
@@ -1,0 +1,14 @@
+import type { View } from '@wordpress/dataviews';
+
+export const DEFAULT_VIEW: View = {
+	type: 'table',
+	layout: {},
+	sort: {
+		field: 'timestamp',
+		direction: 'desc',
+	},
+	perPage: 10,
+	fields: [ 'site', 'mode', 'status', 'score', 'timestamp' ],
+};
+
+export const DEFAULT_LAYOUTS = { table: {} };

--- a/client/dashboard/app-a4a/section.ts
+++ b/client/dashboard/app-a4a/section.ts
@@ -10,6 +10,7 @@ export const A4A_DASHBOARD_SECTION_PATHS = [
 	'/overview',
 	'/agency/tiers',
 	'/agency/amplify',
+	'/agency/amplify/reports',
 	'/client',
 	'/client/subscriptions',
 ];

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -1,4 +1,10 @@
-import { activeAgencyQuery, agencyQuery, queryClient } from '@automattic/api-queries';
+import {
+	activeAgencyQuery,
+	agencyQuery,
+	amplifyReportsQuery,
+	amplifyJobsQuery,
+	queryClient,
+} from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { redirectAsNotAllowed } from './redirect';
@@ -79,6 +85,37 @@ const agencyAmplifyRoute = createRoute( {
 	)
 );
 
+// `/agency/amplify/reports` – Amplify reports table
+const agencyAmplifyReportsRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Amplify reports' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyRoute,
+	path: 'agency/amplify/reports',
+	loader: async () => {
+		const agency = await queryClient.ensureQueryData( activeAgencyQuery() );
+		if ( agency ) {
+			await queryClient.ensureQueryData( amplifyReportsQuery( agency.id ) );
+			queryClient.prefetchQuery( amplifyJobsQuery( agency.id ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../agency/amplify/reports' ).then( ( d ) =>
+		createLazyRoute( 'agency-amplify-reports' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
-	agencyRoute.addChildren( [ agencyOverviewRoute, agencyTiersRoute, agencyAmplifyRoute ] ),
+	agencyRoute.addChildren( [
+		agencyOverviewRoute,
+		agencyTiersRoute,
+		agencyAmplifyRoute,
+		agencyAmplifyReportsRoute,
+	] ),
 ];


### PR DESCRIPTION
Part of A4A-XXXX

Based on #111759 (Amplify overview foundation) → #111751 (data layer) → #111342 (Tiers).

## Proposed Changes

Adds a read-only Amplify reports screen at `/agency/amplify/reports`, consuming the data layer from #111751. Finished reports and in-flight/failed runs are shown together in a DataViews table. The submission flow (starting an analysis) is a separate follow-up.

* **`client/dashboard/agency/amplify/reports/types.ts`**, **`to-rows.ts`** — a normalized `AmplifyReportRow` model and a helper that merges `amplifyReportsQuery` results (`completed`) with `amplifyJobsQuery` results (`pending`/`failed`) into one row list.
* **`client/dashboard/agency/amplify/reports/fields.tsx`**, **`views.ts`** — DataViews fields (Site, Analysis type, Status, Scores, Date) with type/status filters and global search, and a default view sorted newest-first.
* **`client/dashboard/agency/amplify/reports/index.tsx`** — the screen: loads reports + jobs, renders the dashboard `DataViews` table with a **Download PDF** action on completed rows, an empty state, and failure reasons on failed rows. In-flight runs poll automatically (the jobs query refetches every 15s while any run is pending).
* **`client/dashboard/app/router/agency.tsx`** — registers the `/agency/amplify/reports` route with a loader that prefetches reports + jobs.
* **`client/dashboard/app-a4a/section.ts`** — serves `/agency/amplify/reports` from the A4A dashboard section.

The **Amplify a site** CTA on the overview screen (#111759) now resolves to this page.

## Why are these changes being made?

Splitting the reports view (read) from the analysis-submission flow (write) keeps each PR small and reviewable. This screen reuses the agency-scoped data layer so both the Dashboard and, later, a8c-for-agencies can share one source of truth. Archive is intentionally not carried over — the API has no archive concept.

## Testing Instructions

1. Run `yarn start-dashboard` and open `my.a4a.localhost:3000/agency/amplify` logged in as an agency user (`a4a_administrator`/`a4a_developer`).
2. Click **Amplify a site** → it lands on `/agency/amplify/reports`.
3. Confirm the table lists completed reports with Site / Analysis type / Status / Scores / Date, and that **Download PDF** on a completed row opens the report PDF.
4. Confirm global search and the Analysis type / Status filters work, and the default sort is newest-first.
5. If a run is in progress, confirm it shows status **In progress** and the jobs request re-polls every ~15s until it’s no longer pending; a failed run shows its failure reason.
6. Confirm the empty state renders when there are no reports or jobs, and that there are no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
