### PR TITLE
Fix masterbar site badge alignment

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -965,14 +965,14 @@ body.is-mobile-app-view {
 	min-width: 248px;
 	padding: 12px;
 
-	.masterbar__site-info-label {
-		margin-bottom: 4px;
-	}
-
 	.masterbar__info-badges {
 		display: flex;
+		flex: 1;
 		flex-wrap: wrap;
 		gap: 4px;
+		justify-content: flex-end;
+		margin-left: 16px;
+		min-width: 0;
 	}
 
 	// TODO: Remove this once the new Badge APIs are implemented (DS-203).


### PR DESCRIPTION
## Proposed Changes

* Remove the stale bottom margin from the masterbar site info label.
* Right-align wrapped site status badges.

## Screenshots

These are the bad margins that no longer apply.

| 1 | 2 |
|--------|--------|
| <img width="262" height="145" alt="Screenshot 2026-06-22 at 3 34 17 PM" src="https://github.com/user-attachments/assets/f300a7a6-aca8-4851-b3ee-1d2d1f2abb05" /> | <img width="279" height="153" alt="Screenshot 2026-06-22 at 3 44 42 PM" src="https://github.com/user-attachments/assets/04b69ddb-4c8a-4024-b2dd-b9acc2a2f80e" /> |

**Final**

| Before | After |
|--------|--------|
| <img width="270" height="206" alt="Screenshot 2026-06-22 at 3 31 24 PM" src="https://github.com/user-attachments/assets/d047c68f-6378-44e2-8bfd-b65aef655bdd" /> | <img width="267" height="200" alt="Screenshot 2026-06-22 at 3 29 46 PM" src="https://github.com/user-attachments/assets/936b3c33-5de9-4d79-b84d-1f376fb30947" /> |

## Why are these changes being made?

* The label margin offsets horizontal badge rows.
* Multiple status badges should read as right-aligned metadata.
* The margin was added when Status and Plan lived in the same site-info panel.
* It appears to have been intended as vertical breathing room in that original grouped panel.
* Later refactors moved Plan out and split Status into its own horizontal row, but the label margin stayed behind.

## Testing Instructions

* Ran `yarn lint:css client/layout/masterbar/style.scss`.
* Navigate to Calypso page like `{Calypso Live}/home/:siteSlug`
* Hover over your site name in the omnibar. Expect the items to be spaced consistently.
* Try different sites/status to see the different badges. Expect them to be consistent.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
