### PR TITLE
Overview card: drop icon background for warning and error intents

### DIFF
--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -65,13 +65,11 @@
 	}
 
 	.dashboard-overview-card--error & {
-		background-color: color-mix(in srgb, var(--dashboard__background-color-error) 8%, transparent);
 		color: var(--dashboard__background-color-error );
 		fill: var(--dashboard__background-color-error );
 	}
 
 	.dashboard-overview-card--warning & {
-		background-color: color-mix(in srgb, var(--dashboard__background-color-warning) 8%, transparent);
 		color: var(--dashboard__background-color-warning);
 		fill: var(--dashboard__background-color-warning);
 	}

--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -65,8 +65,8 @@
 	}
 
 	.dashboard-overview-card--error & {
-		color: var(--dashboard__background-color-error );
-		fill: var(--dashboard__background-color-error );
+		color: var(--dashboard__background-color-error);
+		fill: var(--dashboard__background-color-error);
 	}
 
 	.dashboard-overview-card--warning & {


### PR DESCRIPTION
## Proposed Changes

* Remove the translucent `background-color` from the `--warning` and `--error` icon variants in the overview card, so all intents render the icon with color/fill only.

## Why are these changes being made?

The warning and error icon variants painted a faint colored square behind the icon, while the success variant did not. This was visually inconsistent — e.g. the domain "Expires" (warning) card showed a background behind the calendar icon, whereas the "Renews" (success) card looked clean without one. Dropping the background makes the icon styling uniform across all intents.

| Before | After |
|--------|--------|
| <img width="348" height="160" alt="Screenshot 2026-06-18 at 13 42 26" src="https://github.com/user-attachments/assets/4170af37-1fef-4094-b128-41680ee3015a" /> | <img width="339" height="164" alt="Screenshot 2026-06-18 at 22 05 02" src="https://github.com/user-attachments/assets/d6dd8a74-9ab0-4dcc-bef5-7c807e7d759b" /> | 

## Testing Instructions

* Open a domain overview where the expiry/renewal featured card is shown.
* For a domain expiring soon (warning) or expired (error), confirm the calendar icon no longer has a background square behind it.
* Compare with an auto-renewing (success) domain — the icons should now look consistent, differing only in color.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?