### PR TITLE
Desktop: fix Invalid URL crash when relaunching on Windows

### DIFF
--- a/desktop/app/window-handlers/incoming-urls/index.js
+++ b/desktop/app/window-handlers/incoming-urls/index.js
@@ -1,5 +1,6 @@
 const { app } = require( 'electron' );
 const Config = require( '../../lib/config' );
+const log = require( '../../lib/logger' )( 'desktop:incoming-urls' );
 
 module.exports = function ( { view, mainWindow } ) {
 	// Mac.
@@ -14,16 +15,35 @@ module.exports = function ( { view, mainWindow } ) {
 			}
 			mainWindow.focus();
 		}
-		// The commandLine is an array of strings in which the last element is the url.
-		handleUrl( view, commandLine.pop() );
+		// A second launch is not necessarily a deep link: a plain relaunch passes argv such
+		// as the executable path or CLI flags, none of which are URLs. Only forward an
+		// argument that actually looks like one of our protocol URLs.
+		handleUrl( view, findProtocolUrl( commandLine ) );
 	} );
 };
+
+function findProtocolUrl( args ) {
+	if ( ! Array.isArray( args ) ) {
+		return undefined;
+	}
+	const prefix = `${ Config.protocol }://`.toLowerCase();
+	return args.find( ( arg ) => typeof arg === 'string' && arg.toLowerCase().startsWith( prefix ) );
+}
 
 function handleUrl( view, url ) {
 	if ( ! url ) {
 		return;
 	}
-	const u = new URL( url );
+
+	let u;
+	try {
+		u = new URL( url );
+	} catch ( error ) {
+		// Guard against malformed input reaching the WHATWG URL parser, which throws
+		// `TypeError: Invalid URL` and would otherwise crash the main process. (DOTAPP-8)
+		log.info( `Ignoring unparseable incoming URL "${ url }": ${ error.message }` );
+		return;
+	}
 
 	// It should not be possible that the protocol is not Config.protocol, but you never know.
 	if ( u.protocol !== `${ Config.protocol }:` ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTAPP-8

## Proposed Changes

* Fix a `TypeError: Invalid URL` crash in the desktop app's main process on Windows. The `second-instance` handler assumed the **last** element of the relaunch command line was always a deep-link URL and passed it straight to `new URL()`. On a normal relaunch (no deep link) that last argument is an executable path or a Chromium/CLI flag, so `new URL()` threw and the app crashed.
* `incoming-urls` now selects the deep-link argument by matching the `wpdesktop://` protocol prefix (`findProtocolUrl`) instead of blindly taking the last argument. A relaunch with no deep link simply restores/focuses the existing window.
* `handleUrl` now wraps `new URL()` in a try/catch as a safety net — unparseable input is logged and ignored so a stray argument can never crash the main process again. This also hardens the macOS `open-url` path.
* No new automated tests: the `desktop/` package has no unit-test harness (Playwright e2e only). The parsing was factored into a small pure helper to keep it testable if unit infra is added later; the fix was verified manually (see below).

## Why are these changes being made?

On Windows the app minimizes to the tray on close, so the process stays alive holding the single-instance lock. The next launch fails to acquire the lock and signals the running instance, firing `second-instance`. Because the handler parsed the last command-line argument as a URL, any relaunch without a deep link crashed with `Invalid URL`.

This matches the reported behavior exactly: the app worked once after a reboot, then failed on every relaunch until the next reboot (a reboot clears the stale background process). The issue had 10+ customer reports within 48 hours, on both Windows 10 and Windows 11.

## Testing Instructions

The fix can be verified from source — `yarn dev` runs the patched main process directly, no packaging required:

1. `cd desktop && yarn install`
2. Run `yarn dev` and wait for the window to load.
3. In a second terminal, run `yarn dev` again to launch a second instance.
4. **Before** this change the first instance crashed with `TypeError: Invalid URL`; **after**, it simply restores/focuses the existing window with no error.

Regression check — deep-link login still works:

* A real `wpdesktop://token#<hash>` URL still routes to the login finalize step, and `wpdesktop://token` with no hash falls back to the login page.

Optional packaged-app check on Windows: build the installer, then close the window (it minimizes to the tray) and relaunch from the Start menu — it should focus the existing window instead of crashing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
