### PR TITLE
Enable post-expiry and within-refund-period downgrades

### DIFF
--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -39,7 +39,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
-		"plans/expired-downgrade": false,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -36,7 +36,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
-		"plans/expired-downgrade": false,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -123,7 +123,7 @@
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
-		"plans/expired-downgrade": false,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-2090/implement-post-expiry-downgrade-flow
Fixes https://linear.app/a8c/issue/SHILL-2109/implement-downgrade-flow-for-users-within-refund-period

## Proposed Changes

This PR enables two self-serve downgrade flows:

- Post-expiry downgrades. If a plan has passed its expiry date but is still active (during its grace period before the plan is removed), it is now possible to click the "Downgrade" button on the plans page and be taken to checkout to purchase the lower-tier plan which will automatically replace the active plan. See https://github.com/Automattic/wp-calypso/pull/111408
- Instant downgrades during refund period. If a plan is within its refund period, it is now possible to click the "Downgrade" button on the plans page and be instantly downgraded to the lower-tier plan with a refund for the difference. See https://github.com/Automattic/wp-calypso/pull/111453

Both flows can also be reached by clicking the new "Change plan" button in the purchase settings page for the site's plan.

Calypso             |  Dashboard
:-------------------------:|:-------------------------:
<img width="1499" height="765" alt="Screenshot 2026-06-18 at 2 29 55 PM" src="https://github.com/user-attachments/assets/8cf1fa0b-9fc9-4abd-89ef-a198ac35b742" /> | <img width="679" height="850" alt="Screenshot 2026-06-08 at 1 25 52 PM" src="https://github.com/user-attachments/assets/edf789a4-0b48-4ee0-8f43-81bfc4322fbe" />

<img width="1274" height="758" alt="Screenshot 2026-06-08 at 6 18 33 PM" src="https://github.com/user-attachments/assets/2a8ae36c-89b7-4bcb-8336-4789628f402c" />

> [!NOTE]
> The "Downgrade" buttons already exist, but currently they open a support chat session. For plans which are past their refund period and before expiry, the "Downgrade" button retains its current behavior. Future PRs may add additional downgrade options (eg: https://linear.app/a8c/issue/SHILL-2117/implement-delayed-plan-downgrade).

## Why are these changes being made?

These downgrade flows have been tested and adjusted and are ready to be launched to production.

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/111408 and https://github.com/Automattic/wp-calypso/pull/111453