### PR TITLE
Newsletter plan add/edit modal - adjust description field for layout consistency

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -389,6 +389,20 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
 					) }
 				</FormFieldset>
+				{ ! isOnlyTier && (
+					<FormFieldset className="memberships__dialog-sections-type">
+						<ToggleControl
+							onChange={ ( newValue ) => {
+								setEditedPostIsTier( newValue );
+								setEditedPostPaidNewsletter( newValue );
+							} }
+							checked={ editedPostIsTier }
+							disabled={ !! product.ID }
+							label={ translate( 'Paid newsletter tier' ) }
+						/>
+					</FormFieldset>
+				) }
+				{ isOnlyTier && <input type="hidden" name="type" value={ TYPE_TIER } /> }
 				{ editedPostIsTier && (
 					<FormFieldset>
 						<FormLabel htmlFor="tier-description">
@@ -408,7 +422,12 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						/>
 						<FormSettingExplanation>
 							{ translate(
-								'Optional. Shown to readers when they choose a paid tier on your site. Basic {{a}}Markdown{{/a}} — bold, italics, lists, and links — is supported.',
+								'Optional. Shown to readers when they choose a paid tier on your site.'
+							) }
+						</FormSettingExplanation>
+						<FormSettingExplanation>
+							{ translate(
+								'Basic {{a}}Markdown{{/a}} — bold, italics, lists, and links — is supported.',
 								{
 									components: {
 										a: (
@@ -434,20 +453,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						) }
 					</FormFieldset>
 				) }
-				{ ! isOnlyTier && (
-					<FormFieldset className="memberships__dialog-sections-type">
-						<ToggleControl
-							onChange={ ( newValue ) => {
-								setEditedPostIsTier( newValue );
-								setEditedPostPaidNewsletter( newValue );
-							} }
-							checked={ editedPostIsTier }
-							disabled={ !! product.ID }
-							label={ translate( 'Paid newsletter tier' ) }
-						/>
-					</FormFieldset>
-				) }
-				{ isOnlyTier && <input type="hidden" name="type" value={ TYPE_TIER } /> }
 				{ editing && editedPrice && (
 					<Notice
 						text={ translate(

--- a/client/my-sites/earn/components/free-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/free-plan-modal/index.tsx
@@ -148,7 +148,12 @@ const FreePlanModal = ( { closeDialog, siteId }: FreePlanModalProps ) => {
 					/>
 					<FormSettingExplanation>
 						{ translate(
-							'Optional. Shown to readers when they choose a newsletter tier on your site. Basic {{a}}Markdown{{/a}} — bold, italics, lists, and links — is supported.',
+							'Optional. Shown to readers when they choose a newsletter tier on your site.'
+						) }
+					</FormSettingExplanation>
+					<FormSettingExplanation>
+						{ translate(
+							'Basic {{a}}Markdown{{/a}} — bold, italics, lists, and links — is supported.',
 							{
 								components: {
 									a: (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # p1781890697938799-slack-C03NLNTPZ2T

## Proposed Changes

* Moves the description field for newsletter tiers below the toggle for being a newsletter tier (prevents the vertical jumpyness).
* Moves the markdown hint in the fields description to its own line. This prevents the horizontal jumpyness and feels better  than inline wrapping since this copy gets long and is expressing separate thought.

AFTER
<img width="729" height="823" alt="Screenshot 2026-06-19 at 2 46 56 PM" src="https://github.com/user-attachments/assets/f871452b-27f9-43ae-a559-dd1d4b1d2c7e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Layout consistency, less jarring shifts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the add plan modal on */earn/payments/{siteSlug}
* toggle to newsletter
* verify it doesn't jump jarringly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?