### PR TITLE
Help Center: stop showing "Happiness Engineer" on automated messages

### DIFF
--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -80,6 +80,32 @@ function clusterMessagesBySender( messages: Message[] ) {
 		return [];
 	}
 
+	const shouldStartNewGroup = (
+		message: Message,
+		currentGroup: {
+			role:
+				| MessageRole
+				| 'csat'
+				| 'attachment'
+				| 'feedback'
+				| 'zendesk-intro'
+				| 'business-automated';
+			messages: Message[];
+		}
+	) => {
+		const presentedRole = getPresentedRole( message );
+
+		if ( presentedRole !== currentGroup.role ) {
+			return true;
+		}
+
+		return (
+			presentedRole === 'business-automated' &&
+			currentGroup.messages.length > 0 &&
+			message.displayName !== currentGroup.messages[ 0 ]?.displayName
+		);
+	};
+
 	let currentGroup: {
 		id: string;
 		role: MessageRole | 'csat' | 'attachment' | 'feedback' | 'zendesk-intro' | 'business-automated';
@@ -97,7 +123,7 @@ function clusterMessagesBySender( messages: Message[] ) {
 			continue;
 		}
 
-		if ( getPresentedRole( message ) !== currentGroup.role ) {
+		if ( shouldStartNewGroup( message, currentGroup ) ) {
 			currentGroup = {
 				id: crypto.randomUUID(),
 				role: getPresentedRole( message ),

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -7,6 +7,7 @@ import { isCSATMessage } from '../../../utils';
 import {
 	hasFeedbackForm,
 	isAttachment,
+	isHappinessEngineerMessage,
 	isZendeskChatStartedMessage,
 	isZendeskIntroMessage,
 } from '../../../utils/csat';
@@ -32,6 +33,10 @@ function getPresentedRole( message: Message ) {
 		return 'feedback';
 	} else if ( isZendeskIntroMessage( message ) ) {
 		return 'zendesk-intro';
+	} else if ( message.role === 'business' && ! isHappinessEngineerMessage( message ) ) {
+		// Automated/system business messages (messaging triggers, etc.) keep their Zendesk-configured
+		// name and must cluster separately from real Happiness Engineer messages.
+		return 'business-automated';
 	}
 	return message.role;
 }
@@ -77,7 +82,7 @@ function clusterMessagesBySender( messages: Message[] ) {
 
 	let currentGroup: {
 		id: string;
-		role: MessageRole | 'csat' | 'attachment' | 'feedback' | 'zendesk-intro';
+		role: MessageRole | 'csat' | 'attachment' | 'feedback' | 'zendesk-intro' | 'business-automated';
 		messages: Message[];
 	} = {
 		id: crypto.randomUUID(),
@@ -115,13 +120,19 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 		const endingHumanSupport = group.messages.some( isCSATMessage );
 
 		const messageHeader = () => {
-			// Only business messages have a header.
+			// Real Happiness Engineer messages always show the "Happiness Engineer" override so that
+			// silent transfers between HEs don't leak individual agent names.
 			if ( group.role === 'business' ) {
 				return (
 					<div className="message-header business">
 						{ __( 'Happiness Engineer', __i18n_text_domain__ ) }
 					</div>
 				);
+			}
+			// Automated/system messages keep whatever name is configured for them in Zendesk.
+			if ( group.role === 'business-automated' ) {
+				const displayName = group.messages[ 0 ]?.displayName;
+				return displayName ? <div className="message-header business">{ displayName }</div> : null;
 			}
 			return null;
 		};

--- a/packages/odie-client/src/components/message/messages-cluster/style.scss
+++ b/packages/odie-client/src/components/message/messages-cluster/style.scss
@@ -47,7 +47,8 @@
 		}
 	}
 
-	&.role-business {
+	&.role-business,
+	&.role-business-automated {
 		display: flex;
 		flex-direction: column;
 		align-self: flex-start;

--- a/packages/odie-client/src/components/message/test/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/test/messages-cluster.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { MessagesClusterizer } from '../messages-cluster/messages-cluster';
+import type { Message } from '../../../types';
+
+jest.mock( '../../../utils', () => ( {
+	isCSATMessage: () => false,
+} ) );
+
+jest.mock( '../../../utils/csat', () => ( {
+	hasFeedbackForm: () => false,
+	isAttachment: () => false,
+	isHappinessEngineerMessage: ( message: Message ) =>
+		!! message?.metadata?.[ '__zendesk_msg.agent.id' ],
+	isZendeskChatStartedMessage: () => false,
+	isZendeskIntroMessage: () => false,
+} ) );
+
+jest.mock( '..', () => ( {
+	__esModule: true,
+	default: ( { message, header }: { message: Message; header?: React.ReactNode } ) => (
+		<div>
+			{ header }
+			<div>{ message.content }</div>
+		</div>
+	),
+} ) );
+
+jest.mock( '../../chat-with-support', () => () => null );
+
+const createBusinessMessage = ( {
+	content,
+	displayName,
+	received,
+	agentId,
+}: {
+	content: string;
+	displayName: string;
+	received: number;
+	agentId?: string;
+} ): Message => ( {
+	content,
+	displayName,
+	received,
+	role: 'business',
+	type: 'message',
+	metadata: agentId ? { '__zendesk_msg.agent.id': agentId } : {},
+} );
+
+describe( 'MessagesClusterizer', () => {
+	beforeEach( () => {
+		let nextId = 0;
+		jest.spyOn( crypto, 'randomUUID' ).mockImplementation( () => `fake-uuid-${ ++nextId }` );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'splits automated business message groups when the display name changes', () => {
+		render(
+			<MessagesClusterizer
+				messages={ [
+					createBusinessMessage( {
+						content: 'First automated message',
+						displayName: 'WordPress.com',
+						received: 1,
+					} ),
+					createBusinessMessage( {
+						content: 'Second automated message',
+						displayName: 'Jetpack',
+						received: 2,
+					} ),
+				] }
+			/>
+		);
+
+		expect( screen.getByText( 'WordPress.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Jetpack' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/odie-client/src/components/message/test/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/test/messages-cluster.tsx
@@ -49,7 +49,11 @@ const createBusinessMessage = ( {
 describe( 'MessagesClusterizer', () => {
 	beforeEach( () => {
 		let nextId = 0;
-		jest.spyOn( crypto, 'randomUUID' ).mockImplementation( () => `fake-uuid-${ ++nextId }` );
+		jest
+			.spyOn( crypto, 'randomUUID' )
+			.mockImplementation(
+				() => `00000000-0000-0000-0000-${ String( ++nextId ).padStart( 12, '0' ) }`
+			);
 	} );
 
 	afterEach( () => {

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -145,6 +145,7 @@ export type ChatFeedbackActions = {
 export type Message = {
 	content: ReactNode;
 	context?: Context;
+	displayName?: string;
 	internal_message_id?: string;
 	message_id?: number;
 	meta?: Record< string, string >;

--- a/packages/odie-client/src/utils/csat.ts
+++ b/packages/odie-client/src/utils/csat.ts
@@ -15,6 +15,15 @@ export const isZendeskIntroMessage = ( message: Message | ZendeskMessage ) =>
 export const isZendeskChatStartedMessage = ( message: Message ) =>
 	message?.internal_message_id === 'zendesk-chat-started';
 
+/**
+ * A business message is sent by a real Happiness Engineer only when it carries a non-empty
+ * Zendesk agent id in its metadata. Automated/system messages (messaging triggers, CSAT, etc.)
+ * have an empty or missing agent id, so the "Happiness Engineer" name override must not apply to
+ * them — they keep their Zendesk-configured display name instead.
+ */
+export const isHappinessEngineerMessage = ( message: Message | ZendeskMessage ) =>
+	message?.role === 'business' && !! message?.metadata?.[ '__zendesk_msg.agent.id' ];
+
 export const hasCSATMessage = ( chat: Chat ) => {
 	return chat?.messages.some( isCSATMessage );
 };

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -93,6 +93,7 @@ export type ZendeskMessage = {
 	text: string;
 	altText?: string;
 	avatarUrl?: string;
+	displayName?: string;
 	sendStatus?: 'sending';
 	id: string;
 	actions?: MessageAction[];

--- a/packages/zendesk-client/src/zendesk-message-converter.tsx
+++ b/packages/zendesk-client/src/zendesk-message-converter.tsx
@@ -104,6 +104,7 @@ export const zendeskMessageConverter = ( message: ZendeskMessage ) => {
 		...message,
 		content: getContentMessage( message ),
 		context: { site_id: null },
+		displayName: message.displayName,
 		role,
 		type: message.type as MessageType,
 		quotedMessageId: message.id,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17660/stop-showing-happiness-engineer-on-automated-messages-in-help-center

## Proposed Changes

**Automated Zendesk messages in the Help Center chat now keep their Zendesk-configured sender name instead of being mislabelled as “Happiness Engineer”.**

- Real HE messages are identified by a non-empty `__zendesk_msg.agent.id` in their metadata. Only those keep the “Happiness Engineer” name override.
- Automated/system messages (messaging triggers, etc.) have an empty or missing agent id, so they cluster separately and render their Zendesk `displayName`.
- The sender `displayName` is now carried through the Zendesk message converter (it was previously dropped).

## Why are these changes being made?

When a customer moves from the AI assistant (Odie) to support, Zendesk sends automated tier messages — configured in Zendesk’s messaging triggers with a name like “Automated Response”. These weren’t written by a person, but the Help Center showed them as coming from a “Happiness Engineer”, which is misleading.

The Help Center overrides the sender name to always show “Happiness Engineer”. That override exists for a good reason: it lets HEs do silent transfers without renaming themselves in Zendesk. The bug was that the override was also applied to automated messages. This change scopes the override to real agent messages only, using a reliable metadata identifier rather than matching on a fragile name string — which also sets us up better as messaging expands across divisions. See [DOTCOM-17660](https://linear.app/a8c/issue/DOTCOM-17660).

## Testing Instructions

1. Run `yarn start`.
2. Open the Help Center, ask the AI assistant a question, then escalate to support so an automated tier message is sent.
3. Confirm the automated message shows its Zendesk-configured name (e.g. “Automated Response”), not “Happiness Engineer”.
4. Have a real Happiness Engineer reply and confirm that message still shows “Happiness Engineer”.
