### PR TITLE
Onboarding: shorten domain-step help label to "Help" on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -506,7 +506,7 @@ const DomainSearchStep: StepType< {
 								<span className="domain-search--top-bar-divider" aria-hidden="true" />
 							) }
 							<Step.LinkButton icon={ help } iconSize={ 20 } onClick={ toggleHelpCenter }>
-								{ __( 'Need help?' ) }
+								{ isMobileViewport ? __( 'Help' ) : __( 'Need help?' ) }
 							</Step.LinkButton>
 						</>
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,6 +1,7 @@
 import { HelpCenter } from '@automattic/data-stores';
 import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { help } from '@wordpress/icons';
@@ -61,6 +62,7 @@ const UseMyDomain: StepType< {
 		| undefined;
 } > = function UseMyDomain( { navigation, flow } ) {
 	const { __ } = useI18n();
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const { goNext, goBack, submit } = navigation;
 	const location = useLocation();
 	const { site } = useSiteData();
@@ -259,7 +261,7 @@ const UseMyDomain: StepType< {
 										) }
 										{ showHelpCenter && (
 											<Step.LinkButton icon={ help } iconSize={ 20 } onClick={ toggleHelpCenter }>
-												{ __( 'Need help?' ) }
+												{ isMobileViewport ? __( 'Help' ) : __( 'Need help?' ) }
 											</Step.LinkButton>
 										) }
 									</>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-431/domains-help-center-is-not-recommending-relevant-links

## Proposed Changes

**On mobile, the onboarding domain steps now show a shorter “Help” label for the Help Center entry instead of “Need help?”.**

- Applies to the domains and use-my-domain steps; the help “?” icon is kept, only the text shortens on small viewports (`useViewportMatch( 'small', '<' )`).
- Desktop is unchanged (`Need help?`).
- The entry is still gated by the `calypso_onboarding_domains_help_cta_202606` experiment — this only changes its label at mobile widths.

## Why are these changes being made?

On small screens the domains top bar runs out of room: back link, step counter, “Use a domain I own”, and “Need help?” all compete for one row, so the help text wraps/crowds ([DOTSUP-431](https://linear.app/a8c/issue/DOTSUP-431) discussion). Shortening it to “Help” on mobile keeps the entry usable without dropping it, while desktop keeps the clearer “Need help?”.

## Testing Instructions

1. Run `yarn start`, open `/setup/onboarding/domains` logged in, in the experiment’s `treatment` arm.
2. At desktop width the top right reads `⊘ Need help?`.
3. Narrow to a mobile viewport (or device emulation) and confirm it now reads `⊘ Help`, sitting cleanly next to “Use a domain I own”.
4. Repeat on the use-my-domain step.
