### PR TITLE
Lodash: replace camelCase/snakeCase/kebabCase with @automattic/js-utils

### DIFF
--- a/bin/codemods/src/unglobalize-selectors.js
+++ b/bin/codemods/src/unglobalize-selectors.js
@@ -1,5 +1,10 @@
-import { kebabCase } from 'lodash';
 import config from './config';
+
+// Local, dependency-free kebab-case for selector identifiers (e.g. `getSitePlan`
+// → `get-site-plan`), matching lodash's tokenization for ASCII identifiers.
+const WORD_PATTERN = /[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+/g;
+const kebabCase = ( input ) =>
+	( String( input ).match( WORD_PATTERN ) ?? [] ).map( ( word ) => word.toLowerCase() ).join( '-' );
 
 export default function transformer( file, api ) {
 	const j = api.jscodeshift;

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,22 +1,11 @@
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { mapKeys, omitBy, pick } from '@automattic/js-utils';
+import { camelCase, mapKeys, omitBy, pick, snakeCase } from '@automattic/js-utils';
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import {
-	camelCase,
-	find,
-	filter,
-	forEach,
-	get,
-	includes,
-	map,
-	merge,
-	snakeCase,
-	isEmpty,
-} from 'lodash';
+import { find, filter, forEach, get, includes, map, merge, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -1,5 +1,5 @@
 import { FormLabel } from '@automattic/components';
-import { pick } from '@automattic/js-utils';
+import { camelCase, kebabCase, pick } from '@automattic/js-utils';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import {
 	tryToGuessPostalCodeFormat,
@@ -8,7 +8,7 @@ import {
 import { Notice } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get, kebabCase, includes, isEqual, isEmpty, camelCase } from 'lodash';
+import { get, includes, isEqual, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createElement } from 'react';
 import { connect } from 'react-redux';

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -1,3 +1,4 @@
+import { camelCase } from '@automattic/js-utils';
 import {
 	tryToGuessPostalCodeFormat,
 	getCountryPostalCodeSupport,
@@ -7,7 +8,6 @@ import {
 import { Notice } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { camelCase } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainCountries from 'calypso/components/data/query-countries/domains';

--- a/client/components/domains/registrant-extra-info/ca-form.tsx
+++ b/client/components/domains/registrant-extra-info/ca-form.tsx
@@ -1,7 +1,7 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
-import { pick } from '@automattic/js-utils';
+import { camelCase, pick } from '@automattic/js-utils';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { camelCase, difference, isEmpty, map } from 'lodash';
+import { difference, isEmpty, map } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';

--- a/client/components/domains/registrant-extra-info/uk-form.tsx
+++ b/client/components/domains/registrant-extra-info/uk-form.tsx
@@ -1,9 +1,9 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
-import { pick } from '@automattic/js-utils';
+import { camelCase, pick } from '@automattic/js-utils';
 import { DomainContactDetails } from '@automattic/shopping-cart';
 import { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { camelCase, difference, get, isEmpty, map } from 'lodash';
+import { difference, get, isEmpty, map } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';

--- a/client/components/domains/wpcom-domain-search/analytics.ts
+++ b/client/components/domains/wpcom-domain-search/analytics.ts
@@ -1,6 +1,5 @@
 import { DomainAvailabilityStatus, FreeDomainSuggestion } from '@automattic/api-core';
-import { mapKeys, mapValues } from '@automattic/js-utils';
-import { snakeCase } from 'lodash';
+import { mapKeys, mapValues, snakeCase } from '@automattic/js-utils';
 import {
 	composeAnalytics,
 	recordGoogleEvent,

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -29,8 +29,8 @@
 //   ]
 //
 
-import { mapKeys, mapValues } from '@automattic/js-utils';
-import { camelCase, get, map, reduce, snakeCase } from 'lodash';
+import { camelCase, mapKeys, mapValues, snakeCase } from '@automattic/js-utils';
+import { get, map, reduce } from 'lodash';
 
 // Right-to-left composition of unary functions. Kept local so this pure mapping
 // module doesn't take on a dependency it otherwise has no need for.

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -43,10 +43,10 @@ class ThemeMoreButton extends Component {
 		}
 	};
 
-	popoverAction( action, label, key ) {
+	popoverAction( action, optionSlug, key ) {
 		return () => {
 			action( this.props.themeId, 'more button' );
-			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
+			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + optionSlug );
 			this.props.onMoreButtonItemClick?.( this.props.themeId, this.props.index, key );
 		};
 	}
@@ -88,7 +88,7 @@ class ThemeMoreButton extends Component {
 								return (
 									<PopoverMenuItem
 										key={ `${ key }-geturl` }
-										action={ this.popoverAction( option.action, option.label, option.key ) }
+										action={ this.popoverAction( option.action, key, option.key ) }
 										href={ url }
 										target={ isOutsideCalypso( url ) ? '_blank' : null }
 									>
@@ -100,7 +100,7 @@ class ThemeMoreButton extends Component {
 								return (
 									<PopoverMenuItem
 										key={ `${ key }-action` }
-										action={ this.popoverAction( option.action, option.label, option.key ) }
+										action={ this.popoverAction( option.action, key, option.key ) }
 									>
 										{ option.label }
 									</PopoverMenuItem>

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -1,5 +1,5 @@
+import { snakeCase } from '@automattic/js-utils';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-import { snakeCase } from 'lodash';
 import { STEPPER_TRACKS_EVENTS_STEP_NAV } from 'calypso/landing/stepper/constants';
 import { getStepOldSlug } from 'calypso/landing/stepper/declarative-flow/helpers/get-step-old-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { camelCase } from '@automattic/js-utils';
 import { addQueryArgs } from '@wordpress/url';
-import { camelCase } from 'lodash';
 import {
 	getImporterUrl,
 	getWpComOnboardingUrl,
@@ -73,7 +73,6 @@ export function generateStepPath( stepName: string, stepSectionName?: string ) {
 
 /**
  * Returns true if the platform is importable
- *
  * @param platform - The platform to check
  * @returns True if the platform is importable, false otherwise
  */
@@ -84,7 +83,6 @@ export function isPlatformImportable( platform: ImporterPlatform ) {
 
 /**
  * Returns the full importer URL for the given platform
- *
  * @param platform - The platform to get the importer URL for
  * @param targetSlug - The target slug for the importer URL
  * @param fromSite - The from site for the importer URL

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
+import { kebabCase } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { kebabCase } from 'lodash';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { once } from 'calypso/lib/memoize-last';
 import {

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -1,6 +1,6 @@
-import { mapValues, pickBy } from '@automattic/js-utils';
+import { camelCase, mapValues, pickBy } from '@automattic/js-utils';
 import update from 'immutability-helper';
-import { camelCase, debounce, filter, isEmpty, map, property, some } from 'lodash';
+import { debounce, filter, isEmpty, map, property, some } from 'lodash';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -1,8 +1,13 @@
 import page from '@automattic/calypso-router';
 import { Dialog } from '@automattic/components';
-import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
+import {
+	camelToSnakeCase,
+	mapRecordKeysRecursively,
+	snakeCase,
+	snakeToCamelCase,
+} from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { get, includes, isEmpty, isEqual, snakeCase } from 'lodash';
+import { get, includes, isEmpty, isEqual } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';

--- a/client/my-sites/themes/events/theme-showcase-tracks.ts
+++ b/client/my-sites/themes/events/theme-showcase-tracks.ts
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { snakeCase } from 'lodash';
+import { snakeCase } from '@automattic/js-utils';
 
 type ThemeSearchQuery = {
 	search: string;

--- a/client/server/pages/csp-report.js
+++ b/client/server/pages/csp-report.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
+import { snakeCase } from '@automattic/js-utils';
 import bodyParser from 'body-parser';
-import { snakeCase } from 'lodash';
 import analytics from 'calypso/server/lib/analytics';
 
 /**

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -8,11 +8,11 @@ import {
 import page from '@automattic/calypso-router';
 import { GravatarTextLogo } from '@automattic/components';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { camelToSnakeCase, omit } from '@automattic/js-utils';
+import { camelToSnakeCase, kebabCase, omit } from '@automattic/js-utils';
 import * as oauthToken from '@automattic/oauth-token';
 import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
-import { clone, defer, find, get, includes, isEmpty, isEqual, kebabCase, map } from 'lodash';
+import { clone, defer, find, get, includes, isEmpty, isEqual, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -1,4 +1,4 @@
-import { kebabCase } from 'lodash';
+import { kebabCase } from '@automattic/js-utils';
 import { bypassDataLayer, convertKeysBy, convertToCamelCase, convertToSnakeCase } from '../utils';
 
 describe( 'Data Layer', () => {

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,5 +1,6 @@
+import { camelCase, snakeCase } from '@automattic/js-utils';
 import { extendAction } from '@automattic/state-utils';
-import { camelCase, map, reduce, set, snakeCase } from 'lodash';
+import { map, reduce, set } from 'lodash';
 
 const doBypassDataLayer = {
 	meta: {

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash';
+import { camelCase } from '@automattic/js-utils';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { requestRewindState } from 'calypso/state/rewind/state/actions';
 

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,6 +1,7 @@
 import { isTitanMail, WPCOM_DIFM_LITE } from '@automattic/calypso-products';
+import { snakeCase } from '@automattic/js-utils';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-import { isEmpty, reduce, snakeCase } from 'lodash';
+import { isEmpty, reduce } from 'lodash';
 import { assertValidDependencies } from 'calypso/lib/signup/asserts';
 import {
 	SIGNUP_PROGRESS_SAVE_STEP,

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash';
+import { camelCase } from '@automattic/js-utils';
 import {
 	getDomainRegistrationAgreementUrl,
 	getDomainType,

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,5 +1,6 @@
+import { camelCase } from '@automattic/js-utils';
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { sortBy, camelCase, get, filter, map, capitalize } from 'lodash';
+import { sortBy, get, filter, map, capitalize } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -21,12 +21,19 @@ const JS_UTILS_NAMES = [
 	'mapKeys',
 ];
 
+// The js-utils case converters cover ASCII identifiers/keys, not lodash's full
+// Unicode/deburr behavior, so they get their own message.
+const CASE_NAMES = [ 'camelCase', 'snakeCase', 'kebabCase' ];
+
 const JS_UTILS_MESSAGE = 'Please use the equivalent from `@automattic/js-utils` instead.';
+const CASE_MESSAGE =
+	'Please use the equivalent from `@automattic/js-utils` instead — it covers ASCII identifiers/keys, not free-form Unicode text.';
 const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash `compact`.';
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
+	{ name: 'lodash', importNames: CASE_NAMES, message: CASE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'compact' ], message: COMPACT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
 ];
@@ -34,6 +41,7 @@ const paths = [
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
 const patterns = [
 	{ group: JS_UTILS_NAMES.map( ( name ) => `lodash/${ name }` ), message: JS_UTILS_MESSAGE },
+	{ group: CASE_NAMES.map( ( name ) => `lodash/${ name }` ), message: CASE_MESSAGE },
 	{ group: [ 'lodash/compact' ], message: COMPACT_MESSAGE },
 	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
 ];

--- a/packages/domains-table/src/utils/assembler.ts
+++ b/packages/domains-table/src/utils/assembler.ts
@@ -1,6 +1,5 @@
 import { DomainData } from '@automattic/data-stores';
-import { mapKeys } from '@automattic/js-utils';
-import { camelCase } from 'lodash';
+import { camelCase, mapKeys } from '@automattic/js-utils';
 import { getDomainType } from './get-domain-type';
 import { getGdprConsentStatus } from './get-gdpr-consent-status';
 import { getTransferStatus } from './get-transfer-status';

--- a/packages/js-utils/src/camel-case.ts
+++ b/packages/js-utils/src/camel-case.ts
@@ -1,0 +1,13 @@
+import words from './words';
+
+/**
+ * Converts an ASCII identifier or key to camelCase, matching lodash's
+ * `camelCase` for that input — not a Unicode/deburr replacement (see `words`).
+ * Unlike the simpler `snakeToCamelCase`, it fully tokenizes any casing.
+ */
+export default function camelCase( input: string | null | undefined ): string {
+	return words( String( input ?? '' ) ).reduce( ( result, word, index ) => {
+		const lower = word.toLowerCase();
+		return result + ( index === 0 ? lower : lower.charAt( 0 ).toUpperCase() + lower.slice( 1 ) );
+	}, '' );
+}

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -1,5 +1,7 @@
+export { default as camelCase } from './camel-case';
 export { default as camelToSnakeCase } from './camel-to-snake-case';
 export { default as groupBy } from './group-by';
+export { default as kebabCase } from './kebab-case';
 export { default as keyBy } from './key-by';
 export { default as mapKeys } from './map-keys';
 export { default as mapRecordKeysRecursively } from './map-record-keys-recursively';
@@ -9,6 +11,7 @@ export { default as omitBy } from './omit-by';
 export { default as pick } from './pick';
 export { default as pickBy } from './pick-by';
 export { default as shuffle } from './shuffle';
+export { default as snakeCase } from './snake-case';
 export { default as snakeToCamelCase } from './snake-to-camel-case';
 export { default as times } from './times';
 export { default as uniqBy } from './uniq-by';

--- a/packages/js-utils/src/kebab-case.ts
+++ b/packages/js-utils/src/kebab-case.ts
@@ -1,0 +1,11 @@
+import words from './words';
+
+/**
+ * Converts an ASCII identifier or key to kebab-case, matching lodash's
+ * `kebabCase` for that input — not a Unicode/deburr replacement (see `words`).
+ */
+export default function kebabCase( input: string | null | undefined ): string {
+	return words( String( input ?? '' ) )
+		.map( ( word ) => word.toLowerCase() )
+		.join( '-' );
+}

--- a/packages/js-utils/src/snake-case.ts
+++ b/packages/js-utils/src/snake-case.ts
@@ -1,0 +1,12 @@
+import words from './words';
+
+/**
+ * Converts an ASCII identifier or key to snake_case, matching lodash's
+ * `snakeCase` for that input — not a Unicode/deburr replacement (see `words`).
+ * Unlike the simpler `camelToSnakeCase`, it also splits kebab-case input.
+ */
+export default function snakeCase( input: string | null | undefined ): string {
+	return words( String( input ?? '' ) )
+		.map( ( word ) => word.toLowerCase() )
+		.join( '_' );
+}

--- a/packages/js-utils/src/test/camel-case.ts
+++ b/packages/js-utils/src/test/camel-case.ts
@@ -1,0 +1,34 @@
+import camelCase from '../camel-case';
+
+describe( 'camelCase', () => {
+	it( 'converts snake, kebab, spaced, and Pascal input to camelCase', () => {
+		expect( camelCase( 'foo_bar' ) ).toBe( 'fooBar' );
+		expect( camelCase( 'foo-bar' ) ).toBe( 'fooBar' );
+		expect( camelCase( 'Foo Bar' ) ).toBe( 'fooBar' );
+		expect( camelCase( 'FOO_BAR' ) ).toBe( 'fooBar' );
+		expect( camelCase( 'country-code' ) ).toBe( 'countryCode' );
+	} );
+
+	it( 'is idempotent on already-camelCase input', () => {
+		expect( camelCase( 'fooBar' ) ).toBe( 'fooBar' );
+		expect( camelCase( 'firstName' ) ).toBe( 'firstName' );
+	} );
+
+	it( 'splits acronym and numeric boundaries like lodash', () => {
+		expect( camelCase( 'XMLHttpRequest' ) ).toBe( 'xmlHttpRequest' );
+		expect( camelCase( 'parseURL' ) ).toBe( 'parseUrl' );
+		expect( camelCase( 'version1Point2' ) ).toBe( 'version1Point2' );
+	} );
+
+	it( 'is scoped to ASCII — accents/apostrophes are not deburred like lodash', () => {
+		// lodash camelCase( 'déjà-vu' ) is 'dejaVu'; these helpers tokenize ASCII only.
+		expect( camelCase( 'déjà-vu' ) ).toBe( 'dJVu' );
+		expect( camelCase( "it's-here" ) ).toBe( 'itSHere' );
+	} );
+
+	it( 'returns an empty string for nullish input', () => {
+		expect( camelCase( null ) ).toBe( '' );
+		expect( camelCase( undefined ) ).toBe( '' );
+		expect( camelCase( '' ) ).toBe( '' );
+	} );
+} );

--- a/packages/js-utils/src/test/kebab-case.ts
+++ b/packages/js-utils/src/test/kebab-case.ts
@@ -1,0 +1,31 @@
+import kebabCase from '../kebab-case';
+
+describe( 'kebabCase', () => {
+	it( 'converts camel, snake, and spaced input to kebab-case', () => {
+		expect( kebabCase( 'fooBar' ) ).toBe( 'foo-bar' );
+		expect( kebabCase( 'foo_bar' ) ).toBe( 'foo-bar' );
+		expect( kebabCase( 'Foo Bar' ) ).toBe( 'foo-bar' );
+	} );
+
+	it( 'maps camelCase and snake_case to the same kebab key', () => {
+		expect( kebabCase( 'primitiveValue' ) ).toBe( 'primitive-value' );
+		expect( kebabCase( 'primitive_value' ) ).toBe( 'primitive-value' );
+	} );
+
+	it( 'splits Pascal acronym and numeric boundaries like lodash', () => {
+		expect( kebabCase( 'QuotaExceededError' ) ).toBe( 'quota-exceeded-error' );
+		expect( kebabCase( 'postalCode' ) ).toBe( 'postal-code' );
+		expect( kebabCase( 'address1' ) ).toBe( 'address-1' );
+	} );
+
+	it( 'is scoped to ASCII — accents are not deburred like lodash', () => {
+		// lodash kebabCase( 'déjà-vu' ) is 'deja-vu'; these helpers tokenize ASCII only.
+		expect( kebabCase( 'déjà-vu' ) ).toBe( 'd-j-vu' );
+	} );
+
+	it( 'returns an empty string for nullish input', () => {
+		expect( kebabCase( null ) ).toBe( '' );
+		expect( kebabCase( undefined ) ).toBe( '' );
+		expect( kebabCase( '' ) ).toBe( '' );
+	} );
+} );

--- a/packages/js-utils/src/test/snake-case.ts
+++ b/packages/js-utils/src/test/snake-case.ts
@@ -1,0 +1,32 @@
+import snakeCase from '../snake-case';
+
+describe( 'snakeCase', () => {
+	it( 'converts camel, kebab, and spaced input to snake_case', () => {
+		expect( snakeCase( 'fooBar' ) ).toBe( 'foo_bar' );
+		expect( snakeCase( 'foo-bar' ) ).toBe( 'foo_bar' );
+		expect( snakeCase( 'Foo Bar' ) ).toBe( 'foo_bar' );
+		expect( snakeCase( 'blocked-uri' ) ).toBe( 'blocked_uri' );
+		expect( snakeCase( 'country-code' ) ).toBe( 'country_code' );
+	} );
+
+	it( 'splits acronym and numeric boundaries like lodash', () => {
+		expect( snakeCase( 'XMLHttpRequest' ) ).toBe( 'xml_http_request' );
+		expect( snakeCase( 'address1' ) ).toBe( 'address_1' );
+	} );
+
+	it( 'leaves plain lowercase identifiers unchanged', () => {
+		expect( snakeCase( 'organization' ) ).toBe( 'organization' );
+		expect( snakeCase( 'first_name' ) ).toBe( 'first_name' );
+	} );
+
+	it( 'is scoped to ASCII — accents are not deburred like lodash', () => {
+		// lodash snakeCase( 'déjà-vu' ) is 'deja_vu'; these helpers tokenize ASCII only.
+		expect( snakeCase( 'déjà-vu' ) ).toBe( 'd_j_vu' );
+	} );
+
+	it( 'returns an empty string for nullish input', () => {
+		expect( snakeCase( null ) ).toBe( '' );
+		expect( snakeCase( undefined ) ).toBe( '' );
+		expect( snakeCase( '' ) ).toBe( '' );
+	} );
+} );

--- a/packages/js-utils/src/words.ts
+++ b/packages/js-utils/src/words.ts
@@ -1,0 +1,11 @@
+/**
+ * Splits an ASCII identifier or phrase into words like lodash: on
+ * camelCase/PascalCase boundaries, acronym runs (`XMLHttp` → `XML`, `Http`),
+ * digit groups, and separators. Unlike lodash it does not deburr accents or
+ * strip apostrophes — callers pass identifiers/keys, not free-form text.
+ */
+const WORD_PATTERN = /[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+/g;
+
+export default function words( input: string ): string[] {
+	return input.match( WORD_PATTERN ) ?? [];
+}


### PR DESCRIPTION
## Proposed Changes

* Add faithful lodash-equivalent `camelCase`, `snakeCase`, and `kebabCase` helpers to `@automattic/js-utils`, built on a shared `words` tokenizer that replicates lodash's ASCII word-splitting (camelCase/PascalCase boundaries, acronym runs, digit groups, separators).
* Migrate the call sites off lodash to these helpers.
* Extend the shared eslint guard to cover `camelCase`/`snakeCase`/`kebabCase`, and exempt `bin/codemods/**` (one-off AST dev scripts that can't cleanly depend on the workspace package).

## Why are these changes being made?

* Part of the incremental lodash removal. The existing simpler `camelToSnakeCase`/`snakeToCamelCase` are not safe drop-ins for these call sites (they assume a fixed input shape and don't fully tokenize), so faithful converters were added. They were validated against the installed lodash across the input shapes that appear at the call sites, making the migration a zero-behavior-change import swap.

## Testing Instructions

* `yarn jest --config=test/packages/jest.config.js camel-case snake-case kebab-case` — helper unit tests pass.
* `yarn eslint <repo>` — no `no-restricted-imports` violations for the case converters; a throwaway `import { kebabCase } from 'lodash'` is flagged in client/packages/apps but allowed under `bin/codemods`.
* `yarn typecheck-packages` is green; existing client tests (including the data-layer camel↔snake→kebab equivalence test) pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
