### PR TITLE
E2E: measure post-publish 404 availability window

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -205,6 +205,95 @@ export async function reloadAndRetry(
 	return;
 }
 
+export type AvailabilityClock = {
+	now: () => number;
+	sleep: ( ms: number ) => Promise< void >;
+};
+
+const realAvailabilityClock: AvailabilityClock = {
+	now: () => Date.now(),
+	sleep: ( ms ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) ),
+};
+
+/**
+ * Result of polling a single target for availability.
+ */
+export type ProbeTargetResult = {
+	label: string;
+	/** Time (relative to `AvailabilityProbe.measuredFrom`) at which the target first returned 200, or null if it never did within the cap. */
+	recoveredMs: number | null;
+	/** Last HTTP status seen: 200 when recovered, otherwise the final failing status, or -1 on network error. */
+	lastStatus: number;
+};
+
+/**
+ * Aggregate result of a post-publish availability probe.
+ */
+export type AvailabilityProbe = {
+	capMs: number;
+	measuredFrom: 'publish' | 'probe-start';
+	targets: ProbeTargetResult[];
+};
+
+/**
+ * Polls `getStatus` until it returns 200 or `capMs` elapses since the first call.
+ *
+ * The cap is strict: no poll is started and no sleep runs once the budget is
+ * exhausted, and each call receives the remaining budget so callers can clamp
+ * their own per-request timeout to it. The clock is injectable so the loop can be
+ * unit tested without real timers or network access.
+ *
+ * @param {Function} getStatus Async function that receives the remaining budget (ms) and returns an HTTP status code (use -1 for a network error).
+ * @param {Object} options Poll options.
+ * @param {number} options.capMs Maximum time to keep polling, measured from the first call.
+ * @param {number} options.intervalMs Delay between polls.
+ * @param {AvailabilityClock} options.clock Injectable clock, defaults to real time.
+ * @returns {Promise} `recoveredAfterMs` (ms from the first call to the first 200, or null) and the last status seen.
+ */
+export async function pollUntilAvailable(
+	getStatus: ( remainingMs: number ) => Promise< number >,
+	{
+		capMs,
+		intervalMs,
+		clock = realAvailabilityClock,
+	}: { capMs: number; intervalMs: number; clock?: AvailabilityClock }
+): Promise< { recoveredAfterMs: number | null; lastStatus: number } > {
+	const start = clock.now();
+	const remaining = () => capMs - ( clock.now() - start );
+
+	let lastStatus = await getStatus( capMs );
+
+	while ( lastStatus !== 200 && remaining() > 0 ) {
+		await clock.sleep( Math.min( intervalMs, remaining() ) );
+		if ( remaining() <= 0 ) {
+			break;
+		}
+		lastStatus = await getStatus( remaining() );
+	}
+
+	if ( lastStatus === 200 ) {
+		return { recoveredAfterMs: clock.now() - start, lastStatus };
+	}
+	return { recoveredAfterMs: null, lastStatus };
+}
+
+/**
+ * Formats an availability probe for inclusion in a failure message.
+ *
+ * @param {AvailabilityProbe} probe The probe result.
+ * @returns {string} A multi-line, log-correlation-friendly summary.
+ */
+export function formatAvailabilityProbe( probe: AvailabilityProbe ): string {
+	const lines = probe.targets.map( ( target ) => {
+		if ( target.recoveredMs !== null ) {
+			return `  ${ target.label }: recovered after ${ target.recoveredMs }ms (since ${ probe.measuredFrom })`;
+		}
+		return `  ${ target.label }: not recovered within ${ probe.capMs }ms (last status ${ target.lastStatus })`;
+	} );
+
+	return [ `Availability probe (cap ${ probe.capMs }ms):`, ...lines ].join( '\n' );
+}
+
 /**
  * Gets and validates the block ID from a Locator to a parent Block element in the editor.
  *

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -238,17 +238,9 @@ export type AvailabilityProbe = {
 /**
  * Polls `getStatus` until it returns 200 or `capMs` elapses since the first call.
  *
- * The cap is strict: no poll is started and no sleep runs once the budget is
- * exhausted, and each call receives the remaining budget so callers can clamp
- * their own per-request timeout to it. The clock is injectable so the loop can be
- * unit tested without real timers or network access.
- *
- * @param {Function} getStatus Async function that receives the remaining budget (ms) and returns an HTTP status code (use -1 for a network error).
- * @param {Object} options Poll options.
- * @param {number} options.capMs Maximum time to keep polling, measured from the first call.
- * @param {number} options.intervalMs Delay between polls.
- * @param {AvailabilityClock} options.clock Injectable clock, defaults to real time.
- * @returns {Promise} `recoveredAfterMs` (ms from the first call to the first 200, or null) and the last status seen.
+ * Cap is strict: no poll starts and no sleep runs once the budget is exhausted.
+ * Each call receives the remaining budget so callers can clamp per-request timeouts.
+ * Clock is injectable for unit testing without real timers or network access.
  */
 export async function pollUntilAvailable(
 	getStatus: ( remainingMs: number ) => Promise< number >,
@@ -279,9 +271,6 @@ export async function pollUntilAvailable(
 
 /**
  * Formats an availability probe for inclusion in a failure message.
- *
- * @param {AvailabilityProbe} probe The probe result.
- * @returns {string} A multi-line, log-correlation-friendly summary.
  */
 export function formatAvailabilityProbe( probe: AvailabilityProbe ): string {
 	const lines = probe.targets.map( ( target ) => {

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -1,6 +1,12 @@
-import { Page, ElementHandle, Response, Locator } from 'playwright';
+import { Page, ElementHandle, Response, Locator, request } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
-import { reloadAndRetry } from '../../element-helper';
+import {
+	reloadAndRetry,
+	pollUntilAvailable,
+	formatAvailabilityProbe,
+	type AvailabilityProbe,
+	type ProbeTargetResult,
+} from '../../element-helper';
 import envVariables from '../../env-variables';
 import {
 	EditorComponent,
@@ -72,6 +78,10 @@ type ResponseDiagnostic = {
 type PublishDiagnostics = {
 	publishedURL: string;
 	publishResponse: ResponseDiagnostic;
+	/** The REST by-ID endpoint (the publish response URL), used to probe by-ID resolution. */
+	restByIdURL?: string;
+	/** `Date.now()` when the publish response was received, used to measure the read-after-write window. */
+	publishedAtMs?: number;
 	postId?: number | string;
 	postSlug?: string;
 	postStatus?: string;
@@ -130,13 +140,16 @@ function getResponseDiagnostic( response: Response | null, action: string ): Res
 function getPublishDiagnostics(
 	response: Response,
 	body: PublishResponseBody,
-	publishedURL: string
+	publishedURL: string,
+	publishedAtMs?: number
 ): PublishDiagnostics {
 	const publishedContent = body.body ?? body;
 
 	return {
 		publishedURL: sanitizeURLForDiagnostics( publishedURL ),
 		publishResponse: getResponseDiagnostic( response, 'publish' ),
+		restByIdURL: sanitizeURLForDiagnostics( response.url() ),
+		publishedAtMs,
 		postId: publishedContent.id ?? publishedContent.ID,
 		postSlug: publishedContent.slug,
 		postStatus: publishedContent.status,
@@ -200,6 +213,103 @@ function getPublishedPost404Message( {
 				: 'not captured'
 		}`,
 	].join( '\n' );
+}
+
+const PUBLISHED_POST_PROBE_CAP_MS = 20 * 1000;
+const PUBLISHED_POST_PROBE_INTERVAL_MS = 1000;
+
+/**
+ * After a post-publish 404, measures when (if ever, within a cap) the published
+ * post becomes routable. This bounds the read-after-write window and isolates the
+ * failing layer. It is diagnostic only and does not change the failure outcome.
+ *
+ * Probes three targets in parallel until each returns 200 or the cap elapses:
+ *  - `permalink-authenticated`: the permalink with the test session cookies (what the test saw).
+ *  - `permalink-anonymous`: the permalink with no cookies (what a logged-out visitor sees).
+ *  - `rest-by-id`: the REST by-ID endpoint, isolating permalink/rewrite resolution from row visibility.
+ *
+ * @param {Page} page The page whose request context (cookies) mirrors the test session.
+ * @param {string} permalink The published permalink that returned 404.
+ * @param {PublishDiagnostics} publishDiagnostics Captured publish diagnostics, if available.
+ */
+async function probePublishedPostAvailability(
+	page: Page,
+	permalink: string,
+	publishDiagnostics?: PublishDiagnostics
+): Promise< AvailabilityProbe > {
+	const capMs = PUBLISHED_POST_PROBE_CAP_MS;
+	const intervalMs = PUBLISHED_POST_PROBE_INTERVAL_MS;
+	const probeStartMs = Date.now();
+	const publishedAtMs = publishDiagnostics?.publishedAtMs;
+	const restByIdURL = publishDiagnostics?.restByIdURL;
+
+	// Convert a probe-relative recovery time into a publish-relative one when the
+	// publish timestamp is known, so the reported number reflects the full window.
+	const toReportedMs = ( recoveredAfterMs: number | null ): number | null => {
+		if ( recoveredAfterMs === null ) {
+			return null;
+		}
+		if ( publishedAtMs === undefined ) {
+			return recoveredAfterMs;
+		}
+		return probeStartMs - publishedAtMs + recoveredAfterMs;
+	};
+
+	// Bound each request to the smaller of a fixed ceiling and the remaining cap
+	// budget, so the probe never runs meaningfully past `capMs`.
+	const maxRequestTimeout = intervalMs * 5;
+	const clampTimeout = ( remainingMs: number ): number =>
+		Math.max( 1, Math.min( maxRequestTimeout, remainingMs ) );
+
+	const probeTarget = async (
+		label: string,
+		get: ( timeout: number ) => Promise< { status: () => number } >
+	): Promise< ProbeTargetResult > => {
+		const result = await pollUntilAvailable(
+			async ( remainingMs ) => {
+				try {
+					const response = await get( clampTimeout( remainingMs ) );
+					return response.status();
+				} catch {
+					return -1;
+				}
+			},
+			{ capMs, intervalMs }
+		);
+		return {
+			label,
+			recoveredMs: toReportedMs( result.recoveredAfterMs ),
+			lastStatus: result.lastStatus,
+		};
+	};
+
+	// Cookie-less context mirrors a logged-out public visitor.
+	const anonymousContext = await request.newContext();
+
+	try {
+		const targets: Promise< ProbeTargetResult >[] = [
+			probeTarget( 'permalink-authenticated', ( timeout ) =>
+				page.request.get( permalink, { timeout } )
+			),
+			probeTarget( 'permalink-anonymous', ( timeout ) =>
+				anonymousContext.get( permalink, { timeout } )
+			),
+		];
+
+		if ( restByIdURL ) {
+			targets.push(
+				probeTarget( 'rest-by-id', ( timeout ) => page.request.get( restByIdURL, { timeout } ) )
+			);
+		}
+
+		return {
+			capMs,
+			measuredFrom: publishedAtMs === undefined ? 'probe-start' : 'publish',
+			targets: await Promise.all( targets ),
+		};
+	} finally {
+		await anonymousContext.dispose();
+	}
 }
 
 /**
@@ -1022,6 +1132,7 @@ export class EditorPage {
 		);
 
 		// Resolve the promises.
+		let publishedAtMs: number | undefined;
 		const [ response ] = await Promise.all( [
 			// First URL matches Atomic requests while the second matches Simple requests.
 			Promise.race( [
@@ -1037,7 +1148,12 @@ export class EditorPage {
 						response.request().method() === 'PUT',
 					{ timeout: timeout }
 				),
-			] ),
+			] ).then( ( publishResponse ) => {
+				// Captured the moment the publish response arrives, before the remaining
+				// publish-panel actions settle, so the probe measures the full window.
+				publishedAtMs = Date.now();
+				return publishResponse;
+			} ),
 			...actionsArray,
 		] );
 
@@ -1049,7 +1165,7 @@ export class EditorPage {
 		}
 		// `response` is the Promise.race winner — either the POST (Atomic) or the PUT (Simple).
 		// The `publishResponse.method` field in diagnostics will reflect whichever verb won.
-		const publishDiagnostics = getPublishDiagnostics( response, json, publishedURL );
+		const publishDiagnostics = getPublishDiagnostics( response, json, publishedURL, publishedAtMs );
 
 		if ( visit ) {
 			await this.visitPublishedPost( publishedURL, { timeout: timeout, publishDiagnostics } );
@@ -1166,11 +1282,29 @@ export class EditorPage {
 		// `reloadAndRetry` re-throws without reloading, so the response for the last
 		// page load before the error is not captured — `publicResponses` reflects all
 		// attempts up to but not including the final failing check.
-		await reloadAndRetry( this.page, confirmPostShown, {
-			onReload: ( response ) => {
-				publicResponses.push( getResponseDiagnostic( response, 'published-url-reload' ) );
-			},
-		} );
+		try {
+			await reloadAndRetry( this.page, confirmPostShown, {
+				onReload: ( response ) => {
+					publicResponses.push( getResponseDiagnostic( response, 'published-url-reload' ) );
+				},
+			} );
+		} catch ( error ) {
+			// On a post-publish 404, measure when the post actually becomes routable to
+			// bound the read-after-write window and isolate the failing layer. This is
+			// diagnostic only: the original error is always re-thrown, so pass/fail is
+			// unchanged even if the probe itself fails.
+			if ( error instanceof Error && error.message.startsWith( 'Post not found - 404' ) ) {
+				try {
+					const probe = await probePublishedPostAvailability( this.page, url, publishDiagnostics );
+					error.message = `${ error.message }\n${ formatAvailabilityProbe( probe ) }`;
+				} catch ( probeError ) {
+					error.message = `${ error.message }\nAvailability probe failed: ${
+						probeError instanceof Error ? probeError.message : String( probeError )
+					}`;
+				}
+			}
+			throw error;
+		}
 
 		/**
 		 * Closure to confirm that post is shown on screen as expected.

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -219,18 +219,9 @@ const PUBLISHED_POST_PROBE_CAP_MS = 20 * 1000;
 const PUBLISHED_POST_PROBE_INTERVAL_MS = 1000;
 
 /**
- * After a post-publish 404, measures when (if ever, within a cap) the published
- * post becomes routable. This bounds the read-after-write window and isolates the
- * failing layer. It is diagnostic only and does not change the failure outcome.
- *
- * Probes three targets in parallel until each returns 200 or the cap elapses:
- *  - `permalink-authenticated`: the permalink with the test session cookies (what the test saw).
- *  - `permalink-anonymous`: the permalink with no cookies (what a logged-out visitor sees).
- *  - `rest-by-id`: the REST by-ID endpoint, isolating permalink/rewrite resolution from row visibility.
- *
- * @param {Page} page The page whose request context (cookies) mirrors the test session.
- * @param {string} permalink The published permalink that returned 404.
- * @param {PublishDiagnostics} publishDiagnostics Captured publish diagnostics, if available.
+ * After a post-publish 404, probes when the permalink and REST by-ID endpoint
+ * become routable to bound the read-after-write window and isolate the failing
+ * layer. Diagnostic only — does not change the failure outcome.
  */
 async function probePublishedPostAvailability(
 	page: Page,
@@ -1260,6 +1251,7 @@ export class EditorPage {
 		}: { timeout?: number; publishDiagnostics?: PublishDiagnostics } = {}
 	): Promise< void > {
 		const publicResponses: ResponseDiagnostic[] = [];
+		let post404 = false;
 
 		// Some blocks, like "Click To Tweet" or "Logos" cause the post-publish
 		// panel to close immediately and leave the post in the unsaved state for
@@ -1293,7 +1285,7 @@ export class EditorPage {
 			// bound the read-after-write window and isolate the failing layer. This is
 			// diagnostic only: the original error is always re-thrown, so pass/fail is
 			// unchanged even if the probe itself fails.
-			if ( error instanceof Error && error.message.startsWith( 'Post not found - 404' ) ) {
+			if ( post404 && error instanceof Error ) {
 				try {
 					const probe = await probePublishedPostAvailability( this.page, url, publishDiagnostics );
 					error.message = `${ error.message }\n${ formatAvailabilityProbe( probe ) }`;
@@ -1325,6 +1317,7 @@ export class EditorPage {
 			const error404 = main.locator( 'div.error-404' );
 			if ( ( await error404.count() ) > 0 ) {
 				await page.waitForTimeout( 1000 ); // Give it a second before retrying.
+				post404 = true;
 				throw new Error(
 					getPublishedPost404Message( {
 						publishDiagnostics,

--- a/packages/calypso-e2e/src/test/element-helper.test.ts
+++ b/packages/calypso-e2e/src/test/element-helper.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+	pollUntilAvailable,
+	formatAvailabilityProbe,
+	type AvailabilityClock,
+	type AvailabilityProbe,
+} from '../element-helper';
+
+/**
+ * Deterministic clock: time only advances when `sleep()` is called, so the
+ * polling loop can be tested without real timers.
+ */
+function fakeClock( startMs = 0 ): AvailabilityClock {
+	let current = startMs;
+	return {
+		now: () => current,
+		sleep: ( ms: number ) => {
+			current += ms;
+			return Promise.resolve();
+		},
+	};
+}
+
+describe( 'pollUntilAvailable', () => {
+	test( 'reports recovery at 0ms when the first poll is already 200', async () => {
+		const result = await pollUntilAvailable( () => Promise.resolve( 200 ), {
+			capMs: 10000,
+			intervalMs: 1000,
+			clock: fakeClock(),
+		} );
+		expect( result ).toEqual( { recoveredAfterMs: 0, lastStatus: 200 } );
+	} );
+
+	test( 'measures elapsed time across multiple polls before recovery', async () => {
+		const statuses = [ 404, 404, 404, 200 ];
+		let i = 0;
+		const result = await pollUntilAvailable( () => Promise.resolve( statuses[ i++ ] ), {
+			capMs: 10000,
+			intervalMs: 1000,
+			clock: fakeClock(),
+		} );
+		// Three 1000ms sleeps happened before the fourth poll returned 200.
+		expect( result ).toEqual( { recoveredAfterMs: 3000, lastStatus: 200 } );
+	} );
+
+	test( 'gives up at the cap and reports the last failing status', async () => {
+		const result = await pollUntilAvailable( () => Promise.resolve( 404 ), {
+			capMs: 3000,
+			intervalMs: 1000,
+			clock: fakeClock(),
+		} );
+		expect( result.recoveredAfterMs ).toBeNull();
+		expect( result.lastStatus ).toBe( 404 );
+	} );
+
+	test( 'treats a network error (-1) as not-yet-available and keeps polling', async () => {
+		const statuses = [ -1, -1, 200 ];
+		let i = 0;
+		const result = await pollUntilAvailable( () => Promise.resolve( statuses[ i++ ] ), {
+			capMs: 10000,
+			intervalMs: 500,
+			clock: fakeClock(),
+		} );
+		expect( result ).toEqual( { recoveredAfterMs: 1000, lastStatus: 200 } );
+	} );
+
+	test( 'enforces a strict cap: no poll starts past the budget, remaining is passed down', async () => {
+		const remainingSeen: number[] = [];
+		const result = await pollUntilAvailable(
+			( remainingMs ) => {
+				remainingSeen.push( remainingMs );
+				return Promise.resolve( 404 );
+			},
+			{ capMs: 3000, intervalMs: 1000, clock: fakeClock() }
+		);
+		// Polls at elapsed 0, 1000, 2000; the sleep to 3000 exhausts the budget so no
+		// fourth poll runs.
+		expect( remainingSeen ).toEqual( [ 3000, 2000, 1000 ] );
+		expect( result.recoveredAfterMs ).toBeNull();
+		expect( result.lastStatus ).toBe( 404 );
+	} );
+} );
+
+describe( 'formatAvailabilityProbe', () => {
+	test( 'renders recovered and not-recovered targets', () => {
+		const probe: AvailabilityProbe = {
+			capMs: 20000,
+			measuredFrom: 'publish',
+			targets: [
+				{ label: 'permalink-authenticated', recoveredMs: 4200, lastStatus: 200 },
+				{ label: 'permalink-anonymous', recoveredMs: null, lastStatus: 404 },
+				{ label: 'rest-by-id', recoveredMs: 800, lastStatus: 200 },
+			],
+		};
+
+		const output = formatAvailabilityProbe( probe );
+
+		expect( output ).toContain( 'Availability probe (cap 20000ms):' );
+		expect( output ).toContain( 'permalink-authenticated: recovered after 4200ms (since publish)' );
+		expect( output ).toContain(
+			'permalink-anonymous: not recovered within 20000ms (last status 404)'
+		);
+		expect( output ).toContain( 'rest-by-id: recovered after 800ms (since publish)' );
+	} );
+} );


### PR DESCRIPTION
Part of [TESTOPS-131](https://linear.app/a8c/issue/TESTOPS-131)

## Proposed Changes

- On a post-publish 404 in `EditorPage.publish({ visit: true })`, probe the published permalink (authenticated and anonymous) and the REST by-ID endpoint until each returns 200 or a 20s cap, then append the timing to the failure message.
- Add `pollUntilAvailable` (deadline-aware, injectable clock), `formatAvailabilityProbe`, and the probe types to `element-helper.ts`; wire `probePublishedPostAvailability` into `editor-page.ts`.
- Capture the publish timestamp the moment the publish response resolves, so the reported window reflects the full read-after-write gap rather than excluding trailing publish-panel work.
- Unit tests for `pollUntilAvailable` (immediate 200, multi-poll recovery, strict cap, network error) and `formatAvailabilityProbe`.

## Why are these changes being made?

Follow-up to #111401. That PR captured a snapshot of the post-publish 404 (publish response, post ID, cache/routing headers) and showed the public 404 is a real origin response (`BYPASS`), not stale page cache. It does not measure how long the gap lasts or which layer is stale: the helper stops after 3 reads, and the CI retry creates a fresh post, so the original URL's recovery is never observed.

This probe turns the next failure into a measurement. It reports when the permalink and the by-ID endpoint actually become routable, and whether the gap is auth-keyed (authenticated vs anonymous diverge) or a permalink/rewrite-resolution issue (by-ID recovers before the permalink). That data is needed to choose between a product-side read-after-write fix and a bounded E2E wait.

Diagnostic only: the original 404 error is always re-thrown (the probe runs in its own try/catch), so pass/fail behavior is unchanged.

## Testing Instructions

- `yarn test-packages calypso-e2e/src/test/element-helper.test.ts`
- `yarn workspace @automattic/calypso-e2e build`
- `yarn eslint packages/calypso-e2e/src/element-helper.ts packages/calypso-e2e/src/lib/pages/editor-page.ts packages/calypso-e2e/src/test/element-helper.test.ts`
- The live probe path only runs on a real post-publish 404, which is backend-timing-driven and not reproducible on demand. The next CI 404 will carry the `Availability probe (cap 20000ms): ...` lines in the failure message.
