### PR TITLE
Odie: change Zendesk transfer label to "Support request started"

### DIFF
--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -143,7 +143,7 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 				</div>
 				{ startingHumanSupport && (
 					<ChatWithSupportLabel
-						labelText={ __( 'Chat with support team started', __i18n_text_domain__ ) }
+						labelText={ __( 'Support request started', __i18n_text_domain__ ) }
 					/>
 				) }
 			</Fragment>

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -1,3 +1,4 @@
+import { translationExists } from '@automattic/i18n-utils';
 import { __ } from '@wordpress/i18n';
 import cx from 'clsx';
 import { Fragment } from 'react';
@@ -143,7 +144,11 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 				</div>
 				{ startingHumanSupport && (
 					<ChatWithSupportLabel
-						labelText={ __( 'Support request started', __i18n_text_domain__ ) }
+						labelText={
+							translationExists( 'Support request started' )
+								? __( 'Support request started', __i18n_text_domain__ )
+								: __( 'Chat with support team started', __i18n_text_domain__ )
+						}
 					/>
 				) }
 			</Fragment>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/HAPAI-3593/change-odie-zendesk-transfer-text-to-support-request-started

## Proposed Changes

**Renames the Odie → Zendesk transfer label from “Chat with support team started” to “Support request started”, with a translation-aware fallback.**

- Updates the `ChatWithSupportLabel` text shown when a conversation starts human support in `packages/odie-client`.
- Uses `translationExists()` so the new string shows only when the locale is English or a translation is available; otherwise it keeps the already-translated “Chat with support team started” to avoid showing an untranslated string to non-English users.

## Why are these changes being made?

When Odie hands a conversation off to the support team, the chat showed a label reading “CHAT WITH SUPPORT TEAM STARTED”. That phrasing implies a live chat is beginning, which over-promises on response time. “Support request started” sets clearer expectations for customers about what just happened ([HAPAI-3593](https://linear.app/a8c/issue/HAPAI-3593)).

Because the new string ships before its translations land, non-English users would otherwise see raw English. The fallback keeps the existing translated label until the new copy is translated.

## Testing Instructions

1. Run `yarn start` and open the Help Center.
2. Start an Odie conversation and escalate to human support.
3. With an English locale, confirm the label at the transfer point reads “Support request started”.
4. Switch to a locale that has no translation for the new string and confirm it falls back to “Chat with support team started”.
