### PR TITLE
Notifications: move the note excerpt into a DataViews description field

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -60,6 +60,21 @@
 		}
 	}
 
+	// DataViews' default list metrics leave the rows taller than we want, so
+	// tighten the title and field rows to a 20px min-height and line-height.
+	.dataviews-view-list__title-field,
+	.dataviews-view-list__fields .dataviews-view-list__field-value {
+		min-height: calc(var(--wpds-dimension-base, 4px) * 5);
+		line-height: var(--wpds-typography-line-height-sm, 20px);
+	}
+
+	// Notes without an excerpt render an empty description field, but DataViews
+	// still emits its cell as a flex item in the column, which doubles the row
+	// gap. Drop the empty cell so only one gap remains.
+	.dataviews-view-list__field-wrapper > .dataviews-view-list__field:empty {
+		display: none;
+	}
+
 	// We override styles with the selected styles for unread items.
 	div[role="article"]:has(.is-unread),
 	div[role="article"]:has(.is-unread):focus-within {

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -93,17 +93,20 @@ export function getFields(): Field< Note >[] {
 					links: false,
 				} ),
 			render: ( { field, item } ) => (
-				<div className={ clsx( 'wpnc__note-list-item', { 'is-unread': ! item.read } ) }>
-					<div
-						className="wpnc__subject"
-						/* eslint-disable-next-line react/no-danger */
-						dangerouslySetInnerHTML={ { __html: field.getValue( { item } ) } }
-					/>
-					{ item.subject.length > 1 && (
-						<div className="wpnc__excerpt">{ item.subject[ 1 ].text }</div>
-					) }
-				</div>
+				<div
+					className="wpnc__subject"
+					/* eslint-disable-next-line react/no-danger */
+					dangerouslySetInnerHTML={ { __html: field.getValue( { item } ) } }
+				/>
 			),
