### PR TITLE
Onboarding: tighten divider→help-icon spacing on the domains step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -5,6 +5,12 @@
 	inline-size: 1px;
 	block-size: 1.25rem;
 	background-color: var( --color-border-subtle );
+
+	// Drop the help button's leading padding so the gap from the divider to the
+	// help icon matches the gap from "Use a domain I own" to the divider.
+	+ .components-button.components-button {
+		padding-inline-start: 0;
+	}
 }
 
 .domain-search--step-container {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-431/domains-help-center-is-not-recommending-relevant-links

## Proposed Changes

**Tightens the spacing between the divider and the help icon on the onboarding domains step so it matches the spacing on the other side of the divider.**

- The top-bar right element is a flex row with a 16px gap. The help button (icon + label) also carries 8px of leading padding, so the gap from the divider to the help icon rendered at 24px while the gap from "Use a domain I own" to the divider was 16px.
- Zero the help button's leading padding so both sides of the divider are 16px.

## Why are these changes being made?

Design feedback on the mobile top bar: the help entry sat a touch too far from the divider, making the right side look uneven (`Use a domain I own │   ⊘ Help`). Most visible on mobile, where the bar is tightest. Now the divider has equal 16px breathing room on both sides.

## Testing Instructions

1. Run `yarn start`, open `/setup/onboarding/domains` logged in, in the experiment's `treatment` arm, and search a domain (so "Use a domain I own" shows).
2. Confirm the divider sits an equal distance from "Use a domain I own" and from the help icon.
3. Narrow to a mobile viewport and confirm the same, with the `⊘ Help` label.
