### PR TITLE
Onboarding: fire unified help-click event on plans and checkout steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -272,7 +272,15 @@ function UnifiedPlansStep( {
 		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
 		[]
 	);
-	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
+	const toggleHelpCenter = () => {
+		if ( ! isHelpCenterShown ) {
+			recordTracksEvent( 'calypso_onboarding_help_center_click', {
+				flow: flowName,
+				step: 'plans',
+			} );
+		}
+		setShowHelpCenter( ! isHelpCenterShown );
+	};
 	const stepCounter = useOnboardingStepCounter( flowName, 'plans' );
 	const showProgress = useShowOnboardingProgress( isOnboardingFlow( flowName ) );
 	const initializedSitesBackUrl = useSelector( ( state ) => {

--- a/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
@@ -4,6 +4,7 @@ import {
 	useProductsCustomOptions,
 	useProductsWithPremiumSupport,
 } from '@automattic/help-center/src/hooks';
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	useDispatch as useDataStoreDispatch,
@@ -47,6 +48,16 @@ export const useCheckoutHelpCenter = (): {
 			force_site_id: true,
 			location: 'thank-you-help-center',
 		} );
+
+		// Unified onboarding help-adoption signal, tagged by step. Only in the
+		// onboarding-flow checkout and only when opening (matches the domains,
+		// use-my-domain and plans steps).
+		if ( ! isShowingHelpCenter ) {
+			const flow = new URLSearchParams( window.location.search ).get( 'flow' );
+			if ( flow === ONBOARDING_FLOW ) {
+				recordTracksEvent( 'calypso_onboarding_help_center_click', { flow, step: 'checkout' } );
+			}
+		}
 
 		setShowHelpCenter( ! isShowingHelpCenter, { hasPremiumSupport, ...helpCenterOptions } );
 		if ( hasPremiumSupport ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-431/domains-help-center-is-not-recommending-relevant-links

## Proposed Changes

**Fires the existing `calypso_onboarding_help_center_click` event on the plans and checkout steps too, so onboarding help-adoption is tracked consistently across every step.**

- The domains and use-my-domain steps already fire `calypso_onboarding_help_center_click` with `{ flow, step }`. This adds the same event on **plans** (`step: 'plans'`) and **checkout** (`step: 'checkout'`).
- Same event name, one extra call site each — no new event type. The `step` prop identifies where the help open came from, giving one comparable dataset across domains / use-my-domain / plans / checkout.
- Fires on **open** only (matches the other steps).
- Checkout's toggle lives in a shared hook used by all checkouts, so the event is **gated to the onboarding-flow checkout** (`flow === ONBOARDING_FLOW`). Checkout keeps its existing `calypso_thank_you_inlinehelp_*` event unchanged.

## Why are these changes being made?

Today help-adoption tracking in onboarding is uneven: domains/use-my-domain emit `calypso_onboarding_help_center_click`, plans emits nothing on its help button, and checkout emits a differently-named event. That makes it impossible to compare how often users open help at each step. Standardizing on one event (tagged by `step`) gives a single, source-attributed signal for the onboarding-help work and the running A/B experiment.

## Testing Instructions

1. Run `yarn start`, open `/setup/onboarding/plans` logged in, click "Need help?", and confirm a `calypso_onboarding_help_center_click` event fires with `step: 'plans'` (and the flow name).
2. Go through onboarding to checkout (`/checkout/...?flow=onboarding`), open the help entry, and confirm the event fires with `step: 'checkout'`.
3. Open a non-onboarding checkout, open help, and confirm the onboarding event does **not** fire (only the existing `calypso_thank_you_inlinehelp_show`).
