### PR TITLE
Reader Spaces: virtualized multi-layout space feed (POC)

### DIFF
--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -8,7 +8,13 @@ import {
 	updateReadSpaceMutation,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { ReadSpace } from '@automattic/api-core';
+import { useCallback } from 'react';
+import type {
+	ReadSpace,
+	ReadSpaceDetails,
+	SpaceFeedLayout,
+	SpaceLayout,
+} from '@automattic/api-core';
 
 /**
  * The user's spaces for the sidebar and space views, from the live list
@@ -76,4 +82,34 @@ export function useAddSpaceSource() {
 export function useDeleteSpaceSource() {
 	const queryClient = useQueryClient();
 	return useMutation( deleteReadSpaceSourceMutation( queryClient ) );
+}
+
+/**
+ * Set a space's feed layout (`layout.view`).
+ *
+ * INTERIM: the API does not persist `layout.view` yet, so we write the choice
+ * straight into the React Query cache (both the detail and the matching list
+ * summary). This is session-only — the spaces queries are not persisted, so a
+ * reload drops it, and a later space mutation that overwrites the detail cache
+ * with a server response (which omits `view`) clears it. Swap this for the
+ * real `useUpdateSpace({ layout: { view } })` once the endpoint accepts it.
+ */
+export function useSetSpaceLayoutView() {
+	const queryClient = useQueryClient();
+	return useCallback(
+		( spaceId: string, view: SpaceFeedLayout ) => {
+			const withView = ( layout: SpaceLayout ): SpaceLayout => ( { ...layout, view } );
+			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( spaceId ).queryKey, ( prev ) =>
+				prev ? { ...prev, layout: withView( prev.layout ) } : prev
+			);
+			queryClient.setQueryData< ReadSpace[] >(
+				readSpacesQuery().queryKey,
+				( prev ) =>
+					prev?.map( ( space ) =>
+						space.id === spaceId ? { ...space, layout: withView( space.layout ) } : space
+					)
+			);
+		},
+		[ queryClient ]
+	);
 }

--- a/client/reader/hooks/use-infinite-list/index.ts
+++ b/client/reader/hooks/use-infinite-list/index.ts
@@ -1,0 +1,111 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useState } from 'react';
+import { useLoadMore } from './use-load-more';
+import { useScrollMargin } from './use-scroll-margin';
+import { readScrollSnapshot, useScrollRestore } from './use-scroll-restore';
+import type { UseInfiniteListOptions, UseInfiniteListResult } from './types';
+
+export type {
+	UseInfiniteListOptions,
+	UseInfiniteListResult,
+	ListContainerProps,
+	ScrollAlign,
+} from './types';
+export { ScrollDebugOverlay } from './scroll-debug';
+
+const noop = () => {};
+
+/**
+ * ⚠️ EXPERIMENTAL / UNSTABLE — Reader-internal, the API may change without
+ * notice. Built for the Spaces feed proof-of-concept; not yet a stable,
+ * general-purpose engine. Don't depend on it from outside `client/reader` until
+ * it stabilizes.
+ *
+ * Headless engine for a virtualized, infinite-scrolling list over TanStack
+ * Virtual. Bundles the mechanics shared by every feed layout — windowing, the
+ * scroll margin, infinite loading, scroll restoration and edge anchoring — and
+ * returns the windowed items plus helpers. The consumer owns all markup: it
+ * decides what an index means (a single item, a chunked grid row, a masonry
+ * tile) and how to position and render it.
+ * @example
+ * const { getListProps, items, measureElement, scrollMargin } = useInfiniteList( {
+ * 	scrollElement,
+ * 	count: posts.length,
+ * 	estimateSize: 420,
+ * 	getItemKey: ( i ) => posts[ i ].ID,
+ * 	hasMore,
+ * 	isLoadingMore,
+ * 	loadMore,
+ * } );
+ * return (
+ * 	<div { ...getListProps( { className: 'magazine-feed' } ) }>
+ * 		{ items.map( ( vi ) => (
+ * 			<div
+ * 				key={ vi.key }
+ * 				ref={ measureElement }
+ * 				style={ { position: 'absolute', inlineSize: '100%', transform: `translateY(${ vi.start - scrollMargin }px)` } }
+ * 			>
+ * 				<MagazineCard post={ posts[ vi.index ] } />
+ * 			</div>
+ * 		) ) }
+ * 	</div>
+ * );
+ */
+export function useInfiniteList( {
+	scrollElement,
+	count,
+	estimateSize,
+	getItemKey,
+	overscan,
+	lanes,
+	gap,
+	anchorTo,
+	hasMore = false,
+	isLoadingMore = false,
+	loadMore,
+	restoreKey,
+}: UseInfiniteListOptions ): UseInfiniteListResult {
+	// State (not a ref) so the scroll margin recomputes once the list attaches.
+	const [ listElement, setListElement ] = useState< HTMLElement | null >( null );
+	const scrollMargin = useScrollMargin( listElement, scrollElement );
+	const sizeFn = typeof estimateSize === 'number' ? () => estimateSize : estimateSize;
+	const snapshot = readScrollSnapshot( restoreKey );
+
+	const virtualizer = useVirtualizer< HTMLElement, Element >( {
+		count,
+		getScrollElement: () => scrollElement,
+		estimateSize: sizeFn,
+		getItemKey,
+		overscan,
+		lanes,
+		gap,
+		anchorTo,
+		scrollMargin,
+		initialMeasurementsCache: snapshot?.measurements,
+		initialOffset: snapshot?.offset,
+	} );
+
+	const items = virtualizer.getVirtualItems();
+	useLoadMore( {
+		lastIndex: items[ items.length - 1 ]?.index,
+		count,
+		hasMore,
+		isLoadingMore,
+		loadMore: loadMore ?? noop,
+	} );
+	useScrollRestore( virtualizer, restoreKey );
+
+	return {
+		getListProps: ( props = {} ) => ( {
+			ref: setListElement,
+			className: props.className,
+			// Consumer styles first; the two the virtualizer relies on are enforced last.
+			style: { ...props.style, position: 'relative', blockSize: virtualizer.getTotalSize() },
+		} ),
+		items,
+		scrollMargin,
+		measureElement: virtualizer.measureElement,
+		scrollToIndex: virtualizer.scrollToIndex,
+		scrollToOffset: virtualizer.scrollToOffset,
+	};
+}

