### PR TITLE
Reader: remove header click navigation from Spaces sidebar menu

### DIFF
--- a/client/reader/sidebar/spaces/index.tsx
+++ b/client/reader/sidebar/spaces/index.tsx
@@ -56,26 +56,12 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 		page( getManageSourcesPath( space.id ) );
 	};
 
-	const handleMainClick = () => {
-		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_spaces_clicked' ) );
-		if ( ! isOpen ) {
-			setIsOpen( true );
-		}
-		// When the user isn't already viewing a specific space, clicking the
-		// header takes them to the Spaces landing route; otherwise it just
-		// opens the menu without yanking them off the page they're on.
-		if ( activeId === null && path !== SPACES_BASE_PATH ) {
-			page( SPACES_BASE_PATH );
-		}
-	};
-
 	return (
 		<li>
 			<ExpandableSidebarMenu
 				expanded={ isOpen }
 				title={ translate( 'Spaces' ) }
 				customIcon={ <Icon className="sidebar__menu-icon" icon={ category } /> }
-				onClick={ handleMainClick }
 				expandableIconClick={ () => setIsOpen( ! isOpen ) }
 				disableFlyout
 				className={ ! isOpen && isOnSpaces ? 'sidebar__menu--selected' : undefined }


### PR DESCRIPTION
Closes READ-564

## Proposed Changes

* Remove the header `onClick` handler (`handleMainClick`) from the **Spaces** expandable sidebar menu in the Reader. The menu now expands/collapses only via the chevron icon (`expandableIconClick`).
* Clicking the "Spaces" header no longer navigates to the `/reader/spaces` landing route, nor fires the `calypso_reader_sidebar_spaces_clicked` Tracks event.

## Why are these changes being made?

* The header click behavior was redundant/undesired: tapping the label both navigated away and toggled the menu. Decoupling navigation from the expander makes the menu behave like a pure expand/collapse control, consistent with the chevron-driven interaction.

## Testing Instructions

* Open the Reader sidebar with the `reader/spaces` feature enabled.
* Click the chevron next to **Spaces** — the menu should expand/collapse.
* Click the **Spaces** label text — it should no longer navigate to `/reader/spaces`.
* Individual space rows and the **Add a space** button continue to work as before.
* `yarn test-client client/reader/sidebar/spaces` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)