### PR TITLE
Help Center: fix support-interaction env check to honor test mode

### DIFF
--- a/packages/odie-client/src/data/test/use-current-support-interaction.test.tsx
+++ b/packages/odie-client/src/data/test/use-current-support-interaction.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useCurrentSupportInteraction } from '../use-current-support-interaction';
+
+const mockNavigate = jest.fn();
+let mockSearch = '';
+let mockQueryStatus: 'pending' | 'success' | 'error' = 'pending';
+
+jest.mock( 'react-router-dom', () => ( {
+	useLocation: () => ( { search: mockSearch } ),
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '../use-get-support-interaction-by-id', () => ( {
+	useGetSupportInteractionById: () => ( { status: mockQueryStatus } ),
+} ) );
+
+describe( 'useCurrentSupportInteraction', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockSearch = '';
+		mockQueryStatus = 'pending';
+	} );
+
+	it( 'navigates to /odie once when the interaction errors, even across re-renders', () => {
+		mockSearch = '?id=int-1';
+		mockQueryStatus = 'error';
+
+		const { rerender } = renderHook( () => useCurrentSupportInteraction() );
+		// Re-render repeatedly while the query stays in the error state.
+		rerender();
+		rerender();
+		rerender();
+
+		expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+		expect( mockNavigate ).toHaveBeenCalledWith( '/odie' );
+	} );
+
+	it( 'does not navigate when the interaction loads successfully', () => {
+		mockSearch = '?id=int-1';
+		mockQueryStatus = 'success';
+
+		renderHook( () => useCurrentSupportInteraction() );
+
+		expect( mockNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not navigate when there is no id', () => {
+		mockSearch = '';
+		mockQueryStatus = 'error';
+
+		renderHook( () => useCurrentSupportInteraction() );
+
+		expect( mockNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'supports the legacy odieInteractionId param', () => {
+		mockSearch = '?odieInteractionId=int-2';
+		mockQueryStatus = 'error';
+
+		renderHook( () => useCurrentSupportInteraction() );
+
+		expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+		expect( mockNavigate ).toHaveBeenCalledWith( '/odie' );
+	} );
+} );

--- a/packages/odie-client/src/data/test/use-get-support-interaction-by-id.test.tsx
+++ b/packages/odie-client/src/data/test/use-get-support-interaction-by-id.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useGetSupportInteractionById } from '../use-get-support-interaction-by-id';
+
+const mockIsTestModeEnvironment = jest.fn();
+const mockFetch = jest.fn();
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	isTestModeEnvironment: () => mockIsTestModeEnvironment(),
+} ) );
+
+jest.mock( '../handle-support-interactions-fetch', () => ( {
+	handleSupportInteractionsFetch: ( ...args: unknown[] ) => mockFetch( ...args ),
+} ) );
+
+const renderForInteraction = (
+	environment: 'staging' | 'production',
+	{ isTestMode }: { isTestMode: boolean }
+) => {
+	mockIsTestModeEnvironment.mockReturnValue( isTestMode );
+	mockFetch.mockResolvedValue( { uuid: 'int-1', environment } );
+
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	return renderHook( () => useGetSupportInteractionById( 'int-1' ), { wrapper } );
+};
+
+describe( 'useGetSupportInteractionById env check', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'accepts a production interaction when in test mode (local dev / staging proxying production)', async () => {
+		const { result } = renderForInteraction( 'production', { isTestMode: true } );
+
+		await waitFor( () => expect( result.current.status ).toBe( 'success' ) );
+		expect( result.current.data ).toEqual( { uuid: 'int-1', environment: 'production' } );
+	} );
+
+	it( 'accepts a staging interaction when in test mode', async () => {
+		const { result } = renderForInteraction( 'staging', { isTestMode: true } );
+
+		await waitFor( () => expect( result.current.status ).toBe( 'success' ) );
+		expect( result.current.data ).toEqual( { uuid: 'int-1', environment: 'staging' } );
+	} );
+
+	it( 'accepts a production interaction when in production mode', async () => {
+		const { result } = renderForInteraction( 'production', { isTestMode: false } );
+
+		await waitFor( () => expect( result.current.status ).toBe( 'success' ) );
+		expect( result.current.data ).toEqual( { uuid: 'int-1', environment: 'production' } );
+	} );
+
+	it( 'rejects a staging interaction when in production mode', async () => {
+		const { result } = renderForInteraction( 'staging', { isTestMode: false } );
+
+		await waitFor( () => expect( result.current.status ).toBe( 'error' ) );
+		expect( result.current.error?.message ).toBe( 'Support interaction not found' );
+	} );
+} );

