### PR TITLE
Help Center: refine course lesson navigation and header

### DIFF
--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -1,4 +1,3 @@
-import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import type { LessonNavigation } from '../../types';
@@ -23,12 +22,7 @@ export const ArticleLessonNavigation = ( {
 					to={ `?link=${ encodeURIComponent( previous.url ) }` }
 					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--previous"
 				>
-					<span className="help-center-article-lesson-navigation__label">
-						← { __( 'Back', __i18n_text_domain__ ) }
-					</span>
-					<span className="help-center-article-lesson-navigation__title">
-						{ decodeEntities( previous.title ) }
-					</span>
+					← { __( 'Previous lesson', __i18n_text_domain__ ) }
 				</Link>
 			) }
 			{ next?.url && (
@@ -36,12 +30,7 @@ export const ArticleLessonNavigation = ( {
 					to={ `?link=${ encodeURIComponent( next.url ) }` }
 					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--next"
 				>
-					<span className="help-center-article-lesson-navigation__label">
-						{ __( 'Up next', __i18n_text_domain__ ) } →
-					</span>
-					<span className="help-center-article-lesson-navigation__title">
-						{ decodeEntities( next.title ) }
-					</span>
+					{ __( 'Next lesson', __i18n_text_domain__ ) } →
 				</Link>
 			) }
 		</nav>

--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -1,3 +1,4 @@
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import type { LessonNavigation } from '../../types';

--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import type { LessonNavigation } from '../../types';
 
@@ -29,6 +29,11 @@ export const ArticleLessonNavigation = ( {
 				<Link
 					to={ `?link=${ encodeURIComponent( next.url ) }` }
 					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--next"
+					aria-label={ sprintf(
+						/* translators: %s is the title of the next lesson */
+						__( 'Next lesson: %s', __i18n_text_domain__ ),
+						next.title
+					) }
 				>
 					{ __( 'Next lesson', __i18n_text_domain__ ) } →
 				</Link>

--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -24,7 +24,7 @@ export const ArticleLessonNavigation = ( {
 					aria-label={ sprintf(
 						/* translators: %s is the title of the previous lesson */
 						__( 'Previous lesson: %s', __i18n_text_domain__ ),
-						previous.title
+						decodeEntities( previous.title )
 					) }
 				>
 					← { __( 'Previous lesson', __i18n_text_domain__ ) }
@@ -37,7 +37,7 @@ export const ArticleLessonNavigation = ( {
 					aria-label={ sprintf(
 						/* translators: %s is the title of the next lesson */
 						__( 'Next lesson: %s', __i18n_text_domain__ ),
-						next.title
+						decodeEntities( next.title )
 					) }
 				>
 					{ __( 'Next lesson', __i18n_text_domain__ ) } →

--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -21,6 +21,11 @@ export const ArticleLessonNavigation = ( {
 				<Link
 					to={ `?link=${ encodeURIComponent( previous.url ) }` }
 					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--previous"
+					aria-label={ sprintf(
+						/* translators: %s is the title of the previous lesson */
+						__( 'Previous lesson: %s', __i18n_text_domain__ ),
+						previous.title
+					) }
 				>
 					← { __( 'Previous lesson', __i18n_text_domain__ ) }
 				</Link>

--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -28,7 +28,11 @@ const ArticleContent = ( {
 					<SupportArticleHeader post={ post } isLoading={ false } />
 					<EmbedContainer>
 						<div
-							className="help-center-article-content__main"
+							className={
+								post.lesson_navigation
+									? 'help-center-article-content__main help-center-article-content__main--with-lesson-navigation'
+									: 'help-center-article-content__main'
+							}
 							// eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={ { __html: post.content } }
 							ref={ articleContentRef }

--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -33,14 +33,14 @@ const ArticleContent = ( {
 							dangerouslySetInnerHTML={ { __html: post.content } }
 							ref={ articleContentRef }
 						/>
-						{ post.lesson_navigation && (
-							<ArticleLessonNavigation lessonNavigation={ post.lesson_navigation } />
-						) }
 						<HelpCenterFeedbackForm
 							postId={ post.ID }
 							isEligibleForChat={ isEligibleForChat }
 							forceEmailSupport={ forceEmailSupport }
 						/>
+						{ post.lesson_navigation && (
+							<ArticleLessonNavigation lessonNavigation={ post.lesson_navigation } />
+						) }
 					</EmbedContainer>
 				</>
 			) }

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -38,6 +38,7 @@
 				svg.gridicons-external {
 					top: 3px;
 					fill: currentColor;
+					opacity: 0.6;
 				}
 			}
 
@@ -45,6 +46,7 @@
 				font-size: 1.75rem;
 				font-weight: 600;
 				line-height: 1.2;
+				margin-top: 0;
 			}
 		}
 
@@ -535,6 +537,15 @@
 				}
 			}
 
+			// Course lesson videos span the full width of the Help Center,
+			// bleeding past the article's horizontal padding.
+			.wp-block-embed.is-type-video {
+				margin-left: -16px;
+				margin-right: -16px;
+				max-width: none;
+				width: calc( 100% + 32px );
+			}
+
 			.wp-block-wpsupport3-update-plan-cta {
 				.container .card {
 					margin-top: 16px;
@@ -652,45 +663,26 @@
 
 	.help-center-article-lesson-navigation {
 		display: flex;
+		justify-content: space-between;
 		gap: 16px;
 		margin-top: 24px;
 		padding-top: 24px;
 		border-top: 1px solid var( --color-neutral-10 );
 
 		&__link {
-			display: flex;
-			flex-direction: column;
-			gap: 4px;
+			font-size: $font-body;
+			font-weight: 500;
+			color: var( --studio-gray-80 );
 			text-decoration: none;
-			flex: 1;
 
 			&:hover {
-				text-decoration: none;
-
-				.help-center-article-lesson-navigation__title {
-					text-decoration: underline;
-				}
-			}
-
-			&--previous {
-				align-items: flex-start;
+				text-decoration: underline;
 			}
 
 			&--next {
-				align-items: flex-end;
+				margin-left: auto;
 				text-align: right;
 			}
-		}
-
-		&__label {
-			font-size: $font-body-small;
-			color: var( --color-neutral-50 );
-		}
-
-		&__title {
-			font-size: $font-body;
-			font-weight: 500;
-			color: var( --color-text );
 		}
 	}
 }

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -537,13 +537,15 @@
 				}
 			}
 
-			// Course lesson videos span the full width of the Help Center,
-			// bleeding past the article's horizontal padding.
-			.wp-block-embed.is-type-video {
-				margin-left: -16px;
-				margin-right: -16px;
-				max-width: none;
-				width: calc( 100% + 32px );
+			&.help-center-article-content__main--with-lesson-navigation {
+				// Course lesson videos span the full width of the Help Center,
+				// bleeding past the article's horizontal padding.
+				.wp-block-embed.is-type-video {
+					margin-left: -16px;
+					margin-right: -16px;
+					max-width: none;
+					width: calc( 100% + 32px );
+				}
 			}
 
 			.wp-block-wpsupport3-update-plan-cta {

--- a/packages/support-articles/src/components/help-center-article/help-center-support-article-header.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-support-article-header.tsx
@@ -27,7 +27,9 @@ export const SupportArticleHeader = ( {
 				target="_blank"
 				icon
 			>
-				{ __( 'Open support page', __i18n_text_domain__ ) }
+				{ post.lesson_navigation
+					? __( 'Open full course', __i18n_text_domain__ )
+					: __( 'Open support page', __i18n_text_domain__ ) }
 			</ExternalLink>
 		</div>
 	);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15981/help-center-courses-navigation-feedback

## Proposed Changes

**Polishes the course lesson layout rendered inside the Help Center article view, per design feedback.**

- Lesson navigation now reads “Previous lesson” / “Next lesson” (no full lesson titles) in a darker tone so it no longer looks disabled.
- The lesson navigation moves below the “Was it helpful?” feedback block so it acts as a bookend.
- Course videos now span the full width of the article view.
- The header link reads “Open full course” on course lessons (still “Open support page” for regular articles).
- The external-link icon opacity is reduced to `0.6`, and the gap between the title and the link is tightened (no extra space above the title).

All of this lives in `packages/support-articles` — the React layer that renders `wordpress.com/support` content inside the Help Center — not in the `wpsupport3` theme. The theme only supplies the `lesson_navigation` data and the body HTML; the layout being tweaked here is all client-side.

## Before / After

Same course lesson, rendered inside the Help Center.

**Before**
<img width="448" height="772" alt="image" src="https://github.com/user-attachments/assets/65e0160c-3170-4685-8f32-87620a1a9bf0" />

**After**

<img width="448" height="772" alt="image" src="https://github.com/user-attachments/assets/5534d728-c7e9-4265-a9a9-df3081d47621" />

**New lesson navigation — now below the "Was this helpful?" block**

<img width="448" height="620" alt="image" src="https://github.com/user-attachments/assets/26a3135c-e868-4acb-8daa-ddffec822167" />



## Why are these changes being made?

Courses show up inside the Help Center in a much narrower column than on the full support site. The right-aligned lesson titles were hard to read, the navigation felt unrelated where it sat, and a few header details (icon contrast, spacing, link wording) read awkwardly at that width. These changes adapt the course lesson view to the Help Center’s space so it reads clearly. See [DOTCOM-15981](https://linear.app/a8c/issue/DOTCOM-15981/help-center-courses-navigation-feedback).

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center and navigate to a course lesson (e.g. search for a course such as “Create your website”, open it, and follow into a lesson).
3. Verify: the video is full width; the header link says “Open full course”; the external-link icon is softer; the title/link spacing is tight; the “Previous lesson” / “Next lesson” navigation appears below the “Was it helpful?” block in a readable, darker tone.
4. Open a regular (non-course) support article and confirm the header link still says “Open support page” and no lesson navigation appears.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center and repeat the course-lesson checks from the Calypso steps above.
