### PR TITLE
Help Center: fix escalation copy when 3rd-party cookies are disabled

### DIFF
--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -157,7 +157,7 @@ export const getOdieThirdPartyMessageContent = (): string =>
 		'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. Please turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
 		__i18n_text_domain__
 	) } \n\n ${ __(
-		'Once you’re done, you can come back here to start talking with someone by clicking on the following button.',
+		'Once you’re done, you can come back here and ask me to speak with a human. I’ll connect you to our support right away.',
 		__i18n_text_domain__
 	) }`;
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15250/hc-weird-escalation-message

## Proposed Changes

**Fix the escalation message shown when a user tries to reach a human with 3rd-party cookies disabled — it no longer promises a button that isn’t there.**

- Replaces the old line *“…come back here to start talking with someone by clicking on the following button.”* with the design-approved wording from [DOTCOM-15250](https://linear.app/a8c/issue/DOTCOM-15250/hc-weird-escalation-message): *“Once you’re done, you can come back here and ask me to speak with a human. I’ll connect you to our support right away.”*
- Copy-only change in `getOdieThirdPartyMessageContent` (`packages/odie-client/src/constants.tsx`).

## Why are these changes being made?

When 3rd-party cookies are blocked, live chat can’t load, so the Help Center falls back to a different escalation path (email / get-support). But the message still told people to click a button to “start talking with someone” — a button that either says something else (“Send an email”) or, in some states, doesn’t render at all. The result was a confusing dead-end message that pointed at a control that wasn’t there.

The new wording stops referencing a specific button and instead invites the user to come back and ask for a human once cookies are enabled, matching the design sign-off on [DOTCOM-15250](https://linear.app/a8c/issue/DOTCOM-15250/hc-weird-escalation-message).

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Disable 3rd-party cookies in your browser.
3. Open the Help Center as a paid user and escalate to human support.
4. Confirm the message reads *“Once you’re done, you can come back here and ask me to speak with a human. I’ll connect you to our support right away.”* and no longer mentions clicking a button.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Repeat steps 2–4 above and verify the same message.
