### PR TITLE
Name servers: stop upsell illustration flickering on keystroke

### DIFF
--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -138,87 +138,86 @@ export default function NameServersForm( {
 		[]
 	);
 
+	// Separate memo (no formData dep) keeps the Edit reference stable across
+	// keystrokes, so DataForm doesn't remount it and reload the UpsellNudge image.
+	const useWpcomNameServersField = useMemo< Field< FormData > >(
+		() => ( {
+			id: 'useWpcomNameServers',
+			label: __( 'Use WordPress.com name servers' ),
+			type: 'boolean',
+			Edit: ( { onChange, data } ) => {
+				return (
+					<VStack spacing={ 4 }>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Use WordPress.com name servers' ) }
+							checked={ data.useWpcomNameServers }
+							disabled={ isBusy }
+							onChange={ ( value ) => {
+								// Track toggle button click
+								recordTracksEvent(
+									'calypso_dashboard_domain_management_name_servers_wpcom_name_servers_toggle_button_click',
+									{
+										domain: domainName,
+										enabled: value,
+									}
+								);
+
+								// Create nameServer fields dynamically
+								const ns = Object.fromEntries(
+									Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) => [
+										`nameServer${ i + 1 }` as NameServerKey,
+										value ? defaultNameServers[ i ] : '',
+									] )
+								);
+
+								onChange( {
+									useWpcomNameServers: value,
+									...ns,
+								} );
+							} }
+						/>
+						{ showUpsellNudge && (
+							<UpsellNudge domainName={ domainName } domainSiteSlug={ domainSiteSlug } />
+						) }
+						{ ! data.useWpcomNameServers && (
+							<Text>
+								{ createInterpolateElement(
+									/* translators: <link> will be replaced with an anchor tag to open the support article in a new tab */
+									__( '<link>Look up</link> the name servers for popular hosts.' ),
+									{
+										link: (
+											<InlineSupportLink
+												supportContext="change-name-servers-finding-out-new-ns"
+												onClick={ () => {
+													recordTracksEvent(
+														'calypso_dashboard_domain_management_name_servers_wpcom_name_servers_look_up_click',
+														{
+															domain: domainName,
+														}
+													);
+												} }
+											/>
+										),
+									}
+								) }
+							</Text>
+						) }
+					</VStack>
+				);
+			},
+		} ),
+		[ isBusy, showUpsellNudge, domainName, domainSiteSlug, recordTracksEvent, defaultNameServers ]
+	);
+
 	const fields = useMemo(
 		(): Field< FormData >[] => [
-			{
-				id: 'useWpcomNameServers',
-				label: __( 'Use WordPress.com name servers' ),
-				type: 'boolean',
-				Edit: ( { onChange, data } ) => {
-					return (
-						<VStack spacing={ 4 }>
-							<ToggleControl
-								__nextHasNoMarginBottom
-								label={ __( 'Use WordPress.com name servers' ) }
-								checked={ data.useWpcomNameServers }
-								disabled={ isBusy }
-								onChange={ ( value ) => {
-									// Track toggle button click
-									recordTracksEvent(
-										'calypso_dashboard_domain_management_name_servers_wpcom_name_servers_toggle_button_click',
-										{
-											domain: domainName,
-											enabled: value,
-										}
-									);
-
-									// Create nameServer fields dynamically
-									const ns = Object.fromEntries(
-										Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) => [
-											`nameServer${ i + 1 }` as NameServerKey,
-											value ? defaultNameServers[ i ] : '',
-										] )
-									);
-
-									onChange( {
-										useWpcomNameServers: value,
-										...ns,
-									} );
-								} }
-							/>
-							{ showUpsellNudge && (
-								<UpsellNudge domainName={ domainName } domainSiteSlug={ domainSiteSlug } />
-							) }
-							{ ! data.useWpcomNameServers && (
-								<Text>
-									{ createInterpolateElement(
-										/* translators: <link> will be replaced with an anchor tag to open the support article in a new tab */
-										__( '<link>Look up</link> the name servers for popular hosts.' ),
-										{
-											link: (
-												<InlineSupportLink
-													supportContext="change-name-servers-finding-out-new-ns"
-													onClick={ () => {
-														recordTracksEvent(
-															'calypso_dashboard_domain_management_name_servers_wpcom_name_servers_look_up_click',
-															{
-																domain: domainName,
-															}
-														);
-													} }
-												/>
-											),
-										}
-									) }
-								</Text>
-							) }
-						</VStack>
-					);
-				},
-			},
+			useWpcomNameServersField,
 			...Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) =>
 				createNameServerField( i + 1, formData, isBusy )
 			),
 		],
