### PR TITLE
Calypso E2E: fix test-account/site cleanup harness gaps (TESTOPS-124)

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -209,7 +209,9 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 				cd test/e2e
 				# Clear any stale teardown-leak markers from a reused checkout before this run.
-				rm -rf output/teardown-leaks
+				# Recursive over output/: markers should land in output/teardown-leaks, but a
+				# path drift must not leave a stale marker that fails a later run.
+				find output -name 'account-*.json' -delete 2>/dev/null || true
 				echo "CALYPSO_BASE_URL=%CALYPSO_BASE_URL%"
 				export CALYPSO_BASE_URL="%CALYPSO_BASE_URL%"
 				echo "DASHBOARD_BASE_URL=%DASHBOARD_BASE_URL%"
@@ -226,14 +228,18 @@ object CalypsoE2ETestsBuildTemplate : Template({
 			// Runs even when tests passed or failed: a leaked test user can occur on a green run.
 			executionMode = BuildStep.ExecutionMode.ALWAYS
 			scriptContent = """
-				LEAK_DIR="test/e2e/output/teardown-leaks"
-				if [ -d "${'$'}LEAK_DIR" ] && [ -n "${'$'}( ls "${'$'}LEAK_DIR"/account-*.json 2>/dev/null || true )" ]; then
-					COUNT=${'$'}( ls -1 "${'$'}LEAK_DIR"/account-*.json 2>/dev/null | wc -l | tr -d ' ' || true )
+				# Recursive over output/ rather than only output/teardown-leaks: if the
+				# marker path ever drifts from the spec-side LEAK_DIR, a hardcoded subdir
+				# check would find nothing and pass a leaking run green. Markers are named
+				# account-*.json wherever they land.
+				MARKERS=${'$'}( find test/e2e/output -name 'account-*.json' 2>/dev/null || true )
+				if [ -n "${'$'}MARKERS" ]; then
+					COUNT=${'$'}( printf '%s\n' "${'$'}MARKERS" | wc -l | tr -d ' ' )
 					echo "E2E TEARDOWN LEAK - the following test users were not closed (their blogs leak with them):"
-					cat "${'$'}LEAK_DIR"/account-*.json 2>/dev/null || true
+					printf '%s\n' "${'$'}MARKERS" | while IFS= read -r marker; do cat "${'$'}marker" 2>/dev/null || true; done
 					# A buildProblem service message fails the build regardless of the runner exit code
 					# (nonZeroExitCode = false). Do NOT add 'exit 1': this ALWAYS step must leave green runs green.
-					echo "##teamcity[buildProblem description='E2E teardown leak: ${'$'}COUNT test user(s) not closed - see %PROJECT%/output/teardown-leaks' identity='e2e_teardown_leak']"
+					echo "##teamcity[buildProblem description='E2E teardown leak: ${'$'}COUNT test user(s) not closed - see %PROJECT%/output' identity='e2e_teardown_leak']"
 				fi
 				""".trimIndent()
 			dockerImage = "%docker_image_e2e%"

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -208,6 +208,8 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 
 				cd test/e2e
+				# Clear any stale teardown-leak markers from a reused checkout before this run.
+				rm -rf output/teardown-leaks
 				echo "CALYPSO_BASE_URL=%CALYPSO_BASE_URL%"
 				export CALYPSO_BASE_URL="%CALYPSO_BASE_URL%"
 				echo "DASHBOARD_BASE_URL=%DASHBOARD_BASE_URL%"
@@ -215,6 +217,25 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "Running Playwright tests for project: %PROJECT%"
 				yarn test:pw:%PROJECT% ${'$'}GREP_FLAG
 				"""
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Check for E2E teardown leaks"
+			id = "check_teardown_leaks"
+			// Runs even when tests passed or failed: a leaked test user can occur on a green run.
+			executionMode = BuildStep.ExecutionMode.ALWAYS
+			scriptContent = """
+				LEAK_DIR="test/e2e/output/teardown-leaks"
+				if [ -d "${'$'}LEAK_DIR" ] && [ -n "${'$'}( ls "${'$'}LEAK_DIR"/account-*.json 2>/dev/null || true )" ]; then
+					COUNT=${'$'}( ls -1 "${'$'}LEAK_DIR"/account-*.json 2>/dev/null | wc -l | tr -d ' ' || true )
+					echo "E2E TEARDOWN LEAK - the following test users were not closed (their blogs leak with them):"
+					cat "${'$'}LEAK_DIR"/account-*.json 2>/dev/null || true
+					# A buildProblem service message fails the build regardless of the runner exit code
+					# (nonZeroExitCode = false). Do NOT add 'exit 1': this ALWAYS step must leave green runs green.
+					echo "##teamcity[buildProblem description='E2E teardown leak: ${'$'}COUNT test user(s) not closed - see %PROJECT%/output/teardown-leaks' identity='e2e_teardown_leak']"
+				fi
+				""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}
 

--- a/packages/calypso-e2e/src/index.ts
+++ b/packages/calypso-e2e/src/index.ts
@@ -10,4 +10,5 @@ export * from './secrets';
 export * from './email-client';
 export * from './totp-client';
 export * from './rest-api-client';
+export * from './teardown-markers';
 export * from './types';

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -289,22 +289,29 @@ export class RestAPIClient {
 			return null;
 		}
 
-		console.log( `Deleting site ${ targetSite.domain }.` );
-
-		const scheme = 'http://';
-		const targetDomain = targetSite.domain.startsWith( scheme )
-			? targetSite.domain.replace( scheme, '' )
-			: targetSite.domain;
+		// `/all-domains/` returns scheme-less `domain` values, while callers commonly
+		// pass `blog_details.url` (e.g. `https://e2eflowtesting….wordpress.com`). Strip
+		// any scheme and trailing slash so the ownership comparison below matches.
+		const targetDomain = targetSite.domain.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
 
 		const mySites: AllDomainsResponse = await this.getAllDomains();
 
-		const match = mySites.domains.filter( ( site: DomainData ) => {
-			site.blog_id === targetSite.id && site.domain === targetDomain;
-		} );
+		// Ensure the target site actually belongs to the authenticated user before
+		// issuing the deletion. The `.some()` predicate returns a real boolean; the
+		// previous `.filter()` callback returned no value (always an empty, truthy
+		// array), so this ownership guard never fired.
+		const isOwnedByUser = mySites.domains.some(
+			( site: DomainData ) => site.blog_id === targetSite.id && site.domain === targetDomain
+		);
 
-		if ( ! match ) {
+		if ( ! isOwnedByUser ) {
+			console.warn(
+				`Aborting site deletion: site ${ targetSite.id } (${ targetDomain }) is not owned by the authenticated user.`
+			);
 			return null;
 		}
+
+		console.log( `Deleting site ${ targetSite.domain }.` );
 
 		const params: RequestParams = {
 			method: 'post',

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -289,10 +289,19 @@ export class RestAPIClient {
 			return null;
 		}
 
-		// `/all-domains/` returns scheme-less `domain` values, while callers commonly
-		// pass `blog_details.url` (e.g. `https://e2eflowtesting….wordpress.com`). Strip
-		// any scheme and trailing slash so the ownership comparison below matches.
-		const targetDomain = targetSite.domain.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
+		// `/all-domains/` returns scheme-less, lowercase `domain` values, while
+		// callers commonly pass `blog_details.url` (e.g.
+		// `https://e2eflowtesting….wordpress.com/`). Normalize both sides (strip
+		// scheme, path and trailing slash; lowercase) so the ownership comparison
+		// below is not defeated by a formatting or case difference, which would
+		// abort a legitimate cleanup and leak the site.
+		const normalizeDomain = ( value: string ): string =>
+			value
+				.trim()
+				.replace( /^https?:\/\//i, '' )
+				.replace( /\/.*$/, '' )
+				.toLowerCase();
+		const targetDomain = normalizeDomain( targetSite.domain );
 
 		const mySites: AllDomainsResponse = await this.getAllDomains();
 
@@ -301,7 +310,8 @@ export class RestAPIClient {
 		// previous `.filter()` callback returned no value (always an empty, truthy
 		// array), so this ownership guard never fired.
 		const isOwnedByUser = mySites.domains.some(
-			( site: DomainData ) => site.blog_id === targetSite.id && site.domain === targetDomain
+			( site: DomainData ) =>
+				site.blog_id === targetSite.id && normalizeDomain( site.domain ) === targetDomain
 		);
 
 		if ( ! isOwnedByUser ) {

--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -6,7 +6,11 @@ import type { AccountClosureResponse, AccountDetails } from './types';
 const MAX_ERROR_LENGTH = 300;
 
 export interface AccountLeak {
-	userID: number;
+	/**
+	 * Numeric user ID; absent when a signup response created an account but did
+	 * not return its ID. Markers then fall back to keying on the email.
+	 */
+	userID?: number;
 	username: string;
 	email: string;
 	/** Optional blog URLs the caller tracked, surfaced in the marker for richer evidence. */
@@ -16,24 +20,49 @@ export interface AccountLeak {
 }
 
 /**
- * Absolute path of the marker file for a given user inside `leakDir`.
+ * Absolute path of the marker file for a given account inside `leakDir`. Keyed
+ * by user ID when known, otherwise by a filesystem-safe form of the email so an
+ * account created without a returned ID is still recorded.
  *
  * @param {string} leakDir Directory where markers are written.
- * @param {number} userID The user ID.
+ * @param {number|string} key The user ID, or an email/identifier fallback.
  * @returns {string} Absolute marker file path.
  */
-function markerPath( leakDir: string, userID: number ): string {
-	return path.join( leakDir, `account-${ userID }.json` );
+function markerPath( leakDir: string, key: number | string ): string {
+	// `encodeURIComponent` is injective, so distinct emails never collide on the
+	// same marker file (a plain character-class replacement would collapse e.g.
+	// `+` and `@` to `_` and let two accounts overwrite each other).
+	const safeKey = typeof key === 'number' ? String( key ) : encodeURIComponent( key );
+	return path.join( leakDir, `account-${ safeKey }.json` );
 }
 
 /**
- * Reduces an unknown error to a short, single-line message safe to embed in a marker.
+ * Reduces an unknown error to a short, single-line message safe to embed in a
+ * marker. Plain objects (e.g. a `{ success: false, … }` close response) are
+ * JSON-serialized so the CI artifact says why the close failed rather than the
+ * useless `"[object Object]"` that `String()` would produce.
  *
  * @param {unknown} error The error value.
  * @returns {string} A bounded message string.
  */
 function errorMessage( error: unknown ): string {
-	const message = error instanceof Error ? error.message : String( error ?? '' );
+	let message: string;
+	if ( error instanceof Error ) {
+		message = error.message;
+	} else if ( error && typeof error === 'object' ) {
+		// `JSON.stringify` returns `undefined` (not `"undefined"`) when the value
+		// serializes to nothing, e.g. a custom `toJSON()` returning undefined; fall
+		// back to `String()` so `.slice` below never throws.
+		let serialized: string | undefined;
+		try {
+			serialized = JSON.stringify( error );
+		} catch {
+			serialized = undefined;
+		}
+		message = serialized !== undefined ? serialized : String( error );
+	} else {
+		message = String( error ?? '' );
+	}
 	return message.slice( 0, MAX_ERROR_LENGTH );
 }
 
@@ -45,6 +74,14 @@ function errorMessage( error: unknown ): string {
  * should be cleared (account already closed) or kept (state unknown -> assume leak).
  * Errors thrown by `RestAPIClient.getMyAccountInformation` are `Error`s whose
  * message is `"<code>: <message>"` (e.g. `"invalid_token: …"`).
+ *
+ * Assumption: an auth error here means the account was closed. This is not
+ * provable in general - a revoked or expired token on a still-open account would
+ * be misclassified as closed, clearing a real leak. It holds in practice because
+ * the accounts torn down here are created within the same test and live for
+ * minutes: the bearer token is long-lived relative to that window, so a token
+ * going dead mid-test for any reason other than the account being closed (e.g.
+ * the in-body UI close, which is exactly the no-leak case) is unlikely.
  *
  * @param {unknown} error The error value.
  * @returns {boolean} True only for a confirmed dead-token / unauthorized error.
@@ -64,18 +101,19 @@ export function isAccountClosedError( error: unknown ): boolean {
  * @param {AccountLeak} leak Details of the leaked account.
  */
 export function recordAccountLeak( leakDir: string, leak: AccountLeak ): void {
+	const key = leak.userID || leak.email;
 	try {
 		mkdirSync( leakDir, { recursive: true } );
 		const payload = {
-			userID: leak.userID,
+			...( leak.userID ? { userID: leak.userID } : {} ),
 			username: leak.username,
 			email: leak.email,
 			...( leak.blogs && leak.blogs.length ? { blogs: leak.blogs } : {} ),
 			error: errorMessage( leak.error ),
 		};
-		writeFileSync( markerPath( leakDir, leak.userID ), JSON.stringify( payload ) + '\n' );
+		writeFileSync( markerPath( leakDir, key ), JSON.stringify( payload ) + '\n' );
 	} catch ( error ) {
-		console.warn( `Failed to record teardown leak marker for user ${ leak.userID }: ${ error }` );
+		console.warn( `Failed to record teardown leak marker for account ${ key }: ${ error }` );
 	}
 }
 

--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -1,0 +1,151 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { RestAPIClient } from './rest-api-client';
+import type { AccountClosureResponse, AccountDetails } from './types';
+
+const MAX_ERROR_LENGTH = 300;
+
+export interface AccountLeak {
+	userID: number;
+	username: string;
+	email: string;
+	/** Optional blog URLs the caller tracked, surfaced in the marker for richer evidence. */
+	blogs?: string[];
+	/** The error that caused the leak; reduced to its message in the marker. */
+	error?: unknown;
+}
+
+/**
+ * Absolute path of the marker file for a given user inside `leakDir`.
+ *
+ * @param {string} leakDir Directory where markers are written.
+ * @param {number} userID The user ID.
+ * @returns {string} Absolute marker file path.
+ */
+function markerPath( leakDir: string, userID: number ): string {
+	return path.join( leakDir, `account-${ userID }.json` );
+}
+
+/**
+ * Reduces an unknown error to a short, single-line message safe to embed in a marker.
+ *
+ * @param {unknown} error The error value.
+ * @returns {string} A bounded message string.
+ */
+function errorMessage( error: unknown ): string {
+	const message = error instanceof Error ? error.message : String( error ?? '' );
+	return message.slice( 0, MAX_ERROR_LENGTH );
+}
+
+/**
+ * Whether an error from a `/me` request indicates the account is gone (a dead or
+ * invalid bearer token), as opposed to a transient/network/server error.
+ *
+ * Used to decide, after a failed account close, whether a surviving leak marker
+ * should be cleared (account already closed) or kept (state unknown -> assume leak).
+ * Errors thrown by `RestAPIClient.getMyAccountInformation` are `Error`s whose
+ * message is `"<code>: <message>"` (e.g. `"invalid_token: …"`).
+ *
+ * @param {unknown} error The error value.
+ * @returns {boolean} True only for a confirmed dead-token / unauthorized error.
+ */
+export function isAccountClosedError( error: unknown ): boolean {
+	const message = error instanceof Error ? error.message : String( error ?? '' );
+	return /invalid_token|authorization_required|unauthorized|user_not_found/i.test( message );
+}
+
+/**
+ * Records a teardown leak for an account that could not be closed.
+ *
+ * Writes one whole file per user under `leakDir`. Distinct user IDs map to
+ * distinct files, so concurrent Playwright workers never contend. Never throws.
+ *
+ * @param {string} leakDir Directory where markers are written.
+ * @param {AccountLeak} leak Details of the leaked account.
+ */
+export function recordAccountLeak( leakDir: string, leak: AccountLeak ): void {
+	try {
+		mkdirSync( leakDir, { recursive: true } );
+		const payload = {
+			userID: leak.userID,
+			username: leak.username,
+			email: leak.email,
+			...( leak.blogs && leak.blogs.length ? { blogs: leak.blogs } : {} ),
+			error: errorMessage( leak.error ),
+		};
+		writeFileSync( markerPath( leakDir, leak.userID ), JSON.stringify( payload ) + '\n' );
+	} catch ( error ) {
+		console.warn( `Failed to record teardown leak marker for user ${ leak.userID }: ${ error }` );
+	}
+}
+
+/**
+ * Clears the teardown leak marker for an account that was successfully closed
+ * (or confirmed already gone). Idempotent and never throws.
+ *
+ * @param {string} leakDir Directory where markers are written.
+ * @param {number} userID The user ID.
+ */
+export function clearAccountLeak( leakDir: string, userID: number ): void {
+	try {
+		rmSync( markerPath( leakDir, userID ), { force: true } );
+	} catch ( error ) {
+		console.warn( `Failed to clear teardown leak marker for user ${ userID }: ${ error }` );
+	}
+}
+
+/**
+ * Closes a test account and maintains its teardown leak marker as CI evidence.
+ *
+ * Records a marker only when the account is confirmed to still exist after a
+ * close that did not succeed: it probes `getMyAccountInformation` (which throws
+ * on a dead token). A confirmed dead-token error means the account is already
+ * gone (e.g. closed via the UI earlier in the test) -> not a leak, clear the
+ * marker. Any other probe failure is treated conservatively as a possible leak
+ * (recorded), so a transient error never silently drops a real leak. Never throws,
+ * so it is safe to call from an `afterAll`.
+ *
+ * @param {RestAPIClient} client REST API client authenticated as the account.
+ * @param {AccountDetails} accountDetails Identity of the account to close.
+ * @param {string} leakDir Directory where leak markers are written.
+ */
+export async function closeAccountAndRecordLeak(
+	client: RestAPIClient,
+	accountDetails: AccountDetails,
+	leakDir: string
+): Promise< void > {
+	console.log( `Closing account ${ accountDetails.userID }.` );
+
+	let closeError: unknown;
+	try {
+		const response: AccountClosureResponse = await client.closeAccount( accountDetails );
+
+		if ( response.success === true ) {
+			console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
+			clearAccountLeak( leakDir, accountDetails.userID );
+			return;
+		}
+
+		console.warn( `Failed to delete user ID ${ accountDetails.userID }` );
+		console.warn( response );
+		closeError = response;
+	} catch ( error ) {
+		console.warn( `Error closing account ${ accountDetails.userID }: ${ error }` );
+		closeError = error;
+	}
+
+	try {
+		await client.getMyAccountInformation();
+		// Account still exists and we failed to close it: a real leak.
+		recordAccountLeak( leakDir, { ...accountDetails, error: closeError } );
+	} catch ( probeError ) {
+		if ( isAccountClosedError( probeError ) ) {
+			// Dead token: the account is already gone. Not a leak.
+			clearAccountLeak( leakDir, accountDetails.userID );
+		} else {
+			// Could not confirm the account is gone (transient/network error).
+			// Be conservative and record so the CI check does not miss a real leak.
+			recordAccountLeak( leakDir, { ...accountDetails, error: closeError } );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/test/rest-api-client.deleteSite.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.deleteSite.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for RestAPIClient.deleteSite, focused on the ownership pre-check.
+ *
+ * The pre-check previously used a `.filter()` callback with no `return`, which
+ * always produced an empty (truthy) array, so the `if ( ! match )` guard never
+ * fired and deletion proceeded for any `e2e`-prefixed domain. These tests pin
+ * the fixed `.some()` behavior: delete only when the target is among the user's
+ * own domains.
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import nock from 'nock';
+import { RestAPIClient, BEARER_TOKEN_URL } from '../rest-api-client';
+import { SecretsManager } from '../secrets';
+import type { Secrets } from '../secrets';
+
+const fakeSecrets = {
+	calypsoOauthApplication: {
+		client_id: 'some_value',
+		client_secret: 'some_value',
+	},
+} as unknown as Secrets;
+
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
+
+// Persist and intercept all bearer token calls in these tests.
+nock( BEARER_TOKEN_URL )
+	.persist()
+	.post( /.*/ )
+	.reply( 200, {
+		success: true,
+		data: {
+			bearer_token: 'abcdefghijklmn',
+			token_links: [ 'link_1', 'link_2' ],
+		},
+	} );
+
+describe( 'RestAPIClient: deleteSite', function () {
+	const restAPIClient = new RestAPIClient( {
+		username: 'fake_user',
+		password: 'fake_password',
+	} );
+
+	const targetSite = { id: 12345, domain: 'e2eflowtesting12345.wordpress.com' };
+	const allDomainsURL = restAPIClient.getRequestURL( '1.1', '/all-domains/' );
+	const deleteURL = restAPIClient.getRequestURL( '1.1', `/sites/${ targetSite.id }/delete` );
+
+	beforeEach( function () {
+		nock.cleanAll();
+		// Re-persist the bearer token endpoint after cleanAll.
+		nock( BEARER_TOKEN_URL )
+			.persist()
+			.post( /.*/ )
+			.reply( 200, {
+				success: true,
+				data: { bearer_token: 'abcdefghijklmn', token_links: [] },
+			} );
+	} );
+
+	test( 'deletes a site that belongs to the user', async function () {
+		nock( allDomainsURL.origin )
+			.get( allDomainsURL.pathname )
+			.reply( 200, {
+				domains: [
+					{ blog_id: targetSite.id, domain: targetSite.domain },
+					{ blog_id: 99999, domain: 'e2eflowtestingother.wordpress.com' },
+				],
+			} );
+
+		const deleteScope = nock( deleteURL.origin )
+			.post( deleteURL.pathname )
+			.reply( 200, { status: 'deleted' } );
+
+		const response = await restAPIClient.deleteSite( targetSite );
+
+		expect( deleteScope.isDone() ).toBe( true );
+		expect( response ).not.toBeNull();
+		expect( response?.status ).toBe( 'deleted' );
+	} );
+
+	test( 'aborts and returns null when the site is not owned by the user', async function () {
+		nock( allDomainsURL.origin )
+			.get( allDomainsURL.pathname )
+			.reply( 200, {
+				// Target site is absent: only an unrelated domain is owned.
+				domains: [ { blog_id: 99999, domain: 'e2eflowtestingother.wordpress.com' } ],
+			} );
+
+		// Register the delete endpoint so we can assert it is NOT called.
+		const deleteScope = nock( deleteURL.origin )
+			.post( deleteURL.pathname )
+			.reply( 200, { status: 'deleted' } );
+
+		const response = await restAPIClient.deleteSite( targetSite );
+
+		expect( response ).toBeNull();
+		expect( deleteScope.isDone() ).toBe( false );
+	} );
+
+	test( 'aborts when only the blog_id matches but the domain differs', async function () {
+		nock( allDomainsURL.origin )
+			.get( allDomainsURL.pathname )
+			.reply( 200, {
+				domains: [ { blog_id: targetSite.id, domain: 'e2eflowtestingDIFFERENT.wordpress.com' } ],
+			} );
+
+		const deleteScope = nock( deleteURL.origin )
+			.post( deleteURL.pathname )
+			.reply( 200, { status: 'deleted' } );
+
+		const response = await restAPIClient.deleteSite( targetSite );
+
+		expect( response ).toBeNull();
+		expect( deleteScope.isDone() ).toBe( false );
+	} );
+
+	test( 'returns null for a non-e2e domain without querying domains', async function () {
+		// No /all-domains/ interceptor: if the method queried it, nock would error.
+		const response = await restAPIClient.deleteSite( {
+			id: 777,
+			domain: 'realsite.wordpress.com',
+		} );
+
+		expect( response ).toBeNull();
+	} );
+
+	test( 'strips an http:// scheme before matching ownership', async function () {
+		nock( allDomainsURL.origin )
+			.get( allDomainsURL.pathname )
+			.reply( 200, {
+				domains: [ { blog_id: targetSite.id, domain: targetSite.domain } ],
+			} );
+
+		const deleteScope = nock( deleteURL.origin )
+			.post( deleteURL.pathname )
+			.reply( 200, { status: 'deleted' } );
+
+		const response = await restAPIClient.deleteSite( {
+			id: targetSite.id,
+			domain: `http://${ targetSite.domain }`,
+		} );
+
+		expect( deleteScope.isDone() ).toBe( true );
+		expect( response?.status ).toBe( 'deleted' );
+	} );
+
+	test( 'strips an https:// scheme (the create-site blog_details.url form) before matching ownership', async function () {
+		nock( allDomainsURL.origin )
+			.get( allDomainsURL.pathname )
+			.reply( 200, {
+				domains: [ { blog_id: targetSite.id, domain: targetSite.domain } ],
+			} );
+
+		const deleteScope = nock( deleteURL.origin )
+			.post( deleteURL.pathname )
+			.reply( 200, { status: 'deleted' } );
+
+		const response = await restAPIClient.deleteSite( {
+			id: targetSite.id,
+			domain: `https://${ targetSite.domain }/`,
+		} );
+
+		expect( deleteScope.isDone() ).toBe( true );
+		expect( response?.status ).toBe( 'deleted' );
+	} );
+} );

--- a/packages/calypso-e2e/src/test/rest-api-client.deleteSite.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.deleteSite.test.ts
@@ -162,4 +162,22 @@ describe( 'RestAPIClient: deleteSite', function () {
 		expect( deleteScope.isDone() ).toBe( true );
 		expect( response?.status ).toBe( 'deleted' );
 	} );
+
+	test( 'matches ownership case-insensitively', async function () {
+		nock( allDomainsURL.origin )
+			.get( allDomainsURL.pathname )
+			.reply( 200, {
+				// `/all-domains/` casing differs from the caller-passed domain.
+				domains: [ { blog_id: targetSite.id, domain: 'E2EFlowTesting12345.WordPress.com' } ],
+			} );
+
+		const deleteScope = nock( deleteURL.origin )
+			.post( deleteURL.pathname )
+			.reply( 200, { status: 'deleted' } );
+
+		const response = await restAPIClient.deleteSite( targetSite );
+
+		expect( deleteScope.isDone() ).toBe( true );
+		expect( response?.status ).toBe( 'deleted' );
+	} );
 } );

--- a/packages/calypso-e2e/src/test/teardown-markers.test.ts
+++ b/packages/calypso-e2e/src/test/teardown-markers.test.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
+import {
+	clearAccountLeak,
+	closeAccountAndRecordLeak,
+	isAccountClosedError,
+	recordAccountLeak,
+} from '../teardown-markers';
+import type { RestAPIClient } from '../rest-api-client';
+
+let leakDir: string;
+
+beforeEach( () => {
+	leakDir = mkdtempSync( path.join( tmpdir(), 'teardown-markers-' ) );
+} );
+
+afterEach( () => {
+	rmSync( leakDir, { recursive: true, force: true } );
+} );
+
+const markerFile = ( userID: number ): string => path.join( leakDir, `account-${ userID }.json` );
+
+const details = {
+	userID: 2001,
+	username: 'e2eflowtestinginvited2001',
+	email: 'e2e+2001@mailosaur.io',
+};
+
+// closeAccountAndRecordLeak only calls `closeAccount` and `getMyAccountInformation`,
+// so a loose stub returning arbitrary payloads suffices. The double cast keeps the
+// mocks free of the client's exact return types without using `any`.
+const fakeClient = ( impl: {
+	closeAccount: () => Promise< unknown >;
+	getMyAccountInformation: () => Promise< unknown >;
+} ): RestAPIClient => impl as unknown as RestAPIClient;
+
+describe( 'teardown-markers: record / clear', () => {
+	test( 'recordAccountLeak writes a per-user marker with identity, optional blogs, and a bounded error', () => {
+		recordAccountLeak( leakDir, {
+			userID: 1001,
+			username: 'e2eflowtestinginvited1001',
+			email: 'e2e+1001@mailosaur.io',
+			blogs: [ 'e2eflowtesting1001.wordpress.com' ],
+			error: new Error( 'x'.repeat( 1000 ) ),
+		} );
+
+		expect( existsSync( markerFile( 1001 ) ) ).toBe( true );
+		const data = JSON.parse( readFileSync( markerFile( 1001 ), 'utf8' ) );
+		expect( data.userID ).toBe( 1001 );
+		expect( data.username ).toBe( 'e2eflowtestinginvited1001' );
+		expect( data.email ).toBe( 'e2e+1001@mailosaur.io' );
+		expect( data.blogs ).toEqual( [ 'e2eflowtesting1001.wordpress.com' ] );
+		expect( data.error.length ).toBeLessThanOrEqual( 300 );
+	} );
+
+	test( 'record-then-clear for the same user leaves no file (the retry-safety invariant)', () => {
+		recordAccountLeak( leakDir, { userID: 1002, username: 'u', email: 'e@mailosaur.io' } );
+		expect( existsSync( markerFile( 1002 ) ) ).toBe( true );
+
+		clearAccountLeak( leakDir, 1002 );
+		expect( existsSync( markerFile( 1002 ) ) ).toBe( false );
+	} );
+
+	test( 'clearAccountLeak is a safe no-op when no marker exists', () => {
+		expect( () => clearAccountLeak( leakDir, 999999 ) ).not.toThrow();
+	} );
+} );
+
+describe( 'teardown-markers: isAccountClosedError', () => {
+	test.each( [
+		'invalid_token: The OAuth2 token is invalid',
+		'authorization_required: An active access token must be used.',
+		'Request was unauthorized',
+		'user_not_found: account is gone',
+	] )( 'returns true for a dead-token / auth error (%s)', ( message ) => {
+		expect( isAccountClosedError( new Error( message ) ) ).toBe( true );
+	} );
+
+	test.each( [
+		'500: Internal Server Error',
+		'fetch failed',
+		'ETIMEDOUT connecting to host',
+		'Unexpected token < in JSON at position 0',
+	] )( 'returns false for a transient / non-auth error (%s)', ( message ) => {
+		expect( isAccountClosedError( new Error( message ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'closeAccountAndRecordLeak', () => {
+	test( 'close succeeds: clears the marker and never probes', async () => {
+		const getMyAccountInformation = jest.fn( async () => ( {} ) );
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => ( { success: true } ) ),
+				getMyAccountInformation,
+			} ),
+			details,
+			leakDir
+		);
+
+		expect( getMyAccountInformation ).not.toHaveBeenCalled();
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
+	} );
+
+	test( 'close returns non-success and the account still exists: records a marker', async () => {
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => ( { success: false } ) ),
+				getMyAccountInformation: jest.fn( async () => ( {} ) ),
+			} ),
+			details,
+			leakDir
+		);
+
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+	} );
+
+	test( 'close throws and the token is dead (probe throws auth error): no marker, account already gone', async () => {
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => {
+					throw new Error( 'invalid_token: dead' );
+				} ),
+				getMyAccountInformation: jest.fn( async () => {
+					throw new Error( 'invalid_token: dead' );
+				} ),
+			} ),
+			details,
+			leakDir
+		);
+
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
+	} );
+
+	test( 'close throws and probe fails transiently: records a marker (conservative, no missed leak)', async () => {
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => {
+					throw new Error( '500: server error' );
+				} ),
+				getMyAccountInformation: jest.fn( async () => {
+					throw new Error( 'fetch failed' );
+				} ),
+			} ),
+			details,
+			leakDir
+		);
+
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+	} );
+
+	test( 'a stale marker is cleared once the account is confirmed gone', async () => {
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => ( { success: false } ) ),
+				getMyAccountInformation: jest.fn( async () => ( {} ) ),
+			} ),
+			details,
+			leakDir
+		);
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => {
+					throw new Error( 'invalid_token' );
+				} ),
+				getMyAccountInformation: jest.fn( async () => {
+					throw new Error( 'invalid_token' );
+				} ),
+			} ),
+			details,
+			leakDir
+		);
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
+	} );
+
+	test( 'never throws even when the client throws', async () => {
+		await expect(
+			closeAccountAndRecordLeak(
+				fakeClient( {
+					closeAccount: jest.fn( async () => {
+						throw new Error( 'boom' );
+					} ),
+					getMyAccountInformation: jest.fn( async () => {
+						throw new Error( 'boom' );
+					} ),
+				} ),
+				details,
+				leakDir
+			)
+		).resolves.toBeUndefined();
+	} );
+} );