--- a/packages/odie-client/src/data/use-current-support-interaction.ts
+++ b/packages/odie-client/src/data/use-current-support-interaction.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useGetSupportInteractionById } from './use-get-support-interaction-by-id';
 /**
@@ -14,10 +14,20 @@ export const useCurrentSupportInteraction = () => {
 	const id = oldId || newId;
 	const query = useGetSupportInteractionById( id || null );
 
+	// Track the last id we navigated away from so we redirect at most once per id.
+	const navigatedAwayFromId = useRef< string | null >( null );
+
 	useEffect( () => {
-		// If the support interaction is not found, drop the id param to automatically create a new one.
-		// This happens when jumping from staging to production.
-		if ( id && query.status === 'error' ) {
+		// If the support interaction can't be loaded, drop the id param to automatically create a
+		// new one. This happens when jumping from staging to production, and when the interaction
+		// fetch itself fails — e.g. 3rd-party cookies are blocked, which breaks the cross-origin
+		// wpcom proxy request.
+		//
+		// The error can be persistent (a blocked-cookie fetch keeps failing), so guard on a ref:
+		// without it, `navigate` re-runs on every render while `query.status` stays 'error',
+		// pushing history endlessly until React throws "Maximum update depth exceeded".
+		if ( id && query.status === 'error' && navigatedAwayFromId.current !== id ) {
+			navigatedAwayFromId.current = id;
 			navigate( '/odie' );
 		}
 	}, [ query.status, navigate, id ] );

--- a/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
+++ b/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
@@ -23,10 +23,14 @@ export const useGetSupportInteractionById = ( interactionId: string | null ) => 
 		enabled: !! interactionId,
 		staleTime: 1000 * 10, // 10 seconds,
 		select: ( interaction ) => {
-			const env = isTestMode ? 'staging' : 'production';
-			// getting a support interaction by ID doesn't honor the isTestMode flag, so we need to throw an error if the interaction is in staging and we're not in test mode.
-			// this way to act as if the interaction is not found and create a new one. This is needed for people who have access to both staging and production.
-			if ( interaction?.environment !== env ) {
+			// Getting a support interaction by ID doesn't honor the isTestMode flag, so the
+			// response can come back from either environment. Only reject a staging interaction
+			// when we're NOT in test mode — production must never load staging data. Test-mode
+			// clients (real staging, and local dev proxying to the production API) can read both,
+			// so accept production interactions there: rejecting them treats every interaction as
+			// "not found" and triggers an infinite create/navigate loop on local dev, where
+			// is_test_mode is true but the backing data store is production.
+			if ( ! isTestMode && interaction?.environment === 'staging' ) {
 				throw new Error( 'Support interaction not found' );
 			}
 			return interaction;


### PR DESCRIPTION
## Proposed Changes

**Fix the support-interaction environment check so it stops rejecting valid interactions in test mode — which caused an infinite render loop (`Maximum update depth exceeded`) in the Help Center chat on local dev.**

- `useGetSupportInteractionById`’s `select` previously threw `Support interaction not found` whenever `interaction.environment` didn’t strictly equal the current mode (`'staging'` in test mode, `'production'` otherwise).
- It now throws only when we are **not** in test mode and the interaction is `'staging'` — i.e. production must never load staging data, but test-mode clients can read both. This matches the comment that was already in the code.
- Adds a unit test covering all four env/mode combinations.

## Why are these changes being made?

The `environment` field on a support interaction reflects which physical data store it lives in (staging vs production), not the client’s `is_test_mode` flag. On `calypso.localhost` you run in test mode but the app proxies the **production** wpcom API, so every interaction comes back as `production`. The old strict equality treated all of them as “not found”, which made `useCurrentSupportInteraction` call `navigate('/odie')` on every render — React then bailed with `Maximum update depth exceeded`, and you couldn’t open or continue a chat locally.

On production this never triggered (env matches), so the bug was invisible there but blocked local Help Center chat work, especially while reproducing the 3rd-party-cookie escalation path.

## Testing Instructions

### Calypso

1. Run `yarn start` and open `http://calypso.localhost:3000`.
2. Open the Help Center, escalate to support, and start / reopen a conversation (optionally with 3rd-party cookies blocked).
3. Confirm the chat loads with no `Maximum update depth exceeded` error in the console and the page doesn’t freeze in a navigation loop.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center, start / reopen a support conversation, and confirm it loads without the loop.
