### PR TITLE
Help Center: show enable-cookies message when live chat can't load

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -1,13 +1,4 @@
-import {
-	getConversationLimitReachedMessage,
-	getOdieForwardToForumsMessage,
-	getOdieForwardToZendeskMessage,
-	getOdieThirdPartyMessageContent,
-	getOdieEmailFallbackMessageContent,
-	getOdieErrorMessage,
-	getOdieErrorMessageNonEligible,
-	getOdieZendeskConnectionErrorMessageContent,
-} from '../../constants';
+import { getConversationLimitReachedMessage } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useCurrentSupportInteraction } from '../../data/use-current-support-interaction';
 import { useOpenLiveInteractions } from '../../hooks/use-open-interaction-status-map';
@@ -16,6 +7,7 @@ import {
 	getIsRequestingHumanSupport,
 	getIsLastBotMessage,
 	getIsErrorMessage,
+	getDisplayMessage,
 } from '../../utils';
 import BotMessageActions from './bot-message-actions';
 import CustomALink from './custom-a-link';
@@ -23,42 +15,6 @@ import { GetSupport } from './get-support';
 import { MarkdownOrChildren } from './mardown-or-children';
 import Sources from './sources';
 import type { Message } from '../../types';
-
-const getDisplayMessage = (
-	userHasRecentOpenConversation: boolean,
-	isUserEligibleForPaidSupport: boolean,
-	canConnectToZendesk: boolean,
-	forceEmailSupport?: boolean,
-	isChatRestricted?: boolean,
-	isErrorMessage?: boolean,
-	isChatLoaded?: boolean
-) => {
-	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk ) {
-		return getOdieThirdPartyMessageContent();
-	}
-
-	if ( isUserEligibleForPaidSupport && forceEmailSupport ) {
-		return getOdieEmailFallbackMessageContent( isChatRestricted );
-	}
-
-	if ( isErrorMessage && ! isUserEligibleForPaidSupport ) {
-		return getOdieErrorMessageNonEligible();
-	}
-
-	const forwardMessage = isUserEligibleForPaidSupport
-		? getOdieForwardToZendeskMessage( userHasRecentOpenConversation )
-		: getOdieForwardToForumsMessage();
-
-	if ( isErrorMessage ) {
-		return getOdieErrorMessage();
-	}
-
-	if ( isUserEligibleForPaidSupport && ! isChatLoaded ) {
-		return getOdieZendeskConnectionErrorMessageContent();
-	}
-
-	return forwardMessage;
-};
 
 export const UserMessage = ( {
 	message,

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -302,31 +302,6 @@ export const getErrorTryAgainLaterMessage = (): Message => {
 	};
 };
 
-export const getOdieZendeskConnectionErrorMessageContent = (): string => {
-	return __(
-		"Sorry, I couldn't connect you to our support team right now. Please try again later or use the button below to reach out via email.",
-		__i18n_text_domain__
-	);
-};
-
-export const getOdieZendeskConnectionErrorMessage = (): Message => {
-	return {
-		content: getOdieZendeskConnectionErrorMessageContent(),
-		role: 'bot',
-		type: 'message',
-		context: {
-			site_id: null,
-			flags: {
-				is_error_message: false,
-				forward_to_human_support: true,
-			},
-			question_tags: {
-				inquiry_type: 'request-for-human-support',
-			},
-		},
-	};
-};
-
 export const getZendeskChatStartedMetaMessage = (): Message => ( {
 	content: null,
 	role: 'bot',

--- a/packages/odie-client/src/utils/get-display-message.ts
+++ b/packages/odie-client/src/utils/get-display-message.ts
@@ -1,0 +1,62 @@
+import {
+	getOdieForwardToForumsMessage,
+	getOdieForwardToZendeskMessage,
+	getOdieThirdPartyMessageContent,
+	getOdieEmailFallbackMessageContent,
+	getOdieErrorMessage,
+	getOdieErrorMessageNonEligible,
+} from '../constants';
+
+/**
+ * Decides which message to show for a "talk to human" / human-support escalation
+ * when the conversation has not been handed off to a live Zendesk agent yet.
+ *
+ * Note on the chat-not-loaded branch: when a paid-eligible user has the live chat
+ * SDK fail to initialize (`isChatLoaded` stays false after an attempt), the most
+ * common real-world cause is 3rd-party cookies being blocked — Smooch.init() throws
+ * and never flips `isChatLoaded` to true. The `canConnectToZendesk` ping
+ * (`/embeddable/config`) succeeds even with cookies blocked, so it can't catch this
+ * case on its own. We therefore route a paid user whose chat couldn't load to the
+ * "enable 3rd-party cookies" guidance instead of a generic connection error.
+ */
+export const getDisplayMessage = (
+	userHasRecentOpenConversation: boolean,
+	isUserEligibleForPaidSupport: boolean,
+	canConnectToZendesk: boolean,
+	forceEmailSupport?: boolean,
+	isChatRestricted?: boolean,
+	isErrorMessage?: boolean,
+	isChatLoaded?: boolean
+) => {
+	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk ) {
+		return getOdieThirdPartyMessageContent();
+	}
+
+	if ( isUserEligibleForPaidSupport && forceEmailSupport ) {
+		return getOdieEmailFallbackMessageContent( isChatRestricted );
+	}
+
+	if ( isErrorMessage && ! isUserEligibleForPaidSupport ) {
+		return getOdieErrorMessageNonEligible();
+	}
+
+	const forwardMessage = isUserEligibleForPaidSupport
+		? getOdieForwardToZendeskMessage( userHasRecentOpenConversation )
+		: getOdieForwardToForumsMessage();
+
+	if ( isErrorMessage ) {
+		return getOdieErrorMessage();
+	}
+
+	// Paid-eligible user, but the live chat SDK never finished initializing. The
+	// dominant cause is blocked 3rd-party cookies (Smooch.init() throws), which the
+	// `canConnectToZendesk` config ping cannot detect. Surface the cookie guidance
+	// rather than a generic "couldn't connect" error so the user has an actionable
+	// next step. This intentionally also covers rarer transient/network init failures
+	// — see false-positive note in the PR.
+	if ( isUserEligibleForPaidSupport && ! isChatLoaded ) {
+		return getOdieThirdPartyMessageContent();
+	}
+
+	return forwardMessage;
+};

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -9,6 +9,7 @@ export {
 	getOdieIdFromInteraction,
 } from './support-interaction-utils';
 export { isCSATMessage, hasCSATMessage, hasSubmittedCSATRating } from './csat';
+export { getDisplayMessage } from './get-display-message';
 import type { Chat, Message } from '../types';
 
 export const getIsRequestingHumanSupport = ( message: Message ) => {

--- a/packages/odie-client/src/utils/test/get-display-message.test.ts
+++ b/packages/odie-client/src/utils/test/get-display-message.test.ts
@@ -1,0 +1,85 @@
+// `../../constants` only needs `isTestModeEnvironment` from the zendesk-client
+// package. Mock it so importing the real constants does not pull in the full
+// `@automattic/zendesk-client` index (and its `@automattic/agenttic-ui` dependency).
+jest.mock( '@automattic/zendesk-client', () => ( {
+	isTestModeEnvironment: () => false,
+} ) );
+
+import {
+	getOdieForwardToForumsMessage,
+	getOdieForwardToZendeskMessage,
+	getOdieThirdPartyMessageContent,
+	getOdieEmailFallbackMessageContent,
+	getOdieErrorMessage,
+	getOdieErrorMessageNonEligible,
+} from '../../constants';
+import { getDisplayMessage } from '../get-display-message';
+
+describe( 'getDisplayMessage', () => {
+	const CHAT_LOADED = true;
+	const CHAT_NOT_LOADED = false;
+
+	it( 'returns the 3rd-party-cookie message when a paid user cannot reach Zendesk', () => {
+		expect(
+			getDisplayMessage(
+				false, // userHasRecentOpenConversation
+				true, // isUserEligibleForPaidSupport
+				false, // canConnectToZendesk
+				false, // forceEmailSupport
+				false, // isChatRestricted
+				false, // isErrorMessage
+				CHAT_LOADED
+			)
+		).toBe( getOdieThirdPartyMessageContent() );
+	} );
+
+	it( 'returns the 3rd-party-cookie message when a paid user can reach Zendesk but chat never loaded (cookie-blocked Smooch init failure)', () => {
+		expect(
+			getDisplayMessage(
+				false, // userHasRecentOpenConversation
+				true, // isUserEligibleForPaidSupport
+				true, // canConnectToZendesk (config ping succeeds even with cookies blocked)
+				false, // forceEmailSupport
+				false, // isChatRestricted
+				false, // isErrorMessage
+				CHAT_NOT_LOADED
+			)
+		).toBe( getOdieThirdPartyMessageContent() );
+	} );
+
+	it( 'returns the email fallback when email support is forced for a paid user', () => {
+		expect( getDisplayMessage( false, true, true, true, false, false, CHAT_LOADED ) ).toBe(
+			getOdieEmailFallbackMessageContent( false )
+		);
+	} );
+
+	it( 'returns the non-eligible error message for a non-paid user on an error message', () => {
+		expect( getDisplayMessage( false, false, true, false, false, true, CHAT_LOADED ) ).toBe(
+			getOdieErrorMessageNonEligible()
+		);
+	} );
+
+	it( 'returns the generic offline error for a paid user on an error message', () => {
+		expect( getDisplayMessage( false, true, true, false, false, true, CHAT_LOADED ) ).toBe(
+			getOdieErrorMessage()
+		);
+	} );
+
+	it( 'forwards a paid user to Zendesk when chat is loaded and there is no error', () => {
+		expect( getDisplayMessage( false, true, true, false, false, false, CHAT_LOADED ) ).toBe(
+			getOdieForwardToZendeskMessage( false )
+		);
+	} );
+
+	it( 'forwards a non-paid user to the forums when there is no error', () => {
+		expect( getDisplayMessage( false, false, true, false, false, false, CHAT_LOADED ) ).toBe(
+			getOdieForwardToForumsMessage()
+		);
+	} );
+
+	it( 'does not show the cookie message to a non-paid user whose chat never loaded', () => {
+		expect( getDisplayMessage( false, false, true, false, false, false, CHAT_NOT_LOADED ) ).toBe(
+			getOdieForwardToForumsMessage()
+		);
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

**When 3rd-party cookies are blocked, a paid user escalating to a human now sees the “enable 3rd-party cookies” guidance instead of a stack of generic connection errors.**

- Routes a paid-eligible user whose live chat never loaded (`isChatLoaded` false) to `getOdieThirdPartyMessageContent()` instead of the generic `getOdieZendeskConnectionErrorMessageContent()`.
- Extracts `getDisplayMessage` out of `user-message.tsx` into a pure, unit-testable helper (`utils/get-display-message.ts`) — the component behaviour is unchanged.
- Removes the now-dead `getOdieZendeskConnectionErrorMessage` / `getOdieZendeskConnectionErrorMessageContent`.
- Adds unit tests covering every branch, including the exact bug (paid user, `canConnectToZendesk` true, `isChatLoaded` false → cookie message).

> Stacked on `fix/support-interaction-env-check-test-mode-loop` (that branch fixes the infinite-loop crash that otherwise happens before any message renders). Will retarget to `trunk` once that merges.

> Heuristic, by design: any paid-user init failure that leaves `isChatLoaded` false (transient/network, or a brief pre-init race) now shows the cookie guidance. The previous message was equally generic in those cases, so no case gets worse guidance. A durable follow-up can classify the actual `Smooch.init()` error (cookie vs network) at `help-center-smooch.tsx`.

## Why are these changes being made?

Live chat (Zendesk Smooch) needs 3rd-party cookies. When they’re blocked, `Smooch.init()` throws and the chat never finishes loading. But the code that decides what to tell the user keyed off `canConnectToZendesk`, which only pings Zendesk’s public `/embeddable/config` endpoint — that succeeds with or without cookies. So the app thought chat was fine and fell through to repeated “Sorry, I couldn’t connect you…” / “unknown error” messages, with no hint that the user’s own cookie setting was the cause. Now they get a clear, actionable message pointing at the cookie guide.

## Testing Instructions

### Calypso

1. Run `yarn start` and open `http://calypso.localhost:3000`.
2. Block 3rd-party cookies in the browser.
3. Open the Help Center as a paid user and click “talk to human”.
4. Confirm you see the “enable 3rd-party cookies / use our guide” message instead of stacked “couldn’t connect” / “unknown error” messages.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Repeat steps 2–4 above and verify the same message.
