### PR TITLE
Lodash: replace simple lodash get() with optional chaining (round 1)

### DIFF
--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -1,6 +1,5 @@
 import { pick } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -72,8 +71,8 @@ class CommentLikeButtonContainer extends Component {
 
 	render() {
 		const props = pick( this.props, [ 'showZeroCount', 'tagName' ] );
-		const likeCount = get( this.props.comment, 'like_count' );
-		const iLike = get( this.props.comment, 'i_like' );
+		const likeCount = this.props.comment?.like_count;
+		const iLike = this.props.comment?.i_like;
 		const likedLabel = translate( 'Liked' );
 
 		const likeIcon = ReaderLikeIcon( {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -437,7 +437,7 @@ class Login extends Component {
 							locale={ locale }
 							isWoo={ isWoo }
 							isWooJPC={ isWooJPC }
-							from={ get( currentQuery, 'from' ) }
+							from={ currentQuery?.from }
 							isJetpack={ isJetpack }
 						/>
 					</div>
@@ -630,7 +630,7 @@ export default connect(
 		isFromPassport: isPassportRedirect( getRedirectToOriginal( state ) ),
 
 		isFromAutomatticForAgenciesPlugin:
-			'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
+			'automattic-for-agencies-client' === getCurrentQueryArguments( state )?.from ||
 			'automattic-for-agencies-client' ===
 				new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 		isWooJPC: isWooJPCFlow( state ),
@@ -650,7 +650,7 @@ export default connect(
 		isSendingEmail: isFetchingMagicLoginEmail( state ),
 		emailRequested: isMagicLoginEmailRequested( state ),
 		isLoggedIn: isUserLoggedIn( state ),
-		from: get( getCurrentQueryArguments( state ), 'from' ),
+		from: getCurrentQueryArguments( state )?.from,
 	} ),
 	{
 		rebootAfterLogin,
@@ -675,7 +675,7 @@ export default connect(
 					isWooJPC: stateProps.isWooJPC,
 					isJetpack: ownProps.isJetpack,
 				} ) && { tokenType: 'code' } ),
-				source: stateProps.isWooJPC ? 'woo-passwordless-jpc' + '-' + get( stateProps, 'from' ) : '',
+				source: stateProps.isWooJPC ? 'woo-passwordless-jpc' + '-' + stateProps?.from : '',
 				flow:
 					( ownProps.isJetpack && 'jetpack' ) ||
 					( ownProps.isGravPoweredClient && getGravatarOAuth2Flow( ownProps.oauth2Client ) ) ||

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import cookie from 'cookie';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { capitalize, defer, includes, get } from 'lodash';
+import { capitalize, defer, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -506,7 +506,7 @@ export class LoginForm extends Component {
 							locale: this.props.locale,
 							action: this.props.isWooJPC ? 'jetpack/lostpassword' : 'lostpassword',
 							oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-							from: get( this.props.currentQuery, 'from' ),
+							from: this.props.currentQuery?.from,
 						} )
 					);
 				} }
@@ -1028,7 +1028,7 @@ export default connect(
 			isFormDisabled: isFormDisabledSelector( state ),
 			oauth2Client,
 			isFromAutomatticForAgenciesPlugin:
-				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
+				'automattic-for-agencies-client' === getCurrentQueryArguments( state )?.from,
 			allowedSocialServices: getPartnerAllowedSocialServices( oauth2Client ),
 			isWooJPC: isWooJPCFlow( state ),
 			isWoo: getIsWoo( state ),
@@ -1045,7 +1045,7 @@ export default connect(
 			wccomFrom: getWccomFrom( state ),
 			currentQuery,
 			isBlazePro: getIsBlazePro( state ),
-			isOneTapAuth: !! get( getCurrentQueryArguments( state ), 'oneTapAuth' ),
+			isOneTapAuth: !! getCurrentQueryArguments( state )?.oneTapAuth,
 			isGravatarFixedAccountLogin:
 				isFromGravatar3rdPartyApp || isFromGravatarQuickEditor || isGravatarFlowWithEmail,
 			isGravPoweredClient: isGravPoweredOAuth2Client( oauth2Client ),

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -3,7 +3,6 @@ import { Card } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import BlogStickers from 'calypso/blocks/blog-stickers';
@@ -37,14 +36,14 @@ class ReaderFeedHeader extends Component {
 		const description = getSiteDescription( { site, feed } );
 		const siteTitle = getSiteName( { feed, site } );
 		const siteUrl = getSiteUrl( { feed, site } );
-		const siteIcon = site ? get( site, 'icon.img' ) : null;
+		const siteIcon = site ? site?.icon?.img : null;
 		const narrowDisplay = width < 480;
 
 		const classes = clsx( 'reader-feed-header', {
 			'is-placeholder': ! site && ! feed,
 		} );
 
-		let feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
+		let feedIcon = feed ? feed.site_icon ?? feed?.image : null;
 		// don't show the default favicon for some sites
 		if ( feedIcon?.endsWith( 'wp.com/i/buttonw-com.png' ) ) {
 			feedIcon = null;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -5,7 +5,6 @@ import { isDefaultLocale } from '@automattic/i18n-utils';
 import { pickBy } from '@automattic/js-utils';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component, useMemo } from 'react';
 import { connect } from 'react-redux';
@@ -149,9 +148,9 @@ export class FullPostView extends Component {
 	componentDidUpdate( prevProps ) {
 		// Send page view if applicable
 		if (
-			get( prevProps, 'post.ID' ) !== get( this.props, 'post.ID' ) ||
-			get( prevProps, 'feed.ID' ) !== get( this.props, 'feed.ID' ) ||
-			get( prevProps, 'site.ID' ) !== get( this.props, 'site.ID' )
+			prevProps?.post?.ID !== this.props?.post?.ID ||
+			prevProps?.feed?.ID !== this.props?.feed?.ID ||
+			prevProps?.site?.ID !== this.props?.site?.ID
 		) {
 			this.hasSentPageView = false;
 			this.hasLoaded = false;
@@ -159,7 +158,7 @@ export class FullPostView extends Component {
 			this.maybeDisableAppBanner();
 
 			// If the post being viewed changes, track the reading time.
-			if ( get( prevProps, 'post.ID' ) !== get( this.props, 'post.ID' ) ) {
+			if ( prevProps?.post?.ID !== this.props?.post?.ID ) {
 				this.trackReadingTime( prevProps.post );
 				this.trackScrollDepth( prevProps.post );
 				this.trackExitBeforeCompletion( prevProps.post );
@@ -720,9 +719,9 @@ export class FullPostView extends Component {
 
 		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
 		const startingCommentId = this.getCommentIdFromUrl();
-		const commentCount = get( post, 'discussion.comment_count' );
+		const commentCount = post?.discussion?.comment_count;
 		const contentWidth = readerContentWidth();
-		const feedUrl = get( post, 'feed_URL' );
+		const feedUrl = post?.feed_URL;
 		const shouldShowMarkAsSeen =
 			isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) && canBeMarkedAsSeen( { post } );
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -5,7 +5,7 @@ import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { find, filter, forEach, get, includes, map, merge, isEmpty } from 'lodash';
+import { find, filter, forEach, includes, map, merge, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -831,7 +831,7 @@ export default connect(
 			currentUser: getCurrentUser( state ),
 			oauth2Client,
 			sectionName: getSectionName( state ),
-			from: get( getCurrentQueryArguments( state ), 'from' ),
+			from: getCurrentQueryArguments( state )?.from,
 			wccomFrom: getWccomFrom( state ),
 			isWoo: getIsWoo( state ),
 			isWooJPC,

--- a/client/blocks/site-icon/docs/example.jsx
+++ b/client/blocks/site-icon/docs/example.jsx
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import SiteIcon from '../';
@@ -13,7 +12,7 @@ const EN_BLOG_SITE_ID = 3584907;
 const SiteIconExample = ( { siteId } ) => <SiteIcon siteId={ siteId || EN_BLOG_SITE_ID } />;
 
 const ConnectedSiteIconExample = connect( ( state ) => ( {
-	siteId: get( getCurrentUser( state ), 'primary_blog' ),
+	siteId: getCurrentUser( state )?.primary_blog,
 } ) )( SiteIconExample );
 
 ConnectedSiteIconExample.displayName = 'SiteIcon';

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -1,6 +1,6 @@
 import { pick } from '@automattic/js-utils';
 import { throttle } from '@wordpress/compose';
-import { escapeRegExp, findIndex, get } from 'lodash';
+import { escapeRegExp, findIndex } from 'lodash';
 import { createRef, Component, Fragment } from 'react';
 import getCaretCoordinates from 'textarea-caret';
 import UserMentionSuggestionList from './suggestion-list';
@@ -281,7 +281,7 @@ export default ( WrappedComponent ) =>
 
 			this.matchingSuggestions = this.getMatchingSuggestions( suggestions, query );
 			const selectedSuggestionId =
-				this.state.selectedSuggestionId || get( this.matchingSuggestions[ 0 ], 'ID' );
+				this.state.selectedSuggestionId || this.matchingSuggestions[ 0 ]?.ID;
 
 			const popoverPosition = pick( this.state.popoverPosition, [ 'top', 'left' ] );
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -6,7 +6,7 @@ import { HUNDRED_YEAR_DOMAIN_FLOW } from '@automattic/onboarding';
 import { HTTPS_SSL } from '@automattic/urls';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -596,7 +596,7 @@ class DomainRegistrationSuggestion extends Component {
 }
 
 const mapStateToProps = ( state, props ) => {
-	const productSlug = get( props, 'suggestion.product_slug' );
+	const productSlug = props?.suggestion?.product_slug;
 	const productsList = props.products ?? getProductsList( state );
 	const currentUserCurrencyCode =
 		props.suggestion.currency_code || getCurrentUserCurrencyCode( state );

--- a/client/components/domains/trademark-claims-notice/trademark-claim.jsx
+++ b/client/components/domains/trademark-claims-notice/trademark-claim.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { trademarkDecisionText } from './trademark-constants';
@@ -47,7 +46,7 @@ class TrademarkClaim extends Component {
 	};
 
 	renderGoodsAndServices = ( claim ) => {
-		const goodsAndServices = get( claim, 'goodsAndServices' );
+		const goodsAndServices = claim?.goodsAndServices;
 
 		return (
 			goodsAndServices &&
@@ -60,7 +59,7 @@ class TrademarkClaim extends Component {
 	};
 
 	renderInternationalClassification = ( claim ) => {
-		const classDesc = get( claim, 'classDesc' );
+		const classDesc = claim?.classDesc;
 
 		return (
 			classDesc &&
@@ -77,7 +76,7 @@ class TrademarkClaim extends Component {
 			return;
 		}
 
-		const addr = get( contact, 'addr' );
+		const addr = contact?.addr;
 
 		const contactData = [];
 		contact.name && contactData.push( this.renderItem( 'name', 'Name', contact.name ) );
@@ -99,7 +98,7 @@ class TrademarkClaim extends Component {
 	};
 
 	renderRegistrant = ( claim ) => {
-		const holder = get( claim, 'holder' );
+		const holder = claim?.holder;
 		return (
 			holder &&
 			this.renderItem( 'holder', 'Trademark Registrant', this.renderContactInfo( holder ) )
@@ -107,7 +106,7 @@ class TrademarkClaim extends Component {
 	};
 
 	renderContact = ( claim ) => {
-		const contact = get( claim, 'contact' );
+		const contact = claim?.contact;
 		return contact && this.renderItem( 'contact', 'Contact', this.renderContactInfo( contact ) );
 	};
 
@@ -139,14 +138,14 @@ class TrademarkClaim extends Component {
 	};
 
 	renderCases = ( claim ) => {
-		const notExactMatch = get( claim, 'notExactMatch' );
+		const notExactMatch = claim?.notExactMatch;
 
 		if ( ! notExactMatch ) {
 			return;
 		}
 
-		const courtCases = get( notExactMatch, 'court' );
-		const udrpCases = get( notExactMatch, 'udrp' );
+		const courtCases = notExactMatch?.court;
+		const udrpCases = notExactMatch?.udrp;
 
 		return (
 			<div className="trademark-claims-notice__claim-item" key="claim-cases">

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -8,7 +8,6 @@ import {
 } from '@automattic/urls';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -86,7 +85,7 @@ class TransferDomainPrecheck extends Component {
 
 	refreshStatus = () => {
 		this.props.refreshStatus( this.statusRefreshed ).then( ( result ) => {
-			const isUnlocked = get( result, 'inboundTransferStatus.unlocked' );
+			const isUnlocked = result?.inboundTransferStatus?.unlocked;
 			this.props.recordUnlockedCheckButtonClick( this.props.domain, isUnlocked );
 		} );
 	};
@@ -104,7 +103,7 @@ class TransferDomainPrecheck extends Component {
 
 	checkAuthCode = () => {
 		this.props.checkAuthCode( this.props.domain, this.state.authCode ).then( ( result ) => {
-			const authCodeValid = get( result, 'authCodeValid' );
+			const authCodeValid = result?.authCodeValid;
 			this.props.recordAuthCodeCheckButtonClick( this.props.domain, authCodeValid );
 		} );
 	};

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -1,7 +1,7 @@
 import { Button, Spinner } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -198,7 +198,7 @@ VerifyEmailDialog.defaultProps = {
 export default connect(
 	( state ) => ( {
 		email: getCurrentUserEmail( state ),
-		emailVerificationStatus: get( state, 'currentUser.emailVerification.status' ),
+		emailVerificationStatus: state?.currentUser?.emailVerification?.status,
 		currentRoute: getCurrentRoute( state ),
 		isPendingEmailChange: isPendingEmailChange( state ),
 		userSettings: getUserSettings( state ),

--- a/client/components/wpadmin-auto-login/index.jsx
+++ b/client/components/wpadmin-auto-login/index.jsx
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -31,7 +30,7 @@ export default class WpadminAutoLogin extends Component {
 	};
 
 	componentDidMount() {
-		const siteUrl = get( this.props.site, 'URL' );
+		const siteUrl = this.props.site?.URL;
 		const requestUrl = this.getPixelUrl( siteUrl );
 
 		setTimeout( tryLogin.bind( null, requestUrl, this.props.delay, 0 ), this.props.delay );

--- a/client/jetpack-connect/authorize.jsx
+++ b/client/jetpack-connect/authorize.jsx
@@ -11,7 +11,7 @@ import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -749,7 +749,7 @@ export class JetpackAuthorize extends Component {
 			return null;
 		}
 
-		if ( includes( get( authorizeError, 'message' ), 'already_connected' ) ) {
+		if ( includes( authorizeError?.message, 'already_connected' ) ) {
 			return (
 				<JetpackConnectNotices
 					noticeType={ ALREADY_CONNECTED }

--- a/client/jetpack-connect/sso-flow-primitives.js
+++ b/client/jetpack-connect/sso-flow-primitives.js
@@ -1,7 +1,5 @@
-import { get } from 'lodash';
-
 export function getAdminUrlFromBlogDetails( blogDetails ) {
-	return get( blogDetails, 'admin_url' );
+	return blogDetails?.admin_url;
 }
 
 export function navigateToUrl( url ) {

--- a/client/lib/media/utils/is-exceeding-site-max-upload-size.js
+++ b/client/lib/media/utils/is-exceeding-site-max-upload-size.js
@@ -1,4 +1,4 @@
-import { includes, get } from 'lodash';
+import { includes } from 'lodash';
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
 
 /**
@@ -23,7 +23,7 @@ export function isExceedingSiteMaxUploadSize( item, site ) {
 
 	if (
 		site.jetpack &&
-		includes( get( site, 'options.active_modules' ), 'videopress' ) &&
+		includes( site?.options?.active_modules, 'videopress' ) &&
 		( getMimeType( item ) ?? '' ).startsWith( 'video/' )
 	) {
 		return null;

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -1,4 +1,4 @@
-import { filter, get, maxBy } from 'lodash';
+import { filter, maxBy } from 'lodash';
 import { getSections } from 'calypso/sections-helper';
 
 export default function pathToSection( path ) {
@@ -20,7 +20,7 @@ export default function pathToSection( path ) {
 	}
 	// make sure the best match is actually a match (in case nothing matches)
 	if ( bestMatch.paths.some( ( sectionPath ) => ( path ?? '' ).startsWith( sectionPath ) ) ) {
-		return get( bestMatch, 'name' );
+		return bestMatch?.name;
 	}
 	return null;
 }

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -1,5 +1,5 @@
 import { safeImageUrl } from '@automattic/calypso-url';
-import { find, get } from 'lodash';
+import { find } from 'lodash';
 import { isUrlLikelyAnImage } from './utils';
 
 /**
@@ -52,8 +52,8 @@ export default function pickCanonicalMedia( post ) {
 	) {
 		post.canonical_media = {
 			src: post.featured_image,
-			height: get( post, 'post_thumbnail.height' ),
-			width: get( post, 'post_thumbnail.width' ),
+			height: post?.post_thumbnail?.height,
+			width: post?.post_thumbnail?.width,
 			mediaType: 'image',
 		};
 		return post;

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -52,7 +51,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 				locale: this.props.locale,
 				action: 'lostpassword', // TODO add jetpack/lostpassword
 				oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-				from: get( this.props.currentQuery, 'from' ),
+				from: this.props.currentQuery?.from,
 			} )
 		);
 	};

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -4,7 +4,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -186,7 +185,7 @@ export class Login extends Component {
 									? 'jetpack/lostpassword'
 									: 'lostpassword',
 							oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-							from: get( this.props.currentQuery, 'from' ),
+							from: this.props.currentQuery?.from,
 						} )
 					);
 				} }
@@ -208,7 +207,7 @@ export class Login extends Component {
 							redirectTo: this.props.redirectTo,
 							locale: this.props.locale,
 							oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-							from: get( this.props.currentQuery, 'from' ),
+							from: this.props.currentQuery?.from,
 							isJetpack: this.props.isJetpack,
 						} )
 					);
@@ -483,10 +482,10 @@ export default connect(
 		const currentRoute = getCurrentRoute( state );
 
 		const redirectParams = new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] );
-		const connectorFromParam = redirectParams.get( 'from' ) || get( currentQuery, 'from' );
+		const connectorFromParam = redirectParams.get( 'from' ) || currentQuery?.from;
 		const isFromJetpackConnector = connectorFromParam === 'jetpack-connector';
 		const connectorPlugins = isFromJetpackConnector
-			? ( redirectParams.get( 'plugins' ) || get( currentQuery, 'plugins' ) || '' )
+			? ( redirectParams.get( 'plugins' ) || currentQuery?.plugins || '' )
 					.split( ',' )
 					.map( trimString )
 					.filter( Boolean )
@@ -527,7 +526,7 @@ export default connect(
 			currentQuery,
 			redirectTo: getRedirectToOriginal( state ),
 			isFromAutomatticForAgenciesPlugin:
-				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
+				'automattic-for-agencies-client' === getCurrentQueryArguments( state )?.from ||
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 			isFromJetpackConnector,

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -12,7 +12,7 @@ import {
 } from '@automattic/urls';
 import _debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { intersection, map, find, get } from 'lodash';
+import { intersection, map, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -160,8 +160,8 @@ export class DomainWarnings extends PureComponent {
 		debug( 'Rendering wrongNSMappedDomains' );
 
 		if (
-			get( this.props, 'selectedSite.jetpack' ) &&
-			! get( this.props, 'selectedSite.options.is_automated_transfer' )
+			this.props?.selectedSite?.jetpack &&
+			! this.props?.selectedSite?.options?.is_automated_transfer
 		) {
 			return null;
 		}
@@ -581,7 +581,7 @@ export class DomainWarnings extends PureComponent {
 	};
 
 	newDomains = () => {
-		if ( get( this.props, 'selectedSite.options.is_domain_only' ) ) {
+		if ( this.props?.selectedSite?.options?.is_domain_only ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -90,7 +90,7 @@ export class MapDomain extends Component {
 	};
 
 	handleRegisterDomain = ( suggestion ) => {
-		const trademarkClaimsNoticeInfo = get( suggestion, 'trademark_claims_notice_info' );
+		const trademarkClaimsNoticeInfo = suggestion?.trademark_claims_notice_info;
 		if ( ! isEmpty( trademarkClaimsNoticeInfo ) ) {
 			this.setState( {
 				suggestion,
@@ -185,8 +185,8 @@ export class MapDomain extends Component {
 
 	trademarkClaimsNotice = () => {
 		const { suggestion } = this.state;
-		const domain = get( suggestion, 'domain_name' );
-		const trademarkClaimsNoticeInfo = get( suggestion, 'trademark_claims_notice_info' );
+		const domain = suggestion?.domain_name;
+		const trademarkClaimsNoticeInfo = suggestion?.trademark_claims_notice_info;
 
 		return (
 			<TrademarkClaimsNotice

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -75,7 +75,7 @@ export class TransferDomain extends Component {
 	};
 
 	handleRegisterDomain = ( suggestion ) => {
-		const trademarkClaimsNoticeInfo = get( suggestion, 'trademark_claims_notice_info' );
+		const trademarkClaimsNoticeInfo = suggestion?.trademark_claims_notice_info;
 		if ( ! isEmpty( trademarkClaimsNoticeInfo ) ) {
 			this.setState( {
 				suggestion,
@@ -138,8 +138,8 @@ export class TransferDomain extends Component {
 
 	trademarkClaimsNotice = () => {
 		const { suggestion } = this.state;
-		const domain = get( suggestion, 'domain_name' );
-		const trademarkClaimsNoticeInfo = get( suggestion, 'trademark_claims_notice_info' );
+		const domain = suggestion?.domain_name;
+		const trademarkClaimsNoticeInfo = suggestion?.trademark_claims_notice_info;
 
 		return (
 			<TrademarkClaimsNotice

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
 import { importSite, importSubstackSite } from 'calypso/my-sites/importer/controller';
@@ -32,7 +31,7 @@ export default function () {
 	// Importing doesn't have any routes for subsections.
 	// Redirect to parent `/import`.
 	page( '/import/*/:site_id', ( context ) => {
-		const site_id = get( context, 'params.site_id' );
+		const site_id = context?.params?.site_id;
 		return page.redirect( `/import/${ site_id }` );
 	} );
 }

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -8,7 +8,6 @@ import {
 import { CompactCard, ProductIcon, Gridicon, PlanPrice } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -63,8 +62,8 @@ class StepUpgrade extends Component {
 			translate,
 			isEcommerceTrial,
 		} = this.props;
-		const sourceSiteDomain = get( sourceSite, 'domain' );
-		const targetSiteDomain = get( targetSite, 'domain' );
+		const sourceSiteDomain = sourceSite?.domain;
+		const targetSiteDomain = targetSite?.domain;
 		const backHref = `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }`;
 		const upsellPlanName = isEcommerceTrial
 			? getPlan( PLAN_WOOEXPRESS_SMALL )?.getTitle()
@@ -159,7 +158,7 @@ class StepUpgrade extends Component {
 
 const WrappedStepUpgrade = ( props ) => {
 	const { targetSite } = props;
-	const currentPlanSlug = get( targetSite, 'plan.product_slug' );
+	const currentPlanSlug = targetSite?.plan?.product_slug;
 	const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 	const plan = isEcommerceTrial ? getPlan( PLAN_WOOEXPRESS_SMALL ) : getPlan( PLAN_BUSINESS );
 	const planSlug = plan.getStoreSlug();

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -41,7 +40,7 @@ export class PeopleInviteDetails extends PureComponent {
 	}
 
 	goBack = () => {
-		const siteSlug = get( this.props, 'site.slug' );
+		const siteSlug = this.props?.site?.slug;
 		const route = isEnabled( 'user-management-revamp' ) ? 'team-members' : 'invites';
 		const fallback = siteSlug ? `/people/${ route }/${ siteSlug }` : `/people/${ route }/`;
 

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -2,7 +2,6 @@ import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -32,8 +31,8 @@ class PeopleListSectionHeader extends Component {
 	};
 
 	getAddLink() {
-		const siteSlug = get( this.props, 'site.slug' );
-		const isJetpack = get( this.props, 'site.jetpack' );
+		const siteSlug = this.props?.site?.slug;
+		const isJetpack = this.props?.site?.jetpack;
 
 		if ( ! siteSlug || ( isJetpack && this.props.isFollower ) ) {
 			return false;
@@ -47,7 +46,7 @@ class PeopleListSectionHeader extends Component {
 	}
 
 	getAddSubscriberLink() {
-		const siteSlug = get( this.props, 'site.slug' );
+		const siteSlug = this.props?.site?.slug;
 
 		return '/people/add-subscribers/' + siteSlug;
 	}

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { get } from 'lodash';
 import { makeLayout, redirectIfDuplicatedView, render as clientRender } from 'calypso/controller';
 import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
 import {
@@ -41,9 +40,9 @@ export default function () {
 
 	// Redirect settings pages for import and export now that they have their own sections.
 	page( '/settings/:importOrExport(import|export)/:subroute(.*)', ( context ) => {
-		const importOrExport = get( context, 'params.importOrExport' );
-		const subroute = get( context, 'params.subroute' );
-		const queryString = get( context, 'querystring' );
+		const importOrExport = context?.params?.importOrExport;
+		const subroute = context?.params?.subroute;
+		const queryString = context?.querystring;
 		let redirectPath = `/${ importOrExport }`;
 
 		if ( subroute ) {

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment, Component } from 'react';
 import { connect } from 'react-redux';
@@ -29,7 +28,7 @@ class StatsOverview extends Component {
 		const statsPath = path === '/stats' ? '/stats/day' : path;
 		const sitesSorted = sites.map( ( site ) => {
 			let momentSiteZone = moment();
-			const gmtOffset = get( site, 'options.gmt_offset' );
+			const gmtOffset = site?.options?.gmt_offset;
 			if ( Number.isFinite( gmtOffset ) ) {
 				momentSiteZone = moment().utcOffset( gmtOffset );
 			}
@@ -60,7 +59,7 @@ class StatsOverview extends Component {
 		} );
 
 		const sitesList = sitesSorted.map( ( site, index ) => {
-			const gmtOffset = get( site, 'options.gmt_offset' );
+			const gmtOffset = site?.options?.gmt_offset;
 			const date = moment()
 				.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
 				.format( 'YYYY-MM-DD' );

--- a/client/my-sites/stats/stats-comment-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-comment-followers-page/index.jsx
@@ -2,7 +2,6 @@ import { Card } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -33,7 +32,7 @@ class StatModuleFollowersPage extends Component {
 			siteId,
 			translate,
 		} = this.props;
-		const noData = ! get( data, 'posts' );
+		const noData = ! data?.posts;
 		const isLoading = requestingFollowers && noData;
 		const classes = [
 			'stats-module',
@@ -46,7 +45,7 @@ class StatModuleFollowersPage extends Component {
 			},
 		];
 
-		const total = get( data, 'total' );
+		const total = data?.total;
 
 		let paginationSummary;
 		if ( total ) {

--- a/client/my-sites/stats/stats-date-label/index.jsx
+++ b/client/my-sites/stats/stats-date-label/index.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { useMemo } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -191,7 +190,7 @@ function StatsDateLabel( {
 		);
 	}
 
-	const isSummarizeQuery = get( query, 'summarize' );
+	const isSummarizeQuery = query?.summarize;
 	const { selectedShortcut } = getShortcuts( reduxState, dateRange, translate );
 	const shortDisplayDate = isShort ? dateForDisplay( selectedShortcut ) : null;
 	const summarizeDisplayDate = isSummarizeQuery ? dateForSummarize() : null;

--- a/client/my-sites/themes/use-theme-showcase-description.js
+++ b/client/my-sites/themes/use-theme-showcase-description.js
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 import { useSelector } from 'react-redux';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
@@ -8,13 +8,13 @@ export default function useThemeShowcaseDescription( { filter, tier, vertical } 
 	const translate = useTranslate();
 	const description = useSelector( ( state ) => {
 		if ( vertical ) {
-			return get( getThemeFilterTerm( state, 'subject', vertical ), 'description' );
+			return getThemeFilterTerm( state, 'subject', vertical )?.description;
 		}
 	} );
 	const filterDescription = useSelector( ( state ) => {
 		// If we have *one* filter, use its description
 		if ( filter && ! includes( filter, '+' ) ) {
-			return get( findThemeFilterTerm( state, filter ), 'description' );
+			return findThemeFilterTerm( state, filter )?.description;
 		}
 	} );
 

--- a/client/my-sites/themes/use-theme-showcase-title.js
+++ b/client/my-sites/themes/use-theme-showcase-title.js
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 import { useSelector } from 'react-redux';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
@@ -9,14 +9,14 @@ export default function useThemeShowcaseTitle( { filter, tier, vertical } = {} )
 
 	const verticalName = useSelector( ( state ) => {
 		if ( vertical ) {
-			return get( getThemeFilterTerm( state, 'subject', vertical ), 'name' );
+			return getThemeFilterTerm( state, 'subject', vertical )?.name;
 		}
 	} );
 
 	// If we have *one* filter, use its name
 	const filterName = useSelector( ( state ) => {
 		if ( filter && ! includes( filter, '+' ) ) {
-			return get( findThemeFilterTerm( state, filter ), 'name' );
+			return findThemeFilterTerm( state, filter )?.name;
 		}
 	} );
 

--- a/client/reader/components/reader-infinite-stream/row-renderers.js
+++ b/client/reader/components/reader-infinite-stream/row-renderers.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import ConnectedSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 
 export const siteRowRenderer = ( {
@@ -9,10 +8,10 @@ export const siteRowRenderer = ( {
 } ) => {
 	const site = items[ rowRendererProps.index ];
 
-	const feedUrl = get( site, 'feed_URL' );
-	const feedId = +get( site, 'feed_ID' );
-	const siteId = +get( site, 'blog_ID' );
-	const railcar = get( site, 'railcar' );
+	const feedUrl = site?.feed_URL;
+	const feedId = +site?.feed_ID;
+	const siteId = +site?.blog_ID;
+	const railcar = site?.railcar;
 
 	const props = {
 		url: feedUrl,

--- a/client/reader/conversations/stream.jsx
+++ b/client/reader/conversations/stream.jsx
@@ -1,5 +1,4 @@
 import { useTranslate, fixMe } from 'i18n-calypso';
-import { get } from 'lodash';
 import ConversationsEmptyContent from 'calypso/blocks/conversations/empty';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -10,7 +9,7 @@ import './stream.scss';
 const emptyContent = () => <ConversationsEmptyContent />;
 
 export default function ConversationsStream( props ) {
-	const isInternal = get( props, 'store.id' ) === 'conversations-a8c';
+	const isInternal = props?.store?.id === 'conversations-a8c';
 	const intro = () => <ConversationsIntro isInternal={ isInternal } />;
 	const translate = useTranslate();
 

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -1,6 +1,5 @@
 import '../style.scss';
 import { Count } from '@automattic/components';
-import { get } from 'lodash';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -21,8 +20,8 @@ const ReaderListFollowingItem = ( props ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { site } = useSite( siteId );
 	const { data: feed } = useFeedQuery( follow?.feed_ID );
-	const siteIcon = site ? site.site_icon ?? get( site, 'icon.img' ) : null;
-	let feedIcon = get( follow, 'site_icon' );
+	const siteIcon = site ? site.site_icon ?? site?.icon?.img : null;
+	let feedIcon = follow?.site_icon;
 
 	if ( ! follow ) {
 		return null;
@@ -30,7 +29,7 @@ const ReaderListFollowingItem = ( props ) => {
 
 	// If feed available, check feed for feed icon
 	if ( feed && feed.image ) {
-		feedIcon = get( feed, 'image' );
+		feedIcon = feed?.image;
 	}
 
 	const handleSidebarClick = ( event, streamLink ) => {
@@ -92,7 +91,7 @@ const ReaderListFollowingItem = ( props ) => {
 
 export default connect(
 	( _state, ownProps ) => {
-		const siteId = get( ownProps.follow, 'blog_ID' );
+		const siteId = ownProps.follow?.blog_ID;
 
 		return {
 			siteId: siteId,

--- a/client/sites/marketing/connections/service.jsx
+++ b/client/sites/marketing/connections/service.jsx
@@ -4,7 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import requestExternalAccess from '@automattic/request-external-access';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { isEqual, find, some, get } from 'lodash';
+import { isEqual, find, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
 import { connect } from 'react-redux';
@@ -373,7 +373,7 @@ export class SharingService extends Component {
 			 * This immediately connects the account, which is needed for non-publicize accounts
 			 */
 			if (
-				get( nextProps, 'service.type' ) !== 'publicize' &&
+				nextProps?.service?.type !== 'publicize' &&
 				this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts )
 			) {
 				const account = find( nextProps.availableExternalAccounts, { isConnected: false } );
@@ -516,12 +516,12 @@ export class SharingService extends Component {
 		if ( ! config.isEnabled( 'mailchimp' ) ) {
 			return false;
 		}
-		return get( this, 'props.service.ID' ) === 'mailchimp';
+		return this?.props?.service?.ID === 'mailchimp';
 	};
 
 	// Is the service a Google Photos that requires migration to Google Photos Picker API
 	isGooglePhotosMigration( status ) {
-		if ( status === 'must-disconnect' && get( this, 'props.service.ID' ) === 'google_photos' ) {
+		if ( status === 'must-disconnect' && this?.props?.service?.ID === 'google_photos' ) {
 			return true;
 		}
 

--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING,
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS,
@@ -22,7 +21,7 @@ export const getAuthAccountType = ( action ) =>
 	);
 
 export const receiveSuccess = ( action, data ) => {
-	const isPasswordless = get( data, 'passwordless' );
+	const isPasswordless = data?.passwordless;
 
 	return [
 		{

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -1,6 +1,6 @@
 import { omit, omitBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
-import { get, isEmpty, map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import {
 	IMPORTS_AUTHORS_SET_MAPPING,
 	IMPORTS_AUTHORS_START_MAPPING,
@@ -127,7 +127,7 @@ function importerStatus( state = {}, action ) {
 					customData: {
 						...state[ action.importerId ]?.customData,
 						sourceAuthors: map(
-							get( state[ action.importerId ], 'customData.sourceAuthors' ),
+							state[ action.importerId ]?.customData?.sourceAuthors,
 							( author ) =>
 								action.sourceAuthor.id === author.id
 									? {

--- a/client/state/jitm/actions.js
+++ b/client/state/jitm/actions.js
@@ -1,6 +1,5 @@
 import { HelpCenter } from '@automattic/data-stores';
 import { dispatch as dataStoreDispatch } from '@wordpress/data';
-import { get } from 'lodash';
 import {
 	JITM_DISMISS,
 	JITM_FETCH,
@@ -55,7 +54,7 @@ export const clearJITM = ( siteId, messagePath ) => ( {
  * @param {Function} dispatch dispather function
  */
 export const setupDevTool = ( siteId, dispatch ) => {
-	if ( typeof window === 'undefined' || siteId === get( window, '_jitm.siteId' ) ) {
+	if ( typeof window === 'undefined' || siteId === window?._jitm?.siteId ) {
 		return;
 	}
 

--- a/client/state/login/actions/send-sms-code.js
+++ b/client/state/login/actions/send-sms-code.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import {
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE,
@@ -44,7 +43,7 @@ export const sendSmsCode = ( flow ) => ( dispatch, getState ) => {
 					message,
 					status: 'is-success',
 				},
-				twoStepNonce: get( response, 'body.data.two_step_nonce' ),
+				twoStepNonce: response?.body?.data?.two_step_nonce,
 			} );
 		} )
 		.catch( ( httpError ) => {
@@ -53,7 +52,7 @@ export const sendSmsCode = ( flow ) => ( dispatch, getState ) => {
 			dispatch( {
 				type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE,
 				error,
-				twoStepNonce: get( httpError, 'response.body.data.two_step_nonce' ),
+				twoStepNonce: httpError?.response?.body?.data?.two_step_nonce,
 			} );
 		} );
 };

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,6 +1,6 @@
 import { pick } from '@automattic/js-utils';
 import { createSelector } from '@automattic/state-utils';
-import { filter, find, get, reduce, some, sortBy } from 'lodash';
+import { filter, find, reduce, some, sortBy } from 'lodash';
 import {
 	getSite,
 	getSiteTitle,
@@ -230,7 +230,7 @@ export function getSiteObjectsWithPlugin( state, siteIds, pluginSlug ) {
 export function getSitesWithoutPlugin( state, siteIds, pluginSlug ) {
 	const installedOnSiteIds = getSitesWithPlugin( state, siteIds, pluginSlug ) || [];
 	return filter( siteIds, function ( siteId ) {
-		if ( ! get( getSite( state, siteId ), 'visible' ) || ! isJetpackSite( state, siteId ) ) {
+		if ( ! getSite( state, siteId )?.visible || ! isJetpackSite( state, siteId ) ) {
 			return false;
 		}
 

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import versionCompare from 'calypso/lib/version-compare';
 import wpcom from 'calypso/lib/wp';
@@ -257,7 +256,7 @@ function configure( site, plugin, dispatch ) {
 		`/sites/${ site.ID }/option`,
 		{ option_name: option },
 		( getError, getData ) => {
-			if ( get( getData, 'option_value' ) === optionValue ) {
+			if ( getData?.option_value === optionValue ) {
 				// Already registered with this key
 				dispatch( {
 					type: PLUGIN_SETUP_FINISH,

--- a/client/state/posts/utils/is-author-equal.js
+++ b/client/state/posts/utils/is-author-equal.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 /**
  * Returns true if the locally edited author ID is equal to the saved post author's ID. Other
  * properties of the `author` object are irrelevant.
@@ -8,5 +6,5 @@ import { get } from 'lodash';
  * @returns {boolean}                 are the locally edited and saved values equal?
  */
 export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
-	return get( localAuthorEdit, 'ID' ) === get( savedAuthor, 'ID' );
+	return localAuthorEdit?.ID === savedAuthor?.ID;
 }

--- a/client/state/selectors/get-inline-support-article-post-id.js
+++ b/client/state/selectors/get-inline-support-article-post-id.js
@@ -1,9 +1,7 @@
 import 'calypso/state/inline-support-article/init';
 
-import { get } from 'lodash';
-
 /**
  * @param {Object} state Global app state
  * @returns {Object} ...
  */
-export default ( state ) => get( state, 'inlineSupportArticle.postId' );
+export default ( state ) => state?.inlineSupportArticle?.postId;

--- a/client/state/selectors/get-jetpack-settings-save-request-status.js
+++ b/client/state/selectors/get-jetpack-settings-save-request-status.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { saveJetpackSettings } from 'calypso/state/jetpack/settings/actions';
 import getRequest from 'calypso/state/selectors/get-request';
 
@@ -10,5 +9,5 @@ import getRequest from 'calypso/state/selectors/get-request';
  * @returns {string}            The request status (pending, success or error)
  */
 export default function getJetpackSettingsSaveRequestStatus( state, siteId, settings ) {
-	return get( getRequest( state, saveJetpackSettings( siteId, settings ) ), 'status' );
+	return getRequest( state, saveJetpackSettings( siteId, settings ) )?.status;
 }

--- a/client/state/selectors/get-jetpack-wp-admin-url.js
+++ b/client/state/selectors/get-jetpack-wp-admin-url.js
@@ -1,11 +1,10 @@
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
-import { get } from 'lodash';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export default function getJetpackWpAdminUrl( state ) {
 	const site = getSelectedSite( state );
 
-	const adminUrl = get( site, 'options.admin_url' );
+	const adminUrl = site?.options?.admin_url;
 	return adminUrl
 		? getUrlFromParts( {
 				...getUrlParts( adminUrl + 'admin.php' ),

--- a/client/state/selectors/has-unsaved-user-settings.js
+++ b/client/state/selectors/has-unsaved-user-settings.js
@@ -1,4 +1,4 @@
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 import 'calypso/state/user-settings/init';
 
@@ -8,5 +8,5 @@ import 'calypso/state/user-settings/init';
  * @returns {boolean} are there any unsaved settings?
  */
 export default function hasUnsavedUserSettings( state ) {
-	return ! isEmpty( get( state, 'userSettings.unsavedSettings' ) );
+	return ! isEmpty( state?.userSettings?.unsavedSettings );
 }

--- a/client/state/selectors/is-primary-domain-by-site-id.js
+++ b/client/state/selectors/is-primary-domain-by-site-id.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 
 /**
@@ -10,5 +9,5 @@ import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain
  * @returns {boolean} primary domain
  */
 export default function isPrimaryDomainBySiteId( state, siteId, domain ) {
-	return domain === get( getPrimaryDomainBySiteId( state, siteId ), 'domain' );
+	return domain === getPrimaryDomainBySiteId( state, siteId )?.domain;
 }

--- a/client/state/selectors/is-transient-media.js
+++ b/client/state/selectors/is-transient-media.js
@@ -1,6 +1,5 @@
-import { get } from 'lodash';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 
 export default function isTransientMedia( state, siteId, mediaId ) {
-	return !! get( getMediaItem( state, siteId, mediaId ), 'transient' );
+	return !! getMediaItem( state, siteId, mediaId )?.transient;
 }

--- a/client/state/selectors/is-woo-jpc-flow.ts
+++ b/client/state/selectors/is-woo-jpc-flow.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { isWooDnaFlow } from './is-woo-dna-flow';
@@ -9,19 +8,19 @@ import type { AppState } from 'calypso/types';
 // and is now absorbed into the Woo JPC Onboarding flow.
 // See https://github.com/Automattic/wp-calypso/pull/99558 for more details.
 const isLegacyJetpackWooOnboardingFlow = ( state: AppState ) => {
-	return 'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
+	return 'woocommerce-onboarding' === getCurrentQueryArguments( state )?.from;
 };
 
 export const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
 	const from =
-		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
-		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
-		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-onboarding' ||
-		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-onboarding';
+		getInitialQueryArguments( state )?.from === 'woocommerce-payments' ||
+		getCurrentQueryArguments( state )?.from === 'woocommerce-payments' ||
+		getInitialQueryArguments( state )?.from === 'woocommerce-onboarding' ||
+		getCurrentQueryArguments( state )?.from === 'woocommerce-onboarding';
 
 	const redirectTo =
-		get( getInitialQueryArguments( state ), 'redirect_to' ) ||
-		get( getCurrentQueryArguments( state ), 'redirect_to' );
+		getInitialQueryArguments( state )?.redirect_to ||
+		getCurrentQueryArguments( state )?.redirect_to;
 
 	// Unlike WooCommerce Core Profiler flow, we use both `from` and `plugin_name` to determine if the user is in the Woo Payments onboarding flow.
 	// `plugin_name` might not present in the query arguments, so we need to check the `redirect_to` query argument as well.
@@ -36,8 +35,8 @@ export const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
 		} )();
 
 	const plugin =
-		get( getInitialQueryArguments( state ), 'plugin_name' ) === 'woocommerce-payments' ||
-		get( getCurrentQueryArguments( state ), 'plugin_name' ) === 'woocommerce-payments' ||
+		getInitialQueryArguments( state )?.plugin_name === 'woocommerce-payments' ||
+		getCurrentQueryArguments( state )?.plugin_name === 'woocommerce-payments' ||
 		redirectToHasWooCommercePayments;
 
 	return from && plugin;

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import type { AppState } from 'calypso/types';
@@ -12,8 +11,8 @@ import type { AppState } from 'calypso/types';
 export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
 	const allowedFrom = [ 'woocommerce-core-profiler' ];
 	return (
-		allowedFrom.includes( get( getInitialQueryArguments( state ), 'from' ) as string ) ||
-		allowedFrom.includes( get( getCurrentQueryArguments( state ), 'from' ) as string ) ||
+		allowedFrom.includes( getInitialQueryArguments( state )?.from as string ) ||
+		allowedFrom.includes( getCurrentQueryArguments( state )?.from as string ) ||
 		new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
 			'woocommerce-core-profiler'
 	);

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -1,5 +1,5 @@
 import { omit } from '@automattic/js-utils';
-import { merge, get, includes, reduce, isEqual } from 'lodash';
+import { merge, includes, reduce, isEqual } from 'lodash';
 import {
 	MEDIA_DELETE,
 	SITE_LEAVE_RECEIVE,
@@ -241,7 +241,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 
 		case MEDIA_DELETE: {
 			const { siteId, mediaIds } = action;
-			const siteIconId = get( state[ siteId ], 'icon.media_id' );
+			const siteIconId = state[ siteId ]?.icon?.media_id;
 			if ( siteIconId && includes( mediaIds, siteIconId ) ) {
 				return {
 					...state,
@@ -254,7 +254,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 
 		case SITE_PLUGIN_UPDATED: {
 			const { siteId } = action;
-			const siteUpdates = get( state[ siteId ], 'updates' );
+			const siteUpdates = state[ siteId ]?.updates;
 			if ( ! siteUpdates ) {
 				return state;
 			}

--- a/packages/components/src/select-dropdown/index.jsx
+++ b/packages/components/src/select-dropdown/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { filter, find, get, noop } from 'lodash';
+import { filter, find, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component, forwardRef } from 'react';
 import Count from '../count';
@@ -106,10 +106,7 @@ class SelectDropdown extends Component {
 		}
 
 		// Otherwise find the first option that is an item, i.e., not label or separator
-		return get(
-			find( this.props.options, ( item ) => item && ! item.isLabel ),
-			'value'
-		);
+		return find( this.props.options, ( item ) => item && ! item.isLabel )?.value;
 	}
 
 	getSelectedText() {
@@ -121,7 +118,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected text
-		return get( find( options, { value: selected } ), 'label' );
+		return find( options, { value: selected } )?.label;
 	}
 
 	getSelectedIcon() {
@@ -133,7 +130,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected icon
-		return get( find( options, { value: selected } ), 'icon' );
+		return find( options, { value: selected } )?.icon;
 	}
 
 	getSelectedSecondaryIcon() {
@@ -144,7 +141,7 @@ class SelectDropdown extends Component {
 			return selectedSecondaryIcon;
 		}
 
-		return get( find( options, { value: selected } ), 'secondaryIcon' );
+		return find( options, { value: selected } )?.secondaryIcon;
 	}
 
 	dropdownOptions() {
@@ -414,3 +411,4 @@ export default SelectDropdown;
 export const SelectDropdownForwardingRef = forwardRef( ( props, ref ) => (
 	<SelectDropdown { ...props } innerRef={ ref } />
 ) );
+SelectDropdownForwardingRef.displayName = 'SelectDropdownForwardingRef';


### PR DESCRIPTION
## Proposed Changes

* Convert the lowest-risk lodash `get` usages to native optional chaining: 2-argument calls with a string-literal dot-path and **no default value** (e.g. `get( obj, 'a.b' )` → `obj?.a?.b`). Done via a one-off jscodeshift codemod, then the now-unused `get` import is dropped.
* Scoped to the 54 files where *every* `get` usage was that simple form, so lodash `get` is fully removed from each (399 → 345 files still importing it).

## Why are these changes being made?

* First focused round of removing lodash `get` (the largest remaining lodash surface). These conversions are exact equivalents — both lodash `get` (no default) and optional chaining yield `undefined` for a missing path — so they're safe to do in bulk.
* Calls with a default value (lodash defaults only on `undefined`, whereas `??` also triggers on `null`), bracket/array paths, and dynamic paths are intentionally deferred to later rounds. No eslint guard is added yet, since `get` is not fully migrated.

## Testing Instructions

* `yarn typecheck-client` is green (no `any`→stricter-type fallout from the conversions).
* `yarn eslint` is clean on the changed files.
* Related client test suites pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
