### PR TITLE
Global Nav 2026: mixed-case "New" badge in gray + drop dead link_click name

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -101,7 +101,6 @@ export function recordNavLinkClick( link: HTMLAnchorElement ): void {
 		is_floating: isFloating,
 		href: link.href,
 		text: ( link.textContent || '' ).trim(),
-		name: link.dataset.dropdownTrigger || null,
 		source,
 		category,
 	} );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -168,9 +168,9 @@ $x-color-link-hover: var( --studio-wordpress-blue-60 );
 $x-color-link-background-hover: var( --studio-wordpress-blue-5 );
 $x-color-link: var( --studio-wordpress-blue-50 );
 $x-color-content-separator: rgba( $studio-gray-5, 0.85 );
-// "New" badge (2026 nav). Brand green per design; no Studio token matches #48ff50.
+// "New" badge (2026 nav). Brand green background; no Studio token matches #48ff50.
 $x-nav-2026-badge-new-bg: #48ff50;
-$x-nav-2026-badge-new-color: #003d03;
+$x-nav-2026-badge-new-color: var( --studio-gray-100 );
 $x-content-min-z-index: 801;
 // One above the nav, in its stacking band, so it never escapes above Calypso modals.
 $x-nav-2026-dropdown-z-index: $x-content-min-z-index + 1;
@@ -1500,7 +1500,6 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		padding: 0 10px;
 		font-size: 10px;
 		line-height: 1;
-		text-transform: uppercase;
 		color: $x-nav-2026-badge-new-color;
 		background: $x-nav-2026-badge-new-bg;
 		border-radius: 4px;
@@ -1887,7 +1886,6 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		font-size: 10px;
 		font-weight: $lp-font-weight-medium;
 		line-height: 1;
-		text-transform: uppercase;
 		color: $x-nav-2026-badge-new-color;
 		background: $x-nav-2026-badge-new-bg;
 		border-radius: 4px;


### PR DESCRIPTION
Related to [WPBRAND-413](https://linear.app/a8c/issue/WPBRAND-413/create-the-tracks-events) (Dotcom Global Nav Redesign 2026).

## Proposed changes

* Render the global-nav "New" badge in mixed case (was all-caps) and switch its text to the standard dark gray; the green background is unchanged.
* Drop an analytics property from the nav link-click event that could never be populated (it always logged "null"); the remaining properties already cover it.

## Why are these changes being made?

* Design polish on the 2026 nav badge.
* Tidy-up of a no-op field flagged by the data consumer on WPBRAND-413.

## Testing instructions

* On a `nav_2026` surface, open a dropdown that shows the "New" badge and confirm it renders in mixed case with dark-gray text on the green background.
* Click a link inside a dropdown and confirm the `calypso_global_nav_link_click` event no longer carries a `name` property (it still carries `href`, `text`, `source`, `category`).
