### PR TITLE
Stepper: don't load the AI assistant on the domain-transfer flows

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -12,6 +12,8 @@ import {
 	AI_SITE_BUILDER_FLOW,
 	AI_SITE_BUILDER_SPEC_FLOW,
 	DOMAIN_FLOW,
+	DOMAIN_TRANSFER,
+	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	WOO_HOSTED_PLANS_FLOW,
 	setRequester as setOnboardingRequester,
 } from '@automattic/onboarding';
@@ -102,6 +104,17 @@ const FLOWS_WITHOUT_HELP_CENTER = new Set< string >( [
 	AI_SITE_BUILDER_FLOW,
 	AI_SITE_BUILDER_SPEC_FLOW,
 	DOMAIN_FLOW,
+] );
+
+/**
+ * Flows that should not mount the unified AI agent (Agents Manager). The docked agent dock is
+ * geared toward site management, not focused checkout-style flows; on the domain-transfer flows
+ * it also overlaps with the narrow, fixed-width step layout. This mirrors the sibling
+ * `DOMAIN_FLOW` (`/setup/domain`), which already runs without the agent dock.
+ */
+const FLOWS_WITHOUT_AGENTS_MANAGER = new Set< string >( [
+	DOMAIN_TRANSFER,
+	HUNDRED_YEAR_DOMAIN_TRANSFER,
 ] );
 
 const HELP_CENTER_STORE = HelpCenter.register();
@@ -289,12 +302,14 @@ async function main() {
 									currentUser={ user as UserStore.CurrentUser }
 									sectionName="stepper"
 								/>
-								<AsyncLoad
-									require={ loadAgentsManagerLoader }
-									placeholder={ null }
-									sectionName={ flowName }
-									loadAgentsManager
-								/>
+								{ ! FLOWS_WITHOUT_AGENTS_MANAGER.has( flowName ) && (
+									<AsyncLoad
+										require={ loadAgentsManagerLoader }
+										placeholder={ null }
+										sectionName={ flowName }
+										loadAgentsManager
+									/>
+								) }
 							</>
 						) ) }
 					{ 'development' === process.env.NODE_ENV && (

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -311,10 +311,6 @@ body.is-section-stepper.agents-manager-sidebar-container {
 		overflow: hidden;
 	}
 
-	.domain-transfer {
-		max-width: unset;
-	}
-
 	&.agents-manager-sidebar-container--sidebar-open {
 		@include sidebar-open-base( '#wpcom .step-route' );
 


### PR DESCRIPTION
Fixes #


Domain transfer flow has a gray background if AI Agent is enabled:

https://wordpress.com/setup/domain-transfer/domains?dashboard=dotcom&back_to=https%3A%2F%2Fmy.wordpress.com%2Fdomains

<img width="1587" height="1296" alt="image" src="https://github.com/user-attachments/assets/41235880-6277-45f8-bbc8-fff33b05ffdb" />


## Proposed Changes

* Stop mounting the unified AI agent (Agents Manager) dock on the `domain-transfer` and `hundred-year-domain-transfer` stepper flows, via a new `FLOWS_WITHOUT_AGENTS_MANAGER` gate in the stepper boot (`client/landing/stepper/index.tsx`). Help Center behavior is unchanged.
* Remove the now-dead `.domain-transfer { max-width: unset }` override from the agent-dock styles — it only applied while the dock was mounted on that flow.

## Why are these changes being made?

On `/setup/domain-transfer/domains` the page rendered mostly black around the centered "Add your domains" column.

The agent dock darkens the page `body` as a backdrop for its sidebar and assumes the section's main container fills the viewport. The domain-transfer "domains" step constrains its `.step-route` element to a fixed `width: 754px`, so the dark body bled around the column.

Rather than patch the layout, this removes the dock from these flows entirely: it's geared toward site management, not focused checkout-style flows, and the sibling `DOMAIN_FLOW` (`/setup/domain`, incl. `use-my-domain`) already runs without it — so this also makes the two domain entry points consistent.

## Testing Instructions

1. `yarn start`, ensure the Agents Manager dock is enabled for your account.
2. Visit `/setup/domain-transfer/domains?dashboard=dotcom` (reach it via the domain-transfer intro step, or the Dashboard domains "Transfer domain name" entry on a domain-only account).
3. Confirm: the assistant FAB / dock no longer appears, and the page renders on the normal light background with no black bleed around the column.
4. Repeat for `/setup/hundred-year-domain-transfer`.
5. Regression check: open another stepper flow that *should* keep the assistant (e.g. `site-setup`) and confirm the dock still mounts and opens/closes normally.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)