### PR TITLE
Stepper: add write-on flow at /setup/write-on

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/write-on/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-on/README.md
@@ -21,18 +21,20 @@ survives reloads. The draft is only cleared after the POST succeeds.
 
 ## Testing instructions
 
-1. Open devtools and set a draft in localStorage:
+1. Open devtools on any `calypso.localhost:3000` page (so the localStorage
+   write lands on the right origin) and paste this into the console — the
+   block markup matches what the anon editor's autosave will eventually
+   write, so the Write editor opens the draft without a "classic editor"
+   formatting modal:
 
    ```js
-   localStorage.setItem(
-   	'wpcom-write-anon-draft',
-   	JSON.stringify( { title: 'Hello world', content: 'My first post.', ts: Date.now() } )
-   );
+   localStorage.setItem('wpcom-write-anon-draft', JSON.stringify({title:'Test',content:`<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Testing...</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Test more....</p><!-- /wp:paragraph -->`,ts:Date.now()}));
    ```
 
 2. While logged out, visit `/setup/write-on`.
-3. Complete signup; verify a new site is created and you land on the Write
-   editor for a draft titled "Hello world" on the new blog.
+3. Complete signup; verify a new site is created and you land at
+   `https://{newSlug}.wordpress.com/wp-admin/admin.php?page=write&post={id}`
+   with the three paragraphs already loaded into the Write editor.
 4. Verify `localStorage['wpcom-write-anon-draft']` is cleared.
 5. Visit `/setup/write-on` again with no draft and confirm you are redirected
    to `/setup/onboarding`.

--- a/client/landing/stepper/declarative-flow/flows/write-on/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-on/README.md
@@ -1,0 +1,48 @@
+# write-on flow
+
+Phase 1 fake-door for the Write On experiment: handles the publish → signup →
+site-creation → draft-transfer hand-off for a logged-out visitor who started
+writing in the anonymous Write editor at `/write-editor` and clicked Publish.
+
+## Flow
+
+1. Read `localStorage['wpcom-write-anon-draft']` (set by the anon Write editor).
+   If empty, redirect to `/setup/onboarding`. If the visitor is already
+   authenticated, also redirect to `/setup/onboarding`.
+2. Run the built-in signup step (auto-injected by `__experimentalUseBuiltinAuth`
+   together with `stepsWithRequiredLogin`).
+3. Create the new site (`STEPS.SITE_CREATION_STEP` + `STEPS.PROCESSING`).
+4. POST the anon draft to the new site as a draft via the WP.com REST API.
+5. Clear `localStorage['wpcom-write-anon-draft']` and redirect the user to the
+   Write editor for the just-created draft on their new blog.
+
+A flow refresh mid-signup re-reads the draft from localStorage, so the draft
+survives reloads. The draft is only cleared after the POST succeeds.
+
+## Testing instructions
+
+1. Open devtools and set a draft in localStorage:
+
+   ```js
+   localStorage.setItem(
+   	'wpcom-write-anon-draft',
+   	JSON.stringify( { title: 'Hello world', content: 'My first post.', ts: Date.now() } )
+   );
+   ```
+
+2. While logged out, visit `/setup/write-on`.
+3. Complete signup; verify a new site is created and you land on the Write
+   editor for a draft titled "Hello world" on the new blog.
+4. Verify `localStorage['wpcom-write-anon-draft']` is cleared.
+5. Visit `/setup/write-on` again with no draft and confirm you are redirected
+   to `/setup/onboarding`.
+6. Visit `/setup/write-on` while logged in and confirm you are redirected to
+   `/setup/onboarding`.
+
+## Owned by
+
+@allilevine
+
+## Context
+
+- Linear: READ-559 (full Phase 1 scope and cross-repo sequencing live there).

--- a/client/landing/stepper/declarative-flow/flows/write-on/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-on/README.md
@@ -4,6 +4,12 @@ Phase 1 fake-door for the Write On experiment: handles the publish → signup �
 site-creation → draft-transfer hand-off for a logged-out visitor who started
 writing in the anonymous Write editor at `/write-editor` and clicked Publish.
 
