### PR TITLE
Legacy contact: show setup status in security list

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -633,6 +633,9 @@ export const securityIndexRoute = createRoute( {
 			queryClient.ensureQueryData( accountRecoveryQuery() ),
 			queryClient.ensureQueryData( connectedApplicationsQuery() ),
 			queryClient.ensureQueryData( sshKeysQuery() ),
+			...( isEnabled( 'me/legacy-contact' )
+				? [ queryClient.ensureQueryData( legacyContactsQuery() ) ]
+				: [] ),
 		] );
 	},
 } ).lazy( () =>

--- a/client/dashboard/me/security-legacy-contact/summary.tsx
+++ b/client/dashboard/me/security-legacy-contact/summary.tsx
@@ -1,10 +1,24 @@
+import { legacyContactsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { Density } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
 export default function SecurityLegacyContactSummary( { density }: { density?: Density } ) {
+	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
+
+	const badges: SummaryButtonBadgeProps[] = [
+		{
+			text: contact ? __( 'Legacy contact added' ) : __( 'No legacy contact added' ),
+			intent: contact ? 'info' : 'default',
+		},
+	];
+
 	return (
 		<RouterLinkSummaryButton
 			density={ density }
@@ -12,6 +26,7 @@ export default function SecurityLegacyContactSummary( { density }: { density?: D
 			title={ __( 'Legacy contact' ) }
 			description={ __( 'Choose someone you trust to manage your account after your death.' ) }
 			decoration={ <Icon icon={ people } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/security-legacy-contact/summary.tsx
+++ b/client/dashboard/me/security-legacy-contact/summary.tsx
@@ -15,7 +15,7 @@ export default function SecurityLegacyContactSummary( { density }: { density?: D
 	const badges: SummaryButtonBadgeProps[] = [
 		{
 			text: contact ? __( 'Legacy contact added' ) : __( 'No legacy contact added' ),
-			intent: contact ? 'info' : 'default',
+			intent: contact ? 'success' : 'default',
 		},
 	];
 


### PR DESCRIPTION
Fixes RSM-4422

## Proposed Changes

* Add a status badge to the **Legacy contact** entry in the Dashboard security list (`client/dashboard/me/security`), matching the other sections (e.g. SSH key, social logins).
* Shows **"Legacy contact added"** (`success` intent) when a legacy contact exists, or **"No legacy contact added"** (`default` intent) when none is set up — mirroring the SSH key section's single-item pattern.
* Reuses the existing `legacyContactsQuery()` via `useSuspenseQuery` — the same data source the legacy contact detail page already uses.

<img width="693" height="197" alt="Screenshot 2026-06-18 at 14 05 33" src="https://github.com/user-attachments/assets/f0408c61-905f-4a95-8804-4c3818769b46" />
<img width="707" height="141" alt="Screenshot 2026-06-18 at 14 01 53" src="https://github.com/user-attachments/assets/0490de1e-7440-4020-b036-4316b87b55d0" />


## Why are these changes being made?

* Every other section in the security list surfaces its current status at a glance, but Legacy contact showed only a title and description. This brings it in line with the rest of the list so users can see whether a legacy contact is configured without opening the section.

## Testing Instructions

* Enable the `me/legacy-contact` feature flag and navigate to **Me → Security** in the Dashboard.
* With no legacy contact configured, confirm the Legacy contact row shows a **"No legacy contact added"** badge (default/grey intent).
* To preview the populated state without setting up a real contact, temporarily mock the fetcher in `packages/api-core/src/me-legacy-contacts/fetchers.ts` by returning a stub at the top of `fetchLegacyContacts`:
  ```ts
  return [ { email: 'trusted.contact@example.com', token: 'mock-token' } ];
  ```
  Reload and confirm the badge shows **"Legacy contact added"** (green/success intent). Revert the mock when done.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)