### PR TITLE
Skip REST proxy prefetch in Firefox

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -2,7 +2,13 @@ import config from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import Favicons from './favicons';
 
-const Head = ( { title = 'WordPress.com', children, branchName, faviconUrl } ) => {
+const Head = ( {
+	title = 'WordPress.com',
+	children,
+	branchName,
+	faviconUrl,
+	shouldPrefetchRestProxy = true,
+} ) => {
 	return (
 		<head>
 			<title>{ title }</title>
@@ -16,11 +22,13 @@ const Head = ( { title = 'WordPress.com', children, branchName, faviconUrl } ) =
 			<meta name="theme-color" content={ config( 'theme_color' ) } />
 			<meta name="referrer" content="origin" />
 
-			<link
-				rel="prefetch"
-				as="document"
-				href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
-			/>
+			{ shouldPrefetchRestProxy && (
+				<link
+					rel="prefetch"
+					as="document"
+					href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
+				/>
+			) }
 
 			<Favicons environmentFaviconURL={ faviconUrl || config( 'favicon_url' ) } />
 
@@ -44,6 +52,7 @@ Head.propTypes = {
 	children: PropTypes.node,
 	branchName: PropTypes.string,
 	faviconUrl: PropTypes.string,
+	shouldPrefetchRestProxy: PropTypes.bool,
 };
 
 export default Head;

--- a/client/components/head/test/index.jsx
+++ b/client/components/head/test/index.jsx
@@ -5,6 +5,8 @@
 import { render } from '@testing-library/react';
 import Head from '../';
 
+const restProxyHref = 'https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0';
+
 describe( 'Head', () => {
 	test( 'should render default title', () => {
 		render( <Head /> );
@@ -18,5 +20,19 @@ describe( 'Head', () => {
 		const title = 'Arbitrary Custom Title';
 		render( <Head title={ title } /> );
 		expect( document.querySelector( 'title' )?.textContent ).toBe( title );
+	} );
+
+	test( 'should prefetch the REST proxy by default', () => {
+		render( <Head /> );
+		expect(
+			document.querySelector( `link[rel="prefetch"][href="${ restProxyHref }"]` )
+		).toBeTruthy();
+	} );
+
+	test( 'should skip the REST proxy prefetch when disabled', () => {
+		render( <Head shouldPrefetchRestProxy={ false } /> );
+		expect(
+			document.querySelector( `link[rel="prefetch"][href="${ restProxyHref }"]` )
+		).toBeNull();
 	} );
 } );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -153,6 +153,8 @@ class Document extends Component {
 					branchName={ branchName }
 					inlineScriptNonce={ inlineScriptNonce }
 					faviconUrl={ headFaviconUrl }
+					// Firefox can reuse the anonymous REST proxy prefetch after login; see https://github.com/Automattic/wp-calypso/pull/111842.
+					shouldPrefetchRestProxy={ ! app?.isFirefox }
 				>
 					{ head.metas.map( ( props, index ) => (
 						<meta { ...props } key={ index } />

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -311,6 +311,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	context.app = {
 		// use ipv4 address when is ipv4 mapped address
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
+		isFirefox: request.useragent.browser === 'Firefox',
 		isWpMobileApp: isWpMobileApp( request.useragent.source ),
 		isWcMobileApp: isWcMobileApp( request.useragent.source ),
 		isDevelopmentEnv: devEnvironments.includes( calypsoEnv ),


### PR DESCRIPTION
Fixes DOTCOM-17662

## Proposed Changes

* Skip the REST proxy document prefetch for Firefox.
* Keep the prefetch enabled by default for non-Firefox browsers.
* Add test coverage for default prefetch behavior and the disabled path.

## Why are these changes being made?

Firefox 152 can reuse the anonymous prefetched REST proxy document after login. When that happens, the proxy frame does not mint authenticated `wp_api` / `wp_api_sec` cookies or expose JWT tokens, so Calypso API requests run without `X-WPTOKEN` and the user gets sent back into the login flow.

Suppressing only this prefetch for Firefox avoids the stale anonymous proxy frame while preserving the performance hint for other browsers.

## Testing Instructions

* Using FF 152 go to /log-in
* Log in
* You should be redirected to /home/SITE.