### PR TITLE
Bump React 19 compatible package releases

### DIFF
--- a/packages/calypso-jest/CHANGELOG.md
+++ b/packages/calypso-jest/CHANGELOG.md
@@ -8,3 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 Initial release
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/calypso-jest/package.json
+++ b/packages/calypso-jest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-jest",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Shared Calypso config for Jest.",
 	"keywords": [
 		"jest",

--- a/packages/calypso-products/CHANGELOG.md
+++ b/packages/calypso-products/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3]
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## [1.2.0]
 
 ### Added

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-products",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "This module contains information about the various products sold within calypso, such as product slugs, plan intervals, etc.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/calypso-sentry/CHANGELOG.md
+++ b/packages/calypso-sentry/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/calypso-sentry/package.json
+++ b/packages/calypso-sentry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-sentry",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A wrapper of the sentry for Calypso.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-storybook/CHANGELOG.md
+++ b/packages/calypso-storybook/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-storybook",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Shared Storybook config used in Calypso projects.",
 	"keywords": [
 		"storybook",

--- a/packages/calypso-stripe/CHANGELOG.md
+++ b/packages/calypso-stripe/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-stripe",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A set of helper functions and components for using Stripe on WordPress.com.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `Icon`: Remove component. Use `Icon` from `@wordpress/ui` instead.
 
+## 3.0.4
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 3.0.3
 
 - Fix `@wordpress/base-styles/colors` usage ([#107019](https://github.com/Automattic/wp-calypso/pull/107019)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/composite-checkout/CHANGELOG.md
+++ b/packages/composite-checkout/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.2
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## v1.0.0
 
 - Initial release.

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/composite-checkout",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "A set of React components and helpers that can be used to create a checkout flow.",
 	"main": "dist/cjs/public-api.js",
 	"module": "dist/esm/public-api.js",

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 3.2.0
 
 - Update dependencies (#106861).

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"description": "Calypso Data Stores.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/date-range-picker/CHANGELOG.md
+++ b/packages/date-range-picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.0.3
 
 - Fix: restore `*.scss` in `sideEffects` so Calypso (which consumes the package via `calypso:src`) doesn't tree-shake the `import './style.scss'` and lose all of the picker's styles.

--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/domain-search/CHANGELOG.md
+++ b/packages/domain-search/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/domain-search",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Domain search components for WordPress.com.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/explat-client-react-helpers/CHANGELOG.md
+++ b/packages/explat-client-react-helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 0.1.1
 
 - Remove console.log and bump dependency version

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client-react-helpers",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Standalone ExPlat Client: React Helpers.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 0.2.0
 
 ### Added

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/grid",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Grid component for Automattic projects.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -5,6 +5,10 @@
   - After: `const unsubscribe = i18n.subscribe( callback ); unsubscribe();`
 - Breaking: Removed `geolocateCurrencySymbol` function. Country code assignment is handled in the `format-currency` package `setGeoLocation` function.
 
+## 7.4.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 7.5.0
 
 - Add `translationOptions` to fixMe so it can work on translations with context.

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "7.4.0",
+	"version": "7.4.1",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -6,6 +6,10 @@ Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully
 
 Get rid of implicit lodash dependency
 
+## 1.2.4
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.2.3
 
 Get rid of i18n-calypso dependency

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-utils",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "WordPress.com i18n utils.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/interpolate-components/CHANGELOG.md
+++ b/packages/interpolate-components/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2]
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## [1.2.1]
 
 ### Changed

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/interpolate-components",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Convert strings into structured React components.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/jetpack-ai-calypso/CHANGELOG.md
+++ b/packages/jetpack-ai-calypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## v2.0.0
 
 - Add initial complete feature

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-ai-calypso",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Jetpack AI utilities available to Calypso.",
 	"calypso:src": "src/index.ts",
 	"main": "dist/cjs/index.js",

--- a/packages/language-picker/CHANGELOG.md
+++ b/packages/language-picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.0.0-alpha.0
 
 - Add LanguagePicker based on Gutenboarding language picker

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/language-picker",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Automattic Language Picker.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/launchpad/CHANGELOG.md
+++ b/packages/launchpad/CHANGELOG.md
@@ -1,5 +1,8 @@
-
 # Changelog
+
+## 1.2.3
+
+- Declare React 19 compatibility for package consumers (#111721).
 
 ## 1.2.1
 

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/launchpad",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "Launchpad components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/odie-client/CHANGELOG.md
+++ b/packages/odie-client/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/odie-client",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Odie client to chat with bots.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/onboarding",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Onboarding components for WordPress.com.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/plans-grid-next/CHANGELOG.md
+++ b/packages/plans-grid-next/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3
+
+- Declare React 19 compatibility for package consumers (#111721).
 
 ## 1.0.0-alpha.0
 

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/plans-grid-next",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "WordPress.com plans UI grid components and helpers.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 2.1.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 2.1.0
 
 - Fixed mobile cookie banner button's vertical positioning

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/privacy-toolset",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Privacy tools and components for Automattic solutions.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.0.1
 
 - Add search modes

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/search",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Automattic Search.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/shopping-cart/CHANGELOG.md
+++ b/packages/shopping-cart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.2
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## v2.0.0
 
 - Refactor to use a singleton ShoppingCartManagerClient passed to each ShoppingCartProvider.

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/shopping-cart",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "A library to use the WordPress.com shopping cart.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 0.0.1
 
 Initial release of the site-admin package providing a framework for building modern WordPress admin interfaces.

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/site-admin",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "A reusable UI package providing essential resources for building a modern administrative interface within the WordPress admin. It offers structured components, a routing system, and layout utilities.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/sites/CHANGELOG.md
+++ b/packages/sites/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/sites",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Automattic Sites utilities.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/subscriber/CHANGELOG.md
+++ b/packages/subscriber/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 0.0.1
 
 - Initial release

--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/subscriber",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Subscriber importer.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - `Stepper`, `VerticalStepper`, `HorizontalStepper`: Add Stepper component suite with vertical and horizontal orientations, step indicators, linear flow support, and accessible ARIA semantics ([#111036](https://github.com/Automattic/wp-calypso/pull/111036)).
 
+## 1.0.3
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.0.2
 
 ### Enhancements

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/ui",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Automattic Design System UI components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/viewport-react/CHANGELOG.md
+++ b/packages/viewport-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.0.0
 
 - Initial release after extracting from Calypso.

--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/viewport-react",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "React helpers for tracking viewport changes.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Declare React 19 compatibility for package consumers (#111721).
+
 ## 1.1.0
 
 - Update dependency typescript to ^4.5.5 (#60420)

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/viewport",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Vanilla helpers for tracking viewport changes.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/zendesk-client/CHANGELOG.md
+++ b/packages/zendesk-client/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.1
+
+- Declare React 19 compatibility for package consumers (#111721).

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -15,7 +15,7 @@
 		}
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"sideEffects": [
 		"*.scss",
 		"*.css"


### PR DESCRIPTION
Part of #111721

## Proposed Changes

* Bump patch versions for the 31 non-private packages touched by the React 19 compatibility PR.
* Add React 19 compatibility changelog entries for those packages.
* Add missing package changelog files where the touched package did not already have one.

## Why are these changes being made?

* The React 19 compatibility changes have merged to `trunk`, but package consumers need new published versions to receive the widened peer dependency ranges and related compatibility fixes.
* This prepares the npm releases without changing runtime code.

## Testing Instructions

* `yarn install --immutable --mode=skip-build`
* `yarn typecheck-packages`
* `yarn test-packages`
* `yarn eslint $(git diff --name-only --diff-filter=AM -- 'packages/*/package.json')`
* `git diff --check`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
