### PR TITLE
Agents Manager: resolve provider abilities live in multi-provider merge

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -360,6 +360,62 @@ describe( 'loadExternalProviders', () => {
 		expect( hostCode ).toHaveBeenCalled();
 		expect( wooCode ).toHaveBeenCalled();
 	} );
+
+	it( 'resolves abilities registered after load time (queried live, not snapshotted)', async () => {
+		// Big Sky registers its editor abilities (e.g. big-sky/apply-block-edits)
+		// from a React effect that runs after the chat UI mounts, which is after
+		// loadExternalProviders() has run. The merged tool provider must query
+		// each provider's abilities live so those late registrations are visible,
+		// matching the single-provider path and agenttic-client's "callbacks are
+		// called fresh each time" contract. A list snapshotted at load time would
+		// never see them, so the agent's calls to those abilities would silently
+		// never dispatch.
+		const createAbility = ( name: string ) => ( {
+			name,
+			label: name,
+			description: `${ name } description`,
+			category: 'test',
+		} );
+		let editorAbilityRegistered = false;
+		const bigSkyProvider = {
+			getAbilities: jest.fn( () =>
+				Promise.resolve(
+					editorAbilityRegistered ? [ createAbility( 'big-sky/apply-block-edits' ) ] : []
+				)
+			),
+			executeAbility: jest.fn( () => Promise.resolve( { handledBy: 'big-sky' } ) ),
+		};
+		const otherProvider = {
+			getAbilities: jest.fn( () => Promise.resolve( [ createAbility( 'wpcom/manage-site' ) ] ) ),
+			executeAbility: jest.fn( () => Promise.resolve( { handledBy: 'wpcom' } ) ),
+		};
+		const agentsManagerData = {
+			agentProviders: [ { toolProvider: bigSkyProvider }, { toolProvider: otherProvider } ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+		( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		// loadExternalProviders() queries getAbilities() here, before the editor
+		// ability is registered.
+		const providers = await loadExternalProviders();
+
+		// The editor ability registers later, once the chat UI has mounted.
+		editorAbilityRegistered = true;
+
+		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
+			createAbility( 'big-sky/apply-block-edits' ),
+			createAbility( 'wpcom/manage-site' ),
+		] );
+		await expect(
+			providers.toolProvider?.executeAbility( 'big_sky__apply_block_edits', { updates: [] } )
+		).resolves.toEqual( { handledBy: 'big-sky' } );
+		expect( bigSkyProvider.executeAbility ).toHaveBeenCalledWith( 'big_sky__apply_block_edits', {
+			updates: [],
+		} );
+		expect( otherProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
 } );
 
 describe( 'mergeUseSuggestionsHooks', () => {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -496,51 +496,54 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	if ( allToolProviders.length === 1 ) {
 		mergedToolProvider = allToolProviders[ 0 ];
 	} else if ( allToolProviders.length > 1 ) {
-		// Fetch all abilities once and build a name→provider map so that
-		// executeAbility can look up the owning provider in O(1) instead of
-		// re-querying getAbilities() on every call.
-		const allAbilityResults = await Promise.all(
-			allToolProviders.map( async ( tp ) => {
-				try {
-					return await tp.getAbilities();
-				} catch ( error ) {
-					// eslint-disable-next-line no-console
-					console.warn( '[AgentsManager] Failed to load abilities from provider:', error );
-					return [];
-				}
-			} )
-		);
-		const abilityProviderMap = new Map< string, ToolProvider >();
-		const seenAbilities = new Map< string, unknown >();
-		// Normalize ability names: AM converts `/` → `__` and `-` → `_`
-		// when routing tool calls. Index both raw and normalized forms
-		// so executeAbility matches regardless of which form the caller uses.
+		// Normalize ability names: AM converts `/` → `__` and `-` → `_` when
+		// routing tool calls, so we match on either the raw or normalized form.
 		const normalize = ( name: string ) => name.replace( /\//g, '__' ).replace( /-/g, '_' );
-		for ( let i = 0; i < allToolProviders.length; i++ ) {
-			for ( const ability of allAbilityResults[ i ] ) {
-				if ( ! abilityProviderMap.has( ability.name ) ) {
-					abilityProviderMap.set( ability.name, allToolProviders[ i ] );
-					const normalized = normalize( ability.name );
-					if ( normalized !== ability.name ) {
-						abilityProviderMap.set( normalized, allToolProviders[ i ] );
+
+		// Query providers live on each call rather than snapshotting at load.
+		// agenttic-client calls getAbilities()/executeAbility() fresh every turn,
+		// so abilities registered later stay visible. Big Sky, for one, registers
+		// its editor abilities (big-sky/apply-block-edits and friends) from a
+		// React effect that runs after loadExternalProviders(); a captured list
+		// would freeze those out and the agent's calls would silently not dispatch.
+		const collectAbilityResults = async () =>
+			Promise.all(
+				allToolProviders.map( async ( tp ) => {
+					try {
+						return await tp.getAbilities();
+					} catch ( error ) {
+						// eslint-disable-next-line no-console
+						console.warn( '[AgentsManager] Failed to load abilities from provider:', error );
+						return [];
 					}
-					seenAbilities.set( ability.name, ability );
-				}
-			}
-		}
-		const cachedAbilities = [ ...seenAbilities.values() ] as Awaited<
-			ReturnType< ToolProvider[ 'getAbilities' ] >
-		>;
+				} )
+			);
 
 		mergedToolProvider = {
-			getAbilities: async () => cachedAbilities,
+			getAbilities: async () => {
+				const results = await collectAbilityResults();
+				// Dedupe by ability name; earlier providers win on collisions.
+				const seenAbilities = new Map< string, ( typeof results )[ number ][ number ] >();
+				for ( const abilities of results ) {
+					for ( const ability of abilities ) {
+						if ( ! seenAbilities.has( ability.name ) ) {
+							seenAbilities.set( ability.name, ability );
+						}
+					}
+				}
+				return [ ...seenAbilities.values() ];
+			},
 			executeAbility: async ( name: string, args: unknown ) => {
-				// Use the pre-built map — avoids re-querying getAbilities() on
-				// every call and surfaces real errors from the owning provider
-				// instead of silently swallowing them.
-				const provider = abilityProviderMap.get( name );
-				if ( provider ) {
-					return provider.executeAbility( name, args );
+				// Resolve the owning provider live, in registration order, so the
+				// earliest provider that currently exposes the ability handles it.
+				const results = await collectAbilityResults();
+				for ( let i = 0; i < allToolProviders.length; i++ ) {
+					const owns = results[ i ].some(
+						( ability ) => ability.name === name || normalize( ability.name ) === name
+					);
+					if ( owns ) {
+						return allToolProviders[ i ].executeAbility( name, args );
+					}
 				}
 				throw new Error( `No provider handled ability: ${ name }` );
 			},


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes FORNO-378

## Proposed Changes

* Query each provider's abilities live on every getAbilities()/executeAbility() call

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When two or more providers are registered, the merged tool provider snapshotted getAbilities() once at load and served that frozen list and name-to-provider map for the session. Big Sky registers its editor abilities (big-sky/apply-block-edits and friends) from a React effect that runs after loadExternalProviders(), so they were never in the snapshot, and the agent's calls to them silently never dispatched (leaving dangling tool calls). 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout https://github.com/Automattic/jetpack/pull/49811 locally, apply the diff listed in testing steps, and sync to your sandbox
* Sandbox a test simple site and `widgets.wp.com`
* `install-plugin.sh am fix/agents-manager-multi-provider-late-abilities`
* Open a page in the page editor (must be a page so that Dolly and Jetpack AI are both running)
* Send a request to the agent that requires block editing (e.g. ask to move a block, or make an image greyscale)
* Verify the request succeeds and the block edit is performed.
* If you try again without `widgets.wp.com` sandboxed you'll notice the request fails leaving a tool call without results.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
