### PR TITLE
Notifications: stop the note list jumping when older notes load

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
@@ -124,17 +125,14 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		return !! note.read === isRead ? note : { ...note, read: isRead ? 1 : 0 };
 	} );
 
-	// `filterSortAndPaginate` reports `totalItems` as the count of notes loaded
-	// so far. DataViews advances its infinite-scroll window only while
-	// `totalItems` stays ahead of the window, so reporting the loaded count
-	// alone stalls scrolling after the first page: the window catches up, no
-	// `onChangeView` fires, and `loadMore()` is never called again. Report an
-	// optimistic total while the REST client still has notes left to fetch so
-	// DataViews keeps advancing the window and driving `loadMore()`.
+	// Report the real loaded count. DataViews advances its infinite-scroll
+	// window only while `totalItems` stays ahead of the window; the prefetch
+	// effect below keeps a page of notes loaded beyond the window, so the real
+	// count stays ahead on its own. An optimistic total instead let DataViews
+	// advance the window into not-yet-fetched positions, so the load that filled
+	// them arrived asynchronously and DataViews' scroll-anchor restoration then
+	// re-applied a stale anchor — yanking the scroll position.
 	const hasMoreNotes = client?.hasMoreNotes() ?? false;
-	const effectivePaginationInfo = hasMoreNotes
-		? { ...paginationInfo, totalItems: paginationInfo.totalItems + NOTES_PER_PAGE }
-		: paginationInfo;
 
 	const infiniteScrollHandler = useCallback( () => {
 		if ( ! isLoading ) {
@@ -142,13 +140,16 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		}
 	}, [ client, isLoading ] );
 
-	// Keep enough notes loaded to cover the current scroll window, and to
-	// overflow the panel on first paint so a scrollbar exists for DataViews to
-	// drive further loading. A network page (`increment_limit`) can be smaller
-	// than this window, so fetch one page at a time until the window is filled or
-	// the server runs out — re-runs after each page as `visibleNotes` grows.
+	// Keep a full page of notes loaded *beyond* the current scroll window (and
+	// enough to overflow the panel on first paint so a scrollbar exists). This
+	// buffer means DataViews only ever advances its window over notes already in
+	// hand, so a network page never has to arrive mid-advance — which is what let
+	// the scroll-anchor restoration fire against a stale anchor. A network page
+	// (`increment_limit`) can be smaller than this window, so fetch one page at a
+	// time until the buffer is filled or the server runs out — re-runs after each
+	// page as `visibleNotes` grows.
 	useEffect( () => {
-		if ( startPosition + NOTES_PER_PAGE > visibleNotes.length && ! isLoading && hasMoreNotes ) {
+		if ( startPosition + NOTES_PER_PAGE * 2 > visibleNotes.length && ! isLoading && hasMoreNotes ) {
 			infiniteScrollHandler();
 		}
 	}, [ startPosition, visibleNotes.length, isLoading, hasMoreNotes, infiniteScrollHandler ] );
@@ -171,6 +172,27 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	// more cache pages to search, or the Unread fetch in flight.
 	const showEmptyLoader = hasMoreNotes || ( filterName === 'unread' && isLoading );
 
+	// DataViews reads `isLoading` as "the list is being (re)built from scratch"
+	// and uses its transitions to gate scroll-anchor restoration. Our load-more
+	// and the background poll both flip the shared flag while notes are already on
+	// screen; surfacing those as loading makes DataViews restore a stale scroll
+	// anchor once the async fetch lands, jumping the list. Report loading to
+	// DataViews only while there is nothing to show (initial load / empty tab) —
+	// incremental appends are not a from-scratch rebuild — and render our own
+	// load-more spinner (below) for the in-flight incremental case.
+	const isListLoading = isLoading && visibleNotes.length === 0;
+
+	// DataViews' own load-more spinner is gated on the `isLoading` we just scoped
+	// off, so render one ourselves into its scroll container — appended after the
+	// list so it sits at the end and scrolls with the notes, like the native one.
+	const [ scrollContainer, setScrollContainer ] = useState< HTMLElement | null >( null );
+	useEffect( () => {
+		const node =
+			noteListRef.current?.querySelector< HTMLElement >( '.dataviews-layout__container' ) ?? null;
+		setScrollContainer( ( prev ) => ( prev === node ? prev : node ) );
+	} );
+	const showLoadMoreSpinner = isLoading && ! isListLoading && visibleNotes.length > 0;
+
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">
 			{ ! showInitialLoader ? (
@@ -178,9 +200,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					data={ data }
 					fields={ fields }
 					view={ view }
-					isLoading={ isLoading }
+					isLoading={ isListLoading }
 					defaultLayouts={ DEFAULT_LAYOUTS }
-					paginationInfo={ effectivePaginationInfo }
+					paginationInfo={ paginationInfo }
 					empty={
 						// Spinner while still filling; the real message once settled.
 						showEmptyLoader ? (
@@ -208,6 +230,14 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					<Spinner />
 				</VStack>
 			) }
+			{ showLoadMoreSpinner &&
+				scrollContainer &&
+				createPortal(
+					<p className="dataviews-loading-more">
+						<Spinner />
+					</p>,
+					scrollContainer
+				) }
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

Fix the v2 notifications note list jumping its scroll position when more (older) notes load while scrolling.

The list drives `@wordpress/dataviews` 16 infinite scroll. DataViews preserves scroll across a load with an anchor-based `useLayoutEffect`: it captures an anchor element when a load is triggered, then re-applies it once `isLoading` flips to `false`. Two things in our integration made that misfire:

- our load-more is an **async network fetch**, and the `isLoading` we passed is the **shared** flag that background polling also drives — so the restoration ran at the wrong moment, against a **stale** anchor, and yanked the scroll;
- an **optimistic `totalItems`** pushed DataViews' window into not-yet-fetched positions, guaranteeing an async-gap load on every advance.

Changes (all in `apps/notifications/src/app/note-list/index.tsx`):

- Report the **real `totalItems`** instead of an optimistic padded count.
- **Prefetch a page beyond the scroll window** so DataViews only ever advances over notes already in hand (no network page arrives mid-advance).
- **Scope the `isLoading` handed to DataViews** to the from-scratch/empty case, so incremental load-more and polling no longer trip the stale-anchor restoration.
- **Render our own load-more spinner** into the scroll container, since DataViews' own spinner is gated on the now-scoped `isLoading`. It sits at the end of the list and scrolls with the notes, matching the native one.

## Why are these changes being made?

The DataViews 16 infinite-scroll upgrade (and the later `before`-cursor pagination work) introduced an anchor-based scroll restoration that assumes near-synchronous data and a load-only `isLoading`. The notifications panel loads asynchronously over the network and shares its loading flag with background polling, so the restoration re-applied a stale anchor and moved the list under the reader. Aligning the integration with DataViews' contract removes the jump without patching the shared package.

## Testing Instructions

1. Open the notifications panel (it needs enough notifications to overflow and scroll — a short viewport helps).
2. Scroll down through the list so older notes load.
3. Confirm the scroll position stays put as each page loads — the note you are reading does not move.
4. Confirm a loading spinner appears at the bottom of the list while a page is loading, and clears once it lands.
5. Confirm scrolling still reaches the end of the list ("all caught up").

Verified locally by instrumenting the scroll container: a tracked note's on-screen position stayed fixed across a load (previously it was yanked ~2400px), normal continuous scrolling showed zero upward jump, and the load-more spinner renders inside the scroll container during loading. Existing `note-list` unit tests pass (9/9).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