--- a/packages/calypso-e2e/src/test/teardown-markers.test.ts
+++ b/packages/calypso-e2e/src/test/teardown-markers.test.ts
@@ -66,6 +66,37 @@ describe( 'teardown-markers: record / clear', () => {
 	test( 'clearAccountLeak is a safe no-op when no marker exists', () => {
 		expect( () => clearAccountLeak( leakDir, 999999 ) ).not.toThrow();
 	} );
+
+	test( 'serializes a non-Error close failure as JSON, not "[object Object]"', () => {
+		recordAccountLeak( leakDir, {
+			userID: 1003,
+			username: 'u',
+			email: 'e@mailosaur.io',
+			error: { success: false, code: 'has_active_subscription' },
+		} );
+
+		const data = JSON.parse( readFileSync( markerFile( 1003 ), 'utf8' ) );
+		expect( data.error ).toContain( 'has_active_subscription' );
+		expect( data.error ).not.toContain( '[object Object]' );
+	} );
+
+	test( 'records a marker keyed by email when the user ID is unknown', () => {
+		recordAccountLeak( leakDir, {
+			username: 'e2eflowtestinginvited',
+			email: 'e2e+noid@mailosaur.io',
+			error: 'Signup response missing user_id.',
+		} );
+
+		// Keyed by the URL-encoded email so distinct emails never collide.
+		const file = path.join(
+			leakDir,
+			`account-${ encodeURIComponent( 'e2e+noid@mailosaur.io' ) }.json`
+		);
+		expect( existsSync( file ) ).toBe( true );
+		const data = JSON.parse( readFileSync( file, 'utf8' ) );
+		expect( data.userID ).toBeUndefined();
+		expect( data.email ).toBe( 'e2e+noid@mailosaur.io' );
+	} );
 } );
 
 describe( 'teardown-markers: isAccountClosedError', () => {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/e2e-require-account-teardown.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/e2e-require-account-teardown.js
@@ -1,0 +1,136 @@
+/**
+ * @file Flag E2E specs that create a test account (getNewTestUser + a signup
+ *       helper) but register no afterAll `apiCloseAccount` teardown, so the
+ *       account (and its blogs) leaks. Specs may opt out via the `allow` list.
+ * @author Automattic
+ */
+
+const path = require( 'path' );
+
+/**
+ * Whether an ancestor node is an `afterAll(...)` or `test.afterAll(...)` call.
+ * @param {import('estree').Node} ancestor Candidate ancestor node.
+ * @returns {boolean} True if the ancestor is an afterAll call expression.
+ */
+function isAfterAllCall( ancestor ) {
+	if ( ancestor.type !== 'CallExpression' ) {
+		return false;
+	}
+	const callee = ancestor.callee;
+	if ( callee.type === 'Identifier' && callee.name === 'afterAll' ) {
+		return true;
+	}
+	return (
+		callee.type === 'MemberExpression' &&
+		callee.property.type === 'Identifier' &&
+		callee.property.name === 'afterAll'
+	);
+}
+
+/**
+ * Whether a callee references `getNewTestUser` (bare or as a member, e.g.
+ * `DataHelper.getNewTestUser` / `helperData.getNewTestUser`).
+ * @param {import('estree').Node} callee Callee node.
+ * @returns {boolean} True if it references getNewTestUser.
+ */
+function isGetNewTestUser( callee ) {
+	if ( callee.type === 'Identifier' ) {
+		return callee.name === 'getNewTestUser';
+	}
+	return (
+		callee.type === 'MemberExpression' &&
+		callee.property.type === 'Identifier' &&
+		callee.property.name === 'getNewTestUser'
+	);
+}
+
+/**
+ * Whether a callee is a member call whose property starts with `signup`
+ * (signupThroughInvite, signupSocialFirstWithEmail, signupWithEmail, signupWoo,
+ * signupWPCC, and flow-object variants).
+ * @param {import('estree').Node} callee Callee node.
+ * @returns {boolean} True if it is a signup helper member call.
+ */
+function isSignupHelper( callee ) {
+	return (
+		callee.type === 'MemberExpression' &&
+		callee.property.type === 'Identifier' &&
+		/^signup/.test( callee.property.name )
+	);
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+	type: 'problem',
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Require E2E specs that create a test account to register an afterAll apiCloseAccount teardown.',
+		},
+		schema: [
+			{
+				type: 'object',
+				additionalProperties: false,
+				properties: {
+					allow: {
+						type: 'array',
+						uniqueItems: true,
+						items: { type: 'string' },
+					},
+				},
+			},
+		],
+		messages: {
+			missingTeardown:
+				'This spec creates a test account (getNewTestUser + a signup helper) but registers no afterAll apiCloseAccount teardown, so the account and its blogs leak. Add a test.afterAll/afterAll that calls apiCloseAccount, or add this file to the rule allow list with justification.',
+		},
+	},
+	create( context ) {
+		const options = ( context.options && context.options[ 0 ] ) || {};
+		const allow = Array.isArray( options.allow ) ? options.allow : [];
+
+		const filename = context.filename || context.getFilename();
+		const normalized = filename.split( path.sep ).join( '/' );
+		if ( allow.some( ( entry ) => normalized.endsWith( entry ) ) ) {
+			return {};
+		}
+
+		let usesNewTestUser = false;
+		let usesSignupHelper = false;
+		let hasApprovedTeardown = false;
+		let firstAccountNode = null;
+
+		// `context.getAncestors()` was removed from the rule context in ESLint 9;
+		// `SourceCode#getAncestors(node)` works in both 8.40+ and 9.
+		const sourceCode = context.sourceCode || context.getSourceCode();
+
+		return {
+			CallExpression( node ) {
+				const callee = node.callee;
+
+				if ( isGetNewTestUser( callee ) ) {
+					usesNewTestUser = true;
+					if ( ! firstAccountNode ) {
+						firstAccountNode = node;
+					}
+				}
+
+				if ( isSignupHelper( callee ) ) {
+					usesSignupHelper = true;
+				}
+
+				if ( callee.type === 'Identifier' && callee.name === 'apiCloseAccount' ) {
+					if ( sourceCode.getAncestors( node ).some( isAfterAllCall ) ) {
+						hasApprovedTeardown = true;
+					}
+				}
+			},
+			'Program:exit'() {
+				if ( usesNewTestUser && usesSignupHelper && ! hasApprovedTeardown ) {
+					context.report( { node: firstAccountNode, messageId: 'missingTeardown' } );
+				}
+			},
+		};
+	},
+};

