### PR TITLE
Notifications: stop tab shortcuts from firing while typing a reply

### DIFF
--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -11,7 +11,9 @@ import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useEffect, useCallback, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
+import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import CloseButton from '../templates/close-button';
@@ -48,6 +50,7 @@ const NotePanel = ( {
 }: NotePanelProps ) => {
 	const notificationTabs = getNotificationTabs();
 	const tabRefs = useRef< Record< string, HTMLButtonElement > >( {} );
+	const areKeyboardShortcutsEnabled = useSelector( getKeyboardShortcutsEnabled );
 
 	const handleSelect = useCallback(
 		( tabId: string | null | undefined ) => {
@@ -69,6 +72,13 @@ const NotePanel = ( {
 		};
 
 		const handleKeyDown = ( event: KeyboardEvent ) => {
+			// Suppress tab shortcuts while a field (e.g. the reply input) has
+			// focus; it disables shortcuts so typing letters like "a" or "s"
+			// switches tabs and tears down the open note instead of typing.
+			if ( ! areKeyboardShortcutsEnabled ) {
+				return;
+			}
+
 			if ( modifierKeyIsActive( event ) ) {
 				return;
 			}
@@ -96,7 +106,7 @@ const NotePanel = ( {
 		return () => {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
-	}, [ tabRefs, handleSelect ] );
+	}, [ tabRefs, handleSelect, areKeyboardShortcutsEnabled ] );
 
 	return (
 		<>

--- a/apps/notifications/src/app/note-panel/test/index.tsx
+++ b/apps/notifications/src/app/note-panel/test/index.tsx
@@ -1,6 +1,9 @@
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
+import { Provider } from 'react-redux';
+import { init as initStore } from '../../../panel/state';
+import actions from '../../../panel/state/actions';
 import { renderWithProvider } from '../../../testing-library';
 import NodePanel, { getNotificationTabs } from '../index';
 import type { FilterName } from '../../types';
@@ -80,5 +83,56 @@ describe( 'NotePanel', () => {
 				} )
 			).toBeVisible()
 		);
+	} );
+
+	it( 'ignores tab keyboard shortcuts while keyboard shortcuts are disabled', async () => {
+		// The reply input disables keyboard shortcuts on focus. Typing a
+		// letter that maps to a tab (e.g. "u") must not switch tabs or clear
+		// the selected note, which would close the open note and the panel.
+		const store = initStore();
+		const setFilterName = jest.fn();
+		const setSelectedNoteId = jest.fn();
+
+		render(
+			<Provider store={ store }>
+				<NodePanel
+					filterName="all"
+					setFilterName={ setFilterName }
+					selectedNoteId="123"
+					setSelectedNoteId={ setSelectedNoteId }
+				/>
+			</Provider>
+		);
+
+		await waitForComponentToBeInitializedWithSelectedTab( getNotificationTabs()[ 0 ].title );
+
+		await userEvent.keyboard( 'u' );
+
+		expect( setFilterName ).not.toHaveBeenCalled();
+		expect( setSelectedNoteId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'handles tab keyboard shortcuts while keyboard shortcuts are enabled', async () => {
+		const store = initStore();
+		store.dispatch( actions.ui.enableKeyboardShortcuts() );
+		const setFilterName = jest.fn();
+		const setSelectedNoteId = jest.fn();
+
+		render(
+			<Provider store={ store }>
+				<NodePanel
+					filterName="all"
+					setFilterName={ setFilterName }
+					selectedNoteId="123"
+					setSelectedNoteId={ setSelectedNoteId }
+				/>
+			</Provider>
+		);
+
+		await waitForComponentToBeInitializedWithSelectedTab( getNotificationTabs()[ 0 ].title );
+
+		await userEvent.keyboard( 'u' );
+
+		expect( setFilterName ).toHaveBeenCalledWith( 'unread' );
 	} );
 } );


### PR DESCRIPTION
Fixes DOTMSD-1307

## Proposed Changes

* Stop the notifications tab shortcuts (a/u/c/f/s/l) from triggering while a field is focused, by checking the shared keyboard-shortcuts-enabled flag the reply input already toggles.
* Add a regression test.

## Why are these changes being made?

Typing a reply that contained one of those letters quietly switched the notifications tab and cleared the open note, which collapsed the whole panel. Every other shortcut handler already respected that flag — this one didn't.

## Testing Instructions

* Open notifications, click a comment, and type a reply containing letters like "a", "s", or "u".
* The panel should stay open and the letters should appear in the input.
* `yarn jest --config apps/notifications/jest.config.js apps/notifications/src/app/note-panel/test/index.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)