### PR TITLE
Notifications: show the subject in a DataViews description field

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -106,6 +106,14 @@ export function getFields(): Field< Note >[] {
 			),
 		},
 		{
+			id: 'description',
+			label: __( 'Description' ),
+			getValue: ( { item } ) =>
+				html( item.subject[ 0 ], {
+					links: false,
+				} ),
+		},
+		{
 			id: 'info',
 			label: __( 'Info' ),
 			render: ( { item } ) => {

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -96,6 +96,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	const [ initialView, setView ] = useState< View >( {
 		type: 'list',
 		titleField: 'title',
+		descriptionField: 'description',
 		mediaField: 'icon',
 		fields: [ 'info' ],
 		page: 1,

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -151,10 +151,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
-	// Full-panel loader only until DataViews first mounts; never swap it back out
-	// after. DataViews binds its infinite-scroll listener once, on mount, and only
-	// if the scroll container exists, so a remount mid-load leaves scrolling dead.
-	// In-flight loading shows via the `empty` slot instead (see `showEmptyLoader`).
+	// Loader only until DataViews first mounts, then never again: it binds its
+	// scroll listener once, on mount, only if the container exists, so a remount
+	// mid-load leaves scrolling dead. In-flight loading uses the `empty` slot.
 	const showInitialLoader = ! hasRenderedDataViews.current;
 
 	// Spinner instead of an empty message while the view may still be filling —

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -10,6 +10,8 @@ import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
+import { getIsNoteRead } from '../../panel/state/selectors/get-is-note-read';
+import getNotes from '../../panel/state/selectors/get-notes';
 import getUnreadNoteIds from '../../panel/state/selectors/get-unread-note-ids';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
@@ -113,6 +115,17 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		fields
 	);
 
+	// The list's unread indicator renders off each note's raw `read` flag, but
+	// marking a note read in-app updates the read state in Redux, not that flag.
+	// Merge the effective read state (which accounts for in-app reads) into the
+	// rendered items so a row sheds its unread styling immediately on open,
+	// without waiting for a server refetch.
+	const notesState = useSelector( getNotes );
+	const data = filteredData.map( ( note ) => {
+		const isRead = getIsNoteRead( notesState, note );
+		return !! note.read === isRead ? note : { ...note, read: isRead ? 1 : 0 };
+	} );
+
 	// `filterSortAndPaginate` reports `totalItems` as the count of notes loaded
 	// so far. DataViews advances its infinite-scroll window only while
 	// `totalItems` stays ahead of the window, so reporting the loaded count
@@ -164,7 +177,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		<div ref={ noteListRef } className="wpnc__note-list">
 			{ ! showInitialLoader ? (
 				<DataViews< Note >
-					data={ filteredData }
+					data={ data }
 					fields={ fields }
 					view={ view }
 					isLoading={ isLoading }

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -151,12 +151,14 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
-	// Hold the loader while the Unread fetch is in flight (DataViews shows `empty`
-	// regardless of `isLoading`). Unread only — other tabs page through the cache
-	// while empty and would otherwise flicker the spinner on every page.
-	const showInitialLoader =
-		! hasRenderedDataViews.current ||
-		( filterName === 'unread' && isLoading && visibleNotes.length === 0 );
+	// Show the full-panel loader only until DataViews first mounts. Once mounted it
+	// must never be swapped back out for the spinner: DataViews binds its
+	// infinite-scroll listener a single time, on mount, and only if the scroll
+	// container is present. Unmounting it mid-load (e.g. while the Unread fetch is
+	// in flight) and remounting it leaves scroll-driven loading dead. The in-flight
+	// Unread spinner is rendered inside DataViews via the `empty` slot instead, so
+	// the mounted instance — and its listener — survives the fetch.
+	const showInitialLoader = ! hasRenderedDataViews.current;
 
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">
@@ -169,12 +171,21 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					paginationInfo={ effectivePaginationInfo }
 					empty={
-						<VStack alignment="center">
-							<Text size={ 15 } weight={ 500 }>
-								{ filter.emptyMessage }
-							</Text>
-							<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
-						</VStack>
+						// While the Unread fetch is in flight DataViews still renders its
+						// `empty` slot (data hasn't landed yet), so show the spinner here
+						// rather than the "all caught up" message to avoid flashing it.
+						filterName === 'unread' && isLoading ? (
+							<VStack alignment="center" style={ { padding: '40px 0' } }>
+								<Spinner />
+							</VStack>
+						) : (
+							<VStack alignment="center">
+								<Text size={ 15 } weight={ 500 }>
+									{ filter.emptyMessage }
+								</Text>
+								<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
+							</VStack>
+						)
 					}
 					getItemId={ ( item ) => item.id.toString() }
 					selection={ selectedNoteId ? [ selectedNoteId ] : [] }

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -79,6 +79,13 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		hasRenderedDataViews.current = true;
 	}
 
+	// A fresh Unread mount fetches after first paint; until that fetch starts, an
+	// empty view isn't "all caught up" yet. Latch once loading begins.
+	const unreadFetchStarted = useRef( false );
+	if ( filterName === 'unread' && isLoading ) {
+		unreadFetchStarted.current = true;
+	}
+
 	// Drive the client's server-side filter from the active tab. Only "unread"
 	// maps to a filter today; other tabs stay client-filtered.
 	useEffect( () => {
@@ -151,14 +158,16 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
-	// Show the full-panel loader only until DataViews first mounts. Once mounted it
-	// must never be swapped back out for the spinner: DataViews binds its
-	// infinite-scroll listener a single time, on mount, and only if the scroll
-	// container is present. Unmounting it mid-load (e.g. while the Unread fetch is
-	// in flight) and remounting it leaves scroll-driven loading dead. The in-flight
-	// Unread spinner is rendered inside DataViews via the `empty` slot instead, so
-	// the mounted instance — and its listener — survives the fetch.
+	// Full-panel loader only until DataViews first mounts; never swap it back out
+	// after. DataViews binds its infinite-scroll listener once, on mount, and only
+	// if the scroll container exists, so a remount mid-load leaves scrolling dead.
+	// In-flight loading shows via the `empty` slot instead (see `showEmptyLoader`).
 	const showInitialLoader = ! hasRenderedDataViews.current;
+
+	// Spinner instead of an empty message while the view may still be filling —
+	// more cache pages to search, or the Unread fetch not started/settled yet.
+	const showEmptyLoader =
+		hasMoreNotes || ( filterName === 'unread' && ( isLoading || ! unreadFetchStarted.current ) );
 
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">
@@ -171,10 +180,8 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					paginationInfo={ effectivePaginationInfo }
 					empty={
-						// While the Unread fetch is in flight DataViews still renders its
-						// `empty` slot (data hasn't landed yet), so show the spinner here
-						// rather than the "all caught up" message to avoid flashing it.
-						filterName === 'unread' && isLoading ? (
+						// Spinner while still filling; the real message once settled.
+						showEmptyLoader ? (
 							<VStack alignment="center" style={ { padding: '40px 0' } }>
 								<Spinner />
 							</VStack>

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -79,13 +79,6 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		hasRenderedDataViews.current = true;
 	}
 
-	// A fresh Unread mount fetches after first paint; until that fetch starts, an
-	// empty view isn't "all caught up" yet. Latch once loading begins.
-	const unreadFetchStarted = useRef( false );
-	if ( filterName === 'unread' && isLoading ) {
-		unreadFetchStarted.current = true;
-	}
-
 	// Drive the client's server-side filter from the active tab. Only "unread"
 	// maps to a filter today; other tabs stay client-filtered.
 	useEffect( () => {
@@ -165,9 +158,8 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	const showInitialLoader = ! hasRenderedDataViews.current;
 
 	// Spinner instead of an empty message while the view may still be filling —
-	// more cache pages to search, or the Unread fetch not started/settled yet.
-	const showEmptyLoader =
-		hasMoreNotes || ( filterName === 'unread' && ( isLoading || ! unreadFetchStarted.current ) );
+	// more cache pages to search, or the Unread fetch in flight.
+	const showEmptyLoader = hasMoreNotes || ( filterName === 'unread' && isLoading );
 
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -139,6 +139,27 @@ describe( 'NoteList loading state', () => {
 		expect( screen.queryByText( 'Trash me' ) ).not.toBeInTheDocument();
 	} );
 
+	// Reading a note in-app must update the list row's unread styling right away,
+	// before any server refetch flips the note's raw `read` flag.
+	it( 'drops the unread styling from a row the moment its note is read', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.addNotes( [ makeNote( 950, 'Read me' ) ] ) );
+		store.dispatch( actions.ui.loadedNotes() );
+
+		renderTab( store, 'all' as FilterName );
+
+		const row = screen.getByText( 'Read me' ).closest( '.wpnc__note-list-item' );
+		expect( row ).toHaveClass( 'is-unread' );
+
+		act( () => {
+			store.dispatch( actions.notes.readNote( 950 ) );
+		} );
+
+		expect( screen.getByText( 'Read me' ).closest( '.wpnc__note-list-item' ) ).not.toHaveClass(
+			'is-unread'
+		);
+	} );
+
 	it( 'client-filters the Comments tab from the shared cache', () => {
 		const store = initStore();
 		store.dispatch(

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -22,10 +22,14 @@ const makeNote = ( id: number, label: string, type = 'comment' ) => ( {
 	subject: [ { text: label, ranges: [], media: [] } ],
 } );
 
-const renderTab = ( store: ReturnType< typeof initStore >, filterName: FilterName ) =>
+const renderTab = (
+	store: ReturnType< typeof initStore >,
+	filterName: FilterName,
+	clientOverride: Partial< typeof client > = {}
+) =>
 	render(
 		<Provider store={ store }>
-			<AppProvider client={ client as never } locale="en">
+			<AppProvider client={ { ...client, ...clientOverride } as never } locale="en">
 				<NoteList
 					filterName={ filterName }
 					selectedNoteId={ undefined }
@@ -43,21 +47,25 @@ describe( 'NoteList loading state', () => {
 		Element.prototype.scrollIntoView = noop;
 	} );
 
-	it( 'shows the loader, not the empty message, while a filtered fetch is in flight', () => {
+	it( 'shows the loader, not the empty message, until the Unread fetch settles', () => {
 		const store = initStore();
-		// Settle once with no notes so DataViews has mounted and shows its empty state.
-		store.dispatch( actions.ui.loadedNotes() );
 		const { container } = renderUnread( store );
-		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
 
-		// A filtered fetch begins: loading is true while the data is still empty.
+		// Fresh mount: the fetch hasn't run yet, so the empty message must not flash.
+		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
+
+		// The fetch runs and is still in flight: loading, data empty.
 		act( () => {
 			store.dispatch( actions.ui.loadNotes() );
 		} );
-
-		// The "all caught up" message must not show until the fetch settles.
 		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
-		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
+
+		// It settles with no unread notes: now the real message shows.
+		act( () => {
+			store.dispatch( actions.ui.loadedNotes() );
+		} );
+		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
 	} );
 
 	// Regression: a refetch that flips `isLoading` on while the Unread list is
@@ -153,22 +161,31 @@ describe( 'NoteList loading state', () => {
 		expect( screen.queryByText( 'A like' ) ).not.toBeInTheDocument();
 	} );
 
-	// A client-filtered tab pages through the shared cache and is often empty
-	// mid-paging. The full loader must not re-take over on each page (that looked
-	// like it continually restarted); the empty/DataViews view stays put.
-	it( 'keeps the view (not the loader) while a client-filtered tab pages empty', () => {
+	// Once the cache is exhausted (no more to page), a background refresh must not
+	// flash the spinner over the settled empty message.
+	it( 'keeps the empty message on a settled client-filtered tab during a refresh', () => {
 		const store = initStore();
-		// Settle once with no notes so DataViews has mounted on the Comments tab.
 		store.dispatch( actions.ui.loadedNotes() );
-		renderTab( store, 'comments' as FilterName );
+		renderTab( store, 'comments' as FilterName ); // client.hasMoreNotes() is false
 		expect( screen.getByText( 'No new comments yet!' ) ).toBeVisible();
 
-		// A paging fetch begins while no comments are loaded yet.
 		act( () => {
 			store.dispatch( actions.ui.loadNotes() );
 		} );
 
-		// The empty view stays — the full loader does not take over per page.
 		expect( screen.getByText( 'No new comments yet!' ) ).toBeVisible();
+	} );
+
+	// While a client-filtered tab still has cache pages to search, show the spinner
+	// rather than flashing its empty message before matching notes arrive.
+	it( 'shows the loader on a client-filtered tab while the cache still has pages', () => {
+		const store = initStore();
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderTab( store, 'comments' as FilterName, {
+			hasMoreNotes: () => true,
+		} );
+
+		expect( screen.queryByText( 'No new comments yet!' ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
 	} );
 } );

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -60,6 +60,32 @@ describe( 'NoteList loading state', () => {
 		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
 	} );
 
+	// Regression: a refetch that flips `isLoading` on while the Unread list is
+	// briefly empty must not unmount DataViews. DataViews binds its infinite-scroll
+	// listener a single time, on mount, so tearing it down here leaves scrolling
+	// dead until the next tab switch.
+	it( 'keeps DataViews mounted when the Unread list empties mid-fetch', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.addNotes( [ makeNote( 800, 'Unread one' ) ] ) );
+		store.dispatch( actions.notes.setUnreadNoteIds( [ 800 ] ) );
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderUnread( store );
+
+		const dataViews = container.querySelector( '.dataviews-layout__container' );
+		expect( dataViews ).toBeTruthy();
+
+		// A refetch clears the id list and flips loading on: the list is empty while
+		// the request is in flight.
+		act( () => {
+			store.dispatch( actions.notes.setUnreadNoteIds( [] ) );
+			store.dispatch( actions.ui.loadNotes() );
+		} );
+
+		// The same DataViews node is still mounted — it was not swapped for the
+		// full-panel loader and remounted.
+		expect( container.querySelector( '.dataviews-layout__container' ) ).toBe( dataViews );
+	} );
+
 	it( 'renders only the notes in the unread id list, not the whole cache', () => {
 		const store = initStore();
 		// Two cached notes the client would both treat as unread; only one is in

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -47,25 +47,21 @@ describe( 'NoteList loading state', () => {
 		Element.prototype.scrollIntoView = noop;
 	} );
 
-	it( 'shows the loader, not the empty message, until the Unread fetch settles', () => {
+	it( 'shows the loader, not the empty message, while a filtered fetch is in flight', () => {
 		const store = initStore();
+		// Settle once with no notes so DataViews has mounted and shows its empty state.
+		store.dispatch( actions.ui.loadedNotes() );
 		const { container } = renderUnread( store );
+		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
 
-		// Fresh mount: the fetch hasn't run yet, so the empty message must not flash.
-		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
-		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
-
-		// The fetch runs and is still in flight: loading, data empty.
+		// A filtered fetch begins: loading is true while the data is still empty.
 		act( () => {
 			store.dispatch( actions.ui.loadNotes() );
 		} );
-		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
 
-		// It settles with no unread notes: now the real message shows.
-		act( () => {
-			store.dispatch( actions.ui.loadedNotes() );
-		} );
-		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
+		// The "all caught up" message must not show until the fetch settles.
+		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
 	} );
 
 	// Regression: a refetch that flips `isLoading` on while the Unread list is

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -64,10 +64,8 @@ describe( 'NoteList loading state', () => {
 		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
 	} );
 
-	// Regression: a refetch that flips `isLoading` on while the Unread list is
-	// briefly empty must not unmount DataViews. DataViews binds its infinite-scroll
-	// listener a single time, on mount, so tearing it down here leaves scrolling
-	// dead until the next tab switch.
+	// Regression: a refetch that empties the Unread list mid-flight must not
+	// unmount DataViews — it binds its scroll listener once, on mount.
 	it( 'keeps DataViews mounted when the Unread list empties mid-fetch', () => {
 		const store = initStore();
 		store.dispatch( actions.notes.addNotes( [ makeNote( 800, 'Unread one' ) ] ) );

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -3,6 +3,7 @@ import repliesCache from '../comment-replies-cache';
 import { store } from '../state';
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
+import getUnreadNoteIds from '../state/selectors/get-unread-note-ids';
 import { fetchNote, listNotes, sendLastSeenTime, subscribeToNoteStream } from './wpcom';
 
 const debug = debugFactory( 'notifications:rest-client' );
@@ -394,21 +395,31 @@ function setFilter( filter ) {
  * server's answer for which notes belong to the view is kept as an ordered id
  * list (`unreadNoteIds`) that the Unread tab renders looked up in the store.
  */
-function getFilteredNotes() {
+function getFilteredNotes( before ) {
 	if ( ! this.filter || this.gettingFilteredNotes ) {
 		return;
 	}
 	this.gettingFilteredNotes = true;
 
+	const unreadIds = getUnreadNoteIds( store.getState() );
+
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		number: this.filteredRequestLimit,
+		// Without `before` this re-requests the authoritative top window. With it,
+		// load-more pages an older slice in additively — only what's left under the
+		// cap, so a page can't push the view past max_limit.
+		number: before
+			? Math.min( settings.increment_limit, settings.max_limit - unreadIds.length )
+			: this.filteredRequestLimit,
 		locale: this.locale,
 		...this.filter,
 	};
+	if ( before ) {
+		parameters.before = before;
+	}
 
 	// Only show the full-panel spinner for the first page; later pages stream in.
-	if ( this.filteredRequestLimit === settings.initial_limit ) {
+	if ( ! before && this.filteredRequestLimit === settings.initial_limit ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
 
@@ -424,17 +435,33 @@ function getFilteredNotes() {
 
 		store.dispatch( actions.notes.addNotes( data.notes ) );
 
-		// The latest response is authoritative, so replace the id list — notes the
-		// server no longer returns (read/deleted elsewhere) drop from the view.
 		// Guard on the filter so a response landing after a tab switch is ignored,
 		// and so only `unread` writes the unread list.
 		if ( this.filter?.unread ) {
-			store.dispatch( actions.notes.setUnreadNoteIds( data.notes.map( ( note ) => note.id ) ) );
-		}
+			const pageIds = data.notes.map( ( note ) => note.id );
+			if ( before ) {
+				// Append the older page to the view's id list, de-duped — a filtered
+				// fetch can return notes an earlier page already loaded.
+				const current = getUnreadNoteIds( store.getState() );
+				const known = new Set( current );
+				const fresh = pageIds.filter( ( id ) => ! known.has( id ) );
+				store.dispatch( actions.notes.setUnreadNoteIds( current.concat( fresh ) ) );
 
-		// A full page back implies the server may have more matching notes.
-		this.filteredHasMore =
-			data.notes.length >= parameters.number && this.filteredRequestLimit < settings.max_limit;
+				// Keep paging only while an older page is full and still adds new ids
+				// (an inclusive `before` can echo the anchor back) and there's room
+				// left under the cap.
+				this.filteredHasMore =
+					fresh.length > 0 && data.notes.length >= parameters.number && parameters.number > 0;
+			} else {
+				// The top window is authoritative, so replace the id list — notes the
+				// server no longer returns (read/deleted elsewhere) drop from the view.
+				store.dispatch( actions.notes.setUnreadNoteIds( pageIds ) );
+
+				// A full page back implies the server may have more matching notes.
+				this.filteredHasMore =
+					data.notes.length >= parameters.number && this.filteredRequestLimit < settings.max_limit;
+			}
+		}
 	} );
 }
 
@@ -604,11 +631,22 @@ function loadMore() {
 		if ( this.gettingFilteredNotes || ! this.filteredHasMore ) {
 			return;
 		}
+		// Grow the refresh window so the polling re-fetch keeps covering every
+		// matching note paged in (mirrors the unfiltered noteRequestLimit).
 		this.filteredRequestLimit = Math.min(
 			this.filteredRequestLimit + settings.increment_limit,
 			settings.max_limit
 		);
-		this.getFilteredNotes();
+		// Page older matching notes in additively, anchored on the oldest note in
+		// the view's own id list — `before` is the endpoint's UNIX epoch seconds
+		// cursor, so a raw ISO timestamp would be ignored and refetch page one.
+		const unreadIds = getUnreadNoteIds( store.getState() );
+		const oldestId = unreadIds[ unreadIds.length - 1 ];
+		const oldest = oldestId && getAllNotes( store.getState() ).find( ( n ) => n.id === oldestId );
+		if ( ! oldest ) {
+			return;
+		}
+		this.getFilteredNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
 		return;
 	}
 

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -35,6 +35,9 @@ export function Client() {
 	this.filteredRequestLimit = settings.initial_limit;
 	this.filteredHasMore = false;
 	this.gettingFilteredNotes = false;
+	// Bumped on every setFilter so an in-flight fetch whose filter was reset
+	// (tab switched away and back) can discard its now-stale response.
+	this.filterGeneration = 0;
 	this.retries = 0;
 	this.subscribeTry = 0;
 	this.subscribeTries = 3;
@@ -187,13 +190,17 @@ function getNotes( before ) {
 	this.gettingNotes = true;
 
 	const notes = getAllNotes( store.getState() );
+	// Cap older pages by this view's own loaded count (`noteList`), matching
+	// hasMoreNotes — a filtered fetch can inflate the shared store, which would
+	// otherwise shrink the request to zero while the view still has a gap.
+	const loaded = this.noteList.length || notes.length;
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
 		// Older pages only request what's left under max_limit, so an additive
 		// page can't push the loaded count past the cap.
 		number: before
-			? Math.min( settings.increment_limit, settings.max_limit - notes.length )
+			? Math.min( settings.increment_limit, settings.max_limit - loaded )
 			: this.noteRequestLimit,
 		locale: this.locale,
 	};
@@ -374,6 +381,7 @@ function setFilter( filter ) {
 	this.filter = filter ?? null;
 	this.filteredRequestLimit = settings.initial_limit;
 	this.filteredHasMore = false;
+	this.filterGeneration++;
 
 	// Reset the filtered view's id list so the tab doesn't show a stale set
 	// before the fresh fetch lands.
@@ -396,6 +404,7 @@ function getFilteredNotes( before ) {
 		return;
 	}
 	this.gettingFilteredNotes = true;
+	const generation = this.filterGeneration;
 
 	const unreadIds = getUnreadNoteIds( store.getState() );
 
@@ -425,6 +434,16 @@ function getFilteredNotes( before ) {
 		if ( error ) {
 			// Leave the polling path's state untouched; it will recover on its
 			// own schedule. A retry happens when the user re-enters the tab.
+			return;
+		}
+
+		// The filter was reset (tab switched away and back) while this was in
+		// flight: drop the stale response and refetch the current view, since
+		// setFilter's own fetch was skipped while this request held the lock.
+		if ( generation !== this.filterGeneration ) {
+			if ( this.filter && this.isVisible ) {
+				this.getFilteredNotes();
+			}
 			return;
 		}
 

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -239,13 +239,9 @@ function getNotes( before ) {
 		}
 
 		if ( before ) {
-			// Also stop when an older page adds no new ids — e.g. an inclusive
-			// `before` echoes back only the anchor note, or capping near max_limit
-			// left room for just that anchor. Such a page isn't "short", so without
-			// this the catch-up loop would refetch the same notes forever. Compare
-			// against this view's own window, not the shared store: a filtered fetch
-			// may have cached an older matching note that this page legitimately
-			// brings into the All view, which must still count as new.
+			// Stop when an older page adds nothing new (an inclusive `before` can
+			// echo back just the anchor). Compare against the view's own window so
+			// a note already cached by a filtered fetch still counts as new.
 			const viewNotes = this.noteList.length ? this.noteList : getAllNotes( store.getState() );
 			const knownIds = new Set( viewNotes.map( ( n ) => n.id ) );
 			if ( ! data.notes.some( ( n ) => ! knownIds.has( n.id ) ) ) {
@@ -405,9 +401,8 @@ function getFilteredNotes( before ) {
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		// Without `before` this re-requests the authoritative top window. With it,
-		// load-more pages an older slice in additively — only what's left under the
-		// cap, so a page can't push the view past max_limit.
+		// No `before`: re-request the authoritative top window. With it: page an
+		// older slice, capped to what's left under max_limit.
 		number: before
 			? Math.min( settings.increment_limit, settings.max_limit - unreadIds.length )
 			: this.filteredRequestLimit,
@@ -447,9 +442,8 @@ function getFilteredNotes( before ) {
 				const fresh = pageIds.filter( ( id ) => ! known.has( id ) );
 				store.dispatch( actions.notes.setUnreadNoteIds( current.concat( fresh ) ) );
 
-				// Keep paging only while an older page is full and still adds new ids
-				// (an inclusive `before` can echo the anchor back) and there's room
-				// left under the cap.
+				// More only while the page is full, adds new ids (an inclusive
+				// `before` can echo the anchor), and there's room under the cap.
 				this.filteredHasMore =
 					fresh.length > 0 && data.notes.length >= parameters.number && parameters.number > 0;
 			} else {
@@ -631,15 +625,13 @@ function loadMore() {
 		if ( this.gettingFilteredNotes || ! this.filteredHasMore ) {
 			return;
 		}
-		// Grow the refresh window so the polling re-fetch keeps covering every
-		// matching note paged in (mirrors the unfiltered noteRequestLimit).
+		// Grow the refresh window so the poll keeps covering paged-in notes.
 		this.filteredRequestLimit = Math.min(
 			this.filteredRequestLimit + settings.increment_limit,
 			settings.max_limit
 		);
-		// Page older matching notes in additively, anchored on the oldest note in
-		// the view's own id list — `before` is the endpoint's UNIX epoch seconds
-		// cursor, so a raw ISO timestamp would be ignored and refetch page one.
+		// Page older notes additively, anchored on the view's oldest. `before` is
+		// epoch seconds, not the ISO timestamp.
 		const unreadIds = getUnreadNoteIds( store.getState() );
 		const oldestId = unreadIds[ unreadIds.length - 1 ];
 		const oldest = oldestId && getAllNotes( store.getState() ).find( ( n ) => n.id === oldestId );
@@ -654,12 +646,9 @@ function loadMore() {
 		return;
 	}
 
-	// Page from this view's own window (`noteList`), newest-first, so its last
-	// entry is the oldest note this view has paged in. A filtered (Unread) fetch
-	// drops matching notes — often older ones — into the shared store, so pacing
-	// the `before` cursor off `getAllNotes()` could jump it past notes the All
-	// view hasn't loaded and strand the rest of the list. Fall back to the store
-	// only before this view has a window of its own.
+	// Anchor on the view's own window (`noteList`), not the shared store: a
+	// filtered fetch seeds the store with older notes, so pacing `before` off it
+	// could skip notes this view hasn't loaded. Fall back to the store only first.
 	const allNotes = getAllNotes( store.getState() );
 	const oldestId = this.noteList.length
 		? this.noteList[ this.noteList.length - 1 ].id

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -440,12 +440,15 @@ function getFilteredNotes( before ) {
 				const current = getUnreadNoteIds( store.getState() );
 				const known = new Set( current );
 				const fresh = pageIds.filter( ( id ) => ! known.has( id ) );
-				store.dispatch( actions.notes.setUnreadNoteIds( current.concat( fresh ) ) );
+				const appended = current.concat( fresh );
+				store.dispatch( actions.notes.setUnreadNoteIds( appended ) );
 
 				// More only while the page is full, adds new ids (an inclusive
-				// `before` can echo the anchor), and there's room under the cap.
+				// `before` can echo the anchor), and the list is under the cap.
 				this.filteredHasMore =
-					fresh.length > 0 && data.notes.length >= parameters.number && parameters.number > 0;
+					fresh.length > 0 &&
+					data.notes.length >= parameters.number &&
+					appended.length < settings.max_limit;
 			} else {
 				// The top window is authoritative, so replace the id list — notes the
 				// server no longer returns (read/deleted elsewhere) drop from the view.
@@ -680,8 +683,10 @@ function hasMoreNotes() {
 	if ( this.filter ) {
 		return this.filteredHasMore;
 	}
-	const notes = getAllNotes( store.getState() );
-	return ! this.allNotesLoaded && notes.length < settings.max_limit;
+	// Measure this view's own window (`noteList`), not the shared store, which a
+	// filtered fetch can inflate to the cap with notes outside this window.
+	const loaded = this.noteList.length || getAllNotes( store.getState() ).length;
+	return ! this.allNotesLoaded && loaded < settings.max_limit;
 }
 
 function setVisibility( { isShowing, isVisible } ) {

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -241,8 +241,12 @@ function getNotes( before ) {
 			// Also stop when an older page adds no new ids — e.g. an inclusive
 			// `before` echoes back only the anchor note, or capping near max_limit
 			// left room for just that anchor. Such a page isn't "short", so without
-			// this the catch-up loop would refetch the same notes forever.
-			const knownIds = new Set( getAllNotes( store.getState() ).map( ( n ) => n.id ) );
+			// this the catch-up loop would refetch the same notes forever. Compare
+			// against this view's own window, not the shared store: a filtered fetch
+			// may have cached an older matching note that this page legitimately
+			// brings into the All view, which must still count as new.
+			const viewNotes = this.noteList.length ? this.noteList : getAllNotes( store.getState() );
+			const knownIds = new Set( viewNotes.map( ( n ) => n.id ) );
 			if ( ! data.notes.some( ( n ) => ! knownIds.has( n.id ) ) ) {
 				this.allNotesLoaded = true;
 			}
@@ -612,10 +616,17 @@ function loadMore() {
 		return;
 	}
 
-	// getAllNotes is newest-first, so the last entry is the oldest loaded note —
-	// the cursor for the next, older page.
-	const notes = getAllNotes( store.getState() );
-	const oldest = notes[ notes.length - 1 ];
+	// Page from this view's own window (`noteList`), newest-first, so its last
+	// entry is the oldest note this view has paged in. A filtered (Unread) fetch
+	// drops matching notes — often older ones — into the shared store, so pacing
+	// the `before` cursor off `getAllNotes()` could jump it past notes the All
+	// view hasn't loaded and strand the rest of the list. Fall back to the store
+	// only before this view has a window of its own.
+	const allNotes = getAllNotes( store.getState() );
+	const oldestId = this.noteList.length
+		? this.noteList[ this.noteList.length - 1 ].id
+		: allNotes[ allNotes.length - 1 ]?.id;
+	const oldest = allNotes.find( ( note ) => note.id === oldestId );
 	if ( ! oldest ) {
 		return;
 	}

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -184,6 +184,16 @@ describe( 'RestClient', () => {
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 90 ), last_seen_time: 0 } );
 			expect( client.hasMoreNotes() ).toBe( true );
 		} );
+
+		// hasMoreNotes must measure this view's own window, not the shared store a
+		// filtered fetch can inflate to the cap.
+		it( 'keeps paging when a filtered fetch fills the shared store to the cap', () => {
+			seedFirstWindow(); // All window: ids 100..91 (10 notes)
+			// A filtered (Unread) visit dumps older notes into the store, filling it
+			// to max_limit, while the All view's own window stays at 10.
+			store.dispatch( actions.notes.addNotes( fullPage( 90, 90 ) ) ); // store now 100
+			expect( client.hasMoreNotes() ).toBe( true );
+		} );
 	} );
 
 	describe( 'server-side (unread) filtering', () => {
@@ -316,6 +326,28 @@ describe( 'RestClient', () => {
 			expect( client.filteredHasMore ).toBe( false );
 
 			// No more pages: load-more is a no-op.
+			getCalls.length = 0;
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 0 );
+		} );
+
+		// Reaching the cap with a full page must clear `filteredHasMore`, or the next
+		// load-more fires a zero-count request (number = max_limit - 100).
+		it( 'stops filtered paging at the cap without a zero-count request', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+
+			// Page in full older pages until the list reaches max_limit (100).
+			for ( let oldest = 199; oldest >= 119; oldest -= 10 ) {
+				getCalls.length = 0;
+				client.loadMore();
+				getCalls[ 0 ].callback( null, { notes: fullPage( 10, oldest ), last_seen_time: 0 } );
+			}
+
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 100 );
+			expect( client.filteredHasMore ).toBe( false );
+
+			// At the cap, load-more must not fire another request.
 			getCalls.length = 0;
 			client.loadMore();
 			expect( getCalls ).toHaveLength( 0 );

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -214,18 +214,37 @@ describe( 'RestClient', () => {
 			expect( getCalls ).toHaveLength( 0 );
 		} );
 
-		it( 'keeps paginating with a larger window while the server has more', () => {
+		it( 'pages older unread notes in with a before cursor while the server has more', () => {
 			client.setFilter( { unread: 1 } );
-			// A full page back implies more may exist.
-			const firstPage = Array.from( { length: 10 }, ( _, i ) => makeNote( 200 + i ) );
-			getCalls[ 0 ].callback( null, { notes: firstPage, last_seen_time: 0 } );
+			// A full first window (newest-first, oldest id 200) implies more may exist.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 
 			expect( client.filteredHasMore ).toBe( true );
 
 			getCalls.length = 0;
 			client.loadMore();
 			expect( getCalls ).toHaveLength( 1 );
-			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 20 } );
+			// Load-more pages a fixed increment older than the oldest loaded note —
+			// not a re-request of the whole grown window.
+			expect( getCalls[ 0 ].query ).toMatchObject( {
+				unread: 1,
+				number: 10,
+				before: Math.floor( Date.parse( makeNote( 200 ).timestamp ) / 1000 ),
+			} );
+		} );
+
+		it( 'de-dupes an older unread page that echoes an already-loaded id', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
+			getCalls.length = 0;
+
+			client.loadMore();
+			// The server's inclusive `before` echoes the anchor (200) back alongside
+			// genuinely older notes (199..191).
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 200 ), last_seen_time: 0 } );
+
+			// Only the nine genuinely-older ids are appended; the anchor isn't duped.
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 19 );
 		} );
 
 		it( 'replaces the unread id list with the response, leaving the shared store intact', () => {
@@ -268,29 +287,33 @@ describe( 'RestClient', () => {
 			expect( getAllNotes( store.getState() ).length ).toBe( before );
 		} );
 
-		it( 'accumulates unread notes across load-more pages and stops when exhausted', () => {
-			// Each fetch re-requests a growing top-N window, so every response is a
-			// superset; the id list is replaced and therefore grows.
-			const page = ( count ) => Array.from( { length: count }, ( _, i ) => makeNote( 300 + i ) );
-
+		it( 'pages older unread notes in additively and stops when exhausted', () => {
 			client.setFilter( { unread: 1 } );
-			getCalls[ 0 ].callback( null, { notes: page( 10 ), last_seen_time: 0 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
 			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 10 );
 			expect( client.filteredHasMore ).toBe( true );
 
-			// Page 2: load-more requests number=20 and the list grows to 20.
+			// Page 2: a fixed increment older than the oldest loaded note (200).
 			getCalls.length = 0;
 			client.loadMore();
-			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 20 } );
-			getCalls[ 0 ].callback( null, { notes: page( 20 ), last_seen_time: 0 } );
+			expect( getCalls[ 0 ].query ).toMatchObject( {
+				unread: 1,
+				number: 10,
+				before: Math.floor( Date.parse( makeNote( 200 ).timestamp ) / 1000 ),
+			} );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } ); // 199..190
 			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 20 );
 			expect( client.filteredHasMore ).toBe( true );
 
-			// Page 3: requests number=30 but the server returns fewer (25) — exhausted.
+			// Page 3: older than the new oldest (190); a short page means exhausted.
 			getCalls.length = 0;
 			client.loadMore();
-			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 30 } );
-			getCalls[ 0 ].callback( null, { notes: page( 25 ), last_seen_time: 0 } );
+			expect( getCalls[ 0 ].query ).toMatchObject( {
+				unread: 1,
+				number: 10,
+				before: Math.floor( Date.parse( makeNote( 190 ).timestamp ) / 1000 ),
+			} );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 5, 189 ), last_seen_time: 0 } ); // 189..185
 			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 25 );
 			expect( client.filteredHasMore ).toBe( false );
 

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -150,6 +150,42 @@ describe( 'RestClient', () => {
 			client.loadMore();
 			expect( getCalls ).toHaveLength( 0 );
 		} );
+
+		// A filtered (Unread) fetch drops matching notes — sometimes older than the
+		// All view's loaded window — into the shared store. Load-more must keep
+		// pacing off this view's own window (`noteList`), not those stray notes, or
+		// the `before` cursor jumps past unloaded notes, the next page comes back
+		// short, and paging latches with the list half-loaded.
+		it( 'keeps paging the All view from its own window after an Unread visit', () => {
+			// All view's first window: ids 100..91 (oldest loaded = 91).
+			seedFirstWindow();
+
+			// Visit Unread; the response includes a note far older than the window.
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, {
+				notes: [ makeNote( 91 ), makeNote( 5 ) ],
+				last_seen_time: 0,
+			} );
+			getCalls.length = 0;
+
+			// Back to the All view.
+			client.setFilter( null );
+			getCalls.length = 0;
+
+			// Load-more must anchor on the All window's oldest (91), not the stray
+			// unread note (5), and still consider there to be more to load.
+			expect( client.hasMoreNotes() ).toBe( true );
+			client.loadMore();
+
+			expect( getCalls ).toHaveLength( 1 );
+			expect( getCalls[ 0 ].query.before ).toBe(
+				Math.floor( Date.parse( makeNote( 91 ).timestamp ) / 1000 )
+			);
+
+			// A full older page keeps the catch-up going instead of latching.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 90 ), last_seen_time: 0 } );
+			expect( client.hasMoreNotes() ).toBe( true );
+		} );
 	} );
 
 	describe( 'server-side (unread) filtering', () => {

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -185,14 +185,24 @@ describe( 'RestClient', () => {
 			expect( client.hasMoreNotes() ).toBe( true );
 		} );
 
-		// hasMoreNotes must measure this view's own window, not the shared store a
-		// filtered fetch can inflate to the cap.
+		// Both hasMoreNotes and the request size must measure this view's own
+		// window, not the shared store a filtered fetch can inflate to the cap —
+		// otherwise the next page is requested as number=0 and the view stalls.
 		it( 'keeps paging when a filtered fetch fills the shared store to the cap', () => {
-			seedFirstWindow(); // All window: ids 100..91 (10 notes)
+			seedFirstWindow(); // All window: noteList = ids 100..91 (10 notes)
 			// A filtered (Unread) visit dumps older notes into the store, filling it
 			// to max_limit, while the All view's own window stays at 10.
 			store.dispatch( actions.notes.addNotes( fullPage( 90, 90 ) ) ); // store now 100
 			expect( client.hasMoreNotes() ).toBe( true );
+
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 1 );
+			// Anchored on the view's oldest (91) and sized off its own count (10 left
+			// under the cap), not 0 from the full store.
+			expect( getCalls[ 0 ].query ).toMatchObject( {
+				number: 10,
+				before: Math.floor( Date.parse( makeNote( 91 ).timestamp ) / 1000 ),
+			} );
 		} );
 	} );
 
@@ -351,6 +361,31 @@ describe( 'RestClient', () => {
 			getCalls.length = 0;
 			client.loadMore();
 			expect( getCalls ).toHaveLength( 0 );
+		} );
+
+		// Switching tabs away and back while a load-more is in flight resets the
+		// filter; the stale older-page response must not append to the cleared list.
+		it( 'discards a stale unread load-more response after a filter reset', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+
+			// Start a load-more; capture its still-pending callback.
+			getCalls.length = 0;
+			client.loadMore();
+			const staleCallback = getCalls[ 0 ].callback;
+
+			// User switches to All and back to Unread before it resolves. The fresh
+			// fetch is skipped because the in-flight request still holds the lock.
+			client.setFilter( null );
+			client.setFilter( { unread: 1 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [] );
+
+			// The stale older page lands: it must be dropped, not appended…
+			getCalls.length = 0;
+			staleCallback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } );
+			expect( getUnreadNoteIds( store.getState() ) ).toEqual( [] );
+			// …and a fresh fetch for the re-selected filter must be kicked off.
+			expect( getCalls.find( ( call ) => call.query.unread ) ).toBeTruthy();
 		} );
 
 		// A new note arriving via the polling/push path (getNotes) while a filter is

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -151,11 +151,9 @@ describe( 'RestClient', () => {
 			expect( getCalls ).toHaveLength( 0 );
 		} );
 
-		// A filtered (Unread) fetch drops matching notes — sometimes older than the
-		// All view's loaded window — into the shared store. Load-more must keep
-		// pacing off this view's own window (`noteList`), not those stray notes, or
-		// the `before` cursor jumps past unloaded notes, the next page comes back
-		// short, and paging latches with the list half-loaded.
+		// A filtered (Unread) fetch drops older notes into the shared store. The All
+		// view's load-more must pace off its own window (`noteList`), or the `before`
+		// cursor jumps past unloaded notes and paging latches half-loaded.
 		it( 'keeps paging the All view from its own window after an Unread visit', () => {
 			// All view's first window: ids 100..91 (oldest loaded = 91).
 			seedFirstWindow();


### PR DESCRIPTION
## Proposed Changes

* Display the notification subject in a DataViews `description` field in the notifications note list. A new `description` field is added to `getFields()` (returning `item.subject[0]` rendered via `html(..., { links: false })`, mirroring the title), and the list view now sets `descriptionField: 'description'`.

This builds on the prior commits in this branch, which migrate the notifications note list to DataViews and fix its infinite-scroll / read-state behavior (per-tab paging, in-app read state reflected immediately, empty-slot loaders).

## Why are these changes being made?

* Surface the notification subject through the standard DataViews list layout's description slot so it renders consistently with the rest of the list.

## Testing Instructions

* Run the notifications app and open the note list.
* Confirm each row shows its subject text in the description position beneath the title.
* Verify the All and Unread tabs still load and scroll as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
