### PR TITLE
Notifications: reflect in-app read state in the note list immediately

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -10,6 +10,8 @@ import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
+import { getIsNoteRead } from '../../panel/state/selectors/get-is-note-read';
+import getNotes from '../../panel/state/selectors/get-notes';
 import getUnreadNoteIds from '../../panel/state/selectors/get-unread-note-ids';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
@@ -113,6 +115,17 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		fields
 	);
 
+	// The list's unread indicator renders off each note's raw `read` flag, but
+	// marking a note read in-app updates the read state in Redux, not that flag.
+	// Merge the effective read state (which accounts for in-app reads) into the
+	// rendered items so a row sheds its unread styling immediately on open,
+	// without waiting for a server refetch.
+	const notesState = useSelector( getNotes );
+	const data = filteredData.map( ( note ) => {
+		const isRead = getIsNoteRead( notesState, note );
+		return !! note.read === isRead ? note : { ...note, read: isRead ? 1 : 0 };
+	} );
+
 	// `filterSortAndPaginate` reports `totalItems` as the count of notes loaded
 	// so far. DataViews advances its infinite-scroll window only while
 	// `totalItems` stays ahead of the window, so reporting the loaded count
@@ -164,7 +177,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		<div ref={ noteListRef } className="wpnc__note-list">
 			{ ! showInitialLoader ? (
 				<DataViews< Note >
-					data={ filteredData }
+					data={ data }
 					fields={ fields }
 					view={ view }
 					isLoading={ isLoading }

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -115,11 +115,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		fields
 	);
 
-	// The list's unread indicator renders off each note's raw `read` flag, but
-	// marking a note read in-app updates the read state in Redux, not that flag.
-	// Merge the effective read state (which accounts for in-app reads) into the
-	// rendered items so a row sheds its unread styling immediately on open,
-	// without waiting for a server refetch.
+	// DataViews shows the unread dot from `note.read`, which an in-app read leaves
+	// stale. Swap in the effective read state, reusing the note when unchanged so
+	// only the affected row re-renders.
 	const notesState = useSelector( getNotes );
 	const data = filteredData.map( ( note ) => {
 		const isRead = getIsNoteRead( notesState, note );

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -139,6 +139,27 @@ describe( 'NoteList loading state', () => {
 		expect( screen.queryByText( 'Trash me' ) ).not.toBeInTheDocument();
 	} );
 
+	// Reading a note in-app must update the list row's unread styling right away,
+	// before any server refetch flips the note's raw `read` flag.
+	it( 'drops the unread styling from a row the moment its note is read', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.addNotes( [ makeNote( 950, 'Read me' ) ] ) );
+		store.dispatch( actions.ui.loadedNotes() );
+
+		renderTab( store, 'all' as FilterName );
+
+		const row = screen.getByText( 'Read me' ).closest( '.wpnc__note-list-item' );
+		expect( row ).toHaveClass( 'is-unread' );
+
+		act( () => {
+			store.dispatch( actions.notes.readNote( 950 ) );
+		} );
+
+		expect( screen.getByText( 'Read me' ).closest( '.wpnc__note-list-item' ) ).not.toHaveClass(
+			'is-unread'
+		);
+	} );
+
 	it( 'client-filters the Comments tab from the shared cache', () => {
 		const store = initStore();
 		store.dispatch(


### PR DESCRIPTION
## Proposed Changes

* Make the notifications note list reflect a note's read/unread state immediately when it is read in-app, instead of waiting for a server refetch.
* The list's unread indicator renders off each note's raw `read` flag. Marking a note read in-app updates the read state in Redux (`noteReads`), not that flag, so the `NoteList` component never re-rendered and the row kept its unread styling — and the Unread tab kept showing the note — until the next server refresh.
* Subscribe `NoteList` to the notes slice and merge the effective read state (via `getIsNoteRead`, which accounts for in-app reads and localStorage) into the items handed to DataViews. The row now sheds its unread styling, and drops out of the Unread view, the moment the note is read.
* Added a regression test covering the All tab: a row loses its `is-unread` class as soon as its note is marked read.

## Why are these changes being made?

When a note was opened, the detail view updated to "read" but the list row stayed visually unread until the background poll refreshed the note from the server. The list was reading the raw server `read` flag rather than the same `getIsNoteRead` selector the rest of the app uses, so in-app reads were not reflected. This made the UI feel stale and inconsistent between the detail pane and the list.

## Testing Instructions

* Open the notifications panel with at least one unread notification.
* On the **All** tab, click a notification to open it. The list row should immediately lose its unread (bold / dot) styling — no refetch needed.
* On the **Unread** tab, open a notification; it should drop out of the list immediately.
* Run `yarn jest -c=test/apps/jest.config.js note-list`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
