### PR TITLE
Notifications: restore time-grouped sections via DataViews groupBy

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -35,12 +35,28 @@
 	gap: 0 !important;
 }
 
-// Align the header padding with the row content (`12px 16px`) so they share a
-// left edge; the top border separates each section.
+// Match the rows' 16px left edge; tighter 8px vertical padding; top border
+// separates sections.
 .wpnc__note-list .dataviews-view-list__group-header {
 	margin: 0;
-	padding: $grid-unit-15 $grid-unit-20;
+	padding: $grid-unit-10 $grid-unit-20;
 	border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+	// Shrink the default 15px heading-sized label, keeping core weight and color.
+	font-size: var(--wpds-typography-font-size-sm, 13px);
+}
+
+// Persistent divider under the tabs, even on non-grouped views. The wrapper
+// draws it; the first group header drops its border so they don't stack.
+.wpnc__note-list > .dataviews-wrapper {
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+}
+
+.wpnc__note-list
+	.dataviews-view-list__group
+	> .dataviews-view-list
+	> div:first-child
+	> .dataviews-view-list__group-header {
+	border-top: 0;
 }
 
 .wpnc__note-list .dataviews-view-list {

--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -27,7 +27,30 @@
 	}
 }
 
+// In grouped mode DataViews nests `@wordpress/ui` Stacks whose inline `gap`
+// over-spaces the list (16px between groups, 8px within). Collapse those gaps
+// via structural selectors — no build-hashed class — so spacing is driven by
+// the rows and the list's own margin. The first selector targets each per-group
+// Stack (the div whose first child is the group header); the second targets the
+// outer Stack holding all groups. The gap is set inline, so `!important` is
+// required to override it.
+.wpnc__note-list div:has(> .dataviews-view-list__group-header),
+.wpnc__note-list .dataviews-view-list__group .dataviews-view-list {
+	gap: 0 !important;
+}
+
+// Align the section header's text with the row content below it. DataViews
+// defaults to `0 24px`; match the item-wrapper's `12px 16px` so the header and
+// the notes share a left edge. The top border separates each section.
+.wpnc__note-list .dataviews-view-list__group-header {
+	margin: 0;
+	padding: $grid-unit-15 $grid-unit-20;
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+}
+
 .wpnc__note-list .dataviews-view-list {
+	margin-top: $grid-unit-10;
+
 	// When displaying fields in the DataViews, using the --wp-admin-theme-color color on hover is overwhelming.
 	// We override the hover color with the text color.
 	div[role="article"] {

--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -28,20 +28,15 @@
 }
 
 // In grouped mode DataViews nests `@wordpress/ui` Stacks whose inline `gap`
-// over-spaces the list (16px between groups, 8px within). Collapse those gaps
-// via structural selectors — no build-hashed class — so spacing is driven by
-// the rows and the list's own margin. The first selector targets each per-group
-// Stack (the div whose first child is the group header); the second targets the
-// outer Stack holding all groups. The gap is set inline, so `!important` is
-// required to override it.
+// over-spaces the list. Collapse the per-group and outer Stack gaps via
+// structural selectors (no build-hashed class); `!important` beats the inline gap.
 .wpnc__note-list div:has(> .dataviews-view-list__group-header),
 .wpnc__note-list .dataviews-view-list__group .dataviews-view-list {
 	gap: 0 !important;
 }
 
-// Align the section header's text with the row content below it. DataViews
-// defaults to `0 24px`; match the item-wrapper's `12px 16px` so the header and
-// the notes share a left edge. The top border separates each section.
+// Align the header padding with the row content (`12px 16px`) so they share a
+// left edge; the top border separates each section.
 .wpnc__note-list .dataviews-view-list__group-header {
 	margin: 0;
 	padding: $grid-unit-15 $grid-unit-20;

--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -49,8 +49,6 @@
 }
 
 .wpnc__note-list .dataviews-view-list {
-	margin-top: $grid-unit-10;
-
 	// When displaying fields in the DataViews, using the --wp-admin-theme-color color on hover is overwhelming.
 	// We override the hover color with the text color.
 	div[role="article"] {

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,4 +1,4 @@
-import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	chartBar,
@@ -47,7 +47,9 @@ const groupTitles = [
 	__( 'Older than a month' ),
 ];
 
-const RelativeDate = ( { timestamp }: { timestamp: string } ) => {
+// Map a note's timestamp to its time-group index (0 = Today … 4 = Older than a
+// month), using the same day boundaries the classic panel grouped by.
+const getTimeGroupKey = ( timestamp: string ): number => {
 	const now = new Date().setHours( 0, 0, 0, 0 );
 	const timeBoundaries = [
 		Infinity,
@@ -63,9 +65,7 @@ const RelativeDate = ( { timestamp }: { timestamp: string } ) => {
 		.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
 
 	const time = new Date( timestamp );
-	const groupKey = timeGroups.findIndex( ( [ after, before ] ) => before < time && time <= after );
-
-	return <span>{ groupTitles[ groupKey ] }</span>;
+	return timeGroups.findIndex( ( [ after, before ] ) => before < time && time <= after );
 };
 
 export function getFields(): Field< Note >[] {
@@ -114,15 +114,24 @@ export function getFields(): Field< Note >[] {
 		{
 			id: 'info',
 			label: __( 'Info' ),
-			render: ( { item } ) => {
-				return (
-					<HStack spacing={ 1 }>
-						<RelativeDate timestamp={ item.timestamp } />
-						<span>•</span>
-						<span>{ item.title }</span>
-					</HStack>
-				);
-			},
+			render: ( { item } ) => <span>{ item.title }</span>,
+		},
+		{
+			// Group-only field: drives the time-section headers ("Today",
+			// "Yesterday", "Older than 2 days"…) restored from the classic panel.
+			// It is never added to the view's visible `fields`, so it only renders
+			// as a group header, never as a cell.
+			//
+			// `enableSorting: false` keeps `filterSortAndPaginate` from reordering
+			// notes by this field — its value is a localized label, which would sort
+			// the groups alphabetically. The notes already arrive newest-first, and
+			// the group boundaries are monotonic in time, so plain insertion order
+			// yields correctly ordered, non-repeating groups (as the classic panel
+			// did when it reduced over the already-sorted notes).
+			id: 'timeGroup',
+			label: __( 'Date' ),
+			enableSorting: false,
+			getValue: ( { item } ) => groupTitles[ getTimeGroupKey( item.timestamp ) ],
 		},
 	];
 }

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -47,8 +47,7 @@ const groupTitles = [
 	__( 'Older than a month' ),
 ];
 
-// Map a note's timestamp to its time-group index (0 = Today … 4 = Older than a
-// month), using the same day boundaries the classic panel grouped by.
+// Map a note's timestamp to its time-group index (0 = Today … 4 = Older than a month).
 const getTimeGroupKey = ( timestamp: string ): number => {
 	const now = new Date().setHours( 0, 0, 0, 0 );
 	const timeBoundaries = [
@@ -117,17 +116,10 @@ export function getFields(): Field< Note >[] {
 			render: ( { item } ) => <span>{ item.title }</span>,
 		},
 		{
-			// Group-only field: drives the time-section headers ("Today",
-			// "Yesterday", "Older than 2 days"…) restored from the classic panel.
-			// It is never added to the view's visible `fields`, so it only renders
-			// as a group header, never as a cell.
-			//
-			// `enableSorting: false` keeps `filterSortAndPaginate` from reordering
-			// notes by this field — its value is a localized label, which would sort
-			// the groups alphabetically. The notes already arrive newest-first, and
-			// the group boundaries are monotonic in time, so plain insertion order
-			// yields correctly ordered, non-repeating groups (as the classic panel
-			// did when it reduced over the already-sorted notes).
+			// Group-only field for the time-section headers; never added to the
+			// view's `fields`, so it only renders as a header. `enableSorting: false`
+			// keeps notes in their newest-first arrival order rather than sorting by
+			// this label, which would order the groups alphabetically.
 			id: 'timeGroup',
 			label: __( 'Date' ),
 			enableSorting: false,

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -111,11 +111,6 @@ export function getFields(): Field< Note >[] {
 				) : null,
 		},
 		{
-			id: 'info',
-			label: __( 'Info' ),
-			render: ( { item } ) => <span>{ item.title }</span>,
-		},
-		{
 			// Group-only field for the time-section headers; never added to the
 			// view's `fields`, so it only renders as a header. `enableSorting: false`
 			// keeps notes in their newest-first arrival order rather than sorting by

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -106,6 +106,11 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		page: 1,
 		infiniteScrollEnabled: true,
 		startPosition: 1,
+		// Restore the classic panel's time-grouped sections. The notes already
+		// arrive newest-first and `timeGroup` opts out of sorting, so `direction`
+		// is inert here; DataViews requires it on the type. `showLabel: false`
+		// renders just the group title ("Today") instead of "Date: Today".
+		groupBy: { field: 'timeGroup', direction: 'asc', showLabel: false },
 	} );
 
 	const view = { ...initialView, perPage: NOTES_PER_PAGE };

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -102,7 +102,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		titleField: 'title',
 		descriptionField: 'description',
 		mediaField: 'icon',
-		fields: [ 'info' ],
+		fields: [],
 		page: 1,
 		infiniteScrollEnabled: true,
 		startPosition: 1,

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -106,10 +106,8 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		page: 1,
 		infiniteScrollEnabled: true,
 		startPosition: 1,
-		// Restore the classic panel's time-grouped sections. The notes already
-		// arrive newest-first and `timeGroup` opts out of sorting, so `direction`
-		// is inert here; DataViews requires it on the type. `showLabel: false`
-		// renders just the group title ("Today") instead of "Date: Today".
+		// Group notes into time sections ("Today", "Yesterday", …). `direction` is
+		// required by the type but inert, since `timeGroup` opts out of sorting.
 		groupBy: { field: 'timeGroup', direction: 'asc', showLabel: false },
 	} );
 

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -21,7 +21,7 @@
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;
-		white-space: pre-wrap;
+		white-space: normal;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -160,9 +160,6 @@ describe( 'NoteList loading state', () => {
 		expect( getRow()?.querySelector( '.is-unread' ) ).not.toBeInTheDocument();
 	} );
 
-	// The classic panel's time-grouped sections are restored via DataViews'
-	// `groupBy`: notes are bucketed under "Today" / "Older than a month" / … headers
-	// in newest-first order.
 	it( 'renders time-grouped section headers in newest-first order', () => {
 		const store = initStore();
 		const today = new Date().toISOString();

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -160,6 +160,28 @@ describe( 'NoteList loading state', () => {
 		expect( getRow()?.querySelector( '.is-unread' ) ).not.toBeInTheDocument();
 	} );
 
+	// The classic panel's time-grouped sections are restored via DataViews'
+	// `groupBy`: notes are bucketed under "Today" / "Older than a month" / … headers
+	// in newest-first order.
+	it( 'renders time-grouped section headers in newest-first order', () => {
+		const store = initStore();
+		const today = new Date().toISOString();
+		store.dispatch(
+			actions.notes.addNotes( [
+				{ ...makeNote( 700, 'Fresh note' ), timestamp: today },
+				{ ...makeNote( 701, 'Ancient note' ), timestamp: '2020-01-01T00:00:00+00:00' },
+			] )
+		);
+		store.dispatch( actions.ui.loadedNotes() );
+
+		const { container } = renderTab( store, 'all' as FilterName );
+
+		const headers = Array.from(
+			container.querySelectorAll( '.dataviews-view-list__group-header' )
+		).map( ( el ) => el.textContent );
+		expect( headers ).toEqual( [ 'Today', 'Older than a month' ] );
+	} );
+
 	it( 'client-filters the Comments tab from the shared cache', () => {
 		const store = initStore();
 		store.dispatch(


### PR DESCRIPTION
Part of DOTMSD-1322 · DOTMSD-1294

## Proposed Changes

Restore the classic notifications panel's **time-grouped section headers** ("Today", "Yesterday", "Older than 2 days", "Older than a week", "Older than a month") that the v2/DataViews redesign dropped, using DataViews 16's native `groupBy` view option rather than a bespoke list.

- Add a group-only `timeGroup` field whose value is the localized section title. It's never added to the view's visible `fields`, so it only renders as a group header, never as a cell. `enableSorting: false` keeps `filterSortAndPaginate` from reordering notes by the label string (which would sort groups alphabetically) — notes already arrive newest-first and the boundaries are monotonic in time, so plain insertion order yields correctly ordered, non-repeating groups (matching how the classic panel reduced over the already-sorted notes).
- Extract the classic day-boundary logic into a `getTimeGroupKey` helper (previously inlined in `RelativeDate`).
- Set `groupBy: { field: 'timeGroup', direction: 'asc', showLabel: false }` on the list view.
- Drop the now-redundant inline relative-date from the info row; the section header conveys the time bucket.
- Style the grouped list to match the panel: collapse the nested `@wordpress/ui` Stack gaps (via structural, hash-free selectors — `:has(> .dataviews-view-list__group-header)` and `.dataviews-view-list__group .dataviews-view-list`), align the header padding with the row content (`12px 16px`), zero its default margin, and add a section top border.
- Set the excerpt's `white-space` back to `normal` (it was `pre-wrap`) so a leading newline in `subject[1].text` collapses away instead of rendering an empty first line that ate one of the two clamped lines — matching the classic panel's behavior.

<img width="459" height="654" alt="image" src="https://github.com/user-attachments/assets/ec4b9f4c-d828-40f8-a51e-a9fca6a4575b" />


## Why are these changes being made?

The redesign removed the time-grouped sections, which contradicted the "visual-only, all functionality remains the same" framing and was called out as a meaningful loss of value — the grouping let users understand the time context of notifications at a glance. This restores that affordance using the framework's built-in grouping.

## Known caveats / for reviewers

DataViews 16's `groupBy` was not designed to fully co-exist with `infiniteScrollEnabled`. Data accumulation and the scroll-driven `loadMore()` still work (both key off `view.infiniteScrollEnabled`), but in grouped mode:

- The list-layout's `isInfiniteScroll` becomes `false`, so the list is marked `inert` while `isLoading` is true (i.e. briefly non-interactive during background polls / load-more), and the built-in "loading more" spinner doesn't render.
- Grouped rows are rendered without `aria-posinset`, so DataViews' anchor-based scroll-jump restoration (the mechanism behind the note-list scroll-jump work) is a no-op in grouped mode.
- The grouped Stack's `gap` is hardcoded (`lg`/`sm`) in the package with no view/prop to override it, hence the CSS overrides with `!important`. A Gutenberg PR to make this configurable (or to honor `layout.density` in the grouped branch) would let us drop those overrides.

Flagging these so we can decide whether to address them here, upstream in `@wordpress/dataviews`, or in a follow-up.

## Testing Instructions

1. Open the notifications panel (bell) with the `notifications/redesign` flag enabled.
2. Confirm notes are grouped under "Today" / "Yesterday" / "Older than 2 days" / "Older than a week" / "Older than a month" headers, newest-first, with no repeated headers.
3. Scroll to load older notes and confirm grouping continues correctly as more notes load.
4. Verify the header text aligns with the row content's left edge, sections are separated by a top border, and rows sit flush (no oversized gaps).
5. Confirm note excerpts don't render a stray empty first line when the excerpt text begins with a newline.
6. Check dark mode and keyboard navigation.

A unit test (`apps/notifications/src/app/note-list/test/index.test.tsx`) asserts the section headers render in newest-first order.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
