### PR TITLE
Raise Agents Manager or Help Center panels on focus

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -171,7 +171,7 @@ $z-layers: (
 		".wpcom-site__global-noscript": 300000,
 
 		// Sits above the @automattic/privacy-toolset cookie banner (z-index 50001).
-		// The Help Center panel itself ($help-center-z-index: 500000) renders on
+		// The Help Center panel itself ($help-center-z-index: 999990) renders on
 		// top — that's intentional, since the panel has its own close button.
 		".help-center-fab": 50002,
 

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.65",
+		"@automattic/agenttic-ui": "^0.1.67",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.67",
+		"@automattic/agenttic-ui": "^0.1.68",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.68",
+		"@automattic/agenttic-ui": "^0.1.69",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.68",
-		"@automattic/agenttic-ui": "^0.1.68",
+		"@automattic/agenttic-client": "^0.1.69",
+		"@automattic/agenttic-ui": "^0.1.69",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.66",
-		"@automattic/agenttic-ui": "^0.1.66",
+		"@automattic/agenttic-client": "^0.1.67",
+		"@automattic/agenttic-ui": "^0.1.67",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.67",
-		"@automattic/agenttic-ui": "^0.1.67",
+		"@automattic/agenttic-client": "^0.1.68",
+		"@automattic/agenttic-ui": "^0.1.68",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -1,4 +1,3 @@
-import { SubmitOptions } from '@automattic/agenttic-client';
 import {
 	AgentUI,
 	createMessageRenderer,
@@ -54,7 +53,7 @@ interface Props {
 	/** Indicates if the chat is expanded (floating mode). */
 	isOpen: boolean;
 	/** Called when the user submits a message. */
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void > | void;
+	onSubmit: ( message: string, files?: File[] ) => Promise< void > | void;
 	/** Called when the user aborts the current request. */
 	onAbort: () => void;
 	/** Called when the chat is closed. */

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -170,10 +170,10 @@ export default function AgentChat( {
 	onContextCardAction,
 	onContextCardDismiss,
 }: Props ) {
-	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
+	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const conversationViewRef = useRef< HTMLDivElement >( null );
 	const imageUploaderRef = useRef< ImageUploaderHandle >( null );
-	const { floatingPosition } = useSelect( ( select ) => {
+	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -263,6 +263,8 @@ export default function AgentChat( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
+			initialFreeDragPosition={ freeDragPosition ?? undefined }
+			onFreeDragEnd={ setFreeDragPosition }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ messages }
 			isProcessing={ isProcessing }

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -271,6 +271,7 @@ export default function AgentChat( {
 			error={ error }
 			onSubmit={ onSubmit }
 			variant={ isDocked ? 'embedded' : 'floating' }
+			freeDrag={ ! isDocked }
 			suggestions={ suggestions }
 			clearSuggestions={ clearSuggestions }
 			onSuggestionClick={ onSuggestionClick }

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -431,13 +431,7 @@ body.post-new-php.agents-manager-sidebar-container {
 	padding: $layout-spacing;
 	width: $sidebar-width;
 	box-sizing: border-box;
-	z-index: $agents-manager-z-index-docked;
-
-	// Raise above the Help Center panel while focused, so the last-clicked
-	// panel wins. Both panels share one base/focused scale.
-	&.is-focused {
-		z-index: $agents-manager-z-index-focused;
-	}
+	z-index: $agents-manager-z-index-sidebar;
 
 	.agents-manager-sidebar-fab {
 		visibility: visible;

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -433,6 +433,12 @@ body.post-new-php.agents-manager-sidebar-container {
 	box-sizing: border-box;
 	z-index: $agents-manager-z-index-docked;
 
+	// Raise above the Help Center panel while focused, so the last-clicked
+	// panel wins. Both panels share one base/focused scale.
+	&.is-focused {
+		z-index: $agents-manager-z-index-focused;
+	}
+
 	.agents-manager-sidebar-fab {
 		visibility: visible;
 		position: fixed;
@@ -703,10 +709,15 @@ body.post-new-php.agents-manager-sidebar-container {
 	}
 }
 
+.agents-manager-chat--undocked.is-focused .agenttic.Chat-module_container.Chat-module_floating {
+	z-index: $agents-manager-z-index-focused;
+}
+
 /* Agenttic UI: Styles for the undocked chat */
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
-	// Fix the undocked chat overlapping with the nav menu
-	z-index: 9999;
+	// Shared overlay base keeps the floating chat above the nav menu and lets it
+	// trade stacking with the Help Center panel via the focused offset above.
+	z-index: $agents-manager-z-index-docked;
 
 	.big-sky__dock__menu__variation-picker .edit-site-global-styles-variations_item {
 		&:not( .is-active ):hover {

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -38,8 +38,8 @@ export default function AgentHistory( {
 }: Props ) {
 	const { resumeActiveChat } = useAgentsManagerContext();
 
-	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
-	const { floatingPosition } = useSelect( ( select ) => {
+	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
+	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -54,6 +54,8 @@ export default function AgentHistory( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
+			initialFreeDragPosition={ freeDragPosition ?? undefined }
+			onFreeDragEnd={ setFreeDragPosition }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -60,6 +60,7 @@ export default function AgentHistory( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
+			freeDrag={ ! isDocked }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			triggerTitle={ title }
 			onClose={ onClose }

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -55,9 +55,10 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 					controls={ options }
 					icon={ moreVertical }
 					label={ __( 'More Options', '__i18n_text_domain__' ) }
-					// Body-level popovers need a stable anchor for public host style isolation.
+					// Render inside the panel node so opening the menu doesn't blur them panel
 					popoverProps={ {
 						className: 'agents-manager-chat-header__menu-popover',
+						inline: true,
 					} }
 					toggleProps={ { size: 'small' } }
 				/>

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -55,7 +55,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 					controls={ options }
 					icon={ moreVertical }
 					label={ __( 'More Options', '__i18n_text_domain__' ) }
-					// Render inside the panel node so opening the menu doesn't blur them panel
+					// Render inside the panel node so opening the menu doesn't blur the panel
 					popoverProps={ {
 						className: 'agents-manager-chat-header__menu-popover',
 						inline: true,

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -70,6 +70,7 @@ export default function SupportGuide( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
+			freeDrag={ ! isDocked }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			triggerTitle={ title }
 			onClose={ onClose }

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -38,8 +38,8 @@ export default function SupportGuide( {
 	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
 	const navigate = useNavigate();
 	const { state } = useLocation();
-	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
-	const { floatingPosition } = useSelect( ( select ) => {
+	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
+	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -64,6 +64,8 @@ export default function SupportGuide( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
+			initialFreeDragPosition={ freeDragPosition ?? undefined }
+			onFreeDragEnd={ setFreeDragPosition }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -140,6 +140,7 @@ export default function SupportGuides( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
+			freeDrag={ ! isDocked }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			triggerTitle={ title }
 			onClose={ onClose }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -120,8 +120,8 @@ export default function SupportGuides( {
 	const [ searchInput, setSearchInput, debouncedSearchInput ] = useDebouncedInput(
 		state?.searchQuery ?? ''
 	);
-	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
-	const { floatingPosition } = useSelect( ( select ) => {
+	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
+	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -134,6 +134,8 @@ export default function SupportGuides( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
+			initialFreeDragPosition={ freeDragPosition ?? undefined }
+			onFreeDragEnd={ setFreeDragPosition }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -4,6 +4,7 @@ import { useMediaQuery } from '@wordpress/compose';
 import {
 	createPortal,
 	useCallback,
+	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -204,23 +205,26 @@ export default function useAgentLayoutManager( {
 		}
 	}, [ container, isDocked, isReady, shouldRenderSidebar ] );
 
-	// Track focus on the chat panel so it can raise its z-index above the Help
-	// Center panel when interacted with. Both panels share one base/focused
-	// scale, so the last-clicked panel ends up on top. `pointerdown` also covers
-	// clicks on non-focusable regions (e.g. scroll areas) that skip `focusin`.
-	useLayoutEffect( () => {
+	// Track focus on the chat panel so the floating chat can raise its z-index. `pointerdown` also
+	// covers clicks on non-focusable regions (e.g. scroll areas) that skip `focusin`
+	useEffect( () => {
 		const node = portalRef.current;
-		if ( ! isPortalReady || ! node ) {
+
+		if ( ! isPortalReady || ! node || shouldRenderSidebar ) {
+			node?.classList.remove( 'is-focused' );
 			return;
 		}
+
 		const setFocused = () => {
 			node.classList.add( 'is-focused' );
 		};
+
 		const handleFocusOut = ( e: FocusEvent ) => {
 			if ( ! node.contains( e.relatedTarget as Node | null ) ) {
 				node.classList.remove( 'is-focused' );
 			}
 		};
+
 		const handleDocumentPointerDown = ( e: PointerEvent ) => {
 			if ( ! node.contains( e.target as Node | null ) ) {
 				node.classList.remove( 'is-focused' );
@@ -240,7 +244,7 @@ export default function useAgentLayoutManager( {
 			document.removeEventListener( 'pointerdown', handleDocumentPointerDown );
 			stopCanvasObserver();
 		};
-	}, [ isPortalReady ] );
+	}, [ isPortalReady, shouldRenderSidebar ] );
 
 	// Reflect split-screen state on the container as `is-split-screen`.
 	useLayoutEffect( () => {

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { AI } from '../../components/icons';
+import observeEditorCanvasPointerDown from '../../utils/observe-editor-canvas-pointerdown';
 
 const SIDEBAR_TRANSITION_DURATION_MS = 200;
 
@@ -202,6 +203,44 @@ export default function useAgentLayoutManager( {
 			onUndockRef.current();
 		}
 	}, [ container, isDocked, isReady, shouldRenderSidebar ] );
+
+	// Track focus on the chat panel so it can raise its z-index above the Help
+	// Center panel when interacted with. Both panels share one base/focused
+	// scale, so the last-clicked panel ends up on top. `pointerdown` also covers
+	// clicks on non-focusable regions (e.g. scroll areas) that skip `focusin`.
+	useLayoutEffect( () => {
+		const node = portalRef.current;
+		if ( ! isPortalReady || ! node ) {
+			return;
+		}
+		const setFocused = () => {
+			node.classList.add( 'is-focused' );
+		};
+		const handleFocusOut = ( e: FocusEvent ) => {
+			if ( ! node.contains( e.relatedTarget as Node | null ) ) {
+				node.classList.remove( 'is-focused' );
+			}
+		};
+		const handleDocumentPointerDown = ( e: PointerEvent ) => {
+			if ( ! node.contains( e.target as Node | null ) ) {
+				node.classList.remove( 'is-focused' );
+			}
+		};
+
+		node.addEventListener( 'focusin', setFocused );
+		node.addEventListener( 'focusout', handleFocusOut );
+		node.addEventListener( 'pointerdown', setFocused );
+		document.addEventListener( 'pointerdown', handleDocumentPointerDown );
+		const stopCanvasObserver = observeEditorCanvasPointerDown( handleDocumentPointerDown );
+
+		return () => {
+			node.removeEventListener( 'focusin', setFocused );
+			node.removeEventListener( 'focusout', handleFocusOut );
+			node.removeEventListener( 'pointerdown', setFocused );
+			document.removeEventListener( 'pointerdown', handleDocumentPointerDown );
+			stopCanvasObserver();
+		};
+	}, [ isPortalReady ] );
 
 	// Reflect split-screen state on the container as `is-split-screen`.
 	useLayoutEffect( () => {

--- a/packages/agents-manager/src/styles/variables.scss
+++ b/packages/agents-manager/src/styles/variables.scss
@@ -16,6 +16,7 @@ $overlay-panel-z-index-base: 999990;
 $overlay-panel-z-index-focused: 999995;
 $agents-manager-z-index-docked: $overlay-panel-z-index-base;
 $agents-manager-z-index-focused: $overlay-panel-z-index-focused;
+$agents-manager-z-index-sidebar: $overlay-panel-z-index-base - 1;
 
 /* WP Admin */
 $admin-menu-width-unified: 272px;

--- a/packages/agents-manager/src/styles/variables.scss
+++ b/packages/agents-manager/src/styles/variables.scss
@@ -9,7 +9,13 @@ $chat-header-height: 38px;
 $main-border-radius: 8px;
 $transition-duration: 0.2s;
 $transition-timing: $transition-duration cubic-bezier( 0.4, 0, 0.2, 1 );
-$agents-manager-z-index-docked: 999999;
+// Shared overlay-panel stacking, mirrored in Help Center
+// (packages/help-center/src/components/_variables.scss). A focused panel must
+// always beat an unfocused one, so they share one base + focused offset.
+$overlay-panel-z-index-base: 999990;
+$overlay-panel-z-index-focused: 999995;
+$agents-manager-z-index-docked: $overlay-panel-z-index-base;
+$agents-manager-z-index-focused: $overlay-panel-z-index-focused;
 
 /* WP Admin */
 $admin-menu-width-unified: 272px;

--- a/packages/agents-manager/src/utils/__tests__/observe-editor-canvas-pointerdown.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-editor-canvas-pointerdown.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import observeEditorCanvasPointerDown from '../observe-editor-canvas-pointerdown';
+
+// MutationObserver callbacks run as microtasks; awaiting a resolved promise
+// lets queued mutations flush so `attach` re-runs.
+const flushMutations = () => Promise.resolve();
+
+const addCanvasIframe = (): HTMLIFrameElement => {
+	const iframe = document.createElement( 'iframe' );
+	iframe.name = 'editor-canvas';
+	document.body.appendChild( iframe );
+	return iframe;
+};
+
+// jsdom keeps a removed iframe's `contentDocument.defaultView` non-null, so we
+// override it to reproduce the real-browser stale signal the prune relies on.
+const markDetached = ( doc: Document ) => {
+	Object.defineProperty( doc, 'defaultView', { value: null, configurable: true } );
+};
+
+const dispatchPointerDown = ( doc: Document ) => {
+	doc.dispatchEvent( new Event( 'pointerdown' ) );
+};
+
+describe( 'observeEditorCanvasPointerDown', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'is a no-op and cleans up safely when no canvas iframe is present', () => {
+		const handler = jest.fn();
+		const cleanup = observeEditorCanvasPointerDown( handler );
+
+		expect( handler ).not.toHaveBeenCalled();
+		expect( () => cleanup() ).not.toThrow();
+	} );
+
+	it( 'forwards pointerdown from a canvas iframe present at call time', () => {
+		const iframe = addCanvasIframe();
+		const handler = jest.fn();
+		const cleanup = observeEditorCanvasPointerDown( handler );
+
+		dispatchPointerDown( iframe.contentDocument as Document );
+		expect( handler ).toHaveBeenCalledTimes( 1 );
+
+		cleanup();
+	} );
+
+	it( 'attaches to a canvas iframe that mounts after the observer starts', async () => {
+		const handler = jest.fn();
+		const cleanup = observeEditorCanvasPointerDown( handler );
+
+		const iframe = addCanvasIframe();
+		await flushMutations();
+
+		dispatchPointerDown( iframe.contentDocument as Document );
+		expect( handler ).toHaveBeenCalledTimes( 1 );
+
+		cleanup();
+	} );
+
+	it( 'prunes the stale document on remount and forwards from the new one', async () => {
+		const firstIframe = addCanvasIframe();
+		const handler = jest.fn();
+		const cleanup = observeEditorCanvasPointerDown( handler );
+
+		const oldDoc = firstIframe.contentDocument as Document;
+		dispatchPointerDown( oldDoc );
+		expect( handler ).toHaveBeenCalledTimes( 1 );
+
+		// Remount: the old canvas is replaced by a fresh iframe. We stop matching
+		// the old iframe (renaming it) and mark its document detached
+		// (`defaultView === null`) instead of removing it from the DOM — jsdom
+		// neutralizes a removed document's dispatch, which would mask whether the
+		// prune actually removed the listener. Keeping it connected but renamed
+		// lets a later dispatch prove the listener was removed by the prune.
+		firstIframe.name = 'editor-canvas-detached';
+		markDetached( oldDoc );
+		const secondIframe = addCanvasIframe();
+		await flushMutations();
+
+		const newDoc = secondIframe.contentDocument as Document;
+		dispatchPointerDown( newDoc );
+		expect( handler ).toHaveBeenCalledTimes( 2 );
+
+		// The stale document's listener was pruned, so it no longer fires.
+		dispatchPointerDown( oldDoc );
+		expect( handler ).toHaveBeenCalledTimes( 2 );
+
+		cleanup();
+	} );
+
+	it( 'detaches remaining listeners on cleanup', () => {
+		const iframe = addCanvasIframe();
+		const handler = jest.fn();
+		const cleanup = observeEditorCanvasPointerDown( handler );
+		const doc = iframe.contentDocument as Document;
+
+		cleanup();
+
+		dispatchPointerDown( doc );
+		expect( handler ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/agents-manager/src/utils/observe-editor-canvas-pointerdown.ts
+++ b/packages/agents-manager/src/utils/observe-editor-canvas-pointerdown.ts
@@ -1,0 +1,42 @@
+/**
+ * The Gutenberg Site Editor renders its canvas inside `<iframe name="editor-canvas">`.
+ * Pointerdown events originating in that iframe never bubble to the parent document,
+ * so any logic that relies on parent-document pointerdowns (e.g. blurring a panel when
+ * the user clicks elsewhere) misses clicks on editor content. This watches for the
+ * canvas iframe — including remounts on template switch, which yield a fresh
+ * contentDocument — and forwards its pointerdown events to the given handler.
+ * @param onPointerDown Called for pointerdown events inside the canvas iframe.
+ * @returns Cleanup function that stops observing and detaches all listeners.
+ */
+export default function observeEditorCanvasPointerDown(
+	onPointerDown: ( event: PointerEvent ) => void
+): () => void {
+	const attachedDocs = new Set< Document >();
+
+	const attach = () => {
+		const iframe = document.querySelector< HTMLIFrameElement >( 'iframe[name="editor-canvas"]' );
+		const doc = iframe?.contentDocument ?? null;
+		if ( ! doc || attachedDocs.has( doc ) ) {
+			return;
+		}
+		attachedDocs.add( doc );
+		doc.addEventListener( 'pointerdown', onPointerDown );
+	};
+
+	// Cover the canvas already being present when this runs.
+	attach();
+
+	// The canvas iframe mounts after first paint and remounts on template switch
+	// (a new contentDocument), so re-attach on any DOM mutation under body.
+	const observer = new MutationObserver( attach );
+	if ( document.body ) {
+		observer.observe( document.body, { childList: true, subtree: true } );
+	}
+
+	return () => {
+		observer.disconnect();
+		attachedDocs.forEach( ( doc ) => {
+			doc.removeEventListener( 'pointerdown', onPointerDown );
+		} );
+	};
+}

--- a/packages/agents-manager/src/utils/observe-editor-canvas-pointerdown.ts
+++ b/packages/agents-manager/src/utils/observe-editor-canvas-pointerdown.ts
@@ -16,6 +16,16 @@ export default function observeEditorCanvasPointerDown(
 	const attach = () => {
 		const iframe = document.querySelector< HTMLIFrameElement >( 'iframe[name="editor-canvas"]' );
 		const doc = iframe?.contentDocument ?? null;
+
+		// Drop documents from detached iframes (a remount yields a fresh
+		// contentDocument); a detached doc has `defaultView === null`.
+		attachedDocs.forEach( ( attached ) => {
+			if ( attached !== doc && ! attached.defaultView ) {
+				attached.removeEventListener( 'pointerdown', onPointerDown );
+				attachedDocs.delete( attached );
+			}
+		} );
+
 		if ( ! doc || attachedDocs.has( doc ) ) {
 			return;
 		}

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.67",
+		"@automattic/agenttic-client": "^0.1.68",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.65",
+		"@automattic/agenttic-client": "^0.1.67",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.68",
+		"@automattic/agenttic-client": "^0.1.69",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/data-stores/src/agents-manager/actions.ts
+++ b/packages/data-stores/src/agents-manager/actions.ts
@@ -106,6 +106,13 @@ export function* setFloatingPosition(
 	} as const;
 }
 
+export function setFreeDragPosition( freeDragPosition: { x: number; y: number } | null ) {
+	return {
+		type: 'AGENTS_MANAGER_SET_FREE_DRAG_POSITION',
+		freeDragPosition,
+	} as const;
+}
+
 export function setLastActivity( lastActivity: PerSiteLastActivity | undefined ) {
 	return {
 		type: 'AGENTS_MANAGER_SET_LAST_ACTIVITY',
@@ -145,6 +152,7 @@ export type AgentsManagerAction =
 	| ReturnType< typeof setIsLoading >
 	| ReturnType< typeof setHasLoaded >
 	| ReturnType< typeof setIsSplitScreen >
+	| ReturnType< typeof setFreeDragPosition >
 	| GeneratorReturnType< typeof setIsOpen >
 	| GeneratorReturnType< typeof setIsDocked >
 	| GeneratorReturnType< typeof setIsMinimized >

--- a/packages/data-stores/src/agents-manager/actions.ts
+++ b/packages/data-stores/src/agents-manager/actions.ts
@@ -106,6 +106,11 @@ export function* setFloatingPosition(
 	} as const;
 }
 
+/**
+ * Set the free-drag position of the floating panel. Session-scoped —
+ * intentionally not persisted to the backend (unlike floatingPosition); it
+ * survives view switches via the in-memory store but resets on full reload.
+ */
 export function setFreeDragPosition( freeDragPosition: { x: number; y: number } | null ) {
 	return {
 		type: 'AGENTS_MANAGER_SET_FREE_DRAG_POSITION',

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -76,6 +76,17 @@ const floatingPosition: Reducer< 'left' | 'right', AgentsManagerAction > = (
 	return state;
 };
 
+const freeDragPosition: Reducer< { x: number; y: number } | null, AgentsManagerAction > = (
+	state = null,
+	action
+) => {
+	switch ( action.type ) {
+		case 'AGENTS_MANAGER_SET_FREE_DRAG_POSITION':
+			return action.freeDragPosition;
+	}
+	return state;
+};
+
 export const isSplitScreen: Reducer< boolean, AgentsManagerAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_SPLIT_SCREEN':
@@ -98,6 +109,7 @@ const reducer = combineReducers( {
 	isLoading,
 	hasLoaded,
 	floatingPosition,
+	freeDragPosition,
 	isSplitScreen,
 } );
 

--- a/packages/data-stores/src/agents-manager/selectors.ts
+++ b/packages/data-stores/src/agents-manager/selectors.ts
@@ -9,6 +9,7 @@ export const getAgentsManagerState = ( state: State ) => ( {
 	isLoading: state.isLoading,
 	hasLoaded: state.hasLoaded,
 	floatingPosition: state.floatingPosition,
+	freeDragPosition: state.freeDragPosition,
 	isSplitScreen: state.isSplitScreen,
 } );
 export const getIsOpen = ( state: State ) => state.isOpen;
@@ -30,3 +31,4 @@ export const getLastActivity = ( state: State, siteKey: string ) => {
 export const getIsLoading = ( state: State ) => state.isLoading;
 export const getHasLoaded = ( state: State ) => state.hasLoaded;
 export const getFloatingPosition = ( state: State ) => state.floatingPosition;
+export const getFreeDragPosition = ( state: State ) => state.freeDragPosition;

--- a/packages/help-center/src/components/_variables.scss
+++ b/packages/help-center/src/components/_variables.scss
@@ -11,7 +11,13 @@ $font-title-small: 1.25em;
 $root-font-size: 1em;
 
 $head-foot-height: 56px;
-$help-center-z-index: 500000;
+// Shared overlay-panel stacking, mirrored in Agents Manager
+// (packages/agents-manager/src/styles/variables.scss). A focused panel must
+// always beat an unfocused one, so they share one base + focused offset.
+$overlay-panel-z-index-base: 999990;
+$overlay-panel-z-index-focused: 999995;
+$help-center-z-index: $overlay-panel-z-index-base;
+$help-center-z-index-focused: $overlay-panel-z-index-focused;
 $help-center-blue: #3858e9;
 $help-center-notice-background: #FDF7E9;
 $help-center-notice-color: #644B1C;

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -104,13 +104,29 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 		if ( ! node ) {
 			return;
 		}
+		// Raise the panel on open so it paints above Agents Manager. Paint-order
+		// only — no real DOM focus. The handlers below still demote it afterward.
+		if ( show && ! hidden ) {
+			setIsFocused( true );
+		}
 		const handleFocusIn = () => {
 			setIsFocused( true );
 		};
-		const handleFocusOut = ( e: FocusEvent ) => {
-			if ( ! node.contains( e.relatedTarget as Node | null ) ) {
-				setIsFocused( false );
+		let pendingFocusOut: number | undefined;
+		const handleFocusOut = () => {
+			// Defer: in-panel navigation unmounts the focused element, transiently
+			// dropping focus to <body>. Re-test activeElement after focus settles so
+			// we only demote when it truly moved to a real element outside the panel.
+			if ( pendingFocusOut !== undefined ) {
+				cancelAnimationFrame( pendingFocusOut );
 			}
+			pendingFocusOut = requestAnimationFrame( () => {
+				pendingFocusOut = undefined;
+				const active = document.activeElement;
+				if ( active !== document.body && ! node.contains( active ) ) {
+					setIsFocused( false );
+				}
+			} );
 		};
 		const handlePointerDown = () => {
 			setIsFocused( true );
@@ -128,6 +144,9 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 		const stopCanvasObserver = observeEditorCanvasPointerDown( handleDocumentPointerDown );
 
 		return () => {
+			if ( pendingFocusOut !== undefined ) {
+				cancelAnimationFrame( pendingFocusOut );
+			}
 			node.removeEventListener( 'focusin', handleFocusIn );
 			node.removeEventListener( 'focusout', handleFocusOut );
 			node.removeEventListener( 'pointerdown', handlePointerDown );

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import observeEditorCanvasPointerDown from '@automattic/agents-manager/src/utils/observe-editor-canvas-pointerdown';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useWindowDimensions } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
@@ -59,8 +60,10 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 	const { sectionName } = useHelpCenterContext();
 	const nodeRef = useRef< HTMLDivElement >( null );
 	const isMobile = useMobileBreakpoint();
+	const [ isFocused, setIsFocused ] = useState( false );
 	const classNames = clsx( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
+		'is-focused': isFocused,
 	} );
 
 	useActionHooks();
@@ -92,6 +95,46 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 			document.removeEventListener( 'keydown', handleKeydown );
 		};
 	}, [ shouldCloseOnEscapeRef, onDismiss ] );
+
+	// Track focus so this panel can raise its z-index above the Agents Manager
+	// panel when the user interacts with it. `pointerdown` also covers clicks on
+	// non-focusable regions (drag handle, scroll area) that don't fire `focusin`.
+	useEffect( () => {
+		const node = nodeRef.current;
+		if ( ! node ) {
+			return;
+		}
+		const handleFocusIn = () => {
+			setIsFocused( true );
+		};
+		const handleFocusOut = ( e: FocusEvent ) => {
+			if ( ! node.contains( e.relatedTarget as Node | null ) ) {
+				setIsFocused( false );
+			}
+		};
+		const handlePointerDown = () => {
+			setIsFocused( true );
+		};
+		const handleDocumentPointerDown = ( e: PointerEvent ) => {
+			if ( ! node.contains( e.target as Node | null ) ) {
+				setIsFocused( false );
+			}
+		};
+
+		node.addEventListener( 'focusin', handleFocusIn );
+		node.addEventListener( 'focusout', handleFocusOut );
+		node.addEventListener( 'pointerdown', handlePointerDown );
+		document.addEventListener( 'pointerdown', handleDocumentPointerDown );
+		const stopCanvasObserver = observeEditorCanvasPointerDown( handleDocumentPointerDown );
+
+		return () => {
+			node.removeEventListener( 'focusin', handleFocusIn );
+			node.removeEventListener( 'focusout', handleFocusOut );
+			node.removeEventListener( 'pointerdown', handlePointerDown );
+			document.removeEventListener( 'pointerdown', handleDocumentPointerDown );
+			stopCanvasObserver();
+		};
+	}, [ show, hidden ] );
 
 	if ( ! show || hidden ) {
 		return null;

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -82,7 +82,12 @@ const EllipsisMenu = () => {
 	};
 
 	return (
-		<DropdownMenu icon={ moreVertical } label={ __( 'Help Center Options', __i18n_text_domain__ ) }>
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Help Center Options', __i18n_text_domain__ ) }
+			// Render the popover inside the panel node so opening the menu doesn't blur the panel
+			popoverProps={ { inline: true } }
+		>
 			{ ( { onClose } ) => (
 				<>
 					<MenuGroup>

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -12,6 +12,12 @@
 	background-color: var(--color-surface);
 	z-index: $help-center-z-index;
 	cursor: default;
+
+	// Raise above the Agents Manager panel while focused, so the last-clicked
+	// panel wins. Both panels share one base/focused scale.
+	&.is-focused {
+		z-index: $help-center-z-index-focused;
+	}
 	transition: max-height 0.5s;
 	animation: slideIn 0.2s ease-out forwards;
 	transform-origin: bottom;

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.65",
-		"@automattic/agenttic-ui": "^0.1.65",
+		"@automattic/agenttic-client": "^0.1.67",
+		"@automattic/agenttic-ui": "^0.1.67",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.67",
-		"@automattic/agenttic-ui": "^0.1.67",
+		"@automattic/agenttic-client": "^0.1.68",
+		"@automattic/agenttic-ui": "^0.1.68",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.68",
-		"@automattic/agenttic-ui": "^0.1.68",
+		"@automattic/agenttic-client": "^0.1.69",
+		"@automattic/agenttic-ui": "^0.1.69",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.65",
+		"@automattic/agenttic-client": "^0.1.67",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.68",
+		"@automattic/agenttic-client": "^0.1.69",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.67",
+		"@automattic/agenttic-client": "^0.1.68",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.65",
+		"@automattic/agenttic-ui": "^0.1.67",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.67",
+		"@automattic/agenttic-ui": "^0.1.68",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.68",
+		"@automattic/agenttic-ui": "^0.1.69",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.68"
-    "@automattic/agenttic-ui": "npm:^0.1.68"
+    "@automattic/agenttic-client": "npm:^0.1.69"
+    "@automattic/agenttic-ui": "npm:^0.1.69"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,9 +180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.68":
-  version: 0.1.68
-  resolution: "@automattic/agenttic-client@npm:0.1.68"
+"@automattic/agenttic-client@npm:^0.1.69":
+  version: 0.1.69
+  resolution: "@automattic/agenttic-client@npm:0.1.69"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -196,13 +196,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 72b67aa6efbe69b803ac6fa62c4754441da556b8a119d8c8839d7744c8d22b9f047ca9cc27e6ff80c47ace8cd1a096e81045a9e8bdb1a9cd8550a74d33051d42
+  checksum: ba07edc8d44edc09eb419658d809b41b206fe4a82fb91db47eade626a8f2c776bd860cd3ec65a03538d1ac12c013a418f09e63298c4612d954d3a402593a3f91
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.68":
-  version: 0.1.68
-  resolution: "@automattic/agenttic-ui@npm:0.1.68"
+"@automattic/agenttic-ui@npm:^0.1.69":
+  version: 0.1.69
+  resolution: "@automattic/agenttic-ui@npm:0.1.69"
   dependencies:
     "@automattic/charts": "npm:>=0.58.0 <1.0.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -228,7 +228,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: f1385618051bc85311bc5a9b4eaec2aba0166f9fe72a62bf4fcefa434f07e283cbed8c030f550f6ef26b499ec3c608d0dbc8161f770259a662ae85c96ce4228f
+  checksum: 997ae168a36257f01efe2163117b2b4ab10d724c703c61ac5dcc0dbccb130a4b98f717473d30b4c4695ab1213f74d010d40f106a70229e44b5c5007354e1ee9b
   languageName: node
   linkType: hard
 
@@ -345,7 +345,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.68"
+    "@automattic/agenttic-client": "npm:^0.1.69"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1523,8 +1523,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.68"
-    "@automattic/agenttic-ui": "npm:^0.1.68"
+    "@automattic/agenttic-client": "npm:^0.1.69"
+    "@automattic/agenttic-ui": "npm:^0.1.69"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1619,7 +1619,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.68"
+    "@automattic/agenttic-client": "npm:^0.1.69"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1884,7 +1884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.68"
+    "@automattic/agenttic-ui": "npm:^0.1.69"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14338,7 +14338,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.68"
+    "@automattic/agenttic-ui": "npm:^0.1.69"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.67"
-    "@automattic/agenttic-ui": "npm:^0.1.67"
+    "@automattic/agenttic-client": "npm:^0.1.68"
+    "@automattic/agenttic-ui": "npm:^0.1.68"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,9 +180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.67":
-  version: 0.1.67
-  resolution: "@automattic/agenttic-client@npm:0.1.67"
+"@automattic/agenttic-client@npm:^0.1.68":
+  version: 0.1.68
+  resolution: "@automattic/agenttic-client@npm:0.1.68"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -196,13 +196,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: bcf6792c2385f686ec2debf7af4509b40a6ed898dbe12e5be12704222b3e9235d0043e136851bf0f313fd3f6802995cacb9933753bd6c20b28e25df3fea1a89d
+  checksum: 72b67aa6efbe69b803ac6fa62c4754441da556b8a119d8c8839d7744c8d22b9f047ca9cc27e6ff80c47ace8cd1a096e81045a9e8bdb1a9cd8550a74d33051d42
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.67":
-  version: 0.1.67
-  resolution: "@automattic/agenttic-ui@npm:0.1.67"
+"@automattic/agenttic-ui@npm:^0.1.68":
+  version: 0.1.68
+  resolution: "@automattic/agenttic-ui@npm:0.1.68"
   dependencies:
     "@automattic/charts": "npm:>=0.58.0 <1.0.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -228,7 +228,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 4aa156d15469088a7bd49fa5ba8cc7ad1bcd52b812e7c78297bf30534716e970bab521fcb0ac19d94433fc2f5e445cbf9c9be0e1f091564b9f7b2a932208f6e0
+  checksum: f1385618051bc85311bc5a9b4eaec2aba0166f9fe72a62bf4fcefa434f07e283cbed8c030f550f6ef26b499ec3c608d0dbc8161f770259a662ae85c96ce4228f
   languageName: node
   linkType: hard
 
@@ -345,7 +345,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.67"
+    "@automattic/agenttic-client": "npm:^0.1.68"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1523,8 +1523,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.67"
-    "@automattic/agenttic-ui": "npm:^0.1.67"
+    "@automattic/agenttic-client": "npm:^0.1.68"
+    "@automattic/agenttic-ui": "npm:^0.1.68"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1619,7 +1619,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.67"
+    "@automattic/agenttic-client": "npm:^0.1.68"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1884,7 +1884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.67"
+    "@automattic/agenttic-ui": "npm:^0.1.68"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14338,7 +14338,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.67"
+    "@automattic/agenttic-ui": "npm:^0.1.68"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.66"
-    "@automattic/agenttic-ui": "npm:^0.1.66"
+    "@automattic/agenttic-client": "npm:^0.1.67"
+    "@automattic/agenttic-ui": "npm:^0.1.67"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,9 +180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.65, @automattic/agenttic-client@npm:^0.1.66":
-  version: 0.1.66
-  resolution: "@automattic/agenttic-client@npm:0.1.66"
+"@automattic/agenttic-client@npm:^0.1.67":
+  version: 0.1.67
+  resolution: "@automattic/agenttic-client@npm:0.1.67"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -196,13 +196,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: aa53a625848bd2cc68d1d3a31be36a9b9edbd1d5e6be7b026c069cb9d022fa981982fcf097f600ab576ffe876c6140da9262d3e45781d7dbaf00bcae54ee8313
+  checksum: bcf6792c2385f686ec2debf7af4509b40a6ed898dbe12e5be12704222b3e9235d0043e136851bf0f313fd3f6802995cacb9933753bd6c20b28e25df3fea1a89d
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.65, @automattic/agenttic-ui@npm:^0.1.66":
-  version: 0.1.66
-  resolution: "@automattic/agenttic-ui@npm:0.1.66"
+"@automattic/agenttic-ui@npm:^0.1.67":
+  version: 0.1.67
+  resolution: "@automattic/agenttic-ui@npm:0.1.67"
   dependencies:
     "@automattic/charts": "npm:>=0.58.0 <1.0.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -228,7 +228,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: c8f06341d171d3c272ed29e5247cf765b2d7265ae7c2cf4983a7fac94ff82f0b8ab225a200745864e135fe1bc9eea1b064499214afd3ef950ee368e936c3beb9
+  checksum: 4aa156d15469088a7bd49fa5ba8cc7ad1bcd52b812e7c78297bf30534716e970bab521fcb0ac19d94433fc2f5e445cbf9c9be0e1f091564b9f7b2a932208f6e0
   languageName: node
   linkType: hard
 
@@ -345,7 +345,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.65"
+    "@automattic/agenttic-client": "npm:^0.1.67"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1523,8 +1523,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.65"
-    "@automattic/agenttic-ui": "npm:^0.1.65"
+    "@automattic/agenttic-client": "npm:^0.1.67"
+    "@automattic/agenttic-ui": "npm:^0.1.67"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1619,7 +1619,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.65"
+    "@automattic/agenttic-client": "npm:^0.1.67"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1884,7 +1884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.65"
+    "@automattic/agenttic-ui": "npm:^0.1.67"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14338,7 +14338,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.65"
+    "@automattic/agenttic-ui": "npm:^0.1.67"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
Fixes AI-997

## Proposed Changes

* Add a mechanism to control the focused panel (Agents Manager or Help Center) z-index and make sure it will appear on top
* Update agenttic package to v0.1.68
* Enable `freeDrag` for Agents Manager so the chat panel can be moved around freely

## Why are these changes being made?

When both the Help Center and Agents Manager chat panels are open at the same time, they can overlap, and the panel the user is interacting with isn't reliably on top.

## Testing Instructions

* You might need to sync BigSky `trunk` with your sandbox (some necessary changes were not deployed to wpcom)
  * `WPCOM_USERNAME=jcheringer pnpm run dev:wpcom`
* Sync the Agents Manager app with your sandbox
  * `cd apps/agents-manager/ &&  WPCOM_SANDBOX=wordpress yarn dev --sync`
* Sync the Help Center app with your sandbox
  * `cd apps/help-center/ &&  WPCOM_SANDBOX=wordpress yarn dev --sync`
* Open the site editor `/wp-admin/site-editor.php?p=%2F&canvas=edit`
* Undock Agents Manager
  * Check if you can move it freely around the viewport
* Click the `?` at the top to open the Help Center
* Move the panels around and check if the focused panel is always on top  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
