### PR TITLE
Fix masterbar submenu group spacing

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -274,7 +274,19 @@ body.is-mobile-app-view {
 			line-height: 2;
 
 			&.masterbar__item-subitems-item--odd {
-				background: var(--color-sidebar-submenu-background, var(--color-masterbar-item-hover-background));
+				background: var(
+					--color-masterbar-submenu-group-background,
+					var(--color-sidebar-submenu-background, var(--color-masterbar-item-hover-background))
+				);
+			}
+
+			&:not(.masterbar__item-subitems-item--odd) + .masterbar__item-subitems-item--odd {
+				margin-top: 6px;
+				padding-top: 6px;
+			}
+
+			&.masterbar__item-subitems-item--odd:last-child {
+				padding-bottom: 6px;
 			}
 
 			a,
@@ -299,8 +311,11 @@ body.is-mobile-app-view {
 				}
 			}
 
-			&:hover {
+			&:not(.masterbar__item-subitems-item--odd):hover {
 				background: var(--color-global-masterbar-submenu-hover-background, var(--color-masterbar-item-hover-background));
+			}
+
+			&:hover {
 				a {
 					color: var(--color-masterbar-submenu-hover-text, var(--color-masterbar-highlight));
 				}
@@ -314,6 +329,10 @@ body.is-mobile-app-view {
 				padding: 8px 16px;
 			}
 		}
+	}
+
+	& + .masterbar__item-subitems:has(> .masterbar__item-subitems-item--odd:last-child) {
+		padding-bottom: 0;
 	}
 
 	.masterbar--is-checkout & {

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
@@ -35,6 +35,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
+	--color-masterbar-submenu-group-background: #013856; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-100);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
 	--color-masterbar-submenu-group-background: #013856; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-100);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -70,6 +70,7 @@ Used studio-blue for the primary+accent.
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-text-color);
 	--color-masterbar-submenu-group-background: #74b6ce; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -69,6 +69,7 @@ Used studio-blue for the primary+accent.
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-text-color);
+	--color-masterbar-submenu-group-background: #74b6ce; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
@@ -35,6 +35,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-accent-20);
+	--color-masterbar-submenu-group-background: var(--color-deprecated-blue-80); /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-70);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-accent-20);
 	--color-masterbar-submenu-group-background: var(--color-deprecated-blue-80); /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-70);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
@@ -37,6 +37,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-accent-30);
 	--color-masterbar-submenu-group-background: var(--color-deprecated-blue-80); /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-70);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-accent-30);
+	--color-masterbar-submenu-group-background: var(--color-deprecated-blue-80); /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-70);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -121,6 +121,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: #00b9eb;
 	--color-masterbar-submenu-group-background: #404040; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: #333;
 	--color-masterbar-item-active-background: #23282d;
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -120,6 +120,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: #00b9eb;
+	--color-masterbar-submenu-group-background: #404040; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: #333;
 	--color-masterbar-item-active-background: #23282d;
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -67,6 +67,7 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: #656463; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -68,6 +68,7 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-submenu-group-background: #656463; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -41,6 +41,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
 	--color-masterbar-submenu-group-background: #283036; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--studio-gray-90);
 	--color-masterbar-item-active-background: var(--studio-gray-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-70);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -40,6 +40,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
+	--color-masterbar-submenu-group-background: #283036; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--studio-gray-90);
 	--color-masterbar-item-active-background: var(--studio-gray-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-70);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -215,6 +215,7 @@
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: var(--color-sidebar-submenu-background);
 
 	/* Sidebar Submenu - Nav Unification */
 	--color-sidebar-submenu-background: #32373c; /* theme-default */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -216,6 +216,7 @@
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-submenu-group-background: var(--color-sidebar-submenu-background);
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 
 	/* Sidebar Submenu - Nav Unification */
 	--color-sidebar-submenu-background: #32373c; /* theme-default */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -92,6 +92,7 @@ Created this definition in color-studio to generate 0-100 shades:
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-submenu-group-background: #64537c; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -91,6 +91,7 @@ Created this definition in color-studio to generate 0-100 shades:
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: #64537c; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -85,6 +85,7 @@ Primary+Accent is studio blue.
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-submenu-group-background: #f7f7f7; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -84,6 +84,7 @@ Primary+Accent is studio blue.
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: #f7f7f7; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -61,6 +61,7 @@ $notification-color: #69a8bb;
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-submenu-group-background: #4c4c4d; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -60,6 +60,7 @@ $notification-color: #69a8bb;
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: #4c4c4d; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -80,6 +80,7 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--color-masterbar-highlight: #7b90ff; /* $menu-submenu-focus-text */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 	--color-masterbar-submenu-group-background: #303030;
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);
 	--color-masterbar-item-active-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -79,6 +79,7 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: #7b90ff; /* $menu-submenu-focus-text */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
+	--color-masterbar-submenu-group-background: #303030;
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);
 	--color-masterbar-item-active-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-hightlight: var(--color-accent-30);
 	--color-masterbar-submenu-group-background: #013856; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-80);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
