### PR TITLE
A4A Amplify: analysis submission flow

### DIFF
--- a/client/dashboard/agency/amplify/reports/amplify-analysis-modal.tsx
+++ b/client/dashboard/agency/amplify/reports/amplify-analysis-modal.tsx
@@ -1,0 +1,143 @@
+import { submitAmplifyAnalysisMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	Modal,
+	TextControl,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+import { ButtonStack } from '../../../components/button-stack';
+import { ANALYSIS_TYPES } from './constants';
+import { normalizeUrl } from './validate-url';
+import type { AmplifyMode } from '@automattic/api-core';
+
+export default function AmplifyAnalysisModal( {
+	agencyId,
+	onClose,
+}: {
+	agencyId: number;
+	onClose: () => void;
+} ) {
+	const { recordTracksEvent } = useAnalytics();
+	const mutation = useMutation( submitAmplifyAnalysisMutation( agencyId ) );
+	const [ stage, setStage ] = useState< 'site' | 'type' >( 'site' );
+	const [ url, setUrl ] = useState( '' );
+	const [ normalizedUrl, setNormalizedUrl ] = useState( '' );
+	const [ urlError, setUrlError ] = useState( '' );
+
+	const handleNext = () => {
+		const normalized = normalizeUrl( url );
+		if ( ! normalized ) {
+			setUrlError(
+				__( 'That doesn’t look like a valid URL. Try something like https://example.com.' )
+			);
+			return;
+		}
+		setUrlError( '' );
+		setNormalizedUrl( normalized );
+		setStage( 'type' );
+		recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
+			site_url: normalized,
+			entry_point: 'reports_amplify_button',
+		} );
+	};
+
+	const handleSelectType = ( mode: AmplifyMode ) => {
+		recordTracksEvent( 'calypso_a4a_amplify_analysis_start', {
+			analysis_type: mode,
+			site_url: normalizedUrl,
+		} );
+		mutation.mutate( { url: normalizedUrl, mode } );
+	};
+
+	return (
+		<Modal title={ __( 'Amplify a site' ) } onRequestClose={ onClose }>
+			{ stage === 'site' && (
+				<VStack spacing={ 4 }>
+					<TextControl
+						label={ __( 'Site URL' ) }
+						value={ url }
+						onChange={ setUrl }
+						placeholder="https://yourgroovydomain.com"
+						help={ urlError || undefined }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<ButtonStack justify="flex-end">
+						<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
+						<Button variant="primary" onClick={ handleNext }>
+							{ __( 'Next' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			) }
+
+			{ stage === 'type' && mutation.isSuccess && (
+				<VStack spacing={ 4 }>
+					<Heading level={ 3 }>{ __( 'Analysis in progress' ) }</Heading>
+					<Text>
+						{ sprintf(
+							/* translators: %s is the analyzed site URL. */
+							__(
+								'Running your analysis for %s. This may take 10 to 20 minutes depending on the size of your site.'
+							),
+							normalizedUrl
+						) }
+					</Text>
+					<Text variant="muted">
+						{ __(
+							'You can navigate away — your report will appear in this list when it’s ready.'
+						) }
+					</Text>
+					<ButtonStack justify="flex-end">
+						<Button variant="primary" onClick={ onClose }>
+							{ __( 'View reports' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			) }
+
+			{ stage === 'type' && mutation.isError && (
+				<VStack spacing={ 4 }>
+					<Text>
+						{ __( 'We were unable to start your analysis. Please try again in a moment.' ) }
+					</Text>
+					<ButtonStack justify="flex-end">
+						<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
+						<Button variant="primary" onClick={ () => mutation.reset() }>
+							{ __( 'Try again' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			) }
+
+			{ stage === 'type' && ! mutation.isSuccess && ! mutation.isError && (
+				<VStack spacing={ 3 }>
+					<Text>{ __( 'Choose an analysis type.' ) }</Text>
+					{ ANALYSIS_TYPES.map( ( type ) => (
+						<Button
+							key={ type.mode }
+							variant="secondary"
+							onClick={ () => handleSelectType( type.mode ) }
+							disabled={ mutation.isPending }
+							isBusy={ mutation.isPending }
+							__next40pxDefaultSize
+						>
+							<VStack spacing={ 1 }>
+								<Text weight={ 500 }>{ type.title }</Text>
+								<Text variant="muted" size={ 12 }>
+									{ type.description }
+								</Text>
+							</VStack>
+						</Button>
+					) ) }
+				</VStack>
+			) }
+		</Modal>
+	);
+}

--- a/client/dashboard/agency/amplify/reports/constants.ts
+++ b/client/dashboard/agency/amplify/reports/constants.ts
@@ -1,0 +1,28 @@
+import { __ } from '@wordpress/i18n';
+import type { AmplifyMode } from '@automattic/api-core';
+
+export interface AnalysisTypeOption {
+	mode: AmplifyMode;
+	title: string;
+	description: string;
+}
+
+export const ANALYSIS_TYPES: AnalysisTypeOption[] = [
+	{
+		mode: 'human',
+		title: __( 'Human-centric analysis' ),
+		description: __( 'Score how potential clients perceive your site when they land on it.' ),
+	},
+	{
+		mode: 'ai',
+		title: __( 'AI analysis' ),
+		description: __(
+			'Score how AI tools like ChatGPT, Gemini, and Perplexity read and rank your site.'
+		),
+	},
+	{
+		mode: 'fullanalysis',
+		title: __( 'Full analysis' ),
+		description: __( 'Run both lenses for a complete picture and prompt-ready findings.' ),
+	},
+];

--- a/client/dashboard/agency/amplify/reports/index.tsx
+++ b/client/dashboard/agency/amplify/reports/index.tsx
@@ -1,5 +1,6 @@
 import { activeAgencyQuery, amplifyReportsQuery, amplifyJobsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -7,6 +8,7 @@ import { useAnalytics } from '../../../app/analytics';
 import { DataViews, DataViewsCard, DataViewsEmptyStateLayout } from '../../../components/dataviews';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import AmplifyAnalysisModal from './amplify-analysis-modal';
 import { useReportFields } from './fields';
 import { toRows } from './to-rows';
 import { DEFAULT_LAYOUTS, DEFAULT_VIEW } from './views';
@@ -17,6 +19,7 @@ function AmplifyReportsList( { agencyId }: { agencyId: number } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const fields = useReportFields();
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ isFlowOpen, setIsFlowOpen ] = useState( false );
 
 	const { data: reports } = useSuspenseQuery( amplifyReportsQuery( agencyId ) );
 	const { data: jobs } = useSuspenseQuery( amplifyJobsQuery( agencyId ) );
@@ -47,13 +50,23 @@ function AmplifyReportsList( { agencyId }: { agencyId: number } ) {
 
 	const hasRows = rows.length > 0;
 
+	const amplifyButton = (
+		<Button variant="primary" onClick={ () => setIsFlowOpen( true ) }>
+			{ __( 'Amplify a site' ) }
+		</Button>
+	);
+
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Amplify reports' ) } /> }>
+		<PageLayout
+			header={ <PageHeader title={ __( 'Amplify reports' ) } actions={ amplifyButton } /> }
+		>
 			{ ! hasRows ? (
 				<DataViewsEmptyStateLayout
 					title={ __( 'No reports yet' ) }
-					description={ __( 'Run an analysis from the Amplify overview to see reports here.' ) }
-				/>
+					description={ __( 'Run your first analysis to see reports here.' ) }
+				>
+					{ amplifyButton }
+				</DataViewsEmptyStateLayout>
 			) : (
 				<DataViewsCard>
 					<DataViews< AmplifyReportRow >
@@ -75,6 +88,9 @@ function AmplifyReportsList( { agencyId }: { agencyId: number } ) {
 						}
 					/>
 				</DataViewsCard>
+			) }
+			{ isFlowOpen && (
+				<AmplifyAnalysisModal agencyId={ agencyId } onClose={ () => setIsFlowOpen( false ) } />
 			) }
 		</PageLayout>
 	);

--- a/client/dashboard/agency/amplify/reports/validate-url.ts
+++ b/client/dashboard/agency/amplify/reports/validate-url.ts
@@ -1,0 +1,34 @@
+const MAX_URL_LENGTH = 2048;
+
+/**
+ * Normalize user input into a valid http(s) URL, or return null if it can't be.
+ * Prepends https:// when no scheme is present; rejects non-http(s) schemes,
+ * hostnames without a dot (except localhost), and over-long URLs.
+ */
+export function normalizeUrl( raw: string ): string | null {
+	const trimmed = raw.trim();
+	if ( ! trimmed || trimmed.length > MAX_URL_LENGTH ) {
+		return null;
+	}
+
+	const withScheme = /^https?:\/\//i.test( trimmed ) ? trimmed : `https://${ trimmed }`;
+
+	let parsed: URL;
+	try {
+		parsed = new URL( withScheme );
+	} catch {
+		return null;
+	}
+
+	if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
+		return null;
+	}
+	if ( ! parsed.hostname.includes( '.' ) && parsed.hostname !== 'localhost' ) {
+		return null;
+	}
+	if ( parsed.href.length > MAX_URL_LENGTH ) {
+		return null;
+	}
+
+	return parsed.href;
+}


### PR DESCRIPTION
Part of A4A-XXXX

Based on #111762 (Amplify reports table) → #111759 (overview) → #111751 (data layer) → #111342 (Tiers).

## Proposed Changes

Adds the “Amplify a site” submission flow to the reports screen, so agency users can start an analysis. Submission goes through the `submitAmplifyAnalysisMutation` from #111751; the new run shows up as a pending row (the mutation invalidates the jobs query) and polls to completion. Manual URL entry only — the connected-sites picker is a separate follow-up.

* **`client/dashboard/agency/amplify/reports/constants.ts`** — the three analysis types (`human` / `ai` / `fullanalysis`) with titles and descriptions.
* **`client/dashboard/agency/amplify/reports/validate-url.ts`** — `normalizeUrl()`: trims, prepends `https://` when no scheme, rejects non-http(s) schemes and hostnames without a dot (except `localhost`), and enforces the API’s 2048-char limit.
* **`client/dashboard/agency/amplify/reports/amplify-analysis-modal.tsx`** — a staged `Modal`: enter URL → choose analysis type → submit, with in-progress and error states driven by the mutation. Records `calypso_a4a_amplify_audit_open` and `calypso_a4a_amplify_analysis_start`.
* **`client/dashboard/agency/amplify/reports/index.tsx`** — adds the **Amplify a site** button to the reports header and empty state, and mounts the modal.

## Why are these changes being made?

This completes the read/write split: #111762 added the reports table (read), and this PR adds the submission flow (write) on top of the shared data layer. Keeping them separate kept each PR small and reviewable. Submitting reuses the agency-scoped mutation, so the in-flight run surfaces in the same table without any extra client-side bookkeeping.

## Testing Instructions

1. Run `yarn start-dashboard` and open `my.a4a.localhost:3000/agency/amplify/reports` logged in as an agency user (`a4a_administrator`/`a4a_developer`).
2. Click **Amplify a site** — the modal opens.
3. Enter an invalid value (e.g. `not a url`) and click **Next** — confirm the validation message; enter a valid URL — confirm it advances to the analysis-type step.
4. Pick a type — on success the **Analysis in progress** screen shows; close it and confirm a **pending** row appears in the table and polls (~15s) until it resolves.
5. Confirm a submission failure shows the error screen with **Try again**, and that the empty state also surfaces the **Amplify a site** button.
6. Confirm there are no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
