### PR TITLE
[DOTMSD-1308] Fix backup download dark mode graphic

### DIFF
--- a/client/dashboard/sites/backup-download/backup-download-illustration.svg
+++ b/client/dashboard/sites/backup-download/backup-download-illustration.svg
@@ -1,5 +1,4 @@
 <svg width="408" height="280" viewBox="0 0 408 280" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="408" height="280" fill="white"/>
 <rect x="82" y="43" width="189" height="126" rx="6" fill="white" stroke="#F0F0F0"/>
 <rect x="96" y="57" width="189" height="126" rx="6" fill="white" stroke="#DDDDDD"/>
 <rect x="110" y="71" width="189" height="126" rx="6" fill="white" stroke="url(#paint0_linear_5209_83348)"/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-1308

## Proposed Changes

<img width="1272" height="1320" alt="CleanShot 2026-06-18 at 14 45 31@2x" src="https://github.com/user-attachments/assets/180c208d-3761-40a0-8555-ed3618a8c166" />
<img width="1240" height="1242" alt="CleanShot 2026-06-18 at 14 46 48@2x" src="https://github.com/user-attachments/assets/cca852dd-24f8-42d6-972a-fa285f93cfd1" />

* Remove the opaque white canvas from the Dashboard backup download progress illustration. (I'm keeping the window backgrounds to make them more visible, but maybe @lucasmendes-design might have better ideas on how to approach this)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Dashboard backups flow shows an illustration while selected files are being packed for download. In dark mode, that SVG painted a full white rectangle behind the artwork, so the progress graphic appeared as a bright white block inside the dark interface.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start Calypso locally and go to `http://my.localhost:3000/sites/<site>/backups/<backupId>`.
* In dark mode, select one or more files from the backup details panel.
* Click “Download selected files”.
* Confirm the packing/download progress illustration no longer shows a solid white background around the artwork.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