@@ -35,6 +35,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-hightlight: var(--color-accent-30);
+	--color-masterbar-submenu-group-background: #013856; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--color-deprecated-blue-90);
 	--color-masterbar-item-active-background: var(--color-deprecated-blue-80);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -73,6 +73,7 @@ opinion.  Celadon seems to match the ocean colors better.
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-submenu-group-background: #8f9a9e; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -72,6 +72,7 @@ opinion.  Celadon seems to match the ocean colors better.
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: #8f9a9e; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
@@ -35,6 +35,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-accent-30);
+	--color-masterbar-submenu-group-background: var(--studio-gray-70); /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--studio-gray-80);
 	--color-masterbar-item-active-background: var(--studio-gray-70);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-accent-30);
 	--color-masterbar-submenu-group-background: var(--studio-gray-70); /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--studio-gray-80);
 	--color-masterbar-item-active-background: var(--studio-gray-70);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -35,6 +35,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-deprecated-blue-20);
+	--color-masterbar-submenu-group-background: var(--studio-celadon-70); /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--studio-celadon-80);
 	--color-masterbar-item-active-background: var(--studio-celadon-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--color-deprecated-blue-20);
 	--color-masterbar-submenu-group-background: var(--studio-celadon-70); /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--studio-celadon-80);
 	--color-masterbar-item-active-background: var(--studio-celadon-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -72,6 +72,7 @@ Well use studio-orange for both the primary and accent colors
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-submenu-hover-text-color);
 	--color-masterbar-submenu-group-background: #cf6b67; /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -71,6 +71,7 @@ Well use studio-orange for both the primary and accent colors
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-submenu-hover-text-color);
+	--color-masterbar-submenu-group-background: #cf6b67; /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
@@ -35,6 +35,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
+	--color-masterbar-submenu-group-background: var(--studio-red-80); /* wp-admin ul.ab-sub-secondary */
 	--color-masterbar-item-hover-background: var(--studio-red-90);
 	--color-masterbar-item-active-background: var(--studio-red-100);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
@@ -36,6 +36,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
 	--color-masterbar-submenu-group-background: var(--studio-red-80); /* wp-admin ul.ab-sub-secondary */
+	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-item-hover-background: var(--studio-red-90);
 	--color-masterbar-item-active-background: var(--studio-red-100);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);


### PR DESCRIPTION
Fixes: DOTMSD-1339

## Proposed Changes

* Add `--color-masterbar-submenu-group-background` to Calypso color schemes.
* Use the new token for odd/grouped masterbar submenu items.
* Set `--color-global-masterbar-site-info-background` to the scheme's grouped submenu background so the site status surface matches it (classic masterbar only; the global-sidebar and dark-mode overrides remain).
* Set the grouped submenu background for every admin color scheme, taken from each scheme's wp-admin `ul.ab-sub-secondary` color (mapped to existing palette tokens where they match exactly).
* Keep grouped item backgrounds stable on hover while preserving hover text color.
* Move submenu bottom spacing into grouped items and remove the dark strip below grouped submenus.


### Screenshots

**my.wordpress.com**
| Before | After |
|--------|--------|
| <img width="150" height="146" alt="Screenshot 2026-06-23 at 8 59 37 AM" src="https://github.com/user-attachments/assets/8a292c6c-0d6b-459f-b13f-d8b55828ebfc" /> | <img width="154" height="160" alt="Screenshot 2026-06-23 at 8 59 14 AM" src="https://github.com/user-attachments/assets/541e0903-fe3f-4660-8979-e47c1917f697" /> |

**Dashboard: Modern**
| `wp-admin/index.php` | `/home/:siteSlug` Before | `/home/:siteSlug` After |
|--------|--------|--------|
| <img width="156" height="159" alt="Screenshot 2026-06-23 at 10 21 35 AM" src="https://github.com/user-attachments/assets/88aad53b-6443-46b5-b37d-64fafbe52d5e" /> | <img width="153" height="143" alt="Screenshot 2026-06-23 at 10 24 34 AM" src="https://github.com/user-attachments/assets/c2ebe228-bd5e-4e5d-87a4-4dfc7fdb73d7" /> | <img width="152" height="159" alt="Screenshot 2026-06-23 at 10 23 40 AM" src="https://github.com/user-attachments/assets/fc49849a-b487-4b71-a54b-29cb56941cbe" /> |

**All admin color schemes**

The **my sites** menu — Sites / Domains, then the secondary **About WordPress / Get Involved** group that now picks up the grouped background and spacing in every scheme:

![my sites menu across schemes](https://raw.githubusercontent.com/StevenDufresne/pr-screenshots/main/masterbar-followup-spacing/my-sites-menu-all-schemes.png)

Profile menu and site dropdown across every admin color scheme:

| Profile menu | Site dropdown |
|--------|--------|
| ![profile menu across schemes](https://raw.githubusercontent.com/StevenDufresne/pr-screenshots/main/masterbar-followup-spacing/profile-menu-all-schemes.png) | ![site dropdown across schemes](https://raw.githubusercontent.com/StevenDufresne/pr-screenshots/main/masterbar-followup-spacing/site-dropdown-all-schemes.png) |

## Why are these changes being made?

* The shared submenu padding shows as a dark strip below grey grouped links.
* The grouped links should own their own vertical spacing and background.
* The Modern scheme needs a distinct grouped submenu background from the regular submenu background.
* This adds a masterbar-specific token instead of changing `--color-sidebar-submenu-background` because the sidebar token still represents the regular sidebar submenu surface. The grouped masterbar submenu is a separate surface, and changing the sidebar token would risk changing unrelated sidebar/nav styling.

## Testing Instructions

* Ran `yarn lint:css client/layout/masterbar/style.scss packages/calypso-color-schemes/src/shared/color-schemes/_default.scss packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss`.
* Ran `git diff --check`.
* Checked locally on the masterbar menu with `About WordPress` and `Get Involved`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?




