### PR TITLE
Purchases: route classic Change plan to Stepper plan-upgrade flow

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -40,6 +40,10 @@ import {
 	is100Year,
 	isJetpackGrowthPlan,
 	JETPACK_GROWTH_UPGRADE_MAP,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import {
@@ -269,6 +273,24 @@ interface ManagePurchaseState {
 	isRemoving: boolean;
 	isCancelSurveyVisible: boolean;
 	isReinstalling: boolean;
+}
+
+// Map the purchase's billing term to the plan grid's `intervalType` param so the
+// Stepper grid opens on the same term as the current plan. Downgrades only work
+// within the same term, and the grid hides the term selector in the downgrade flow.
+function getPlanGridIntervalType( billPeriodDays: number ): string | undefined {
+	switch ( billPeriodDays ) {
+		case PLAN_MONTHLY_PERIOD:
+			return 'monthly';
+		case PLAN_ANNUAL_PERIOD:
+			return 'yearly';
+		case PLAN_BIENNIAL_PERIOD:
+			return '2yearly';
+		case PLAN_TRIENNIAL_PERIOD:
+			return '3yearly';
+		default:
+			return undefined;
+	}
 }
 
 class ManagePurchase extends Component<
@@ -608,16 +630,31 @@ class ManagePurchase extends Component<
 	}
 
 	renderChangePlanNavItem() {
-		const { siteSlug, getManagePurchaseUrlFor = managePurchase, translate } = this.props;
-		if ( ! this.shouldRenderDowngradeOption() ) {
+		const { purchase, siteSlug, getManagePurchaseUrlFor = managePurchase, translate } = this.props;
+		if ( ! this.shouldRenderDowngradeOption() || ! purchase ) {
 			return null;
 		}
-		// Land back on the newly-provisioned plan's manage-purchase page after
-		// checkout with a success notice. The `:purchaseId` placeholder is
-		// substituted by the checkout pending page once the new subscription
-		// appears (analogous to `:receiptId`).
+		// Route to the Stepper plan-upgrade flow, whose plan grid and downgrade
+		// dialog are more polished than the classic `/plans` page. The downgrade
+		// logic itself is shared (both pages render `PlansFeaturesMain`), and it
+		// reads `redirect_to`/`cancel_to` straight off the URL, so we still land
+		// back on this manage-purchase page afterwards. The `:purchaseId`
+		// placeholder is substituted with the newly-provisioned plan's purchase by
+		// either the instant-downgrade handler or the checkout pending page
+		// (analogous to `:receiptId`).
 		const redirectTo = getManagePurchaseUrlFor( siteSlug, ':purchaseId' ) + '?plan_changed=true';
-		const href = addQueryArgs( { redirect_to: redirectTo }, `/plans/${ siteSlug }` );
+		const cancelTo = getManagePurchaseUrlFor( siteSlug, purchase.id );
+		const intervalType = getPlanGridIntervalType( purchase.billPeriodDays );
+		const href = addQueryArgs(
+			{
+				siteSlug,
+				allow_downgrade: 'true',
+				redirect_to: redirectTo,
+				cancel_to: cancelTo,
+				...( intervalType && { intervalType } ),
+			},
+			'/setup/plan-upgrade'
+		);
 		return (
 			<CompactCard tagName="a" displayAsLink href={ href }>
 				<Icon icon={ column } className="card__icon" />


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2162/

## Proposed changes

Routes the classic manage-purchase "Change plan" button to the Stepper plan-upgrade flow (`/setup/plan-upgrade`) instead of the classic `/plans` page, so downgrades use the more polished Stepper plan grid and dialog while still landing users back on the same manage-purchase page afterwards.

Starting at | Before             |  After
:-------------------------:|:-------------------------:|:-------------------------:
 <img width="1499" height="765" alt="Screenshot 2026-06-18 at 2 29 55 PM" src="https://github.com/user-attachments/assets/239a3fd0-36bf-4e96-b23e-88e71be25b35" /> | <img width="1503" height="821" alt="Screenshot 2026-06-18 at 2 28 23 PM" src="https://github.com/user-attachments/assets/75947320-392b-4ae6-9c3c-bc75167a2ffb" /> | <img width="1404" height="641" alt="Screenshot 2026-06-18 at 2 27 37 PM" src="https://github.com/user-attachments/assets/19284e2e-1078-4dcd-bbab-4b8ce2cedaa0" />

## Why are these changes being made?

We recently added two downgrade features — instant downgrades within the refund period and post-expiry downgrades — both reachable from the purchase settings page via "Change plan". There are two purchase-settings pages (classic and Dashboard) and two plans pages (classic `/plans` and the Stepper plan-upgrade flow). The Stepper plan grid and downgrade dialog are more polished for this purpose, and the Dashboard's "View plans" entry point already uses them.

This change makes the classic entry point use the same Stepper flow. It's a low-risk change because both plans pages render the same `PlansFeaturesMain` component, whose downgrade handlers read `redirect_to`/`cancel_to` directly off the URL. By keeping the same `redirect_to` the classic button used before, the instant-downgrade handler and the checkout pending page both substitute the `:purchaseId` placeholder and land the user back on the classic manage-purchase page exactly as today. The classic `/plans` downgrade path is left intact since it may still be reached by other means.

## Testing instructions

* In a sandbox, go to a plan's manage-purchase page (`/me/purchases/{site}/{purchaseId}`) where "Change plan" appears — either a plan still within its refund window, or an expired plan in the grace period.
* Click "Change plan" and confirm it opens the Stepper plan grid at `/setup/plan-upgrade` (free/enterprise plans and the term selector are hidden, and the grid opens on the current plan's term).
* Pick a lower plan and confirm the downgrade dialog appears:
  * Within refund window → "instant" dialog showing the refund amount.
  * Expired/post-expiry → routes through checkout.
* After completing each downgrade, confirm you land back on `/me/purchases/{site}/{newPurchaseId}` with the "Your plan has been updated" notice.
* Click Back/cancel in the Stepper flow and confirm you return to the originating manage-purchase page.

