### PR TITLE
Fix Agents Manager Zendesk handoff route

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -303,6 +303,23 @@ describe( 'AgentDock', () => {
 		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/zendesk' );
 	} );
 
+	it( 'keeps the Zendesk route available when the unified Help Center experience is off', () => {
+		useWpAdminAgent();
+		mockShouldUseUnifiedAgent = false;
+
+		renderAgentDock( '/zendesk' );
+
+		expect( screen.getByTestId( 'zendesk-chat' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/zendesk' );
+	} );
+
+	it( 'hides the Zendesk route for reader chat', () => {
+		renderAgentDock( '/zendesk' );
+
+		expect( screen.queryByTestId( 'zendesk-chat' ) ).toBeNull();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/chat' );
+	} );
+
 	it( 'opens Reader Chat without saving shared Agents Manager state', () => {
 		mockAgentsManagerState = { isOpen: false, isDocked: false };
 		renderAgentDock();

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -174,8 +174,9 @@ export default function AgentDock( {
 	// Route visibility. All are hidden in reader chat (public blog frontends);
 	// some add a further requirement, noted below. Ordered to match the routes.
 	//
-	// `/zendesk` also needs the unified agent or using Woo AI.
-	const showZendeskChat = shouldUseUnifiedAgent && ! isReaderChat;
+	// `/zendesk` is used by agent handoff buttons. Keep it available for
+	// non-reader agents even when the full unified Help Center experience is off.
+	const showZendeskChat = ! isReaderChat;
 	// `/support-guides` (the list) also needs the unified agent, and is only
 	// reachable from the AI chat entry button (WP admin bar or Calypso masterbar).
 	const showSupportGuides = shouldUseUnifiedAgent && ! isReaderChat && hasAiChatEntry;


### PR DESCRIPTION
## Summary

- Keep the Agents Manager `/zendesk` route available for non-reader agents even when the full unified Help Center experience is disabled.
- Add regression coverage for Dolly/block-editor-style handoff and ensure reader chat still falls back to `/chat`.

## Root cause

Dolly in the editor can load Agents Manager through the block-editor enablement path without enabling the full unified Help Center experience. The `/zendesk` route was gated on that unified experience flag, so the handoff button navigated to an unavailable route and the catch-all route redirected back to `/chat` as a new Dolly conversation.

## Testing

Automated:

- `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager/src/components/__tests__/agent-dock.test.tsx --runInBand`
- `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts --runInBand`
- `git diff --check`

Manual sandbox flow:

1. `cd apps/agents-manager`
2. `yarn dev --sync`
3. Sandbox the test site and `widgets.wp.com`.
4. In the editor with Dolly/Agents Manager, trigger “Switch to Happiness Engineer” and confirm it stays in Agents Manager on the Zendesk handoff route instead of starting a new Dolly chat.
