### PR TITLE
Dashboard: gate auto-renew CTA behind domain state

### DIFF
--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -4,6 +4,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { purchaseSettingsRoute } from '../../app/router/me';
 import { Text } from '../../components/text';
+import { canEnableAutoRenew } from '../../utils/domain';
 import type { DomainSummary } from '@automattic/api-core';
 
 export const DomainExpiryField = ( {
@@ -31,21 +32,21 @@ export const DomainExpiryField = ( {
 		return '-';
 	}
 
+	const renewLabel = domain.auto_renewing
+		? __( 'Auto-renew is on' )
+		: canEnableAutoRenew( domain ) && (
+				<Link
+					to={ purchaseSettingsRoute.fullPath }
+					params={ { purchaseId: domain.subscription_id } }
+				>
+					{ __( 'Turn on auto-renew' ) }
+				</Link>
+		  );
+
 	return (
 		<VStack justify="flex-start" alignment="left" spacing={ 1 }>
 			<Text intent={ domain.expired ? 'error' : undefined }>{ value }</Text>
-			<Text variant="muted">
-				{ domain.auto_renewing ? (
-					__( 'Auto-renew is on' )
-				) : (
-					<Link
-						to={ purchaseSettingsRoute.fullPath }
-						params={ { purchaseId: domain.subscription_id } }
-					>
-						{ __( 'Turn on auto-renew' ) }
-					</Link>
-				) }
-			</Text>
+			{ renewLabel && <Text variant="muted">{ renewLabel }</Text> }
 		</VStack>
 	);
 };

--- a/client/dashboard/domains/dataviews/test/field-expiry.test.tsx
+++ b/client/dashboard/domains/dataviews/test/field-expiry.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainStatus, DomainSubtype } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { DomainExpiryField } from '../field-expiry';
+import type { DomainSummary } from '@automattic/api-core';
+
+const getMockedDomain = ( customProps: Partial< DomainSummary > = {} ): DomainSummary =>
+	( {
+		domain: 'example.com',
+		subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
+		auto_renewing: false,
+		expired: false,
+		expiry: '2027-01-01',
+		subscription_id: 'sub123',
+		is_domain_only_site: false,
+		domain_status: { id: DomainStatus.ACTIVE, label: 'Active', type: 'success' },
+		...customProps,
+	} ) as DomainSummary;
+
+describe( '<DomainExpiryField>', () => {
+	test( 'offers "Turn on auto-renew" for an active domain with auto-renew off', () => {
+		render(
+			<DomainExpiryField
+				inOverview={ false }
+				domain={ getMockedDomain() }
+				value="January 1, 2027"
+			/>
+		);
+
+		expect( screen.getByRole( 'link', { name: 'Turn on auto-renew' } ) ).toBeVisible();
+	} );
+
+	test( 'shows "Auto-renew is on" when auto-renew is enabled', () => {
+		render(
+			<DomainExpiryField
+				inOverview={ false }
+				domain={ getMockedDomain( { auto_renewing: true } ) }
+				value="January 1, 2027"
+			/>
+		);
+
+		expect( screen.getByText( 'Auto-renew is on' ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Turn on auto-renew' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not offer "Turn on auto-renew" for an expired domain', () => {
+		render(
+			<DomainExpiryField
+				inOverview={ false }
+				domain={ getMockedDomain( {
+					expired: true,
+					domain_status: { id: DomainStatus.EXPIRED, label: 'Expired', type: 'error' },
+				} ) }
+				value="January 1, 2024"
+			/>
+		);
+
+		expect( screen.queryByRole( 'link', { name: 'Turn on auto-renew' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -59,7 +59,8 @@ export function isDomainRenewable( domain: DomainSummary ): boolean {
 
 /**
  * Whether "Turn on auto-renew" is meaningful for a domain, or whether it must
- * be renewed/redeemed first (expired, redeemable, in auction, pending renewal).
+ * be renewed/redeemed first (no subscription, expired/redeemable/in auction, or
+ * pending renewal/transfer/registration).
  */
 export function canEnableAutoRenew( domain: DomainSummary ): boolean {
 	// Auto-renew is managed through the domain's subscription.

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -57,6 +57,35 @@ export function isDomainRenewable( domain: DomainSummary ): boolean {
 	);
 }
 
+/**
+ * Whether "Turn on auto-renew" is meaningful for a domain, or whether it must
+ * be renewed/redeemed first (expired, redeemable, in auction, pending renewal).
+ */
+export function canEnableAutoRenew( domain: DomainSummary ): boolean {
+	// Auto-renew is managed through the domain's subscription.
+	if ( ! domain.subscription_id ) {
+		return false;
+	}
+
+	// Expired domains (including redeemable and cancelled-but-recoverable ones,
+	// which are surfaced as expired in the list) must be renewed or redeemed
+	// before auto-renew can apply.
+	if ( domain.expired ) {
+		return false;
+	}
+
+	// Domains in a transitional state (renewal, transfer, or registration in
+	// progress, or past redemption and in auction) must be resolved before
+	// auto-renew is meaningful. This matches the pending states that
+	// `isDomainRenewable` rejects.
+	return ! (
+		domain.domain_status.id === DomainStatus.PENDING_RENEWAL ||
+		domain.domain_status.id === DomainStatus.PENDING_TRANSFER ||
+		domain.domain_status.id === DomainStatus.PENDING_REGISTRATION ||
+		domain.domain_status.id === DomainStatus.EXPIRED_IN_AUCTION
+	);
+}
+
 export function isDomainInGracePeriod( domain: DomainSummary ) {
 	if ( domain.expiry === null ) {
 		return true;

--- a/client/dashboard/utils/test/domain.js
+++ b/client/dashboard/utils/test/domain.js
@@ -1,5 +1,10 @@
-import { DomainSubtype, WhoisType } from '@automattic/api-core';
-import { findRegistrantWhois, findPrivacyServiceWhois, isPendingPrimaryDomain } from '../domain';
+import { DomainStatus, DomainSubtype, WhoisType } from '@automattic/api-core';
+import {
+	canEnableAutoRenew,
+	findRegistrantWhois,
+	findPrivacyServiceWhois,
+	isPendingPrimaryDomain,
+} from '../domain';
 
 describe( 'utils', () => {
 	const whoisData = [
@@ -66,6 +71,98 @@ describe( 'utils', () => {
 				isPendingPrimaryDomain( {
 					...baseDomain,
 					subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Connection' },
+				} )
+			).toBe( false );
+		} );
+	} );
+
+	describe( 'canEnableAutoRenew', () => {
+		const baseDomain = {
+			subscription_id: 'sub123',
+			expired: false,
+			is_domain_only_site: false,
+			domain_status: { id: DomainStatus.ACTIVE, label: 'Active', type: 'success' },
+		};
+
+		test( 'returns true for an active domain with a subscription', () => {
+			expect( canEnableAutoRenew( baseDomain ) ).toBe( true );
+		} );
+
+		test( 'returns false when the domain has no subscription', () => {
+			expect( canEnableAutoRenew( { ...baseDomain, subscription_id: null } ) ).toBe( false );
+		} );
+
+		test( 'returns false for an expired domain', () => {
+			// Redeemable and cancelled-but-recoverable domains also surface as
+			// expired in the list, so this guards those states too.
+			expect(
+				canEnableAutoRenew( {
+					...baseDomain,
+					expired: true,
+					domain_status: { id: DomainStatus.EXPIRED, label: 'Expired', type: 'error' },
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false for a parked (domain-only) expired domain', () => {
+			expect(
+				canEnableAutoRenew( {
+					...baseDomain,
+					expired: true,
+					is_domain_only_site: true,
+					domain_status: { id: DomainStatus.EXPIRED, label: 'Expired', type: 'error' },
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false for a domain expired in auction', () => {
+			expect(
+				canEnableAutoRenew( {
+					...baseDomain,
+					domain_status: {
+						id: DomainStatus.EXPIRED_IN_AUCTION,
+						label: 'Expired',
+						type: 'error',
+					},
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false for a domain with a renewal in progress', () => {
+			expect(
+				canEnableAutoRenew( {
+					...baseDomain,
+					domain_status: {
+						id: DomainStatus.PENDING_RENEWAL,
+						label: 'Pending renewal',
+						type: 'warning',
+					},
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false for a domain with a transfer in progress', () => {
+			expect(
+				canEnableAutoRenew( {
+					...baseDomain,
+					domain_status: {
+						id: DomainStatus.PENDING_TRANSFER,
+						label: 'Pending transfer',
+						type: 'warning',
+					},
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false for a domain pending registration', () => {
+			expect(
+				canEnableAutoRenew( {
+					...baseDomain,
+					domain_status: {
+						id: DomainStatus.PENDING_REGISTRATION,
+						label: 'Pending registration',
+						type: 'warning',
+					},
 				} )
 			).toBe( false );
 		} );


### PR DESCRIPTION
Fixes pdtkmj-4B3-p2#comment-8895

## Proposed Changes

* In the Multi-site Dashboard domain list, the expiry column showed a "Turn on auto-renew" link whenever auto-renew was off — even for expired, redeemable, or transitional domains that must be renewed or redeemed first.
* Added a `canEnableAutoRenew()` helper in `client/dashboard/utils/domain.ts` that returns `false` when the domain has no subscription, is expired, or is in a pending state (`PENDING_RENEWAL`, `PENDING_TRANSFER`, `PENDING_REGISTRATION`, `EXPIRED_IN_AUCTION`).
* `field-expiry.tsx` now gates the "Turn on auto-renew" CTA on this helper. The renew/redeem action remains surfaced by the Status column.
* The helper intentionally does not restrict by domain type, so mapped and connected domains can still auto-renew.

| Before | After |
|--------|--------|
| <img width="449" height="128" alt="Screenshot 2026-06-19 at 15 45 08" src="https://github.com/user-attachments/assets/92fc6fe5-1aa4-4129-96d9-2ca20521d1be" /> | <img width="441" height="125" alt="Screenshot 2026-06-19 at 15 45 19" src="https://github.com/user-attachments/assets/6a0607fa-55b0-4428-8205-25a2c22df721" /> | 

## Why are these changes being made?

* CfT feedback: offering "Turn on auto-renew" for expired, parked, or redeemable domains is misleading — the user needs to renew or redeem first, so surfacing auto-renew puts a future-facing setting ahead of the required action.
* The rejected pending states are aligned with the existing `isDomainRenewable()` helper to keep the two predicates consistent.

## Testing Instructions

* Open the Multi-site Dashboard domains list.
* Active domain with auto-renew off: still shows "Turn on auto-renew".
* Domain with auto-renew on: shows "Auto-renew is on".
* Expired / redeemable / pending domain: no longer shows "Turn on auto-renew"; the Status column surfaces the renew/redeem action instead.
* Run unit tests:
  `yarn test-client client/dashboard/utils/test/domain.js client/dashboard/domains/dataviews/test/field-expiry.test.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)