-		[
-			formData,
-			isBusy,
-			showUpsellNudge,
-			domainName,
-			domainSiteSlug,
-			recordTracksEvent,
-			defaultNameServers,
-		]
+		[ useWpcomNameServersField, formData, isBusy ]
 	);
 
 	const handleSubmit = useCallback(

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -142,7 +142,7 @@ export default function NameServersForm( {
 
 	// Separate memo (no formData dep) keeps the Edit reference stable across
 	// keystrokes, so DataForm doesn't remount it and reload the UpsellNudge image.
-	const useWpcomNameServersField = useMemo< Field< FormData > >(
+	const wpcomNameServersField = useMemo< Field< FormData > >(
 		() => ( {
 			id: 'useWpcomNameServers',
 			label: __( 'Use WordPress.com name servers' ),
@@ -214,12 +214,12 @@ export default function NameServersForm( {
 
 	const fields = useMemo(
 		(): Field< FormData >[] => [
-			useWpcomNameServersField,
+			wpcomNameServersField,
 			...Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) =>
 				createNameServerField( i + 1, formData, isBusy )
 			),
 		],
-		[ useWpcomNameServersField, formData, isBusy ]
+		[ wpcomNameServersField, formData, isBusy ]
 	);
 
 	const handleSubmit = useCallback(

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -167,7 +167,7 @@ export default function NameServersForm( {
 								const ns = Object.fromEntries(
 									Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) => [
 										`nameServer${ i + 1 }` as NameServerKey,
-										value ? defaultNameServers[ i ] : '',
+										value ? defaultNameServers[ i ] ?? '' : '',
 									] )
 								);
 

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -15,6 +15,8 @@ import { MIN_NAME_SERVERS_LENGTH, MAX_NAME_SERVERS_LENGTH, FormData, NameServerK
 import UpsellNudge from './upsell-nudge';
 import { validateHostname } from './utils';
 
+const EMPTY_DEFAULT_NAME_SERVERS: string[] = [];
+
 const createNameServerField = ( index: number, formData: FormData, isBusy?: boolean ) => {
 	const baseField = {
 		id: `nameServer${ index }` as NameServerKey,
@@ -102,7 +104,7 @@ export default function NameServersForm( {
 	domainSiteSlug,
 	showUpsellNudge,
 	nameServers = [],
-	defaultNameServers = [],
+	defaultNameServers = EMPTY_DEFAULT_NAME_SERVERS,
 	isUsingDefaultNameServers = false,
 	isBusy,
 	onSubmit,


### PR DESCRIPTION
## Proposed Changes

* Move the `useWpcomNameServers` boolean field into its own `useMemo` so its `Edit` reference stays stable as `formData` changes.

## Why are these changes being made?

In the domain name servers form, the upsell nudge illustration re-rendered on every keystroke in a custom name server field. The `fields` memo depended on `formData`, so each keystroke rebuilt the array — including a brand-new `Edit` function for the toggle field. Because `DataForm` renders `<field.Edit />` by reference, a new function identity made React unmount and remount that subtree, recreating the `UpsellNudge` `<img>`. With DevTools "Disable cache" on, the SVG re-downloaded each time, producing a visible flicker (and unnecessary remount work otherwise). Splitting the field into its own memo keeps the `Edit` reference stable across keystrokes, so the field re-renders instead of remounting.

**Before:**
https://github.com/user-attachments/assets/81045f39-121c-4a50-8495-6610b645de22

## Testing Instructions

* Open a domain that shows the upsell nudge in the name servers form (a domain forwarded to a site, on a free plan).
* Open DevTools → Network with "Disable cache" enabled.
* Toggle off "Use WordPress.com name servers" and type in a custom name server field.
* Confirm the upsell illustration no longer re-fetches/flickers on each keystroke.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?