### PR TITLE
SEO tools: display the correct plan name in the SEO upsell

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -2,7 +2,9 @@ import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
 	PLAN_BUSINESS,
+	PLAN_PREMIUM,
 	TYPE_BUSINESS,
+	TYPE_PREMIUM,
 	findFirstSimilarPlanKey,
 	getPlan,
 } from '@automattic/calypso-products';
@@ -52,6 +54,7 @@ import {
 	isJetpackSite,
 	isRequestingSite,
 } from 'calypso/state/sites/selectors';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -217,6 +220,7 @@ export class SiteSettingsFormSEO extends Component {
 	render() {
 		const {
 			conflictedSeoPlugin,
+			hasGatingFlag,
 			isFetchingSite,
 			siteId,
 			siteIsJetpack,
@@ -248,6 +252,14 @@ export class SiteSettingsFormSEO extends Component {
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 
+		const upsellPlan = hasGatingFlag ? PLAN_PREMIUM : PLAN_BUSINESS;
+		const upsellPlanType = hasGatingFlag ? TYPE_PREMIUM : TYPE_BUSINESS;
+		// eslint-disable-next-line no-unused-vars
+		const upsellMessagePlaceholder = translate(
+			'Boost your search engine ranking with the powerful SEO tools in the %(planName)s plan',
+			{ args: { planName: getPlan( upsellPlan ).getTitle() } }
+		);
+
 		const upsellProps =
 			siteIsJetpack && ! isAtomic
 				? {
@@ -258,13 +270,13 @@ export class SiteSettingsFormSEO extends Component {
 				: {
 						title: translate(
 							'Boost your search engine ranking with the powerful SEO tools in the %(businessPlanName)s plan',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+							{ args: { businessPlanName: getPlan( upsellPlan ).getTitle() } }
 						),
 						feature: FEATURE_ADVANCED_SEO,
 						plan:
 							selectedSite.plan &&
 							findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
-								type: TYPE_BUSINESS,
+								type: upsellPlanType,
 							} ),
 				  };
 
@@ -458,6 +470,7 @@ const mapStateToProps = ( state ) => {
 		: null;
 	return {
 		conflictedSeoPlugin,
+		hasGatingFlag: !! getSiteOption( state, siteId, 'is_gating_business_q1' ),
 		isFetchingSite: isRequestingSite( state, siteId ),
 		siteId,
 		siteIsJetpack,

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -12,12 +12,12 @@ import {
 	PLAN_FREE,
 	PLAN_BLOGGER,
 	PLAN_BLOGGER_2_YEARS,
+	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
-	PLAN_BUSINESS,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -186,6 +186,50 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 				expect.objectContaining( {
 					href: expect.stringContaining( PLAN_JETPACK_SECURITY_DAILY ),
 				} )
+			);
+		}
+	);
+} );
+
+describe( 'UpsellNudge with gating flag should get Premium plan constant', () => {
+	afterEach( () => {
+		UpsellNudge.mockClear();
+	} );
+
+	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL ] )(
+		`Premium 1 year for (%s)`,
+		( product_slug ) => {
+			render(
+				<SeoForm
+					{ ...props }
+					siteIsJetpack={ false }
+					selectedSite={ { plan: { product_slug } } }
+					hasGatingFlag
+				/>
+			);
+			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_PREMIUM } )
+			);
+		}
+	);
+
+	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS ] )(
+		`Premium 2 year for (%s)`,
+		( product_slug ) => {
+			render(
+				<SeoForm
+					{ ...props }
+					siteIsJetpack={ false }
+					selectedSite={ { plan: { product_slug } } }
+					hasGatingFlag
+				/>
+			);
+			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } )
 			);
 		}
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17636

## Proposed Changes

* Display the appropriate minimal plan which has the Advanced SEO feature, in the upsell message.

**New site**
<img width="663" height="154" alt="Screenshot 2026-06-19 at 19 32 38" src="https://github.com/user-attachments/assets/4f8ec90c-e2bd-47a4-bfe7-948a6343979c" />

**Old site**
<img width="663" height="154" alt="Screenshot 2026-06-19 at 19 33 20" src="https://github.com/user-attachments/assets/ed632a34-4714-4ebd-806c-2fbb954c8fd9" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Older sites required Business plans, while newer sites have the feature available on Premium plans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Jetpack->Traffic on a Free or Personal site.
* On an old site (ideally created before 2026), the message would refer to a Business plan.
* On a new site it'd mention the Premium plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
