### PR TITLE
Lodash: replace no-default get() with optional chaining

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -3,7 +3,6 @@ import { pickBy } from '@automattic/js-utils';
 import { Icon, published } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
@@ -441,9 +440,7 @@ class PostCommentList extends Component {
 		// we always count prevSum, children sum, and +1 for the current processed comment
 		return commentIds.reduce(
 			( prevSum, commentId ) =>
-				prevSum +
-				this.getCommentsCount( get( this.props.commentsTree, [ commentId, 'children' ] ) ) +
-				1,
+				prevSum + this.getCommentsCount( this.props.commentsTree?.[ commentId ]?.children ) + 1,
 			0
 		);
 	};

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -14,9 +14,9 @@ function PostCommentWithError( {
 	repliesList,
 } ) {
 	const commentParentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], null );
-	const commentText = get( commentsTree, [ commentId, 'data', 'content' ] );
-	const placeholderError = get( commentsTree, [ commentId, 'data', 'placeholderError' ] );
-	const placeholderErrorType = get( commentsTree, [ commentId, 'data', 'placeholderErrorType' ] );
+	const commentText = commentsTree?.[ commentId ]?.data?.content;
+	const placeholderError = commentsTree?.[ commentId ]?.data?.placeholderError;
+	const placeholderErrorType = commentsTree?.[ commentId ]?.data?.placeholderErrorType;
 
 	const [ comment, setComment ] = useState( commentText );
 

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -211,7 +211,7 @@ class PostComment extends PureComponent {
 			maxDepth,
 		} = this.props;
 
-		const commentChildrenIds = get( commentsTree, [ commentId, 'children' ] );
+		const commentChildrenIds = commentsTree?.[ commentId ]?.children;
 		// Hide children if more than maxChildrenToShow, but not if replying
 		const exceedsMaxChildrenToShow =
 			commentChildrenIds && commentChildrenIds.length < maxChildrenToShow;
@@ -292,11 +292,8 @@ class PostComment extends PureComponent {
 		}
 
 		// If a comment save is pending, don't show the form
-		const placeholderState = get( this.props.commentsTree, [
-			this.props.commentId,
-			'data',
-			'placeholderState',
-		] );
+		const placeholderState =
+			this.props.commentsTree?.[ this.props.commentId ]?.data?.placeholderState;
 		if ( placeholderState === PLACEHOLDER_STATE.PENDING ) {
 			return null;
 		}
@@ -404,7 +401,7 @@ class PostComment extends PureComponent {
 			shouldHighlightNew,
 		} = this.props;
 
