### PR TITLE
Lodash: replace without() and difference() with native array methods

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -3,7 +3,7 @@ import { AutoSizer, List } from '@automattic/react-virtualized';
 import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { difference, filter, includes, isEqual, map, memoize, range, reduce } from 'lodash';
+import { filter, includes, isEqual, map, memoize, range, reduce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -127,13 +127,10 @@ class TermTreeSelectorList extends Component {
 
 	setRequestedPages = ( { startIndex, stopIndex } ) => {
 		const { requestedPages } = this.state;
-		const pagesToRequest = difference(
-			range(
-				this.getPageForIndex( startIndex - LOAD_OFFSET ),
-				this.getPageForIndex( stopIndex + LOAD_OFFSET ) + 1
-			),
-			requestedPages
-		);
+		const pagesToRequest = range(
+			this.getPageForIndex( startIndex - LOAD_OFFSET ),
+			this.getPageForIndex( stopIndex + LOAD_OFFSET ) + 1
+		).filter( ( page ) => ! requestedPages.includes( page ) );
 
 		if ( ! pagesToRequest.length ) {
 			return;

--- a/client/components/domains/registrant-extra-info/ca-form.tsx
+++ b/client/components/domains/registrant-extra-info/ca-form.tsx
@@ -1,7 +1,7 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { camelCase, pick } from '@automattic/js-utils';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { difference, isEmpty, map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -91,9 +91,9 @@ export class RegistrantExtraInfoCaForm extends PureComponent<
 
 	componentDidMount() {
 		// Add defaults to redux state to make accepting default values work.
-		const neededRequiredDetails = difference(
-			[ 'lang', 'legalType', 'ciraAgreementAccepted' ],
-			Object.keys( this.props.ccTldDetails )
+		const providedDetails = Object.keys( this.props.ccTldDetails );
+		const neededRequiredDetails = [ 'lang', 'legalType', 'ciraAgreementAccepted' ].filter(
+			( key ) => ! providedDetails.includes( key )
 		);
 
 		// Bail early as we already have the details from a previous purchase.

--- a/client/components/domains/registrant-extra-info/uk-form.tsx
+++ b/client/components/domains/registrant-extra-info/uk-form.tsx
@@ -3,7 +3,7 @@ import { camelCase, pick } from '@automattic/js-utils';
 import { DomainContactDetails } from '@automattic/shopping-cart';
 import { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { difference, get, isEmpty, map } from 'lodash';
+import { get, isEmpty, map } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -59,9 +59,9 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 
 	componentDidMount() {
 		// Add defaults to redux state to make accepting default values work.
-		const neededRequiredDetails = difference(
-			[ 'registrantType' ],
-			Object.keys( this.props.ccTldDetails )
+		const providedDetails = Object.keys( this.props.ccTldDetails );
+		const neededRequiredDetails = [ 'registrantType' ].filter(
+			( key ) => ! providedDetails.includes( key )
 		);
 
 		// Bail early as we already have the details from a previous purchase.

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -1,7 +1,7 @@
 import { RootChild, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { includes, without } from 'lodash';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import TranslatableString from 'calypso/components/translatable/proptype';
@@ -104,7 +104,8 @@ export class DropZone extends Component {
 				return;
 			}
 
-			this.dragEnterNodes = without( this.dragEnterNodes, Array.from( mutation.removedNodes ) );
+			const removedNodes = Array.from( mutation.removedNodes );
+			this.dragEnterNodes = this.dragEnterNodes.filter( ( node ) => node !== removedNodes );
 		} );
 	};
 
@@ -114,7 +115,7 @@ export class DropZone extends Component {
 		if ( 'dragenter' === event.type && ! includes( this.dragEnterNodes, event.target ) ) {
 			this.dragEnterNodes.push( event.target );
 		} else if ( 'dragleave' === event.type ) {
-			this.dragEnterNodes = without( this.dragEnterNodes, event.target );
+			this.dragEnterNodes = this.dragEnterNodes.filter( ( node ) => node !== event.target );
 		}
 
 		// In some contexts, it may be necessary to capture and redirect the
@@ -137,7 +138,7 @@ export class DropZone extends Component {
 		if ( window.CustomEvent && event instanceof window.CustomEvent ) {
 			// For redirected CustomEvent instances, immediately remove window
 			// from tracked nodes since another "real" event will be triggered.
-			this.dragEnterNodes = without( this.dragEnterNodes, window );
+			this.dragEnterNodes = this.dragEnterNodes.filter( ( node ) => node !== window );
 		}
 	};
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
-import { difference } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import isSuggestionLabel from './helpers';
@@ -345,7 +344,9 @@ class TokenField extends PureComponent {
 		const containsMatch = [];
 
 		if ( match.length === 0 ) {
-			suggestions = difference( suggestions, this.props.value );
+			suggestions = suggestions.filter(
+				( suggestion ) => ! this.props.value.includes( suggestion )
+			);
 		} else {
 			match = match.toLocaleLowerCase();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import { CheckboxControl, SelectControl, TextControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { without } from 'lodash';
 import { FormEvent, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -62,7 +61,7 @@ const BusinessInfo: Step = function ( props ) {
 		const productTypes = getProfileValue( 'product_types' ) || [];
 
 		const newTypes = productTypes.includes( type )
-			? without( productTypes, type )
+			? productTypes.filter( ( productType: string ) => productType !== type )
 			: [ ...productTypes, type ];
 
 		updateOnboardingProfile( 'product_types', newTypes );

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,5 +1,5 @@
 import { omit } from '@automattic/js-utils';
-import { clone, difference, get, isEqual, map, reduce } from 'lodash';
+import { clone, get, isEqual, map, reduce } from 'lodash';
 import QueryKey from './key';
 
 /**
@@ -304,9 +304,8 @@ export default class QueryManager {
 					// When merging into a query where items already exist,
 					// omit incoming keys from existing set. These keys will
 					// be restored below during match testing.
-					nextQueryReceivedItemKeys = difference(
-						this.data.queries[ receivedQueryKey ].itemKeys,
-						receivedItemKeys
+					nextQueryReceivedItemKeys = this.data.queries[ receivedQueryKey ].itemKeys.filter(
+						( key ) => ! receivedItemKeys.includes( key )
 					);
 				} else {
 					// If not merging, assign incoming keys as next items

--- a/client/lib/signup/asserts.js
+++ b/client/lib/signup/asserts.js
@@ -1,11 +1,10 @@
-import { get, difference } from 'lodash';
+import { get } from 'lodash';
 import steps from 'calypso/signup/config/steps-pure';
 
 export function assertValidDependencies( stepName, providedDependencies ) {
 	const providesDependencies = get( steps, [ stepName, 'providesDependencies' ], [] );
-	const extraDependencies = difference(
-		Object.keys( providedDependencies || {} ),
-		providesDependencies
+	const extraDependencies = Object.keys( providedDependencies || {} ).filter(
+		( dependency ) => ! providesDependencies.includes( dependency )
 	);
 
 	if ( extraDependencies.length > 0 ) {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { pick } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { translate } from 'i18n-calypso';
-import { difference, filter, find, forEach, includes, isEmpty, reject, reduce } from 'lodash';
+import { filter, find, forEach, includes, isEmpty, reject, reduce } from 'lodash';
 import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -207,10 +207,11 @@ export default class SignupFlowController {
 	}
 
 	_assertFlowProvidedDependenciesFromConfig( providedDependencies: Dependencies ) {
-		const dependencyDiff = difference(
-			this._flow.providesDependenciesInQuery,
-			this._flow.optionalDependenciesInQuery || [],
-			Object.keys( providedDependencies || {} )
+		const optionalInQuery = this._flow.optionalDependenciesInQuery || [];
+		const providedKeys = Object.keys( providedDependencies || {} );
+		const dependencyDiff = ( this._flow.providesDependenciesInQuery ?? [] ).filter(
+			( dependency ) =>
+				! optionalInQuery.includes( dependency ) && ! providedKeys.includes( dependency )
 		);
 		if ( dependencyDiff.length > 0 ) {
 			throw new Error(
@@ -231,10 +232,10 @@ export default class SignupFlowController {
 			const dependenciesFound = Object.keys(
 				pick( getSignupDependencyStore( this._reduxStore.getState() ), step.dependencies )
 			);
-			const dependenciesNotProvided = difference(
-				step.dependencies,
-				dependenciesFound,
-				this._getFlowProvidesDependencies()
+			const flowProvides = this._getFlowProvidesDependencies();
+			const dependenciesNotProvided = step.dependencies.filter(
+				( dependency ) =>
+					! dependenciesFound.includes( dependency ) && ! flowProvides.includes( dependency )
 			);
 
 			if ( dependenciesNotProvided.length > 0 ) {
@@ -264,10 +265,10 @@ export default class SignupFlowController {
 
 			const optionalDependencies = step.optionalDependencies || [];
 
-			const dependenciesNotProvided = difference(
-				step.providesDependencies,
-				optionalDependencies,
-				storedDependencies
+			const dependenciesNotProvided = step.providesDependencies.filter(
+				( dependency ) =>
+					! optionalDependencies.includes( dependency ) &&
+					! storedDependencies.includes( dependency )
 			);
 
 			if ( dependenciesNotProvided.length > 0 ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -9,7 +9,7 @@ import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { pick } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { difference, get, includes, isEmpty } from 'lodash';
+import { get, includes, isEmpty } from 'lodash';
 import { buildUpgradeFunction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import {
@@ -1001,10 +1001,10 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 	const stepProvidesDependencies = steps[ stepName ].providesDependencies;
 	const stepOptionalDependencies = steps[ stepName ].optionalDependencies;
 
-	const dependenciesNotProvided = difference(
-		stepProvidesDependencies,
-		stepOptionalDependencies,
-		fulfilledDependencies
+	const dependenciesNotProvided = ( stepProvidesDependencies ?? [] ).filter(
+		( dependency ) =>
+			! ( stepOptionalDependencies ?? [] ).includes( dependency ) &&
+			! fulfilledDependencies.includes( dependency )
 	);
 
 	return isEmpty( dependenciesNotProvided );

--- a/client/me/concierge/reschedule/calendar-step.jsx
+++ b/client/me/concierge/reschedule/calendar-step.jsx
@@ -1,6 +1,5 @@
 import { CompactCard, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { without } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -56,7 +55,7 @@ class CalendarStep extends Component {
 	getFilteredTimeSlots = () => {
 		// filter out current timeslot
 		const { appointmentDetails, availableTimes } = this.props;
-		return without( availableTimes, appointmentDetails.beginTimestamp );
+		return availableTimes.filter( ( time ) => time !== appointmentDetails.beginTimestamp );
 	};
 
 	componentDidMount() {

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -1,6 +1,5 @@
 import { CheckboxControl, SelectControl, TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { without } from 'lodash';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -30,7 +29,7 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ) {
 		const productTypes = getProfileValue( 'product_types' ) || [];
 
 		const newTypes = productTypes.includes( type )
-			? without( productTypes, type )
+			? productTypes.filter( ( productType: string ) => productType !== type )
 			: [ ...productTypes, type ];
 
 		updateOnboardingProfile( 'product_types', newTypes );

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,4 +1,4 @@
-import { get, includes, map, without } from 'lodash';
+import { get, includes, map } from 'lodash';
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -82,7 +82,11 @@ export const queries = ( state = {}, action ) => {
 					.sort( query.order === 'DESC' ? sortDescending : sortAscending );
 				return deepUpdateComments( state, sortedList, query );
 			}
-			return deepUpdateComments( state, without( comments, action.commentId ), query );
+			return deepUpdateComments(
+				state,
+				( comments ?? [] ).filter( ( commentId ) => commentId !== action.commentId ),
+				query
+			);
 		}
 		case COMMENTS_QUERY_UPDATE:
 			return typeof action?.query?.page === 'undefined'

--- a/client/state/comments/ui/test/reducer.js
+++ b/client/state/comments/ui/test/reducer.js
@@ -109,6 +109,29 @@ describe( 'reducer', () => {
 			expect( query ).toEqual( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
 		} );
 
+		test( 'should not throw when deleting a comment on an uncached page', () => {
+			const state = deepFreeze( {} );
+			const query = queries( state, {
+				type: COMMENTS_DELETE,
+				siteId,
+				commentId: 5,
+				refreshCommentListQuery: { page: 1, status: 'all' },
+			} );
+			expect( query ).toEqual( { site: { 'all?order=DESC': { 1: [] } } } );
+		} );
+
+		test( 'should not throw when changing comment status on an uncached page', () => {
+			const state = deepFreeze( {} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 5,
+				status: 'approved',
+				refreshCommentListQuery: { page: 1, status: 'spam' },
+			} );
+			expect( query ).toEqual( { site: { 'spam?order=DESC': { 1: [] } } } );
+		} );
+
 		test( 'should remove a comment from a page when the comment status is changed', () => {
 			const state = deepFreeze( {
 				site: { 'spam?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -1,6 +1,6 @@
 import { pick } from '@automattic/js-utils';
 import update from 'immutability-helper';
-import { filter, find, findIndex, matches, reject, some, without } from 'lodash';
+import { filter, find, findIndex, matches, reject, some } from 'lodash';
 import {
 	DOMAINS_DNS_ADD,
 	DOMAINS_DNS_ADD_COMPLETED,
@@ -40,7 +40,7 @@ function removeDuplicateWpcomRecords( domain, records ) {
 	const customRootAaaaRecords = filter( records, isRootAaaaRecord( domain ) );
 
 	if ( wpcomARecord && ( customARecord || customRootAaaaRecords ) ) {
-		return without( records, wpcomARecord );
+		return records.filter( ( record ) => record !== wpcomARecord );
 	}
 
 	return records;

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -1,4 +1,3 @@
-import { without } from 'lodash';
 import {
 	JETPACK_SYNC_STATUS_REQUEST,
 	JETPACK_SYNC_STATUS_SUCCESS,
@@ -227,17 +226,12 @@ describe( 'reducer', () => {
 			const state = syncStatus( undefined, successfulSyncStatusRequest );
 			expect( state ).toHaveProperty( String( successfulSyncStatusRequest.siteId ) );
 			// legacy sync status will not have `progress` property.
-			without(
-				getExpectedResponseKeys().concat( [
-					'error',
-					'isRequesting',
-					'lastSuccessfulStatus',
-					'errorCounter',
-				] ),
-				'progress'
-			).forEach( ( key ) => {
-				expect( state[ successfulSyncStatusRequest.siteId ] ).toHaveProperty( key );
-			} );
+			getExpectedResponseKeys()
+				.concat( [ 'error', 'isRequesting', 'lastSuccessfulStatus', 'errorCounter' ] )
+				.filter( ( key ) => key !== 'progress' )
+				.forEach( ( key ) => {
+					expect( state[ successfulSyncStatusRequest.siteId ] ).toHaveProperty( key );
+				} );
 		} );
 
 		test( 'should set errorCounter to 0 after a successful request', () => {

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -1,6 +1,6 @@
 import { mapValues, omit, pickBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
-import { isEmpty, without, merge, isEqual } from 'lodash';
+import { isEmpty, merge, isEqual } from 'lodash';
 import { ValidationErrors as MediaValidationErrors } from 'calypso/lib/media/constants';
 import isTransientMediaId from 'calypso/lib/media/utils/is-transient-media-id';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
@@ -107,7 +107,7 @@ export const errors = ( state = {}, action ) => {
 				...state,
 				[ action.siteId ]: pickBy(
 					mapValues( state[ action.siteId ], ( mediaErrors ) =>
-						without( mediaErrors, action.errorType )
+						mediaErrors.filter( ( errorType ) => errorType !== action.errorType )
 					),
 					( mediaErrors ) => ! isEmpty( mediaErrors )
 				),

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -1,5 +1,4 @@
 import { keyBy, omit } from '@automattic/js-utils';
-import { without } from 'lodash';
 import {
 	KEYRING_CONNECTION_DELETE,
 	KEYRING_CONNECTIONS_RECEIVE,
@@ -65,7 +64,9 @@ export const items = withSchemaValidation( itemSchema, ( state = {}, action ) =>
 			const { connection } = action;
 			const { keyring_connection_ID: id, site_ID: siteId } = connection;
 			const keyringConnection = state[ id ];
-			const sites = without( keyringConnection.sites, siteId.toString() );
+			const sites = keyringConnection.sites.filter(
+				( connectedSiteId ) => connectedSiteId !== siteId.toString()
+			);
 
 			return { ...state, [ id ]: { ...keyringConnection, sites } };
 		}

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -36,6 +36,10 @@ const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash 
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
 const DEFER_MESSAGE = 'Please use native `setTimeout( fn, 0 )` instead of lodash `defer`.';
 const DELAY_MESSAGE = 'Please use native `setTimeout( fn, wait )` instead of lodash `delay`.';
+const WITHOUT_MESSAGE =
+	'Please use native `array.filter( ( item ) => item !== value )` instead of lodash `without`.';
+const DIFFERENCE_MESSAGE =
+	'Please use native `array.filter( ( item ) => ! other.includes( item ) )` instead of lodash `difference`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -45,6 +49,8 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
 	{ name: 'lodash', importNames: [ 'defer' ], message: DEFER_MESSAGE },
 	{ name: 'lodash', importNames: [ 'delay' ], message: DELAY_MESSAGE },
+	{ name: 'lodash', importNames: [ 'without' ], message: WITHOUT_MESSAGE },
+	{ name: 'lodash', importNames: [ 'difference' ], message: DIFFERENCE_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -56,6 +62,8 @@ const patterns = [
 	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
 	{ group: [ 'lodash/defer' ], message: DEFER_MESSAGE },
 	{ group: [ 'lodash/delay' ], message: DELAY_MESSAGE },
+	{ group: [ 'lodash/without' ], message: WITHOUT_MESSAGE },
+	{ group: [ 'lodash/difference' ], message: DIFFERENCE_MESSAGE },
 ];
 
 module.exports = { paths, patterns };


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `without` with `array.filter( ( item ) => item !== value )`.
* Replace lodash `difference` with `array.filter( ( item ) => ! other.includes( item ) )` (multi-array calls get additional `&& ! other.includes( item )` clauses).
* Add nullish guards (`?? []`) where lodash tolerated an undefined first/other argument, preserving behavior.
* Extend the eslint guard so neither can be reintroduced from lodash.

Part of the incremental lodash removal.

## Why are these changes being made?

`without` and `difference` are small lodash array helpers with exact native equivalents. Removing them shrinks the lodash surface, and the eslint guard keeps the replacements from regressing.

## Testing Instructions

* `yarn test-client` related suites pass (the only failing suites are pre-existing `reader/spaces` breakage on trunk, unrelated to this change).
* `yarn typecheck-client` reports no new errors from these files.
* No behavior change is expected.

### Note for reviewers

`client/components/drop-zone/index.jsx` contained a lodash call that was already a no-op — `without` does not flatten array arguments, so removing an array of nodes never matched anything. This change preserves that behavior faithfully rather than altering it; the latent issue is best addressed separately with browser/E2E coverage.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