+## Feature flag
+
+Gated by `calypso/write-on-flow`. Enabled on `development`, `stage`, and
+`wpcalypso`; disabled on `production` and `horizon`. When the flag is off,
+`initialize()` redirects to `/setup/onboarding` before any steps mount.
+
 ## Flow
 
 1. Read `localStorage['wpcom-write-anon-draft']` (set by the anon Write editor).

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -5,7 +5,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
-import writeOn, { ANON_DRAFT_STORAGE_KEY } from '../write-on';
+import writeOn, { ANON_DRAFT_STORAGE_KEY, MAX_DRAFT_SIZE } from '../write-on';
 
 const mockIsEnabled = jest.fn( ( flag: string ) => flag === 'calypso/write-on-flow' );
 
@@ -186,6 +186,66 @@ describe( 'write-on flow', () => {
 			site_id: 99,
 			error: 'x'.repeat( 200 ),
 		} );
+	} );
+
+	it( 'treats an oversized localStorage payload as no draft at publish time', async () => {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 'T', content: 'x'.repeat( MAX_DRAFT_SIZE + 1 ) } )
+		);
+		wpcomPostMock.mockResolvedValue( { ID: 7 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( wpcomPostMock ).toHaveBeenCalledWith(
+			'/sites/99/posts/new',
+			{ apiVersion: '1.2' },
+			{ title: '', content: '', status: 'draft' }
+		);
+	} );
+
+	it( 'coerces non-string draft fields to empty strings', async () => {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 12345, content: '<p>Body</p>' } )
+		);
+		wpcomPostMock.mockResolvedValue( { ID: 7 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( wpcomPostMock ).toHaveBeenCalledWith(
+			'/sites/99/posts/new',
+			{ apiVersion: '1.2' },
+			{ title: '', content: '<p>Body</p>', status: 'draft' }
+		);
+	} );
+
+	it( 'treats a draft with no string fields as no draft', async () => {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 12345, content: [ 'not', 'a', 'string' ] } )
+		);
+		wpcomPostMock.mockResolvedValue( { ID: 7 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( wpcomPostMock ).toHaveBeenCalledWith(
+			'/sites/99/posts/new',
+			{ apiVersion: '1.2' },
+			{ title: '', content: '', status: 'draft' }
+		);
 	} );
 
 	it( 'sends empty title and content when no localStorage draft exists at publish time', async () => {

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
@@ -26,6 +27,10 @@ jest.mock( 'calypso/lib/wp', () => ( {
 
 jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
 } ) );
 
 jest.mock( 'calypso/landing/stepper/stores', () => ( {
@@ -80,13 +85,16 @@ describe( 'write-on flow', () => {
 		expect( writeOn.__experimentalUseBuiltinAuth ).toBe( true );
 	} );
 
-	it( 'redirects to /setup/onboarding and exposes no steps when the feature flag is off', () => {
+	it( 'redirects to /setup/onboarding, records a blocked event, and exposes no steps when the feature flag is off', () => {
 		mockIsEnabled.mockReturnValue( false );
 
 		const steps = writeOn.initialize();
 
 		expect( steps ).toEqual( [] );
 		expect( window.location.replace ).toHaveBeenCalledWith( '/setup/onboarding' );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_on_flow_blocked', {
+			reason: 'flag_off',
+		} );
 	} );
 
 	it( 'navigates from create-site to processing', async () => {
@@ -123,6 +131,9 @@ describe( 'write-on flow', () => {
 			'https://example.wordpress.com/wp-admin/admin.php?page=write&post=42'
 		);
 		expect( window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY ) ).toBeNull();
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_on_draft_transfer_succeeded', {
+			site_id: 99,
+		} );
 	} );
 
 	it( 'preserves the localStorage draft, logs to logstash, and lands on the site home when the POST fails', async () => {
@@ -151,6 +162,30 @@ describe( 'write-on flow', () => {
 				} ),
 			} )
 		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_on_draft_transfer_failed', {
+			site_id: 99,
+			error: 'boom',
+		} );
+	} );
+
+	it( 'truncates the error message on the failed-transfer tracks event', async () => {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 'Keep me', content: '<p>Body</p>', ts: 1 } )
+		);
+		const longError = 'x'.repeat( 500 );
+		wpcomPostMock.mockRejectedValue( new Error( longError ) );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_on_draft_transfer_failed', {
+			site_id: 99,
+			error: 'x'.repeat( 200 ),
+		} );
 	} );
 
 	it( 'sends empty title and content when no localStorage draft exists at publish time', async () => {

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ */
+import wpcom from 'calypso/lib/wp';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
+import writeOn, { ANON_DRAFT_STORAGE_KEY } from '../write-on';
+
+jest.mock( '@automattic/onboarding', () => ( {
+	WRITE_ON_FLOW: 'write-on',
+} ) );
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { post: jest.fn() } },
+} ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'ONBOARD_STORE',
+} ) );
+
+jest.mock( 'calypso/landing/stepper/utils/steps-with-required-login', () => ( {
+	stepsWithRequiredLogin: ( steps: unknown ) => steps,
+} ) );
+
+jest.mock( '../../../internals/steps', () => ( {
+	STEPS: {
+		SITE_CREATION_STEP: { slug: 'create-site' },
+		PROCESSING: { slug: 'processing' },
+	},
+} ) );
+
+const submitFor = ( step: 'create-site' | 'processing', providedDependencies: object ) => {
+	const navigation = writeOn.useStepNavigation( step, jest.fn() );
+	return navigation.submit?.( {
+		slug: step,
+		providedDependencies,
+	} as Parameters< NonNullable< typeof navigation.submit > >[ 0 ] );
+};
+
+describe( 'write-on flow', () => {
+	const wpcomPostMock = wpcom.req.post as jest.Mock;
+	const originalLocation = window.location;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.localStorage.clear();
+		Object.defineProperty( window, 'location', {
+			value: { assign: jest.fn(), replace: jest.fn() },
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'is registered as a signup flow with built-in auth', () => {
+		expect( writeOn.name ).toBe( 'write-on' );
+		expect( writeOn.isSignupFlow ).toBe( true );
+		expect( writeOn.__experimentalUseBuiltinAuth ).toBe( true );
+	} );
+
+	it( 'navigates from create-site to processing', async () => {
+		const navigate = jest.fn();
+		const { submit } = writeOn.useStepNavigation( 'create-site', navigate );
+
+		await submit?.( {
+			slug: 'create-site',
+			providedDependencies: {},
+		} as Parameters< NonNullable< typeof submit > >[ 0 ] );
+
+		expect( navigate ).toHaveBeenCalledWith( 'processing', undefined, true );
+	} );
+
+	it( 'POSTs the localStorage draft and redirects to the Write editor on success', async () => {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 'My title', content: '<p>Body</p>', ts: 1 } )
+		);
+		wpcomPostMock.mockResolvedValue( { ID: 42 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( wpcomPostMock ).toHaveBeenCalledWith(
+			'/sites/99/posts/new',
+			{ apiVersion: '1.2' },
+			{ title: 'My title', content: '<p>Body</p>', status: 'draft' }
+		);
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://example.wordpress.com/wp-admin/admin.php?page=write&post=42'
+		);
+		expect( window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY ) ).toBeNull();
+	} );
+
+	it( 'preserves the localStorage draft and lands on the site home when the POST fails', async () => {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 'Keep me', content: '<p>Body</p>', ts: 1 } )
+		);
+		wpcomPostMock.mockRejectedValue( new Error( 'boom' ) );
+		const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( window.location.assign ).toHaveBeenCalledWith( '/home/example.wordpress.com' );
+		expect( window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY ) ).not.toBeNull();
+
+		consoleError.mockRestore();
+	} );
+
+	it( 'sends empty title and content when no localStorage draft exists at publish time', async () => {
+		wpcomPostMock.mockResolvedValue( { ID: 7 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( wpcomPostMock ).toHaveBeenCalledWith(
+			'/sites/99/posts/new',
+			{ apiVersion: '1.2' },
+			{ title: '', content: '', status: 'draft' }
+		);
+	} );
+
+	it( 'does nothing on processing failure', async () => {
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.FAILURE,
+		} );
+
+		expect( wpcomPostMock ).not.toHaveBeenCalled();
+		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when processing succeeds without site identifiers', async () => {
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+		} );
+
+		expect( wpcomPostMock ).not.toHaveBeenCalled();
+		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
 import writeOn, { ANON_DRAFT_STORAGE_KEY } from '../write-on';
