### PR TITLE
Notifications: improve contrast of read-state note icon badge

### DIFF
--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -51,7 +51,7 @@
 		border: 1.5px solid $white;
 		border-radius: 50%;
 		color: $white;
-		background: $gray-300;
+		background: $gray-600;
 		overflow: hidden;
 		z-index: 1;
 


### PR DESCRIPTION
## Proposed Changes

* Change the read-state notification icon badge background from `$gray-300` (#ddd) to `$gray-600` (#949494) in `apps/notifications/src/app/note-list/style.scss`.

| Before | After |
| - | - |
|<img width="434" height="155" alt="image" src="https://github.com/user-attachments/assets/3784c683-485a-47c4-871b-9f53fcf50aac" />|<img width="436" height="155" alt="image" src="https://github.com/user-attachments/assets/d8484ccb-be32-4714-95b9-043bc8b58c07" />|

## Why are these changes being made?

The small circular type/status badge overlaid on each notification's avatar uses a white icon (`color: $white`). On the previous `$gray-300` (#ddd) background, the white-on-gray contrast was only ~1.6:1 — well below the WCAG AA minimum of 3:1 for graphical/icon elements, making the icon hard to distinguish for the default (read) state.

`$gray-600` (#949494) is documented in `@wordpress/base-styles` as the value that "Meets 3:1 UI or large text contrast against white," so it clears the 3:1 bar while remaining clearly distinct from the blue unread badge (which is unchanged).

## Testing Instructions

1. Enable the notifications redesign and open the notifications panel.
2. Observe the small icon badge on the bottom-right of each notification's avatar.
3. Confirm the white icon on a **read** notification badge is clearly visible against the darker gray background.
4. Confirm **unread** badges still use the blue admin theme color and are visually distinct.

Before: white icon on #ddd (~1.6:1). After: white icon on #949494 (~3.0:1).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
