### PR TITLE
A4A Amplify: analysis submission flow

### DIFF
--- a/client/a8c-for-agencies/data/amplify/types.ts
+++ b/client/a8c-for-agencies/data/amplify/types.ts
@@ -41,3 +41,23 @@ export interface AmplifyJobsResponse {
 export interface AmplifyReportsResponse {
 	reports: AmplifyReport[];
 }
+
+export interface StartAmplifyAnalysisParams {
+	url: string;
+	mode: AmplifyMode;
+}
+
+// 202 response from POST /reports — the newly created run, always `pending`.
+export interface AmplifyAnalysisRun {
+	id: string;
+	status: 'pending';
+	url: string;
+	mode: AmplifyMode;
+	timestamp: string;
+}
+
+export interface AmplifyApiError {
+	status: number;
+	code: string | null;
+	message: string;
+}

--- a/client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts
+++ b/client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts
@@ -1,0 +1,54 @@
+import {
+	useMutation,
+	useQueryClient,
+	UseMutationOptions,
+	UseMutationResult,
+} from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getAmplifyJobsQueryKey } from './use-fetch-amplify-jobs';
+import type { AmplifyAnalysisRun, AmplifyApiError, StartAmplifyAnalysisParams } from './types';
+
+function startAmplifyAnalysis(
+	params: StartAmplifyAnalysisParams,
+	agencyId: number
+): Promise< AmplifyAnalysisRun > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/amplify/reports`,
+		body: { url: params.url, mode: params.mode },
+	} );
+}
+
+export default function useStartAmplifyAnalysis< TContext = unknown >(
+	options?: UseMutationOptions<
+		AmplifyAnalysisRun,
+		AmplifyApiError,
+		StartAmplifyAnalysisParams,
+		TContext
+	>
+): UseMutationResult< AmplifyAnalysisRun, AmplifyApiError, StartAmplifyAnalysisParams, TContext > {
+	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< AmplifyAnalysisRun, AmplifyApiError, StartAmplifyAnalysisParams, TContext >( {
+		...options,
+		mutationFn: ( params ) => {
+			if ( ! agencyId ) {
+				return Promise.reject( {
+					status: 400,
+					code: 'no_active_agency',
+					message: 'No active agency in context.',
+				} as AmplifyApiError );
+			}
+			return startAmplifyAnalysis( params, agencyId );
+		},
+		onSuccess: ( data, variables, context ) => {
+			// A new run starts as `pending`; refresh the jobs list so it surfaces
+			// immediately (and polling picks up from there).
+			queryClient.invalidateQueries( { queryKey: getAmplifyJobsQueryKey( agencyId ) } );
+			options?.onSuccess?.( data, variables, context );
+		},
+	} );
+}

--- a/client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts
+++ b/client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts
@@ -8,7 +8,12 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getAmplifyJobsQueryKey } from './use-fetch-amplify-jobs';
-import type { AmplifyAnalysisRun, AmplifyApiError, StartAmplifyAnalysisParams } from './types';
+import type {
+	AmplifyAnalysisRun,
+	AmplifyApiError,
+	AmplifyJob,
+	StartAmplifyAnalysisParams,
+} from './types';
 
 function startAmplifyAnalysis(
 	params: StartAmplifyAnalysisParams,
@@ -45,9 +50,18 @@ export default function useStartAmplifyAnalysis< TContext = unknown >(
 			return startAmplifyAnalysis( params, agencyId );
 		},
 		onSuccess: ( data, variables, context ) => {
-			// A new run starts as `pending`; refresh the jobs list so it surfaces
-			// immediately (and polling picks up from there).
-			queryClient.invalidateQueries( { queryKey: getAmplifyJobsQueryKey( agencyId ) } );
+			// Seed the jobs cache with the new pending run so its row appears
+			// immediately and the jobs query starts polling (its refetchInterval
+			// keys off the presence of a pending job) — without waiting for a
+			// manual page refresh. We seed rather than only invalidate because the
+			// server's /jobs list may not reflect the run on an immediate refetch.
+			queryClient.setQueryData< AmplifyJob[] >(
+				getAmplifyJobsQueryKey( agencyId ),
+				( previous ) => {
+					const existing = previous ?? [];
+					return existing.some( ( job ) => job.id === data.id ) ? existing : [ data, ...existing ];
+				}
+			);
 			options?.onSuccess?.( data, variables, context );
 		},
 	} );

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/analysis-progress.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/analysis-progress.tsx
@@ -1,0 +1,33 @@
+import {
+	ProgressBar,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+export default function AnalysisProgress( { url }: { url: string } ) {
+	return (
+		<VStack spacing={ 8 } alignment="center">
+			<VStack spacing={ 4 } alignment="center">
+				<Text align="center" weight={ 500 }>
+					{ sprintf(
+						/* translators: %s is the site URL being analyzed. */
+						__( 'We’re analyzing %s.' ),
+						url
+					) }
+				</Text>
+				<Text align="center" variant="muted">
+					{ __(
+						'This usually takes 10 to 20 minutes, depending on the size of the site and how much content there is to review.'
+					) }
+				</Text>
+				<Text align="center" variant="muted">
+					{ __(
+						'The analysis will keep running in the background, and your report will be ready to view shortly. You can safely close this window and keep working.'
+					) }
+				</Text>
+			</VStack>
+			<ProgressBar />
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/analysis-type-cards.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/analysis-type-cards.tsx
@@ -1,0 +1,130 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
+import clsx from 'clsx';
+import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
+
+const ICON_PERSON = (
+	<svg
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+		<circle cx="12" cy="7" r="4" />
+	</svg>
+);
+
+const ICON_SPARKLES = (
+	<svg
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<path d="M12 3l1.9 5.4L19 11l-5.1 2.6L12 19l-1.9-5.4L5 11l5.1-2.6z" />
+		<path d="M5 3v4M3 5h4M19 17v4M17 19h4" />
+	</svg>
+);
+
+const ICON_TARGET = (
+	<svg
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<circle cx="12" cy="12" r="10" />
+		<circle cx="12" cy="12" r="6" />
+		<circle cx="12" cy="12" r="2" />
+	</svg>
+);
+
+type Option = {
+	value: AmplifyMode;
+	icon: JSX.Element;
+	iconClass: string;
+	title: string;
+	description: string;
+};
+
+function options(): Option[] {
+	return [
+		{
+			value: 'human',
+			icon: ICON_PERSON,
+			iconClass: 'is-human',
+			title: __( 'Human-centric analysis' ),
+			description: __( 'Score how a human audience reads and understands your site.' ),
+		},
+		{
+			value: 'ai',
+			icon: ICON_SPARKLES,
+			iconClass: 'is-ai',
+			title: __( 'AI analysis' ),
+			description: __(
+				'Score how AI tools like ChatGPT, Gemini, and Perplexity read and rank your site.'
+			),
+		},
+		{
+			value: 'fullanalysis',
+			icon: ICON_TARGET,
+			iconClass: 'is-full',
+			title: __( 'Full analysis' ),
+			description: __( 'Run both lenses for a complete picture and prompt-ready findings.' ),
+		},
+	];
+}
+
+export default function AnalysisTypeCards( {
+	value,
+	onChange,
+}: {
+	value: AmplifyMode | null;
+	onChange: ( mode: AmplifyMode ) => void;
+} ) {
+	return (
+		<VStack spacing={ 3 }>
+			<Text weight={ 500 }>{ __( 'Choose your analysis type' ) }</Text>
+			<VStack spacing={ 2 } role="radiogroup" aria-label={ __( 'Analysis type' ) }>
+				{ options().map( ( option ) => {
+					const isSelected = value === option.value;
+					return (
+						<button
+							key={ option.value }
+							type="button"
+							role="radio"
+							aria-checked={ isSelected }
+							className={ clsx( 'amplify-analysis-card', { 'is-selected': isSelected } ) }
+							onClick={ () => onChange( option.value ) }
+						>
+							<HStack spacing={ 4 } alignment="center" justify="flex-start">
+								<span
+									className={ clsx( 'amplify-analysis-card__icon', option.iconClass ) }
+									aria-hidden="true"
+								>
+									<Icon icon={ option.icon } size={ 20 } />
+								</span>
+								<VStack spacing={ 1 }>
+									<Text weight={ 500 }>{ option.title }</Text>
+									<Text variant="muted">{ option.description }</Text>
+								</VStack>
+							</HStack>
+						</button>
+					);
+				} ) }
+			</VStack>
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/analysis-type-cards.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/analysis-type-cards.tsx
@@ -6,7 +6,9 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useRef } from 'react';
 import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
+import type { KeyboardEvent } from 'react';
 
 const ICON_PERSON = (
 	<svg
@@ -94,20 +96,54 @@ export default function AnalysisTypeCards( {
 	value: AmplifyMode | null;
 	onChange: ( mode: AmplifyMode ) => void;
 } ) {
+	const items = options();
+	const buttonRefs = useRef< ( HTMLButtonElement | null )[] >( [] );
+
+	// Roving tabindex: a single card is reachable via Tab. Fall back to the first
+	// card when nothing is selected yet, per the ARIA radio group pattern.
+	const selectedIndex = items.findIndex( ( option ) => option.value === value );
+	const focusableIndex = selectedIndex === -1 ? 0 : selectedIndex;
+
+	const moveSelection = ( fromIndex: number, delta: number ) => {
+		const nextIndex = ( fromIndex + delta + items.length ) % items.length;
+		onChange( items[ nextIndex ].value );
+		buttonRefs.current[ nextIndex ]?.focus();
+	};
+
+	const handleKeyDown = ( event: KeyboardEvent< HTMLButtonElement >, index: number ) => {
+		switch ( event.key ) {
+			case 'ArrowDown':
+			case 'ArrowRight':
+				event.preventDefault();
+				moveSelection( index, 1 );
+				break;
+			case 'ArrowUp':
+			case 'ArrowLeft':
+				event.preventDefault();
+				moveSelection( index, -1 );
+				break;
+		}
+	};
+
 	return (
 		<VStack spacing={ 3 }>
 			<Text weight={ 500 }>{ __( 'Choose your analysis type' ) }</Text>
 			<VStack spacing={ 2 } role="radiogroup" aria-label={ __( 'Analysis type' ) }>
-				{ options().map( ( option ) => {
+				{ items.map( ( option, index ) => {
 					const isSelected = value === option.value;
 					return (
 						<button
 							key={ option.value }
+							ref={ ( element ) => {
+								buttonRefs.current[ index ] = element;
+							} }
 							type="button"
 							role="radio"
 							aria-checked={ isSelected }
+							tabIndex={ index === focusableIndex ? 0 : -1 }
 							className={ clsx( 'amplify-analysis-card', { 'is-selected': isSelected } ) }
 							onClick={ () => onChange( option.value ) }
+							onKeyDown={ ( event ) => handleKeyDown( event, index ) }
 						>
 							<HStack spacing={ 4 } alignment="center" justify="flex-start">
 								<span

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/index.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import AmplifyAddSiteModal from './modal';
+
+export default function AmplifyAddSite() {
+	const dispatch = useDispatch();
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleOpen = useCallback( () => {
+		setIsOpen( true );
+		dispatch( recordTracksEvent( 'calypso_a4a_amplify_add_site_button_click' ) );
+	}, [ dispatch ] );
+
+	return (
+		<>
+			<Button __next40pxDefaultSize variant="primary" onClick={ handleOpen }>
+				{ __( 'Amplify a site' ) }
+			</Button>
+			{ isOpen && <AmplifyAddSiteModal onClose={ () => setIsOpen( false ) } /> }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/modal.tsx
@@ -1,0 +1,78 @@
+import {
+	Button,
+	__experimentalSpacer as Spacer,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
+import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import useStartAmplifyAnalysis from 'calypso/a8c-for-agencies/data/amplify/use-start-amplify-analysis';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import AnalysisTypeCards from './analysis-type-cards';
+import AmplifySiteSelector from './site-selector';
+import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
+
+import './style.scss';
+
+export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void } ) {
+	const dispatch = useDispatch();
+
+	const [ targetUrl, setTargetUrl ] = useState( '' );
+	const [ mode, setMode ] = useState< AmplifyMode | null >( null );
+
+	const handleTargetChange = useCallback( ( url: string ) => setTargetUrl( url ), [] );
+
+	const mutation = useStartAmplifyAnalysis( {
+		onSuccess: () => {
+			dispatch(
+				successNotice( __( 'Analysis started. Your report will appear here when it’s ready.' ), {
+					id: 'amplify-analysis-started',
+					duration: 5000,
+				} )
+			);
+			onClose();
+		},
+		onError: () => {
+			dispatch(
+				errorNotice( __( 'Could not start the analysis. Please try again.' ), {
+					id: 'amplify-analysis-error',
+					duration: 8000,
+				} )
+			);
+		},
+	} );
+
+	const handleSubmit = () => {
+		if ( ! targetUrl || ! mode ) {
+			return;
+		}
+		dispatch( recordTracksEvent( 'calypso_a4a_amplify_start_analysis_click', { mode } ) );
+		mutation.mutate( { url: targetUrl, mode } );
+	};
+
+	return (
+		<A4AModal
+			title={ __( 'Amplify a site' ) }
+			subtile={ __( 'Enter a URL or pick a connected site, then choose the analysis to run.' ) }
+			onClose={ onClose }
+			extraActions={
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					disabled={ ! targetUrl || ! mode || mutation.isPending }
+					isBusy={ mutation.isPending }
+				>
+					{ __( 'Amplify it' ) }
+				</Button>
+			}
+		>
+			<Spacer marginTop={ 4 } marginBottom={ 0 } />
+			<VStack spacing={ 6 }>
+				<AmplifySiteSelector onChange={ handleTargetChange } disabled={ mutation.isPending } />
+				<AnalysisTypeCards value={ mode } onChange={ setMode } />
+			</VStack>
+		</A4AModal>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/modal.tsx
@@ -9,7 +9,8 @@ import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import useStartAmplifyAnalysis from 'calypso/a8c-for-agencies/data/amplify/use-start-amplify-analysis';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import AnalysisProgress from './analysis-progress';
 import AnalysisTypeCards from './analysis-type-cards';
 import AmplifySiteSelector from './site-selector';
 import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
@@ -21,19 +22,15 @@ export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void 
 
 	const [ targetUrl, setTargetUrl ] = useState( '' );
 	const [ mode, setMode ] = useState< AmplifyMode | null >( null );
+	const [ inProgress, setInProgress ] = useState( false );
 
 	const handleTargetChange = useCallback( ( url: string ) => setTargetUrl( url ), [] );
 
 	const mutation = useStartAmplifyAnalysis( {
-		onSuccess: () => {
-			dispatch(
-				successNotice( __( 'Analysis started. Your report will appear here when it’s ready.' ), {
-					id: 'amplify-analysis-started',
-					duration: 5000,
-				} )
-			);
-			onClose();
-		},
+		// The run is seeded into the jobs cache by the hook, so closing this
+		// modal reveals the in-progress row. Here we just switch to the
+		// progress view instead of showing a notice.
+		onSuccess: () => setInProgress( true ),
 		onError: () => {
 			dispatch(
 				errorNotice( __( 'Could not start the analysis. Please try again.' ), {
@@ -51,6 +48,24 @@ export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void 
 		dispatch( recordTracksEvent( 'calypso_a4a_amplify_start_analysis_click', { mode } ) );
 		mutation.mutate( { url: targetUrl, mode } );
 	};
+
+	if ( inProgress ) {
+		return (
+			<A4AModal
+				title={ __( 'Analysis in progress' ) }
+				subtile={ null }
+				onClose={ onClose }
+				showCloseButton={ false }
+				extraActions={
+					<Button variant="primary" onClick={ onClose }>
+						{ __( 'View reports' ) }
+					</Button>
+				}
+			>
+				<AnalysisProgress url={ targetUrl } />
+			</A4AModal>
+		);
+	}
 
 	return (
 		<A4AModal

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
@@ -8,32 +8,18 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
+import { isValidUrl } from 'calypso/a8c-for-agencies/components/form/utils';
+import { addSchemeIfMissing } from 'calypso/lib/url';
 import useConnectableSites from './use-connectable-sites';
 
 /**
- * Normalize a user-typed URL. Prepends `https://` when no scheme is given,
- * then validates. Returns the canonical href, or `null` when the input is
- * empty or isn't a plausible http(s) URL. A bare label like "foo" (no dot)
- * is rejected as a likely typo.
+ * Normalize a user-typed URL: validate it looks like an http(s) site and add a
+ * default `https://` scheme when none is given. Returns `null` when the input
+ * isn't a plausible URL.
  */
