### PR TITLE
Notifications: fix the note list jumping by prefetching, not faking loading state

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -125,17 +125,15 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		return !! note.read === isRead ? note : { ...note, read: isRead ? 1 : 0 };
 	} );
 
-	// `filterSortAndPaginate` reports `totalItems` as the count of notes loaded
-	// so far. DataViews advances its infinite-scroll window only while
-	// `totalItems` stays ahead of the window, so reporting the loaded count
-	// alone stalls scrolling after the first page: the window catches up, no
-	// `onChangeView` fires, and `loadMore()` is never called again. Report an
-	// optimistic total while the REST client still has notes left to fetch so
-	// DataViews keeps advancing the window and driving `loadMore()`.
+	// Report the real loaded count to DataViews. It advances its infinite-scroll
+	// window only while `totalItems` stays ahead of the window; the prefetch
+	// effect below keeps a page of notes loaded beyond the window, so the real
+	// count stays ahead on its own and keeps the window advancing. Reporting an
+	// optimistic total instead lets DataViews advance the window into
+	// not-yet-fetched positions, so the page that fills them arrives mid-advance
+	// and its scroll-anchor restoration re-applies a stale anchor — yanking the
+	// scroll position.
 	const hasMoreNotes = client?.hasMoreNotes() ?? false;
-	const effectivePaginationInfo = hasMoreNotes
-		? { ...paginationInfo, totalItems: paginationInfo.totalItems + NOTES_PER_PAGE }
-		: paginationInfo;
 
 	const infiniteScrollHandler = useCallback( () => {
 		if ( ! isLoading ) {
@@ -143,13 +141,16 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		}
 	}, [ client, isLoading ] );
 
-	// Keep enough notes loaded to cover the current scroll window, and to
-	// overflow the panel on first paint so a scrollbar exists for DataViews to
-	// drive further loading. A network page (`increment_limit`) can be smaller
-	// than this window, so fetch one page at a time until the window is filled or
-	// the server runs out — re-runs after each page as `visibleNotes` grows.
+	// Keep a full page of notes loaded *beyond* the current scroll window (and
+	// enough to overflow the panel on first paint so a scrollbar exists). This
+	// buffer means DataViews only ever advances its window over notes already in
+	// hand, so a network page never has to arrive mid-advance — which is what let
+	// the scroll-anchor restoration fire against a stale anchor and jump the list.
+	// A network page (`increment_limit`) can be smaller than this window, so fetch
+	// one page at a time until the buffer is filled or the server runs out —
+	// re-runs after each page as `visibleNotes` grows.
 	useEffect( () => {
-		if ( startPosition + NOTES_PER_PAGE > visibleNotes.length && ! isLoading && hasMoreNotes ) {
+		if ( startPosition + NOTES_PER_PAGE * 2 > visibleNotes.length && ! isLoading && hasMoreNotes ) {
 			infiniteScrollHandler();
 		}
 	}, [ startPosition, visibleNotes.length, isLoading, hasMoreNotes, infiniteScrollHandler ] );
@@ -181,7 +182,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					view={ view }
 					isLoading={ isLoading }
 					defaultLayouts={ DEFAULT_LAYOUTS }
-					paginationInfo={ effectivePaginationInfo }
+					paginationInfo={ paginationInfo }
 					empty={
 						// Spinner while still filling; the real message once settled.
 						showEmptyLoader ? (


### PR DESCRIPTION
## Proposed Changes

- Report the **real** loaded count to DataViews (drops the optimistic `totalItems`).
- Keep a full page of notes buffered *beyond* the scroll window (`NOTES_PER_PAGE * 2`) so the window only ever advances over notes already loaded.
- Pass the truthful `isLoading` to DataViews, so its own scroll-anchoring and load-more spinner stay intact.

Net: +18/−17 in one file, `apps/notifications/src/app/note-list/index.tsx`.

## Why are these changes being made?

The note list jumps when older notes load. The root cause is the window advancing into not-yet-fetched positions: the page that fills them arrives mid-advance, and DataViews' scroll-anchor restoration then re-applies a stale anchor and yanks the scroll position.

This is an alternative to the prior approach (an optimistic `totalItems` + suppressing `isLoading` + portaling a hand-rolled spinner into DataViews' private DOM). That approach worked by *disabling* DataViews' anchoring and depending on its internal `.dataviews-layout__container` / `.dataviews-loading-more` classes — a silent-failure coupling to an unversioned DOM contract, and it removed the anchoring safety net for the scroll-up (prepend) case.

This version attacks the cause instead: with real `totalItems` and a prefetch buffer, advances only ever step over loaded notes, so a network page never arrives mid-advance and anchor restoration never sees a stale anchor. Keeping `isLoading` truthful preserves DataViews' own anchoring and spinner rather than reimplementing them.

On the Unread tab this is safe by construction: filtered load-more never flips the shared `isLoading`, so the anchor-restore mechanism isn't even engaged there.

## Testing Instructions

1. Open the Notifications panel.
2. Throttle the network (DevTools → Network → Slow 3G).
3. Scroll **down** through several pages of notes — the list should keep its position as each older page loads (no jump).
4. Scroll back **up** to exercise the prepend/anchor path — still no jump.
5. Repeat on the **Unread** tab.
6. Confirm load-more still triggers near the bottom and the load-more spinner appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)