@@ -21,6 +22,10 @@ jest.mock( '@automattic/onboarding', () => ( {
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
 	default: { req: { post: jest.fn() } },
+} ) );
+
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
 } ) );
 
 jest.mock( 'calypso/landing/stepper/stores', () => ( {
@@ -120,13 +125,12 @@ describe( 'write-on flow', () => {
 		expect( window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY ) ).toBeNull();
 	} );
 
-	it( 'preserves the localStorage draft and lands on the site home when the POST fails', async () => {
+	it( 'preserves the localStorage draft, logs to logstash, and lands on the site home when the POST fails', async () => {
 		window.localStorage.setItem(
 			ANON_DRAFT_STORAGE_KEY,
 			JSON.stringify( { title: 'Keep me', content: '<p>Body</p>', ts: 1 } )
 		);
 		wpcomPostMock.mockRejectedValue( new Error( 'boom' ) );
-		const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 
 		await submitFor( 'processing', {
 			processingResult: ProcessingResult.SUCCESS,
@@ -136,8 +140,17 @@ describe( 'write-on flow', () => {
 
 		expect( window.location.assign ).toHaveBeenCalledWith( '/home/example.wordpress.com' );
 		expect( window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY ) ).not.toBeNull();
-
-		consoleError.mockRestore();
+		expect( logToLogstash ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				feature: 'calypso_client',
+				severity: 'error',
+				blog_id: 99,
+				properties: expect.objectContaining( {
+					type: 'write_on_draft_transfer_failed',
+					error: 'boom',
+				} ),
+			} )
+		);
 	} );
 
 	it( 'sends empty title and content when no localStorage draft exists at publish time', async () => {

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -5,6 +5,15 @@ import wpcom from 'calypso/lib/wp';
 import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
 import writeOn, { ANON_DRAFT_STORAGE_KEY } from '../write-on';
 
+const mockIsEnabled = jest.fn( ( flag: string ) => flag === 'calypso/write-on-flow' );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const fn = Object.assign( ( key: string ) => key, {
+		isEnabled: ( flag: string ) => mockIsEnabled( flag ),
+	} );
+	return { __esModule: true, default: fn };
+} );
+
 jest.mock( '@automattic/onboarding', () => ( {
 	WRITE_ON_FLOW: 'write-on',
 } ) );
@@ -43,6 +52,7 @@ describe( 'write-on flow', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockIsEnabled.mockImplementation( ( flag: string ) => flag === 'calypso/write-on-flow' );
 		window.localStorage.clear();
 		Object.defineProperty( window, 'location', {
 			value: { assign: jest.fn(), replace: jest.fn() },
@@ -63,6 +73,15 @@ describe( 'write-on flow', () => {
 		expect( writeOn.name ).toBe( 'write-on' );
 		expect( writeOn.isSignupFlow ).toBe( true );
 		expect( writeOn.__experimentalUseBuiltinAuth ).toBe( true );
+	} );
+
+	it( 'redirects to /setup/onboarding and exposes no steps when the feature flag is off', () => {
+		mockIsEnabled.mockReturnValue( false );
+
+		const steps = writeOn.initialize();
+
+		expect( steps ).toEqual( [] );
+		expect( window.location.replace ).toHaveBeenCalledWith( '/setup/onboarding' );
 	} );
 
 	it( 'navigates from create-site to processing', async () => {

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -145,11 +145,7 @@ const writeOn: FlowV2< typeof initialize > = {
 			}
 		};
 
-		const goBack = () => {
-			window.history.back();
-		};
-
-		return { submit, goBack };
+		return { submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -87,12 +87,11 @@ const writeOn: FlowV2< typeof initialize > = {
 			if ( hasRunEntryChecks.current ) {
 				return;
 			}
+			hasRunEntryChecks.current = true;
 			if ( currentStepSlug ) {
 				// The flow already advanced past entry — entry checks aren't needed.
-				hasRunEntryChecks.current = true;
 				return;
 			}
-			hasRunEntryChecks.current = true;
 
 			// Phase 1 is a logged-out fake door. If the visitor is already
 			// authenticated they should not be here — send them to the standard
@@ -133,8 +132,7 @@ const writeOn: FlowV2< typeof initialize > = {
 						return;
 					}
 
-					const siteId = providedDependencies.siteId as number | undefined;
-					const siteSlug = providedDependencies.siteSlug as string | undefined;
+					const { siteId, siteSlug } = providedDependencies;
 					if ( ! siteId || ! siteSlug ) {
 						return;
 					}

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -3,6 +3,7 @@ import { OnboardActions } from '@automattic/data-stores';
 import { WRITE_ON_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
@@ -52,6 +53,7 @@ function initialize() {
 	// flow has nothing to land users on in production. Redirect to the
 	// standard onboarding flow when the feature flag is off.
 	if ( ! config.isEnabled( 'calypso/write-on-flow' ) ) {
+		recordTracksEvent( 'calypso_write_on_flow_blocked', { reason: 'flag_off' } );
 		window.location.replace( '/setup/onboarding' );
 		return [];
 	}
@@ -86,15 +88,21 @@ const writeOn: FlowV2< typeof initialize > = {
 			// authenticated they should not be here — send them to the standard
 			// onboarding flow.
 			if ( isLoggedIn ) {
+				recordTracksEvent( 'calypso_write_on_flow_blocked', { reason: 'logged_in' } );
 				window.location.replace( '/setup/onboarding' );
 				return;
 			}
 
 			const draft = readAnonDraft();
 			if ( ! draft ) {
+				recordTracksEvent( 'calypso_write_on_flow_blocked', { reason: 'no_draft' } );
 				window.location.replace( '/setup/onboarding' );
 				return;
 			}
+
+			recordTracksEvent( 'calypso_write_on_flow_entered', {
+				draft_size: ( draft.title?.length ?? 0 ) + ( draft.content?.length ?? 0 ),
+			} );
 
 			if ( draft.title ) {
 				setSiteTitle( draft.title );
@@ -134,6 +142,10 @@ const writeOn: FlowV2< typeof initialize > = {
 
 						clearAnonDraft();
 
+						recordTracksEvent( 'calypso_write_on_draft_transfer_succeeded', {
+							site_id: siteId,
+						} );
+
 						window.location.assign(
 							`https://${ siteSlug }/wp-admin/admin.php?page=write&post=${ post.ID }`
 						);
@@ -142,6 +154,14 @@ const writeOn: FlowV2< typeof initialize > = {
 						// the standard new-site flow; fall back to the site's home
 						// so they at least land somewhere meaningful with the draft
 						// preserved in localStorage for a retry.
+						const errorMessage = ( error instanceof Error ? error.message : String( error ) ).slice(
+							0,
+							200
+						);
+						recordTracksEvent( 'calypso_write_on_draft_transfer_failed', {
+							site_id: siteId,
+							error: errorMessage,
+						} );
 						logToLogstash( {
 							feature: 'calypso_client',
 							message: 'write-on: failed to transfer anon draft',
@@ -149,7 +169,7 @@ const writeOn: FlowV2< typeof initialize > = {
 							blog_id: siteId,
 							properties: {
 								type: 'write_on_draft_transfer_failed',
-								error: error instanceof Error ? error.message : String( error ),
+								error: errorMessage,
 							},
 						} );
 						window.location.assign( `/home/${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -1,7 +1,7 @@
 import { OnboardActions } from '@automattic/data-stores';
 import { WRITE_ON_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -57,14 +57,21 @@ const writeOn: FlowV2< typeof initialize > = {
 	useSideEffect( currentStepSlug ) {
 		const { setSiteTitle } = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const isLoggedIn = useSelector( isUserLoggedIn );
+		const hasRunEntryChecks = useRef( false );
 
-		// Runs only on flow entry (before any step is selected). The flow re-reads
-		// localStorage at publish time, so a refresh mid-signup still finds the
-		// draft.
+		// Entry checks must fire at most once per mount. Re-running them on a
+		// later isLoggedIn flip (e.g. mid-signup) would redirect the user out of
+		// the flow during the auth round-trip.
 		useEffect( () => {
-			if ( currentStepSlug ) {
+			if ( hasRunEntryChecks.current ) {
 				return;
 			}
+			if ( currentStepSlug ) {
+				// The flow already advanced past entry — entry checks aren't needed.
+				hasRunEntryChecks.current = true;
+				return;
+			}
+			hasRunEntryChecks.current = true;
 
 			// Phase 1 is a logged-out fake door. If the visitor is already
 			// authenticated they should not be here — send them to the standard

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { OnboardActions } from '@automattic/data-stores';
 import { WRITE_ON_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
@@ -46,6 +47,13 @@ function clearAnonDraft() {
 }
 
 function initialize() {
+	// Phase 1 is staging-only; the companion endpoint is proxy-gated so the
+	// flow has nothing to land users on in production. Redirect to the
+	// standard onboarding flow when the feature flag is off.
+	if ( ! config.isEnabled( 'calypso/write-on-flow' ) ) {
+		window.location.replace( '/setup/onboarding' );
+		return [];
+	}
 	return stepsWithRequiredLogin( [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ] );
 }
 

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -3,6 +3,7 @@ import { OnboardActions } from '@automattic/data-stores';
 import { WRITE_ON_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -141,8 +142,16 @@ const writeOn: FlowV2< typeof initialize > = {
 						// the standard new-site flow; fall back to the site's home
 						// so they at least land somewhere meaningful with the draft
 						// preserved in localStorage for a retry.
-						// eslint-disable-next-line no-console
-						console.error( 'write-on: failed to transfer anon draft', error );
+						logToLogstash( {
+							feature: 'calypso_client',
+							message: 'write-on: failed to transfer anon draft',
+							severity: 'error',
+							blog_id: siteId,
+							properties: {
+								type: 'write_on_draft_transfer_failed',
+								error: error instanceof Error ? error.message : String( error ),
+							},
+						} );
 						window.location.assign( `/home/${ siteSlug }` );
 					}
 					return;

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -16,22 +16,32 @@ import { type FlowV2, type SubmitHandler } from '../../internals/types';
 
 export const ANON_DRAFT_STORAGE_KEY = 'wpcom-write-anon-draft';
 
+// Cap the localStorage payload at ~200K characters. A long blog post in
+// Gutenberg block markup is well under 100K; anything larger is almost
+// certainly corrupted or hostile and is treated as "no draft."
+export const MAX_DRAFT_SIZE = 200_000;
+
 type AnonDraft = {
-	title?: string;
-	content?: string;
-	ts?: number;
+	title: string;
+	content: string;
 };
 
 function readAnonDraft(): AnonDraft | null {
 	try {
 		const raw = window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY );
-		if ( ! raw ) {
+		if ( ! raw || raw.length > MAX_DRAFT_SIZE ) {
 			return null;
 		}
 		const parsed = JSON.parse( raw );
-		if ( parsed && typeof parsed === 'object' ) {
-			return parsed as AnonDraft;
+		if ( ! parsed || typeof parsed !== 'object' ) {
+			return null;
 		}
+		const title = typeof parsed.title === 'string' ? parsed.title : '';
+		const content = typeof parsed.content === 'string' ? parsed.content : '';
+		if ( ! title && ! content ) {
+			return null;
+		}
+		return { title, content };
 	} catch {
 		// Treat unreadable storage as "no draft" — the side-effect handler will
 		// redirect to standard onboarding rather than running an empty flow.
@@ -101,7 +111,7 @@ const writeOn: FlowV2< typeof initialize > = {
 			}
 
 			recordTracksEvent( 'calypso_write_on_flow_entered', {
-				draft_size: ( draft.title?.length ?? 0 ) + ( draft.content?.length ?? 0 ),
+				draft_size: draft.title.length + draft.content.length,
 			} );
 
 			if ( draft.title ) {

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -1,0 +1,149 @@
+import { OnboardActions } from '@automattic/data-stores';
+import { WRITE_ON_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { ONBOARD_STORE } from '../../../stores';
+import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import { STEPS } from '../../internals/steps';
+import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
+import { type FlowV2, type SubmitHandler } from '../../internals/types';
+
+export const ANON_DRAFT_STORAGE_KEY = 'wpcom-write-anon-draft';
+
+type AnonDraft = {
+	title?: string;
+	content?: string;
+	ts?: number;
+};
+
+function readAnonDraft(): AnonDraft | null {
+	try {
+		const raw = window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY );
+		if ( ! raw ) {
+			return null;
+		}
+		const parsed = JSON.parse( raw );
+		if ( parsed && typeof parsed === 'object' ) {
+			return parsed as AnonDraft;
+		}
+	} catch {
+		// Treat unreadable storage as "no draft" — the side-effect handler will
+		// redirect to standard onboarding rather than running an empty flow.
+	}
+	return null;
+}
+
+function clearAnonDraft() {
+	try {
+		window.localStorage.removeItem( ANON_DRAFT_STORAGE_KEY );
+	} catch {
+		// Ignore — failing to clear leaves the draft for a future visit, which
+		// is harmless.
+	}
+}
+
+function initialize() {
+	return stepsWithRequiredLogin( [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ] );
+}
+
+const writeOn: FlowV2< typeof initialize > = {
+	name: WRITE_ON_FLOW,
+	isSignupFlow: true,
+	__experimentalUseBuiltinAuth: true,
+	initialize,
+	useSideEffect( currentStepSlug ) {
+		const { setSiteTitle } = useDispatch( ONBOARD_STORE ) as OnboardActions;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+
+		// Runs only on flow entry (before any step is selected). The flow re-reads
+		// localStorage at publish time, so a refresh mid-signup still finds the
+		// draft.
+		useEffect( () => {
+			if ( currentStepSlug ) {
+				return;
+			}
+
+			// Phase 1 is a logged-out fake door. If the visitor is already
+			// authenticated they should not be here — send them to the standard
+			// onboarding flow.
+			if ( isLoggedIn ) {
+				window.location.replace( '/setup/onboarding' );
+				return;
+			}
+
+			const draft = readAnonDraft();
+			if ( ! draft ) {
+				window.location.replace( '/setup/onboarding' );
+				return;
+			}
+
+			if ( draft.title ) {
+				setSiteTitle( draft.title );
+			}
+		}, [ currentStepSlug, isLoggedIn, setSiteTitle ] );
+	},
+	useStepNavigation( currentStepSlug, navigate ) {
+		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
+			const { slug, providedDependencies } = submittedStep;
+			switch ( slug ) {
+				case 'create-site':
+					return navigate( 'processing', undefined, true );
+
+				case 'processing': {
+					if ( providedDependencies.processingResult !== ProcessingResult.SUCCESS ) {
+						// Site creation failed. Stay on the flow so the processing
+						// step's error UI surfaces; nothing further we can do here.
+						return;
+					}
+
+					const siteId = providedDependencies.siteId as number | undefined;
+					const siteSlug = providedDependencies.siteSlug as string | undefined;
+					if ( ! siteId || ! siteSlug ) {
+						return;
+					}
+
+					const draft = readAnonDraft();
+					const title = draft?.title ?? '';
+					const content = draft?.content ?? '';
+
+					try {
+						const post = ( await wpcom.req.post(
+							`/sites/${ siteId }/posts/new`,
+							{ apiVersion: '1.2' },
+							{ title, content, status: 'draft' }
+						) ) as { ID: number };
+
+						clearAnonDraft();
+
+						window.location.assign(
+							`https://${ siteSlug }/wp-admin/admin.php?page=write&post=${ post.ID }`
+						);
+					} catch ( error ) {
+						// Surfacing the failure to the user is handled upstream by
+						// the standard new-site flow; fall back to the site's home
+						// so they at least land somewhere meaningful with the draft
+						// preserved in localStorage for a retry.
+						// eslint-disable-next-line no-console
+						console.error( 'write-on: failed to transfer anon draft', error );
+						window.location.assign( `/home/${ siteSlug }` );
+					}
+					return;
+				}
+
+				default:
+					return;
+			}
+		};
+
+		const goBack = () => {
+			window.history.back();
+		};
+
+		return { submit, goBack };
+	},
+};
+
+export default writeOn;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -22,6 +22,7 @@ import {
 	WOO_HOSTED_PLANS_FLOW,
 	ART_PROMO_FLOW,
 	DIRECT_TO_CART_FLOW,
+	WRITE_ON_FLOW,
 } from '@automattic/onboarding';
 import type { Flow, FlowV2 } from '../declarative-flow/internals/types';
 
@@ -70,6 +71,9 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 
 	[ ART_PROMO_FLOW ]: () =>
 		import( /* webpackChunkName: "artpromo-flow" */ './flows/artpromo/artpromo' ),
+
+	[ WRITE_ON_FLOW ]: () =>
+		import( /* webpackChunkName: "write-on-flow" */ './flows/write-on/write-on' ),
 };
 
 /**

--- a/config/development.json
+++ b/config/development.json
@@ -58,6 +58,7 @@
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
 		"calypso/refund-eligibility-notice": false,
+		"calypso/write-on-flow": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
 		"checkout/stripe-upi": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,6 +18,7 @@
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/write-on-flow": false,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,6 +31,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/write-on-flow": false,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,6 +28,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/write-on-flow": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/write-on-flow": true,
 		"catch-js-errors": false,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -12,6 +12,7 @@ export const SITE_MIGRATION_FLOW = 'site-migration';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
+export const WRITE_ON_FLOW = 'write-on';
 export const START_WRITING_FLOW = 'start-writing';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';
@@ -96,6 +97,10 @@ export const isBuildFlow = ( flowName: string | null ) => {
 
 export const isWriteFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ WRITE_FLOW ].includes( flowName ) );
+};
+
+export const isWriteOnFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ WRITE_ON_FLOW ].includes( flowName ) );
 };
 
 export const isUpdateDesignFlow = ( flowName: string | null ) => {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -99,10 +99,6 @@ export const isWriteFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ WRITE_FLOW ].includes( flowName ) );
 };
 
-export const isWriteOnFlow = ( flowName: string | null ) => {
-	return Boolean( flowName && [ WRITE_ON_FLOW ].includes( flowName ) );
-};
-
 export const isUpdateDesignFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ UPDATE_DESIGN_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
Part of READ-559.

## Proposed Changes

* New FlowV2 at `/setup/write-on`. The flow reads a draft from `localStorage['wpcom-write-anon-draft']`, runs built-in signup, creates a site via `STEPS.SITE_CREATION_STEP` + `STEPS.PROCESSING`, POSTs the draft to `/sites/{siteId}/posts/new` as a status-`draft` post, and redirects to `wp-admin/admin.php?page=write&post={newPostId}` on the new site.
* The localStorage entry is only cleared after the POST succeeds, so a flow refresh mid-signup re-hydrates the draft and a transient failure leaves it intact for retry.
* If the visitor is already logged in, or has no readable draft, the flow redirects to `/setup/onboarding`. These entry guards run only on first mount at the flow root (`/setup/write-on`); direct visits to a sub-step URL (e.g. `/setup/write-on/create-site`) skip the logged-in / has-draft checks. This is intentional for Phase 1 since the only intended entry point is the anon Write editor's Publish handoff and the feature is flag-off in production.
* `WRITE_ON_FLOW` constant exported from `@automattic/onboarding`; flow registered in `registered-flows.ts`.
* Gated by the `calypso/write-on-flow` feature flag — enabled on `development`, `stage`, and `wpcalypso`; off on `production` and `horizon`. When the flag is off, `initialize()` redirects to `/setup/onboarding` and exposes no steps, so the URL has no live surface in production until the flag flips.

<img width="1181" height="548" alt="Screenshot 2026-06-18 at 5 10 28 PM" src="https://github.com/user-attachments/assets/15abec6f-2ea4-44ec-bb95-c043d3db9fe2" />
<img width="610" height="393" alt="Screenshot 2026-06-18 at 5 10 50 PM" src="https://github.com/user-attachments/assets/53f78f15-13a9-4aa8-9b7e-a7632fe8d97f" />
<img width="1120" height="563" alt="Screenshot 2026-06-18 at 5 11 21 PM" src="https://github.com/user-attachments/assets/0ea6ac85-131b-4e8e-bcdc-93f957833dea" />


## Why are these changes being made?

See READ-559.

## Testing Instructions

Unit tests: `yarn test-client client/landing/stepper/declarative-flow/flows/write-on/` — covers flow shape, navigation, the disabled-flag redirect, and the processing handler's success and failure paths (POST payload, redirect URL, localStorage clear vs. preserve).

Manual verification on `http://calypso.localhost:3000/` (the flag is enabled in `development.json`, so the flow is live locally):

1. Open devtools on any `calypso.localhost:3000` page (so the localStorage write lands on the right origin) and paste this into the console. The block markup matches what the anon editor's autosave will eventually write, so the Write editor opens the draft without a "classic editor" formatting modal:

   ```js
   localStorage.setItem('wpcom-write-anon-draft', JSON.stringify({title:'Test',content:`<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Testing...</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Test more....</p><!-- /wp:paragraph -->`,ts:Date.now()}));
   ```

2. While logged out, visit `/setup/write-on`. URL should stay on `/setup/write-on/user`; the signup wall renders; post-login redirect target is `/setup/write-on/create-site`.
3. Complete signup with a fresh email. After site creation completes you should land at `https://{newSlug}.wordpress.com/wp-admin/admin.php?page=write&post={id}` with the three paragraphs already loaded into the Write editor, and `localStorage['wpcom-write-anon-draft']` should be cleared.
4. Clear the localStorage draft and revisit `/setup/write-on` logged out. Should redirect to `/setup/onboarding/user`.
5. Set localStorage to malformed JSON and revisit. Should also redirect to `/setup/onboarding/user`.
6. Visit `/setup/write-on` while already logged in. Should redirect to `/setup/onboarding`.
7. Flip `calypso/write-on-flow` to `false` in `config/development.json`, restart the dev server, and revisit `/setup/write-on`. Should redirect to `/setup/onboarding` before any steps render.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