+		},
+		{
+			id: 'description',
+			label: __( 'Description' ),
+			render: ( { item } ) =>
+				item.subject.length > 1 ? (
+					<div className="wpnc__excerpt">{ item.subject[ 1 ].text }</div>
+				) : null,
 		},
 		{
 			id: 'info',

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -96,6 +96,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	const [ initialView, setView ] = useState< View >( {
 		type: 'list',
 		titleField: 'title',
+		descriptionField: 'description',
 		mediaField: 'icon',
 		fields: [ 'info' ],
 		page: 1,

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -1,5 +1,3 @@
-@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
-
 @import '@wordpress/base-styles/colors';
 
 .wpnc__note-list {
@@ -15,31 +13,17 @@
 		min-height: 0;
 	}
 
-	.wpnc__note-list-item {
-		.wpnc__subject,
-		.wpnc__excerpt {
-			display: -webkit-box;
-			-webkit-line-clamp: 2;
-			-webkit-box-orient: vertical;
-			white-space: pre-wrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
-		}
-
-		.wpnc__excerpt {
-			font-weight: normal;
-			color: var(--color-text-subtle);
-			padding-top: 2px;
-
-			@include ui-mixins.when-dark-theme {
-				color: var(--dashboard__text-muted-color, var(--color-text-subtle));
-			}
-		}
-
-		&:hover .wpnc__excerpt,
-		&:focus-within .wpnc__excerpt {
-			color: inherit;
-		}
+	// The subject and excerpt render in separate DataViews cells (the title and
+	// description fields), so they're styled directly rather than under a shared
+	// row wrapper.
+	.wpnc__subject,
+	.wpnc__excerpt {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		white-space: pre-wrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.wpnc__note-icon .wpnc__gridicon {

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -139,8 +139,9 @@ describe( 'NoteList loading state', () => {
 		expect( screen.queryByText( 'Trash me' ) ).not.toBeInTheDocument();
 	} );
 
-	// Reading a note in-app must update the list row's unread styling right away,
-	// before any server refetch flips the note's raw `read` flag.
+	// Reading a note in-app must drop the row's unread indicator right away,
+	// before any server refetch flips the note's raw `read` flag. The indicator
+	// is the `is-unread` icon badge rendered for each unread row.
 	it( 'drops the unread styling from a row the moment its note is read', () => {
 		const store = initStore();
 		store.dispatch( actions.notes.addNotes( [ makeNote( 950, 'Read me' ) ] ) );
@@ -148,16 +149,14 @@ describe( 'NoteList loading state', () => {
 
 		renderTab( store, 'all' as FilterName );
 
-		const row = screen.getByText( 'Read me' ).closest( '.wpnc__note-list-item' );
-		expect( row ).toHaveClass( 'is-unread' );
+		const getRow = () => screen.getByText( 'Read me' ).closest( '[role="article"]' );
+		expect( getRow()?.querySelector( '.is-unread' ) ).toBeInTheDocument();
 
 		act( () => {
 			store.dispatch( actions.notes.readNote( 950 ) );
 		} );
 
-		expect( screen.getByText( 'Read me' ).closest( '.wpnc__note-list-item' ) ).not.toHaveClass(
-			'is-unread'
-		);
+		expect( getRow()?.querySelector( '.is-unread' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'client-filters the Comments tab from the shared cache', () => {

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -3,12 +3,10 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	CardHeader,
-	Icon,
 	privateApis,
 } from '@wordpress/components';
 import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
-import { bell } from '@wordpress/icons';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useEffect, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
@@ -113,7 +111,6 @@ const NotePanel = ( {
 				<VStack>
 					<HStack>
 						<HStack justify="flex-start">
-							<Icon icon={ bell } />
 							<Heading level={ 3 } size={ 15 } weight={ 500 }>
 								{ __( 'Notifications' ) }
 							</Heading>

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -266,11 +266,6 @@
 
 	.wpnc__user-description-separator {
 		color: $gray-700;
-
-		&:first-child,
-		&:last-child {
-			display: none;
-		}
 	}
 
 	a {

--- a/apps/notifications/src/app/templates/block-user.tsx
+++ b/apps/notifications/src/app/templates/block-user.tsx
@@ -4,12 +4,14 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
 import { useAppContext } from '../context';
 import NoteIcon from '../note-icon';
 import FollowLink, { followStatTypes } from './follow-link';
 import type { Note, Block } from '../types';
+import type { ReactElement } from 'react';
 
 function getDisplayURL( url: string ) {
 	const parser = document.createElement( 'a' );
@@ -61,6 +63,39 @@ export default function UserBlock( { note, block }: { note: Note; block: Block }
 			? getDisplayURL( homeLink )
 			: block.meta?.titles?.home;
 
+	// Build the present description items, then interleave a single separator
+	// between them — so there's never a leading, trailing, or doubled separator
+	// when an item is absent.
+	const descriptionParts = [
+		note.type === 'comment' && (
+			<a key="date" href={ note.url } target="_blank" rel="noreferrer" style={ { flexShrink: 0 } }>
+				<Text variant="muted">{ formatDate( note.timestamp, locale ) }</Text>
+			</a>
+		),
+		homeTitle && (
+			<a
+				key="home"
+				href={ homeLink }
+				target="_blank"
+				rel="noopener noreferrer"
+				style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+			>
+				{ homeTitle }
+			</a>
+		),
+		note.type !== 'comment' &&
+			!! block.meta?.ids?.site &&
+			block.actions &&
+			'follow' in block.actions && (
+				<FollowLink
+					key="follow"
+					site={ block.meta.ids.site }
+					isFollowing={ !! block.actions.follow }
+					noteType={ note.type as keyof typeof followStatTypes }
+				/>
+			),
+	].filter( ( part ): part is ReactElement => Boolean( part ) );
+
 	return (
 		<HStack className="wpnc__user" justify="flex-start" alignment="flex-start" spacing={ 4 }>
 			<a
@@ -81,33 +116,12 @@ export default function UserBlock( { note, block }: { note: Note; block: Block }
 					<Text>{ block.text }</Text>
 				</a>
 				<HStack className="wpnc__user-description" spacing={ 1 }>
-					{ note.type === 'comment' && (
-						<a href={ note.url } target="_blank" rel="noreferrer" style={ { flexShrink: 0 } }>
-							<Text variant="muted">{ formatDate( note.timestamp, locale ) }</Text>
-						</a>
-					) }
-					<span className="wpnc__user-description-separator">•</span>
-					{ homeTitle && (
-						<a
-							href={ homeLink }
-							target="_blank"
-							rel="noopener noreferrer"
-							style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
-						>
-							{ homeTitle }
-						</a>
-					) }
-					<span className="wpnc__user-description-separator">•</span>
-					{ note.type !== 'comment' &&
-						!! block.meta?.ids?.site &&
-						block.actions &&
-						'follow' in block.actions && (
-							<FollowLink
-								site={ block.meta.ids.site }
-								isFollowing={ !! block.actions.follow }
-								noteType={ note.type as keyof typeof followStatTypes }
-							/>
-						) }
+					{ descriptionParts.map( ( part, index ) => (
+						<Fragment key={ part.key }>
+							{ index > 0 && <span className="wpnc__user-description-separator">•</span> }
+							{ part }
+						</Fragment>
+					) ) }
 				</HStack>
 			</VStack>
 		</HStack>


### PR DESCRIPTION
## Proposed Changes

* **Move the note excerpt into a DataViews description field.** Render the second subject line (`item.subject[1].text`) through the list view's `descriptionField` slot instead of inline in the title field, and remove the inline excerpt markup from the title render.
  * Drop the now-redundant `wpnc__note-list-item` wrapper from the title render. The `is-unread` marker is no longer carried on the subject either — the gridicon badge already provides one, and the row's unread treatment keys off `div[role="article"]:has(.is-unread)`, so a single marker per row suffices.
  * Rescope the subject/excerpt CSS off the removed wrapper, tighten the title and field rows to a 20px `min-height`/`line-height`, and let the excerpt inherit the row's default text treatment.
  * Hide the description cell when a note has no excerpt — DataViews always emits the (empty) cell as a flex item, which would otherwise double the row gap.
* **Remove the bell icon from the notifications panel header.**
* **Interleave the user-description separator between present items.** Render the `•` separator only between items that are actually present, so an absent timestamp, site title, or follow action no longer leaves a leading, trailing, or doubled separator. Removes the dead `:first-child`/`:last-child` separator CSS that this replaces.

## Why are these changes being made?

* The excerpt was hand-rendered inside the title cell. Moving it to the standard DataViews `descriptionField` slot lets the list layout own its placement, keeps the title field focused on the subject alone, and removes wrapper markup and styling that only existed to host both lines together.
* The separator markup emitted bullets unconditionally, so missing fields produced stray/duplicated separators; rendering them only between present items fixes that at the source.

## Testing Instructions

* Run the notifications app and open the note list.
* Confirm notes with an excerpt (a second subject line) show it beneath the title, and notes without one render no empty description row or extra gap.
* Confirm unread rows still show their unread treatment (tinted background + accent bar).
* Confirm the panel header no longer shows the bell icon.
* Open notes whose detail header has different combinations of timestamp / site title / follow action and confirm there are no leading, trailing, or doubled `•` separators.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
