### PR TITLE
Lodash: replace defer() with native setTimeout( fn, 0 )

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import cookie from 'cookie';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { capitalize, defer, includes } from 'lodash';
+import { capitalize, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -128,7 +128,8 @@ export class LoginForm extends Component {
 
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isFormDisabledWhileLoading: false }, () => {
-			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+			! disableAutoFocus &&
+				setTimeout( () => this.usernameOrEmail && this.usernameOrEmail.focus(), 0 );
 		} );
 		// Remove url param to keep the last used login consistent upon refresh
 		const url = new URL( window.location );
@@ -169,11 +170,12 @@ export class LoginForm extends Component {
 		}
 
 		if ( requestError.field === 'password' ) {
-			! disableAutoFocus && defer( () => this.password && this.password.focus() );
+			! disableAutoFocus && setTimeout( () => this.password && this.password.focus(), 0 );
 		}
 
 		if ( requestError.field === 'usernameOrEmail' ) {
-			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+			! disableAutoFocus &&
+				setTimeout( () => this.usernameOrEmail && this.usernameOrEmail.focus(), 0 );
 		}
 
 		// User entered an email address or username that doesn't have a corresponding WPCOM account
@@ -203,11 +205,12 @@ export class LoginForm extends Component {
 		if ( this.props.hasAccountTypeLoaded && ! nextProps.hasAccountTypeLoaded ) {
 			this.setState( { password: '' } );
 
-			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+			! disableAutoFocus &&
+				setTimeout( () => this.usernameOrEmail && this.usernameOrEmail.focus(), 0 );
 		}
 
 		if ( ! this.props.hasAccountTypeLoaded && isRegularAccount( nextProps.accountType ) ) {
-			! disableAutoFocus && defer( () => this.password && this.password.focus() );
+			! disableAutoFocus && setTimeout( () => this.password && this.password.focus(), 0 );
 		}
 
 		if ( nextProps.requestError ) {

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -2,7 +2,6 @@ import { Card, FormInputValidation, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -53,7 +52,7 @@ class VerificationCodeForm extends Component {
 		const isNewPage = prevProps.twoFactorAuthType !== twoFactorAuthType;
 
 		if ( isNewPage || ( hasNewError && twoFactorAuthRequestError.field === 'twoStepCode' ) ) {
-			defer( () => this.input.focus() );
+			setTimeout( () => this.input.focus(), 0 );
 		}
 	}
 

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
@@ -65,10 +64,10 @@ class ReaderShare extends Component {
 			clearTimeout( this.closeHandle );
 		}
 
-		this.closeHandle = defer( () => {
+		this.closeHandle = setTimeout( () => {
 			this.closeHandle = null;
 			this.setState( { showingMenu: showing } );
-		} );
+		}, 0 );
 	};
 
 	toggle = () => {

--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -1,5 +1,4 @@
 import isShallowEqual from '@wordpress/is-shallow-equal';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -14,7 +13,7 @@ import { DEFAULT_HEARTBEAT } from './constants';
 
 class QuerySiteStats extends Component {
 	componentDidMount() {
-		this.deferredTimer = defer( () => this.request() );
+		this.deferredTimer = setTimeout( () => this.request(), 0 );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/components/domains/trademark-claims-notice/index.jsx
+++ b/client/components/domains/trademark-claims-notice/index.jsx
@@ -1,7 +1,7 @@
 import { Button, CompactCard } from '@automattic/components';
 import { TRADE_MARK_CLAIMS_MODAL_COPY } from '@automattic/domain-search';
 import { localize } from 'i18n-calypso';
-import { defer, get, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -133,7 +133,7 @@ class TrademarkClaimsNotice extends Component {
 		const { domain } = this.props;
 		this.setState( { showFullNotice: true } );
 		window.addEventListener( 'scroll', this.handleScroll );
-		defer( this.checkWindowIsScrollable );
+		setTimeout( this.checkWindowIsScrollable, 0 );
 		this.props.recordShowTrademarkNoticeButtonClickInTrademarkNotice( domain );
 	};
 

--- a/client/components/infinite-scroll/index.jsx
+++ b/client/components/infinite-scroll/index.jsx
@@ -1,5 +1,4 @@
 import { throttle } from '@wordpress/compose';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
@@ -44,12 +43,12 @@ class InfiniteScrollWithIntersectionObserver extends Component {
 	componentDidUpdate() {
 		if ( ! this.deferredPageFetch && ! this.hasScrolledPastBottom ) {
 			// We still need more pages, so schedule a page fetch.
-			this.deferredPageFetch = defer( () => {
+			this.deferredPageFetch = setTimeout( () => {
 				if ( ! this.hasScrolledPastBottom ) {
 					this.getNextPage();
 				}
 				this.deferredPageFetch = null;
-			} );
+			}, 0 );
 		}
 	}
 

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -1,7 +1,6 @@
 import { isMobile } from '@automattic/viewport';
 import { debounce, throttle } from '@wordpress/compose';
 import clsx from 'clsx';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
@@ -129,13 +128,13 @@ class StickyPanelWithIntersectionObserver extends Component {
 		window.addEventListener( 'resize', this.throttleOnResize );
 		window.addEventListener( 'scroll', this.throttleOnScroll );
 
-		this.deferredMount = defer( () => {
+		this.deferredMount = setTimeout( () => {
 			this.observer = new IntersectionObserver( this.onIntersection, {
 				threshold: [ 0, 1 ],
 				rootMargin: `-${ calculateOffset() }px 0px 0px 0px`,
 			} );
 			this.observer.observe( this.state._ref.current );
-		} );
+		}, 0 );
 	}
 
 	componentWillUnmount() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -5,7 +5,6 @@ import {
 } from '@automattic/sites';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { defer } from 'lodash';
 import React, { useState, useEffect } from 'react';
 import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -98,7 +97,7 @@ const SitePickerStep: Step< {
 				setShowConfirmModal( false );
 			} }
 			onConfirm={ () => {
-				defer( () => destinationSite && selectSite( destinationSite ) );
+				setTimeout( () => destinationSite && selectSite( destinationSite ), 0 );
 			} }
 		>
 			<p>

--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -1,5 +1,4 @@
 import { RootChild } from '@automattic/components';
-import { defer } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
@@ -32,9 +31,9 @@ class GuidedToursComponent extends Component {
 			} );
 		}
 
-		defer( () => {
+		setTimeout( () => {
 			this.props.dispatch( nextGuidedTourStep( { tour, stepName: nextStepName } ) );
-		} );
+		}, 0 );
 	};
 
 	quit = ( { step, tour, tourVersion: tour_version, isLastStep } ) => {

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -2,7 +2,6 @@ import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
-import { defer } from 'lodash';
 import { Component, CSSProperties, FunctionComponent } from 'react';
 import pathToSection from 'calypso/lib/path-to-section';
 import { ROUTE_SET } from 'calypso/state/action-types';
@@ -295,14 +294,14 @@ export default class Step extends Component< Props, State > {
 		);
 
 		if ( ! hasContinue && hasJustNavigated && this.isDifferentSection( lastAction.path ) ) {
-			defer( () => {
+			setTimeout( () => {
 				debug( 'Step.quitIfInvalidRoute: quitting (different section)' );
 				( this.context as SectionContext ).quit( this.context as SectionContext );
-			} );
+			}, 0 );
 		}
 
 		// quit if we have a target but cant find it
-		defer( () => {
+		setTimeout( () => {
 			const { quit } = this.context as SectionContext;
 			const target = targetForSlug( this.props.target );
 			if ( this.props.target && ! target ) {
@@ -311,7 +310,7 @@ export default class Step extends Component< Props, State > {
 			} else {
 				debug( 'Step.quitIfInvalidRoute: not quitting' );
 			}
-		} );
+		}, 0 );
 	}
 
 	isDifferentSection( path: string ) {

--- a/client/lib/analytics/test/mocks/lib/load-script/index.js
+++ b/client/lib/analytics/test/mocks/lib/load-script/index.js
@@ -1,9 +1,7 @@
-import { defer } from 'lodash';
-
 function fakeLoader( url, callback ) {
 	fakeLoader.urlsLoaded.push( url );
 	if ( callback ) {
-		defer( callback );
+		setTimeout( callback, 0 );
 	}
 }
 

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -3,17 +3,7 @@ import page from '@automattic/calypso-router';
 import { pick } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { translate } from 'i18n-calypso';
-import {
-	defer,
-	difference,
-	filter,
-	find,
-	forEach,
-	includes,
-	isEmpty,
-	reject,
-	reduce,
-} from 'lodash';
+import { difference, filter, find, forEach, includes, isEmpty, reject, reduce } from 'lodash';
 import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -375,7 +365,7 @@ export default class SignupFlowController {
 			this._assertFlowProvidedRequiredDependencies();
 			// deferred to ensure that the onComplete function is called after the stores have
 			// emitted their final change events.
-			defer( () => this._onComplete( dependencies, this._destination( dependencies ) ) );
+			setTimeout( () => this._onComplete( dependencies, this._destination( dependencies ) ), 0 );
 		}
 	}
 
@@ -430,9 +420,9 @@ export default class SignupFlowController {
 		}
 
 		// deferred because a step can be processed as soon as it is submitted
-		defer( () => {
+		setTimeout( () => {
 			this._reduxStore.dispatch( processStep( step ) );
-		} );
+		}, 0 );
 
 		const apiFunction = steps[ step.stepName ].apiRequestFunction;
 		if ( ! apiFunction ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -9,7 +9,7 @@ import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { pick } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { defer, difference, get, includes, isEmpty } from 'lodash';
+import { difference, get, includes, isEmpty } from 'lodash';
 import { buildUpgradeFunction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import {
@@ -325,7 +325,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, themeStyleVariation } ) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
-		defer( callback );
+		setTimeout( callback, 0 );
 		return;
 	}
 
@@ -447,7 +447,7 @@ export function submitWebsiteContent( callback, { siteSlug }, step, reduxStore )
 	const state = reduxStore.getState();
 	const websiteContent = getWebsiteContent( state );
 	if ( ! websiteContent ) {
-		defer( callback );
+		setTimeout( callback, 0 );
 		return;
 	}
 
@@ -489,7 +489,7 @@ export function addWithThemePlanToCart( callback, dependencies, stepProvidedItem
 	 * If the user selected the free option, then we should abort the checkout part.
 	 */
 	if ( ! planCartItem ) {
-		defer( callback );
+		setTimeout( callback, 0 );
 		return;
 	}
 
@@ -618,7 +618,7 @@ export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxS
 	const { cartItems, lastKnownFlow } = stepProvidedItems;
 	if ( isEmpty( cartItems ) && isEmpty( emailItem ) ) {
 		// the user selected the free plan
-		defer( callback );
+		setTimeout( callback, 0 );
 
 		return;
 	}
@@ -643,7 +643,7 @@ export function addAddOnsToCart(
 	const providedDependencies = stepProvidedDependencies || { cartItem };
 	if ( ! cartItem || isEmpty( cartItem ) ) {
 		// the user hans't selected any addons
-		defer( callback );
+		setTimeout( callback, 0 );
 
 		return;
 	}
@@ -787,7 +787,7 @@ export function createAccount(
 		// If purchasing item in this flow, return without creating a user account.
 		if ( isPurchasingItem ) {
 			const providedDependencies = { allowUnauthenticated: true };
-			return defer( () => callback( undefined, providedDependencies ) );
+			return setTimeout( () => callback( undefined, providedDependencies ), 0 );
 		}
 	}
 

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -1,5 +1,3 @@
-import { defer } from 'lodash';
-
 export default {
 	stepA: {
 		stepName: 'stepA',
@@ -17,7 +15,7 @@ export default {
 	asyncStep: {
 		stepName: 'asyncStep',
 		apiRequestFunction: function ( callback, dependencies, stepData ) {
-			defer( callback );
+			setTimeout( callback, 0 );
 			stepData.done();
 		},
 	},
@@ -27,10 +25,10 @@ export default {
 		dependencies: [ 'bearer_token' ],
 		providesDependencies: [ 'siteSlug' ],
 		apiRequestFunction: function ( callback, dependencies, stepData ) {
-			defer( function () {
+			setTimeout( function () {
 				callback( null, { siteSlug: 'testsite.wordpress.com' } );
 				stepData.stepCallback( dependencies );
-			} );
+			}, 0 );
 		},
 	},
 
@@ -39,9 +37,9 @@ export default {
 		providesToken: true,
 		providesDependencies: [ 'bearer_token' ],
 		apiRequestFunction: function ( callback ) {
-			defer( function () {
+			setTimeout( function () {
 				callback( null, { bearer_token: 'TOKEN' } );
-			} );
+			}, 0 );
 		},
 	},
 
@@ -50,7 +48,7 @@ export default {
 		providesToken: true,
 		providesDependencies: [ 'bearer_token' ],
 		apiRequestFunction: function ( callback ) {
-			defer( callback );
+			setTimeout( callback, 0 );
 		},
 	},
 
@@ -60,7 +58,7 @@ export default {
 		delayApiRequestUntilComplete: true,
 		apiRequestFunction: function ( callback, dependencies, stepData ) {
 			stepData.stepCallback();
-			defer( callback );
+			setTimeout( callback, 0 );
 		},
 	},
 

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import AuthorSelector from 'calypso/blocks/author-selector';
@@ -63,7 +62,7 @@ class ImporterAuthorMapping extends PureComponent {
 			 * TODO: Refactor this to not automate the UI but use proper state
 			 * TODO: A better way might be to handle this call in the backend and leave the UI out of the decision
 			 */
-			defer( () => selectAuthor( users[ 0 ] ) );
+			setTimeout( () => selectAuthor( users[ 0 ] ), 0 );
 		}
 	};
 
@@ -110,8 +109,8 @@ class ImporterAuthorMapping extends PureComponent {
 	}
 }
 
-const withUsers = createHigherOrderComponent(
-	( Component ) => ( props ) => {
+const withUsers = createHigherOrderComponent( ( Component ) => {
+	const WithUsers = ( props ) => {
 		const { siteId } = props;
 		const { data } = useUsersQuery( siteId, {
 			authors_only: 1,
@@ -120,8 +119,8 @@ const withUsers = createHigherOrderComponent(
 		const users = data?.users ?? [];
 
 		return <Component users={ users } { ...props } />;
-	},
-	'withUsers'
-);
+	};
+	return WithUsers;
+}, 'withUsers' );
 
 export default localize( withUsers( ImporterAuthorMapping ) );

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -3,7 +3,6 @@ import { omit } from '@automattic/js-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
@@ -298,7 +297,7 @@ class EditUserForm extends Component {
 		this.props.markChanged();
 		if ( this.props.autoSave ) {
 			// defer to pick up the most recent form values
-			defer( () => this.updateUser() );
+			setTimeout( () => this.updateUser(), 0 );
 		}
 	}
 

--- a/client/reader/full-post/controller.jsx
+++ b/client/reader/full-post/controller.jsx
@@ -1,4 +1,3 @@
-import { defer } from 'lodash';
 import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -13,11 +12,11 @@ const loadSidebar = () =>
 const analyticsPageTitle = 'Reader';
 
 const scrollTopIfNoHash = () =>
-	defer( () => {
+	setTimeout( () => {
 		if ( typeof window !== 'undefined' && ! window.location.hash ) {
 			window.scrollTo( 0, 0 );
 		}
-	} );
+	}, 0 );
 
 export function blogPost( context, next ) {
 	const state = context.store.getState();

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -8,7 +8,6 @@ import { Icon, commentAuthorAvatar, plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import closest from 'component-closest';
 import i18n, { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
 import { Component, useMemo } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { withReaderOrganizations } from 'calypso/components/data/with-reader-organizations';
@@ -108,10 +107,10 @@ export class ReaderSidebar extends Component {
 	highlightNewTag( tagSlug ) {
 		const tagStreamUrl = getTagStreamUrl( tagSlug );
 		if ( tagStreamUrl !== page.current ) {
-			defer( function () {
+			setTimeout( function () {
 				page( tagStreamUrl );
 				window.scrollTo( 0, 0 );
-			} );
+			}, 0 );
 		}
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -12,7 +12,7 @@ import { camelToSnakeCase, kebabCase, omit } from '@automattic/js-utils';
 import * as oauthToken from '@automattic/oauth-token';
 import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
-import { clone, defer, find, get, includes, isEmpty, isEqual, map } from 'lodash';
+import { clone, find, get, includes, isEmpty, isEqual, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -654,7 +654,7 @@ class Signup extends Component {
 			}
 
 			// deferred in case the user is logged in and the redirect triggers a dispatch
-			defer( () => {
+			setTimeout( () => {
 				debug( `Redirecting you to "${ destination }"` );
 				// Experimental: added the flowName check to restrict this functionality only for the 'website-design-services' flow.
 				if ( destination?.startsWith( '/checkout/' ) && 'website-design-services' === flowName ) {
@@ -662,7 +662,7 @@ class Signup extends Component {
 					return;
 				}
 				window.location.href = destination;
-			} );
+			}, 0 );
 
 			return;
 		}

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmailSignupTitanCard from 'calypso/components/emails/email-signup-titan-card';
@@ -56,7 +55,7 @@ class EmailsStep extends Component {
 	};
 
 	submitEmailPurchase = ( emailItem ) => {
-		defer( () => {
+		setTimeout( () => {
 			const { goToNextStep, stepName, stepSectionName } = this.props;
 
 			this.props.submitSignupStep(
@@ -71,7 +70,7 @@ class EmailsStep extends Component {
 			);
 
 			goToNextStep();
-		} );
+		}, 0 );
 	};
 
 	renderSideContent = () => {

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { once, defer } from 'lodash';
+import { once } from 'lodash';
 import {
 	ROUTE_SET,
 	SELECTED_SITE_SET,
@@ -50,9 +50,9 @@ const notifyAboutImmediateLoginLinkEffects = once( ( dispatch, action, getState 
 	}
 
 	// Let redux process all dispatches that are currently queued and show the message
-	defer( () => {
+	setTimeout( () => {
 		dispatch( successNotice( createImmediateLoginMessage( action.query.login_reason, email ) ) );
-	} );
+	}, 0 );
 } );
 
 const handler = async ( dispatch, action, getState ) => {

--- a/client/state/login/actions/auth-account-type.js
+++ b/client/state/login/actions/auth-account-type.js
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { defer } from 'lodash';
 import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUEST,
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING,
@@ -38,12 +37,12 @@ export const getAuthAccountType = ( usernameOrEmail ) => ( dispatch ) => {
 			} )
 		);
 
-		defer( () => {
+		setTimeout( () => {
 			dispatch( {
 				type: LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE,
 				error,
 			} );
-		} );
+		}, 0 );
 
 		return;
 	}

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -34,6 +34,7 @@ const CASE_MESSAGE =
 const COMPOSE_MESSAGE = 'Please use the equivalent from `@wordpress/compose` instead.';
 const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash `compact`.';
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
+const DEFER_MESSAGE = 'Please use native `setTimeout( fn, 0 )` instead of lodash `defer`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -41,6 +42,7 @@ const paths = [
 	{ name: 'lodash', importNames: COMPOSE_NAMES, message: COMPOSE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'compact' ], message: COMPACT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
+	{ name: 'lodash', importNames: [ 'defer' ], message: DEFER_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -50,6 +52,7 @@ const patterns = [
 	{ group: COMPOSE_NAMES.map( ( name ) => `lodash/${ name }` ), message: COMPOSE_MESSAGE },
 	{ group: [ 'lodash/compact' ], message: COMPACT_MESSAGE },
 	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
+	{ group: [ 'lodash/defer' ], message: DEFER_MESSAGE },
 ];
 
 module.exports = { paths, patterns };

--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { useRtl } from 'i18n-calypso';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, useState, useEffect, Component } from 'react';
 import ReactDom from 'react-dom';
@@ -80,10 +79,10 @@ class PopoverInner extends Component {
 		// setting and checking `this.scheduledPositionUpdate`.
 		// See https://github.com/Automattic/wp-calypso/commit/38e779cfebf6dd42bb30d8be7127951b0c531ae2
 		if ( this.scheduledPositionUpdate == null ) {
-			this.scheduledPositionUpdate = defer( () => {
+			this.scheduledPositionUpdate = setTimeout( () => {
 				this.setPosition();
 				this.scheduledPositionUpdate = null;
-			} );
+			}, 0 );
 		}
 	}
 
@@ -208,12 +207,12 @@ class PopoverInner extends Component {
 		// { top: -9999, left: -9999 } where it already has dimensions. These dimensions are measured
 		// and used to calculate the final position.
 		// Focusing the element while it's off the screen would cause unwanted scrolling.
-		this.scheduledFocus = defer( () => {
+		this.scheduledFocus = setTimeout( () => {
 			if ( this.popoverNodeRef.current ) {
 				this.popoverNodeRef.current.focus();
 			}
 			this.scheduledFocus = null;
-		} );
+		}, 0 );
 	}
 
 	getPositionClass( position ) {


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `defer` with native `setTimeout( fn, 0 )` across the client and the shared `@automattic/components` package.
* Add an eslint guard so `defer` cannot be reintroduced from lodash.

Part of the incremental lodash removal.

## Why are these changes being made?

`defer` is a thin lodash wrapper around `setTimeout`. Dropping it removes another lodash dependency surface with an exact native equivalent: both schedule a single macrotask, return a clearable timer id, and forward trailing arguments. The eslint guard keeps the replacement from regressing.

## Testing Instructions

* `yarn test-client` passes (full suite green).
* `yarn typecheck-client` shows no new errors from these files.
* No behavior change is expected — deferred callbacks still run on the next macrotask, and `clearTimeout` on the returned id still cancels them.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