-		const comment = get( commentsTree, [ commentId, 'data' ] );
+		const comment = commentsTree?.[ commentId ]?.data;
 		const isPingbackOrTrackback = comment.type === 'trackback' || comment.type === 'pingback';
 
 		if ( ! comment || ( hidePingbacksAndTrackbacks && isPingbackOrTrackback ) ) {
@@ -421,9 +418,8 @@ class PostComment extends PureComponent {
 
 		// todo: connect this constants to the state (new selector)
 		const haveReplyWithError = some(
-			get( commentsTree, [ this.props.commentId, 'children' ] ),
-			( childId ) =>
-				get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR
+			commentsTree?.[ this.props.commentId ]?.children,
+			( childId ) => commentsTree?.[ childId ]?.data?.placeholderState === PLACEHOLDER_STATE.ERROR
 		);
 
 		// If it's a pending comment, use the current user as the author

--- a/client/blocks/comments/utils.jsx
+++ b/client/blocks/comments/utils.jsx
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 /**
  * @param {Object} ancestor potential ancestor comment
  * @param {Object} child potential child comment
@@ -11,7 +9,7 @@ export const isAncestor = ( ancestor, child, commentsTree ) => {
 		return false;
 	}
 
-	const nextParent = get( commentsTree, [ child.parent.ID, 'data' ] );
+	const nextParent = commentsTree?.[ child.parent.ID ]?.data;
 
 	return child.parent.ID === ancestor.ID || isAncestor( ancestor, nextParent, commentsTree );
 };

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -28,7 +28,7 @@ class ConversationCaterpillarComponent extends Component {
 	getExpandableComments = () => {
 		const { comments, commentsToShow, parentCommentId, commentsTree } = this.props;
 		const isRoot = ! parentCommentId;
-		const parentComment = get( commentsTree, [ parentCommentId, 'data' ] );
+		const parentComment = commentsTree?.[ parentCommentId ]?.data;
 
 		const childComments = isRoot
 			? comments

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -157,8 +157,7 @@ export class ConversationCommentList extends Component {
 			} );
 	}
 
-	getParentId = ( commentsTree, childId ) =>
-		get( commentsTree, [ childId, 'data', 'parent', 'ID' ] );
+	getParentId = ( commentsTree, childId ) => commentsTree?.[ childId ]?.data?.parent?.ID;
 	commentHasParent = ( commentsTree, childId ) => !! this.getParentId( commentsTree, childId );
 	commentIsLoaded = ( commentsTree, commentId ) => !! get( commentsTree, commentId );
 

--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 export default function DefaultTemplate( {
@@ -24,7 +23,7 @@ export default function DefaultTemplate( {
 				dismissTemporary
 				onDismissClick={ onDismiss }
 				onClick={ onClick }
-				event={ get( tracks, [ 'click', 'name' ] ) || `jitm_nudge_click_${ id }` }
+				event={ tracks?.click?.name || `jitm_nudge_click_${ id }` }
 				href={ CTA.link }
 				horizontal
 				target={ CTA.target }

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -11,7 +10,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 const noop = () => {};
 
 const ReaderFullPostUnavailable = ( { post, onBackClick = noop, translate, layout } ) => {
-	const statusCode = get( post, [ 'error', 'statusCode' ] );
+	const statusCode = post?.error?.statusCode;
 	const isRecentLayout = layout === 'recent';
 	let errorTitle = translate( 'Post unavailable' );
 	let errorDescription = translate( "Sorry, we can't display that post right now." );
@@ -29,7 +28,7 @@ const ReaderFullPostUnavailable = ( { post, onBackClick = noop, translate, layou
 		errorTitle = translate( 'Post not found' );
 	}
 
-	const postPermalink = get( post, [ 'error', 'data', 'permalink' ] );
+	const postPermalink = post?.error?.data?.permalink;
 
 	return (
 		<ReaderMain className="reader-full-post reader-full-post__unavailable">

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -227,7 +227,7 @@ export default connect(
 		const site = getSite( state, siteId );
 		const siteSettings = getSiteSettings( state, siteId );
 		const canSetAsDefault = taxonomy === 'category';
-		const isDefault = canSetAsDefault && get( siteSettings, [ 'default_category' ] ) === term.ID;
+		const isDefault = canSetAsDefault && siteSettings?.default_category === term.ID;
 		const siteSlug = site?.slug;
 		const siteUrl = site?.URL;
 		const isPodcastingCategory =

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -3,7 +3,6 @@ import page from '@automattic/calypso-router';
 import { omit } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -220,7 +219,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 			return (
 				this.state.url &&
 				this.isCurrentUrlFetched() &&
-				get( this.props.jetpackConnectSite, [ 'error', 'error' ] ) === error
+				this.props.jetpackConnectSite?.error?.error === error
 			);
 		}
 

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -11,7 +11,6 @@ import { Modal } from '@wordpress/components';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -262,7 +261,7 @@ export class JetpackSignup extends Component {
 			} );
 			return;
 		}
-		if ( get( error, [ 'error' ] ) === 'password_invalid' ) {
+		if ( error?.error === 'password_invalid' ) {
 			errorNotice( error.message, { id: 'user-creation-error-password_invalid' } );
 			return;
 		}

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -124,7 +124,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2_redirect: redirectTo,
 		} );
 
-		const wccomFrom = get( currentQuery, 'wccom-from' );
+		const wccomFrom = currentQuery?.[ 'wccom-from' ];
 		if ( wccomFrom ) {
 			oauth2Params.set( 'wccom-from', wccomFrom );
 		}

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -315,10 +315,7 @@ export default class QueryManager {
 			}
 
 			let nextQueryFound;
-			if (
-				options.found >= 0 &&
-				options.found !== get( nextQueries, [ receivedQueryKey, 'found' ] )
-			) {
+			if ( options.found >= 0 && options.found !== nextQueries?.[ receivedQueryKey ]?.found ) {
 				nextQueryFound = options.found;
 			}
 

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -442,7 +442,7 @@ class ActivityLog extends Component {
 
 		const disableRestore =
 			! enableRewind ||
-			[ 'queued', 'running' ].includes( get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
+			[ 'queued', 'running' ].includes( this.props?.restoreProgress?.status ) ||
 			( ! isAtomic && areCredentialsInvalid ) ||
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -5,7 +5,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { groupBy, pickBy } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { localize, fixMe } from 'i18n-calypso';
-import { filter, get, some } from 'lodash';
+import { filter, some } from 'lodash';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -230,7 +230,7 @@ class InvitePeople extends Component {
 		if ( errorToDisplay && value !== errorToDisplay ) {
 			return null;
 		}
-		return get( errors, [ value, 'message' ] );
+		return errors?.[ value ]?.message;
 	};
 
 	getTokensWithStatus = () => {

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -89,9 +89,9 @@ class CloneCredentialsStep extends Component {
 export default connect(
 	( state, ownProps ) => {
 		const originSiteName = get( ownProps, [ 'signupDependencies', 'originSiteName' ], '' );
-		const originBlogId = get( ownProps, [ 'signupDependencies', 'originBlogId' ] );
-		const destinationSiteName = get( ownProps, [ 'signupDependencies', 'destinationSiteName' ] );
-		const destinationSiteUrl = get( ownProps, [ 'signupDependencies', 'destinationSiteUrl' ] );
+		const originBlogId = ownProps?.signupDependencies?.originBlogId;
+		const destinationSiteName = ownProps?.signupDependencies?.destinationSiteName;
+		const destinationSiteUrl = ownProps?.signupDependencies?.destinationSiteUrl;
 
 		return {
 			originBlogId,

--- a/client/signup/steps/clone-ready/index.jsx
+++ b/client/signup/steps/clone-ready/index.jsx
@@ -151,7 +151,7 @@ class CloneReadyStep extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		destinationSiteName: get( ownProps, [ 'signupDependencies', 'destinationSiteName' ] ),
+		destinationSiteName: ownProps?.signupDependencies?.destinationSiteName,
 		payload: get( ownProps, [ 'signupDependencies' ], {} ),
 	} ),
 	{

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -503,7 +503,7 @@ export const counts = ( state = {}, action ) => {
 				return state;
 			}
 			const { site: siteCounts, [ postId ]: postCounts } = state[ siteId ];
-			const status = get( action, [ 'comments', 0, 'status' ] );
+			const status = action?.comments?.[ 0 ]?.status;
 
 			const newSiteCounts = updateCount( siteCounts, status, 1 );
 			const newPostCounts = updateCount( postCounts, status, 1 );

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -60,7 +60,7 @@ export const queries = ( state = {}, action ) => {
 			const { page, postId, status } = query;
 			const parent = postId || 'site';
 			const filter = getFiltersKey( query );
-			const comments = get( state, [ parent, filter, page ] );
+			const comments = state?.[ parent ]?.[ filter ]?.[ page ];
 
 			if (
 				COMMENTS_CHANGE_STATUS === action.type &&

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -36,7 +36,7 @@ export const commentsFromApi = ( comments ) =>
 					...comment,
 					author: {
 						...comment.author,
-						name: decodeEntities( get( comment, [ 'author', 'name' ] ) ),
+						name: decodeEntities( comment?.author?.name ),
 					},
 			  }
 			: comment

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -1,6 +1,5 @@
 import { omit } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import { trailingslashit } from 'calypso/lib/route';
 import { JETPACK_SETTINGS_REQUEST, JETPACK_SETTINGS_SAVE } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
@@ -134,7 +133,7 @@ export const retryOrAnnounceSaveFailure = ( action, { message: errorMessage } ) 
 	// since it might just be a slow server that actually ends up installing it
 	// properly, in which case a subsequent request will return 'success'.
 	if (
-		get( settings, [ 'onboarding', 'installWooCommerce' ] ) !== true ||
+		settings?.onboarding?.installWooCommerce !== true ||
 		! ( errorMessage ?? '' ).startsWith( 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {

--- a/client/state/jetpack-connect/selectors/get-auth-attempts.js
+++ b/client/state/jetpack-connect/selectors/get-auth-attempts.js
@@ -1,11 +1,10 @@
-import { get } from 'lodash';
 import { AUTH_ATTEMPS_TTL } from 'calypso/state/jetpack-connect/constants';
 import { isStale } from 'calypso/state/jetpack-connect/utils';
 
 import 'calypso/state/jetpack-connect/init';
 
 export const getAuthAttempts = ( state, slug ) => {
-	const attemptsData = get( state, [ 'jetpackConnect', 'jetpackAuthAttempts', slug ] );
+	const attemptsData = state?.jetpackConnect?.jetpackAuthAttempts?.[ slug ];
 	if ( attemptsData && isStale( attemptsData.timestamp, AUTH_ATTEMPS_TTL ) ) {
 		return 0;
 	}

--- a/client/state/jetpack-connect/selectors/get-authorization-data.js
+++ b/client/state/jetpack-connect/selectors/get-authorization-data.js
@@ -1,7 +1,5 @@
-import { get } from 'lodash';
-
 import 'calypso/state/jetpack-connect/init';
 
 export const getAuthorizationData = ( state ) => {
-	return get( state, [ 'jetpackConnect', 'jetpackConnectAuthorize' ] );
+	return state?.jetpackConnect?.jetpackConnectAuthorize;
 };

--- a/client/state/jetpack-connect/selectors/get-connecting-site.js
+++ b/client/state/jetpack-connect/selectors/get-connecting-site.js
@@ -1,7 +1,5 @@
-import { get } from 'lodash';
-
 import 'calypso/state/jetpack-connect/init';
 
 export const getConnectingSite = ( state ) => {
-	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
+	return state?.jetpackConnect?.jetpackConnectSite;
 };

--- a/client/state/jetpack-connect/selectors/get-sso.js
+++ b/client/state/jetpack-connect/selectors/get-sso.js
@@ -1,7 +1,5 @@
-import { get } from 'lodash';
-
 import 'calypso/state/jetpack-connect/init';
 
 export const getSSO = ( state ) => {
-	return get( state, [ 'jetpackConnect', 'jetpackSSO' ] );
+	return state?.jetpackConnect?.jetpackSSO;
 };

--- a/client/state/jetpack-connect/selectors/is-site-blocked-error.js
+++ b/client/state/jetpack-connect/selectors/is-site-blocked-error.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors/get-authorization-data';
 
 import 'calypso/state/jetpack-connect/init';
@@ -11,5 +10,5 @@ import 'calypso/state/jetpack-connect/init';
 export const isSiteBlockedError = function ( state ) {
 	const authorizeData = getAuthorizationData( state );
 
-	return get( authorizeData, [ 'authorizeError', 'error' ] ) === 'connection_disabled';
+	return authorizeData?.authorizeError?.error === 'connection_disabled';
 };

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -1,4 +1,4 @@
-import { get, reduce } from 'lodash';
+import { reduce } from 'lodash';
 
 import 'calypso/state/jetpack-sync/init';
 
@@ -9,7 +9,7 @@ import 'calypso/state/jetpack-sync/init';
  * @returns {Object}          Sync status object
  */
 function getSyncStatus( state, siteId ) {
-	return get( state, [ 'jetpackSync', 'syncStatus', siteId ] );
+	return state?.jetpackSync?.syncStatus?.[ siteId ];
 }
 
 /**
@@ -19,7 +19,7 @@ function getSyncStatus( state, siteId ) {
  * @returns {Object}          Full sync request object
  */
 function getFullSyncRequest( state, siteId ) {
-	return get( state, [ 'jetpackSync', 'fullSyncRequest', siteId ] );
+	return state?.jetpackSync?.fullSyncRequest?.[ siteId ];
 }
 
 /**

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -1,5 +1,5 @@
 import { pickBy } from '@automattic/js-utils';
-import { forEach, get, merge } from 'lodash';
+import { forEach, merge } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_FAILURE,
@@ -60,7 +60,7 @@ const createSettingsItemsReducer = () => {
 	return ( state, { siteId, settings } ) => {
 		let updatedState = state;
 		const moduleActivationState = pickBy( settings, ( settingValue, settingName ) => {
-			return get( state, [ siteId, settingName ] ) !== undefined;
+			return state?.[ siteId ]?.[ settingName ] !== undefined;
 		} );
 
 		forEach( moduleActivationState, ( active, moduleSlug ) => {

--- a/client/state/memberships/earnings/selectors.js
+++ b/client/state/memberships/earnings/selectors.js
@@ -1,9 +1,7 @@
-import { get } from 'lodash';
-
 import 'calypso/state/memberships/init';
 
 export function getEarningsForSiteId( state, siteId ) {
-	return get( state, [ 'memberships', 'earnings', 'summary', siteId ] );
+	return state?.memberships?.earnings?.summary?.[ siteId ];
 }
 
 export function getEarningsWithDefaultsForSiteId( state, siteId ) {

--- a/client/state/notification-settings/selectors.js
+++ b/client/state/notification-settings/selectors.js
@@ -1,13 +1,12 @@
 import isEqual from 'fast-deep-equal/es6';
-import { get } from 'lodash';
 
 import 'calypso/state/notification-settings/init';
 
 export const getNotificationSettings = ( state, source ) =>
-	get( state, [ 'notificationSettings', 'settings', 'dirty', source ] );
+	state?.notificationSettings?.settings?.dirty?.[ source ];
 
 export const getNotificationSettingsClean = ( state, source ) =>
-	get( state, [ 'notificationSettings', 'settings', 'clean', source ] );
+	state?.notificationSettings?.settings?.clean?.[ source ];
 
 export const hasUnsavedNotificationSettingsChanges = ( state, source ) =>
 	! isEqual(

--- a/client/state/notification-settings/toggle-state.js
+++ b/client/state/notification-settings/toggle-state.js
@@ -39,7 +39,7 @@ export default {
 			other: {
 				...state?.dirty?.other,
 				...( isNaN( stream )
-					? toggleInStream( stream, get( state, [ 'dirty', 'other', stream ] ), setting )
+					? toggleInStream( stream, state?.dirty?.other?.[ stream ], setting )
 					: toggleInDevice( devices, stream, setting ) ),
 			},
 		};

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -2,7 +2,7 @@
 
 import { mapValues, omit, omitBy } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { get, set, isEmpty, reduce, merge, findKey } from 'lodash';
+import { set, isEmpty, reduce, merge, findKey } from 'lodash';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
 import {
@@ -320,7 +320,7 @@ export function edits( state = {}, action ) {
 					// Receive a new version of a post object, in most cases returned in the POST
 					// response after a successful save. Removes the edits that have been applied
 					// and leaves only the ones that are not noops.
-					let postEditsLog = get( memoState, [ post.site_ID, post.ID ] );
+					let postEditsLog = memoState?.[ post.site_ID ]?.[ post.ID ];
 
 					if ( ! postEditsLog ) {
 						return memoState;
@@ -393,7 +393,7 @@ export function edits( state = {}, action ) {
 			// process new edit for a post: merge it into the existing edits
 			const siteId = action.siteId;
 			const postId = action.postId || '';
-			const postEditsLog = get( state, [ siteId, postId ] );
+			const postEditsLog = state?.[ siteId ]?.[ postId ];
 			const newEditsLog = appendToPostEditsLog( postEditsLog, action.post );
 
 			return {

--- a/client/state/posts/selectors/get-post-edits.js
+++ b/client/state/posts/selectors/get-post-edits.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { get } from 'lodash';
 import { mergePostEdits, normalizePostForEditing } from 'calypso/state/posts/utils';
 
 import 'calypso/state/posts/init';
@@ -13,7 +12,7 @@ import 'calypso/state/posts/init';
  */
 export const getPostEdits = createSelector(
 	( state, siteId, postId ) => {
-		const postEditsLog = get( state.posts.edits, [ siteId, postId || '' ] );
+		const postEditsLog = state.posts.edits?.[ siteId ]?.[ postId || '' ];
 		if ( ! postEditsLog ) {
 			return null;
 		}

--- a/client/state/posts/utils/is-discussion-equal.js
+++ b/client/state/posts/utils/is-discussion-equal.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 /**
  * Returns true if the modified properties in the local edit of the `discussion` object (the edited
  * properties are a subset of the full object) are equal to the values in the saved post.
@@ -9,6 +7,6 @@ import { get } from 'lodash';
  */
 export function isDiscussionEqual( localDiscussionEdits, savedDiscussion ) {
 	return Object.entries( localDiscussionEdits ).every(
-		( [ key, value ] ) => get( savedDiscussion, [ key ] ) === value
+		( [ key, value ] ) => savedDiscussion?.[ key ] === value
 	);
 }

--- a/client/state/reader/conversations/selectors/is-following-reader-conversation.js
+++ b/client/state/reader/conversations/selectors/is-following-reader-conversation.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { CONVERSATION_FOLLOW_STATUS } from 'calypso/state/reader/conversations/follow-status';
 import { key } from 'calypso/state/reader/conversations/utils';
 
@@ -13,7 +12,7 @@ import 'calypso/state/reader/init';
  */
 export default function isFollowingReaderConversation( state, { siteId, postId } ) {
 	return (
-		get( state, [ 'reader', 'conversations', 'items', key( siteId, postId ) ] ) ===
+		state?.reader?.conversations?.items?.[ key( siteId, postId ) ] ===
 		CONVERSATION_FOLLOW_STATUS.following
 	);
 }

--- a/client/state/reader/site-blocks/selectors/get-site-blocks-last-page.js
+++ b/client/state/reader/site-blocks/selectors/get-site-blocks-last-page.js
@@ -1,9 +1,7 @@
-import { get } from 'lodash';
-
 import 'calypso/state/reader/init';
 
 export const getSiteBlocksLastPage = ( state ) => {
-	return get( state, [ 'reader', 'siteBlocks', 'lastPage' ] );
+	return state?.reader?.siteBlocks?.lastPage;
 };
 
 export default getSiteBlocksLastPage;

--- a/client/state/reader/site-blocks/selectors/is-fetching-site-blocks.js
+++ b/client/state/reader/site-blocks/selectors/is-fetching-site-blocks.js
@@ -1,4 +1,4 @@
-import { get, filter } from 'lodash';
+import { filter } from 'lodash';
 
 import 'calypso/state/reader/init';
 
@@ -7,7 +7,7 @@ import 'calypso/state/reader/init';
  * @returns {boolean} true if we are fetching site blocks
  */
 export default function isFetchingSiteBlocks( state ) {
-	const inflightPages = get( state, [ 'reader', 'siteBlocks', 'inflightPages' ] );
+	const inflightPages = state?.reader?.siteBlocks?.inflightPages;
 	if ( ! inflightPages || inflightPages.length < 1 ) {
 		return false;
 	}

--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -32,7 +32,7 @@ function getPageEditorUrl( state, siteId, pageId ) {
 export default createSelector(
 	( state, siteId ) => {
 		const posts = getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY );
-		const firstPostID = get( find( posts, { type: 'post' } ), [ 0, 'ID' ] );
+		const firstPostID = find( posts, { type: 'post' } )?.[ 0 ]?.ID;
 		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
 		const frontPageUrl = getFrontPageEditorUrl( state, siteId );
 

--- a/client/state/selectors/get-comments-page.js
+++ b/client/state/selectors/get-comments-page.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getFiltersKey } from 'calypso/state/comments/ui/utils';
 
 import 'calypso/state/comments/init';
@@ -19,7 +18,7 @@ export const getCommentsPage = ( state, siteId, query ) => {
 	const { page = 1, postId } = query;
 	const parent = postId || 'site';
 	const filter = getFiltersKey( query );
-	return get( state, [ 'comments', 'ui', 'queries', siteId, parent, filter, page ] );
+	return state?.comments?.ui?.queries?.[ siteId ]?.[ parent ]?.[ filter ]?.[ page ];
 };
 
 export default getCommentsPage;

--- a/client/state/selectors/get-ips-tag-save-status.js
+++ b/client/state/selectors/get-ips-tag-save-status.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/domains/init';
 
 /**
@@ -10,5 +8,5 @@ import 'calypso/state/domains/init';
  * @returns {string}         Transfer status
  */
 export default function getIpsTagSaveStatus( state, domain ) {
-	return get( state.domains.transfer, [ 'items', domain, 'saveStatus' ] );
+	return state.domains.transfer?.items?.[ domain ]?.saveStatus;
 }

--- a/client/state/selectors/get-next-page-handle.js
+++ b/client/state/selectors/get-next-page-handle.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/media/init';
 
 /**
@@ -8,5 +6,5 @@ import 'calypso/state/media/init';
  * @param {number} siteId The site ID
  */
 export default function getNextPageHandle( state, siteId ) {
-	return get( state.media.fetching, [ siteId, 'nextPageHandle' ] );
+	return state.media.fetching?.[ siteId ]?.nextPageHandle;
 }

--- a/client/state/selectors/has-pending-comment-requests.js
+++ b/client/state/selectors/has-pending-comment-requests.js
@@ -1,4 +1,4 @@
-import { get, some } from 'lodash';
+import { some } from 'lodash';
 
 import 'calypso/state/comments/init';
 
@@ -8,8 +8,8 @@ import 'calypso/state/comments/init';
  * @returns {boolean} - true if we have pending actions
  */
 export default ( state ) => {
-	const pendingActions = get( state, [ 'comments', 'ui', 'pendingActions' ] );
+	const pendingActions = state?.comments?.ui?.pendingActions;
 	return some( pendingActions, ( requestKey ) => {
-		return get( state, [ 'dataRequests', requestKey, 'status' ] ) === 'pending';
+		return state?.dataRequests?.[ requestKey ]?.status === 'pending';
 	} );
 };

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -91,7 +91,7 @@ const invalidateStep = ( state, { step, errors } ) => {
 const processStep = ( state, { step } ) => updateStep( state, { ...step, status: 'processing' } );
 
 const saveStep = ( state, { step } ) => {
-	const status = get( state, [ step.stepName, 'status' ] );
+	const status = state?.[ step.stepName ]?.status;
 
 	return state.hasOwnProperty( step.stepName )
 		? updateStep( state, {
@@ -102,7 +102,7 @@ const saveStep = ( state, { step } ) => {
 };
 
 const submitStep = ( state, { step } ) => {
-	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
+	const stepHasApiRequestFunction = stepsConfig?.[ step.stepName ]?.apiRequestFunction;
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
 	return state.hasOwnProperty( step.stepName )

--- a/client/state/stats/chart-tabs/selectors.js
+++ b/client/state/stats/chart-tabs/selectors.js
@@ -32,7 +32,7 @@ export function getCountRecords( state, siteId, date, period, quantity ) {
 export function getLoadingTabs( state, siteId, date, period, quantity ) {
 	const requestKey = `${ date }-${ period }-${ quantity }`;
 
-	return QUERY_FIELDS.filter( ( type ) =>
-		get( state, [ 'stats', 'chartTabs', 'isLoading', siteId, requestKey, type ] )
+	return QUERY_FIELDS.filter(
+		( type ) => state?.stats?.chartTabs?.isLoading?.[ siteId ]?.[ requestKey ]?.[ type ]
 	);
 }

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
 
-import { merge, get } from 'lodash';
+import { merge } from 'lodash';
 import {
 	ALL_SITES_STATS_RECEIVE,
 	SITE_STATS_RECEIVE,
@@ -78,7 +78,7 @@ export const items = withSchemaValidation( itemSchema, ( state = {}, action ) =>
 				[ siteId ]: {
 					...state[ siteId ],
 					[ statType ]: {
-						...get( state, [ siteId, statType ] ),
+						...state?.[ siteId ]?.[ statType ],
 						[ queryKey ]: data || null,
 					},
 				},

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -18,7 +18,7 @@ import 'calypso/state/stats/init';
  */
 export function isRequestingSiteStatsForQuery( state, siteId, statType, query ) {
 	const serializedQuery = getSerializedStatsQuery( query );
-	return !! get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'requesting' ] );
+	return !! state.stats.lists.requests?.[ siteId ]?.[ statType ]?.[ serializedQuery ]?.requesting;
 }
 
 /**
@@ -33,9 +33,9 @@ export function isRequestingSiteStatsForQuery( state, siteId, statType, query ) 
 export function hasSiteStatsForQueryFinished( state, siteId, statType, query ) {
 	const serializedQuery = getSerializedStatsQuery( query );
 	return (
-		get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'status' ] ) ===
+		state.stats.lists.requests?.[ siteId ]?.[ statType ]?.[ serializedQuery ]?.status ===
 			'success' ||
-		get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'status' ] ) === 'error'
+		state.stats.lists.requests?.[ siteId ]?.[ statType ]?.[ serializedQuery ]?.status === 'error'
 	);
 }
 
@@ -51,7 +51,7 @@ export function hasSiteStatsForQueryFinished( state, siteId, statType, query ) {
 export function hasSiteStatsQueryFailed( state, siteId, statType, query ) {
 	const serializedQuery = getSerializedStatsQuery( query );
 	return (
-		get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'status' ] ) === 'error'
+		state.stats.lists.requests?.[ siteId ]?.[ statType ]?.[ serializedQuery ]?.status === 'error'
 	);
 }
 
@@ -190,7 +190,7 @@ export function getSiteStatsCSVData( state, siteId, statType, query, modifierFn 
  */
 export function getSiteStatsQueryDate( state, siteId, statType, query ) {
 	const serializedQuery = getSerializedStatsQuery( query );
-	return get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'date' ] );
+	return state.stats.lists.requests?.[ siteId ]?.[ statType ]?.[ serializedQuery ]?.date;
 }
 
 /**

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -82,7 +82,7 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 				const siteSettings = getSiteSettings( state, siteId );
 				if (
 					taxonomy === 'category' &&
-					get( siteSettings, [ 'default_category' ] ) === termId &&
+					siteSettings?.default_category === termId &&
 					updatedTerm.ID !== termId
 				) {
 					dispatch( updateSiteSettings( siteId, { default_category: updatedTerm.ID } ) );
@@ -159,12 +159,7 @@ const removeTermFromState = ( { dispatch, getState, siteId, taxonomy, termId } )
 	// update default category post count if applicable
 	if ( taxonomy === 'category' && deletedTermPostCount > 0 ) {
 		const siteSettings = getSiteSettings( state, siteId );
-		const defaultCategory = getTerm(
-			state,
-			siteId,
-			taxonomy,
-			get( siteSettings, [ 'default_category' ] )
-		);
+		const defaultCategory = getTerm( state, siteId, taxonomy, siteSettings?.default_category );
 		if ( defaultCategory ) {
 			dispatch(
 				receiveTerm( siteId, taxonomy, {

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { get } from 'lodash';
 import { getSerializedTermsQuery, getSerializedTermsQueryWithoutPage } from './utils';
 
 import 'calypso/state/terms/init';
@@ -15,7 +14,7 @@ import 'calypso/state/terms/init';
  */
 export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
 	const serializedQuery = getSerializedTermsQuery( query );
-	return !! get( state.terms.queryRequests, [ siteId, taxonomy, serializedQuery ] );
+	return !! state.terms.queryRequests?.[ siteId ]?.[ taxonomy ]?.[ serializedQuery ];
 }
 
 /**
@@ -52,14 +51,14 @@ export function isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, 
  */
 export const getTermsForQuery = createSelector(
 	( state, siteId, taxonomy, query ) => {
-		const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+		const manager = state.terms.queries?.[ siteId ]?.[ taxonomy ];
 		if ( ! manager ) {
 			return null;
 		}
 
 		return manager.getItems( query );
 	},
-	( state, siteId, taxonomy ) => get( state.terms.queries, [ siteId, taxonomy ] ),
+	( state, siteId, taxonomy ) => state.terms.queries?.[ siteId ]?.[ taxonomy ],
 	( state, siteId, taxonomy, query ) => {
 		const serializedQuery = getSerializedTermsQuery( query );
 		return [ siteId, taxonomy, serializedQuery ].join();
@@ -77,14 +76,14 @@ export const getTermsForQuery = createSelector(
  */
 export const getTermsForQueryIgnoringPage = createSelector(
 	( state, siteId, taxonomy, query ) => {
-		const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+		const manager = state.terms.queries?.[ siteId ]?.[ taxonomy ];
 		if ( ! manager ) {
 			return null;
 		}
 
 		return manager.getItemsIgnoringPage( query );
 	},
-	( state, siteId, taxonomy ) => get( state.terms.queries, [ siteId, taxonomy ] ),
+	( state, siteId, taxonomy ) => state.terms.queries?.[ siteId ]?.[ taxonomy ],
 	( state, siteId, taxonomy, query ) => {
 		const serializedQuery = getSerializedTermsQueryWithoutPage( query );
 		return [ siteId, taxonomy, serializedQuery ].join();
@@ -101,7 +100,7 @@ export const getTermsForQueryIgnoringPage = createSelector(
  * @returns {?number}          Last terms page
  */
 export function getTermsLastPageForQuery( state, siteId, taxonomy, query ) {
-	const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+	const manager = state.terms.queries?.[ siteId ]?.[ taxonomy ];
 	if ( ! manager ) {
 		return null;
 	}
@@ -122,7 +121,7 @@ export function getTermsLastPageForQuery( state, siteId, taxonomy, query ) {
  * @returns {?Array}          Terms
  */
 export function getTerms( state, siteId, taxonomy ) {
-	const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+	const manager = state.terms.queries?.[ siteId ]?.[ taxonomy ];
 	if ( ! manager ) {
 		return null;
 	}
@@ -139,7 +138,7 @@ export function getTerms( state, siteId, taxonomy ) {
  * @returns {?Object}         Term
  */
 export function getTerm( state, siteId, taxonomy, termId ) {
-	const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+	const manager = state.terms.queries?.[ siteId ]?.[ taxonomy ];
 	if ( ! manager ) {
 		return null;
 	}
@@ -162,7 +161,7 @@ export function getTerm( state, siteId, taxonomy, termId ) {
  * @returns {?number}          Count terms
  */
 export function countFoundTermsForQuery( state, siteId, taxonomy, query ) {
-	const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+	const manager = state.terms.queries?.[ siteId ]?.[ taxonomy ];
 	if ( ! manager ) {
 		return null;
 	}

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -101,12 +101,12 @@ export function normalizeWporgTheme( theme, tier ) {
 		] )
 	);
 
-	const description = get( theme, [ 'sections', 'description' ] );
+	const description = theme?.sections?.description;
 	if ( description ) {
 		normalizedTheme.description = description;
 	}
 
-	const author = get( theme, [ 'author', 'display_name' ] );
+	const author = theme?.author?.display_name;
 	if ( author ) {
 		normalizedTheme.author = author;
 	}


### PR DESCRIPTION
## Proposed Changes

* Replace the no-default, static-path lodash `get( obj, path )` calls with native optional chaining.
* Calls with a default value, dynamic/variable paths, and a couple of selectors whose `state` is typed loosely as `object` are intentionally left on lodash `get`.

This is the faithful subset of the `get` migration: with no default value there is no null-vs-undefined divergence, and optional chaining matches lodash's nullish-safe traversal exactly. The base expression is preserved verbatim — only the path traversal becomes nullish-safe.

No eslint guard is added: `get` is still used in ~500 places, so a guard can only land once it is fully removed. This is an incremental step toward that.

## Why are these changes being made?

* Part of the incremental removal of lodash, starting on the largest remaining function (`get`) with its lowest-risk subset.

## Testing Instructions

* `yarn typecheck-client` passes.
* Unit tests for the affected areas pass (`yarn test-client`).
* The conversion was validated against lodash for nested/missing/null/primitive/numeric-index/computed-key paths (0 mismatches). Spot-check Reader comments, signup dependencies, and stats selectors still read nested values correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
