### PR TITLE
Notifications: fix Settings / Keyboard shortcuts in the in-frame panel

### DIFF
--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -134,7 +134,14 @@ const NotesWrapper = ( { wpcom } ) => {
 			if ( event.button !== 0 ) {
 				return;
 			}
-			if ( event.target.closest( '.wpnc-app__list-pane, .wpnc-app__detail-pane' ) ) {
+			// The panes' own popovers (the Actions menu with its Settings /
+			// Keyboard shortcuts items, and the shortcuts popover) portal to the
+			// iframe body, outside the panes. Treat them as inside, otherwise this
+			// mousedown closes the panel before the menu item's click fires and
+			// those actions appear to do nothing.
+			if (
+				event.target.closest( '.wpnc-app__list-pane, .wpnc-app__detail-pane, .components-popover' )
+			) {
 				return;
 			}
 			// Stop the click from starting a text selection on the backdrop.


### PR DESCRIPTION
## Proposed Changes

* Fix the **Settings** and **Keyboard shortcuts** items in the redesigned notifications panel doing nothing when it runs inside the standalone iframe (e.g. wp-admin masterbar).

The standalone iframe panel (`apps/notifications/src/standalone-app/index.jsx`) is wider than the panel card, so it dismisses itself on any `mousedown` outside the two panes (`.wpnc-app__list-pane` / `.wpnc-app__detail-pane`). The **Actions** menu — which holds the Settings and Keyboard shortcuts items — and the shortcuts popover are `@wordpress/components` popovers that portal to the iframe `<body>`, *outside* those panes. So the `mousedown` closed the panel and unmounted the menu before the item's `click` could fire, and both actions appeared dead.

The fix treats clicks landing inside any app-owned `.components-popover` as "inside" the panel, so the backdrop-dismiss no longer swallows them. As a bonus this also covers the per-note action dropdowns and any DataViews popovers, which had the same latent issue. Backdrop clicks still dismiss the panel (the backdrop has no `.components-popover` ancestor).

This only affected the iframe build ("in frame"); the in-page Calypso path uses a `@wordpress` `Dropdown` whose focus management already handles nested popovers, so it was unaffected.

## Why are these changes being made?

Reported internally: with the new notifications sidebar, the Settings and Keyboard shortcuts buttons weren't doing anything (reproduced unproxied).

## Testing Instructions

1. Enable the `notifications/redesign` flag.
2. Open the notifications panel from a surface that embeds it via the standalone iframe (wp-admin masterbar bell).
3. Click the Actions (⋮) menu in the panel header.
4. Click **Keyboard shortcuts** → the shortcuts popover should appear (panel stays open).
5. Reopen the menu and click **Settings** → `/me/notifications` opens in a new tab (panel stays open).
6. Click on the empty area around the card (the backdrop) → the panel should still dismiss as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)