### PR TITLE
Lodash: replace intersection() and noop() with native equivalents

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -12,7 +12,7 @@ import {
 } from '@automattic/urls';
 import _debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { intersection, map, find } from 'lodash';
+import { map, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -133,7 +133,7 @@ export class DomainWarnings extends PureComponent {
 			this.pendingConsent,
 		];
 		const validRules = this.props.allowedRules.map( ( ruleName ) => this[ ruleName ] );
-		return intersection( allRules, validRules );
+		return allRules.filter( ( rule ) => validRules.includes( rule ) );
 	}
 
 	getDomains() {

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -1,4 +1,4 @@
-import { intersection, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import flows from '../flows';
 import { generateFlows } from '../flows-pure';
 import { getStepModuleMap } from '../step-components';
@@ -19,7 +19,8 @@ jest.mock( '@automattic/calypso-config', () => ( {
 describe( 'index', () => {
 	// eslint-disable-next-line jest/expect-expect
 	test( 'should not have overlapping step/flow names', () => {
-		const overlappingNames = intersection( Object.keys( steps ), Object.keys( flows.getFlows() ) );
+		const flowNames = Object.keys( flows.getFlows() );
+		const overlappingNames = Object.keys( steps ).filter( ( name ) => flowNames.includes( name ) );
 
 		if ( ! isEmpty( overlappingNames ) ) {
 			throw new Error(

--- a/client/signup/steps/design-picker/design-picker.tsx
+++ b/client/signup/steps/design-picker/design-picker.tsx
@@ -12,7 +12,6 @@ import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { noop } from 'lodash';
 import { useMemo } from 'react';
 import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import { filterDesignsByCategory, sortDesigns } from './utils';
@@ -20,6 +19,8 @@ import type { Categorization } from './use-categorization';
 import type { Design } from '@automattic/design-picker';
 import type { FC, ReactNode } from 'react';
 import './design-picker.scss';
+
+const noop = () => {};
 
 const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;
 

--- a/client/state/themes/selectors/is-theme-gutenberg-first.ts
+++ b/client/state/themes/selectors/is-theme-gutenberg-first.ts
@@ -1,4 +1,3 @@
-import { intersection } from 'lodash';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { getThemeTaxonomySlugs } from 'calypso/state/themes/utils';
 import type { AppState } from 'calypso/types';
@@ -20,5 +19,5 @@ export function isThemeGutenbergFirst( state: AppState, themeId: string ): boole
 	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
 	const neededFeatures = [ 'global-styles', 'auto-loading-homepage' ];
 	// The theme should have a positive number of matching features to qualify.
-	return !! intersection( themeFeatures, neededFeatures ).length;
+	return themeFeatures.some( ( feature ) => neededFeatures.includes( feature ) );
 }

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -42,6 +42,10 @@ const WITHOUT_MESSAGE =
 const DIFFERENCE_MESSAGE =
 	'Please use native `array.filter( ( item ) => ! other.includes( item ) )` instead of lodash `difference`.';
 const ISEQUAL_MESSAGE = 'Please use `fast-deep-equal/es6` instead of lodash `isEqual`.';
+const INTERSECTION_MESSAGE =
+	'Please use `array.some( ( item ) => other.includes( item ) )` for a boolean check, or ' +
+	'`Array.from( new Set( array ) ).filter( ( item ) => other.includes( item ) )` to dedupe like lodash `intersection`.';
+const NOOP_MESSAGE = 'Please use a local `const noop = () => {};` instead of lodash `noop`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -54,6 +58,8 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'without' ], message: WITHOUT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'difference' ], message: DIFFERENCE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'isEqual' ], message: ISEQUAL_MESSAGE },
+	{ name: 'lodash', importNames: [ 'intersection' ], message: INTERSECTION_MESSAGE },
+	{ name: 'lodash', importNames: [ 'noop' ], message: NOOP_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -68,6 +74,8 @@ const patterns = [
 	{ group: [ 'lodash/without' ], message: WITHOUT_MESSAGE },
 	{ group: [ 'lodash/difference' ], message: DIFFERENCE_MESSAGE },
 	{ group: [ 'lodash/isEqual' ], message: ISEQUAL_MESSAGE },
+	{ group: [ 'lodash/intersection' ], message: INTERSECTION_MESSAGE },
+	{ group: [ 'lodash/noop' ], message: NOOP_MESSAGE },
 ];
 
 module.exports = { paths, patterns };

--- a/packages/components/src/select-dropdown/index.jsx
+++ b/packages/components/src/select-dropdown/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { filter, find, noop } from 'lodash';
+import { filter, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component, forwardRef } from 'react';
 import Count from '../count';
@@ -9,6 +9,8 @@ import DropdownLabel from './label';
 import DropdownSeparator from './separator';
 import TranslatableString from './translatable/proptype';
 import './style.scss';
+
+const noop = () => {};
 
 class SelectDropdown extends Component {
 	static Item = DropdownItem;


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `intersection` with native `array.filter( ( item ) => other.includes( item ) )` (or `array.some(...)` where only presence was checked).
* Replace lodash `noop` with a local `const noop = () => {};`, matching the convention already used across the repo.
* Extend the eslint guard so neither can be reintroduced from lodash.

Part of the incremental lodash removal.

## Why are these changes being made?

`intersection` and `noop` are small lodash helpers with exact native equivalents. Removing them shrinks the lodash surface, and the eslint guard keeps the replacements from regressing.

## Testing Instructions

* `yarn test-client` related suites pass.
* `yarn typecheck-client` / `yarn typecheck-packages` report no new errors.
* No behavior change is expected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
