### PR TITLE
A4A Amplify: reports/jobs data layer + Reports table

### DIFF
--- a/client/a8c-for-agencies/data/amplify/types.ts
+++ b/client/a8c-for-agencies/data/amplify/types.ts
@@ -1,0 +1,43 @@
+export type AmplifyMode = 'human' | 'ai' | 'fullanalysis';
+
+export type AmplifyJobStatus = 'pending' | 'failed';
+
+// In-flight or failed run, surfaced by GET /jobs. `failure_reason` is present
+// only when `status` is `failed`.
+export interface AmplifyJob {
+	id: string;
+	status: AmplifyJobStatus;
+	url: string;
+	mode: AmplifyMode;
+	timestamp: string;
+	failure_reason?: string;
+}
+
+// `fullanalysis` fills both lenses; a single-lens run fills its own and leaves
+// the other `null`.
+export interface AmplifyScore {
+	human: number | null;
+	ai: number | null;
+}
+
+// Finished, scored run, surfaced by GET /reports and GET /reports/{id}. A
+// report's `id` differs from the originating run's id.
+export interface AmplifyReport {
+	id: string;
+	status: 'completed';
+	url: string;
+	agency_name: string;
+	mode: AmplifyMode;
+	timestamp: string;
+	user_id: number | null;
+	score: AmplifyScore;
+	pdf_url: string | null;
+}
+
+export interface AmplifyJobsResponse {
+	jobs: AmplifyJob[];
+}
+
+export interface AmplifyReportsResponse {
+	reports: AmplifyReport[];
+}

--- a/client/a8c-for-agencies/data/amplify/use-fetch-amplify-jobs.ts
+++ b/client/a8c-for-agencies/data/amplify/use-fetch-amplify-jobs.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { AmplifyJob, AmplifyJobsResponse } from './types';
+
+// While any job is still `pending`, poll so a freshly-submitted run reflects
+// its status changes. Once nothing is pending — the remaining jobs are
+// `failed`, and completed runs have moved to the reports list — polling stops.
+const POLL_INTERVAL = 15 * 1000;
+
+export const getAmplifyJobsQueryKey = ( agencyId?: number ) => [ 'a4a-amplify-jobs', agencyId ];
+
+export function hasPendingJobs( jobs?: AmplifyJob[] ): boolean {
+	return !! jobs?.some( ( job ) => job.status === 'pending' );
+}
+
+function fetchAmplifyJobs( agencyId: number ): Promise< AmplifyJob[] > {
+	return wpcom.req
+		.get( {
+			apiNamespace: 'wpcom/v2',
+			path: `/agency/${ agencyId }/amplify/jobs`,
+		} )
+		.then( ( response: AmplifyJobsResponse ) => response.jobs );
+}
+
+export default function useFetchAmplifyJobs() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery< AmplifyJob[] >( {
+		queryKey: getAmplifyJobsQueryKey( agencyId ),
+		queryFn: () => fetchAmplifyJobs( agencyId as number ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+		refetchInterval: ( query ) => ( hasPendingJobs( query.state.data ) ? POLL_INTERVAL : false ),
+	} );
+}