--- a/packages/eslint-plugin-wpcalypso/lib/rules/e2e-require-account-teardown.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/e2e-require-account-teardown.js
@@ -80,48 +80,137 @@ function isApiCloseAccount( callee ) {
 }
 
 /**
- * Whether `node` is the concise body of an arrow that is itself the `afterAll`
- * callback, e.g. `afterAll( () => apiCloseAccount( ... ) )`. The runner awaits
- * the promise the callback returns, so this is a real teardown. A concise body
- * nested deeper (e.g. a discarded `accounts.map( a => apiCloseAccount( a ) )`)
- * is NOT awaited and must not qualify.
- * @param {import('estree').Node} node The apiCloseAccount CallExpression.
- * @returns {boolean} True if the call is the returned body of the afterAll callback.
+ * Whether a node introduces a function scope.
+ * @param {import('estree').Node} node Candidate node.
+ * @returns {boolean} True for function/arrow nodes.
  */
-function isReturnedFromAfterAllCallback( node ) {
-	const arrow = node.parent;
-	if ( ! arrow || arrow.type !== 'ArrowFunctionExpression' || arrow.body !== node ) {
-		return false;
-	}
-	const call = arrow.parent;
-	return Boolean(
-		call &&
-			call.type === 'CallExpression' &&
-			call.arguments.includes( arrow ) &&
-			isAfterAllCall( call )
+function isFunctionNode( node ) {
+	return (
+		node.type === 'FunctionExpression' ||
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'ArrowFunctionExpression'
 	);
 }
 
 /**
- * Whether the `apiCloseAccount` call at `node` is actually consumed (awaited or
- * returned), not left floating. A floating call inside an `afterAll` races with
- * worker teardown and may never complete, so it does not count as teardown.
- * Accepts `await apiCloseAccount(...)` and `return apiCloseAccount(...)` (which
- * also covers `await Promise.all( accounts.map( ... ) )`), and the direct
- * `afterAll( () => apiCloseAccount(...) )` callback body.
- * @param {import('estree').Node} node The apiCloseAccount CallExpression.
+ * The function passed directly as the callback of the innermost enclosing
+ * `afterAll(...)` / `test.afterAll(...)` call, or null when the node is not
+ * inside an afterAll callback.
  * @param {import('estree').Node[]} ancestors The node's ancestors, root-first.
- * @returns {boolean} True if the call is awaited or returned.
+ * @returns {import('estree').Node|null} The afterAll callback function node.
  */
-function isAwaitedOrReturned( node, ancestors ) {
-	if (
-		ancestors.some(
-			( ancestor ) => ancestor.type === 'AwaitExpression' || ancestor.type === 'ReturnStatement'
-		)
-	) {
+function afterAllCallback( ancestors ) {
+	for ( let i = ancestors.length - 1; i >= 0; i-- ) {
+		if ( ! isAfterAllCall( ancestors[ i ] ) ) {
+			continue;
+		}
+		const callback = ancestors[ i + 1 ];
+		if ( callback && isFunctionNode( callback ) && ancestors[ i ].arguments.includes( callback ) ) {
+			return callback;
+		}
+		return null;
+	}
+	return null;
+}
+
+/**
+ * The nearest enclosing function of a node, given its ancestors, or null.
+ * @param {import('estree').Node[]} ancestors The node's ancestors, root-first.
+ * @returns {import('estree').Node|null} The innermost function/arrow ancestor.
+ */
+function nearestFunction( ancestors ) {
+	for ( let i = ancestors.length - 1; i >= 0; i-- ) {
+		if ( isFunctionNode( ancestors[ i ] ) ) {
+			return ancestors[ i ];
+		}
+	}
+	return null;
+}
+
+/**
+ * Whether `array` (an ArrayExpression) is the argument of a `Promise.all(...)` or
+ * `Promise.allSettled(...)` call, i.e. its element promises are actually awaited
+ * together. A bare array (`await [ p ]`, `return [ p ]`) is a non-thenable that
+ * swallows its element promises, so it must not count as consuming them.
+ * @param {import('estree').Node} array The ArrayExpression node.
+ * @returns {boolean} True if the array is a Promise.all / Promise.allSettled argument.
+ */
+function isPromiseAllArgument( array ) {
+	const call = array.parent;
+	return Boolean(
+		call &&
+			call.type === 'CallExpression' &&
+			call.arguments.includes( array ) &&
+			call.callee.type === 'MemberExpression' &&
+			call.callee.object.type === 'Identifier' &&
+			call.callee.object.name === 'Promise' &&
+			call.callee.property.type === 'Identifier' &&
+			( call.callee.property.name === 'all' || call.callee.property.name === 'allSettled' )
+	);
+}
+
+/**
+ * Whether `node`'s promise is directly consumed, so awaiting/returning it gates
+ * the enclosing function. "Directly" is deliberately strict to avoid accepting a
+ * floated promise: only the operand of `await`/`return`, the concise arrow body
+ * itself, or an element of a `Promise.all`/`allSettled` array whose call is in
+ * turn directly consumed. Anything that merely *evaluates* the promise but
+ * yields a different value - `void p`, `( p, x )`, `p && x`, `p ? a : b`,
+ * `` tag`${ p }` ``, `wrapper( p )`, `p.then( … )` - does NOT consume it.
+ * @param {import('estree').Node} node The node whose promise must be consumed.
+ * @param {import('estree').Node} callback The afterAll callback function.
+ * @returns {boolean} True if the promise is awaited or returned.
+ */
+function isDirectlyConsumed( node, callback ) {
+	if ( node === callback.body ) {
+		// Concise arrow body: the runner awaits the implicitly returned promise.
 		return true;
 	}
-	return isReturnedFromAfterAllCallback( node );
+	const parent = node.parent;
+	if ( ! parent ) {
+		return false;
+	}
+	if ( parent.type === 'AwaitExpression' && parent.argument === node ) {
+		return true;
+	}
+	if ( parent.type === 'ReturnStatement' && parent.argument === node ) {
+		return true;
+	}
+	if ( parent.type === 'ArrayExpression' && isPromiseAllArgument( parent ) ) {
+		// Element of Promise.all/allSettled([...]): consumed iff the call itself is.
+		return isDirectlyConsumed( parent.parent, callback );
+	}
+	return false;
+}
+
+/**
+ * Whether the `apiCloseAccount` call at `node` is consumed (awaited or returned)
+ * in the afterAll callback's OWN body, so the callback's promise gates on it.
+ *
+ * The call must live directly in the callback body, not in a nested callback
+ * (e.g. a `.map()` callback the afterAll discards), and must be directly
+ * consumed (see {@link isDirectlyConsumed}). Supported: `await apiCloseAccount(
+ * ... )`, `return apiCloseAccount( ... )`, the concise body `() =>
+ * apiCloseAccount( ... )`, `() => Promise.all( [ ... ] )`, and an awaited/
+ * returned `Promise.all`/`allSettled` array. Known limitation: `Promise.all(
+ * accounts.map( ( a ) => apiCloseAccount( a ) ) )` (close in a nested callback)
+ * and method chains like `apiCloseAccount( … ).then( … )` are not recognized;
+ * use a for-of loop, an awaited array literal, or the allow list.
+ * @param {import('estree').Node} node The apiCloseAccount CallExpression.
+ * @param {import('estree').Node[]} ancestors The node's ancestors, root-first.
+ * @returns {boolean} True if the call is awaited or returned by the afterAll callback.
+ */
+function isConsumedByAfterAll( node, ancestors ) {
+	const callback = afterAllCallback( ancestors );
+	if ( ! callback ) {
+		return false;
+	}
+	// The close must be in the callback's own body, not a nested function whose
+	// result the callback discards.
+	if ( nearestFunction( ancestors ) !== callback ) {
+		return false;
+	}
+	return isDirectlyConsumed( node, callback );
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -185,8 +274,7 @@ module.exports = {
 				}
 
 				if ( isApiCloseAccount( callee ) ) {
-					const ancestors = sourceCode.getAncestors( node );
-					if ( ancestors.some( isAfterAllCall ) && isAwaitedOrReturned( node, ancestors ) ) {
+					if ( isConsumedByAfterAll( node, sourceCode.getAncestors( node ) ) ) {
 						hasApprovedTeardown = true;
 					}
 				}

--- a/packages/eslint-plugin-wpcalypso/lib/rules/e2e-require-account-teardown.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/e2e-require-account-teardown.js
@@ -1,7 +1,10 @@
 /**
  * @file Flag E2E specs that create a test account (getNewTestUser + a signup
- *       helper) but register no afterAll `apiCloseAccount` teardown, so the
- *       account (and its blogs) leaks. Specs may opt out via the `allow` list.
+ *       helper) but register no afterAll teardown that awaits `apiCloseAccount`,
+ *       so the account (and its blogs) leaks. A floating (unawaited) call does
+ *       not count, since it races worker teardown. Specs may opt out via the
+ *       `allow` list. This is a coarse presence backstop, not a proof that the
+ *       teardown is wired to the created account.
  * @author Automattic
  */
 
@@ -59,9 +62,70 @@ function isSignupHelper( callee ) {
 	);
 }
 
+/**
+ * Whether a callee references `apiCloseAccount` (bare or as a member, e.g.
+ * `shared.apiCloseAccount`).
+ * @param {import('estree').Node} callee Callee node.
+ * @returns {boolean} True if it references apiCloseAccount.
+ */
+function isApiCloseAccount( callee ) {
+	if ( callee.type === 'Identifier' ) {
+		return callee.name === 'apiCloseAccount';
+	}
+	return (
+		callee.type === 'MemberExpression' &&
+		callee.property.type === 'Identifier' &&
+		callee.property.name === 'apiCloseAccount'
+	);
+}
+
+/**
+ * Whether `node` is the concise body of an arrow that is itself the `afterAll`
+ * callback, e.g. `afterAll( () => apiCloseAccount( ... ) )`. The runner awaits
+ * the promise the callback returns, so this is a real teardown. A concise body
+ * nested deeper (e.g. a discarded `accounts.map( a => apiCloseAccount( a ) )`)
+ * is NOT awaited and must not qualify.
+ * @param {import('estree').Node} node The apiCloseAccount CallExpression.
+ * @returns {boolean} True if the call is the returned body of the afterAll callback.
+ */
+function isReturnedFromAfterAllCallback( node ) {
+	const arrow = node.parent;
+	if ( ! arrow || arrow.type !== 'ArrowFunctionExpression' || arrow.body !== node ) {
+		return false;
+	}
+	const call = arrow.parent;
+	return Boolean(
+		call &&
+			call.type === 'CallExpression' &&
+			call.arguments.includes( arrow ) &&
+			isAfterAllCall( call )
+	);
+}
+
+/**
+ * Whether the `apiCloseAccount` call at `node` is actually consumed (awaited or
+ * returned), not left floating. A floating call inside an `afterAll` races with
+ * worker teardown and may never complete, so it does not count as teardown.
+ * Accepts `await apiCloseAccount(...)` and `return apiCloseAccount(...)` (which
+ * also covers `await Promise.all( accounts.map( ... ) )`), and the direct
+ * `afterAll( () => apiCloseAccount(...) )` callback body.
+ * @param {import('estree').Node} node The apiCloseAccount CallExpression.
+ * @param {import('estree').Node[]} ancestors The node's ancestors, root-first.
+ * @returns {boolean} True if the call is awaited or returned.
+ */
+function isAwaitedOrReturned( node, ancestors ) {
+	if (
+		ancestors.some(
+			( ancestor ) => ancestor.type === 'AwaitExpression' || ancestor.type === 'ReturnStatement'
+		)
+	) {
+		return true;
+	}
+	return isReturnedFromAfterAllCallback( node );
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
-	type: 'problem',
 	meta: {
 		type: 'problem',
 		docs: {
@@ -83,7 +147,7 @@ module.exports = {
 		],
 		messages: {
 			missingTeardown:
-				'This spec creates a test account (getNewTestUser + a signup helper) but registers no afterAll apiCloseAccount teardown, so the account and its blogs leak. Add a test.afterAll/afterAll that calls apiCloseAccount, or add this file to the rule allow list with justification.',
+				'This spec creates a test account (getNewTestUser + a signup helper) but registers no afterAll apiCloseAccount teardown, so the account and its blogs leak. Add a test.afterAll/afterAll that awaits apiCloseAccount, or add this file to the rule allow list with justification.',
 		},
 	},
 	create( context ) {
@@ -120,8 +184,9 @@ module.exports = {
 					usesSignupHelper = true;
 				}
 
-				if ( callee.type === 'Identifier' && callee.name === 'apiCloseAccount' ) {
-					if ( sourceCode.getAncestors( node ).some( isAfterAllCall ) ) {
+				if ( isApiCloseAccount( callee ) ) {
+					const ancestors = sourceCode.getAncestors( node );
+					if ( ancestors.some( isAfterAllCall ) && isAwaitedOrReturned( node, ancestors ) ) {
 						hasApprovedTeardown = true;
 					}
 				}

--- a/packages/eslint-plugin-wpcalypso/lib/rules/index.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/index.js
@@ -28,4 +28,5 @@ module.exports = {
 	'post-message-no-wildcard-targets': adapt( require( './post-message-no-wildcard-targets' ) ),
 	'redux-no-bound-selectors': adapt( require( './redux-no-bound-selectors' ) ),
 	'no-unsafe-wp-apis': adapt( require( './no-unsafe-wp-apis' ) ),
+	'e2e-require-account-teardown': adapt( require( './e2e-require-account-teardown' ) ),
 };

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/e2e-require-account-teardown.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/e2e-require-account-teardown.js
@@ -1,0 +1,106 @@
+/**
+ * @file Tests for the e2e-require-account-teardown rule.
+ * @author Automattic
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const RuleTester = require( 'eslint' ).RuleTester;
+const rule = require( '../../../lib/rules/e2e-require-account-teardown' );
+
+const ruleTester = new RuleTester( {
+	parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+} );
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+ruleTester.run( 'e2e-require-account-teardown', rule, {
+	valid: [
+		// getNewTestUser + signup + afterAll that calls apiCloseAccount.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 'invite', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				test.afterAll( async () => {
+					await apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+		},
+		// Bare afterAll + member-form getNewTestUser + flow-object signup helper.
+		{
+			code: `
+				const u = DataHelper.getNewTestUser();
+				flow.userSignupPage.signupWithEmail( u.email );
+				afterAll( async () => {
+					apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+		},
+		// getNewTestUser but NO signup helper (the invite__revoke shape): not a leak.
+		{
+			code: `
+				const u = getNewTestUser();
+				restAPIClient.createInvite( siteId, { email: u.email } );
+			`,
+		},
+		// A signup helper but NO getNewTestUser: not flagged (needs both).
+		{
+			code: `
+				test( 't', async () => {
+					await pageUserSignUp.signupSocialFirstWithEmail( 'static@example.com' );
+				} );
+			`,
+		},
+		// On the allow list: creates an account, no afterAll, but exempt by path.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+			`,
+			filename: 'test/e2e/specs/users/some-exempt.spec.ts',
+			options: [ { allow: [ 'specs/users/some-exempt.spec.ts' ] } ],
+		},
+	],
+
+	invalid: [
+		// getNewTestUser + signup, no afterAll teardown at all.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 'invite', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// apiCloseAccount present, but in the test body rather than an afterAll.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 'invite', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+					await apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// helperData.getNewTestUser + signupSocialFirstWithEmail, no afterAll.
+		{
+			code: `
+				const u = helperData.getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupSocialFirstWithEmail( u.email );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/e2e-require-account-teardown.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/e2e-require-account-teardown.js
@@ -38,8 +38,30 @@ ruleTester.run( 'e2e-require-account-teardown', rule, {
 				const u = DataHelper.getNewTestUser();
 				flow.userSignupPage.signupWithEmail( u.email );
 				afterAll( async () => {
-					apiCloseAccount( client, { userID: u.id } );
+					await apiCloseAccount( client, { userID: u.id } );
 				} );
+			`,
+		},
+		// Member-form apiCloseAccount, awaited inside afterAll.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				test.afterAll( async () => {
+					await shared.apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+		},
+		// apiCloseAccount returned (not awaited) from an afterAll callback.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( () => apiCloseAccount( client, { userID: u.id } ) );
 			`,
 		},
 		// getNewTestUser but NO signup helper (the invite__revoke shape): not a leak.
@@ -98,6 +120,33 @@ ruleTester.run( 'e2e-require-account-teardown', rule, {
 				const u = helperData.getNewTestUser();
 				test( 't', async () => {
 					await pageUserSignUp.signupSocialFirstWithEmail( u.email );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// apiCloseAccount in afterAll but floating (unawaited): races teardown, does not count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// Concise arrow body, but nested in a discarded `.map()` (not the afterAll
+		// callback): the promises are dropped, so this does not count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( () => {
+					[ u ].map( ( a ) => apiCloseAccount( client, { userID: a.id } ) );
 				} );
 			`,
 			errors: [ { messageId: 'missingTeardown' } ],

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/e2e-require-account-teardown.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/e2e-require-account-teardown.js
@@ -64,6 +64,74 @@ ruleTester.run( 'e2e-require-account-teardown', rule, {
 				afterAll( () => apiCloseAccount( client, { userID: u.id } ) );
 			`,
 		},
+		// Awaited inside a for-of loop in the afterAll callback's own body (the
+		// shape invite__new-user.spec.ts uses): consumed, so it counts.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					for ( const a of accounts ) {
+						await apiCloseAccount( client, { userID: a.id } );
+					}
+				} );
+			`,
+		},
+		// Awaited array literal: each close is a direct argument (no nested
+		// function), so Promise.all gates the callback on all of them.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await Promise.all( [
+						apiCloseAccount( client, { userID: a.id } ),
+						apiCloseAccount( client, { userID: b.id } ),
+					] );
+				} );
+			`,
+		},
+		// `return apiCloseAccount(...)` from a block body (not concise): the runner
+		// awaits the returned promise, so it counts.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( () => {
+					return apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+		},
+		// Member-form afterAll with a concise body: test.afterAll( () => apiCloseAccount(...) ).
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				test.afterAll( () => apiCloseAccount( client, { userID: u.id } ) );
+			`,
+		},
+		// Concise body returning Promise.all of an array of direct close calls: the
+		// runner awaits the returned promise and Promise.all awaits each element.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( () => Promise.all( [
+					apiCloseAccount( client, { userID: a.id } ),
+					apiCloseAccount( client, { userID: b.id } ),
+				] ) );
+			`,
+		},
 		// getNewTestUser but NO signup helper (the invite__revoke shape): not a leak.
 		{
 			code: `
@@ -147,6 +215,160 @@ ruleTester.run( 'e2e-require-account-teardown', rule, {
 				} );
 				afterAll( () => {
 					[ u ].map( ( a ) => apiCloseAccount( client, { userID: a.id } ) );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// `await` INSIDE a discarded `.map()` callback: each promise is awaited in
+		// its own inner function, but the afterAll callback never awaits the array
+		// of promises the map returns, so they race teardown. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					accounts.map( async ( a ) => await apiCloseAccount( client, { userID: a.id } ) );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// `return accounts.map( ... )` returns an array of promises, not a single
+		// promise the runner awaits element-wise (no Promise.all), so the closes
+		// float. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( () => accounts.map( ( a ) => apiCloseAccount( client, { userID: a.id } ) ) );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// Known limitation: `await Promise.all( accounts.map( ( a ) => apiCloseAccount(
+		// a ) ) )` is technically correct teardown, but the close sits in a nested
+		// `.map()` callback so the rule cannot tell it from a dropped map and flags
+		// it. Use an awaited array literal or a for-of loop instead, or allow-list.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await Promise.all( accounts.map( ( a ) => apiCloseAccount( client, { userID: a.id } ) ) );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// afterEach (not afterAll) does not satisfy the rule: it intentionally
+		// targets a single suite-level afterAll teardown.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterEach( async () => {
+					await apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// `await [ apiCloseAccount(...) ]` awaits the array, not the element promise,
+		// which still floats. A bare array (no Promise.all) must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await [ apiCloseAccount( client, { userID: u.id } ) ];
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// `return [ apiCloseAccount(...) ]` returns an array of promises, not a
+		// thenable the runner awaits element-wise. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( () => [ apiCloseAccount( client, { userID: u.id } ) ] );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// `void apiCloseAccount(...)` evaluates the close but yields undefined, so the
+		// awaited value is not the close promise: it floats. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await void apiCloseAccount( client, { userID: u.id } );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// Sequence expression: `( apiCloseAccount(...), other() )` returns the LAST
+		// operand, so the close promise floats. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await ( apiCloseAccount( client, { userID: u.id } ), Promise.resolve() );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// Logical expression: `apiCloseAccount(...) && other()` returns `other()`
+		// (the close promise is truthy), so the close floats. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await ( apiCloseAccount( client, { userID: u.id } ) && Promise.resolve() );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// Conditional with the close as the test: the truthy promise selects a
+		// branch and the close itself floats. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await ( apiCloseAccount( client, { userID: u.id } ) ? a : b );
+				} );
+			`,
+			errors: [ { messageId: 'missingTeardown' } ],
+		},
+		// Wrapped in an arbitrary call: `wrapper( apiCloseAccount(...) )` awaits the
+		// wrapper's result, not the close promise, which may be discarded. Must NOT count.
+		{
+			code: `
+				const u = getNewTestUser();
+				test( 't', async () => {
+					await pageUserSignUp.signupThroughInvite( u.email );
+				} );
+				afterAll( async () => {
+					await wrapper( apiCloseAccount( client, { userID: u.id } ) );
 				} );
 			`,
 			errors: [ { messageId: 'missingTeardown' } ],

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -12,6 +12,10 @@ module.exports = {
 				// We use jest-runner-groups to run spec suites, and these involve a custom doc header tag.
 				'jsdoc/check-tag-names': [ 'error', { definedTags: [ 'group', 'browser' ] } ],
 				'jest/no-standalone-expect': [ 'error', { additionalTestBlockFunctions: [ 'skipItIf' ] } ],
+				// Specs that create a test account (getNewTestUser + a signup helper) must register
+				// an afterAll apiCloseAccount teardown, or the account and its blogs leak. Opt out
+				// via `allow` only with justification.
+				'wpcalypso/e2e-require-account-teardown': [ 'error', { allow: [] } ],
 			},
 		},
 		{

--- a/test/e2e/specs/shared/api-close-account.ts
+++ b/test/e2e/specs/shared/api-close-account.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { closeAccountAndRecordLeak } from '@automattic/calypso-e2e';
-import type { AccountDetails, RestAPIClient } from '@automattic/calypso-e2e';
+import { closeAccountAndRecordLeak, recordAccountLeak } from '@automattic/calypso-e2e';
+import type { AccountDetails, AccountLeak, RestAPIClient } from '@automattic/calypso-e2e';
 
 // Teardown leak markers live under the published, gitignored e2e output dir.
 // Playwright transpiles TS in place, so `__dirname` is the source dir:
@@ -25,4 +25,16 @@ export async function apiCloseAccount(
 	accountDetails: AccountDetails
 ): Promise< void > {
 	await closeAccountAndRecordLeak( client, accountDetails, LEAK_DIR );
+}
+
+/**
+ * Records a teardown leak marker under the shared e2e output dir for an account
+ * that cannot be closed by ID (e.g. signup created the account but returned no
+ * user ID), so CI still surfaces the leak. Keyed by email when the ID is absent.
+ * Never throws.
+ *
+ * @param {AccountLeak} leak Details of the leaked account.
+ */
+export function recordAccountLeakMarker( leak: AccountLeak ): void {
+	recordAccountLeak( LEAK_DIR, leak );
 }

--- a/test/e2e/specs/shared/api-close-account.ts
+++ b/test/e2e/specs/shared/api-close-account.ts
@@ -1,32 +1,28 @@
-import { RestAPIClient } from '@automattic/calypso-e2e';
-import type { AccountDetails, AccountClosureResponse } from '@automattic/calypso-e2e';
+import path from 'node:path';
+import { closeAccountAndRecordLeak } from '@automattic/calypso-e2e';
+import type { AccountDetails, RestAPIClient } from '@automattic/calypso-e2e';
+
+// Teardown leak markers live under the published, gitignored e2e output dir.
+// Playwright transpiles TS in place, so `__dirname` is the source dir:
+// `test/e2e/specs/shared` -> `test/e2e/output/teardown-leaks`.
+const LEAK_DIR = path.resolve( __dirname, '..', '..', 'output', 'teardown-leaks' );
 
 /**
- * Makes an API request to close the user account.
+ * Makes an API request to close the user account, maintaining a teardown leak
+ * marker as CI evidence.
  *
- * Note that closing an user account will also close any existing sites
- * belonging to the user, thus it is not required to close sites if this
- * function is called first.
+ * Closing an account also closes any sites belonging to the user, so it is not
+ * required to delete sites first. A marker is recorded only when a close that
+ * did not succeed is followed by confirmation that the account still exists, so
+ * calling this on an already-closed account (e.g. one closed via the UI) is a
+ * safe no-op. Never throws. See `closeAccountAndRecordLeak` for the full logic.
  *
  * @param {RestAPIClient} client Client to interact with the WP REST API.
  * @param {AccountDetails} accountDetails Details of the account to close.
- * @returns { AccountClosureResponse} Response denoting whether deletion was successful.
  */
 export async function apiCloseAccount(
 	client: RestAPIClient,
 	accountDetails: AccountDetails
 ): Promise< void > {
-	console.log( `Closing account ${ accountDetails.userID }.` );
-	try {
-		const response: AccountClosureResponse = await client.closeAccount( accountDetails );
-
-		if ( response.success !== true ) {
-			console.warn( `Failed to delete user ID ${ accountDetails.userID }` );
-			console.warn( response );
-		} else {
-			console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
-		}
-	} catch ( error ) {
-		console.warn( `Error closing account ${ accountDetails.userID }: ${ error }` );
-	}
+	await closeAccountAndRecordLeak( client, accountDetails, LEAK_DIR );
 }

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -7,7 +7,7 @@ import {
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, recordAccountLeakMarker } from '../shared';
 import type { NewUserResponse } from '@automattic/calypso-e2e';
 
 test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
@@ -162,7 +162,14 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 	test.afterAll( async function () {
 		for ( const acct of accountsToCleanup ) {
 			if ( ! acct.user?.user_id ) {
-				// No account identity at all: nothing to close or flag by ID.
+				// The account was queued (created) but the signup response carried no
+				// user ID, so it cannot be closed by ID. Record a leak marker keyed by
+				// email so CI still surfaces it rather than dropping it silently.
+				recordAccountLeakMarker( {
+					username: acct.user?.username ?? '',
+					email: acct.email,
+					error: 'Signup response missing user_id; account created but not closeable by ID.',
+				} );
 				continue;
 			}
 			// Prefer the bearer token captured at signup; fall back to the signup

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -106,16 +106,25 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 			const signUpResponse = await userSignupPage.signupThroughInvite( testUser.email );
 
 			const created = signUpResponse.body;
-			// Runtime guards: the signup response is untyped JSON, so the declared
-			// type is not a wire guarantee. Assert the full identity the afterAll
-			// teardown consumes, not just the username.
-			expect( created?.user_id ).toBeDefined();
-			expect( created?.bearer_token ).toBeDefined();
+			// Queue teardown before asserting the rest of the identity: a created
+			// account must be scheduled for cleanup even if the response is partial.
+			// Otherwise a failed assertion below aborts the test before the in-body
+			// UI close, and the account leaks with no teardown and no leak marker.
 			accountsToCleanup.push( {
 				user: created,
 				password: testUser.password,
 				email: testUser.email,
 			} );
+
+			// Runtime guards: the signup response is untyped JSON, so the declared
+			// type is not a wire guarantee. Require the identity the afterAll teardown
+			// consumes to be truthy, not merely defined: an empty/null token passes
+			// `toBeDefined` but RestAPIClient treats it as absent and would fetch a
+			// fresh token from credentials, which fails on an already-closed account
+			// and records a false leak marker. Failing here aborts before the in-body
+			// UI close, so the queued account stays open and the fallback is correct.
+			expect( created?.user_id ).toBeTruthy();
+			expect( created?.bearer_token ).toBeTruthy();
 
 			signedUpUsername = created.username;
 			expect( signedUpUsername ).toBeDefined();
@@ -152,11 +161,18 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 	test.afterAll( async function () {
 		for ( const acct of accountsToCleanup ) {
-			if ( ! acct.user?.bearer_token ) {
+			if ( ! acct.user?.user_id ) {
+				// No account identity at all: nothing to close or flag by ID.
 				continue;
 			}
+			// Prefer the bearer token captured at signup; fall back to the signup
+			// credentials so an account whose response omitted a token is still torn
+			// down. RestAPIClient fetches a fresh token from the credentials, which
+			// works because such an account never reached the in-body UI close and is
+			// therefore still open. apiCloseAccount records a leak marker when it
+			// cannot confirm closure, so a leak is never silently dropped.
 			const restAPIClient = new RestAPIClient(
-				{ username: acct.user.username, password: acct.password },
+				{ username: acct.user.username ?? acct.email, password: acct.password },
 				acct.user.bearer_token
 			);
 			await apiCloseAccount( restAPIClient, {

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -1,11 +1,14 @@
 import {
 	DataHelper,
 	CloseAccountFlow,
+	RestAPIClient,
 	RoleValue,
 	Roles,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+import type { NewUserResponse } from '@automattic/calypso-e2e';
 
 test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 	skipIfMailosaurLimitReached();
@@ -17,6 +20,17 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 	let userManagementRevampFeature = false;
 	let acceptInviteLink: string;
+
+	// Accounts created during the run, closed via API in afterAll as a guaranteed
+	// teardown. The in-body UI close below stays as product coverage; the API close
+	// is the safety net for any run where the UI close did not happen. If the UI
+	// close did run, this account's token is dead and apiCloseAccount is a safe
+	// no-op (its existence probe writes no leak marker).
+	const accountsToCleanup: {
+		user: NewUserResponse[ 'body' ];
+		password: string;
+		email: string;
+	}[] = [];
 
 	test( 'As a WordPress.com user, I can invite a new user to my site, they can accept the invite and sign up, then I can remove them', async ( {
 		page,
@@ -61,7 +75,9 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'When I navigate to Users > All Users', async function () {
 			await componentSidebar.navigate( 'Users', 'All Users' );
-			! userManagementRevampFeature && ( await pagePeople.clickTab( 'Invites' ) );
+			if ( ! userManagementRevampFeature ) {
+				await pagePeople.clickTab( 'Invites' );
+			}
 			await pagePeople.clickViewAllIfAvailable();
 		} );
 
@@ -89,7 +105,19 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 			const userSignupPage = new UserSignupPage( pageIncognito.getPage() );
 			const signUpResponse = await userSignupPage.signupThroughInvite( testUser.email );
 
-			signedUpUsername = signUpResponse?.body?.username;
+			const created = signUpResponse.body;
+			// Runtime guards: the signup response is untyped JSON, so the declared
+			// type is not a wire guarantee. Assert the full identity the afterAll
+			// teardown consumes, not just the username.
+			expect( created?.user_id ).toBeDefined();
+			expect( created?.bearer_token ).toBeDefined();
+			accountsToCleanup.push( {
+				user: created,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			signedUpUsername = created.username;
 			expect( signedUpUsername ).toBeDefined();
 		} );
 
@@ -120,5 +148,22 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 			const closeAccountFlow = new CloseAccountFlow( pageIncognito.getPage() );
 			await closeAccountFlow.closeAccount();
 		} );
+	} );
+
+	test.afterAll( async function () {
+		for ( const acct of accountsToCleanup ) {
+			if ( ! acct.user?.bearer_token ) {
+				continue;
+			}
+			const restAPIClient = new RestAPIClient(
+				{ username: acct.user.username, password: acct.password },
+				acct.user.bearer_token
+			);
+			await apiCloseAccount( restAPIClient, {
+				userID: acct.user.user_id,
+				username: acct.user.username,
+				email: acct.email,
+			} );
+		}
 	} );
 } );


### PR DESCRIPTION
Part of [TESTOPS-121](https://linear.app/a8c/issue/TESTOPS-121) > [TESTOPS-124](https://linear.app/a8c/issue/TESTOPS-124).

## Proposed Changes

- **`deleteSite` ownership guard**: the `.filter()` pre-check had no `return`, so it produced an empty (truthy) array and the guard never fired — deletion proceeded for any `e2e`-prefixed domain regardless of ownership. Switched to `.some()` and strip the URL scheme (`http`/`https`) and trailing slash so owned sites match the scheme-less `/all-domains/` response.
- **`apiCloseAccount` teardown evidence**: on a close that does not confirm success, record a per-account leak marker under `test/e2e/output/teardown-leaks` — but only after an existence probe confirms the account still exists. A confirmed dead-token clears the marker (account already gone), so closing an already-closed account is a no-op; transient/unknown errors record conservatively so a real leak is never masked. The logic and marker IO live in `@automattic/calypso-e2e` (`closeAccountAndRecordLeak`) so they are unit-tested in CI.
- **`invite__new-user`**: added an `afterAll` API teardown (capturing account details at signup). The in-body UI close stays as the suite's only close-account product coverage.
- **Static check**: new `wpcalypso/e2e-require-account-teardown` ESLint rule flags specs that create a test account (`getNewTestUser` + a signup helper) without an `afterAll` `apiCloseAccount` teardown. Opt out via an allow list for genuine exceptions.
- **CI evidence**: a new `ALWAYS` TeamCity step fails the build with a `buildProblem` (and publishes the marker artifact) when teardown leaves a marker behind. Needed because the e2e build runs with `nonZeroExitCode = false`, so a throwing teardown alone cannot fail the build.

## Why are these changes being made?

Timestamped `e2eflowtesting*` signup accounts (and their blogs) escape per-test teardown and accumulate. These are the low-risk, harness-side gaps that let the leaks happen and kept them silent: a dead ownership check, a spec that closed its account only via the UI in the test body (leaking on any earlier failure), no gate against new specs that create accounts without teardown, and no CI signal when teardown fails.

## Testing Instructions

- `yarn test-packages` — covers `rest-api-client.deleteSite`, `teardown-markers` (record/clear/classify + the close-and-record orchestration), and the ESLint rule. 31 unit tests.
- `yarn typecheck-packages` and `yarn lint:js`.
- Lint a spec that creates an account without an `afterAll` `apiCloseAccount` and confirm the new rule flags it; confirm `invite__revoke` (no signup) and the fixed `invite__new-user` are not flagged.
- The live `invite__new-user.spec.ts` run against staging exercises the UI close plus the `afterAll` API teardown; not run in this change to avoid creating test accounts.