--- a/client/reader/hooks/use-infinite-list/scroll-debug.tsx
+++ b/client/reader/hooks/use-infinite-list/scroll-debug.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Debug aid for `useInfiniteList`: render alongside your list and pass the same
+ * `scrollElement` you give the hook. When enabled it outlines that scroll
+ * container and shows a badge with its tag/class and live
+ * `clientHeight × scrollHeight × scrollTop` — handy for spotting a wrong or
+ * unbounded container (the classic "renders every item / infinite-loads every
+ * page" symptom, where `clientHeight ≈ scrollHeight`). Renders nothing when
+ * disabled.
+ *
+ * Enable with `?scroll-debug` in the URL, or
+ * `localStorage.setItem( 'reader-scroll-debug', '1' )`.
+ */
+const OUTLINE = '3px solid #e34c4c';
+
+function isEnabled(): boolean {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	if ( new URLSearchParams( window.location.search ).has( 'scroll-debug' ) ) {
+		return true;
+	}
+	try {
+		return window.localStorage.getItem( 'reader-scroll-debug' ) === '1';
+	} catch {
+		return false;
+	}
+}
+
+function describe( el: HTMLElement | null ): string {
+	if ( ! el ) {
+		return 'scrollElement: null';
+	}
+	const classes = Array.from( el.classList ).join( '.' );
+	const name = `${ el.tagName.toLowerCase() }${ classes ? `.${ classes }` : '' }`;
+	return `${ name } · ${ el.clientHeight }×${ el.scrollHeight } · scrollTop ${ Math.round(
+		el.scrollTop
+	) }`;
+}
+
+export function ScrollDebugOverlay( { scrollElement }: { scrollElement: HTMLElement | null } ) {
+	const enabled = isEnabled();
+	// Bump on scroll/resize so the badge's live numbers stay fresh.
+	const [ , forceUpdate ] = useState( 0 );
+
+	useEffect( () => {
+		if ( ! enabled || ! scrollElement ) {
+			return;
+		}
+		const prevOutline = scrollElement.style.outline;
+		const prevOffset = scrollElement.style.outlineOffset;
+		scrollElement.style.outline = OUTLINE;
+		scrollElement.style.outlineOffset = '-3px';
+
+		const refresh = () => forceUpdate( ( n ) => n + 1 );
+		scrollElement.addEventListener( 'scroll', refresh, { passive: true } );
+		const observer = new ResizeObserver( refresh );
+		observer.observe( scrollElement );
+
+		return () => {
+			scrollElement.style.outline = prevOutline;
+			scrollElement.style.outlineOffset = prevOffset;
+			scrollElement.removeEventListener( 'scroll', refresh );
+			observer.disconnect();
+		};
+	}, [ enabled, scrollElement ] );
+
+	if ( ! enabled || typeof document === 'undefined' ) {
+		return null;
+	}
+
+	return createPortal(
+		<div
+			style={ {
+				position: 'fixed',
+				insetBlockEnd: 8,
+				insetInlineStart: 8,
+				zIndex: 99999,
+				background: '#e34c4c',
+				color: '#fff',
+				font: '12px/1.4 ui-monospace, monospace',
+				padding: '6px 10px',
+				borderRadius: 6,
+				pointerEvents: 'none',
+				maxInlineSize: '90vw',
+			} }
+		>
+			scroll container → { describe( scrollElement ) }
+		</div>,
+		document.body
+	);
+}

--- a/client/reader/hooks/use-infinite-list/test/helpers/index.ts
+++ b/client/reader/hooks/use-infinite-list/test/helpers/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared jsdom harness for the <VirtualList> unit tests. jsdom has no layout
+ * engine and no ResizeObserver, so these helpers let a test control element
+ * geometry and drive resize callbacks deterministically.
+ */
+
+type RectInit = Partial<
+	Pick< DOMRect, 'top' | 'left' | 'right' | 'bottom' | 'width' | 'height' >
+>;
+
+/**
+ * Override an element's `getBoundingClientRect` with fixed values (jsdom
+ * otherwise reports all zeros).
+ */
+export function setRect( element: HTMLElement, rect: RectInit ): void {
+	element.getBoundingClientRect = () =>
+		( {
+			top: 0,
+			left: 0,
+			right: 0,
+			bottom: 0,
+			width: 0,
+			height: 0,
+			x: rect.left ?? 0,
+			y: rect.top ?? 0,
+			toJSON: () => ( {} ),
+			...rect,
+		} ) as DOMRect;
+}
+
+/**
+ * A ResizeObserver stand-in that records its instances so a test can fire all
+ * callbacks on demand. Install it on `global` before rendering, reset between
+ * tests.
+ */
+export class MockResizeObserver {
+	static instances: MockResizeObserver[] = [];
+
+	callback: ResizeObserverCallback;
+
+	constructor( callback: ResizeObserverCallback ) {
+		this.callback = callback;
+		MockResizeObserver.instances.push( this );
+	}
+
+	observe(): void {}
+	unobserve(): void {}
+	disconnect(): void {}
+
+	static triggerAll(): void {
+		for ( const instance of MockResizeObserver.instances ) {
+			instance.callback( [], instance as unknown as ResizeObserver );
+		}
+	}
+
+	static reset(): void {
+		MockResizeObserver.instances = [];
+	}
+}
+
+/** Install the MockResizeObserver globally and clear any prior instances. */
+export function installResizeObserver(): void {
+	MockResizeObserver.reset();
+	( global as unknown as { ResizeObserver: typeof MockResizeObserver } ).ResizeObserver =
+		MockResizeObserver;
+}

--- a/client/reader/hooks/use-infinite-list/test/index.test.tsx
+++ b/client/reader/hooks/use-infinite-list/test/index.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for useInfiniteList. We do NOT re-test TanStack Virtual's behaviour
+ * (windowing, lanes, gap, measurement) — that's the library's own
+ * responsibility, verified visually in Storybook. These pin only our glue: the
+ * shape the hook returns and the `getListProps` guard-rail.
+ */
+import { renderHook } from '@testing-library/react';
+import { useInfiniteList } from '../index';
+import { installResizeObserver } from './helpers';
+import type { UseInfiniteListOptions } from '../types';
+
+beforeEach( () => {
+	installResizeObserver();
+} );
+
+function setup( overrides: Partial< UseInfiniteListOptions > = {} ) {
+	const scrollElement = document.createElement( 'div' );
+	document.body.appendChild( scrollElement );
+	const options: UseInfiniteListOptions = {
+		scrollElement,
+		count: 10,
+		estimateSize: 100,
+		getItemKey: ( i ) => `item-${ i }`,
+		...overrides,
+	};
+	return renderHook( () => useInfiniteList( options ) );
+}
+
+describe( 'useInfiniteList', () => {
+	it( 'returns the windowed items and a measureElement function', () => {
+		const { result } = setup();
+
+		expect( Array.isArray( result.current.items ) ).toBe( true );
+		expect( typeof result.current.measureElement ).toBe( 'function' );
+		expect( typeof result.current.scrollMargin ).toBe( 'number' );
+	} );
+
+	it( 'getListProps enforces the positioning and sizing the virtualizer needs', () => {
+		const { result } = setup();
+
+		const props = result.current.getListProps();
+		expect( typeof props.ref ).toBe( 'function' );
+		expect( props.style.position ).toBe( 'relative' );
+		expect( props.style.blockSize ).toEqual( expect.any( Number ) );
+	} );
+
+	it( 'getListProps merges consumer className/style but keeps the enforced ones', () => {
+		const { result } = setup();
+
+		const props = result.current.getListProps( {
+			className: 'feed',
+			style: { padding: 12, position: 'static' },
+		} );
+		expect( props.className ).toBe( 'feed' );
+		expect( props.style.padding ).toBe( 12 );
+		expect( props.style.position ).toBe( 'relative' ); // enforced wins over the consumer's
+	} );
+
+	it( 'exposes imperative scroll helpers', () => {
+		const { result } = setup();
+
+		expect( typeof result.current.scrollToIndex ).toBe( 'function' );
+		expect( typeof result.current.scrollToOffset ).toBe( 'function' );
+	} );
+
+	it( 'does not crash when no scroll element is attached yet', () => {
+		expect( () => setup( { scrollElement: null } ) ).not.toThrow();
+	} );
+} );

--- a/client/reader/hooks/use-infinite-list/test/use-load-more.test.ts
+++ b/client/reader/hooks/use-infinite-list/test/use-load-more.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useLoadMore } from '../use-load-more';
+
+function setup( overrides: Partial< Parameters< typeof useLoadMore >[ 0 ] > = {} ) {
+	const loadMore = jest.fn();
+	const props = {
+		lastIndex: 9,
+		count: 10,
+		hasMore: true,
+		isLoadingMore: false,
+		loadMore,
+		...overrides,
+	};
+	const view = renderHook( ( p: Parameters< typeof useLoadMore >[ 0 ] ) => useLoadMore( p ), {
+		initialProps: props,
+	} );
+	return { loadMore, view, props };
+}
+
+describe( 'useLoadMore', () => {
+	it( 'loads more when the last rendered item reaches the end and more remain', () => {
+		const { loadMore } = setup( { lastIndex: 9, count: 10 } );
+
+		expect( loadMore ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not load when the last rendered item is before the end', () => {
+		const { loadMore } = setup( { lastIndex: 4, count: 10 } );
+
+		expect( loadMore ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not load when there are no more pages', () => {
+		const { loadMore } = setup( { hasMore: false } );
+
+		expect( loadMore ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not load while a page is already loading', () => {
+		const { loadMore } = setup( { isLoadingMore: true } );
+
+		expect( loadMore ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not load before anything has rendered', () => {
+		const { loadMore } = setup( { lastIndex: undefined } );
+
+		expect( loadMore ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not re-load on re-render with the same end reached', () => {
+		const { loadMore, view, props } = setup( { lastIndex: 9, count: 10 } );
+		expect( loadMore ).toHaveBeenCalledTimes( 1 );
+
+		view.rerender( { ...props } );
+
+		expect( loadMore ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/reader/hooks/use-infinite-list/test/use-scroll-margin.test.ts
+++ b/client/reader/hooks/use-infinite-list/test/use-scroll-margin.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useScrollMargin } from '../use-scroll-margin';
+import { MockResizeObserver, installResizeObserver, setRect } from './helpers';
+
+beforeEach( () => {
+	installResizeObserver();
+} );
+
+describe( 'useScrollMargin', () => {
+	it( 'returns 0 when either element is missing', () => {
+		const { result } = renderHook( () => useScrollMargin( null, null ) );
+
+		expect( result.current ).toBe( 0 );
+	} );
+
+	it( 'is the list top minus the container top plus the container scroll', () => {
+		const scrollElement = document.createElement( 'div' );
+		const listElement = document.createElement( 'div' );
+		setRect( scrollElement, { top: 50 } );
+		setRect( listElement, { top: 170 } );
+		scrollElement.scrollTop = 30;
+
+		const { result } = renderHook( () => useScrollMargin( listElement, scrollElement ) );
+
+		expect( result.current ).toBe( 150 ); // 170 - 50 + 30
+	} );
+
+	it( 'recomputes when an observed element resizes', () => {
+		const scrollElement = document.createElement( 'div' );
+		const listElement = document.createElement( 'div' );
+		setRect( scrollElement, { top: 0 } );
+		setRect( listElement, { top: 100 } );
+
+		const { result } = renderHook( () => useScrollMargin( listElement, scrollElement ) );
+		expect( result.current ).toBe( 100 );
+
+		setRect( listElement, { top: 140 } ); // a header above the list grew
+		act( () => MockResizeObserver.triggerAll() );
+
+		expect( result.current ).toBe( 140 );
+	} );
+} );

--- a/client/reader/hooks/use-infinite-list/test/use-scroll-restore.test.ts
+++ b/client/reader/hooks/use-infinite-list/test/use-scroll-restore.test.ts
@@ -46,4 +46,16 @@ describe( 'useScrollRestore', () => {
 
 		expect( readScrollSnapshot( undefined ) ).toBeUndefined();
 	} );
+
+	it( 'evicts old snapshots instead of growing without bound', () => {
+		for ( let index = 0; index < 60; index++ ) {
+			const { unmount } = renderHook( () =>
+				useScrollRestore( fakeVirtualizer( [], index ), `feed:${ index }` )
+			);
+			unmount();
+		}
+
+		expect( readScrollSnapshot( 'feed:0' ) ).toBeUndefined();
+		expect( readScrollSnapshot( 'feed:59' ) ).toEqual( { measurements: [], offset: 59 } );
+	} );
 } );

--- a/client/reader/hooks/use-infinite-list/test/use-scroll-restore.test.ts
+++ b/client/reader/hooks/use-infinite-list/test/use-scroll-restore.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useScrollRestore, readScrollSnapshot } from '../use-scroll-restore';
+import type { Virtualizer, VirtualItem } from '@tanstack/react-virtual';
+
+function fakeVirtualizer( measurements: VirtualItem[], offset: number | null ) {
+	return {
+		takeSnapshot: () => measurements,
+		scrollOffset: offset,
+	} as unknown as Virtualizer< HTMLElement, Element >;
+}
+
+describe( 'useScrollRestore', () => {
+	it( 'reads undefined for a key that was never saved', () => {
+		expect( readScrollSnapshot( 'never-saved' ) ).toBeUndefined();
+	} );
+
+	it( 'saves measurements + offset on unmount, readable by key', () => {
+		const measurements = [ { index: 0, key: 'a' } ] as unknown as VirtualItem[];
+		const virtualizer = fakeVirtualizer( measurements, 540 );
+
+		const { unmount } = renderHook( () => useScrollRestore( virtualizer, 'feed:list' ) );
+		expect( readScrollSnapshot( 'feed:list' ) ).toBeUndefined(); // not saved until unmount
+
+		unmount();
+
+		expect( readScrollSnapshot( 'feed:list' ) ).toEqual( { measurements, offset: 540 } );
+	} );
+
+	it( 'treats a null scrollOffset as 0', () => {
+		const virtualizer = fakeVirtualizer( [], null );
+
+		const { unmount } = renderHook( () => useScrollRestore( virtualizer, 'feed:null-offset' ) );
+		unmount();
+
+		expect( readScrollSnapshot( 'feed:null-offset' ) ).toEqual( { measurements: [], offset: 0 } );
+	} );
+
+	it( 'does not save when no restore key is given', () => {
+		const virtualizer = fakeVirtualizer( [], 10 );
+
+		const { unmount } = renderHook( () => useScrollRestore( virtualizer, undefined ) );
+		unmount();
+
+		expect( readScrollSnapshot( undefined ) ).toBeUndefined();
+	} );
+} );

--- a/client/reader/hooks/use-infinite-list/types.ts
+++ b/client/reader/hooks/use-infinite-list/types.ts
@@ -1,0 +1,65 @@
+import type { VirtualItem } from '@tanstack/react-virtual';
+import type { CSSProperties } from 'react';
+
+/** Where to place the target within the viewport. `'auto'` scrolls the least to reveal it. */
+export type ScrollAlign = 'start' | 'center' | 'end' | 'auto';
+
+export interface UseInfiniteListOptions {
+	/** The scrollable container. Pass as state (not a ref) so the virtualizer re-evaluates once it mounts. */
+	scrollElement: HTMLElement | null;
+	/** Number of items the virtualizer counts. The consumer decides what an index means (item, row, …). */
+	count: number;
+	/** Estimated item size in px — a constant or a per-index function (e.g. by item kind). */
+	estimateSize: number | ( ( index: number ) => number );
+	/** Stable, content-derived key per index. Indexes the size + lane caches, so it must not change for the same item. */
+	getItemKey: ( index: number ) => string | number;
+	overscan?: number;
+	/** Number of columns for masonry packing. Omit (or 1) for a single-lane list. */
+	lanes?: number;
+	/** Gap in px between items (use this instead of CSS margins, which distort measurement). */
+	gap?: number;
+	/**
+	 * `'end'` keeps the viewport visually stable when items are added/removed at an
+	 * edge — e.g. prepending new posts at the top doesn't push the current view down.
+	 * Requires a stable, content-derived `getItemKey` (the anchor is tracked by key).
+	 * Default `'start'` (top-anchored, standard list).
+	 */
+	anchorTo?: 'start' | 'end';
+	hasMore?: boolean;
+	/** True while a next page is already loading — gates `loadMore`. */
+	isLoadingMore?: boolean;
+	loadMore?: () => void;
+	/** Stable key under which to save/restore scroll on unmount/remount (e.g. on Back). */
+	restoreKey?: string;
+}
+
+/** Props to spread onto the element that holds the items. */
+export interface ListContainerProps {
+	ref: ( node: HTMLElement | null ) => void;
+	className?: string;
+	style: CSSProperties;
+}
+
+export interface UseInfiniteListResult {
+	/**
+	 * Spread onto the element that holds the items. Enforces the positioning +
+	 * sizing the virtualizer needs (`position: relative`, `block-size: totalSize`),
+	 * while merging any `className` / `style` you pass.
+	 */
+	getListProps: ( props?: { className?: string; style?: CSSProperties } ) => ListContainerProps;
+	/** The windowed items to render. */
+	items: VirtualItem[];
+	/**
+	 * Offset (px) from the scroll container's top to the list's top. Subtract it
+	 * from each item's `start` when positioning — `translateY(start - scrollMargin)` —
+	 * since `start` is measured from the scroll container but items sit within the
+	 * list element below it. Usually 0 in tests / top-anchored lists.
+	 */
+	scrollMargin: number;
+	/** Attach to each rendered item element so it can be measured. */
+	measureElement: ( node: Element | null ) => void;
+	/** Scroll an item into view (accounts for scrollMargin + measured sizes). */
+	scrollToIndex: ( index: number, options?: { align?: ScrollAlign } ) => void;
+	/** Scroll to an absolute pixel offset within the scroll container. */
+	scrollToOffset: ( offset: number, options?: { align?: ScrollAlign } ) => void;
+}

--- a/client/reader/hooks/use-infinite-list/use-load-more.ts
+++ b/client/reader/hooks/use-infinite-list/use-load-more.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+export interface UseLoadMoreOptions {
+	/** Index of the last item the virtualizer has rendered, or `undefined` before first render. */
+	lastIndex: number | undefined;
+	/** Total number of items the virtualizer is counting. */
+	count: number;
+	hasMore: boolean;
+	/** True while a next page is already in flight — gates `loadMore`. */
+	isLoadingMore: boolean;
+	loadMore: () => void;
+}
+
+/**
+ * Fire `loadMore` once the virtualizer has rendered up to (or past) the last
+ * item, while more remain and none is already loading. The `isLoadingMore`
+ * guard is essential: without it the effect re-runs on every measurement render
+ * near the end and spams `loadMore`, cascading page loads and freezing the UI.
+ */
+export function useLoadMore( {
+	lastIndex,
+	count,
+	hasMore,
+	isLoadingMore,
+	loadMore,
+}: UseLoadMoreOptions ): void {
+	useEffect( () => {
+		if ( hasMore && ! isLoadingMore && lastIndex !== undefined && lastIndex >= count - 1 ) {
+			loadMore();
+		}
+	}, [ lastIndex, count, hasMore, isLoadingMore, loadMore ] );
+}

--- a/client/reader/hooks/use-infinite-list/use-scroll-margin.ts
+++ b/client/reader/hooks/use-infinite-list/use-scroll-margin.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Offset (px) from the top of the scroll container to the top of the
+ * virtualized list. When the list does not start at the very top of its scroll
+ * container — e.g. a header or toolbar sits above it — the virtualizer needs
+ * this as its `scrollMargin` so the scroll position maps to the right items.
+ * Recomputes when either element resizes.
+ */
+export function useScrollMargin(
+	listElement: HTMLElement | null,
+	scrollElement: HTMLElement | null
+): number {
+	const [ margin, setMargin ] = useState( 0 );
+
+	useEffect( () => {
+		if ( ! listElement || ! scrollElement ) {
+			return;
+		}
+		const measure = () => {
+			const next =
+				listElement.getBoundingClientRect().top -
+				scrollElement.getBoundingClientRect().top +
+				scrollElement.scrollTop;
+			setMargin( ( current ) => ( current === next ? current : next ) );
+		};
+		measure();
+		const observer = new ResizeObserver( measure );
+		observer.observe( scrollElement );
+		observer.observe( listElement );
+		return () => observer.disconnect();
+	}, [ listElement, scrollElement ] );
+
+	return margin;
+}

--- a/client/reader/hooks/use-infinite-list/use-scroll-restore.ts
+++ b/client/reader/hooks/use-infinite-list/use-scroll-restore.ts
@@ -9,6 +9,21 @@ interface ScrollSnapshot {
 // Snapshot per restore key, kept for the SPA session so Back returns to the
 // exact scroll position with measured item sizes already known.
 const snapshots = new Map< string, ScrollSnapshot >();
+const MAX_SNAPSHOTS = 50;
+
+function saveScrollSnapshot( restoreKey: string, snapshot: ScrollSnapshot ): void {
+	// Refresh recency when revisiting the same feed/layout.
+	if ( snapshots.has( restoreKey ) ) {
+		snapshots.delete( restoreKey );
+	}
+	snapshots.set( restoreKey, snapshot );
+	if ( snapshots.size > MAX_SNAPSHOTS ) {
+		const oldestKey = snapshots.keys().next().value;
+		if ( oldestKey ) {
+			snapshots.delete( oldestKey );
+		}
+	}
+}
 
 /**
  * Read a saved scroll snapshot. The component feeds its `measurements` and
@@ -34,7 +49,7 @@ export function useScrollRestore(
 			return;
 		}
 		return () => {
-			snapshots.set( restoreKey, {
+			saveScrollSnapshot( restoreKey, {
 				measurements: virtualizer.takeSnapshot(),
 				offset: virtualizer.scrollOffset ?? 0,
 			} );

--- a/client/reader/hooks/use-infinite-list/use-scroll-restore.ts
+++ b/client/reader/hooks/use-infinite-list/use-scroll-restore.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import type { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
+
+interface ScrollSnapshot {
+	measurements: VirtualItem[];
+	offset: number;
+}
+
+// Snapshot per restore key, kept for the SPA session so Back returns to the
+// exact scroll position with measured item sizes already known.
+const snapshots = new Map< string, ScrollSnapshot >();
+
+/**
+ * Read a saved scroll snapshot. The component feeds its `measurements` and
+ * `offset` into the virtualizer as `initialMeasurementsCache` / `initialOffset`
+ * so a remount (e.g. on Back) restores the exact position — unlike restoring a
+ * raw pixel offset, which can land in an unmeasured region.
+ */
+export function readScrollSnapshot( restoreKey: string | undefined ): ScrollSnapshot | undefined {
+	return restoreKey ? snapshots.get( restoreKey ) : undefined;
+}
+
+/**
+ * Save the virtualizer's snapshot (measured sizes + current offset) under
+ * `restoreKey` when the list unmounts, for {@link readScrollSnapshot} to replay
+ * on the next mount. No-op without a `restoreKey`.
+ */
+export function useScrollRestore(
+	virtualizer: Virtualizer< HTMLElement, Element >,
+	restoreKey: string | undefined
+): void {
+	useEffect( () => {
+		if ( ! restoreKey ) {
+			return;
+		}
+		return () => {
+			snapshots.set( restoreKey, {
+				measurements: virtualizer.takeSnapshot(),
+				offset: virtualizer.scrollOffset ?? 0,
+			} );
+		};
+	}, [ virtualizer, restoreKey ] );
+}

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -1,0 +1,122 @@
+import {
+	Button,
+	Modal,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useSetSpaceLayoutView, useSpace } from 'calypso/reader/data/spaces';
+import { DEFAULT_SPACE_FEED_LAYOUT } from 'calypso/reader/spaces/feed/layouts/registry';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import type { SpaceFeedLayout } from '@automattic/api-core';
+
+import './style.scss';
+
+interface Props {
+	isOpen: boolean;
+	spaceId: string | null;
+	onClose: () => void;
+}
+
+export function CustomizeModal( { isOpen, spaceId, onClose }: Props ) {
+	// Mount fresh each open so the selection resets to the space's current layout.
+	if ( ! isOpen || ! spaceId ) {
+		return null;
+	}
+	return <CustomizeModalContent spaceId={ spaceId } onClose={ onClose } />;
+}
+
+function CustomizeModalContent( { spaceId, onClose }: { spaceId: string; onClose: () => void } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { data: space } = useSpace( spaceId );
+	const setLayoutView = useSetSpaceLayoutView();
+
+	const presets: { id: SpaceFeedLayout; title: string; description: string }[] = [
+		{
+			id: 'standard-list',
+			title: translate( 'List' ),
+			description: translate( 'Many items, fast scanning' ),
+		},
+		{
+			id: 'magazine',
+			title: translate( 'Magazine' ),
+			description: translate( 'One comfortable column' ),
+		},
+		{
+			id: 'gallery',
+			title: translate( 'Gallery' ),
+			description: translate( 'Grid of cards with thumbnails' ),
+		},
+		{
+			id: 'board',
+			title: translate( 'Board' ),
+			description: translate( 'Big roomy cards, casual scroll' ),
+		},
+		{
+			id: 'legacy',
+			title: translate( 'Legacy' ),
+			description: translate( 'Classic Reader stream' ),
+		},
+	];
+
+	const [ selected, setSelected ] = useState< SpaceFeedLayout >(
+		space?.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT
+	);
+
+	const handleSave = () => {
+		setLayoutView( spaceId, selected );
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_spaces_layout_changed', { layout: selected } )
+		);
+		dispatch( successNotice( translate( 'Layout updated.' ), { duration: 5000 } ) );
+		onClose();
+	};
+
+	return (
+		<Modal title={ translate( 'Customize space' ) } size="medium" onRequestClose={ onClose }>
+			<VStack spacing={ 4 }>
+				<p className="customize-space-modal__subtitle">
+					{ translate( 'Choose a layout for this space.' ) }
+				</p>
+				<div
+					className="customize-space-modal__grid"
+					role="radiogroup"
+					aria-label={ translate( 'Layout' ) }
+				>
+					{ presets.map( ( preset ) => (
+						<label
+							key={ preset.id }
+							className="customize-space-modal__card"
+							data-selected={ preset.id === selected }
+						>
+							<input
+								type="radio"
+								className="customize-space-modal__radio"
+								name="space-layout-view"
+								value={ preset.id }
+								checked={ preset.id === selected }
+								onChange={ () => setSelected( preset.id ) }
+							/>
+							<span className="customize-space-modal__card-title">{ preset.title }</span>
+							<span className="customize-space-modal__card-description">
+								{ preset.description }
+							</span>
+						</label>
+					) ) }
+				</div>
+				<HStack justify="flex-end" spacing={ 2 }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button __next40pxDefaultSize variant="primary" onClick={ handleSave }>
+						{ translate( 'Save changes' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSetSpaceLayoutView, useSpace } from 'calypso/reader/data/spaces';
 import { DEFAULT_SPACE_FEED_LAYOUT } from 'calypso/reader/spaces/feed/layouts/registry';
 import { useDispatch } from 'calypso/state';
@@ -67,7 +67,16 @@ function CustomizeModalContent( { spaceId, onClose }: { spaceId: string; onClose
 		space?.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT
 	);
 
+	useEffect( () => {
+		if ( space ) {
+			setSelected( space.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT );
+		}
+	}, [ space ] );
+
 	const handleSave = () => {
+		if ( ! space ) {
+			return;
+		}
 		setLayoutView( spaceId, selected );
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_spaces_layout_changed', { layout: selected } )
@@ -112,7 +121,12 @@ function CustomizeModalContent( { spaceId, onClose }: { spaceId: string; onClose
 					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ translate( 'Cancel' ) }
 					</Button>
-					<Button __next40pxDefaultSize variant="primary" onClick={ handleSave }>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						disabled={ ! space }
+						onClick={ handleSave }
+					>
 						{ translate( 'Save changes' ) }
 					</Button>
 				</HStack>

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -1,0 +1,55 @@
+.customize-space-modal__subtitle {
+	margin: 0;
+	color: var( --color-text-subtle );
+}
+
+.customize-space-modal__grid {
+	display: grid;
+	grid-template-columns: repeat( 2, 1fr );
+	gap: 12px;
+}
+
+.customize-space-modal__card {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	box-sizing: border-box;
+	padding: 16px;
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 8px;
+	cursor: pointer;
+
+	&[data-selected='true'] {
+		border-color: var( --color-primary );
+		box-shadow: 0 0 0 1px var( --color-primary );
+	}
+}
+
+// Visually hidden, but still focusable so the cards keep native radio keyboard
+// behaviour (arrow keys move between options, single tab stop).
+.customize-space-modal__radio {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect( 0 0 0 0 );
+	white-space: nowrap;
+	border: 0;
+}
+
+.customize-space-modal__radio:focus-visible + .customize-space-modal__card-title {
+	outline: 2px solid var( --color-primary );
+	outline-offset: 2px;
+}
+
+.customize-space-modal__card-title {
+	font-weight: 600;
+	color: var( --color-text );
+}
+
+.customize-space-modal__card-description {
+	font-size: 0.875rem;
+	color: var( --color-text-subtle );
+}

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { readSpaceQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { CustomizeModal } from '../index';
+import type { ReadSpaceDetails } from '@automattic/api-core';
+
+const SPACE: ReadSpaceDetails = {
+	id: 'work-id',
+	name: 'Work',
+	tags: [],
+	layout: { color: 'blue', icon: 'inbox', view: 'standard-list' },
+	sources: [],
+};
+
+function render( onClose = jest.fn() ) {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	queryClient.setQueryData( readSpaceQuery( SPACE.id ).queryKey, SPACE );
+
+	const view = renderWithProvider(
+		<CustomizeModal isOpen spaceId={ SPACE.id } onClose={ onClose } />,
+		{ queryClient, initialState: { currentUser: { id: 1 } } }
+	);
+	return { ...view, queryClient, onClose };
+}
+
+describe( 'CustomizeModal', () => {
+	it( 'lists the layout presets and pre-selects the space layout', () => {
+		render();
+
+		expect( screen.getByRole( 'radio', { name: /List/ } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: /Magazine/ } ) ).not.toBeChecked();
+		expect( screen.getByRole( 'radio', { name: /Gallery/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: /Board/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: /Legacy/ } ) ).toBeInTheDocument();
+	} );
+
+	it( 'saves the chosen layout to the space cache and closes', async () => {
+		const user = userEvent.setup();
+		const { queryClient, onClose } = render();
+
+		await user.click( screen.getByRole( 'radio', { name: /Gallery/ } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Save changes' } ) );
+
+		const cached = queryClient.getQueryData< ReadSpaceDetails >(
+			readSpaceQuery( SPACE.id ).queryKey
+		);
+		expect( cached?.layout.view ).toBe( 'gallery' );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'does not change the layout when cancelled', async () => {
+		const user = userEvent.setup();
+		const { queryClient, onClose } = render();
+
+		await user.click( screen.getByRole( 'radio', { name: /Board/ } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		const cached = queryClient.getQueryData< ReadSpaceDetails >(
+			readSpaceQuery( SPACE.id ).queryKey
+		);
+		expect( cached?.layout.view ).toBe( 'standard-list' );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -28,6 +28,20 @@ function render( onClose = jest.fn() ) {
 	return { ...view, queryClient, onClose };
 }
 
+function renderWithPendingSpace( onClose = jest.fn() ) {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	queryClient.prefetchQuery( {
+		...readSpaceQuery( SPACE.id ),
+		queryFn: () => new Promise< never >( () => undefined ),
+	} );
+
+	const view = renderWithProvider(
+		<CustomizeModal isOpen spaceId={ SPACE.id } onClose={ onClose } />,
+		{ queryClient, initialState: { currentUser: { id: 1 } } }
+	);
+	return { ...view, queryClient, onClose };
+}
+
 describe( 'CustomizeModal', () => {
 	it( 'lists the layout presets and pre-selects the space layout', () => {
 		render();
@@ -65,5 +79,16 @@ describe( 'CustomizeModal', () => {
 		);
 		expect( cached?.layout.view ).toBe( 'standard-list' );
 		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'does not allow saving before the space detail has loaded', async () => {
+		const user = userEvent.setup();
+		const { queryClient, onClose } = renderWithPendingSpace();
+
+		await user.click( screen.getByRole( 'radio', { name: /Gallery/ } ) );
+		expect( screen.getByRole( 'button', { name: 'Save changes' } ) ).toBeDisabled();
+
+		expect( queryClient.getQueryData( readSpaceQuery( SPACE.id ).queryKey ) ).toBeUndefined();
+		expect( onClose ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/reader/spaces/feed/components/source-notice.tsx
+++ b/client/reader/spaces/feed/components/source-notice.tsx
@@ -1,0 +1,37 @@
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	failedCount: number;
+	onRetry?: () => void;
+}
+
+/**
+ * "One or more sources couldn't be loaded" banner for an aggregated space feed.
+ * Built but intentionally un-wired in this POC — the per-source failure signal
+ * arrives with the real data layer (deferred). Renders nothing while
+ * `failedCount` is 0, so it's a no-op until something feeds it.
+ */
+export function SpaceFeedSourceNotice( { failedCount, onRetry }: Props ) {
+	const translate = useTranslate();
+
+	if ( failedCount <= 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="space-feed__source-notice" role="status">
+			<span>
+				{ translate(
+					'%(count)d source couldn’t be loaded.',
+					'%(count)d sources couldn’t be loaded.',
+					{ count: failedCount, args: { count: failedCount } }
+				) }
+			</span>
+			{ onRetry && (
+				<button type="button" className="space-feed__source-notice-retry" onClick={ onRetry }>
+					{ translate( 'Retry' ) }
+				</button>
+			) }
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/components/states.tsx
+++ b/client/reader/spaces/feed/components/states.tsx
@@ -1,0 +1,58 @@
+import { Button, Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+/** Shown while the first page of the stream loads. */
+export function SpaceFeedLoading() {
+	const translate = useTranslate();
+	return (
+		<div className="space-feed__status" role="status">
+			<Spinner />
+			<span>{ translate( 'Loading the feed…' ) }</span>
+		</div>
+	);
+}
+
+/** Skeleton shown at the foot of the list while the next page loads. */
+export function SpaceFeedLoadingMore() {
+	const translate = useTranslate();
+	return (
+		<div className="space-feed__loading-more" role="status" aria-busy="true">
+			<span className="screen-reader-text">{ translate( 'Loading more posts…' ) }</span>
+			{ [ 0, 1 ].map( ( index ) => (
+				<div className="space-feed__skeleton-row" key={ index } aria-hidden="true">
+					<span className="space-feed__skeleton-avatar" />
+					<span className="space-feed__skeleton-body">
+						<span className="space-feed__skeleton-line" />
+						<span className="space-feed__skeleton-line is-short" />
+					</span>
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+/** Shown when the stream has loaded but holds no posts. */
+export function SpaceFeedEmpty() {
+	const translate = useTranslate();
+	return (
+		<div className="space-feed__status">
+			<p className="space-feed__status-title">{ translate( 'Nothing here yet' ) }</p>
+			<p className="space-feed__status-line">
+				{ translate( 'Posts from this space’s sources will show up here.' ) }
+			</p>
+		</div>
+	);
+}
+
+/** Shown when the stream request fails; offers a retry. */
+export function SpaceFeedError( { onRetry }: { onRetry: () => void } ) {
+	const translate = useTranslate();
+	return (
+		<div className="space-feed__status">
+			<p className="space-feed__status-title">{ translate( 'Couldn’t load this feed' ) }</p>
+			<Button variant="secondary" onClick={ onRetry }>
+				{ translate( 'Try again' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/components/time-since.tsx
+++ b/client/reader/spaces/feed/components/time-since.tsx
@@ -1,0 +1,76 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useState } from 'react';
+
+interface Props {
+	date: string;
+}
+
+function formatDate( date: Date, locale?: string, options?: Intl.DateTimeFormatOptions ): string {
+	if ( Number.isNaN( date.getTime() ) ) {
+		return '';
+	}
+	return new Intl.DateTimeFormat( locale, options ).format( date );
+}
+
+function useRelativeTime( date: string ) {
+	const [ now, setNow ] = useState( () => new Date() );
+	const translate = useTranslate();
+	const { localeSlug } = translate;
+
+	useEffect( () => {
+		const intervalId = setInterval( () => setNow( new Date() ), 10000 );
+		return () => clearInterval( intervalId );
+	}, [] );
+
+	return useMemo( () => {
+		const dateObj = new Date( date );
+		const millisAgo = now.getTime() - dateObj.getTime();
+		if ( Number.isNaN( dateObj.getTime() ) || millisAgo < 0 ) {
+			return formatDate( dateObj, localeSlug, { dateStyle: 'medium' } );
+		}
+
+		const minutesAgo = Math.floor( millisAgo / 60000 );
+		const hoursAgo = Math.floor( minutesAgo / 60 );
+		const daysAgo = Math.floor( hoursAgo / 24 );
+
+		if ( minutesAgo < 1 ) {
+			return translate( 'just now' );
+		}
+		if ( minutesAgo < 60 ) {
+			return translate( '%(minutes)dm ago', {
+				args: { minutes: minutesAgo },
+				comment: 'example for a resulting string: 2m ago',
+			} );
+		}
+		if ( hoursAgo < 24 ) {
+			return translate( '%(hours)dh ago', {
+				args: { hours: hoursAgo },
+				comment: 'example for a resulting string: 5h ago',
+			} );
+		}
+		if ( daysAgo < 7 ) {
+			return translate( '%(days)dd ago', {
+				args: { days: daysAgo },
+				comment: 'example for a resulting string: 4d ago',
+			} );
+		}
+
+		return formatDate( dateObj, localeSlug, { dateStyle: 'medium' } );
+	}, [ date, localeSlug, now, translate ] );
+}
+
+export function SpaceFeedTimeSince( { date }: Props ) {
+	const translate = useTranslate();
+	const relativeDate = useRelativeTime( date );
+	const dateObj = new Date( date );
+	const fullDate = formatDate( dateObj, translate.localeSlug, {
+		dateStyle: 'full',
+		timeStyle: 'medium',
+	} );
+
+	return (
+		<time dateTime={ date } title={ fullDate }>
+			{ relativeDate }
+		</time>
+	);
+}

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -19,17 +19,17 @@ interface Props {
 	spaceId: string;
 }
 
-function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
+export function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
 	const posts: ReadStreamPost[] = [];
 	for ( const page of pages ) {
-		if ( page.posts?.length ) {
-			posts.push( ...page.posts );
-		} else if ( page.cards?.length ) {
+		if ( page.cards?.length ) {
 			for ( const card of page.cards ) {
 				if ( card.type === 'post' ) {
 					posts.push( card.data );
 				}
 			}
+		} else if ( page.posts?.length ) {
+			posts.push( ...page.posts );
 		}
 	}
 	return posts;

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -42,7 +42,12 @@ function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
  * reads that same per-space query.
  */
 export function SpaceFeed( { spaceId }: Props ) {
-	const { data: space, isLoading: isSpaceLoading } = useSpace( spaceId );
+	const {
+		data: space,
+		error: spaceError,
+		isLoading: isSpaceLoading,
+		refetch: refetchSpace,
+	} = useSpace( spaceId );
 	const layout = space?.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT;
 
 	// The stream is the discover `recommended` feed for the space's tags, so it
@@ -82,6 +87,9 @@ export function SpaceFeed( { spaceId }: Props ) {
 	const renderBody = () => {
 		// Load the space detail before anything else — the stream key is derived
 		// from its tags, and the layout from its `view`.
+		if ( ! space && spaceError ) {
+			return <SpaceFeedError onRetry={ refetchSpace } />;
+		}
 		if ( isSpaceLoading || ! space ) {
 			return <SpaceFeedLoading />;
 		}

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSpace } from 'calypso/reader/data/spaces';
+import { useInfiniteStream } from 'calypso/reader/data/stream';
+import { RECOMMENDED_TAB, buildDiscoverStreamKey } from 'calypso/reader/discover/helper';
+import { ScrollDebugOverlay } from 'calypso/reader/hooks/use-infinite-list';
+import { SpaceFeedSourceNotice } from './components/source-notice';
+import {
+	SpaceFeedEmpty,
+	SpaceFeedError,
+	SpaceFeedLoading,
+	SpaceFeedLoadingMore,
+} from './components/states';
+import { DEFAULT_SPACE_FEED_LAYOUT, getLayout } from './layouts/registry';
+import type { ReadStreamPost, ReadStreamResponse } from '@automattic/api-core';
+
+import './style.scss';
+
+interface Props {
+	spaceId: string;
+}
+
+function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
+	const posts: ReadStreamPost[] = [];
+	for ( const page of pages ) {
+		if ( page.posts?.length ) {
+			posts.push( ...page.posts );
+		} else if ( page.cards?.length ) {
+			for ( const card of page.cards ) {
+				if ( card.type === 'post' ) {
+					posts.push( card.data );
+				}
+			}
+		}
+	}
+	return posts;
+}
+
+/**
+ * The space feed. Loads the space detail first, then derives the feed from it:
+ * the layout from `space.layout.view` (chosen via the Customize modal) and the
+ * stream from the space's `tags` (a discover `recommended` query). Every layout
+ * reads that same per-space query.
+ */
+export function SpaceFeed( { spaceId }: Props ) {
+	const { data: space, isLoading: isSpaceLoading } = useSpace( spaceId );
+	const layout = space?.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT;
+
+	// The stream is the discover `recommended` feed for the space's tags, so it
+	// can't be built until the detail (which carries `tags`) has loaded. The
+	// legacy layout (ReaderStreamV2) fetches the same key itself; React Query
+	// dedupes, so we skip the shell's fetch there to avoid recomputing `items` it
+	// never uses — same query, fetched once.
+	const streamKey = space ? buildDiscoverStreamKey( RECOMMENDED_TAB, space.tags ) : '';
+	const isLegacy = layout === 'legacy';
+	const stream = useInfiniteStream( {
+		streamKey,
+		options: { enabled: Boolean( space ) && ! isLegacy },
+	} );
+	const posts = useMemo( () => collectPosts( stream.pages ), [ stream.pages ] );
+
+	// Scroll on the Reader's main bounded container (`.layout__primary > div`, which
+	// has a fixed height) — the same scrollbar the rest of the Reader uses — instead
+	// of a nested viewport. The virtualizer needs a height-bounded element here: an
+	// unbounded one reports clientHeight ≈ scrollHeight, so it thinks every item is
+	// visible and renders the whole list (and infinite-loads every page). Resolve it
+	// from the rendered viewport (held in state via a callback ref so the virtualizer
+	// re-measures once it is attached) and hand it to the layout. Use `?scroll-debug`
+	// to highlight the resolved container (see ScrollDebugOverlay).
+	const [ scrollElement, setScrollElement ] = useState< HTMLElement | null >( null );
+	const setViewport = useCallback( ( element: HTMLDivElement | null ) => {
+		setScrollElement(
+			element ? element.closest< HTMLElement >( '.layout__primary > div' ) ?? element : null
+		);
+	}, [] );
+	const Layout = getLayout( layout );
+
+	// Skeleton at the foot of the list while the next page loads. Sits below the
+	// virtualized content (which fills the viewport's scroll height) so it shows
+	// at the bottom, where `loadMore` is triggered, for every layout.
+	const showLoadingMore = posts.length > 0 && ! stream.error && stream.isFetchingNextPage;
+
+	const renderBody = () => {
+		// Load the space detail before anything else — the stream key is derived
+		// from its tags, and the layout from its `view`.
+		if ( isSpaceLoading || ! space ) {
+			return <SpaceFeedLoading />;
+		}
+		// Legacy renders ReaderStreamV2, which fetches its own data; it only needs
+		// the stream key, scroll container, and restoreKey from the shell.
+		if ( isLegacy ) {
+			return (
+				<Layout
+					posts={ [] }
+					streamKey={ streamKey }
+					scrollElement={ scrollElement }
+					hasMore={ false }
+					isLoadingMore={ false }
+					loadMore={ () => {} }
+					restoreKey={ `${ spaceId }:${ layout }` }
+				/>
+			);
+		}
+		if ( stream.isLoading ) {
+			return <SpaceFeedLoading />;
+		}
+		if ( stream.error ) {
+			return <SpaceFeedError onRetry={ stream.refetch } />;
+		}
+		if ( posts.length === 0 ) {
+			return <SpaceFeedEmpty />;
+		}
+		return (
+			<Layout
+				posts={ posts }
+				streamKey={ streamKey }
+				scrollElement={ scrollElement }
+				hasMore={ stream.hasNextPage }
+				isLoadingMore={ stream.isFetchingNextPage }
+				loadMore={ stream.fetchNextPage }
+				restoreKey={ `${ spaceId }:${ layout }` }
+			/>
+		);
+	};
+
+	return (
+		<div className="space-feed">
+			<SpaceFeedSourceNotice failedCount={ 0 } />
+			<div className="space-feed__viewport" ref={ setViewport }>
+				{ renderBody() }
+				{ showLoadingMore && <SpaceFeedLoadingMore /> }
+			</div>
+			<ScrollDebugOverlay scrollElement={ scrollElement } />
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/layouts/board/index.tsx
+++ b/client/reader/spaces/feed/layouts/board/index.tsx
@@ -1,0 +1,100 @@
+import page from '@automattic/calypso-router';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { getPostUrl } from 'calypso/reader/route';
+import { getPostFields } from '../../post-fields';
+import type { SpaceFeedLayoutProps } from '../types';
+import type { ReadStreamPost } from '@automattic/api-core';
+
+import './style.scss';
+
+const LANES = 2;
+const ESTIMATED_SIZE = 260;
+
+function BoardCard( { post }: { post: ReadStreamPost } ) {
+	const fields = getPostFields( post );
+	return (
+		<div className="space-feed-board__card">
+			<div className="space-feed-board__hero">
+				{ fields.imageUrl ? (
+					<img className="space-feed-board__image" src={ fields.imageUrl } alt="" loading="lazy" />
+				) : (
+					<SiteIcon iconUrl={ fields.siteIconUrl } size={ 40 } />
+				) }
+			</div>
+			<div className="space-feed-board__body">
+				<h3 className="space-feed-board__title">
+					<a className="space-feed-board__title-link" href={ fields.postHref }>
+						{ fields.title }
+					</a>
+				</h3>
+				{ fields.excerptHtml && (
+					<div
+						className="space-feed-board__excerpt"
+						// Sanitized by the Reader's formatExcerpt (allows only p/br/sup/sub).
+						dangerouslySetInnerHTML={ { __html: fields.excerptHtml } } // eslint-disable-line react/no-danger
+					/>
+				) }
+				<div className="space-feed-board__footer">
+					<span className="space-feed-board__source-group">
+						<SiteIcon iconUrl={ fields.siteIconUrl } size={ 18 } />
+						<span className="space-feed-board__source">{ fields.sourceName }</span>
+					</span>
+					{ fields.timeLabel && (
+						<span className="space-feed-board__time">{ fields.timeLabel }</span>
+					) }
+				</div>
+				<div className="space-feed-board__actions">
+					<ReaderPostActions
+						post={ post }
+						onCommentClick={ () => page( getPostUrl( post ) ) }
+						iconSize={ 18 }
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function BoardLayout( {
+	posts,
+	scrollElement,
+	hasMore,
+	isLoadingMore,
+	loadMore,
+	restoreKey,
+}: SpaceFeedLayoutProps ) {
+	const { getListProps, items, measureElement, scrollMargin } = useInfiniteList( {
+		scrollElement,
+		count: posts.length,
+		estimateSize: ESTIMATED_SIZE,
+		overscan: 6,
+		lanes: LANES,
+		getItemKey: ( index ) => posts[ index ].ID,
+		hasMore,
+		isLoadingMore,
+		loadMore,
+		restoreKey,
+	} );
+
+	return (
+		<div { ...getListProps( { className: 'space-feed-board' } ) }>
+			{ items.map( ( virtualItem ) => (
+				<div
+					key={ virtualItem.key }
+					data-index={ virtualItem.index }
+					ref={ measureElement }
+					className="space-feed-board__item"
+					style={ {
+						insetInlineStart: `${ ( virtualItem.lane * 100 ) / LANES }%`,
+						inlineSize: `${ 100 / LANES }%`,
+						transform: `translateY(${ virtualItem.start - scrollMargin }px)`,
+					} }
+				>
+					<BoardCard post={ posts[ virtualItem.index ] } />
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/layouts/board/index.tsx
+++ b/client/reader/spaces/feed/layouts/board/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { TimeSince } from '@automattic/components';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
@@ -41,8 +42,10 @@ function BoardCard( { post }: { post: ReadStreamPost } ) {
 						<SiteIcon iconUrl={ fields.siteIconUrl } size={ 18 } />
 						<span className="space-feed-board__source">{ fields.sourceName }</span>
 					</span>
-					{ fields.timeLabel && (
-						<span className="space-feed-board__time">{ fields.timeLabel }</span>
+					{ fields.publishedDate && (
+						<span className="space-feed-board__time">
+							<TimeSince date={ fields.publishedDate } />
+						</span>
 					) }
 				</div>
 				<div className="space-feed-board__actions">

--- a/client/reader/spaces/feed/layouts/board/index.tsx
+++ b/client/reader/spaces/feed/layouts/board/index.tsx
@@ -1,10 +1,10 @@
 import page from '@automattic/calypso-router';
-import { TimeSince } from '@automattic/components';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
 import { getPostUrl } from 'calypso/reader/route';
-import { getPostFields } from '../../post-fields';
+import { SpaceFeedTimeSince } from '../../components/time-since';
+import { getPostFieldKey, getPostFields } from '../../post-fields';
 import type { SpaceFeedLayoutProps } from '../types';
 import type { ReadStreamPost } from '@automattic/api-core';
 
@@ -44,7 +44,7 @@ function BoardCard( { post }: { post: ReadStreamPost } ) {
 					</span>
 					{ fields.publishedDate && (
 						<span className="space-feed-board__time">
-							<TimeSince date={ fields.publishedDate } />
+							<SpaceFeedTimeSince date={ fields.publishedDate } />
 						</span>
 					) }
 				</div>
@@ -74,7 +74,7 @@ export function BoardLayout( {
 		estimateSize: ESTIMATED_SIZE,
 		overscan: 6,
 		lanes: LANES,
-		getItemKey: ( index ) => posts[ index ].ID,
+		getItemKey: ( index ) => getPostFieldKey( posts[ index ] ),
 		hasMore,
 		isLoadingMore,
 		loadMore,

--- a/client/reader/spaces/feed/layouts/board/style.scss
+++ b/client/reader/spaces/feed/layouts/board/style.scss
@@ -1,0 +1,96 @@
+.space-feed-board {
+	position: relative;
+	inline-size: 100%;
+}
+
+.space-feed-board__item {
+	position: absolute;
+	inset-block-start: 0;
+	padding: 8px;
+}
+
+.space-feed-board__card {
+	display: block;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--color-surface);
+	color: inherit;
+}
+
+.space-feed-board__actions {
+	margin-block-start: 12px;
+}
+
+.space-feed-board__hero {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-block-size: 120px;
+	background: var(--color-surface-backdrop);
+	overflow: hidden;
+}
+
+.space-feed-board__image {
+	display: block;
+	inline-size: 100%;
+	block-size: auto;
+}
+
+.space-feed-board__body {
+	padding: 14px 16px 16px;
+}
+
+.space-feed-board__title {
+	margin: 0;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.3;
+	color: var(--color-text);
+}
+
+.space-feed-board__title-link {
+	color: inherit;
+	text-decoration: none;
+}
+
+.space-feed-board__title-link:hover {
+	text-decoration: underline;
+}
+
+.space-feed-board__excerpt {
+	margin: 8px 0 0;
+	font-size: 0.875rem;
+	line-height: 1.45;
+	color: var(--color-text-subtle);
+}
+
+.space-feed-board__excerpt p {
+	margin: 0;
+}
+
+.space-feed-board__footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	margin-block-start: 14px;
+	font-size: 0.75rem;
+	color: var(--color-text-subtle);
+}
+
+.space-feed-board__source-group {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-inline-size: 0;
+}
+
+.space-feed-board__source {
+	font-weight: 500;
+	color: var(--color-text);
+}
+
+.space-feed-board__time {
+	color: var(--color-text-subtle);
+}

--- a/client/reader/spaces/feed/layouts/gallery/index.tsx
+++ b/client/reader/spaces/feed/layouts/gallery/index.tsx
@@ -1,0 +1,100 @@
+import page from '@automattic/calypso-router';
+import { useMemo } from 'react';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { getPostUrl } from 'calypso/reader/route';
+import { getPostFields } from '../../post-fields';
+import type { SpaceFeedLayoutProps } from '../types';
+import type { ReadStreamPost } from '@automattic/api-core';
+
+import './style.scss';
+
+const COLUMNS = 3;
+const ROW_SIZE = 248;
+
+function GalleryCard( { post }: { post: ReadStreamPost } ) {
+	const fields = getPostFields( post );
+	return (
+		<div className="space-feed-gallery__card">
+			<div className="space-feed-gallery__thumb">
+				{ fields.imageUrl ? (
+					<img
+						className="space-feed-gallery__image"
+						src={ fields.imageUrl }
+						alt=""
+						loading="lazy"
+					/>
+				) : (
+					<SiteIcon iconUrl={ fields.siteIconUrl } size={ 40 } />
+				) }
+			</div>
+			<h3 className="space-feed-gallery__title">
+				<a className="space-feed-gallery__title-link" href={ fields.postHref }>
+					{ fields.title }
+				</a>
+			</h3>
+			<div className="space-feed-gallery__meta">
+				<SiteIcon iconUrl={ fields.siteIconUrl } size={ 20 } />
+				<span>
+					{ fields.sourceName }
+					{ fields.authorName ? ` · ${ fields.authorName }` : '' }
+				</span>
+			</div>
+			<div className="space-feed-gallery__actions">
+				<ReaderPostActions
+					post={ post }
+					onCommentClick={ () => page( getPostUrl( post ) ) }
+					iconSize={ 18 }
+				/>
+			</div>
+		</div>
+	);
+}
+
+export function GalleryLayout( {
+	posts,
+	scrollElement,
+	hasMore,
+	isLoadingMore,
+	loadMore,
+	restoreKey,
+}: SpaceFeedLayoutProps ) {
+	const rows = useMemo< ReadStreamPost[][] >( () => {
+		const out: ReadStreamPost[][] = [];
+		for ( let index = 0; index < posts.length; index += COLUMNS ) {
+			out.push( posts.slice( index, index + COLUMNS ) );
+		}
+		return out;
+	}, [ posts ] );
+
+	const { getListProps, items, measureElement, scrollMargin } = useInfiniteList( {
+		scrollElement,
+		count: rows.length,
+		estimateSize: ROW_SIZE,
+		overscan: 4,
+		getItemKey: ( index ) => rows[ index ][ 0 ]?.ID ?? index,
+		hasMore,
+		isLoadingMore,
+		loadMore,
+		restoreKey,
+	} );
+
+	return (
+		<div { ...getListProps( { className: 'space-feed-gallery' } ) }>
+			{ items.map( ( virtualRow ) => (
+				<div
+					key={ virtualRow.key }
+					data-index={ virtualRow.index }
+					ref={ measureElement }
+					className="space-feed-gallery__row"
+					style={ { transform: `translateY(${ virtualRow.start - scrollMargin }px)` } }
+				>
+					{ rows[ virtualRow.index ].map( ( post ) => (
+						<GalleryCard key={ post.ID } post={ post } />
+					) ) }
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/layouts/gallery/index.tsx
+++ b/client/reader/spaces/feed/layouts/gallery/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { TimeSince } from '@automattic/components';
 import { useMemo } from 'react';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
@@ -40,6 +41,11 @@ function GalleryCard( { post }: { post: ReadStreamPost } ) {
 					{ fields.sourceName }
 					{ fields.authorName ? ` · ${ fields.authorName }` : '' }
 				</span>
+				{ fields.publishedDate && (
+					<span className="space-feed-gallery__time">
+						<TimeSince date={ fields.publishedDate } />
+					</span>
+				) }
 			</div>
 			<div className="space-feed-gallery__actions">
 				<ReaderPostActions

--- a/client/reader/spaces/feed/layouts/gallery/index.tsx
+++ b/client/reader/spaces/feed/layouts/gallery/index.tsx
@@ -1,11 +1,11 @@
 import page from '@automattic/calypso-router';
-import { TimeSince } from '@automattic/components';
 import { useMemo } from 'react';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
 import { getPostUrl } from 'calypso/reader/route';
-import { getPostFields } from '../../post-fields';
+import { SpaceFeedTimeSince } from '../../components/time-since';
+import { getPostFieldKey, getPostFields } from '../../post-fields';
 import type { SpaceFeedLayoutProps } from '../types';
 import type { ReadStreamPost } from '@automattic/api-core';
 
@@ -43,7 +43,7 @@ function GalleryCard( { post }: { post: ReadStreamPost } ) {
 				</span>
 				{ fields.publishedDate && (
 					<span className="space-feed-gallery__time">
-						<TimeSince date={ fields.publishedDate } />
+						<SpaceFeedTimeSince date={ fields.publishedDate } />
 					</span>
 				) }
 			</div>
@@ -79,7 +79,7 @@ export function GalleryLayout( {
 		count: rows.length,
 		estimateSize: ROW_SIZE,
 		overscan: 4,
-		getItemKey: ( index ) => rows[ index ][ 0 ]?.ID ?? index,
+		getItemKey: ( index ) => ( rows[ index ][ 0 ] ? getPostFieldKey( rows[ index ][ 0 ] ) : index ),
 		hasMore,
 		isLoadingMore,
 		loadMore,
@@ -97,7 +97,7 @@ export function GalleryLayout( {
 					style={ { transform: `translateY(${ virtualRow.start - scrollMargin }px)` } }
 				>
 					{ rows[ virtualRow.index ].map( ( post ) => (
-						<GalleryCard key={ post.ID } post={ post } />
+						<GalleryCard key={ getPostFieldKey( post ) } post={ post } />
 					) ) }
 				</div>
 			) ) }

--- a/client/reader/spaces/feed/layouts/gallery/style.scss
+++ b/client/reader/spaces/feed/layouts/gallery/style.scss
@@ -1,0 +1,71 @@
+.space-feed-gallery {
+	position: relative;
+	inline-size: 100%;
+}
+
+.space-feed-gallery__row {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline: 0;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 16px;
+	padding-block-end: 16px;
+}
+
+.space-feed-gallery__card {
+	display: block;
+	min-inline-size: 0;
+	color: inherit;
+}
+
+.space-feed-gallery__actions {
+	margin-block-start: 8px;
+}
+
+.space-feed-gallery__thumb {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	aspect-ratio: 16 / 9;
+	border-radius: 8px;
+	background: var(--color-surface-backdrop);
+	overflow: hidden;
+}
+
+.space-feed-gallery__image {
+	inline-size: 100%;
+	block-size: 100%;
+	object-fit: cover;
+}
+
+.space-feed-gallery__title {
+	margin: 10px 0 0;
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.35;
+	color: var(--color-text);
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+}
+
+.space-feed-gallery__title-link {
+	color: inherit;
+	text-decoration: none;
+}
+
+.space-feed-gallery__title-link:hover {
+	text-decoration: underline;
+}
+
+.space-feed-gallery__meta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin: 6px 0 0;
+	font-size: 0.75rem;
+	color: var(--color-text-subtle);
+}

--- a/client/reader/spaces/feed/layouts/legacy/index.tsx
+++ b/client/reader/spaces/feed/layouts/legacy/index.tsx
@@ -1,0 +1,22 @@
+import { ReaderStreamV2 } from 'calypso/reader/stream/stream-v2';
+import type { SpaceFeedLayoutProps } from '../types';
+
+/**
+ * Legacy layout: the classic vertical reading experience — a single column of
+ * post cards — now on the `useInfiniteList` engine via {@link ReaderStreamV2},
+ * instead of the Redux + `<InfiniteList>` classic stream. It owns its own data
+ * and scrolls on the shell's Reader container like the other layouts.
+ *
+ * Reads the shell's `streamKey` — the same per-space query every layout uses —
+ * so switching to/from this layout never refetches (React Query dedupes).
+ */
+export function LegacyLayout( { streamKey, scrollElement, restoreKey }: SpaceFeedLayoutProps ) {
+	return (
+		<ReaderStreamV2
+			streamKey={ streamKey }
+			scrollElement={ scrollElement }
+			className="space-feed-legacy"
+			restoreKey={ restoreKey }
+		/>
+	);
+}

--- a/client/reader/spaces/feed/layouts/magazine/index.tsx
+++ b/client/reader/spaces/feed/layouts/magazine/index.tsx
@@ -1,10 +1,10 @@
 import page from '@automattic/calypso-router';
-import { TimeSince } from '@automattic/components';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
 import { getPostUrl } from 'calypso/reader/route';
-import { getPostFields } from '../../post-fields';
+import { SpaceFeedTimeSince } from '../../components/time-since';
+import { getPostFieldKey, getPostFields } from '../../post-fields';
 import type { SpaceFeedLayoutProps } from '../types';
 import type { ReadStreamPost } from '@automattic/api-core';
 
@@ -49,7 +49,7 @@ function MagazineCard( { post }: { post: ReadStreamPost } ) {
 				<p className="space-feed-magazine__meta">
 					{ metaText }
 					{ metaText && fields.publishedDate ? ' · ' : '' }
-					{ fields.publishedDate && <TimeSince date={ fields.publishedDate } /> }
+					{ fields.publishedDate && <SpaceFeedTimeSince date={ fields.publishedDate } /> }
 				</p>
 			) }
 			<div className="space-feed-magazine__actions">
@@ -76,7 +76,7 @@ export function MagazineLayout( {
 		count: posts.length,
 		estimateSize: ESTIMATED_SIZE,
 		overscan: 4,
-		getItemKey: ( index ) => posts[ index ].ID,
+		getItemKey: ( index ) => getPostFieldKey( posts[ index ] ),
 		hasMore,
 		isLoadingMore,
 		loadMore,

--- a/client/reader/spaces/feed/layouts/magazine/index.tsx
+++ b/client/reader/spaces/feed/layouts/magazine/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { TimeSince } from '@automattic/components';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
@@ -13,7 +14,7 @@ const ESTIMATED_SIZE = 420;
 
 function MagazineCard( { post }: { post: ReadStreamPost } ) {
 	const fields = getPostFields( post );
-	const meta = [ fields.authorName, fields.timeLabel ].filter( Boolean ).join( ' · ' );
+	const metaText = [ fields.authorName, fields.siteDomain ].filter( Boolean ).join( ' · ' );
 	return (
 		<div className="space-feed-magazine__card">
 			<div className="space-feed-magazine__hero">
@@ -44,7 +45,13 @@ function MagazineCard( { post }: { post: ReadStreamPost } ) {
 					dangerouslySetInnerHTML={ { __html: fields.excerptHtml } } // eslint-disable-line react/no-danger
 				/>
 			) }
-			{ meta && <p className="space-feed-magazine__meta">{ meta }</p> }
+			{ ( metaText || fields.publishedDate ) && (
+				<p className="space-feed-magazine__meta">
+					{ metaText }
+					{ metaText && fields.publishedDate ? ' · ' : '' }
+					{ fields.publishedDate && <TimeSince date={ fields.publishedDate } /> }
+				</p>
+			) }
 			<div className="space-feed-magazine__actions">
 				<ReaderPostActions
 					post={ post }

--- a/client/reader/spaces/feed/layouts/magazine/index.tsx
+++ b/client/reader/spaces/feed/layouts/magazine/index.tsx
@@ -1,0 +1,94 @@
+import page from '@automattic/calypso-router';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { getPostUrl } from 'calypso/reader/route';
+import { getPostFields } from '../../post-fields';
+import type { SpaceFeedLayoutProps } from '../types';
+import type { ReadStreamPost } from '@automattic/api-core';
+
+import './style.scss';
+
+const ESTIMATED_SIZE = 420;
+
+function MagazineCard( { post }: { post: ReadStreamPost } ) {
+	const fields = getPostFields( post );
+	const meta = [ fields.authorName, fields.timeLabel ].filter( Boolean ).join( ' · ' );
+	return (
+		<div className="space-feed-magazine__card">
+			<div className="space-feed-magazine__hero">
+				{ fields.imageUrl ? (
+					<img
+						className="space-feed-magazine__image"
+						src={ fields.imageUrl }
+						alt=""
+						loading="lazy"
+					/>
+				) : (
+					<SiteIcon iconUrl={ fields.siteIconUrl } size={ 48 } />
+				) }
+			</div>
+			<div className="space-feed-magazine__byline">
+				<SiteIcon iconUrl={ fields.siteIconUrl } size={ 24 } />
+				<span className="space-feed-magazine__kicker">{ fields.sourceName }</span>
+			</div>
+			<h3 className="space-feed-magazine__title">
+				<a className="space-feed-magazine__title-link" href={ fields.postHref }>
+					{ fields.title }
+				</a>
+			</h3>
+			{ fields.excerptHtml && (
+				<div
+					className="space-feed-magazine__excerpt"
+					// Sanitized by the Reader's formatExcerpt (allows only p/br/sup/sub).
+					dangerouslySetInnerHTML={ { __html: fields.excerptHtml } } // eslint-disable-line react/no-danger
+				/>
+			) }
+			{ meta && <p className="space-feed-magazine__meta">{ meta }</p> }
+			<div className="space-feed-magazine__actions">
+				<ReaderPostActions
+					post={ post }
+					onCommentClick={ () => page( getPostUrl( post ) ) }
+					iconSize={ 18 }
+				/>
+			</div>
+		</div>
+	);
+}
+
+export function MagazineLayout( {
+	posts,
+	scrollElement,
+	hasMore,
+	isLoadingMore,
+	loadMore,
+	restoreKey,
+}: SpaceFeedLayoutProps ) {
+	const { getListProps, items, measureElement, scrollMargin } = useInfiniteList( {
+		scrollElement,
+		count: posts.length,
+		estimateSize: ESTIMATED_SIZE,
+		overscan: 4,
+		getItemKey: ( index ) => posts[ index ].ID,
+		hasMore,
+		isLoadingMore,
+		loadMore,
+		restoreKey,
+	} );
+
+	return (
+		<div { ...getListProps( { className: 'space-feed-magazine' } ) }>
+			{ items.map( ( virtualItem ) => (
+				<div
+					key={ virtualItem.key }
+					data-index={ virtualItem.index }
+					ref={ measureElement }
+					className="space-feed-magazine__item"
+					style={ { transform: `translateY(${ virtualItem.start - scrollMargin }px)` } }
+				>
+					<MagazineCard post={ posts[ virtualItem.index ] } />
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/layouts/magazine/style.scss
+++ b/client/reader/spaces/feed/layouts/magazine/style.scss
@@ -1,0 +1,88 @@
+.space-feed-magazine {
+	position: relative;
+	inline-size: 100%;
+	max-inline-size: 640px;
+	margin-inline: auto;
+}
+
+.space-feed-magazine__item {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline: 0;
+	padding-block-end: 32px;
+}
+
+.space-feed-magazine__card {
+	display: block;
+	color: inherit;
+}
+
+.space-feed-magazine__actions {
+	margin-block-start: 12px;
+}
+
+.space-feed-magazine__hero {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-block-size: 200px;
+	border-radius: 8px;
+	background: var(--color-surface-backdrop);
+	overflow: hidden;
+}
+
+.space-feed-magazine__image {
+	inline-size: 100%;
+	block-size: 200px;
+	object-fit: cover;
+}
+
+.space-feed-magazine__byline {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-block-start: 16px;
+}
+
+.space-feed-magazine__kicker {
+	margin: 0;
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-accent, var(--color-primary));
+}
+
+.space-feed-magazine__title {
+	margin: 8px 0 0;
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 1.25;
+	color: var(--color-text);
+}
+
+.space-feed-magazine__title-link {
+	color: inherit;
+	text-decoration: none;
+}
+
+.space-feed-magazine__title-link:hover {
+	text-decoration: underline;
+}
+
+.space-feed-magazine__excerpt {
+	margin: 10px 0 0;
+	font-size: 0.875rem;
+	line-height: 1.5;
+	color: var(--color-text-subtle);
+}
+
+.space-feed-magazine__excerpt p {
+	margin: 0;
+}
+
+.space-feed-magazine__meta {
+	margin: 12px 0 0;
+	font-size: 0.75rem;
+	color: var(--color-text-subtle);
+}

--- a/client/reader/spaces/feed/layouts/registry.ts
+++ b/client/reader/spaces/feed/layouts/registry.ts
@@ -1,0 +1,28 @@
+import { BoardLayout } from './board';
+import { GalleryLayout } from './gallery';
+import { LegacyLayout } from './legacy';
+import { MagazineLayout } from './magazine';
+import { StandardListLayout } from './standard-list';
+import type { SpaceFeedLayoutProps } from './types';
+import type { SpaceFeedLayout } from '@automattic/api-core';
+import type { ComponentType } from 'react';
+
+const LAYOUTS: Record< SpaceFeedLayout, ComponentType< SpaceFeedLayoutProps > > = {
+	'standard-list': StandardListLayout,
+	magazine: MagazineLayout,
+	gallery: GalleryLayout,
+	board: BoardLayout,
+	legacy: LegacyLayout,
+};
+
+export const DEFAULT_SPACE_FEED_LAYOUT: SpaceFeedLayout = 'standard-list';
+
+/**
+ * Resolve a space's feed layout to its component, falling back to the standard
+ * list when the value is missing or names a layout that isn't built.
+ */
+export function getLayout(
+	layout: SpaceFeedLayout | undefined
+): ComponentType< SpaceFeedLayoutProps > {
+	return ( layout && LAYOUTS[ layout ] ) || LAYOUTS[ DEFAULT_SPACE_FEED_LAYOUT ];
+}

--- a/client/reader/spaces/feed/layouts/standard-list/index.tsx
+++ b/client/reader/spaces/feed/layouts/standard-list/index.tsx
@@ -1,3 +1,4 @@
+import { TimeSince } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
@@ -59,11 +60,16 @@ function PostRow( { post }: { post: ReadStreamPost } ) {
 					{ fields.authorName && (
 						<span className="space-feed-standard-list__tag">{ fields.authorName }</span>
 					) }
+					{ fields.siteDomain && (
+						<span className="space-feed-standard-list__tag">{ fields.siteDomain }</span>
+					) }
 				</div>
 			</div>
 			<div className="space-feed-standard-list__aside">
-				{ fields.timeLabel && (
-					<span className="space-feed-standard-list__time">{ fields.timeLabel }</span>
+				{ fields.publishedDate && (
+					<span className="space-feed-standard-list__time">
+						<TimeSince date={ fields.publishedDate } />
+					</span>
 				) }
 				<BookmarkGlyph />
 			</div>

--- a/client/reader/spaces/feed/layouts/standard-list/index.tsx
+++ b/client/reader/spaces/feed/layouts/standard-list/index.tsx
@@ -1,0 +1,146 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { getPostFields, type SpaceFeedDayGroup } from '../../post-fields';
+import type { SpaceFeedLayoutProps } from '../types';
+import type { ReadStreamPost } from '@automattic/api-core';
+
+import './style.scss';
+
+type Row =
+	| { kind: 'header'; key: string; label: string }
+	| { kind: 'post'; key: string; post: ReadStreamPost };
+
+const HEADER_SIZE = 44;
+const ROW_SIZE = 88;
+
+function BookmarkGlyph() {
+	return (
+		<svg
+			className="space-feed-standard-list__bookmark"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			aria-hidden="true"
+		>
+			<path
+				d="M7 4h10a1 1 0 0 1 1 1v15l-6-3.5L6 20V5a1 1 0 0 1 1-1Z"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
+
+function PostRow( { post }: { post: ReadStreamPost } ) {
+	const fields = getPostFields( post );
+	return (
+		<a className="space-feed-standard-list__row" href={ fields.postHref }>
+			<span
+				className="space-feed-standard-list__unread"
+				data-unread={ fields.isUnread }
+				aria-hidden="true"
+			/>
+			<div className="space-feed-standard-list__body">
+				<h3 className="space-feed-standard-list__title">{ fields.title }</h3>
+				{ fields.excerptHtml && (
+					<div
+						className="space-feed-standard-list__excerpt"
+						// Sanitized by the Reader's formatExcerpt (allows only p/br/sup/sub).
+						dangerouslySetInnerHTML={ { __html: fields.excerptHtml } } // eslint-disable-line react/no-danger
+					/>
+				) }
+				<div className="space-feed-standard-list__source-row">
+					<SiteIcon iconUrl={ fields.siteIconUrl } size={ 20 } />
+					<span className="space-feed-standard-list__source">{ fields.sourceName }</span>
+					{ fields.authorName && (
+						<span className="space-feed-standard-list__tag">{ fields.authorName }</span>
+					) }
+				</div>
+			</div>
+			<div className="space-feed-standard-list__aside">
+				{ fields.timeLabel && (
+					<span className="space-feed-standard-list__time">{ fields.timeLabel }</span>
+				) }
+				<BookmarkGlyph />
+			</div>
+		</a>
+	);
+}
+
+export function StandardListLayout( {
+	posts,
+	scrollElement,
+	hasMore,
+	isLoadingMore,
+	loadMore,
+}: SpaceFeedLayoutProps ) {
+	const translate = useTranslate();
+
+	const rows = useMemo< Row[] >( () => {
+		const labelFor = ( group: Exclude< SpaceFeedDayGroup, '' > ): string => {
+			switch ( group ) {
+				case 'today':
+					return translate( 'Today' );
+				case 'yesterday':
+					return translate( 'Yesterday' );
+				case 'earlier':
+					return translate( 'Earlier this week' );
+				case 'older':
+					return translate( 'Older' );
+			}
+		};
+
+		const out: Row[] = [];
+		let lastGroup: SpaceFeedDayGroup = '';
+		posts.forEach( ( post, index ) => {
+			const { dayGroup, id } = getPostFields( post );
+			if ( dayGroup && dayGroup !== lastGroup ) {
+				out.push( {
+					kind: 'header',
+					key: `header-${ dayGroup }-${ index }`,
+					label: labelFor( dayGroup ),
+				} );
+				lastGroup = dayGroup;
+			}
+			out.push( { kind: 'post', key: `post-${ index }-${ id }`, post } );
+		} );
+		return out;
+	}, [ posts, translate ] );
+
+	const { getListProps, items, measureElement, scrollMargin } = useInfiniteList( {
+		scrollElement,
+		count: rows.length,
+		estimateSize: ( index ) => ( rows[ index ].kind === 'header' ? HEADER_SIZE : ROW_SIZE ),
+		getItemKey: ( index ) => rows[ index ].key,
+		hasMore,
+		isLoadingMore,
+		loadMore,
+	} );
+
+	return (
+		<div { ...getListProps( { className: 'space-feed-standard-list' } ) }>
+			{ items.map( ( virtualRow ) => {
+				const row = rows[ virtualRow.index ];
+				return (
+					<div
+						key={ virtualRow.key }
+						data-index={ virtualRow.index }
+						ref={ measureElement }
+						className="space-feed-standard-list__item"
+						style={ { transform: `translateY(${ virtualRow.start - scrollMargin }px)` } }
+					>
+						{ row.kind === 'header' ? (
+							<h2 className="space-feed-standard-list__group">{ row.label }</h2>
+						) : (
+							<PostRow post={ row.post } />
+						) }
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}

--- a/client/reader/spaces/feed/layouts/standard-list/index.tsx
+++ b/client/reader/spaces/feed/layouts/standard-list/index.tsx
@@ -3,15 +3,14 @@ import { useMemo } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
 import { SpaceFeedTimeSince } from '../../components/time-since';
-import { getPostFields, type SpaceFeedDayGroup } from '../../post-fields';
+import { getPostFields, type SpaceFeedDayGroup, type SpaceFeedPostFields } from '../../post-fields';
 import type { SpaceFeedLayoutProps } from '../types';
-import type { ReadStreamPost } from '@automattic/api-core';
 
 import './style.scss';
 
 type Row =
 	| { kind: 'header'; key: string; label: string }
-	| { kind: 'post'; key: string; post: ReadStreamPost };
+	| { kind: 'post'; key: string; fields: SpaceFeedPostFields };
 
 const HEADER_SIZE = 44;
 const ROW_SIZE = 88;
@@ -36,8 +35,7 @@ function BookmarkGlyph() {
 	);
 }
 
-function PostRow( { post }: { post: ReadStreamPost } ) {
-	const fields = getPostFields( post );
+function PostRow( { fields }: { fields: SpaceFeedPostFields } ) {
 	return (
 		<a className="space-feed-standard-list__row" href={ fields.postHref }>
 			<span
@@ -104,7 +102,8 @@ export function StandardListLayout( {
 		const out: Row[] = [];
 		let lastGroup: SpaceFeedDayGroup = '';
 		posts.forEach( ( post, index ) => {
-			const { dayGroup, key } = getPostFields( post );
+			const fields = getPostFields( post );
+			const { dayGroup, key } = fields;
 			if ( dayGroup && dayGroup !== lastGroup ) {
 				out.push( {
 					kind: 'header',
@@ -113,7 +112,7 @@ export function StandardListLayout( {
 				} );
 				lastGroup = dayGroup;
 			}
-			out.push( { kind: 'post', key: `post-${ key }`, post } );
+			out.push( { kind: 'post', key: `post-${ key }`, fields } );
 		} );
 		return out;
 	}, [ posts, translate ] );
@@ -144,7 +143,7 @@ export function StandardListLayout( {
 						{ row.kind === 'header' ? (
 							<h2 className="space-feed-standard-list__group">{ row.label }</h2>
 						) : (
-							<PostRow post={ row.post } />
+							<PostRow fields={ row.fields } />
 						) }
 					</div>
 				);

--- a/client/reader/spaces/feed/layouts/standard-list/index.tsx
+++ b/client/reader/spaces/feed/layouts/standard-list/index.tsx
@@ -1,8 +1,8 @@
-import { TimeSince } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { SpaceFeedTimeSince } from '../../components/time-since';
 import { getPostFields, type SpaceFeedDayGroup } from '../../post-fields';
 import type { SpaceFeedLayoutProps } from '../types';
 import type { ReadStreamPost } from '@automattic/api-core';
@@ -68,7 +68,7 @@ function PostRow( { post }: { post: ReadStreamPost } ) {
 			<div className="space-feed-standard-list__aside">
 				{ fields.publishedDate && (
 					<span className="space-feed-standard-list__time">
-						<TimeSince date={ fields.publishedDate } />
+						<SpaceFeedTimeSince date={ fields.publishedDate } />
 					</span>
 				) }
 				<BookmarkGlyph />
@@ -83,6 +83,7 @@ export function StandardListLayout( {
 	hasMore,
 	isLoadingMore,
 	loadMore,
+	restoreKey,
 }: SpaceFeedLayoutProps ) {
 	const translate = useTranslate();
 
@@ -103,7 +104,7 @@ export function StandardListLayout( {
 		const out: Row[] = [];
 		let lastGroup: SpaceFeedDayGroup = '';
 		posts.forEach( ( post, index ) => {
-			const { dayGroup, id } = getPostFields( post );
+			const { dayGroup, key } = getPostFields( post );
 			if ( dayGroup && dayGroup !== lastGroup ) {
 				out.push( {
 					kind: 'header',
@@ -112,7 +113,7 @@ export function StandardListLayout( {
 				} );
 				lastGroup = dayGroup;
 			}
-			out.push( { kind: 'post', key: `post-${ index }-${ id }`, post } );
+			out.push( { kind: 'post', key: `post-${ key }`, post } );
 		} );
 		return out;
 	}, [ posts, translate ] );
@@ -125,6 +126,7 @@ export function StandardListLayout( {
 		hasMore,
 		isLoadingMore,
 		loadMore,
+		restoreKey,
 	} );
 
 	return (

--- a/client/reader/spaces/feed/layouts/standard-list/style.scss
+++ b/client/reader/spaces/feed/layouts/standard-list/style.scss
@@ -1,0 +1,109 @@
+.space-feed-standard-list {
+	position: relative;
+	inline-size: 100%;
+}
+
+.space-feed-standard-list__item {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline: 0;
+}
+
+.space-feed-standard-list__group {
+	margin: 0;
+	padding-block: 20px 8px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-text-subtle);
+}
+
+.space-feed-standard-list__row {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	padding-block: 16px;
+	border-block-end: 1px solid var(--color-border-subtle);
+	color: inherit;
+	text-decoration: none;
+}
+
+.space-feed-standard-list__row:hover .space-feed-standard-list__title {
+	text-decoration: underline;
+}
+
+.space-feed-standard-list__unread {
+	flex: 0 0 auto;
+	inline-size: 8px;
+	block-size: 8px;
+	margin-block-start: 6px;
+	border-radius: 50%;
+	background: transparent;
+}
+
+.space-feed-standard-list__unread[data-unread='true'] {
+	background: var(--color-accent, var(--color-primary));
+}
+
+.space-feed-standard-list__body {
+	flex: 1 1 auto;
+	min-inline-size: 0;
+}
+
+.space-feed-standard-list__title {
+	margin: 0;
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.35;
+	color: var(--color-text);
+}
+
+.space-feed-standard-list__excerpt {
+	margin: 4px 0 0;
+	font-size: 0.875rem;
+	line-height: 1.4;
+	color: var(--color-text-subtle);
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 1;
+	-webkit-box-orient: vertical;
+}
+
+.space-feed-standard-list__excerpt p {
+	display: inline;
+	margin: 0;
+}
+
+.space-feed-standard-list__source-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-block-start: 8px;
+	font-size: 0.75rem;
+	color: var(--color-text-subtle);
+}
+
+.space-feed-standard-list__source {
+	font-weight: 500;
+	color: var(--color-text);
+}
+
+.space-feed-standard-list__tag::before {
+	content: '·';
+	margin-inline-end: 8px;
+	color: var(--color-text-subtle);
+}
+
+.space-feed-standard-list__aside {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	color: var(--color-text-subtle);
+	font-size: 0.75rem;
+}
+
+.space-feed-standard-list__bookmark {
+	color: var(--color-text-subtle);
+}

--- a/client/reader/spaces/feed/layouts/test/registry.test.ts
+++ b/client/reader/spaces/feed/layouts/test/registry.test.ts
@@ -1,0 +1,24 @@
+import { BoardLayout } from '../board';
+import { GalleryLayout } from '../gallery';
+import { MagazineLayout } from '../magazine';
+import { DEFAULT_SPACE_FEED_LAYOUT, getLayout } from '../registry';
+import { StandardListLayout } from '../standard-list';
+
+describe( 'getLayout', () => {
+	it( 'maps each known layout to its component', () => {
+		expect( getLayout( 'standard-list' ) ).toBe( StandardListLayout );
+		expect( getLayout( 'magazine' ) ).toBe( MagazineLayout );
+		expect( getLayout( 'gallery' ) ).toBe( GalleryLayout );
+		expect( getLayout( 'board' ) ).toBe( BoardLayout );
+	} );
+
+	it( 'falls back to the standard list when the layout is undefined', () => {
+		expect( getLayout( undefined ) ).toBe( StandardListLayout );
+		expect( DEFAULT_SPACE_FEED_LAYOUT ).toBe( 'standard-list' );
+	} );
+
+	it( 'falls back to the standard list for an unknown layout value', () => {
+		// A space whose `feed` names a layout that isn't built yet still renders.
+		expect( getLayout( 'unbuilt-layout' as never ) ).toBe( StandardListLayout );
+	} );
+} );

--- a/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
+++ b/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
@@ -3,6 +3,7 @@
  */
 import { render } from '@testing-library/react';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { getPostFields } from '../../post-fields';
 import { StandardListLayout } from '../standard-list';
 import type { ReadStreamPost } from '@automattic/api-core';
 import type { CSSProperties } from 'react';
@@ -20,7 +21,25 @@ jest.mock( 'calypso/reader/hooks/use-infinite-list', () => ( {
 	} ) ),
 } ) );
 
+jest.mock( '../../post-fields', () => ( {
+	getPostFields: jest.fn( () => ( {
+		id: 1,
+		key: 'blog-1-2',
+		title: 'Test post',
+		excerptHtml: '',
+		sourceName: 'Test site',
+		dayGroup: 'today',
+		postHref: '/reader/blogs/2/posts/1',
+		isUnread: false,
+	} ) ),
+} ) );
+
 const mockUseInfiniteList = useInfiniteList as jest.Mock;
+const mockGetPostFields = getPostFields as jest.Mock;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
 
 describe( 'StandardListLayout', () => {
 	it( 'passes its restore key to the virtualized list engine', () => {
@@ -39,5 +58,28 @@ describe( 'StandardListLayout', () => {
 		expect( mockUseInfiniteList ).toHaveBeenCalledWith(
 			expect.objectContaining( { restoreKey: 'work-id:standard-list' } )
 		);
+	} );
+
+	it( 'reuses extracted post fields when rendering a post row', () => {
+		mockUseInfiniteList.mockReturnValueOnce( {
+			getListProps: ( props: ListProps = {} ) => ( { ...props, style: props.style ?? {} } ),
+			items: [ { index: 1, key: 'post-blog-1-2', start: 44 } ],
+			measureElement: jest.fn(),
+			scrollMargin: 0,
+		} );
+
+		render(
+			<StandardListLayout
+				posts={ [ { ID: 1, site_ID: 2 } as ReadStreamPost ] }
+				streamKey="space:tags"
+				scrollElement={ null }
+				hasMore={ false }
+				isLoadingMore={ false }
+				loadMore={ jest.fn() }
+				restoreKey="work-id:standard-list"
+			/>
+		);
+
+		expect( mockGetPostFields ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
+++ b/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { StandardListLayout } from '../standard-list';
+import type { ReadStreamPost } from '@automattic/api-core';
+import type { CSSProperties } from 'react';
+
+type ListProps = {
+	style?: CSSProperties;
+};
+
+jest.mock( 'calypso/reader/hooks/use-infinite-list', () => ( {
+	useInfiniteList: jest.fn( () => ( {
+		getListProps: ( props: ListProps = {} ) => ( { ...props, style: props.style ?? {} } ),
+		items: [],
+		measureElement: jest.fn(),
+		scrollMargin: 0,
+	} ) ),
+} ) );
+
+const mockUseInfiniteList = useInfiniteList as jest.Mock;
+
+describe( 'StandardListLayout', () => {
+	it( 'passes its restore key to the virtualized list engine', () => {
+		render(
+			<StandardListLayout
+				posts={ [] as ReadStreamPost[] }
+				streamKey="space:tags"
+				scrollElement={ null }
+				hasMore={ false }
+				isLoadingMore={ false }
+				loadMore={ jest.fn() }
+				restoreKey="work-id:standard-list"
+			/>
+		);
+
+		expect( mockUseInfiniteList ).toHaveBeenCalledWith(
+			expect.objectContaining( { restoreKey: 'work-id:standard-list' } )
+		);
+	} );
+} );

--- a/client/reader/spaces/feed/layouts/types.ts
+++ b/client/reader/spaces/feed/layouts/types.ts
@@ -1,0 +1,27 @@
+import type { ReadStreamPost } from '@automattic/api-core';
+
+/**
+ * The contract every space-feed layout implements. The shell owns the data and
+ * the scroll element; each layout owns its own `useVirtualizer` so it can pick
+ * the geometry that fits — vertical list, grid, masonry. A layout calls
+ * `loadMore()` when its last virtual row nears the end and `hasMore` is true.
+ *
+ * `scrollElement` is passed as state (not a ref) so the virtualizer re-evaluates
+ * once the container mounts — on Back the layout and container mount in the same
+ * commit, and a ref would still read `null` during the virtualizer's setup.
+ */
+export interface SpaceFeedLayoutProps {
+	posts: ReadStreamPost[];
+	/**
+	 * The stream the feed reads from. Only the legacy layout (which fetches its
+	 * own data via ReaderStreamV2) needs it; the others read `posts` from the shell.
+	 */
+	streamKey: string;
+	scrollElement: HTMLElement | null;
+	hasMore: boolean;
+	/** True while a next page is already in flight — gates `loadMore`. */
+	isLoadingMore: boolean;
+	loadMore: () => void;
+	/** Stable key (`${spaceId}:${layout}`) for saving/restoring scroll on Back. */
+	restoreKey: string;
+}

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -46,7 +46,7 @@ const asString = ( value: unknown ): string | undefined =>
 const MS_PER_DAY = 86_400_000;
 
 const startOfDay = ( date: Date ): number =>
-	new Date( date.getFullYear(), date.getMonth(), date.getDate() ).getTime();
+	Date.UTC( date.getFullYear(), date.getMonth(), date.getDate() );
 
 function dayGroupOf( dateIso?: string ): SpaceFeedDayGroup {
 	if ( ! dateIso ) {

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -1,0 +1,115 @@
+import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
+import { getPostUrl } from 'calypso/reader/route';
+import type { ReadStreamPost } from '@automattic/api-core';
+
+/**
+ * Day buckets the standard list groups by. The layout maps these to translated
+ * labels (the mapping can't live here — this is a plain, non-component helper).
+ */
+export type SpaceFeedDayGroup = 'today' | 'yesterday' | 'earlier' | 'older' | '';
+
+/**
+ * Display fields the layouts read off a real `ReadStreamPost` (from the existing
+ * Reader stream query). Most arrive through the type's index signature as
+ * `unknown`; narrow them here once so the layout components stay cast-free.
+ */
+export interface SpaceFeedPostFields {
+	id: number;
+	title: string;
+	/**
+	 * Sanitized excerpt HTML (Reader's `formatExcerpt` — same as PostLifecycle's
+	 * `better_excerpt`). Render with `dangerouslySetInnerHTML`, not as text, so
+	 * `<p>`/entities resolve instead of showing literally.
+	 */
+	excerptHtml: string;
+	sourceName: string;
+	authorName?: string;
+	imageUrl?: string;
+	/** Blog/site icon URL (`post.site_icon.ico`); empty falls back to a globe. */
+	siteIconUrl?: string;
+	timeLabel?: string;
+	dayGroup: SpaceFeedDayGroup;
+	/** Reader full-post page path, e.g. `/reader/feeds/:feed/posts/:post`. */
+	postHref: string;
+	isUnread: boolean;
+}
+
+const asString = ( value: unknown ): string | undefined =>
+	typeof value === 'string' && value ? value : undefined;
+
+const MS_PER_DAY = 86_400_000;
+
+const startOfDay = ( date: Date ): number =>
+	new Date( date.getFullYear(), date.getMonth(), date.getDate() ).getTime();
+
+function dayGroupOf( dateIso?: string ): SpaceFeedDayGroup {
+	if ( ! dateIso ) {
+		return '';
+	}
+	const time = new Date( dateIso ).getTime();
+	if ( Number.isNaN( time ) ) {
+		return '';
+	}
+	const diffDays = Math.round(
+		( startOfDay( new Date() ) - startOfDay( new Date( time ) ) ) / MS_PER_DAY
+	);
+	if ( diffDays <= 0 ) {
+		return 'today';
+	}
+	if ( diffDays === 1 ) {
+		return 'yesterday';
+	}
+	if ( diffDays < 7 ) {
+		return 'earlier';
+	}
+	return 'older';
+}
+
+function timeLabelOf( dateIso?: string ): string | undefined {
+	if ( ! dateIso ) {
+		return undefined;
+	}
+	const date = new Date( dateIso );
+	if ( Number.isNaN( date.getTime() ) ) {
+		return undefined;
+	}
+	const hours = String( date.getHours() ).padStart( 2, '0' );
+	const minutes = String( date.getMinutes() ).padStart( 2, '0' );
+	return `${ hours }:${ minutes }`;
+}
+
+function imageOf( post: ReadStreamPost ): string | undefined {
+	const media = post.canonical_media;
+	if ( media && typeof media === 'object' ) {
+		const { src, mediaType } = media as { src?: unknown; mediaType?: unknown };
+		if ( typeof src === 'string' && src && ( mediaType === undefined || mediaType === 'image' ) ) {
+			return src;
+		}
+	}
+	return asString( post.featured_image );
+}
+
+function authorOf( post: ReadStreamPost ): string | undefined {
+	const author = post.author;
+	if ( author && typeof author === 'object' ) {
+		return asString( ( author as { name?: unknown } ).name );
+	}
+	return undefined;
+}
+
+export function getPostFields( post: ReadStreamPost ): SpaceFeedPostFields {
+	const date = asString( post.date );
+	return {
+		id: post.ID,
+		title: asString( post.title ) ?? asString( post.site_name ) ?? '',
+		excerptHtml: formatExcerpt( asString( post.excerpt ) ?? post.description ?? '' ),
+		sourceName: asString( post.site_name ) ?? '',
+		authorName: authorOf( post ),
+		imageUrl: imageOf( post ),
+		siteIconUrl: asString( post.site_icon?.ico ),
+		timeLabel: timeLabelOf( date ),
+		dayGroup: dayGroupOf( date ),
+		postHref: getPostUrl( post ),
+		isUnread: post.is_seen === false,
+	};
+}

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -1,3 +1,4 @@
+import { decodeEntities } from 'calypso/lib/formatting';
 import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
 import { getPostUrl } from 'calypso/reader/route';
 import type { ReadStreamPost } from '@automattic/api-core';
@@ -27,7 +28,10 @@ export interface SpaceFeedPostFields {
 	imageUrl?: string;
 	/** Blog/site icon URL (`post.site_icon.ico`); empty falls back to a globe. */
 	siteIconUrl?: string;
-	timeLabel?: string;
+	/** The blog's domain (host of `feed_URL`), e.g. `example.wordpress.com`. */
+	siteDomain?: string;
+	/** Raw ISO publish date, for a relative `<TimeSince>` (e.g. "6h ago"). */
+	publishedDate?: string;
 	dayGroup: SpaceFeedDayGroup;
 	/** Reader full-post page path, e.g. `/reader/feeds/:feed/posts/:post`. */
 	postHref: string;
@@ -65,17 +69,17 @@ function dayGroupOf( dateIso?: string ): SpaceFeedDayGroup {
 	return 'older';
 }
 
-function timeLabelOf( dateIso?: string ): string | undefined {
-	if ( ! dateIso ) {
+/** The blog's domain from `feed_URL` (fallback the post URL), `www.` stripped. */
+function domainOf( post: ReadStreamPost ): string | undefined {
+	const url = asString( post.feed_URL ) ?? asString( post.URL );
+	if ( ! url ) {
 		return undefined;
 	}
-	const date = new Date( dateIso );
-	if ( Number.isNaN( date.getTime() ) ) {
+	try {
+		return new URL( url ).hostname.replace( /^www\./, '' );
+	} catch {
 		return undefined;
 	}
-	const hours = String( date.getHours() ).padStart( 2, '0' );
-	const minutes = String( date.getMinutes() ).padStart( 2, '0' );
-	return `${ hours }:${ minutes }`;
 }
 
 function imageOf( post: ReadStreamPost ): string | undefined {
@@ -99,15 +103,25 @@ function authorOf( post: ReadStreamPost ): string | undefined {
 
 export function getPostFields( post: ReadStreamPost ): SpaceFeedPostFields {
 	const date = asString( post.date );
+	const author = authorOf( post );
 	return {
 		id: post.ID,
-		title: asString( post.title ) ?? asString( post.site_name ) ?? '',
+		// Title, source and author render as plain text, so decode the HTML
+		// entities the raw API title carries (e.g. `&nbsp;`, `&#039;`) — the legacy
+		// card gets this for free from the normalized post. Titles are sometimes
+		// double-encoded, so decode twice, mirroring the Reader post normalizer
+		// (rule-decode-entities). The excerpt is rendered as HTML, so it doesn't
+		// need this.
+		title: decodeEntities(
+			decodeEntities( asString( post.title ) ?? asString( post.site_name ) ?? '' )
+		),
 		excerptHtml: formatExcerpt( asString( post.excerpt ) ?? post.description ?? '' ),
-		sourceName: asString( post.site_name ) ?? '',
-		authorName: authorOf( post ),
+		sourceName: decodeEntities( asString( post.site_name ) ?? '' ),
+		authorName: author ? decodeEntities( author ) : undefined,
 		imageUrl: imageOf( post ),
 		siteIconUrl: asString( post.site_icon?.ico ),
-		timeLabel: timeLabelOf( date ),
+		siteDomain: domainOf( post ),
+		publishedDate: date,
 		dayGroup: dayGroupOf( date ),
 		postHref: getPostUrl( post ),
 		isUnread: post.is_seen === false,

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -1,5 +1,6 @@
 import { decodeEntities } from 'calypso/lib/formatting';
 import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
+import { keyForPost, keyToString } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
 import type { ReadStreamPost } from '@automattic/api-core';
 
@@ -16,6 +17,7 @@ export type SpaceFeedDayGroup = 'today' | 'yesterday' | 'earlier' | 'older' | ''
  */
 export interface SpaceFeedPostFields {
 	id: number;
+	key: string;
 	title: string;
 	/**
 	 * Sanitized excerpt HTML (Reader's `formatExcerpt` — same as PostLifecycle's
@@ -101,11 +103,20 @@ function authorOf( post: ReadStreamPost ): string | undefined {
 	return undefined;
 }
 
+export function getPostFieldKey( post: ReadStreamPost ): string {
+	return (
+		keyToString( keyForPost( post ) ) ??
+		asString( post.global_ID ) ??
+		`post-${ post.site_ID ?? '' }-${ post.feed_ID ?? '' }-${ post.feed_item_ID ?? '' }-${ post.ID }`
+	);
+}
+
 export function getPostFields( post: ReadStreamPost ): SpaceFeedPostFields {
 	const date = asString( post.date );
 	const author = authorOf( post );
 	return {
 		id: post.ID,
+		key: getPostFieldKey( post ),
 		// Title, source and author render as plain text, so decode the HTML
 		// entities the raw API title carries (e.g. `&nbsp;`, `&#039;`) — the legacy
 		// card gets this for free from the normalized post. Titles are sometimes

--- a/client/reader/spaces/feed/style.scss
+++ b/client/reader/spaces/feed/style.scss
@@ -1,0 +1,129 @@
+.space-feed {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.space-feed__toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.space-feed__viewport {
+	// No nested scroll: the feed scrolls on the Reader's main container
+	// (`.layout__primary > div > div`), the same scrollbar as the rest of the
+	// Reader. This element just holds the list and grows with it.
+	min-block-size: 320px;
+}
+
+.space-feed__status {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding-block: 64px;
+	text-align: center;
+	color: var(--color-text-subtle);
+}
+
+.space-feed__status-title {
+	margin: 0;
+	font-size: 1rem;
+	font-weight: 600;
+	color: var(--color-text);
+}
+
+.space-feed__status-line {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--color-text-subtle);
+}
+
+.space-feed__loading-more {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding-block: 16px;
+}
+
+.space-feed__skeleton-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.space-feed__skeleton-body {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.space-feed__skeleton-avatar {
+	flex: 0 0 auto;
+	inline-size: 18px;
+	block-size: 18px;
+	border-radius: 4px;
+}
+
+.space-feed__skeleton-line {
+	block-size: 12px;
+	border-radius: 4px;
+}
+
+.space-feed__skeleton-line.is-short {
+	inline-size: 40%;
+}
+
+.space-feed__skeleton-avatar,
+.space-feed__skeleton-line {
+	background: linear-gradient(
+		90deg,
+		var(--color-surface-backdrop) 0%,
+		var(--color-border-subtle) 50%,
+		var(--color-surface-backdrop) 100%
+	);
+	background-size: 200% 100%;
+	animation: space-feed-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes space-feed-shimmer {
+	0% {
+		background-position: 200% 0;
+	}
+
+	100% {
+		background-position: -200% 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.space-feed__skeleton-avatar,
+	.space-feed__skeleton-line {
+		animation: none;
+	}
+}
+
+.space-feed__source-notice {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 10px 14px;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	background: var(--color-surface-backdrop);
+	font-size: 0.875rem;
+	color: var(--color-text);
+}
+
+.space-feed__source-notice-retry {
+	border: none;
+	background: none;
+	padding: 0;
+	color: var(--color-accent, var(--color-primary));
+	font-weight: 600;
+	cursor: pointer;
+}

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -3,8 +3,9 @@
  */
 import { readSpaceQuery } from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { useInfiniteStream } from 'calypso/reader/data/stream';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SpaceFeed } from '../index';
@@ -18,6 +19,12 @@ import type {
 jest.mock( 'calypso/reader/data/stream', () => ( {
 	useInfiniteStream: jest.fn(),
 } ) );
+
+jest.mock( 'calypso/state/reader/site-blocks/selectors', () => {
+	const blockedSites: number[] = [];
+	const getBlockedSites = jest.fn( () => blockedSites );
+	return { getBlockedSites };
+} );
 
 const mockUseInfiniteStream = useInfiniteStream as jest.Mock;
 
@@ -44,6 +51,7 @@ function makeSpace( id: string, name: string, view: SpaceFeedLayout ): ReadSpace
 }
 
 const WORK = makeSpace( 'work-id', 'Work', 'standard-list' );
+const BASE = 'https://public-api.wordpress.com';
 
 function render( space: ReadSpaceDetails ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
@@ -60,6 +68,8 @@ describe( 'SpaceFeed', () => {
 		window.history.replaceState( {}, '', '/reader/spaces/work-id' );
 		mockUseInfiniteStream.mockReturnValue( streamResult() );
 	} );
+
+	afterEach( () => nock.cleanAll() );
 
 	it( 'shows the loading state while the stream loads', () => {
 		mockUseInfiniteStream.mockReturnValue( streamResult( { isLoading: true } ) );
@@ -81,10 +91,57 @@ describe( 'SpaceFeed', () => {
 		expect( refetch ).toHaveBeenCalled();
 	} );
 
+	it( 'shows an error with a retry when the space detail fails to load', async () => {
+		const user = userEvent.setup();
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		nock( BASE ).get( `/wpcom/v2/reader/spaces/${ WORK.id }` ).reply( 500, {} );
+		nock( BASE ).get( `/wpcom/v2/reader/spaces/${ WORK.id }` ).reply( 200, {
+			id: WORK.id,
+			title: WORK.name,
+			layout: WORK.layout,
+			follows: [],
+			tags: [],
+		} );
+
+		renderWithProvider( <SpaceFeed spaceId={ WORK.id } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		expect( await screen.findByText( 'Couldn’t load this feed' ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		await waitFor( () =>
+			expect( screen.queryByText( 'Couldn’t load this feed' ) ).not.toBeInTheDocument()
+		);
+		expect( await screen.findByText( 'Nothing here yet' ) ).toBeVisible();
+	} );
+
 	it( 'shows the empty state when the stream has no posts', () => {
 		render( WORK );
 
 		expect( screen.getByText( 'Nothing here yet' ) ).toBeVisible();
+	} );
+
+	it( 'shows the empty state for the legacy layout when the legacy stream has no posts', () => {
+		render( makeSpace( 'work-id', 'Work', 'legacy' ) );
+
+		expect( screen.getByText( 'Nothing here yet' ) ).toBeVisible();
+	} );
+
+	it( 'shows an error with a retry for the legacy layout when the legacy stream fails', async () => {
+		const user = userEvent.setup();
+		const refetch = jest.fn();
+		mockUseInfiniteStream.mockReturnValue(
+			streamResult( { error: new Error( 'boom' ), refetch } )
+		);
+
+		render( makeSpace( 'work-id', 'Work', 'legacy' ) );
+
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		expect( refetch ).toHaveBeenCalled();
 	} );
 
 	it( 'shows the loading-more skeleton while the next page is fetching', () => {

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useInfiniteStream } from 'calypso/reader/data/stream';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import { SpaceFeed } from '../index';
+import { SpaceFeed, collectPosts } from '../index';
 import type {
 	ReadSpaceDetails,
 	ReadStreamPost,
@@ -166,5 +166,29 @@ describe( 'SpaceFeed', () => {
 		render( WORK );
 
 		expect( screen.queryByText( 'Loading more posts…' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'collectPosts', () => {
+	it( 'prefers post cards over the legacy posts field when both are present', () => {
+		const postFromPosts = {
+			ID: 1,
+			site_ID: 2,
+			title: 'posts field',
+		} as unknown as ReadStreamPost;
+		const postFromCard = {
+			ID: 2,
+			site_ID: 3,
+			title: 'card field',
+		} as unknown as ReadStreamPost;
+
+		expect(
+			collectPosts( [
+				{
+					posts: [ postFromPosts ],
+					cards: [ { type: 'post', data: postFromCard }, { type: 'recommendation' } ],
+				} as unknown as ReadStreamResponse,
+			] )
+		).toEqual( [ postFromCard ] );
 	} );
 } );

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+import { readSpaceQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useInfiniteStream } from 'calypso/reader/data/stream';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SpaceFeed } from '../index';
+import type {
+	ReadSpaceDetails,
+	ReadStreamPost,
+	ReadStreamResponse,
+	SpaceFeedLayout,
+} from '@automattic/api-core';
+
+jest.mock( 'calypso/reader/data/stream', () => ( {
+	useInfiniteStream: jest.fn(),
+} ) );
+
+const mockUseInfiniteStream = useInfiniteStream as jest.Mock;
+
+function streamResult( overrides: Partial< ReturnType< typeof useInfiniteStream > > = {} ) {
+	return {
+		items: [],
+		pages: [],
+		isLoading: false,
+		isFetching: false,
+		isFetchingNextPage: false,
+		isRefetching: false,
+		hasNextPage: false,
+		lastPage: true,
+		error: null,
+		fetchNextPage: jest.fn(),
+		refetch: jest.fn(),
+		invalidate: jest.fn(),
+		...overrides,
+	};
+}
+
+function makeSpace( id: string, name: string, view: SpaceFeedLayout ): ReadSpaceDetails {
+	return { id, name, tags: [], layout: { color: 'blue', icon: 'inbox', view }, sources: [] };
+}
+
+const WORK = makeSpace( 'work-id', 'Work', 'standard-list' );
+
+function render( space: ReadSpaceDetails ) {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	queryClient.setQueryData( readSpaceQuery( space.id ).queryKey, space );
+
+	return renderWithProvider( <SpaceFeed spaceId={ space.id } />, {
+		queryClient,
+		initialState: { currentUser: { id: 1 } },
+	} );
+}
+
+describe( 'SpaceFeed', () => {
+	beforeEach( () => {
+		window.history.replaceState( {}, '', '/reader/spaces/work-id' );
+		mockUseInfiniteStream.mockReturnValue( streamResult() );
+	} );
+
+	it( 'shows the loading state while the stream loads', () => {
+		mockUseInfiniteStream.mockReturnValue( streamResult( { isLoading: true } ) );
+		render( WORK );
+
+		expect( screen.getByText( 'Loading the feed…' ) ).toBeVisible();
+	} );
+
+	it( 'shows an error with a retry that refetches the stream', async () => {
+		const user = userEvent.setup();
+		const refetch = jest.fn();
+		mockUseInfiniteStream.mockReturnValue(
+			streamResult( { error: new Error( 'boom' ), refetch } )
+		);
+		render( WORK );
+
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		expect( refetch ).toHaveBeenCalled();
+	} );
+
+	it( 'shows the empty state when the stream has no posts', () => {
+		render( WORK );
+
+		expect( screen.getByText( 'Nothing here yet' ) ).toBeVisible();
+	} );
+
+	it( 'shows the loading-more skeleton while the next page is fetching', () => {
+		const post = { ID: 1, site_ID: 2, site_name: 'Work blog' } as unknown as ReadStreamPost;
+		mockUseInfiniteStream.mockReturnValue(
+			streamResult( {
+				pages: [ { posts: [ post ] } as unknown as ReadStreamResponse ],
+				hasNextPage: true,
+				isFetchingNextPage: true,
+			} )
+		);
+		render( WORK );
+
+		expect( screen.getByText( 'Loading more posts…' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the loading-more skeleton when no page is fetching', () => {
+		const post = { ID: 1, site_ID: 2, site_name: 'Work blog' } as unknown as ReadStreamPost;
+		mockUseInfiniteStream.mockReturnValue(
+			streamResult( { pages: [ { posts: [ post ] } as unknown as ReadStreamResponse ] } )
+		);
+		render( WORK );
+
+		expect( screen.queryByText( 'Loading more posts…' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/reader/spaces/feed/test/post-fields.test.ts
+++ b/client/reader/spaces/feed/test/post-fields.test.ts
@@ -35,6 +35,22 @@ describe( 'getPostFields', () => {
 		expect( getPostFields( post ).postHref ).toBe( '/reader/blogs/20/posts/7' );
 	} );
 
+	it( 'keys posts by the Reader compound identity, not just post id', () => {
+		const first = {
+			ID: 7,
+			site_ID: 20,
+			title: 'First',
+		} as unknown as ReadStreamPost;
+		const second = {
+			ID: 7,
+			site_ID: 21,
+			title: 'Second',
+		} as unknown as ReadStreamPost;
+
+		expect( getPostFields( first ).key ).toBe( 'blog-7-20' );
+		expect( getPostFields( second ).key ).toBe( 'blog-7-21' );
+	} );
+
 	it( 'reads the image from canonical_media and the author name', () => {
 		const post = {
 			ID: 1,

--- a/client/reader/spaces/feed/test/post-fields.test.ts
+++ b/client/reader/spaces/feed/test/post-fields.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getPostFields } from '../post-fields';
+import type { ReadStreamPost } from '@automattic/api-core';
+
+describe( 'getPostFields', () => {
+	it( 'links an external feed post to its reader feed-post page', () => {
+		const post = {
+			ID: 5,
+			feed_ID: 10,
+			feed_item_ID: 99,
+			is_external: true,
+			title: 'Hello',
+			site_name: 'Example Blog',
+			is_seen: false,
+		} as unknown as ReadStreamPost;
+
+		const fields = getPostFields( post );
+
+		expect( fields.postHref ).toBe( '/reader/feeds/10/posts/99' );
+		expect( fields.title ).toBe( 'Hello' );
+		expect( fields.sourceName ).toBe( 'Example Blog' );
+		expect( fields.isUnread ).toBe( true );
+	} );
+
+	it( 'links a blog post to its reader blog-post page', () => {
+		const post = {
+			ID: 7,
+			site_ID: 20,
+			title: 'A post',
+			site_name: 'Site',
+		} as unknown as ReadStreamPost;
+
+		expect( getPostFields( post ).postHref ).toBe( '/reader/blogs/20/posts/7' );
+	} );
+
+	it( 'reads the image from canonical_media and the author name', () => {
+		const post = {
+			ID: 1,
+			site_ID: 2,
+			canonical_media: { src: 'https://example.com/a.jpg', mediaType: 'image' },
+			author: { name: 'Ada' },
+		} as unknown as ReadStreamPost;
+
+		const fields = getPostFields( post );
+
+		expect( fields.imageUrl ).toBe( 'https://example.com/a.jpg' );
+		expect( fields.authorName ).toBe( 'Ada' );
+	} );
+
+	it( 'returns sanitized excerpt HTML whose text decodes entities', () => {
+		const post = {
+			ID: 1,
+			site_ID: 2,
+			excerpt: '<p>Latin, Asian Pop and R&amp;B genres, including the Best&hellip;</p>',
+		} as unknown as ReadStreamPost;
+
+		const { excerptHtml } = getPostFields( post );
+		// Renders as HTML (not escaped), so the displayed text decodes entities.
+		const host = document.createElement( 'div' );
+		host.innerHTML = excerptHtml;
+		expect( host.textContent ).toBe( 'Latin, Asian Pop and R&B genres, including the Best…' );
+	} );
+
+	it( 'reads the blog icon from site_icon.ico', () => {
+		const post = {
+			ID: 1,
+			site_ID: 2,
+			site_icon: { ico: 'https://example.com/blavatar.ico' },
+		} as unknown as ReadStreamPost;
+
+		expect( getPostFields( post ).siteIconUrl ).toBe( 'https://example.com/blavatar.ico' );
+	} );
+} );

--- a/client/reader/spaces/feed/test/post-fields.test.ts
+++ b/client/reader/spaces/feed/test/post-fields.test.ts
@@ -63,6 +63,21 @@ describe( 'getPostFields', () => {
 		expect( host.textContent ).toBe( 'Latin, Asian Pop and R&B genres, including the Best…' );
 	} );
 
+	it( 'decodes HTML entities in the plain-text title, source and author', () => {
+		const post = {
+			ID: 1,
+			site_ID: 2,
+			title: 'Pre-Order Reveal&nbsp;: GTA&nbsp;6',
+			site_name: 'Kendall Lacey&#039;s Webworld',
+			author: { name: 'A &amp; B' },
+		} as unknown as ReadStreamPost;
+
+		const fields = getPostFields( post );
+		expect( fields.title ).toBe( 'Pre-Order Reveal : GTA 6' );
+		expect( fields.sourceName ).toBe( "Kendall Lacey's Webworld" );
+		expect( fields.authorName ).toBe( 'A & B' );
+	} );
+
 	it( 'reads the blog icon from site_icon.ico', () => {
 		const post = {
 			ID: 1,

--- a/client/reader/spaces/style.scss
+++ b/client/reader/spaces/style.scss
@@ -1,3 +1,8 @@
 // Placeholder stylesheet for the Spaces entry point. The full layout arrives
 // with the v0 Spaces work that builds on this foundation; no rules are needed
 // yet, but the file (and its import) stay so styles have a home to land in.
+
+.reader-spaces__section-label {
+	color: var( --color-text-subtle );
+	font-weight: 400;
+}

--- a/client/reader/spaces/test/view.test.tsx
+++ b/client/reader/spaces/test/view.test.tsx
@@ -20,6 +20,12 @@ jest.mock( 'calypso/components/data/document-head', () => ( {
 	default: () => null,
 } ) );
 
+// The feed loads a live Reader stream; this view test only covers the header and
+// sources modal, so stub it out to keep the test off the network.
+jest.mock( 'calypso/reader/spaces/feed', () => ( {
+	SpaceFeed: () => null,
+} ) );
+
 jest.mock( '@automattic/react-virtualized', () => ( {
 	AutoSizer: ( {
 		children,

--- a/client/reader/spaces/view.tsx
+++ b/client/reader/spaces/view.tsx
@@ -1,13 +1,17 @@
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { useSpaces } from 'calypso/reader/data/spaces';
+import { CustomizeModal } from 'calypso/reader/spaces/customize-modal';
+import { SpaceFeed } from 'calypso/reader/spaces/feed';
 import { SourcesModal } from 'calypso/reader/spaces/sources-modal';
 import { getManageSourcesPath, getSpacePath, MANAGE_SOURCES_HASH } from './routes';
+
+import './style.scss';
 
 interface Props {
 	id?: string;
@@ -20,7 +24,18 @@ export function SpacesView( { id }: Props ) {
 	const spaces = useSpaces();
 	const space = id ? spaces.find( ( item ) => item.id === id ) : undefined;
 	const title = space ? space.name : translate( 'Spaces' );
+	// POC: the space feed currently shows the discover content, so label it as such
+	// after the space name in the header.
+	const headerTitle = space ? (
+		<>
+			{ space.name }{ ' ' }
+			<span className="reader-spaces__section-label">{ translate( 'Discover' ) }</span>
+		</>
+	) : (
+		title
+	);
 	const [ hash, setHash ] = useState( getCurrentHash );
+	const [ isCustomizeOpen, setIsCustomizeOpen ] = useState( false );
 	const shouldShowSourcesModal = Boolean( id && space && hash === MANAGE_SOURCES_HASH );
 
 	useEffect( () => {
@@ -57,13 +72,28 @@ export function SpacesView( { id }: Props ) {
 					textOnly: true,
 				} ) }
 			/>
-			<NavigationHeader title={ title }>
+			<NavigationHeader title={ headerTitle }>
 				{ space ? (
-					<Button __next40pxDefaultSize variant="secondary" onClick={ handleManageSources }>
-						{ translate( 'Manage sources' ) }
-					</Button>
+					<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => setIsCustomizeOpen( true ) }
+						>
+							{ translate( 'Customize' ) }
+						</Button>
+						<Button __next40pxDefaultSize variant="secondary" onClick={ handleManageSources }>
+							{ translate( 'Manage sources' ) }
+						</Button>
+					</HStack>
 				) : null }
 			</NavigationHeader>
+			{ id && space ? <SpaceFeed spaceId={ id } /> : null }
+			<CustomizeModal
+				isOpen={ isCustomizeOpen }
+				spaceId={ id ?? null }
+				onClose={ () => setIsCustomizeOpen( false ) }
+			/>
 			<SourcesModal
 				isOpen={ shouldShowSourcesModal }
 				spaceId={ id ?? null }

--- a/client/reader/stream/stream-v2.tsx
+++ b/client/reader/stream/stream-v2.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { INITIAL_FETCH, PER_FETCH, useInfiniteStream } from 'calypso/reader/data/stream';
@@ -52,10 +54,12 @@ export function ReaderStreamV2( {
 	className,
 	restoreKey,
 }: ReaderStreamV2Props ) {
+	const translate = useTranslate();
 	const blockedSites = useSelector( getBlockedSites );
-	const { items, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteStream( {
-		streamKey,
-	} );
+	const { items, isLoading, error, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } =
+		useInfiniteStream( {
+			streamKey,
+		} );
 
 	// Open the full-post view on click, mirroring the classic stream. `showSelectedPost`
 	// returns a thunk that navigates via the router (no Redux dispatch needed), so we
@@ -101,6 +105,28 @@ export function ReaderStreamV2( {
 				{ Array.from( { length: INITIAL_FETCH } ).map( ( _, index ) => (
 					<PostPlaceholder key={ `placeholder-${ index }` } />
 				) ) }
+			</div>
+		);
+	}
+
+	if ( error && items.length === 0 ) {
+		return (
+			<div className="space-feed__status">
+				<p className="space-feed__status-title">{ translate( 'Couldn’t load this feed' ) }</p>
+				<Button variant="secondary" onClick={ refetch }>
+					{ translate( 'Try again' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	if ( items.length === 0 ) {
+		return (
+			<div className="space-feed__status">
+				<p className="space-feed__status-title">{ translate( 'Nothing here yet' ) }</p>
+				<p className="space-feed__status-line">
+					{ translate( 'Posts from this space’s sources will show up here.' ) }
+				</p>
 			</div>
 		);
 	}

--- a/client/reader/stream/stream-v2.tsx
+++ b/client/reader/stream/stream-v2.tsx
@@ -1,0 +1,141 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { INITIAL_FETCH, PER_FETCH, useInfiniteStream } from 'calypso/reader/data/stream';
+import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { keyToString } from 'calypso/reader/post-key';
+import { showSelectedPost } from 'calypso/reader/utils';
+import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
+import PostLifecycleUntyped from './post-lifecycle';
+import PostPlaceholderUntyped from './post-placeholder';
+import type { StreamItem } from 'calypso/reader/data/stream/types';
+import type { ComponentType } from 'react';
+
+// The card calls this when a post (or its comment button) is clicked.
+type PostClickArgs = { comments?: boolean };
+
+// `post-lifecycle` / `post-placeholder` are untyped legacy JSX. Describe only the
+// props this stream passes; PostLifecycle fetches its own post (useCachedPost) and
+// dispatches its own analytics, so it works standalone with Calypso's providers.
+const PostLifecycle = PostLifecycleUntyped as ComponentType< {
+	postKey: StreamItem;
+	streamKey: string;
+	blockedSites: number[];
+	index: number;
+	handleClick: ( args?: PostClickArgs ) => void;
+} >;
+const PostPlaceholder = PostPlaceholderUntyped as ComponentType;
+
+// Average rendered post-card height; the virtualizer measures the real size after mount.
+const GUESSED_POST_HEIGHT = 600;
+
+interface ReaderStreamV2Props {
+	streamKey: string;
+	/** The scrollable container (passed as state so the virtualizer re-evaluates once it mounts). */
+	scrollElement: HTMLElement | null;
+	className?: string;
+	restoreKey?: string;
+}
+
+/**
+ * ⚠️ EXPERIMENTAL / UNSTABLE — built for the Spaces feed proof-of-concept on the
+ * experimental `useInfiniteList` engine; not yet a stable replacement for the
+ * classic stream. The API may change without notice.
+ *
+ * A slim, hook-based Reader stream: `useInfiniteStream` for data + `useInfiniteList`
+ * for windowing + the existing `PostLifecycle` for per-post rendering. The modern
+ * replacement for the legacy Redux + `<InfiniteList>` stream, used first by the
+ * Spaces "legacy" feed layout.
+ */
+export function ReaderStreamV2( {
+	streamKey,
+	scrollElement,
+	className,
+	restoreKey,
+}: ReaderStreamV2Props ) {
+	const blockedSites = useSelector( getBlockedSites );
+	const { items, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteStream( {
+		streamKey,
+	} );
+
+	// Open the full-post view on click, mirroring the classic stream. `showSelectedPost`
+	// returns a thunk that navigates via the router (no Redux dispatch needed), so we
+	// invoke it directly with the clicked item's post key.
+	const openPost = useCallback( ( postKey: StreamItem, comments?: boolean ) => {
+		showSelectedPost( {
+			postKey: {
+				blogId: postKey.blogId ? Number( postKey.blogId ) : undefined,
+				feedId: postKey.feedId ? Number( postKey.feedId ) : undefined,
+				postId: Number( postKey.postId ),
+			},
+			comments,
+		} )();
+	}, [] );
+
+	// While a next page loads, append PER_FETCH skeleton rows at the tail (v1 showed
+	// these via InfiniteList's renderLoadingPlaceholders). Indices past the real
+	// items have no post, so they render a <PostPlaceholder/>.
+	const trailingSkeletons = isFetchingNextPage && hasNextPage ? PER_FETCH : 0;
+	const count = items.length + trailingSkeletons;
+
+	const {
+		getListProps,
+		items: virtualItems,
+		measureElement,
+		scrollMargin,
+	} = useInfiniteList( {
+		scrollElement,
+		count,
+		estimateSize: GUESSED_POST_HEIGHT,
+		getItemKey: ( index ) =>
+			index < items.length ? keyToString( items[ index ] ) ?? index : `placeholder-${ index }`,
+		overscan: 3,
+		hasMore: hasNextPage,
+		isLoadingMore: isFetchingNextPage,
+		loadMore: fetchNextPage,
+		restoreKey,
+	} );
+
+	if ( isLoading && items.length === 0 ) {
+		return (
+			<div className={ className }>
+				{ Array.from( { length: INITIAL_FETCH } ).map( ( _, index ) => (
+					<PostPlaceholder key={ `placeholder-${ index }` } />
+				) ) }
+			</div>
+		);
+	}
+
+	return (
+		<div { ...getListProps( { className } ) }>
+			{ virtualItems.map( ( virtualItem ) => (
+				<div
+					key={ virtualItem.key }
+					data-index={ virtualItem.index }
+					ref={ measureElement }
+					style={ {
+						position: 'absolute',
+						insetInlineStart: 0,
+						inlineSize: '100%',
+						transform: `translateY(${ virtualItem.start - scrollMargin }px)`,
+					} }
+				>
+					{ virtualItem.index < items.length ? (
+						<PostLifecycle
+							postKey={ items[ virtualItem.index ] }
+							streamKey={ streamKey }
+							blockedSites={ blockedSites }
+							index={ virtualItem.index }
+							handleClick={ ( args?: PostClickArgs ) =>
+								openPost( items[ virtualItem.index ], args?.comments )
+							}
+						/>
+					) : (
+						<PostPlaceholder />
+					) }
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+export default ReaderStreamV2;

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
 		"@automattic/zendesk-client": "workspace:^",
 		"@gravatar-com/quick-editor": "^0.8.0",
 		"@paypal/react-paypal-js": "^8.7.0",
+		"@tanstack/react-virtual": "^3.13.0",
 		"@types/cookie": "^0.6.0",
 		"@types/debug": "^4.1.12",
 		"@types/fast-json-stable-stringify": "^2.0.0",

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -35,6 +35,7 @@ describe( 'read spaces adapters', () => {
 			);
 
 			expect( layout ).toEqual( { color: 'celadon', icon: 'star' } );
+			expect( layout ).not.toHaveProperty( 'view' );
 		} );
 
 		it( 'passes through the optional feed layout view when present', () => {

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -37,6 +37,14 @@ describe( 'read spaces adapters', () => {
 			expect( layout ).toEqual( { color: 'celadon', icon: 'star' } );
 		} );
 
+		it( 'passes through the optional feed layout view when present', () => {
+			const { layout } = adaptReadSpace(
+				wireSpace( { layout: { color: 'celadon', icon: 'star', view: 'gallery' } } )
+			);
+
+			expect( layout ).toEqual( { color: 'celadon', icon: 'star', view: 'gallery' } );
+		} );
+
 		it( 'carries neither sources nor tags on the summary shape', () => {
 			const summary = adaptReadSpace( wireSpace() );
 			expect( summary ).not.toHaveProperty( 'sources' );

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -33,7 +33,9 @@ export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
 	return {
 		id: String( item.id ),
 		name: item.title,
-		layout: { color: item.layout.color, icon: item.layout.icon },
+		// `view` is forward-looking: the API does not return it yet (stays
+		// `undefined`), but mapping it now means it flows through once it does.
+		layout: { color: item.layout.color, icon: item.layout.icon, view: item.layout.view },
 	};
 }
 

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -30,12 +30,16 @@ export interface ReadSpaceApiItem {
 
 /** Map a wpcom/v2 summary item onto the client `ReadSpace` (list) shape. */
 export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
+	const layout: SpaceLayout = { color: item.layout.color, icon: item.layout.icon };
+	if ( item.layout.view ) {
+		layout.view = item.layout.view;
+	}
 	return {
 		id: String( item.id ),
 		name: item.title,
 		// `view` is forward-looking: the API does not return it yet (stays
 		// `undefined`), but mapping it now means it flows through once it does.
-		layout: { color: item.layout.color, icon: item.layout.icon, view: item.layout.view },
+		layout,
 	};
 }
 

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -22,12 +22,23 @@ export type SpaceIcon =
 	| 'category';
 
 /**
+ * How a space renders its feed. Each value selects a distinct list geometry —
+ * `standard-list` (dense vertical list), `magazine` (large vertical cards),
+ * `gallery` (grid), `board` (masonry), `legacy` (the classic Reader stream:
+ * InfiniteList + post cards). Unset falls back to `standard-list`.
+ */
+export type SpaceFeedLayout = 'standard-list' | 'magazine' | 'gallery' | 'board' | 'legacy';
+
+/**
  * Presentation settings for a space, grouped so they can grow beyond color and
  * icon (e.g. cover image, sort order) without widening `ReadSpace` itself.
  */
 export interface SpaceLayout {
 	color: SpaceColor;
 	icon: SpaceIcon;
+	// Which feed layout to render. The API does not persist this yet, so the
+	// Customize modal writes it optimistically into the React Query cache.
+	view?: SpaceFeedLayout;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -8806,6 +8806,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.13.0":
+  version: 3.14.2
+  resolution: "@tanstack/react-virtual@npm:3.14.2"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.17.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 6d42161f17fc037663270d68d14340e8d2561bd1b8ea17c295477adf99fa6d5ba4e4cde2ee050047c673217f7f71db92749159d25885530de1c78ca18ef6536d
+  languageName: node
+  linkType: hard
+
 "@tanstack/router-core@npm:1.114.33":
   version: 1.114.33
   resolution: "@tanstack/router-core@npm:1.114.33"
@@ -8821,6 +8833,13 @@ __metadata:
   version: 0.7.7
   resolution: "@tanstack/store@npm:0.7.7"
   checksum: bf90fa957bd97336d7dbc0d7b87379b5fe4baea030efef8a93fe4e49ac1c8bc929247d1a9f84b16a1642e386b67fe53be14df8d5415efdf85f83733ccdf8877a
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.17.0":
+  version: 3.17.0
+  resolution: "@tanstack/virtual-core@npm:3.17.0"
+  checksum: 313c5762343ad93ec0569b528c111a43f9615acc572293a71efc6dcf94ff9d791c97f1ada32b7dfbda79ed7d472834b14315ebe54d74b0221224732e501def6f
   languageName: node
   linkType: hard
 
@@ -33703,6 +33722,7 @@ __metadata:
     "@signal-noise/stylelint-scales": "npm:^2.0.3"
     "@storybook/react": "npm:^9.1.20"
     "@tanstack/eslint-plugin-query": "npm:^5.100.0"
+    "@tanstack/react-virtual": "npm:^3.13.0"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@types/chroma-js": "npm:^2.4.5"
     "@types/cookie": "npm:^0.6.0"


### PR DESCRIPTION
Part of RSM-4148.

## Proposed Changes

- Add an experimental `useInfiniteList` engine for Reader feeds using TanStack Virtual, including scroll margin handling, infinite loading, scroll restoration, and focused regression coverage.
- Add `ReaderStreamV2` and a Spaces feed shell that derives the feed from a Space detail query, renders Discover content for the Space tags, and supports List, Magazine, Gallery, Board, and Legacy layouts.
- Add a Customize modal for session-only layout selection, plus API-core adapter/type coverage for the forward-compatible `layout.view` field.
- Address review findings around compound Reader post keys, Space detail errors, Legacy empty/error states, standard-list scroll restoration, pending detail saves, and deprecated `@automattic/components` usage in the new Reader feed layouts.

## Why are these changes being made?

This is a proof of concept for replacing the legacy Reader `InfiniteList` path with a hook-based, layout-aware virtualization model. Spaces provides a contained surface for validating the data flow, layout switching, and scroll behavior before productionizing the broader Reader feed experience.

Known follow-up work remains tracked separately in RSM-4440, including production tabs, Feed tab content, recommendation injection, and API persistence for `layout.view`. RSM-4427 tracks the last-item skeleton flash.

## Testing Instructions

### Scenario 1 - Space feed loads:
- Go to `/reader/spaces/:id` with the `reader/spaces` feature flag enabled.
- Check if you can see the Space name in the header, the `Discover` label, and feed posts after the loading state clears.

### Scenario 2 - Layout switching:
- Go to `/reader/spaces/:id`.
- Check if clicking **Customize**, choosing each layout option, and saving changes the feed layout without leaving the page.

### Scenario 3 - Legacy layout states:
- Go to `/reader/spaces/:id`.
- Check if choosing **Legacy** in **Customize** shows the classic Reader-style feed, and empty/error states show visible recovery or empty-state UI instead of a blank feed.

### Scenario 4 - Infinite scroll:
- Go to `/reader/spaces/:id`.
- Check if scrolling near the bottom loads more feed content while keeping the page responsive.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
