### PR TITLE
Plugins: show Manage sites CTA for paid non-Atomic sites

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -368,7 +368,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						plugin={ plugin }
 						saasRedirectHRef={ saasRedirectHRef }
 						isWpcomStaging={ isWpcomStaging }
-						sitesWithPlugins={ sitesWithPlugins }
 						installedOnSitesQuantity={ installedOnSitesQuantity }
 					/>
 				</div>
@@ -407,7 +406,6 @@ function PrimaryButton( {
 	plugin,
 	saasRedirectHRef,
 	isWpcomStaging,
-	sitesWithPlugins,
 	installedOnSitesQuantity,
 } ) {
 	const dispatch = useDispatch();
@@ -429,7 +427,7 @@ function PrimaryButton( {
 		);
 	}, [ dispatch, plugin, isLoggedIn ] );
 
-	if ( isLoggedIn && currentUserSiteCount > 0 && sitesWithPlugins.length > 0 && ! selectedSite ) {
+	if ( isLoggedIn && currentUserSiteCount > 0 && ! selectedSite ) {
 		return (
 			<ManageSitesButton plugin={ plugin } installedOnSitesQuantity={ installedOnSitesQuantity } />
 		);


### PR DESCRIPTION
Part of DSGCOM-598

## Proposed Changes

* On a single-plugin Marketplace page viewed with no site selected, show the "Manage sites" CTA to any logged-in user who has a site — not only to users who already own an Atomic site.

## Why are these changes being made?

* Logged-in users whose only sites are Simple paid sites (e.g. Personal/Premium) were dropped into the new-site signup flow, which forces a WordPress.com Business upgrade — even though all paid plans now include plugin installation and the page states plugins are "free on paid plans". With this change, those users can instead pick an existing site and install (or upgrade in place). Behavior is unchanged for logged-out users and for accounts that already own an Atomic site.

## Testing Instructions

* Log in as a user whose only site(s) are on Simple paid plans (no Atomic site).
* Visit a plugin page with no site selected, e.g. `/plugins/zero-bs-crm`.
* Confirm the primary CTA is **"Manage sites"** (opens the site picker), not **"Get started"** (which previously routed into a Business-upgrade signup flow).
* Pick a site and confirm it proceeds to install / an in-place plan upgrade rather than new-site onboarding.
* Regression check: with an Atomic site, and when logged out, the CTA is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
