### PR TITLE
Downgrade modal: stop focus refetch wiping the lost-features list

### DIFF
--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -123,6 +123,12 @@ const DowngradeConfirmationModal = ( {
 	const { data: cancelFeaturesData, isLoading } = useQuery( {
 		...purchaseCancelFeaturesQuery( purchaseId ?? 0, 'control', targetPlanSlug ?? undefined ),
 		enabled: !! purchaseId && !! targetPlanSlug && isOpen,
+		// The feature delta is fixed for the dialog's lifetime. Don't refetch on
+		// window focus: in the instant-downgrade flow the dialog stays open (with its
+		// loader) until the redirect, and a focus refetch after the downgrade has
+		// completed would return an empty delta and wipe out the displayed list.
+		refetchOnWindowFocus: false,
+		staleTime: Infinity,
 	} );
 
 	if ( ! targetPlanSlug || ! isOpen ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2164/

## Proposed changes

This fixes the lost-features list disappearing in the instant-downgrade confirmation dialog by disabling window-focus refetching on the cancel-features query, since that delta is fixed for the dialog's lifetime.

## Why are these changes being made?

In the instant-downgrade flow, the confirmation dialog stays open showing its "lost features" list from the moment the user clicks confirm until the post-success redirect (the parent keeps `isDowngrading` true across the mutation *and* the subsequent purchases refetch). TanStack Query's `refetchOnWindowFocus` defaults to on, so if the user tabs away and back during that window, the cancel-features query refetches. By then the downgrade has already executed server-side, so the endpoint returns the delta against the *already-downgraded* plan — an empty list. `lostFeatures` becomes `[]` and `ModalBody` swaps the feature list for the "your features will stay the same" copy, so the list appears to vanish.

The feature delta between the current and target plan doesn't change for the dialog's lifetime, so refetching it can only hurt, never help. Disabling focus refetch and marking the data stable is the most targeted fix. Opening the dialog for a different target plan still fetches fresh data, because the target slug is part of the query key (`['upgrades', purchaseId, 'cancel-features', variant, targetProductSlug]`).

## Testing instructions

Manual testing:
* Use a site with a paid plan still inside its initial refund window (so `downgradeMode === 'instant'`), with the `plans/expired-downgrade` feature enabled.
* Go to the Plans page and initiate a downgrade to a lower-tier paid plan to open the confirmation dialog — confirm the "here's what you'll lose" feature list renders.
* Click the confirm/downgrade button, then immediately switch to another browser tab and back while the action is in flight.
* Confirm the feature list stays visible (it no longer collapses to "your features will stay the same") until the redirect completes.
* Reopen the dialog for a *different* target plan and confirm its feature list still loads correctly.

