### PR TITLE
Lodash: replace includes() with native Array/String includes

### DIFF
--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -1,4 +1,4 @@
-import { get, includes, reduce } from 'lodash';
+import { get, reduce } from 'lodash';
 
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
 export const GUTENBERG = 'gutenberg-editor';
@@ -66,7 +66,7 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 		return NOTES;
 	}
 
-	if ( includes( ALLOWED_SECTIONS, currentSection ) ) {
+	if ( ALLOWED_SECTIONS.includes( currentSection ) ) {
 		return currentSection;
 	}
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -12,7 +12,6 @@ import { CompactCard, Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { useState } from 'react';
 import { connect } from 'react-redux';
 import DataCenterPicker from 'calypso/blocks/data-center-picker';
@@ -420,19 +419,19 @@ function mergeProps(
 		context = ownProps.currentContext;
 		feature = FEATURE_SFTP;
 		ctaName = 'calypso-hosting-features-eligibility-upgrade-nudge';
-	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
+	} else if ( ownProps.backUrl?.includes( 'plugins' ) ) {
 		context = 'plugins-upload';
 		feature = FEATURE_UPLOAD_PLUGINS;
 		ctaName = 'calypso-plugin-eligibility-upgrade-nudge';
-	} else if ( includes( ownProps.backUrl, 'themes' ) ) {
+	} else if ( ownProps.backUrl?.includes( 'themes' ) ) {
 		context = 'themes';
 		feature = FEATURE_UPLOAD_THEMES;
 		ctaName = 'calypso-theme-eligibility-upgrade-nudge';
-	} else if ( includes( ownProps.backUrl, 'hosting' ) ) {
+	} else if ( ownProps.backUrl?.includes( 'hosting' ) ) {
 		context = 'hosting';
 		feature = FEATURE_SFTP;
 		ctaName = 'calypso-hosting-eligibility-upgrade-nudge';
-	} else if ( includes( ownProps.backUrl, 'performance' ) ) {
+	} else if ( ownProps.backUrl?.includes( 'performance' ) ) {
 		context = 'performance';
 		feature = FEATURE_PERFORMANCE;
 		ctaName = 'calypso-performance-features-activate-nudge';

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -1,4 +1,4 @@
-import { includes, get } from 'lodash';
+import { get } from 'lodash';
 import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
 
 /**
@@ -15,11 +15,11 @@ import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-edi
  * @returns {string}              the default valid aspect ratio image editor should use
  */
 export function getDefaultAspectRatio( aspectRatio = null, aspectRatios = AspectRatiosValues ) {
-	if ( ! includes( aspectRatios, aspectRatio ) ) {
+	if ( ! aspectRatios?.includes( aspectRatio ) ) {
 		aspectRatio = get( aspectRatios, '0', AspectRatios.FREE );
 	}
 
-	return includes( AspectRatiosValues, aspectRatio )
+	return AspectRatiosValues.includes( aspectRatio )
 		? aspectRatio
 		: getDefaultAspectRatio( aspectRatio );
 }

--- a/client/blocks/importer/components/importer-drag/index.tsx
+++ b/client/blocks/importer/components/importer-drag/index.tsx
@@ -1,6 +1,5 @@
 import { SubTitle, Title } from '@automattic/onboarding';
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { UrlData } from 'calypso/blocks/import/types';
@@ -18,14 +17,14 @@ import './style.scss';
 /**
  * Module variables
  */
-const importingStates = [
+const importingStates: string[] = [
 	appStates.IMPORT_FAILURE,
 	appStates.IMPORT_SUCCESS,
 	appStates.IMPORTING,
 	appStates.MAP_AUTHORS,
 ];
 
-const uploadingStates = [
+const uploadingStates: string[] = [
 	appStates.UPLOAD_PROCESSING,
 	appStates.READY_FOR_UPLOAD,
 	appStates.UPLOAD_FAILURE,
@@ -63,7 +62,7 @@ const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
 					importerEngine={ importerData?.engine }
 				/>
 			) }
-			{ includes( importingStates, importerState ) && (
+			{ importingStates.includes( importerState ) && (
 				<ImportingPane
 					importerStatus={ importerStatus }
 					sourceType={ importerData?.title }
@@ -71,7 +70,7 @@ const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
 					urlData={ urlData }
 				/>
 			) }
-			{ includes( uploadingStates, importerState ) && (
+			{ uploadingStates.includes( importerState ) && (
 				<UploadingPane
 					isEnabled={ isEnabled }
 					description={ importerData?.uploadDescription }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -11,7 +11,6 @@ import clsx from 'clsx';
 import cookie from 'cookie';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -352,7 +351,7 @@ export class LoginForm extends Component {
 			} );
 
 			if ( this.props.isJetpack ) {
-				const isEmailAddress = includes( usernameOrEmail, '@' );
+				const isEmailAddress = usernameOrEmail.includes( '@' );
 
 				if ( isEmailAddress && isPasswordlessAccount( this.props.accountType ) ) {
 					this.jetpackCreateAccountWithMagicLink();
@@ -386,7 +385,7 @@ export class LoginForm extends Component {
 		// a username, we need to prompt the user specifically for an email address to proceed with
 		// the WPCOM account creation with magic links.
 
-		const isEmailAddress = includes( this.state.usernameOrEmail, '@' );
+		const isEmailAddress = this.state.usernameOrEmail.includes( '@' );
 		if ( isEmailAddress ) {
 			// With Magic Links, create the user a WPCOM account linked to the entered email address
 			this.props.sendEmailLogin( this.state.usernameOrEmail, {
@@ -467,7 +466,7 @@ export class LoginForm extends Component {
 				size="compact"
 			>
 				<Gridicon icon="arrow-left" size={ 18 } />
-				{ includes( this.state.usernameOrEmail, '@' )
+				{ this.state.usernameOrEmail.includes( '@' )
 					? this.props.translate( 'Change email address' )
 					: this.props.translate( 'Change username' ) }
 			</Button>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -5,7 +5,7 @@ import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { find, filter, forEach, includes, map, merge, isEmpty } from 'lodash';
+import { find, filter, forEach, map, merge, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -293,7 +293,7 @@ class SignupForm extends Component {
 						return;
 					}
 
-					if ( field === 'username' && ! includes( usernamesSearched, fields.username ) ) {
+					if ( field === 'username' && ! usernamesSearched.includes( fields.username ) ) {
 						recordTracksEvent( 'calypso_signup_username_validation_failed', {
 							error: Object.keys( fieldError )[ 0 ],
 							username: fields.username,

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -4,7 +4,7 @@ import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { filter, includes, map, memoize, range, reduce } from 'lodash';
+import { filter, map, memoize, range, reduce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -203,7 +203,7 @@ class TermTreeSelectorList extends Component {
 		}
 
 		// if item has a parent, and parent is in payload, height is already part of parent
-		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
+		if ( item.parent && ! _recurse && this.termIds.includes( item.parent ) ) {
 			return 0;
 		}
 
@@ -274,7 +274,7 @@ class TermTreeSelectorList extends Component {
 
 	renderItem = ( item, _recurse = false ) => {
 		// if item has a parent and it is in current props.terms, do not render
-		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
+		if ( item.parent && ! _recurse && this.termIds.includes( item.parent ) ) {
 			return;
 		}
 
@@ -292,7 +292,7 @@ class TermTreeSelectorList extends Component {
 		const itemId = item.ID;
 		const isPodcastingCategory = taxonomy === 'category' && podcastingCategoryId === itemId;
 		const name = decodeEntities( item.name ) || translate( 'Untitled' );
-		const checked = includes( selected, itemId );
+		const checked = selected.includes( itemId );
 		const InputComponent = multiple ? FormCheckbox : FormRadio;
 		const disabled =
 			multiple && checked && defaultTermId && 1 === selected.length && defaultTermId === itemId;

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement } from 'react';
 
@@ -10,7 +9,7 @@ const validTypeSizes = [ 54, 48, 47, 36, 32, 24, 21, 20, 16, 14, 12, 11 ];
 
 function CardHeading( { tagName = 'h1', size = 20, isBold = false, className, id, children } ) {
 	const classNameObject = {};
-	classNameObject[ 'card-heading-' + size ] = includes( validTypeSizes, size );
+	classNameObject[ 'card-heading-' + size ] = validTypeSizes.includes( size );
 	const classes = clsx(
 		'card-heading',
 		isBold && 'card-heading__bold',

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
@@ -1,5 +1,4 @@
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { Component } from 'react';
 import { Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
 import {
@@ -41,18 +40,18 @@ export class RegionAddressFieldsets extends Component<
 	};
 
 	inputRefCallback( input: { focus: () => void } | undefined | null ) {
-		input && input.focus();
+		input?.focus();
 	}
 
 	getRegionAddressFieldset() {
 		const { countryCode, hasCountryStates } = this.props;
 
 		if ( ! hasCountryStates ) {
-			if ( includes( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES, countryCode ) ) {
+			if ( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES.includes( countryCode ) ) {
 				return <EuAddressFieldset { ...this.props } />;
 			}
 
-			if ( includes( CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES, countryCode ) ) {
+			if ( CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES.includes( countryCode ) ) {
 				return <UkAddressFieldset { ...this.props } />;
 			}
 		}

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -9,7 +9,7 @@ import { Notice } from '@wordpress/components';
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { get, includes, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createElement } from 'react';
 import { connect } from 'react-redux';
@@ -169,8 +169,8 @@ export class ContactDetailsFormFields extends Component {
 		// domains registered according to ancient validation rules may have state set even though not required
 		if (
 			! hasCountryStates &&
-			( includes( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES, countryCode ) ||
-				includes( CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES, countryCode ) )
+			( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES.includes( countryCode ) ||
+				CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES.includes( countryCode ) )
 		) {
 			state = '';
 		}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -6,7 +6,6 @@ import { HUNDRED_YEAR_DOMAIN_FLOW } from '@automattic/onboarding';
 import { HTTPS_SSL } from '@automattic/urls';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -127,7 +126,7 @@ class DomainRegistrationSuggestion extends Component {
 	};
 
 	isUnavailableDomain = ( domain ) => {
-		return includes( this.props.unavailableDomains, domain );
+		return this.props.unavailableDomains?.includes( domain ) ?? false;
 	};
 
 	getSelectDomainAriaLabel() {

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -1,7 +1,6 @@
 import { RootChild, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import TranslatableString from 'calypso/components/translatable/proptype';
@@ -112,7 +111,7 @@ export class DropZone extends Component {
 	toggleDraggingOverDocument = ( event ) => {
 		// Track nodes that have received a drag event. So long as nodes exist
 		// in the set, we can assume that an item is being dragged on the page.
-		if ( 'dragenter' === event.type && ! includes( this.dragEnterNodes, event.target ) ) {
+		if ( 'dragenter' === event.type && ! this.dragEnterNodes.includes( event.target ) ) {
 			this.dragEnterNodes.push( event.target );
 		} else if ( 'dragleave' === event.type ) {
 			this.dragEnterNodes = this.dragEnterNodes.filter( ( node ) => node !== event.target );

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -1,7 +1,6 @@
 import { Button, Spinner } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -99,8 +98,8 @@ class VerifyEmailDialog extends Component {
 				key="resend"
 				primary
 				disabled={
-					includes( [ 'requesting', 'sent', 'error' ], this.props.emailVerificationStatus ) ||
-					includes( [ 'requesting', 'sent', 'error' ], this.state.resendPendingStatus )
+					[ 'requesting', 'sent', 'error' ].includes( this.props.emailVerificationStatus ) ||
+					[ 'requesting', 'sent', 'error' ].includes( this.state.resendPendingStatus )
 				}
 				onClick={ this.verifyEmail }
 			>

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Children, cloneElement, Component } from 'react';
 import Search from 'calypso/components/search';
@@ -178,7 +177,7 @@ class SectionNav extends Component {
 
 		Children.forEach( children, ( child, index ) => {
 			// Checking for at least 2 controls groups that are not null or ignored siblings
-			if ( index && child && ! includes( ignoreSiblings, child.type ) ) {
+			if ( index && child && ! ignoreSiblings.includes( child.type ) ) {
 				this.hasSiblingControls = true;
 			}
 		} );

--- a/client/jetpack-connect/authorize.jsx
+++ b/client/jetpack-connect/authorize.jsx
@@ -11,7 +11,6 @@ import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -749,7 +748,7 @@ export class JetpackAuthorize extends Component {
 			return null;
 		}
 
-		if ( includes( authorizeError?.message, 'already_connected' ) ) {
+		if ( authorizeError.message?.includes( 'already_connected' ) ) {
 			return (
 				<JetpackConnectNotices
 					noticeType={ ALREADY_CONNECTED }

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -1,6 +1,6 @@
 import config, { isCalypsoLive } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { includes, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import validUrl from 'valid-url';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -118,7 +118,7 @@ export function cleanUrl( inputUrl ) {
  * @returns {?string}       Role parsed from scope if found
  */
 export function getRoleFromScope( scope ) {
-	if ( ! includes( scope, ':' ) ) {
+	if ( typeof scope !== 'string' || ! scope.includes( ':' ) ) {
 		return null;
 	}
 	const role = scope.split( ':', 1 )[ 0 ];

--- a/client/lib/compare-props/index.js
+++ b/client/lib/compare-props/index.js
@@ -1,17 +1,16 @@
 import isEqual from 'fast-deep-equal/es6';
-import { includes } from 'lodash';
 
 export default ( options = {} ) => {
 	const { ignore, deep, shallow } = options;
 	return ( prevProps, nextProps ) => {
 		for ( const propName in prevProps ) {
 			// Skip ignored properties
-			if ( ignore && includes( ignore, propName ) ) {
+			if ( ignore && ignore.includes( propName ) ) {
 				continue;
 			}
 
 			// Some properties want to be compared deeply
-			if ( deep && includes( deep, propName ) ) {
+			if ( deep && deep.includes( propName ) ) {
 				if ( ! isEqual( prevProps[ propName ], nextProps[ propName ] ) ) {
 					return false;
 				}
@@ -20,7 +19,7 @@ export default ( options = {} ) => {
 			}
 
 			// Compare all other props (or a selected subset) shallowly
-			if ( ! shallow || includes( shallow, propName ) ) {
+			if ( ! shallow || shallow.includes( propName ) ) {
 				if ( prevProps[ propName ] !== nextProps[ propName ] ) {
 					return false;
 				}
@@ -32,8 +31,8 @@ export default ( options = {} ) => {
 		for ( const propName in nextProps ) {
 			if (
 				! ( propName in prevProps ) &&
-				! ( ignore && includes( ignore, propName ) ) &&
-				! ( shallow && ! includes( shallow, propName ) )
+				! ( ignore && ignore.includes( propName ) ) &&
+				! ( shallow && ! shallow.includes( propName ) )
 			) {
 				return false;
 			}

--- a/client/lib/domains/can-redirect.js
+++ b/client/lib/domains/can-redirect.js
@@ -1,5 +1,4 @@
 import inherits from 'inherits';
-import { includes } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 
 function ValidationError( code ) {
@@ -19,7 +18,7 @@ export function canRedirect( siteId, domainName, onComplete ) {
 		domainName = 'http://' + domainName;
 	}
 
-	if ( includes( domainName, '@' ) ) {
+	if ( domainName.includes( '@' ) ) {
 		onComplete( new ValidationError( 'invalid_domain' ) );
 		return;
 	}

--- a/client/lib/domains/get-domain-suggestion-search.js
+++ b/client/lib/domains/get-domain-suggestion-search.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import { getFixedDomainSearch } from './get-fixed-domain-search';
 
 /*
@@ -19,7 +18,7 @@ export function getDomainSuggestionSearch( search, minLength = 2 ) {
 	// Ignore any searches for generic URL prefixes
 	// getFixedDomainSearch will already have stripped http(s):// and www.
 	const ignoreList = [ 'www', 'http', 'https' ];
-	if ( includes( ignoreList, cleanedSearch ) ) {
+	if ( ignoreList.includes( cleanedSearch ) ) {
 		return '';
 	}
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { addLocaleToPath, isDefaultLocale } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import {
 	isAkismetOAuth2Client,
 	isCrowdsignalOAuth2Client,
@@ -60,8 +60,8 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	) {
 		// Basic validation that we're in a valid Jetpack Authorization flow
 		if (
-			includes( redirectTo, '/jetpack/connect/authorize' ) &&
-			includes( redirectTo, '_wp_nonce' )
+			redirectTo.includes( '/jetpack/connect/authorize' ) &&
+			redirectTo.includes( '_wp_nonce' )
 		) {
 			// If the current query has plugin_name param, but redirect_to doesn't, add it to the redirect_to
 			const pluginName = currentQuery?.plugin_name;

--- a/client/lib/media-serialization/detect-format.js
+++ b/client/lib/media-serialization/detect-format.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import { getMimePrefix } from 'calypso/lib/media/utils';
 import { Formats, MediaTypes } from './constants';
 
@@ -16,11 +15,11 @@ export default function ( node ) {
 		return Formats.DOM;
 	}
 
-	if ( node && node.tag && includes( VALID_SHORTCODE_TYPES, node.type ) ) {
+	if ( node && node.tag && VALID_SHORTCODE_TYPES.includes( node.type ) ) {
 		return Formats.SHORTCODE;
 	}
 
-	if ( node && node.type && includes( MediaTypes, node.type ) ) {
+	if ( node && node.type && MediaTypes.includes( node.type ) ) {
 		return Formats.OBJECT;
 	}
 

--- a/client/lib/media/utils/generate-gallery-shortcode.js
+++ b/client/lib/media/utils/generate-gallery-shortcode.js
@@ -1,5 +1,4 @@
 import { omitBy } from '@automattic/js-utils';
-import { includes } from 'lodash';
 import {
 	GalleryColumnedTypes,
 	GalleryDefaultAttrs,
@@ -31,11 +30,11 @@ export function generateGalleryShortcode( settings ) {
 
 	delete attrs.items;
 
-	if ( ! includes( GalleryColumnedTypes, attrs.type ) ) {
+	if ( ! GalleryColumnedTypes.includes( attrs.type ) ) {
 		delete attrs.columns;
 	}
 
-	if ( ! includes( GallerySizeableTypes, attrs.type ) ) {
+	if ( ! GallerySizeableTypes.includes( attrs.type ) ) {
 		delete attrs.size;
 	}
 

--- a/client/lib/media/utils/is-exceeding-site-max-upload-size.js
+++ b/client/lib/media/utils/is-exceeding-site-max-upload-size.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
 
 /**
@@ -23,7 +22,7 @@ export function isExceedingSiteMaxUploadSize( item, site ) {
 
 	if (
 		site.jetpack &&
-		includes( site?.options?.active_modules, 'videopress' ) &&
+		site.options.active_modules?.includes( 'videopress' ) &&
 		( getMimeType( item ) ?? '' ).startsWith( 'video/' )
 	) {
 		return null;

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,6 +1,6 @@
 /* eslint-disable jsdoc/no-undefined-types */
 
-import { map, includes, some, filter } from 'lodash';
+import { map, some, filter } from 'lodash';
 import getEmbedMetadata from 'calypso/lib/get-video-id';
 import { READER_CONTENT_WIDTH } from 'calypso/reader/data/post/sizes';
 import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
@@ -34,7 +34,7 @@ function isCandidateForContentImage( image ) {
 	const imageUrl = image.getAttribute( 'src' );
 
 	const imageShouldBeExcludedFromCandidacy = some( ineligibleCandidateUrlParts, ( urlPart ) =>
-		includes( imageUrl.toLowerCase(), urlPart )
+		imageUrl.toLowerCase().includes( urlPart )
 	);
 
 	return ! ( isTrackingPixel( image ) || imageShouldBeExcludedFromCandidacy );
@@ -67,7 +67,7 @@ const getAutoplayIframe = ( iframe ) => {
 	const KNOWN_SERVICES = [ 'youtube', 'vimeo', 'videopress', 'pocketcasts' ];
 	const metadata = getEmbedMetadata( iframe.src );
 
-	if ( metadata && includes( KNOWN_SERVICES, metadata.service ) ) {
+	if ( metadata && KNOWN_SERVICES.includes( metadata.service ) ) {
 		const autoplayIframe = iframe.cloneNode();
 		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
 			autoplayIframe.src += '?autoplay=1';

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -1,5 +1,5 @@
 import { getUrlParts, getUrlFromParts, safeImageUrl } from '@automattic/calypso-url';
-import { forEach, some, includes, filter } from 'lodash';
+import { forEach, some, filter } from 'lodash';
 import { resolveRelativePath } from 'calypso/lib/url';
 import { maxWidthPhotonishURL } from './utils';
 
@@ -44,7 +44,7 @@ const imageShouldBeRemovedFromContent = ( imageUrl ) => {
 		'pixel.wp.com',
 	];
 
-	return some( bannedUrlParts, ( part ) => includes( imageUrl.toLowerCase(), part ) );
+	return some( bannedUrlParts, ( part ) => imageUrl.toLowerCase().includes( part ) );
 };
 
 function provideProtocol( post, url ) {

--- a/client/lib/seo/index.js
+++ b/client/lib/seo/index.js
@@ -1,5 +1,3 @@
-import { includes } from 'lodash';
-
 const conflictingSeoPlugins = [
 	'Yoast SEO',
 	'Yoast SEO Premium',
@@ -9,7 +7,7 @@ const conflictingSeoPlugins = [
 
 export const getConflictingSeoPlugins = ( activePlugins ) =>
 	activePlugins
-		.filter( ( { name } ) => includes( conflictingSeoPlugins, name ) )
+		.filter( ( { name } ) => conflictingSeoPlugins.includes( name ) )
 		.map( ( { name, slug } ) => ( { name, slug } ) );
 
 export const getFirstConflictingPlugin = ( activePlugins ) =>

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { pick } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { translate } from 'i18n-calypso';
-import { filter, find, forEach, includes, isEmpty, reject, reduce } from 'lodash';
+import { filter, find, forEach, isEmpty, reject, reduce } from 'lodash';
 import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -343,7 +343,7 @@ export default class SignupFlowController {
 	_process() {
 		const currentSteps = this._getFlowSteps();
 		const signupProgress = filter( getSignupProgress( this._reduxStore.getState() ), ( step ) =>
-			includes( currentSteps, step.stepName )
+			currentSteps.includes( step.stepName )
 		);
 		const pendingSteps = filter( signupProgress, { status: 'pending' } );
 		const completedSteps = filter( signupProgress, { status: 'completed' } );
@@ -377,7 +377,7 @@ export default class SignupFlowController {
 		const currentSteps = this._getFlowSteps();
 		const signupProgress = filter(
 			getSignupProgress( this._reduxStore.getState() ),
-			( { stepName } ) => includes( currentSteps, stepName )
+			( { stepName } ) => currentSteps.includes( stepName )
 		);
 		const allStepsSubmitted =
 			reject( signupProgress, { status: 'in-progress' } ).length === currentSteps.length;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -9,7 +9,7 @@ import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { pick } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { get, includes, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { buildUpgradeFunction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import {
@@ -1032,7 +1032,7 @@ export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 	if (
 		flowName === 'launch-site' &&
 		stepName === 'domains-launch' &&
-		includes( flows.excludedSteps, stepName )
+		flows.excludedSteps.includes( stepName )
 	) {
 		return;
 	}
@@ -1056,7 +1056,7 @@ export function maybeRemoveStepForUserlessCheckout( stepName, defaultDependencie
 	const isPurchasingItem = ! isEmpty( cartItem ) || ! isEmpty( domainItem );
 
 	if ( isPurchasingItem ) {
-		if ( includes( flows.excludedSteps, stepName ) ) {
+		if ( flows.excludedSteps.includes( stepName ) ) {
 			return;
 		}
 
@@ -1071,7 +1071,7 @@ export function maybeRemoveStepForUserlessCheckout( stepName, defaultDependencie
 		if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {
 			flows.excludeStep( stepName );
 		}
-	} else if ( includes( flows.excludedSteps, stepName ) ) {
+	} else if ( flows.excludedSteps.includes( stepName ) ) {
 		flows.resetExcludedStep( stepName );
 		nextProps.removeStep( { stepName } );
 	}

--- a/client/me/concierge/book/info-step.jsx
+++ b/client/me/concierge/book/info-step.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { CompactCard, FormInputValidation, FormLabel } from '@automattic/components';
 import { getLanguage } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -115,7 +114,7 @@ class InfoStep extends Component {
 			translate,
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
-		const isEnglish = includes( config( 'english_locales' ), currentUserLocale );
+		const isEnglish = config( 'english_locales' ).includes( currentUserLocale );
 		const noticeText = translate( 'All sessions are in English (%(language)s is not available)', {
 			args: { language },
 		} );

--- a/client/me/concierge/cancel/index.jsx
+++ b/client/me/concierge/cancel/index.jsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -73,8 +72,7 @@ class ConciergeCancel extends Component {
 
 			default: {
 				const disabledCancelling =
-					includes(
-						[ CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING ],
+					[ CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING ].includes(
 						signupForm.status
 					) ||
 					! appointmentDetails ||

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { removeQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { get, includes, map } from 'lodash';
+import { get, map } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import ConnectDomainStep from 'calypso/components/domains/connect-domain-step';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
@@ -284,7 +284,7 @@ const redirectIfNoSite = ( redirectTo ) => {
 		const sites = getSites( state );
 		const siteIds = map( sites, 'ID' );
 
-		if ( ! includes( siteIds, siteId ) ) {
+		if ( ! siteIds.includes( siteId ) ) {
 			const user = getCurrentUser( state );
 			const visibleSiteCount = get( user, 'visible_site_count', 0 );
 			//if only one site navigate to stats to avoid redirect loop

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { includes, find } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -164,7 +164,7 @@ class DnsAddNew extends React.Component {
 	getFieldsForType( type ) {
 		const dnsRecord =
 			find( this.dnsRecords, ( record ) => {
-				return includes( record.types, type );
+				return record.types.includes( type );
 			} ) ?? this.dnsRecords[ 0 ];
 
 		return {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { get, includes, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -436,7 +436,7 @@ class EditContactInfoFormCard extends Component {
 			[ 'selectedDomain', 'whoisUpdateUnmodifiableFields' ],
 			[]
 		);
-		return this.state.formSubmitting || includes( unmodifiableFields, snakeCase( name ) );
+		return this.state.formSubmitting || unmodifiableFields.includes( snakeCase( name ) );
 	};
 
 	updateWpcomEmail( newContactDetails, updateWpcomEmail ) {

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -83,7 +82,7 @@ class FileImporter extends PureComponent {
 		const { importerStatus, site, fromSite, hideActionButtons, onImportSuccessClose } = this.props;
 		const { errorData, importerState } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
-		const showStart = includes( compactStates, importerState );
+		const showStart = compactStates.includes( importerState );
 		const cardClasses = clsx( 'importer__file-importer-card', {
 			'is-compact': showStart,
 			'is-disabled': ! isEnabled,
@@ -134,10 +133,10 @@ class FileImporter extends PureComponent {
 						} }
 					/>
 				) }
-				{ includes( importingStates, importerState ) && (
+				{ importingStates.includes( importerState ) && (
 					<ImportingPane importerStatus={ importerStatus } sourceType={ title } site={ site } />
 				) }
-				{ includes( uploadingStates, importerState ) && (
+				{ uploadingStates.includes( importerState ) && (
 					<UploadingPane
 						isEnabled={ isEnabled }
 						description={ uploadDescription }

--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -31,7 +30,7 @@ class ImporterHeader extends PureComponent {
 	render() {
 		const { importerStatus, icon, title, description } = this.props;
 		const { importerState } = importerStatus;
-		const showStart = includes( startStates, importerState );
+		const showStart = startStates.includes( importerState );
 		const headerClasses = clsx( 'importer-header', {
 			'importer-header__is-start': showStart,
 		} );

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -75,7 +74,7 @@ class SiteImporter extends PureComponent {
 		const { title, icon, description, uploadDescription, engine } = this.props.importerData;
 		const { importerStatus } = this.props;
 		const isEnabled = appStates.DISABLED !== importerStatus.importerState;
-		const showStart = includes( compactStates, importerStatus.importerState );
+		const showStart = compactStates.includes( importerStatus.importerState );
 		const cardClasses = clsx( 'importer__site-importer-card', {
 			'is-compact': showStart,
 			'is-disabled': ! isEnabled,
@@ -94,7 +93,7 @@ class SiteImporter extends PureComponent {
 					title={ title }
 					description={ description }
 				/>
-				{ includes( importingStates, importerStatus.importerState ) && (
+				{ importingStates.includes( importerStatus.importerState ) && (
 					<ImportingPane
 						{ ...this.props }
 						importerStatus={ importerStatus }
@@ -102,7 +101,7 @@ class SiteImporter extends PureComponent {
 						site={ this.props.site }
 					/>
 				) }
-				{ includes( uploadingStates, importerStatus.importerState ) && (
+				{ uploadingStates.includes( importerStatus.importerState ) && (
 					<SiteImporterInputPane
 						{ ...this.props }
 						description={ uploadDescription }

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -1,7 +1,7 @@
 import { Button, ScreenReaderText, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { find, includes } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -53,7 +53,7 @@ export class MediaLibraryDataSource extends Component {
 				icon: <Gridicon icon="image" size={ 24 } />,
 			},
 		];
-		return sources.filter( ( { value } ) => ! includes( disabledSources, value ) );
+		return sources.filter( ( { value } ) => ! disabledSources.includes( value ) );
 	};
 
 	renderScreenReader( selected ) {

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import PlanStorage from 'calypso/blocks/plan-storage';
@@ -91,7 +90,7 @@ export class MediaLibraryFilterBar extends Component {
 
 	isFilterDisabled( filter ) {
 		const { enabledFilters } = this.props;
-		return enabledFilters && ( ! filter.length || ! includes( enabledFilters, filter ) );
+		return enabledFilters && ( ! filter.length || ! enabledFilters.includes( filter ) );
 	}
 
 	shouldSkipFilters() {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
-import { includes, some } from 'lodash';
+import { some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -28,7 +28,7 @@ import './style.scss';
 // External media sources that do not need a user to connect them should be listed here.
 const noConnectionNeeded = [ 'openverse', 'pexels' ];
 
-const sourceNeedsKeyring = ( source ) => source !== '' && ! includes( noConnectionNeeded, source );
+const sourceNeedsKeyring = ( source ) => source !== '' && ! noConnectionNeeded.includes( source );
 
 const isConnected = ( state, source ) =>
 	! sourceNeedsKeyring( source ) ||

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -5,7 +5,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { groupBy, pickBy } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { localize, fixMe } from 'i18n-calypso';
-import { filter, get, includes, some } from 'lodash';
+import { filter, get, some } from 'lodash';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -245,7 +245,7 @@ class InvitePeople extends Component {
 					onMouseEnter: () => this.setState( { errorToDisplay: value } ),
 				};
 			}
-			if ( ! includes( success, value ) ) {
+			if ( ! success.includes( value ) ) {
 				return {
 					value,
 					status: 'validating',
@@ -330,7 +330,7 @@ class InvitePeople extends Component {
 		this.sendInvites( this.props.siteId, usernamesOrEmails, role, message, isExternal );
 
 		const groupedInvitees = groupBy( usernamesOrEmails, ( invitee ) => {
-			return includes( invitee, '@' ) ? 'email' : 'username';
+			return invitee.includes( '@' ) ? 'email' : 'username';
 		} );
 
 		this.props.recordTracksEvent( 'calypso_invite_people_form_submit', {
@@ -363,7 +363,7 @@ class InvitePeople extends Component {
 		// If there are invitees, and there are no errors, let's check
 		// if there are any pending validations.
 		return some( usernamesOrEmails, ( value ) => {
-			return ! includes( success, value );
+			return ! success.includes( value );
 		} );
 	};
 
@@ -401,7 +401,7 @@ class InvitePeople extends Component {
 
 	isExternalRole = ( role ) => {
 		const roles = [ 'administrator', 'editor', 'author', 'contributor' ];
-		return includes( roles, role );
+		return roles.includes( role );
 	};
 
 	renderInviteForm = () => {

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { find, get, includes } from 'lodash';
+import { find, get } from 'lodash';
 import { Component } from 'react';
 import * as React from 'react';
 import SectionNav from 'calypso/components/section-nav';
@@ -90,7 +90,7 @@ class PeopleSectionNav extends Component {
 		}
 
 		return this.getFilters().filter(
-			( filter ) => this.props.filter === filter.id || includes( allowedFilterIds, filter.id )
+			( filter ) => this.props.filter === filter.id || allowedFilterIds.includes( filter.id )
 		);
 	}
 

--- a/client/my-sites/plugins/controller.jsx
+++ b/client/my-sites/plugins/controller.jsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { includes, some } from 'lodash';
+import { some } from 'lodash';
 import { createElement } from 'react';
 import { PluginsScheduledUpdates } from 'calypso/blocks/plugins-scheduled-updates';
 import { PluginsScheduledUpdatesMultisite } from 'calypso/blocks/plugins-scheduled-updates-multisite';
@@ -62,7 +62,7 @@ function renderPluginList( context, basePath ) {
 // The plugin browser can be rendered by the `/plugins/:plugin/:site_id?` route. In that case,
 // the `:plugin` param is actually the side ID or category.
 export function getCategoryForPluginsBrowser( context ) {
-	if ( context.params.plugin && includes( ALLOWED_CATEGORIES, context.params.plugin ) ) {
+	if ( context.params.plugin && ALLOWED_CATEGORIES.includes( context.params.plugin ) ) {
 		return context.params.plugin;
 	}
 

--- a/client/my-sites/site-settings/allow-list.jsx
+++ b/client/my-sites/site-settings/allow-list.jsx
@@ -1,7 +1,7 @@
 import { Button, Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { includes, some } from 'lodash';
+import { some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -67,14 +67,14 @@ class AllowList extends Component {
 		const allowedIps = this.getProtectAllowedIps().split( '\n' );
 
 		return (
-			includes( allowedIps, ipAddress ) ||
+			allowedIps.includes( ipAddress ) ||
 			some( allowedIps, ( entry ) => {
 				if ( entry.indexOf( '-' ) < 0 ) {
 					return false;
 				}
 
 				const range = entry.split( '-' ).map( ( ip ) => ip.trim() );
-				return includes( range, ipAddress );
+				return range.includes( ipAddress );
 			} )
 		);
 	}

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -1,7 +1,6 @@
 import { FoldableCard } from '@automattic/components';
 import { capitalize } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -54,8 +53,8 @@ export class DateTimeFormat extends Component {
 		}
 
 		return {
-			customDateFormat: ! includes( getDefaultDateFormats(), dateFormat ),
-			customTimeFormat: ! includes( getDefaultTimeFormats(), timeFormat ),
+			customDateFormat: ! getDefaultDateFormats().includes( dateFormat ),
+			customTimeFormat: ! getDefaultTimeFormats().includes( timeFormat ),
 		};
 	}
 
@@ -63,7 +62,7 @@ export class DateTimeFormat extends Component {
 		const { value: format } = event.currentTarget;
 		this.props.updateFields( { [ `${ name }_format` ]: format } );
 		this.setState( {
-			[ `custom${ capitalize( name ) }Format` ]: ! includes( defaultFormats, format ),
+			[ `custom${ capitalize( name ) }Format` ]: ! defaultFormats.includes( format ),
 		} );
 	};
 

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -1,7 +1,6 @@
 import { Button, FoldableCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -49,7 +48,7 @@ class JetpackSiteStats extends Component {
 
 			let groupFields = this.getCurrentGroupFields( groupName );
 
-			if ( includes( groupFields, fieldName ) ) {
+			if ( groupFields.includes( fieldName ) ) {
 				groupFields = groupFields.filter( ( field ) => field !== fieldName );
 			} else {
 				groupFields.push( fieldName );
@@ -123,9 +122,7 @@ class JetpackSiteStats extends Component {
 		return (
 			<PanelCard className="site-settings__traffic-settings">
 				<QueryJetpackConnection siteId={ siteId } />
-
 				<PanelCardHeading>{ translate( 'Jetpack Stats' ) }</PanelCardHeading>
-
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"
 					header={ header }
@@ -156,7 +153,7 @@ class JetpackSiteStats extends Component {
 								this.renderToggle(
 									'count_roles_' + role.name,
 									role.display_name,
-									includes( this.getCurrentGroupFields( 'count_roles' ), role.name ),
+									this.getCurrentGroupFields( 'count_roles' ).includes( role.name ),
 									this.onChangeToggleGroup( 'count_roles', role.name )
 								)
 							) }
@@ -169,13 +166,12 @@ class JetpackSiteStats extends Component {
 								this.renderToggle(
 									'roles_' + role.name,
 									role.display_name,
-									includes( this.getCurrentGroupFields( 'roles' ), role.name ),
+									this.getCurrentGroupFields( 'roles' ).includes( role.name ),
 									this.onChangeToggleGroup( 'roles', role.name )
 								)
 							) }
 					</FormFieldset>
 				</FoldableCard>
-
 				<Button href={ getStatsPathForTab( 'day', siteSlug ) }>
 					{ translate( 'View your site stats' ) }
 				</Button>

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -1,6 +1,5 @@
 import { Card, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import AuthorSelector from 'calypso/blocks/author-selector';
@@ -39,7 +38,7 @@ class SiteOwnership extends Component {
 		return (
 			user.linked_user_ID === false ||
 			user.linked_user_ID === currentUser.ID ||
-			! includes( user.roles, 'administrator' )
+			! user.roles?.includes( 'administrator' )
 		);
 	};
 

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -12,7 +12,7 @@ import {
 	ExternalLink,
 } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -43,7 +43,7 @@ const SpamFilteringSettings = ( {
 } ) => {
 	const { akismet: akismetActive, wordpress_api_key } = fields;
 	const isStoredKey = wordpress_api_key === currentAkismetKey && !! wordpress_api_key;
-	const isDirty = includes( dirtyFields, 'wordpress_api_key' );
+	const isDirty = dirtyFields.includes( 'wordpress_api_key' );
 	const isCurrentKeyEmpty = isEmpty( currentAkismetKey );
 	const isKeyFieldEmpty = isEmpty( wordpress_api_key );
 	const isEmptyKey = isCurrentKeyEmpty || isKeyFieldEmpty;
@@ -159,7 +159,7 @@ export default connect( ( state, { dirtyFields, fields } ) => {
 	const selectedSiteSlug = getSelectedSiteSlug( state );
 	const hasAkismetKeyError =
 		isJetpackSettingsSaveFailure( state, selectedSiteId, fields ) &&
-		includes( dirtyFields, 'wordpress_api_key' );
+		dirtyFields.includes( 'wordpress_api_key' );
 	const hasAkismetFeature = siteHasFeature( state, selectedSiteId, WPCOM_FEATURES_AKISMET );
 	const hasAntiSpamFeature = siteHasFeature( state, selectedSiteId, WPCOM_FEATURES_ANTISPAM );
 	const hasJetpackAntiSpamProduct =

--- a/client/my-sites/stats/annual-site-stats/index.jsx
+++ b/client/my-sites/stats/annual-site-stats/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
 import { localize } from 'i18n-calypso';
-import { find, includes } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -80,7 +80,7 @@ class AnnualSiteStats extends Component {
 	formatTableValue( key, value ) {
 		const singleDecimal = [ 'avg_comments', 'avg_likes' ];
 
-		if ( includes( singleDecimal, key ) ) {
+		if ( singleDecimal.includes( key ) ) {
 			return formatNumber( value, { decimals: 1 } );
 		}
 		if ( 'year' === key ) {

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -225,7 +224,7 @@ class StatsModule extends Component {
 			summarizedTypes.push( 'statsTopPosts' );
 		}
 
-		return summary && includes( summarizedTypes, statType );
+		return summary && summarizedTypes.includes( statType );
 	}
 
 	remapData() {

--- a/client/my-sites/store/app/store-stats/controller.jsx
+++ b/client/my-sites/store/app/store-stats/controller.jsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import { includes } from 'lodash';
 import moment from 'moment';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -21,7 +20,7 @@ function isValidParameters( context ) {
 		unit: [ 'day', 'week', 'month', 'year' ],
 	};
 	return Object.keys( validParameters ).every( ( param ) =>
-		includes( validParameters[ param ], context.params[ param ] )
+		validParameters[ param ].includes( context.params[ param ] )
 	);
 }
 

--- a/client/my-sites/store/components/delta/index.jsx
+++ b/client/my-sites/store/components/delta/index.jsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -14,21 +13,22 @@ export default class Delta extends Component {
 	};
 
 	static defaultProps = {
+		className: '',
 		iconSize: 20,
 	};
 
 	render() {
 		const { className, icon, iconSize, suffix, value } = this.props;
 		const deltaClasses = clsx( 'delta', className );
-		const undefinedIncrease = includes( className, 'is-undefined-increase' );
+		const undefinedIncrease = className.includes( 'is-undefined-increase' );
 
 		let deltaIcon;
 		if ( icon ) {
 			deltaIcon = icon;
 		} else {
 			deltaIcon =
-				includes( className, 'is-increase' ) || undefinedIncrease ? 'arrow-up' : 'arrow-down';
-			deltaIcon = includes( className, 'is-neutral' ) ? 'minus-small' : deltaIcon;
+				className.includes( 'is-increase' ) || undefinedIncrease ? 'arrow-up' : 'arrow-down';
+			deltaIcon = className.includes( 'is-neutral' ) ? 'minus-small' : deltaIcon;
 		}
 
 		return (

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -10,7 +10,7 @@ import {
 import { Card, ProgressBar, Button } from '@automattic/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { includes, find, isEmpty } from 'lodash';
+import { find, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -162,7 +162,7 @@ class Upload extends Component {
 
 		const errorString = JSON.stringify( error ).toLowerCase();
 		const cause = find( errorCauses, ( v, key ) => {
-			return includes( errorString, key );
+			return errorString.includes( key );
 		} );
 
 		const unknownCause = error.error ? `: ${ error.error }` : '';

--- a/client/my-sites/themes/use-theme-showcase-description.js
+++ b/client/my-sites/themes/use-theme-showcase-description.js
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { useSelector } from 'react-redux';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
@@ -13,7 +12,7 @@ export default function useThemeShowcaseDescription( { filter, tier, vertical } 
 	} );
 	const filterDescription = useSelector( ( state ) => {
 		// If we have *one* filter, use its description
-		if ( filter && ! includes( filter, '+' ) ) {
+		if ( filter && ! filter.includes( '+' ) ) {
 			return findThemeFilterTerm( state, filter )?.description;
 		}
 	} );
@@ -37,7 +36,7 @@ export default function useThemeShowcaseDescription( { filter, tier, vertical } 
 	}
 
 	// If we have *one* filter, use its description
-	if ( filter && ! includes( filter, '+' ) ) {
+	if ( filter && ! filter.includes( '+' ) ) {
 		if ( filterDescription ) {
 			return filterDescription;
 		}

--- a/client/my-sites/themes/use-theme-showcase-title.js
+++ b/client/my-sites/themes/use-theme-showcase-title.js
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { useSelector } from 'react-redux';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
@@ -15,7 +14,7 @@ export default function useThemeShowcaseTitle( { filter, tier, vertical } = {} )
 
 	// If we have *one* filter, use its name
 	const filterName = useSelector( ( state ) => {
-		if ( filter && ! includes( filter, '+' ) ) {
+		if ( filter && ! filter.includes( '+' ) ) {
 			return findThemeFilterTerm( state, filter )?.name;
 		}
 	} );

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -1,7 +1,6 @@
 import { SelectDropdown } from '@automattic/components';
 import { times } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -64,7 +63,7 @@ export class EditorMediaModalGalleryFields extends Component {
 	};
 
 	getSizeOptions = () => {
-		if ( ! includes( GallerySizeableTypes, this.props.settings.type ) ) {
+		if ( ! GallerySizeableTypes.includes( this.props.settings.type ) ) {
 			return {};
 		}
 
@@ -116,7 +115,7 @@ export class EditorMediaModalGalleryFields extends Component {
 	};
 
 	renderColumnsOption = () => {
-		if ( ! includes( GalleryColumnedTypes, this.props.settings.type ) ) {
+		if ( ! GalleryColumnedTypes.includes( this.props.settings.type ) ) {
 			return;
 		}
 

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -1,5 +1,4 @@
 import { omit } from '@automattic/js-utils';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, forwardRef, useCallback, useRef } from 'react';
 import { connect } from 'react-redux';
@@ -128,7 +127,7 @@ class PostLifecycle extends Component {
 			return <PostUnavailable post={ post } itemRef={ this.props.itemRef } />;
 		} else if (
 			( ! post.is_external || post.is_jetpack ) &&
-			includes( this.props.blockedSites, +post.site_ID )
+			this.props.blockedSites.includes( +post.site_ID )
 		) {
 			return <PostBlocked post={ post } itemRef={ this.props.itemRef } />;
 		} else if ( isXPost( post ) ) {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -14,7 +14,7 @@ import {
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
 import express from 'express';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import { stringify } from 'qs';
 // eslint-disable-next-line no-restricted-imports
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
@@ -1089,7 +1089,9 @@ function wpcomPages( app ) {
 				const activeFlags = get( data, 'meta.data.flags.active_flags', [] );
 
 				// A8C check
-				if ( ! includes( activeFlags, 'calypso_support_user' ) ) {
+				if (
+					! ( Array.isArray( activeFlags ) && activeFlags.includes( 'calypso_support_user' ) )
+				) {
 					return res.send( renderJsx( 'support-user' ) );
 				}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -6,7 +6,7 @@ import {
 } from '@automattic/design-picker';
 import { DOMAIN_FOR_GRAVATAR_FLOW, isDomainForGravatarFlow } from '@automattic/onboarding';
 import { isURL } from '@wordpress/url';
-import { get, includes, reject } from 'lodash';
+import { get, reject } from 'lodash';
 import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { getOnboardingPostCheckoutDestination } from 'calypso/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination';
@@ -325,7 +325,7 @@ const Flows = {
 
 		return {
 			...flow,
-			steps: reject( flow.steps, ( stepName ) => includes( Flows.excludedSteps, stepName ) ),
+			steps: reject( flow.steps, ( stepName ) => Flows.excludedSteps.includes( stepName ) ),
 		};
 	},
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -13,7 +13,7 @@ import * as oauthToken from '@automattic/oauth-token';
 import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
 import isEqual from 'fast-deep-equal/es6';
-import { clone, find, get, includes, isEmpty, map } from 'lodash';
+import { clone, find, get, isEmpty, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -206,7 +206,7 @@ class Signup extends Component {
 			if (
 				! this.state.shouldShowLoadingScreen &&
 				this.isStepFulfillmentReady( stepName, nextProps ) &&
-				! includes( flows.excludedSteps, stepName ) &&
+				! flows.excludedSteps.includes( stepName ) &&
 				! this._recordedSteps.has( stepName )
 			) {
 				this._recordStepsInOrder( { includeCurrentStep: true, forStep: stepName } );
@@ -290,7 +290,7 @@ class Signup extends Component {
 		if ( siteDomains !== prevProps.siteDomains || didCurrentStepBecomeFulfillmentReady ) {
 			this.removeFulfilledSteps( this.props );
 
-			if ( ! includes( flows.excludedSteps, stepName ) && ! this._recordedSteps.has( stepName ) ) {
+			if ( ! flows.excludedSteps.includes( stepName ) && ! this._recordedSteps.has( stepName ) ) {
 				this._recordStepsInOrder( { includeCurrentStep: true } );
 			}
 		}
@@ -344,7 +344,7 @@ class Signup extends Component {
 
 		for ( const step of rawFlow.steps ) {
 			if ( ! this._recordedSteps.has( step ) ) {
-				if ( includes( flows.excludedSteps, step ) ) {
+				if ( flows.excludedSteps.includes( step ) ) {
 					this.recordSignupStepAndPageView( {
 						skipStepRender: true,
 						overrideStepName: step,
@@ -559,7 +559,7 @@ class Signup extends Component {
 			currentStepIndex >= 0 ? flowSteps.slice( 0, currentStepIndex + 1 ) : flowSteps;
 		const previouslyExcludedSteps = clone( flows.excludedSteps );
 		map( previouslyExcludedSteps, ( flowStepName ) => {
-			if ( includes( stepsToProcess, flowStepName ) ) {
+			if ( stepsToProcess.includes( flowStepName ) ) {
 				this.processFulfilledSteps( flowStepName, nextProps );
 			}
 		} );
@@ -567,7 +567,7 @@ class Signup extends Component {
 			this.processFulfilledSteps( flowStepName, nextProps )
 		);
 
-		if ( includes( flows.excludedSteps, stepName ) ) {
+		if ( flows.excludedSteps.includes( stepName ) ) {
 			this._recordStepsInOrder( { forStep: stepName } );
 			this.goToNextStep( flowName );
 		}
@@ -940,10 +940,9 @@ class Signup extends Component {
 	}
 
 	isCurrentStepRemovedFromFlow() {
-		return ! includes(
-			flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps,
-			this.props.stepName
-		);
+		return ! flows
+			.getFlow( this.props.flowName, this.props.isLoggedIn )
+			.steps.includes( this.props.stepName );
 	}
 
 	shouldWaitToRender() {

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -3,7 +3,7 @@ import { FormLabel } from '@automattic/components';
 import { getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
@@ -109,7 +109,7 @@ class Site extends Component {
 				debug( error, response );
 
 				if ( error && error.message ) {
-					if ( fields.site && ! includes( siteUrlsSearched, fields.site ) ) {
+					if ( fields.site && ! siteUrlsSearched.includes( fields.site ) ) {
 						siteUrlsSearched.push( fields.site );
 
 						recordTracksEvent( 'calypso_signup_site_url_validation_failed', {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,6 +1,6 @@
 import { pick } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { filter, find, includes, isEmpty, sortBy } from 'lodash';
+import { filter, find, isEmpty, sortBy } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
@@ -144,7 +144,7 @@ export function getFilteredSteps( flowName, progress, isUserLoggedIn ) {
 
 	return sortBy(
 		// filter steps...
-		filter( progress, ( step ) => includes( flow.steps, step.stepName ) ),
+		filter( progress, ( step ) => flow.steps.includes( step.stepName ) ),
 		// then order according to the flow definition...
 		( { stepName } ) => flow.steps.indexOf( stepName )
 	);

--- a/client/sites/marketing/connections/service-examples.jsx
+++ b/client/sites/marketing/connections/service-examples.jsx
@@ -1,9 +1,9 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+// eslint-disable-next-line no-restricted-imports
 import googleDriveExample from 'calypso/assets/images/connections/google-drive-screenshot.jpg';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -240,7 +240,7 @@ class SharingServiceExamples extends Component {
 	}
 
 	render() {
-		if ( ! includes( SERVICES_WITH_EXAMPLES, this.props.service.ID ) ) {
+		if ( ! SERVICES_WITH_EXAMPLES.includes( this.props.service.ID ) ) {
 			/**
 			 * TODO: Refactoring this line has to be tackled in a seperate diff.
 			 * Touching this changes services-group.jsx which changes service.jsx

--- a/client/sites/marketing/connections/service-tip.jsx
+++ b/client/sites/marketing/connections/service-tip.jsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -74,8 +73,7 @@ class SharingServiceTip extends Component {
 	render() {
 		const { service } = this.props;
 		if (
-			! includes(
-				this.props.hasJetpack ? JETPACK_SERVICES_WITH_TIPS : SERVICES_WITH_TIPS,
+			! ( this.props.hasJetpack ? JETPACK_SERVICES_WITH_TIPS : SERVICES_WITH_TIPS ).includes(
 				service.ID
 			) ||
 			'google_plus' === service.ID

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,7 +1,7 @@
 import { omit } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { filter, orderBy, has, map, reject, get, includes } from 'lodash';
+import { filter, orderBy, has, map, reject, get } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,
@@ -211,7 +211,7 @@ export function pendingItems( state = {}, action ) {
 				...state,
 				[ stateKey ]: filter(
 					state[ stateKey ],
-					( _comment ) => ! includes( receivedCommentIds, _comment.ID )
+					( _comment ) => ! receivedCommentIds.includes( _comment.ID )
 				),
 			};
 		}
@@ -233,7 +233,7 @@ const isValidExpansionsAction = ( action ) => {
 		siteId &&
 		postId &&
 		Array.isArray( commentIds ) &&
-		includes( Object.values( POST_COMMENT_DISPLAY_TYPES ), displayType )
+		Object.values( POST_COMMENT_DISPLAY_TYPES ).includes( displayType )
 	);
 };
 

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,4 +1,4 @@
-import { get, includes, map } from 'lodash';
+import { get, map } from 'lodash';
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -65,7 +65,7 @@ export const queries = ( state = {}, action ) => {
 			if (
 				COMMENTS_CHANGE_STATUS === action.type &&
 				'all' === status &&
-				includes( comments, action.commentId ) && // if the comment is not in the current view this is an undo
+				comments?.includes( action.commentId ) && // if the comment is not in the current view this is an undo
 				[ 'approved', 'unapproved' ].includes( action.status )
 			) {
 				// No-op when status changes from `approved` or `unapproved` in the All tab

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import { JETPACK_REMOTE_INSTALL } from 'calypso/state/action-types';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
@@ -52,7 +51,7 @@ export const handleError = ( action, error ) => {
 		} )
 	);
 
-	if ( includes( error.message, 'timed out' ) ) {
+	if ( ( error.message ?? '' ).includes( 'timed out' ) ) {
 		if ( retryCount < JETPACK_REMOTE_INSTALL_RETRIES ) {
 			return {
 				type: JETPACK_REMOTE_INSTALL,

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -1,5 +1,5 @@
 import { translate } from 'i18n-calypso';
-import { find, includes } from 'lodash';
+import { find } from 'lodash';
 import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { PLUGIN_INSTALL_REQUEST_SUCCESS, PLUGIN_UPLOAD } from 'calypso/state/action-types';
@@ -40,7 +40,7 @@ const showErrorNotice = ( error ) => {
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
 	};
 	const errorString = `${ error.error }${ error.message }`.toLowerCase();
-	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
+	const knownError = find( knownErrors, ( v, key ) => errorString.includes( key ) );
 
 	if ( knownError ) {
 		return errorNotice( knownError );

--- a/client/state/immediate-login/selectors.js
+++ b/client/state/immediate-login/selectors.js
@@ -1,4 +1,4 @@
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import { REASONS_FOR_MANUAL_RENEWAL } from './constants';
 
 import 'calypso/state/immediate-login/init';
@@ -73,5 +73,5 @@ export const getImmediateLoginLocale = ( state ) => {
  *                      login attempt was made from a manual renewal email
  */
 export const wasManualRenewalImmediateLoginAttempted = ( state ) => {
-	return includes( REASONS_FOR_MANUAL_RENEWAL, getImmediateLoginReason( state ) );
+	return REASONS_FOR_MANUAL_RENEWAL.includes( getImmediateLoginReason( state ) );
 };

--- a/client/state/jetpack-connect/selectors/has-expired-secret-error.js
+++ b/client/state/jetpack-connect/selectors/has-expired-secret-error.js
@@ -1,4 +1,4 @@
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors/get-authorization-data';
 
 import 'calypso/state/jetpack-connect/init';
@@ -13,6 +13,6 @@ export const hasExpiredSecretError = function ( state ) {
 
 	return (
 		!! get( authorizeData, 'authorizationCode', false ) &&
-		includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'verify_secrets_expired' )
+		get( authorizeData, [ 'authorizeError', 'message' ], '' ).includes( 'verify_secrets_expired' )
 	);
 };

--- a/client/state/jetpack-connect/selectors/has-xmlrpc-error.js
+++ b/client/state/jetpack-connect/selectors/has-xmlrpc-error.js
@@ -1,4 +1,4 @@
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors/get-authorization-data';
 
 import 'calypso/state/jetpack-connect/init';
@@ -16,6 +16,6 @@ export const hasXmlrpcError = function ( state ) {
 
 	return (
 		!! get( authorizeData, 'authorizationCode', false ) &&
-		includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'error' )
+		get( authorizeData, [ 'authorizeError', 'message' ], '' ).includes( 'error' )
 	);
 };

--- a/client/state/notification-settings/toggle-state.js
+++ b/client/state/notification-settings/toggle-state.js
@@ -1,10 +1,10 @@
-import { find, findIndex, get, includes } from 'lodash';
+import { find, findIndex, get } from 'lodash';
 
 const replaceAtIndex = ( array, index, newItem ) =>
 	array.map( ( item, idx ) => ( idx === index ? newItem : item ) );
 
 const replaceOrAppend = ( array, originalItem, newItem ) =>
-	includes( array, originalItem )
+	array.includes( originalItem )
 		? replaceAtIndex( array, findIndex( array, originalItem ), newItem )
 		: [ ...array, newItem ];
 

--- a/client/state/posts/selectors/get-posts-for-query.js
+++ b/client/state/posts/selectors/get-posts-for-query.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { includes } from 'lodash';
 import { getQueryManager } from 'calypso/state/posts/selectors/get-query-manager';
 import { getSerializedPostsQuery, normalizePostForDisplay } from 'calypso/state/posts/utils';
 
@@ -35,7 +34,7 @@ export const getPostsForQuery = createSelector(
 		// the WP.com API skips unreadable posts entirely instead of including
 		// them in the results.  See the 'handles items missing from the first
 		// and last pages' test case for PaginatedQueryManager.
-		if ( includes( posts, undefined ) ) {
+		if ( posts.includes( undefined ) ) {
 			return null;
 		}
 

--- a/client/state/selectors/is-authors-email-blocked.js
+++ b/client/state/selectors/is-authors-email-blocked.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 
 /**
@@ -11,7 +10,7 @@ import getSiteSetting from 'calypso/state/selectors/get-site-setting';
  */
 export const isAuthorsEmailBlocked = ( state, siteId, email = '' ) => {
 	const blocklist = getSiteSetting( state, siteId, 'disallowed_keys' ) || '';
-	return includes( blocklist.split( '\n' ), email );
+	return blocklist.split( '\n' ).includes( email );
 };
 
 export default isAuthorsEmailBlocked;

--- a/client/state/selectors/is-jetpack-module-unavailable-in-development-mode.js
+++ b/client/state/selectors/is-jetpack-module-unavailable-in-development-mode.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { includes } from 'lodash';
 import getJetpackModulesRequiringConnection from './get-jetpack-modules-requiring-connection';
 
 /**
@@ -17,7 +16,7 @@ const isJetpackModuleUnavailableInDevelopmentMode = createSelector(
 			return null;
 		}
 
-		return includes( modulesRequiringConnection, moduleSlug );
+		return modulesRequiringConnection.includes( moduleSlug );
 	},
 	getJetpackModulesRequiringConnection
 );

--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -1,6 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
 import { isMobile } from '@automattic/viewport';
-import { includes } from 'lodash';
 import {
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 	ALLOWED_SECTIONS,
@@ -64,7 +63,7 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 		return false;
 	}
 
-	if ( ! includes( ALLOWED_SECTIONS, currentSection ) ) {
+	if ( ! ALLOWED_SECTIONS.includes( currentSection ) ) {
 		return false;
 	}
 

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -1,6 +1,6 @@
 import { omit } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { merge, includes, reduce } from 'lodash';
+import { merge, reduce } from 'lodash';
 import {
 	MEDIA_DELETE,
 	SITE_LEAVE_RECEIVE,
@@ -243,7 +243,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 		case MEDIA_DELETE: {
 			const { siteId, mediaIds } = action;
 			const siteIconId = state[ siteId ]?.icon?.media_id;
-			if ( siteIconId && includes( mediaIds, siteIconId ) ) {
+			if ( siteIconId && mediaIds.includes( siteIconId ) ) {
 				return {
 					...state,
 					[ siteId ]: omit( state[ siteId ], 'icon' ),

--- a/client/state/themes/selectors/get-theme-filter-string-from-term.js
+++ b/client/state/themes/selectors/get-theme-filter-string-from-term.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import { getThemeFilterTermsTable } from 'calypso/state/themes/selectors/get-theme-filter-terms-table';
 
 import 'calypso/state/themes/init';
@@ -33,7 +32,7 @@ export function getThemeFilterStringFromTerm(
 	}
 
 	if ( taxonomy ) {
-		if ( includes( term, ':' ) ) {
+		if ( term.includes( ':' ) ) {
 			return term;
 		}
 		return `${ taxonomy }:${ term }`;

--- a/client/state/themes/selectors/get-themes-for-query.js
+++ b/client/state/themes/selectors/get-themes-for-query.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { includes } from 'lodash';
 import { getSerializedThemesQuery } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
@@ -29,7 +28,7 @@ export const getThemesForQuery = createSelector(
 		// request's `found` value) but the items haven't been received. While
 		// we could impose this on the developer to accommodate, instead we
 		// simply return null when any `undefined` entries exist in the set.
-		if ( includes( themes, undefined ) ) {
+		if ( themes.includes( undefined ) ) {
 			return null;
 		}
 

--- a/client/state/themes/themes-ui/selectors.js
+++ b/client/state/themes/themes-ui/selectors.js
@@ -1,5 +1,4 @@
 import { getLocaleSlug } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { isStaticFilter, constructThemeShowcaseUrl } from 'calypso/my-sites/themes/helpers';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -13,7 +12,7 @@ export function getBackPath( state ) {
 	const siteSlug = getSelectedSiteSlug( state );
 	const queryArgs = getCurrentQueryArguments( state );
 
-	if ( ! siteSlug || includes( backPath, siteSlug ) ) {
+	if ( ! siteSlug || backPath?.includes( siteSlug ) ) {
 		return backPath;
 	}
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -1,5 +1,5 @@
 import { omit, omitBy } from '@automattic/js-utils';
-import { get, includes, map, some } from 'lodash';
+import { get, map, some } from 'lodash';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -206,16 +206,16 @@ export function isThemeMatchingQuery( query, theme ) {
 						theme.taxonomies &&
 						some(
 							theme.taxonomies[ 'theme_' + taxonomy ],
-							( { name } ) => name && includes( name.toLowerCase(), search )
+							( { name } ) => name && name.toLowerCase().includes( search )
 						)
 				);
 
 				return (
 					foundInTaxonomies ||
-					( theme.id && includes( theme.id.toLowerCase(), search ) ) ||
-					( theme.name && includes( theme.name.toLowerCase(), search ) ) ||
-					( theme.author && includes( theme.author.toLowerCase(), search ) ) ||
-					( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) )
+					( theme.id && theme.id.toLowerCase().includes( search ) ) ||
+					( theme.name && theme.name.toLowerCase().includes( search ) ) ||
+					( theme.author && theme.author.toLowerCase().includes( search ) ) ||
+					( theme.descriptionLong && theme.descriptionLong.toLowerCase().includes( search ) )
 				);
 			}
 			case 'filter': {

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -46,6 +46,10 @@ const INTERSECTION_MESSAGE =
 	'Please use `array.some( ( item ) => other.includes( item ) )` for a boolean check, or ' +
 	'`Array.from( new Set( array ) ).filter( ( item ) => other.includes( item ) )` to dedupe like lodash `intersection`.';
 const NOOP_MESSAGE = 'Please use a local `const noop = () => {};` instead of lodash `noop`.';
+const INCLUDES_MESSAGE =
+	'Please use native `array.includes( value )` / `string.includes( substring )` instead of lodash ' +
+	'`includes`. Guard possibly-undefined collections (`value?.includes( … )`), and use ' +
+	'`Object.values( obj ).includes( value )` for object collections.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -60,6 +64,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'isEqual' ], message: ISEQUAL_MESSAGE },
 	{ name: 'lodash', importNames: [ 'intersection' ], message: INTERSECTION_MESSAGE },
 	{ name: 'lodash', importNames: [ 'noop' ], message: NOOP_MESSAGE },
+	{ name: 'lodash', importNames: [ 'includes' ], message: INCLUDES_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -76,6 +81,7 @@ const patterns = [
 	{ group: [ 'lodash/isEqual' ], message: ISEQUAL_MESSAGE },
 	{ group: [ 'lodash/intersection' ], message: INTERSECTION_MESSAGE },
 	{ group: [ 'lodash/noop' ], message: NOOP_MESSAGE },
+	{ group: [ 'lodash/includes' ], message: INCLUDES_MESSAGE },
 ];
 
 module.exports = { paths, patterns };

--- a/packages/components/src/product-icon/index.tsx
+++ b/packages/components/src/product-icon/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { findKey, includes } from 'lodash';
+import { findKey } from 'lodash';
 import * as React from 'react';
 import { iconToProductSlugMap, paths } from './config';
 import type { SupportedSlugs } from './config';
@@ -17,7 +17,7 @@ const ProductIcon: React.FunctionComponent< Props > = ( { className, slug } ) =>
 	}
 
 	const iconSlug = findKey( iconToProductSlugMap, ( products ) =>
-		includes( products, slug )
+		products.includes( slug )
 	) as keyof typeof paths;
 
 	const iconPath = paths[ iconSlug ];


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `includes()` with native `Array/String.prototype.includes` across the codebase (132 call sites in 81 files).
* Add an eslint guard (`no-restricted-imports`) so lodash `includes` cannot be reintroduced.
* Drive-by: clean up two pre-existing lint errors in files this PR touches (an optional-chaining tidy and an unrelated asset-import suppression).

Native `.includes` is a faithful drop-in for array membership, substring checks, and the `fromIndex` argument. The two behavioral differences from lodash are handled explicitly:

* **Possibly-undefined collections** — lodash returns `false` where native would throw, so those sites are guarded with optional chaining (or an empty-string default for `get()`-wrapped values).
* **Object collections** — none were found in the audited call sites.

Two cases that lodash's loose typing had masked are also fixed at the source (an optional value that is now correctly guarded, and array constants that needed a widened element type).

## Why are these changes being made?

* Part of the incremental removal of lodash from the codebase, reducing bundle size and standardizing on native equivalents.

## Testing Instructions

* `yarn typecheck-client` passes.
* Unit tests for the affected areas pass (`yarn test-client`).
* Confirm membership/substring checks still behave correctly — e.g. importer state panels render, signup excluded-step filtering, theme search filtering, and Jetpack connect error notices.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
