### PR TITLE
Lodash: replace delay() with native setTimeout( fn, wait )

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -3,7 +3,7 @@ import { pickBy } from '@automattic/js-utils';
 import { Icon, published } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { get, delay } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
@@ -210,9 +210,9 @@ class PostCommentList extends Component {
 	scrollWhenDOMReady = () => {
 		if ( this.props.startingCommentId && ! this.hasScrolledToComment ) {
 			if ( this.commentIsOnDOM( this.props.startingCommentId ) ) {
-				delay( () => this.scrollToComment(), 50 );
+				setTimeout( () => this.scrollToComment(), 50 );
 			}
-			delay( this.scrollWhenDOMReady, 100 );
+			setTimeout( this.scrollWhenDOMReady, 100 );
 		}
 	};
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -1,4 +1,3 @@
-import { delay } from 'lodash';
 import { AUTOMATED_TRANSFER_STATUS_REQUEST } from 'calypso/state/action-types';
 import {
 	fetchAutomatedTransferStatus,
@@ -28,7 +27,7 @@ export const receiveStatus =
 
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 		if ( status !== transferStates.ERROR && status !== transferStates.COMPLETE ) {
-			delay( dispatch, 3000, fetchAutomatedTransferStatus( siteId ) );
+			setTimeout( dispatch, 3000, fetchAutomatedTransferStatus( siteId ) );
 		}
 
 		if ( status === transferStates.COMPLETE ) {

--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -1,4 +1,3 @@
-import { delay } from 'lodash';
 import { ATOMIC_TRANSFER_REQUEST } from 'calypso/state/action-types';
 import { fetchAtomicTransfer, setAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
@@ -24,7 +23,7 @@ export const receiveTransfer =
 
 		const status = transfer.status;
 		if ( status !== transferStates.ERROR && status !== transferStates.COMPLETED ) {
-			delay( () => dispatch( fetchAtomicTransfer( siteId ) ), 10000 );
+			setTimeout( () => dispatch( fetchAtomicTransfer( siteId ) ), 10000 );
 		}
 
 		if ( status === transferStates.COMPLETED ) {

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -1,4 +1,3 @@
-import { delay } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -217,11 +216,11 @@ export function pollThemeTransferStatus(
 						}
 
 						// poll again
-						return delay( pollStatus, interval, resolve, reject );
+						return setTimeout( pollStatus, interval, resolve, reject );
 					}
 					if ( status !== 'complete' ) {
 						dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
-						return delay( pollStatus, interval, resolve, reject );
+						return setTimeout( pollStatus, interval, resolve, reject );
 					}
 
 					tryThemeFetch( uploaded_theme_slug, resolve );

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -35,6 +35,7 @@ const COMPOSE_MESSAGE = 'Please use the equivalent from `@wordpress/compose` ins
 const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash `compact`.';
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
 const DEFER_MESSAGE = 'Please use native `setTimeout( fn, 0 )` instead of lodash `defer`.';
+const DELAY_MESSAGE = 'Please use native `setTimeout( fn, wait )` instead of lodash `delay`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -43,6 +44,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'compact' ], message: COMPACT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
 	{ name: 'lodash', importNames: [ 'defer' ], message: DEFER_MESSAGE },
+	{ name: 'lodash', importNames: [ 'delay' ], message: DELAY_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -53,6 +55,7 @@ const patterns = [
 	{ group: [ 'lodash/compact' ], message: COMPACT_MESSAGE },
 	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
 	{ group: [ 'lodash/defer' ], message: DEFER_MESSAGE },
+	{ group: [ 'lodash/delay' ], message: DELAY_MESSAGE },
 ];
 
 module.exports = { paths, patterns };


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `delay` with native `setTimeout( fn, wait )`.
* Extend the eslint guard so `delay` cannot be reintroduced from lodash.

Part of the incremental lodash removal, and a direct follow-up to the `defer` → `setTimeout` change.

## Why are these changes being made?

`delay` is a thin lodash wrapper around `setTimeout` with an identical signature — same scheduling, same timer id, same trailing-argument forwarding. Dropping it removes another lodash dependency surface with an exact native equivalent, and the eslint guard keeps the replacement from regressing.

## Testing Instructions

* `yarn test-client` related suites pass.
* No behavior change is expected — scheduled callbacks still run after the same delay, with the same forwarded arguments.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
