### PR TITLE
Subscribers: route the sidebar link to wp-admin for 10% of simple sites

### DIFF
--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -6,7 +6,7 @@ import { isP2Theme } from 'calypso/lib/site/utils';
 import { getAdminMenuGroups } from 'calypso/state/admin-menu/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, isJetpackSite, isSimpleSite } from 'calypso/state/sites/selectors';
 import {
 	getSidebarIsCollapsed,
 	getSelectedSiteId,
@@ -25,6 +25,10 @@ import {
 	isAdminSidebarDevMockActive,
 } from './utils/admin-sidebar-dev-mock';
 import groupMenuItems from './utils/group-menu-items';
+import {
+	isSiteInSubscribersWpAdminLinkBucket,
+	rewriteSubscribersMenuLink,
+} from './utils/subscribers-wp-admin-link';
 import 'calypso/state/admin-menu/init';
 import 'calypso/state/admin-sidebar/expand-state/init';
 import 'calypso/state/admin-sidebar/layout/init';
@@ -66,9 +70,28 @@ function MySitesSidebarUnifiedBodyContent( {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
 	const groups = useSelector( ( state ) => getAdminMenuGroups( state, siteId ) );
+
+	// Roll out the wp-admin Subscribers page to ~10% of simple sites: point the
+	// sidebar "Subscribers" link at the Jetpack Subscribers wp-admin screen
+	// instead of the Calypso route. Deterministic per site id, so the link is
+	// stable across loads. Jetpack/Atomic sites are untouched.
+	const subscribersWpAdminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-subscribers' )
+	);
+	const isSimpleSiteSelected = useSelector( ( state ) => isSimpleSite( state, siteId ) );
+	const shouldUseWpAdminSubscribersLink =
+		isSimpleSiteSelected &&
+		isSiteInSubscribersWpAdminLinkBucket( siteId ) &&
+		!! subscribersWpAdminUrl;
+
 	const transformBaseMenu = useCallback(
-		( baseMenu ) => applyAdminSidebarDevMock( baseMenu, groups ).menuItems,
-		[ groups ]
+		( baseMenu ) => {
+			const menuItems = applyAdminSidebarDevMock( baseMenu, groups ).menuItems;
+			return shouldUseWpAdminSubscribersLink
+				? rewriteSubscribersMenuLink( menuItems, subscribersWpAdminUrl )
+				: menuItems;
+		},
+		[ groups, shouldUseWpAdminSubscribersLink, subscribersWpAdminUrl ]
 	);
 	const menuItems = useSiteMenuItems( workingDelta, transformBaseMenu );
 	const isP2Site =

--- a/client/my-sites/sidebar/utils/subscribers-wp-admin-link.ts
+++ b/client/my-sites/sidebar/utils/subscribers-wp-admin-link.ts
@@ -1,0 +1,66 @@
+import type { AdminMenuItem } from 'calypso/state/admin-menu/types';
+
+/**
+ * The slug the admin-menu API (and the static fallback) use for the
+ * "Subscribers" sidebar item. It lives as a submenu-item under "Users".
+ */
+const SUBSCRIBERS_SLUG = 'subscribers';
+
+/**
+ * Rollout cohort size. `1 / SUBSCRIBERS_WP_ADMIN_LINK_BUCKET_SIZE` of sites land
+ * in the bucket — i.e. `10` ≈ 10% of sites.
+ */
+export const SUBSCRIBERS_WP_ADMIN_LINK_BUCKET_SIZE = 10;
+
+/**
+ * Deterministic ~10% cohort keyed on the site (blog) id. The same site always
+ * resolves to the same answer, so the sidebar link never flips between loads.
+ * @param siteId The selected site id.
+ * @returns Whether the site is in the wp-admin Subscribers link cohort.
+ */
+export function isSiteInSubscribersWpAdminLinkBucket( siteId: number | null | undefined ): boolean {
+	return (
+		Number.isInteger( siteId ) && ( siteId as number ) % SUBSCRIBERS_WP_ADMIN_LINK_BUCKET_SIZE === 0
+	);
+}
+
+/**
+ * Returns a copy of the menu tree with the "Subscribers" item's URL rewritten
+ * to `wpAdminUrl`. Recurses into `children` because Subscribers is nested under
+ * the "Users" menu. When no Subscribers item is present the input is returned
+ * unchanged.
+ * @param menuItems The base menu items (API response or static fallback).
+ * @param wpAdminUrl The absolute wp-admin URL to point Subscribers at.
+ * @returns The (possibly) rewritten menu items.
+ */
+export function rewriteSubscribersMenuLink(
+	menuItems: readonly AdminMenuItem[] | null | undefined,
+	wpAdminUrl: string
+): AdminMenuItem[] {
+	if ( ! Array.isArray( menuItems ) ) {
+		return [];
+	}
+
+	let changed = false;
+	const rewritten = menuItems.map( ( item ) => {
+		const children = Array.isArray( item.children )
+			? rewriteSubscribersMenuLink( item.children, wpAdminUrl )
+			: item.children;
+
+		const childrenChanged = children !== item.children;
+		const isSubscribers = item.slug === SUBSCRIBERS_SLUG && item.url !== wpAdminUrl;
+
+		if ( ! isSubscribers && ! childrenChanged ) {
+			return item;
+		}
+
+		changed = true;
+		return {
+			...item,
+			children,
+			...( isSubscribers ? { url: wpAdminUrl } : {} ),
+		};
+	} );
+
+	return changed ? rewritten : menuItems.slice();
+}

--- a/client/my-sites/sidebar/utils/test/subscribers-wp-admin-link.ts
+++ b/client/my-sites/sidebar/utils/test/subscribers-wp-admin-link.ts
@@ -1,0 +1,88 @@
+import {
+	isSiteInSubscribersWpAdminLinkBucket,
+	rewriteSubscribersMenuLink,
+} from '../subscribers-wp-admin-link';
+import type { AdminMenuItem } from 'calypso/state/admin-menu/types';
+
+const WP_ADMIN_URL = 'https://example.com/wp-admin/admin.php?page=jetpack-subscribers';
+
+const buildMenu = (): AdminMenuItem[] => [
+	{ slug: 'home', title: 'Home', type: 'menu-item', url: '/home/example.com' },
+	{
+		slug: 'users-php',
+		title: 'Users',
+		type: 'menu-item',
+		url: '/people/team/example.com',
+		children: [
+			{
+				slug: 'users-all-people',
+				title: 'All Users',
+				type: 'submenu-item',
+				url: '/people/team/example.com',
+			},
+			{
+				slug: 'subscribers',
+				title: 'Subscribers',
+				type: 'submenu-item',
+				url: '/subscribers/example.com',
+			},
+		],
+	},
+];
+
+describe( 'isSiteInSubscribersWpAdminLinkBucket()', () => {
+	it( 'includes ~10% of sites keyed on the site id', () => {
+		expect( isSiteInSubscribersWpAdminLinkBucket( 10 ) ).toBe( true );
+		expect( isSiteInSubscribersWpAdminLinkBucket( 120 ) ).toBe( true );
+		expect( isSiteInSubscribersWpAdminLinkBucket( 11 ) ).toBe( false );
+		expect( isSiteInSubscribersWpAdminLinkBucket( 7 ) ).toBe( false );
+	} );
+
+	it( 'is deterministic for a given site id', () => {
+		expect( isSiteInSubscribersWpAdminLinkBucket( 30 ) ).toBe(
+			isSiteInSubscribersWpAdminLinkBucket( 30 )
+		);
+	} );
+
+	it( 'returns false for non-integer ids', () => {
+		expect( isSiteInSubscribersWpAdminLinkBucket( null ) ).toBe( false );
+		expect( isSiteInSubscribersWpAdminLinkBucket( undefined ) ).toBe( false );
+		expect( isSiteInSubscribersWpAdminLinkBucket( 10.5 ) ).toBe( false );
+	} );
+} );
+
+describe( 'rewriteSubscribersMenuLink()', () => {
+	it( 'rewrites the nested Subscribers item URL', () => {
+		const result = rewriteSubscribersMenuLink( buildMenu(), WP_ADMIN_URL );
+		const subscribers = result[ 1 ].children?.find( ( item ) => item.slug === 'subscribers' );
+		expect( subscribers?.url ).toBe( WP_ADMIN_URL );
+	} );
+
+	it( 'leaves every other item untouched', () => {
+		const result = rewriteSubscribersMenuLink( buildMenu(), WP_ADMIN_URL );
+		expect( result[ 0 ].url ).toBe( '/home/example.com' );
+		expect( result[ 1 ].url ).toBe( '/people/team/example.com' );
+		const allUsers = result[ 1 ].children?.find( ( item ) => item.slug === 'users-all-people' );
+		expect( allUsers?.url ).toBe( '/people/team/example.com' );
+	} );
+
+	it( 'returns the input unchanged when there is no Subscribers item', () => {
+		const menu: AdminMenuItem[] = [
+			{ slug: 'home', title: 'Home', type: 'menu-item', url: '/home/example.com' },
+		];
+		const result = rewriteSubscribersMenuLink( menu, WP_ADMIN_URL );
+		expect( result ).toEqual( menu );
+	} );
+
+	it( 'is a no-op when the Subscribers item already points at the wp-admin URL', () => {
+		const menu = rewriteSubscribersMenuLink( buildMenu(), WP_ADMIN_URL );
+		const again = rewriteSubscribersMenuLink( menu, WP_ADMIN_URL );
+		const subscribers = again[ 1 ].children?.find( ( item ) => item.slug === 'subscribers' );
+		expect( subscribers?.url ).toBe( WP_ADMIN_URL );
+	} );
+
+	it( 'returns an empty array for non-array input', () => {
+		expect( rewriteSubscribersMenuLink( null, WP_ADMIN_URL ) ).toEqual( [] );
+		expect( rewriteSubscribersMenuLink( undefined, WP_ADMIN_URL ) ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* Route the sidebar **Subscribers** link to the Jetpack Subscribers wp-admin screen (`{site}/wp-admin/admin.php?page=jetpack-subscribers`) instead of the Calypso `/subscribers/{domain}` route, for a deterministic ~10% cohort of **simple** sites.
* Cohort is keyed on the site (blog) id (`siteId % 10 === 0`), so a given site always resolves to the same bucket — the link never flips between loads.
* Jetpack and Atomic sites are untouched; the existing Calypso route remains for the other ~90% of simple sites.
* The rewrite reuses the existing `transformBaseMenu` seam in `client/my-sites/sidebar/body.jsx`, so it applies to both the backend admin-menu API response and the static fallback. New pure helpers live in `client/my-sites/sidebar/utils/subscribers-wp-admin-link.ts` with unit tests.

## Why are these changes being made?

* We want to measure routing simple-site subscriber management to the wp-admin Subscribers experience for a small, stable slice of sites before any wider rollout. A deterministic site-id bucket keeps the cohort consistent without needing an experiment framework.

## Testing Instructions

* On a **simple** site whose id is divisible by 10, open the sidebar and expand **Users** → the **Subscribers** item links to `{site}/wp-admin/admin.php?page=jetpack-subscribers` and opens in the same tab.
* On a simple site whose id is **not** divisible by 10, the Subscribers item still points at the Calypso `/subscribers/{domain}` route.
* On **Jetpack** and **Atomic** sites, behavior is unchanged regardless of site id.
* `yarn test-client client/my-sites/sidebar/utils/test/subscribers-wp-admin-link.ts`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
