### PR TITLE
Lodash: replace escapeRegExp(), once() and isError()

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -34,6 +34,7 @@
 		"@automattic/calypso-router": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",
+		"@automattic/js-utils": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/base-styles": "^9.1.0",
 		"@wordpress/data": "^10.48.0",

--- a/apps/odyssey-stats/src/components/odyssey-query-products.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-products.ts
@@ -1,5 +1,5 @@
+import { isError } from '@automattic/js-utils';
 import { useQuery } from '@tanstack/react-query';
-import { isError } from 'lodash';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -2,8 +2,8 @@
  * This is a Odyssey implementation of 'calypso/components/data/query-site-purchases'.
  */
 import { APIError } from '@automattic/data-stores';
+import { isError } from '@automattic/js-utils';
 import { useQuery } from '@tanstack/react-query';
-import { isError } from 'lodash';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -1,5 +1,5 @@
+import { escapeRegExp } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { escapeRegExp } from 'lodash';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import AutoDirection from 'calypso/components/auto-direction';

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -1,6 +1,6 @@
-import { pick } from '@automattic/js-utils';
+import { pick, escapeRegExp } from '@automattic/js-utils';
 import { throttle } from '@wordpress/compose';
-import { escapeRegExp, findIndex } from 'lodash';
+import { findIndex } from 'lodash';
 import { createRef, Component, Fragment } from 'react';
 import getCaretCoordinates from 'textarea-caret';
 import UserMentionSuggestionList from './suggestion-list';

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
+import { once } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { once } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/reader/follow-helpers.tsx
+++ b/client/reader/follow-helpers.tsx
@@ -1,4 +1,4 @@
-import { escapeRegExp } from 'lodash';
+import { escapeRegExp } from '@automattic/js-utils';
 import {
 	getSiteName,
 	getSiteUrl,

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { once } from 'lodash';
+import { once } from '@automattic/js-utils';
 import {
 	ROUTE_SET,
 	SELECTED_SITE_SET,

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -20,6 +20,9 @@ const JS_UTILS_NAMES = [
 	'groupBy',
 	'mapKeys',
 	'capitalize',
+	'escapeRegExp',
+	'once',
+	'isError',
 ];
 
 // The js-utils case converters cover ASCII identifiers/keys, not lodash's full

--- a/packages/components/src/suggestions/item.tsx
+++ b/packages/components/src/suggestions/item.tsx
@@ -1,5 +1,5 @@
+import { escapeRegExp } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { escapeRegExp } from 'lodash';
 import { useEffect, memo, forwardRef } from 'react';
 import type { ForwardRefRenderFunction, FocusEvent, MouseEvent } from 'react';
 

--- a/packages/js-utils/src/escape-reg-exp.ts
+++ b/packages/js-utils/src/escape-reg-exp.ts
@@ -1,0 +1,13 @@
+/**
+ * Escapes the RegExp special characters in a string so it can be safely embedded
+ * as a literal inside a regular expression, matching lodash's `escapeRegExp` for
+ * string input.
+ *
+ * Intentionally typed for strings only: it does not replicate lodash's coercion
+ * of arbitrary values to strings.
+ * @param value The string to escape.
+ * @returns The string with RegExp special characters escaped.
+ */
+const escapeRegExp = ( value: string ): string => value.replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' );
+
+export default escapeRegExp;

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -1,7 +1,9 @@
 export { default as camelCase } from './camel-case';
 export { default as camelToSnakeCase } from './camel-to-snake-case';
 export { default as capitalize } from './capitalize';
+export { default as escapeRegExp } from './escape-reg-exp';
 export { default as groupBy } from './group-by';
+export { default as isError } from './is-error';
 export { default as kebabCase } from './kebab-case';
 export { default as keyBy } from './key-by';
 export { default as mapKeys } from './map-keys';
@@ -9,6 +11,7 @@ export { default as mapRecordKeysRecursively } from './map-record-keys-recursive
 export { default as mapValues } from './map-values';
 export { default as omit } from './omit';
 export { default as omitBy } from './omit-by';
+export { default as once } from './once';
 export { default as pick } from './pick';
 export { default as pickBy } from './pick-by';
 export { default as shuffle } from './shuffle';

--- a/packages/js-utils/src/is-error.ts
+++ b/packages/js-utils/src/is-error.ts
@@ -1,0 +1,83 @@
+const nativeObjectToString = Object.prototype.toString;
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+const funcToString = Function.prototype.toString;
+const objectCtorString = funcToString.call( Object );
+const symToStringTag = Symbol.toStringTag;
+
+/**
+ * Reads a value's internal tag while ignoring a spoofed `Symbol.toStringTag`, by
+ * temporarily unsetting the symbol before calling `Object.prototype.toString`.
+ * Mirrors lodash's `getRawTag` so a value can't masquerade as another type.
+ */
+const getRawTag = ( value: Record< symbol, unknown > ): string => {
+	const isOwn = hasOwnProperty.call( value, symToStringTag );
+	const tag = value[ symToStringTag ];
+	let unmasked = false;
+
+	try {
+		value[ symToStringTag ] = undefined;
+		unmasked = true;
+	} catch {
+		// The value can't be mutated (e.g. frozen); fall back to its current tag.
+	}
+
+	const result = nativeObjectToString.call( value );
+
+	if ( unmasked ) {
+		if ( isOwn ) {
+			value[ symToStringTag ] = tag;
+		} else {
+			delete value[ symToStringTag ];
+		}
+	}
+	return result;
+};
+
+const getTag = ( value: object ): string =>
+	symToStringTag in value
+		? getRawTag( value as Record< symbol, unknown > )
+		: nativeObjectToString.call( value );
+
+// Mirrors lodash's `isPlainObject`, including its constructor-string check so
+// cross-realm plain objects (e.g. from another iframe) are still recognized as
+// plain rather than mistaken for `Error`-like objects.
+const isPlainObject = ( value: object ): boolean => {
+	if ( getTag( value ) !== '[object Object]' ) {
+		return false;
+	}
+	const proto = Object.getPrototypeOf( value );
+	if ( proto === null ) {
+		return true;
+	}
+	const Ctor = hasOwnProperty.call( proto, 'constructor' ) && proto.constructor;
+	return (
+		typeof Ctor === 'function' &&
+		Ctor instanceof Ctor &&
+		funcToString.call( Ctor ) === objectCtorString
+	);
+};
+
+/**
+ * Checks whether a value is an `Error` (or `Error`-like) object, matching
+ * lodash's `isError`. Unlike a bare `value instanceof Error`, this also detects
+ * `DOMException`s and cross-realm errors (e.g. an `Error` from another iframe),
+ * resists a spoofed `Symbol.toStringTag`, and still returns `false` for plain
+ * objects.
+ * @param value The value to check.
+ * @returns `true` if the value is an error, otherwise `false`.
+ */
+const isError = ( value: unknown ): value is Error => {
+	if ( value === null || typeof value !== 'object' ) {
+		return false;
+	}
+	const tag = getTag( value );
+	return (
+		tag === '[object Error]' ||
+		tag === '[object DOMException]' ||
+		( typeof ( value as Error ).message === 'string' &&
+			typeof ( value as Error ).name === 'string' &&
+			! isPlainObject( value ) )
+	);
+};
+
+export default isError;

--- a/packages/js-utils/src/once.ts
+++ b/packages/js-utils/src/once.ts
@@ -1,0 +1,24 @@
+/**
+ * Wraps a function so it runs at most once. The first invocation calls `fn` and
+ * caches its result; every later invocation returns that cached result without
+ * calling `fn` again (ignoring any later arguments). Matches lodash's `once`.
+ * @param fn The function to restrict to a single invocation.
+ * @returns The restricted function.
+ */
+const once = < Args extends unknown[], Return >(
+	fn: ( ...args: Args ) => Return
+): ( ( ...args: Args ) => Return ) => {
+	let called = false;
+	let result: Return;
+	// Use a regular function (not an arrow) so the caller's `this` is forwarded
+	// to `fn`, matching lodash's `func.apply( this, arguments )`.
+	return function ( this: unknown, ...args: Args ): Return {
+		if ( ! called ) {
+			called = true;
+			result = fn.apply( this, args );
+		}
+		return result;
+	};
+};
+
+export default once;

--- a/packages/js-utils/src/test/escape-reg-exp.ts
+++ b/packages/js-utils/src/test/escape-reg-exp.ts
@@ -1,0 +1,17 @@
+import escapeRegExp from '../escape-reg-exp';
+
+describe( 'escapeRegExp', () => {
+	it( 'escapes RegExp special characters', () => {
+		expect( escapeRegExp( '[lodash](https://lodash.com/)' ) ).toBe(
+			'\\[lodash\\]\\(https://lodash\\.com/\\)'
+		);
+		expect( escapeRegExp( 'a.b*c+?' ) ).toBe( 'a\\.b\\*c\\+\\?' );
+		expect( escapeRegExp( '^start$' ) ).toBe( '\\^start\\$' );
+		expect( escapeRegExp( 'x|y{1}' ) ).toBe( 'x\\|y\\{1\\}' );
+	} );
+
+	it( 'leaves non-special characters untouched', () => {
+		expect( escapeRegExp( 'plain text 123' ) ).toBe( 'plain text 123' );
+		expect( escapeRegExp( '' ) ).toBe( '' );
+	} );
+} );

--- a/packages/js-utils/src/test/is-error.ts
+++ b/packages/js-utils/src/test/is-error.ts
@@ -1,0 +1,37 @@
+import { runInNewContext } from 'vm';
+import isError from '../is-error';
+
+describe( 'isError', () => {
+	it( 'returns true for Error objects and subclasses', () => {
+		expect( isError( new Error( 'boom' ) ) ).toBe( true );
+		expect( isError( new TypeError( 'bad type' ) ) ).toBe( true );
+		expect( isError( new ( class CustomError extends Error {} )( 'custom' ) ) ).toBe( true );
+	} );
+
+	it( 'returns true for DOMException', () => {
+		expect( isError( new DOMException( 'aborted', 'AbortError' ) ) ).toBe( true );
+	} );
+
+	it( 'returns false for plain objects and non-objects', () => {
+		expect( isError( { status: 403, message: 'forbidden' } ) ).toBe( false );
+		expect( isError( { message: 'm', name: 'n' } ) ).toBe( false );
+		expect( isError( {} ) ).toBe( false );
+		expect( isError( null ) ).toBe( false );
+		expect( isError( undefined ) ).toBe( false );
+		expect( isError( 'oops' ) ).toBe( false );
+	} );
+
+	it( 'ignores a spoofed Symbol.toStringTag on plain objects', () => {
+		expect( isError( { [ Symbol.toStringTag ]: 'Error', message: 'm', name: 'n' } ) ).toBe( false );
+		expect( isError( { [ Symbol.toStringTag ]: 'DOMException', message: 'm', name: 'n' } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'handles cross-realm values (Error from another realm is true, plain object is false)', () => {
+		// `runInNewContext` builds values whose prototypes come from a different
+		// realm, so `instanceof Error` / `proto === Object.prototype` would be wrong.
+		expect( isError( runInNewContext( 'new Error( "x" )' ) ) ).toBe( true );
+		expect( isError( runInNewContext( '( { name: "n", message: "m" } )' ) ) ).toBe( false );
+	} );
+} );

--- a/packages/js-utils/src/test/once.ts
+++ b/packages/js-utils/src/test/once.ts
@@ -1,0 +1,21 @@
+import once from '../once';
+
+describe( 'once', () => {
+	it( 'invokes the wrapped function only on the first call', () => {
+		const fn = jest.fn( ( a: number, b: number ) => a + b );
+		const wrapped = once( fn );
+
+		expect( wrapped( 1, 2 ) ).toBe( 3 );
+		expect( wrapped( 5, 6 ) ).toBe( 3 );
+		expect( wrapped( 9, 9 ) ).toBe( 3 );
+		expect( fn ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'forwards the caller’s `this` binding to the wrapped function', () => {
+		const wrapped = once( function ( this: { value: number } ) {
+			return this.value;
+		} );
+
+		expect( wrapped.call( { value: 1 } ) ).toBe( 1 );
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,6 +1909,7 @@ __metadata:
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
     "@automattic/components": "workspace:^"
+    "@automattic/js-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `escapeRegExp()`, `once()` and `isError()` with `@automattic/js-utils` equivalents, and add eslint guards so they cannot be reintroduced.
* `escapeRegExp` and `once` become new js-utils exports. `once` forwards the caller's `this` to the wrapped function, matching lodash.
* `isError` becomes a faithful js-utils helper rather than a bare `instanceof Error`, preserving lodash behavior for `DOMException` and cross-realm errors while returning `false` for plain objects.

## Why are these changes being made?

* Part of the incremental removal of lodash, standardizing on shared native-equivalent utilities. The Odyssey query paths return the caught error as the query data, so the error check is the only error detector and must stay faithful to lodash — hence the dedicated helper instead of `instanceof`.

## Testing Instructions

* `yarn typecheck-packages` and `yarn typecheck-client` pass.
* New js-utils unit tests cover `escapeRegExp`, `once` (including `this` forwarding), and `isError` (Error subclasses, `DOMException`, plain objects).
* Sanity-check the affected surfaces: Reader follow/excerpt highlighting, user-mention matching, suggestions highlighting, importer auto-start, and the Odyssey Stats products/purchases failure dispatch.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
