### PR TITLE
Notifications: fix Pending Approval badge colors in dark mode

### DIFF
--- a/apps/notifications/src/shared/pending-approval-badge.scss
+++ b/apps/notifications/src/shared/pending-approval-badge.scss
@@ -52,7 +52,9 @@
 		color: var(--color-warning-80, #614200);
 		text-decoration: none;
 		font-weight: 500;
-		opacity: 0.5;
+		// Keep the link visibly lighter than the label while still meeting the
+		// WCAG AA 4.5:1 contrast minimum in both light and dark modes.
+		opacity: 0.8;
 		white-space: nowrap;
 
 		@include ui-mixins.when-dark-theme {

--- a/apps/notifications/src/shared/pending-approval-badge.scss
+++ b/apps/notifications/src/shared/pending-approval-badge.scss
@@ -1,3 +1,5 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+
 // Legacy standalone panel (rendered under `.wpnc__main`, where `.wpnc__note`
 // wraps `.wpnc__body`). Left untouched to avoid regressing the old widget.
 .wpnc__note .wpnc__body .wpnc__pending-approval-section {
@@ -9,6 +11,11 @@
 // the `.wpnc-app` root where `.wpnc__note` is a sibling of `.wpnc__body`.
 .wpnc-app .wpnc__pending-approval-section {
 	box-shadow: inset 3px 0 0 var(--color-warning);
+
+	// Match the badge text's lighter warning foreground in dark mode.
+	@include ui-mixins.when-dark-theme {
+		box-shadow: inset 3px 0 0 var(--dashboard__foreground-color-warning, #f5c15c);
+	}
 }
 
 .wpnc-pending-approval-badge {
@@ -23,11 +30,21 @@
 	svg {
 		fill: var(--color-warning, #f0b849);
 		flex-shrink: 0;
+
+		@include ui-mixins.when-dark-theme {
+			fill: var(--dashboard__foreground-color-warning, #f5c15c);
+		}
 	}
 
 	.wpnc-pending-approval-badge__text {
 		font-weight: 500;
 		color: var(--color-warning-80, #614200);
+
+		// The `-80` warning shade is too dark to read in dark mode; use the
+		// lighter warning foreground instead.
+		@include ui-mixins.when-dark-theme {
+			color: var(--dashboard__foreground-color-warning, #f5c15c);
+		}
 	}
 
 	.wpnc-pending-approval-badge__link {
@@ -37,6 +54,10 @@
 		font-weight: 500;
 		opacity: 0.5;
 		white-space: nowrap;
+
+		@include ui-mixins.when-dark-theme {
+			color: var(--dashboard__foreground-color-warning, #f5c15c);
+		}
 
 		&:hover {
 			text-decoration: underline;


### PR DESCRIPTION
Related to DOTMSD-1260

Follow-up to #111767, which fixed the badge layout in light mode. This addresses the same badge in dark mode.

## Proposed Changes

* In dark mode, use the lighter warning foreground for the "Pending Approval" text and "Manage Comments" link, which were previously too dark to read.
* Pin the left accent border and the icon to the same color so all three match.
* Make the "Manage Comments" link a little more opaque so it stays easy to read in both modes.

| Before | After |
|--------|--------|
| <img width="437" height="64" alt="Screenshot 2026-06-18 at 11 01 08 AM" src="https://github.com/user-attachments/assets/ae9573b9-a247-46da-9846-c6e0d730dec2" /> | <img width="430" height="59" alt="Screenshot 2026-06-18 at 11 23 10 AM" src="https://github.com/user-attachments/assets/16e9f3a3-f1bf-4c12-91b9-13eceea19df6" />
 | 





## Why are these changes being made?

In dark mode the badge text used a shade the theme keeps dark, so it was barely visible, and the border and icon looked weaker than the text. The "Manage Comments" link was also a bit too faint to read comfortably.

## Testing Instructions

* Open notifications in the dashboard with dark mode on (or set `data-theme="dark"` on the document) and view a comment pending approval.
* The text, link, left border, and icon should all be the same readable light gold.
* The "Manage Comments" link should be legible in both light and dark modes.
* Confirm light mode and the legacy notifications widget are otherwise unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)