### PR TITLE
Fix notification mention suggestion styles

### DIFF
--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -1,6 +1,7 @@
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "../panel/suggestions/styles";
 
 $wpnc-pane-width: 448px;
 $wpnc-pane-border: 1px solid var(--color-border-subtle, #c3c4c7);

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -1,7 +1,6 @@
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "../panel/suggestions/styles";
 
 $wpnc-pane-width: 448px;
 $wpnc-pane-border: 1px solid var(--color-border-subtle, #c3c4c7);

--- a/apps/notifications/src/panel/suggestions/index.jsx
+++ b/apps/notifications/src/panel/suggestions/index.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import actions from '../state/actions';
 import getSiteSuggestions from '../state/selectors/get-site-suggestions';
 import Suggestion from './suggestion';
+import './styles.scss';
 
 const KEY_ENTER = 13;
 const KEY_ESC = 27;

--- a/apps/notifications/src/panel/suggestions/styles.scss
+++ b/apps/notifications/src/panel/suggestions/styles.scss
@@ -1,3 +1,5 @@
+@use '@automattic/typography/styles/variables' as typography;
+
 $base-background-color: var(--color-surface, #fff);
 $list-background: var(--color-surface, #fff);
 $border-color: var(--color-neutral-10, #c3c4c7);
@@ -21,7 +23,7 @@ $box-shadow: 0 5px 6px color-mix(in srgb, var(--color-neutral-10, #c3c4c7) 50%, 
 	border-radius: $border-radius;
 	box-shadow: $box-shadow;
 	z-index: 20010;
-	font-family: $sans;
+	font-family: typography.$sans;
 	width: 90%;
 
 	ul {


### PR DESCRIPTION
Fixes p1781812325703289-slack-CRWCHQGUB

## Proposed Changes

* Load the shared mention suggestion styles in the redesigned notifications app.
* Make the suggestion stylesheet compile from both the legacy panel and redesigned app entry points.


## Why are these changes being made?
The redesigned notifications pane reuses the legacy `Suggestions` component for `@` mentions, but its styles were only loaded by the legacy panel bundle. This caused the mention picker to render with broken CSS when replying from notifications.

## Testing Instructions
- Open the notifications pane.
- Try to reply to a comment there.
- Mention some, the suggestions dropdown should look good.