--- a/client/a8c-for-agencies/data/amplify/use-fetch-amplify-report.ts
+++ b/client/a8c-for-agencies/data/amplify/use-fetch-amplify-report.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { AmplifyReport } from './types';
+
+export const getAmplifyReportQueryKey = ( agencyId?: number, reportId?: string ) => [
+	'a4a-amplify-report',
+	agencyId,
+	reportId,
+];
+
+function fetchAmplifyReport( agencyId: number, reportId: string ): Promise< AmplifyReport > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/amplify/reports/${ reportId }`,
+	} );
+}
+
+export default function useFetchAmplifyReport( reportId?: string ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery< AmplifyReport >( {
+		queryKey: getAmplifyReportQueryKey( agencyId, reportId ),
+		queryFn: () => fetchAmplifyReport( agencyId as number, reportId as string ),
+		enabled: !! agencyId && !! reportId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/data/amplify/use-fetch-amplify-reports.ts
+++ b/client/a8c-for-agencies/data/amplify/use-fetch-amplify-reports.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { AmplifyReport, AmplifyReportsResponse } from './types';
+
+export const getAmplifyReportsQueryKey = ( agencyId?: number ) => [
+	'a4a-amplify-reports',
+	agencyId,
+];
+
+function fetchAmplifyReports( agencyId: number ): Promise< AmplifyReport[] > {
+	return wpcom.req
+		.get( {
+			apiNamespace: 'wpcom/v2',
+			path: `/agency/${ agencyId }/amplify/reports`,
+		} )
+		.then( ( response: AmplifyReportsResponse ) => response.reports );
+}
+
+export default function useFetchAmplifyReports() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery< AmplifyReport[] >( {
+		queryKey: getAmplifyReportsQueryKey( agencyId ),
+		queryFn: () => fetchAmplifyReports( agencyId as number ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-overview/index.tsx
@@ -1,4 +1,4 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -29,7 +29,9 @@ const AmplifyOverview = () => {
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
-				<Text>{ __( 'Placeholder content for Amplify > Overview.' ) }</Text>
+				<VStack spacing={ 6 }>
+					<Text>{ __( 'Placeholder content for Amplify > Overview.' ) }</Text>
+				</VStack>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/amplify-reports-content.tsx
@@ -19,6 +19,8 @@ import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { DataViews } from 'calypso/components/dataviews';
 import EmptyState from 'calypso/dashboard/components/empty-state';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useAmplifyReportRows, { AmplifyReportRow } from './use-amplify-report-rows';
 import type { BadgeType } from '@automattic/components';
 import type { Field } from '@wordpress/dataviews';
@@ -94,6 +96,7 @@ function openPdf( pdfUrl: string | null ): void {
 }
 
 export default function AmplifyReportsContent() {
+	const dispatch = useDispatch();
 	const { rows, isLoading, error } = useAmplifyReportRows();
 
 	// Align the toolbar controls with the table's column padding: 64px on wide
@@ -219,7 +222,15 @@ export default function AmplifyReportsContent() {
 							icon={ download }
 							iconSize={ 16 }
 							disabled={ ! item.pdfUrl }
-							onClick={ () => openPdf( item.pdfUrl ) }
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_amplify_report_download_click', {
+										report_id: item.id,
+										mode: item.mode,
+									} )
+								);
+								openPdf( item.pdfUrl );
+							} }
 						>
 							{ __( 'Download PDF' ) }
 						</Button>
@@ -229,7 +240,7 @@ export default function AmplifyReportsContent() {
 				enableSorting: false,
 			},
 		],
-		[]
+		[ dispatch ]
 	);
 
 	const { data: items, paginationInfo: pagination } = useMemo(

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/amplify-reports-content.tsx
@@ -1,0 +1,296 @@
+import { Badge } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
+import {
+	Button,
+	Spinner,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __, sprintf } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+import { useMemo, useState } from 'react';
+import {
+	DATAVIEWS_TABLE,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
+import EmptyState from 'calypso/dashboard/components/empty-state';
+import useAmplifyReportRows, { AmplifyReportRow } from './use-amplify-report-rows';
+import type { BadgeType } from '@automattic/components';
+import type { Field } from '@wordpress/dataviews';
+import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
+import type { ReactNode } from 'react';
+
+function modeLabel( mode: AmplifyMode ): string {
+	switch ( mode ) {
+		case 'human':
+			return __( 'Human' );
+		case 'ai':
+			return __( 'AI' );
+		case 'fullanalysis':
+			return __( 'Full' );
+		default:
+			return mode;
+	}
+}
+
+const MODE_BADGE_TYPE: Record< AmplifyMode, BadgeType > = {
+	human: 'info-blue',
+	ai: 'info-purple',
+	fullanalysis: 'info-green',
+};
+
+function formatTimestamp( iso: string ): string {
+	return new Date( iso ).toLocaleString( undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+	} );
+}
+
+function ScoreBadge( { score, label }: { score: number | null; label: string } ) {
+	if ( score === null ) {
+		return null;
+	}
+	let type: BadgeType;
+	if ( score >= 80 ) {
+		type = 'success';
+	} else if ( score >= 50 ) {
+		type = 'warning';
+	} else {
+		type = 'error';
+	}
+	return (
+		<Badge type={ type }>
+			{ sprintf(
+				/* translators: %1$s is the score label (e.g. Human), %2$d is the numeric score */
+				__( '%1$s %2$d' ),
+				label,
+				score
+			) }
+		</Badge>
+	);
+}
+
+// Validate protocol before opening so a tampered payload can't smuggle a
+// javascript:/data: URI through the download button.
+function openPdf( pdfUrl: string | null ): void {
+	if ( ! pdfUrl ) {
+		return;
+	}
+	try {
+		const parsed = new URL( pdfUrl );
+		if ( parsed.protocol === 'https:' ) {
+			window.open( pdfUrl, '_blank', 'noopener,noreferrer' );
+		}
+	} catch {
+		// Invalid URL — do nothing.
+	}
+}
+
+export default function AmplifyReportsContent() {
+	const { rows, isLoading, error } = useAmplifyReportRows();
+
+	// Align the toolbar controls with the table's column padding: 64px on wide
+	// viewports, 16px once the table switches to its narrow padding.
+	const isNarrowView = useBreakpoint( '<660px' );
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		type: DATAVIEWS_TABLE,
+		fields: [ 'site', 'mode', 'scores', 'timestamp', 'download' ],
+		sort: { field: 'timestamp', direction: 'desc' },
+		perPage: 10,
+		layout: {
+			styles: {
+				site: { width: '30%' },
+				mode: { width: '16%' },
+				scores: { width: '18%' },
+				timestamp: { width: '18%' },
+				download: { width: '18%' },
+			},
+		},
+	} );
+
+	const fields: Field< AmplifyReportRow >[] = useMemo(
+		() => [
+			{
+				id: 'site',
+				label: __( 'Site' ),
+				// Join name + url so the search box matches either token.
+				getValue: ( { item }: { item: AmplifyReportRow } ) =>
+					[ item.agencyName, item.url ].filter( Boolean ).join( ' ' ),
+				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => (
+					<VStack spacing={ 0 }>
+						<Text weight={ 500 } truncate>
+							{ item.agencyName || item.url }
+						</Text>
+						{ item.agencyName && (
+							<Text variant="muted" size={ 12 } truncate>
+								{ item.url }
+							</Text>
+						) }
+					</VStack>
+				),
+				enableHiding: false,
+				enableSorting: true,
+				enableGlobalSearch: true,
+			},
+			{
+				id: 'mode',
+				label: __( 'Analysis type' ),
+				getValue: ( { item }: { item: AmplifyReportRow } ) => modeLabel( item.mode ),
+				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => (
+					<Badge type={ MODE_BADGE_TYPE[ item.mode ] }>{ modeLabel( item.mode ) }</Badge>
+				),
+				enableHiding: true,
+				enableSorting: true,
+			},
+			{
+				id: 'scores',
+				label: __( 'Scores' ),
+				getValue: () => '',
+				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => {
+					if ( item.rowStatus !== 'completed' ) {
+						return (
+							<Text variant="muted" aria-label={ __( 'Scores not available' ) }>
+								—
+							</Text>
+						);
+					}
+					return (
+						<HStack spacing={ 2 } justify="flex-start" expanded={ false } wrap>
+							{ item.mode === 'fullanalysis' ? (
+								<>
+									<ScoreBadge score={ item.humanScore } label={ __( 'Human' ) } />
+									<ScoreBadge score={ item.aiScore } label={ __( 'AI' ) } />
+								</>
+							) : (
+								<ScoreBadge
+									score={ item.mode === 'human' ? item.humanScore : item.aiScore }
+									label={ item.mode === 'human' ? __( 'Human' ) : __( 'AI' ) }
+								/>
+							) }
+						</HStack>
+					);
+				},
+				enableHiding: true,
+				enableSorting: false,
+			},
+			{
+				id: 'timestamp',
+				label: __( 'Time & date' ),
+				getValue: ( { item }: { item: AmplifyReportRow } ) => item.timestamp,
+				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => (
+					<Text variant="muted">{ formatTimestamp( item.timestamp ) }</Text>
+				),
+				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'download',
+				label: __( 'Download' ),
+				getValue: () => '',
+				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => {
+					if ( item.rowStatus === 'failed' ) {
+						return (
+							<Badge type="error" title={ item.failureReason }>
+								{ __( 'Analysis failed' ) }
+							</Badge>
+						);
+					}
+					if ( item.rowStatus === 'pending' ) {
+						return (
+							<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
+								<Spinner />
+								<Text variant="muted">{ __( 'Analysis in progress' ) }</Text>
+							</HStack>
+						);
+					}
+					return (
+						<Button
+							variant="secondary"
+							size="compact"
+							icon={ download }
+							iconSize={ 16 }
+							disabled={ ! item.pdfUrl }
+							onClick={ () => openPdf( item.pdfUrl ) }
+						>
+							{ __( 'Download PDF' ) }
+						</Button>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[]
+	);
+
+	const { data: items, paginationInfo: pagination } = useMemo(
+		() => filterSortAndPaginate( rows, dataViewsState, fields ),
+		[ rows, dataViewsState, fields ]
+	);
+
+	if ( isLoading ) {
+		return (
+			<VStack alignment="center" justify="center" spacing={ 3 } style={ { minBlockSize: '240px' } }>
+				<Spinner />
+				<Text variant="muted">{ __( 'Loading reports…' ) }</Text>
+			</VStack>
+		);
+	}
+
+	if ( rows.length === 0 ) {
+		return (
+			<EmptyState.Wrapper isBorderless>
+				<EmptyState>
+					<EmptyState.Header>
+						<EmptyState.Title>
+							{ error ? __( 'Unable to load reports' ) : __( 'No reports yet' ) }
+						</EmptyState.Title>
+						<EmptyState.Description>
+							{ error
+								? __( 'Something went wrong. Please refresh to try again.' )
+								: __( 'Amplify analyses you run will appear here.' ) }
+						</EmptyState.Description>
+					</EmptyState.Header>
+				</EmptyState>
+			</EmptyState.Wrapper>
+		);
+	}
+
+	return (
+		<div className="redesigned-a8c-table full-width">
+			<ItemsDataViews
+				data={ {
+					items,
+					getItemId: ( item: AmplifyReportRow ) => item.id,
+					pagination,
+					enableSearch: true,
+					searchLabel: __( 'Search by site or URL' ),
+					fields,
+					setDataViewsState,
+					dataViewsState,
+					defaultLayouts: { table: {} },
+				} }
+			>
+				<HStack
+					className="dataviews__view-actions"
+					justify="space-between"
+					style={ { paddingInline: isNarrowView ? '16px' : '64px' } }
+				>
+					<DataViews.Search />
+					<DataViews.ViewConfig />
+				</HStack>
+				<DataViews.Layout />
+				<DataViews.Footer />
+			</ItemsDataViews>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/amplify-reports-content.tsx
@@ -79,22 +79,6 @@ function ScoreBadge( { score, label }: { score: number | null; label: string } )
 	);
 }
 
-// Validate protocol before opening so a tampered payload can't smuggle a
-// javascript:/data: URI through the download button.
-function openPdf( pdfUrl: string | null ): void {
-	if ( ! pdfUrl ) {
-		return;
-	}
-	try {
-		const parsed = new URL( pdfUrl );
-		if ( parsed.protocol === 'https:' ) {
-			window.open( pdfUrl, '_blank', 'noopener,noreferrer' );
-		}
-	} catch {
-		// Invalid URL — do nothing.
-	}
-}
-
 export default function AmplifyReportsContent() {
 	const dispatch = useDispatch();
 	const { rows, isLoading, error } = useAmplifyReportRows();
@@ -221,6 +205,9 @@ export default function AmplifyReportsContent() {
 							size="compact"
 							icon={ download }
 							iconSize={ 16 }
+							href={ item.pdfUrl ?? undefined }
+							target="_blank"
+							rel="noopener noreferrer"
 							disabled={ ! item.pdfUrl }
 							onClick={ () => {
 								dispatch(
@@ -229,7 +216,6 @@ export default function AmplifyReportsContent() {
 										mode: item.mode,
 									} )
 								);
-								openPdf( item.pdfUrl );
 							} }
 						>
 							{ __( 'Download PDF' ) }

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/index.tsx
@@ -1,4 +1,3 @@
-import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -9,12 +8,13 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import AmplifyReportsContent from './amplify-reports-content';
 
 const AmplifyReports = () => {
 	const title = __( 'Reports' );
 
 	return (
-		<Layout className="amplify-reports" title={ title } wide>
+		<Layout className="amplify-reports-page full-width-layout-with-table" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb
@@ -29,7 +29,7 @@ const AmplifyReports = () => {
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
-				<Text>{ __( 'Placeholder content for Amplify > Reports.' ) }</Text>
+				<AmplifyReportsContent />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/use-amplify-report-rows.ts
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/use-amplify-report-rows.ts
@@ -29,8 +29,8 @@ export interface AmplifyReportRow {
 	failureReason?: string;
 }
 
-// Pure so it stays testable in isolation from react-query. Jobs come first so a
-// freshly-submitted run reads at the top before the table's timestamp sort runs.
+// Pure so it stays testable in isolation from react-query. The returned order
+// doesn't matter for display — the table sorts every row by timestamp.
 export function mergeAmplifyRows(
 	reports: AmplifyReport[] = [],
 	jobs: AmplifyJob[] = []

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/use-amplify-report-rows.ts
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/use-amplify-report-rows.ts
@@ -1,0 +1,105 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef } from 'react';
+import useFetchAmplifyJobs from 'calypso/a8c-for-agencies/data/amplify/use-fetch-amplify-jobs';
+import useFetchAmplifyReports, {
+	getAmplifyReportsQueryKey,
+} from 'calypso/a8c-for-agencies/data/amplify/use-fetch-amplify-reports';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type {
+	AmplifyJob,
+	AmplifyMode,
+	AmplifyReport,
+} from 'calypso/a8c-for-agencies/data/amplify/types';
+
+export type AmplifyRowStatus = 'completed' | 'pending' | 'failed';
+
+// One unified row for the reports table: completed reports (from /reports) and
+// in-flight/failed runs (from /jobs) share the columns that matter to the list.
+export interface AmplifyReportRow {
+	id: string;
+	url: string;
+	agencyName: string;
+	mode: AmplifyMode;
+	timestamp: string;
+	rowStatus: AmplifyRowStatus;
+	humanScore: number | null;
+	aiScore: number | null;
+	pdfUrl: string | null;
+	failureReason?: string;
+}
+
+// Pure so it stays testable in isolation from react-query. Jobs come first so a
+// freshly-submitted run reads at the top before the table's timestamp sort runs.
+export function mergeAmplifyRows(
+	reports: AmplifyReport[] = [],
+	jobs: AmplifyJob[] = []
+): AmplifyReportRow[] {
+	const jobRows: AmplifyReportRow[] = jobs.map( ( job ) => ( {
+		id: job.id,
+		url: job.url,
+		agencyName: '',
+		mode: job.mode,
+		timestamp: job.timestamp,
+		rowStatus: job.status,
+		humanScore: null,
+		aiScore: null,
+		pdfUrl: null,
+		failureReason: job.failure_reason,
+	} ) );
+
+	const reportRows: AmplifyReportRow[] = reports.map( ( report ) => ( {
+		id: report.id,
+		url: report.url,
+		agencyName: report.agency_name,
+		mode: report.mode,
+		timestamp: report.timestamp,
+		rowStatus: 'completed',
+		humanScore: report.score.human,
+		aiScore: report.score.ai,
+		pdfUrl: report.pdf_url,
+	} ) );
+
+	return [ ...jobRows, ...reportRows ];
+}
+
+function countPending( jobs: AmplifyJob[] = [] ): number {
+	return jobs.filter( ( job ) => job.status === 'pending' ).length;
+}
+
+export default function useAmplifyReportRows(): {
+	rows: AmplifyReportRow[];
+	isLoading: boolean;
+	error: unknown;
+} {
+	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const reportsQuery = useFetchAmplifyReports();
+	// Polls every 15s while any job is `pending` (see use-fetch-amplify-jobs).
+	const jobsQuery = useFetchAmplifyJobs();
+
+	// When a run drops out of /jobs (the pending count falls), it has either
+	// completed or failed. Refetch /reports so a finished run's completed row
+	// surfaces once the index catches up (there's a lag before it appears).
+	const previousPending = useRef( 0 );
+	useEffect( () => {
+		const pending = countPending( jobsQuery.data );
+		if ( pending < previousPending.current ) {
+			queryClient.invalidateQueries( { queryKey: getAmplifyReportsQueryKey( agencyId ) } );
+		}
+		previousPending.current = pending;
+	}, [ jobsQuery.data, queryClient, agencyId ] );
+
+	const rows = useMemo(
+		() => mergeAmplifyRows( reportsQuery.data, jobsQuery.data ),
+		[ reportsQuery.data, jobsQuery.data ]
+	);
+
+	return {
+		rows,
+		isLoading: reportsQuery.isLoading || jobsQuery.isLoading,
+		// Jobs errors are non-fatal — completed reports should still render.
+		error: reportsQuery.error,
+	};
+}


### PR DESCRIPTION
Follow-up to #111789 (Amplify section scaffolding), continuing the refactor of #110262. This PR adds the read-side data layer and the Reports table; it is based on `add/a4a-amplify`.

## Proposed Changes

Adds the agency-scoped getters data layer and wires the **Reports** page to a real DataViews table. The submit/analysis flow (POST) is intentionally held back for a follow-up.

* **`client/a8c-for-agencies/data/amplify/`** — read-side hooks against the agency-scoped `wpcom/v2/agency/{agencyId}/amplify/…` endpoints, following the `mcp-ai` data-layer conventions:
  * `use-fetch-amplify-reports.ts` / `use-fetch-amplify-report.ts` — completed reports (`GET /reports`, `GET /reports/{id}`).
  * `use-fetch-amplify-jobs.ts` — in-flight + failed runs (`GET /jobs`); polls every 15s while any run is `pending` and stops once none are.
  * `types.ts` — shared API types mirroring the endpoints' snake_case shape.
* **`sections/amplify/primary/amplify-reports/use-amplify-report-rows.ts`** — merges completed reports with jobs into one row list, and refetches `/reports` when the pending count drops so a finished run surfaces once the index catches up.
* **`sections/amplify/primary/amplify-reports/amplify-reports-content.tsx`** — the DataViews table (Site, Analysis type, Scores, Time & date, Download), composed with core components (`VStack`/`HStack`/`Text`, `Badge`, `Spinner`) and the shared `EmptyState`. Toolbar controls align to the table's start/end columns; column widths follow #110262's distribution.
* **`sections/amplify/primary/amplify-reports/index.tsx`**, **`amplify-overview/index.tsx`** — render the content in `LayoutBody`; compose page content with `VStack`.

## Why are these changes being made?

Splitting the Amplify refactor into reviewable slices: this lands the read path and list UI on top of the section scaffolding, so the write path (submitting an analysis) can follow in its own PR.

## Testing Instructions

0. If this PR is not merged yet, apply it to your sandbox - 223757-ghe-Automattic/wpcom 
1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify/reports` as an agency user with the `a4a_read_amplify` capability.
2. Confirm completed reports render with Site / Analysis type / Scores / Time & date, and **Download PDF** opens the report.
3. Confirm in-flight runs show **Analysis in progress** and failed runs show **Analysis failed** (with the reason on hover).
4. Confirm search, sorting, pagination, and the empty state work; toolbar controls line up with the table columns.
5. With a pending run present, confirm `GET …/amplify/jobs` re-fires ~15s in the Network tab and stops once nothing is pending.
6. Confirm no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?