-export function normalizeUrl( raw: string ): string | null {
+function normalizeUrl( raw: string ): string | null {
 	const trimmed = raw.trim();
-	if ( ! trimmed ) {
-		return null;
-	}
-	const withScheme = /^https?:\/\//i.test( trimmed ) ? trimmed : `https://${ trimmed }`;
-	try {
-		const parsed = new URL( withScheme );
-		if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
-			return null;
-		}
-		if ( parsed.hostname !== 'localhost' && ! parsed.hostname.includes( '.' ) ) {
-			return null;
-		}
-		return parsed.href;
-	} catch {
-		return null;
-	}
+	return isValidUrl( trimmed ) ? addSchemeIfMissing( trimmed, 'https' ) : null;
 }
 
 type InputSource = 'site' | 'url';

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
@@ -1,0 +1,138 @@
+import {
+	ComboboxControl,
+	TextControl,
+	__experimentalText as Text,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from 'react';
+import useConnectableSites from './use-connectable-sites';
+
+/**
+ * Normalize a user-typed URL. Prepends `https://` when no scheme is given,
+ * then validates. Returns the canonical href, or `null` when the input is
+ * empty or isn't a plausible http(s) URL. A bare label like "foo" (no dot)
+ * is rejected as a likely typo.
+ */
+export function normalizeUrl( raw: string ): string | null {
+	const trimmed = raw.trim();
+	if ( ! trimmed ) {
+		return null;
+	}
+	const withScheme = /^https?:\/\//i.test( trimmed ) ? trimmed : `https://${ trimmed }`;
+	try {
+		const parsed = new URL( withScheme );
+		if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
+			return null;
+		}
+		if ( parsed.hostname !== 'localhost' && ! parsed.hostname.includes( '.' ) ) {
+			return null;
+		}
+		return parsed.href;
+	} catch {
+		return null;
+	}
+}
+
+type InputSource = 'site' | 'url';
+
+type Props = {
+	/**
+	 * Called with the resolved target URL — the picked connected-site URL or the
+	 * normalized typed URL — or an empty string when nothing valid is selected.
+	 * Memoize in the parent to keep it stable.
+	 */
+	onChange: ( url: string ) => void;
+	disabled?: boolean;
+};
+
+/**
+ * Lets the user pick a connected site or enter a URL. A toggle switches between
+ * the two sources so only one field is shown at a time (connected site by
+ * default). Reusable across the analysis modal and the overview hero; the
+ * parent owns the submit action and reads the resolved URL via `onChange`.
+ */
+export default function AmplifySiteSelector( { onChange, disabled }: Props ) {
+	const [ source, setSource ] = useState< InputSource >( 'site' );
+	const [ urlInput, setUrlInput ] = useState( '' );
+	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState< string | null >( null );
+
+	const { sites, isLoading } = useConnectableSites();
+
+	const options = useMemo(
+		() => sites.map( ( site ) => ( { label: site.url, value: site.url } ) ),
+		[ sites ]
+	);
+
+	// Report the resolved target for whichever source is currently active, so
+	// a value left in the hidden field never leaks into the submission.
+	const report = ( nextSource: InputSource, url: string, site: string | null ) => {
+		onChange( nextSource === 'url' ? normalizeUrl( url ) ?? '' : site ?? '' );
+	};
+
+	const handleSourceChange = ( value: string | number | undefined ) => {
+		const next = ( value as InputSource ) ?? 'site';
+		setSource( next );
+		report( next, urlInput, selectedSiteUrl );
+	};
+
+	const handleUrlChange = ( next: string ) => {
+		setUrlInput( next );
+		report( 'url', next, selectedSiteUrl );
+	};
+
+	const handleSiteChange = ( next: string | null | undefined ) => {
+		const nextSite = next ?? null;
+		setSelectedSiteUrl( nextSite );
+		report( 'site', urlInput, nextSite );
+	};
+
+	return (
+		<VStack spacing={ 3 }>
+			<Text weight={ 500 }>{ __( 'Select a site or enter a URL' ) }</Text>
+			<ToggleGroupControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				isBlock
+				hideLabelFromVision
+				label={ __( 'Site source' ) }
+				value={ source }
+				onChange={ handleSourceChange }
+			>
+				<ToggleGroupControlOption value="site" label={ __( 'Connected site' ) } />
+				<ToggleGroupControlOption value="url" label={ __( 'Enter a URL' ) } />
+			</ToggleGroupControl>
+
+			{ source === 'site' ? (
+				<ComboboxControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Pick a connected site' ) }
+					hideLabelFromVision
+					value={ selectedSiteUrl }
+					options={ options }
+					onChange={ handleSiteChange }
+					placeholder={ isLoading ? __( 'Loading sites…' ) : __( 'Choose a site' ) }
+				/>
+			) : (
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Enter a URL' ) }
+					hideLabelFromVision
+					type="text"
+					inputMode="url"
+					value={ urlInput }
+					onChange={ handleUrlChange }
+					placeholder="https://example.com"
+					disabled={ disabled }
+					autoComplete="off"
+					autoCorrect="off"
+					spellCheck={ false }
+				/>
+			) }
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
@@ -101,6 +101,7 @@ export default function AmplifySiteSelector( { onChange, disabled }: Props ) {
 					options={ options }
 					onChange={ handleSiteChange }
 					placeholder={ isLoading ? __( 'Loading sites…' ) : __( 'Choose a site' ) }
+					disabled={ disabled }
 				/>
 			) : (
 				<TextControl

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/index.tsx
@@ -1,5 +1,6 @@
 import {
 	ComboboxControl,
+	Disabled,
 	TextControl,
 	__experimentalText as Text,
 	__experimentalToggleGroupControl as ToggleGroupControl,
@@ -92,17 +93,18 @@ export default function AmplifySiteSelector( { onChange, disabled }: Props ) {
 			</ToggleGroupControl>
 
 			{ source === 'site' ? (
-				<ComboboxControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Pick a connected site' ) }
-					hideLabelFromVision
-					value={ selectedSiteUrl }
-					options={ options }
-					onChange={ handleSiteChange }
-					placeholder={ isLoading ? __( 'Loading sites…' ) : __( 'Choose a site' ) }
-					disabled={ disabled }
-				/>
+				<Disabled isDisabled={ disabled }>
+					<ComboboxControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Pick a connected site' ) }
+						hideLabelFromVision
+						value={ selectedSiteUrl }
+						options={ options }
+						onChange={ handleSiteChange }
+						placeholder={ isLoading ? __( 'Loading sites…' ) : __( 'Choose a site' ) }
+					/>
+				</Disabled>
 			) : (
 				<TextControl
 					__next40pxDefaultSize

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/use-connectable-sites.ts
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/site-selector/use-connectable-sites.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import useFetchActiveSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-active-sites';
+
+export interface ConnectableSite {
+	id: number;
+	url: string;
+}
+
+interface SiteApiShape {
+	id: number;
+	url?: string;
+	features?: {
+		wpcom_atomic?: {
+			state?: string;
+		};
+	};
+}
+
+// The sites a user can amplify: connected sites with a usable URL that aren't
+// mid-provision. Mirrors the filtering the agency sites list applies elsewhere.
+export default function useConnectableSites(): { sites: ConnectableSite[]; isLoading: boolean } {
+	const { data, isLoading } = useFetchActiveSites( { autoRefresh: false } );
+
+	const sites = useMemo< ConnectableSite[] >( () => {
+		const list: SiteApiShape[] = Array.isArray( data ) ? data : [];
+		return list
+			.filter( ( site ): site is SiteApiShape & { url: string } => {
+				if ( typeof site.url !== 'string' || ! site.url ) {
+					return false;
+				}
+				const state = site.features?.wpcom_atomic?.state;
+				return state === undefined || state === 'active';
+			} )
+			.map( ( site ) => ( { id: site.id, url: site.url } ) )
+			.sort( ( a, b ) => b.id - a.id );
+	}, [ data ] );
+
+	return { sites, isLoading };
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/style.scss
@@ -28,13 +28,13 @@
 }
 
 .amplify-analysis-card__icon.is-human {
-	background: var(--color-accent-5);
-	color: var(--color-accent);
+	background: var(--color-primary-5);
+	color: var(--color-primary);
 }
 
 .amplify-analysis-card__icon.is-ai {
-	background: var(--studio-purple-0);
-	color: var(--studio-purple-50);
+	background: color-mix( in srgb, var( --color-woocommerce ) 10%, transparent );
+	color: var( --color-woocommerce );
 }
 
 .amplify-analysis-card__icon.is-full {

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site/style.scss
@@ -1,0 +1,43 @@
+.amplify-analysis-card {
+	inline-size: 100%;
+	padding: 16px;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 4px;
+	text-align: start;
+	cursor: pointer;
+
+	&:hover {
+		border-color: var(--color-primary);
+	}
+
+	&.is-selected {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 1px var(--color-primary);
+	}
+}
+
+.amplify-analysis-card__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 40px;
+	block-size: 40px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.amplify-analysis-card__icon.is-human {
+	background: var(--color-accent-5);
+	color: var(--color-accent);
+}
+
+.amplify-analysis-card__icon.is-ai {
+	background: var(--studio-purple-0);
+	color: var(--studio-purple-50);
+}
+
+.amplify-analysis-card__icon.is-full {
+	background: var(--color-success-5);
+	color: var(--color-success);
+}

--- a/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/amplify-reports/index.tsx
@@ -8,6 +8,7 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import AmplifyAddSite from '../../amplify-add-site';
 import AmplifyReportsContent from './amplify-reports-content';
 
 const AmplifyReports = () => {
@@ -25,6 +26,7 @@ const AmplifyReports = () => {
 					/>
 					<Actions>
 						<MobileSidebarNavigation />
+						<AmplifyAddSite />
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>


### PR DESCRIPTION
Follow-up to #111793 (Amplify reports/jobs data layer + Reports table), continuing the refactor of #110262. This PR adds the analysis submission flow; it is based on `add/a4a-amplify-section-data`.

## Proposed Changes

Adds the write path for Amplify — a header CTA that opens a modal to start an analysis.

* **`client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts`** — `useStartAmplifyAnalysis`, a `POST …/agency/{agencyId}/amplify/reports` mutation. On success it invalidates the jobs query so the newly created `pending` run surfaces (and the existing 15s polling takes over). Request/response/error types live in **`data/amplify/types.ts`** with the rest of the API types.
* **`sections/amplify/amplify-add-site/`** — the **"Amplify a site"** flow, composed with core components:
  * `index.tsx` — the primary header button that opens the modal.
  * `modal.tsx` — an `A4AModal` that submits the selected site + analysis type via the mutation (disabled until both are chosen).
  * `site-selector/` — a reusable selector with a toggle between **Connected site** (searchable `ComboboxControl`) and **Enter a URL** (`TextControl`); reports the resolved URL to the parent. Built so the overview hero can reuse it later.
  * `analysis-type-cards.tsx` + `style.scss` — the **Human / AI / Full** cards (icon, title, description), mirroring #110262's layout and accent colors.
* **`sections/amplify/primary/amplify-reports/index.tsx`** — places the button in the Reports header actions.

## Why are these changes being made?

Completes the Amplify read/write loop on top of the data layer and reports table: agencies can now kick off an analysis, and the run shows up in the table as it moves from in-progress to completed. Keeping it in its own PR follows the slice-by-slice refactor of #110262.

## Testing Instructions

1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify/reports` as an agency user with the `a4a_read_amplify` capability.
2. Click **Amplify a site** in the header.
3. Toggle between **Connected site** (pick from the dropdown) and **Enter a URL** (type one); confirm only one field shows at a time and **Amplify it** stays disabled until a site/URL and an analysis type are both selected.
4. Pick an analysis type and submit; confirm the success notice and that a new **Analysis in progress** row appears in the table (jobs polling).
5. Confirm no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?