### PR TITLE
A4A: show purchase confirmation notice in client referral flow

### DIFF
--- a/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
 import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
+import { isWPCOMHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { CHECKOUT_STORE } from 'calypso/my-sites/checkout/src/lib/wpcom-store';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -36,6 +37,12 @@ export default function useClientCheckout( { expressMode = false }: Props ) {
 	const checkoutStoreDispatch = useDispatch( CHECKOUT_STORE );
 
 	const emailMismatchWithReferralClient = referral?.client?.email !== userEmail;
+
+	// Slug of the WordPress.com hosting product being purchased, if any. Used to surface a
+	// confirmation notice on the subscriptions page after the client completes checkout.
+	const wpcomHostingProductSlug = referredProducts?.find( ( product ) =>
+		isWPCOMHostingProduct( product.slug )
+	)?.slug;
 
 	// Add products to cart when referral data is loaded
 	useEffect( () => {
@@ -125,5 +132,6 @@ export default function useClientCheckout( { expressMode = false }: Props ) {
 		error,
 		emailMismatchWithReferralClient,
 		referral,
+		wpcomHostingProductSlug,
 	};
 }

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -1,5 +1,6 @@
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
@@ -19,9 +20,15 @@ import './style.scss';
 function ClientCheckoutContent() {
 	const translate = useTranslate();
 
-	const { isReady, error, emailMismatchWithReferralClient, referral } = useClientCheckout( {
-		expressMode: false,
-	} );
+	const { isReady, error, emailMismatchWithReferralClient, referral, wpcomHostingProductSlug } =
+		useClientCheckout( {
+			expressMode: false,
+		} );
+
+	const subscriptionsUrl = window.location.origin + '/client/subscriptions';
+	const redirectTo = wpcomHostingProductSlug
+		? addQueryArgs( subscriptionsUrl, { wpcom_plan_purchased: wpcomHostingProductSlug } )
+		: subscriptionsUrl;
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;
@@ -60,7 +67,7 @@ function ClientCheckoutContent() {
 			</div>
 			<CheckoutMain
 				sitelessCheckoutType="a4a"
-				redirectTo={ window.location.origin + '/client/subscriptions' }
+				redirectTo={ redirectTo }
 				customizedPreviousPath="/client/subscriptions"
 				siteSlug=""
 				siteId={ 0 }

--- a/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
@@ -1,5 +1,6 @@
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -16,7 +17,9 @@ function ClientExpressCheckoutContent() {
 	const translate = useTranslate();
 	const userLoggedIn = useSelector( isUserLoggedIn );
 
-	const { isReady, error } = useClientCheckout( { expressMode: ! userLoggedIn } );
+	const { isReady, error, wpcomHostingProductSlug } = useClientCheckout( {
+		expressMode: ! userLoggedIn,
+	} );
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;
@@ -26,10 +29,16 @@ function ClientExpressCheckoutContent() {
 		return <ClientCheckoutV2Error title={ translate( 'Error' ) } message={ error } />;
 	}
 
+	const redirectTo = wpcomHostingProductSlug
+		? addQueryArgs( EXPRESS_CHECKOUT_REDIRECT_URL, {
+				wpcom_plan_purchased: wpcomHostingProductSlug,
+		  } )
+		: EXPRESS_CHECKOUT_REDIRECT_URL;
+
 	return (
 		<CheckoutMain
 			sitelessCheckoutType="a4a"
-			redirectTo={ EXPRESS_CHECKOUT_REDIRECT_URL }
+			redirectTo={ redirectTo }
 			customizedPreviousPath={ EXPRESS_CHECKOUT_REDIRECT_URL }
 			isLoggedOutCart={ ! userLoggedIn }
 			siteSlug=""

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -23,6 +23,7 @@ import {
 	SubscriptionStatus,
 } from './field-content';
 import SubscriptionsListMobileView from './mobile-view';
+import PurchaseConfirmationMessage from './purchase-confirmation-message';
 import type { Subscription } from '../../types';
 
 import './style.scss';
@@ -145,6 +146,8 @@ export default function SubscriptionsList() {
 			withBorder
 		>
 			<LayoutTop>
+				<PurchaseConfirmationMessage />
+
 				<LayoutHeader>
 					<Title>{ title } </Title>
 				</LayoutHeader>

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/purchase-confirmation-message.tsx
@@ -1,0 +1,50 @@
+import page from '@automattic/calypso-router';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function PurchaseConfirmationMessage() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const wpcomHostingPurchased = ( getQueryArg( window.location.href, 'wpcom_plan_purchased' ) ??
+		'' ) as string;
+
+	const [ successNotification, setSuccessNotification ] = useState< boolean >( false );
+
+	// Set the success notification when a WordPress.com site is purchased and remove the query arg from the URL
+	useEffect( () => {
+		if ( wpcomHostingPurchased ) {
+			setSuccessNotification( true );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_client_wpcom_hosting_purchased', {
+					hosting_plan: wpcomHostingPurchased,
+				} )
+			);
+			page(
+				removeQueryArgs( window.location.pathname + window.location.search, 'wpcom_plan_purchased' )
+			);
+		}
+	}, [ dispatch, wpcomHostingPurchased ] );
+
+	return successNotification ? (
+		<LayoutBanner
+			isFullWidth
+			level="success"
+			title={ translate( 'You’ve successfully purchased a WordPress.com site!' ) }
+			onClose={ () => setSuccessNotification( false ) }
+		>
+			{ translate(
+				'Once your agency creates the site, you’ll be added as an admin, and it will appear in your {{a}}site list{{/a}}.',
+				{
+					components: {
+						a: <a href="https://wordpress.com/sites" target="_blank" rel="noreferrer" />,
+					},
+				}
+			) }
+		</LayoutBanner>
+	) : null;
+}

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/purchase-confirmation-message.tsx
@@ -10,8 +10,8 @@ export default function PurchaseConfirmationMessage() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const wpcomHostingPurchased = ( getQueryArg( window.location.href, 'wpcom_plan_purchased' ) ??
-		'' ) as string;
+	const rawArg = getQueryArg( window.location.href, 'wpcom_plan_purchased' );
+	const wpcomHostingPurchased = typeof rawArg === 'string' ? rawArg : '';
 
 	const [ successNotification, setSuccessNotification ] = useState< boolean >( false );
 


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-2673/dotcom-referral-clients-see-no-sites-on-wordpresscom-upon-login
Depends on 223495-ghe-Automattic/wpcom

## Proposed Changes

After a referral client pays for a WordPress.com hosting subscription, surface a success notice on the subscriptions page letting them know the agency will create the site and add them as an admin.

- use-client-checkout: expose the WPCOM hosting product slug, if any
- client checkout (standard + express): append wpcom_plan_purchased to the post-checkout redirect when a WPCOM hosting product is purchased
- subscriptions-list: render a PurchaseConfirmationMessage banner that reads the query arg, records a Tracks event, and clears the arg

<img width="1705" height="467" alt="Screenshot 2026-06-18 at 11 54 25 PM" src="https://github.com/user-attachments/assets/68ee7f61-6de4-4dad-bd68-999fa7001872" />


## Why are these changes being made?
Set clear expectations to the client that the site will be added once the WP.com site has been provisioned by the agency.

## Testing Instructions

* Use the A4A live link and complete a referral purchase that has WP.com site.
* Confirm that you see the notice after a successful checkout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?