### PR TITLE
WOOAI-659 Expose loaded provider IDs in Agents Manager context

### DIFF
--- a/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
+++ b/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
@@ -19,6 +19,7 @@ const mockRegisterPlugin = jest.fn();
 jest.mock( '@wordpress/plugins', () => ( { registerPlugin: mockRegisterPlugin } ) );
 
 const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
+const JETPACK_PROVIDER_ENTRY = { providerId: 'jetpack-ai-sidebar', url: JETPACK_PROVIDER };
 
 const loadRender = () => {
 	let render;
@@ -55,7 +56,7 @@ describe( 'agents-manager-gutenberg entry', () => {
 	it( 'renders nothing when the preview gate suppresses the mount', () => {
 		globalThis.agentsManagerData = {
 			sectionName: 'gutenberg',
-			agentProviders: [ JETPACK_PROVIDER ],
+			agentProviders: [ JETPACK_PROVIDER_ENTRY ],
 			jetpackAiSidebarPreview: { enabled: true },
 		};
 

--- a/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
+++ b/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
@@ -5,6 +5,7 @@
 import { shouldSuppressJetpackAiSidebarPreview } from '../jetpack-ai-sidebar-preview-gate';
 
 const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
+const JETPACK_PROVIDER_ENTRY = { providerId: 'jetpack-ai-sidebar', url: JETPACK_PROVIDER };
 const BIG_SKY_PROVIDER =
 	'https://example.com/wp-content/plugins/big-sky/build/calypso-agent-provider/index.js';
 const BLOCK_NOTES_PROVIDER = 'block-notes/headless-agent-provider';
@@ -56,6 +57,17 @@ describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
 		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
 	} );
 
+	it( 'suppresses metadata provider entries on self-hosted sites', () => {
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER_ENTRY ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
+	} );
+
 	it( 'suppresses on Atomic sites when no providers remain', () => {
 		window._currentSiteType = 'atomic';
 		setAgentsManagerData( {
@@ -72,7 +84,7 @@ describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
 		const objectProvider = { toolProvider: {} };
 		setAgentsManagerData( {
 			sectionName: 'gutenberg',
-			agentProviders: [ objectProvider, BIG_SKY_PROVIDER, JETPACK_PROVIDER ],
+			agentProviders: [ objectProvider, BIG_SKY_PROVIDER, JETPACK_PROVIDER_ENTRY ],
 			jetpackAiSidebarPreview: { enabled: true },
 		} );
 

--- a/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
+++ b/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
@@ -15,6 +15,18 @@
 
 const JETPACK_AI_SIDEBAR_PROVIDER_FILE = 'jetpack-ai-sidebar.provider.mjs';
 
+function getProviderUrl( provider ) {
+	if ( typeof provider === 'string' ) {
+		return provider;
+	}
+
+	if ( provider && typeof provider === 'object' && typeof provider.url === 'string' ) {
+		return provider.url;
+	}
+
+	return '';
+}
+
 /**
  * Gate the Jetpack AI Sidebar preview on non-Simple sites.
  *
@@ -39,8 +51,7 @@ export function shouldSuppressJetpackAiSidebarPreview() {
 
 	const providers = Array.isArray( data.agentProviders ) ? data.agentProviders : [];
 	const remaining = providers.filter(
-		( provider ) =>
-			! ( typeof provider === 'string' && provider.includes( JETPACK_AI_SIDEBAR_PROVIDER_FILE ) )
+		( provider ) => ! getProviderUrl( provider ).includes( JETPACK_AI_SIDEBAR_PROVIDER_FILE )
 	);
 	data.agentProviders = remaining;
 

--- a/apps/agents-manager/jetpack-ai-sidebar.js
+++ b/apps/agents-manager/jetpack-ai-sidebar.js
@@ -21,8 +21,11 @@ import {
 	capabilities,
 } from '@automattic/jetpack-ai-sidebar';
 
+const providerId = 'jetpack-ai-sidebar';
+
 // Expose on window for the ESM wrapper to re-export
 window.__JetpackAIProvider = {
+	providerId,
 	useAbilitiesSetup,
 	toolProvider,
 	contextProvider,

--- a/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
+++ b/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
@@ -16,6 +16,7 @@ const lazy =
 		return typeof fn === 'function' ? fn( ...args ) : undefined;
 	};
 
+export const providerId = 'jetpack-ai-sidebar';
 export const getChatComponent = lazy( 'getChatComponent' );
 export const getEmptyViewSuggestions = lazy( 'getEmptyViewSuggestions' );
 export const useSuggestions = lazy( 'useSuggestions' );

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -153,6 +153,7 @@ function AgentSetup( {
 				currentRoute,
 				toolProvider: providers.toolProvider,
 				contextProvider: providers.contextProvider,
+				providerIds: providers.providerIds,
 				environment: sectionName || 'calypso',
 				agentId,
 				version,

--- a/packages/agents-manager/src/components/headless-agent-initializer.tsx
+++ b/packages/agents-manager/src/components/headless-agent-initializer.tsx
@@ -55,6 +55,7 @@ export default function HeadlessAgentInitializer( {
 				currentRoute,
 				toolProvider: providers.toolProvider,
 				contextProvider: providers.contextProvider,
+				providerIds: providers.providerIds,
 				environment: 'wp-admin',
 			} );
 

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -7,11 +7,12 @@
  * in Jetpack's Agents Manager feature.
  *
  * `agentProviders` entries may be URL strings (dynamically imported as ES
- * modules) or already-loaded `LoadedProviders` objects with the same shape.
+ * modules), URL metadata objects, or already-loaded `LoadedProviders` objects
+ * with the same shape.
  */
 declare const agentsManagerData:
 	| {
-			agentProviders?: ( string | import('./utils/load-external-providers').LoadedProviders )[];
+			agentProviders?: import('./utils/load-external-providers').AgentProviderEntry[];
 			useUnifiedExperience?: boolean;
 			agentId?: string;
 			helpCenterUrl?: string;

--- a/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
@@ -136,6 +136,21 @@ describe( 'createAgentConfig', () => {
 		);
 	} );
 
+	it( 'adds loaded provider IDs to default client context', async () => {
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			agentId: 'dolly',
+			providerIds: [ 'jetpack-ai-sidebar', 'woocommerce-ai' ],
+		} );
+		const context = config.contextProvider?.getClientContext();
+
+		expect( context ).toEqual(
+			expect.objectContaining( {
+				loadedProviderIds: [ 'jetpack-ai-sidebar', 'woocommerce-ai' ],
+			} )
+		);
+	} );
+
 	it( 'merges site editor actions into default client context', async () => {
 		setSiteEditorAction( 'colorPickerItemSelected', 'Ruby' );
 
@@ -162,6 +177,7 @@ describe( 'createAgentConfig', () => {
 			siteId: 987,
 			agentId: 'dolly',
 			environment: 'site-editor',
+			providerIds: [ 'jetpack-ai-sidebar', 'woocommerce-ai' ],
 			contextProvider: {
 				getClientContext: () => ( {
 					url: 'https://example.com/wp-admin/site-editor.php',
@@ -186,6 +202,7 @@ describe( 'createAgentConfig', () => {
 					colorPickerItemSelected: 'Ruby',
 					fontPickerItemSelected: 'Serif',
 				},
+				loadedProviderIds: [ 'jetpack-ai-sidebar', 'woocommerce-ai' ],
 				constructorArguments: {
 					version: 'provider-version',
 					client: 'site-editor',

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -103,6 +103,14 @@ describe( 'loadExternalProviders', () => {
 		expect( providers.useSuggestions ).toEqual( expect.any( Function ) );
 	} );
 
+	it( 'treats malformed agentProviders data as no providers', async () => {
+		setAgentsManagerData( {
+			agentProviders: 'not-an-array',
+		} );
+
+		await expect( loadExternalProviders() ).resolves.toEqual( {} );
+	} );
+
 	it( 'merges abilities from multiple tool providers and dispatches execution to the owner', async () => {
 		const firstProvider = {
 			getAbilities: jest.fn( () => Promise.resolve( [ createAbility( 'host/navigate' ) ] ) ),
@@ -158,6 +166,23 @@ describe( 'loadExternalProviders', () => {
 		);
 		expect( firstProvider.executeAbility ).toHaveBeenCalled();
 		expect( secondProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns valid IDs for loaded providers and ignores missing, empty, and duplicate IDs', async () => {
+		setAgentsManagerData( {
+			agentProviders: [
+				{ providerId: 'jetpack-ai-sidebar', getEmptyViewSuggestions: () => [] },
+				{ providerId: '', getEmptyViewSuggestions: () => [] },
+				{ providerId: 'woocommerce-ai', getEmptyViewSuggestions: () => [] },
+				{ getEmptyViewSuggestions: () => [] },
+				{ providerId: 'jetpack-ai-sidebar', getEmptyViewSuggestions: () => [] },
+				{ providerId: 123, getEmptyViewSuggestions: () => [] },
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.providerIds ).toEqual( [ 'jetpack-ai-sidebar', 'woocommerce-ai' ] );
 	} );
 
 	it( 'merges context from multiple context providers', async () => {

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -22,6 +22,7 @@ export interface CreateAgentConfigOptions {
 	currentRoute?: string;
 	toolProvider?: ToolProvider;
 	contextProvider?: ContextProvider;
+	providerIds?: string[];
 	environment?: string;
 	/** Override the agent ID (e.g., from query string). Defaults to ORCHESTRATOR_AGENT_ID. */
 	agentId?: string;
@@ -103,6 +104,10 @@ function normalizeSiteId( siteId: unknown ): number | undefined {
 	return Number.isFinite( numericSiteId ) && numericSiteId > 0 ? numericSiteId : undefined;
 }
 
+function getProviderIdsContext( providerIds?: string[] ): { loadedProviderIds?: string[] } {
+	return providerIds?.length ? { loadedProviderIds: providerIds } : {};
+}
+
 /**
  * Create a context provider that resolves context entries.
  */
@@ -112,7 +117,8 @@ async function createWrappedContextProvider(
 	agentId?: string,
 	version?: string,
 	environment?: string,
-	currentRoute?: string
+	currentRoute?: string,
+	providerIds?: string[]
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canAccessZendeskForAgent( agentId );
 	return {
@@ -154,6 +160,7 @@ async function createWrappedContextProvider(
 				...( Object.keys( mergedSiteEditorActions ).length > 0 && {
 					siteEditorActions: mergedSiteEditorActions,
 				} ),
+				...getProviderIdsContext( providerIds ),
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...getClientConstructorArguments( environment, currentRoute ),
@@ -172,7 +179,8 @@ async function createDefaultContextProvider(
 	environment: string,
 	siteId?: number,
 	agentId?: string,
-	version?: string
+	version?: string,
+	providerIds?: string[]
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canAccessZendeskForAgent( agentId );
 	return {
@@ -212,6 +220,7 @@ async function createDefaultContextProvider(
 				...( hostData.siteName ? { siteName: hostData.siteName } : {} ),
 				...( hostData.siteUrl ? { siteUrl: hostData.siteUrl } : {} ),
 				...( contextEntries ? { contextEntries } : {} ),
+				...getProviderIdsContext( providerIds ),
 				// TODO: Remove once agenttic-client supports top-level constructorArguments
 				...( Object.keys( constructorArguments ).length && { constructorArguments } ),
 			};
@@ -234,6 +243,7 @@ export async function createAgentConfig(
 		currentRoute,
 		toolProvider,
 		contextProvider,
+		providerIds,
 		environment = 'calypso',
 		agentId = ORCHESTRATOR_AGENT_ID,
 		version,
@@ -261,7 +271,8 @@ export async function createAgentConfig(
 			agentId,
 			version,
 			environment,
-			currentRoute
+			currentRoute,
+			providerIds
 		);
 	} else {
 		config.contextProvider = await createDefaultContextProvider(
@@ -269,7 +280,8 @@ export async function createAgentConfig(
 			environment,
 			siteId,
 			agentId,
-			version
+			version,
+			providerIds
 		);
 	}
 

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -144,6 +144,10 @@ export function mergeCapabilitiesInto( merged: ProviderCapabilities, capabilitie
 }
 
 export interface LoadedProviders {
+	/** Optional stable provider identifier exported by a provider module. */
+	providerId?: string;
+	/** Stable IDs for the provider modules that were successfully loaded. */
+	providerIds?: string[];
 	toolProvider?: ToolProvider;
 	contextProvider?: ContextProvider;
 	/** Function to get empty view suggestions. Called when component is ready. */
@@ -159,6 +163,18 @@ export interface LoadedProviders {
 	useCheckpoint?: UseCheckpointHook;
 	capabilities?: ProviderCapabilities;
 }
+
+export interface ProviderUrlEntry {
+	url: string;
+	providerId?: string;
+}
+
+export type AgentProviderEntry = string | ProviderUrlEntry | LoadedProviders;
+
+type LoadedProviderModule = {
+	module: LoadedProviders;
+	providerId?: string;
+};
 
 export function mergeUseSuggestionsHooks(
 	hooks: UseSuggestionsHook[]
@@ -189,6 +205,45 @@ export function mergeUseSuggestionsHooks(
 
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
+}
+
+function getProviderUrl( providerEntry: AgentProviderEntry ): string | undefined {
+	if ( typeof providerEntry === 'string' ) {
+		return providerEntry;
+	}
+
+	if ( ! isRecord( providerEntry ) ) {
+		return undefined;
+	}
+
+	return typeof providerEntry.url === 'string' ? providerEntry.url : undefined;
+}
+
+function getValidProviderId( providerId: unknown ): string | undefined {
+	if ( typeof providerId !== 'string' ) {
+		return undefined;
+	}
+
+	const trimmedProviderId = providerId.trim();
+	return trimmedProviderId ? trimmedProviderId : undefined;
+}
+
+function getProviderEntryId(
+	providerEntry: AgentProviderEntry | LoadedProviders
+): string | undefined {
+	if ( ! isRecord( providerEntry ) ) {
+		return undefined;
+	}
+
+	return getValidProviderId( providerEntry.providerId );
+}
+
+function addProviderId( providerIds: string[], providerId?: string ): void {
+	if ( ! providerId || providerIds.includes( providerId ) ) {
+		return;
+	}
+
+	providerIds.push( providerId );
 }
 
 function mergeContextEntries(
@@ -376,7 +431,8 @@ export function mergeMarkdownExtensionsFromProviders(
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders = getAgentsManagerInlineData()?.agentProviders ?? [];
+	const rawAgentProviders = getAgentsManagerInlineData()?.agentProviders;
+	const agentProviders = Array.isArray( rawAgentProviders ) ? rawAgentProviders : [];
 
 	// Only the public reader-chat entry registers the follow-up chip globals
 	// (`window.__jetpackReaderFollowupChips` / `reader-chat-followups-updated`).
@@ -414,34 +470,48 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
+	const allProviderIds: string[] = [];
 
 	// Load all providers in parallel to avoid serializing network/module fetches.
 	// Results are processed in registration order to preserve first-write-wins semantics.
-	const loadedModules = await Promise.all(
+	const loadedModules = ( await Promise.all(
 		agentProviders.map( async ( providerEntry ) => {
-			if ( typeof providerEntry === 'object' && providerEntry !== null ) {
-				return providerEntry;
+			const providerEntryId = getProviderEntryId( providerEntry );
+			const providerUrl = getProviderUrl( providerEntry );
+
+			if ( typeof providerEntry === 'object' && providerEntry !== null && ! providerUrl ) {
+				return { module: providerEntry as LoadedProviders, providerId: providerEntryId };
+			}
+
+			if ( ! providerUrl ) {
+				return null;
 			}
 
 			try {
 				// Dynamic import of registered script module
 				// The webpackIgnore comment tells webpack not to bundle this - it's loaded at runtime
-				const module = await import( /* webpackIgnore: true */ providerEntry );
+				const module = ( await import( /* webpackIgnore: true */ providerUrl ) ) as LoadedProviders;
 				// eslint-disable-next-line no-console
-				console.log( `[AgentsManager] Loaded provider "${ providerEntry }"` );
-				return module;
+				console.log( `[AgentsManager] Loaded provider "${ providerUrl }"` );
+				return {
+					module,
+					providerId: getProviderEntryId( module ) || providerEntryId,
+				};
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
-				console.warn( `[AgentsManager] Failed to load provider "${ providerEntry }":`, error );
+				console.warn( `[AgentsManager] Failed to load provider "${ providerUrl }":`, error );
 				return null;
 			}
 		} )
-	);
+	) ) as ( LoadedProviderModule | null )[];
 
-	for ( const module of loadedModules ) {
-		if ( ! module ) {
+	for ( const loadedModule of loadedModules ) {
+		if ( ! loadedModule ) {
 			continue;
 		}
+
+		const { module, providerId } = loadedModule;
+		addProviderId( allProviderIds, providerId );
 
 		// These exports are merged across all providers.
 		if ( module.toolProvider ) {
@@ -604,6 +674,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		getEmptyViewSuggestions: mergedGetEmptyViewSuggestions,
 		markdownComponents: mergedMarkdownComponents,
 		markdownExtensions: mergedMarkdownExtensions,
+		providerIds: allProviderIds.length ? allProviderIds : undefined,
 		useNavigationContinuation: mergedNavigationContinuation,
 		useAbilitiesSetup: mergedAbilitiesSetup,
 		useSuggestions: mergedUseSuggestions,


### PR DESCRIPTION
Part of WOOAI-659

## Proposed Changes

* Add optional `providerId` support for Agents Manager provider modules and URL metadata entries.
* Preserve valid IDs from successfully loaded providers and expose them in request context as `loadedProviderIds`.
* Keep legacy provider strings and providers without IDs working by ignoring missing, empty, invalid, or duplicate IDs.
* Export `jetpack-ai` from the Jetpack AI sidebar wrapper and update the preview gate to handle provider metadata objects.

## Why are these changes being made?

Agents Manager can merge multiple external providers, but the context sent to the agent does not identify which providers actually loaded. Including stable provider IDs in `clientContext` lets downstream agent routing and debugging distinguish combined-provider requests without coupling to bundle URLs.

## Testing Instructions

* `yarn jest -c test/packages/jest.config.js --runTestsByPath packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts`
* `yarn jest -c test/apps/jest.config.js --runTestsByPath apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js apps/agents-manager/__tests__/agents-manager-gutenberg.test.js`
* `yarn eslint apps/agents-manager/__tests__/agents-manager-gutenberg.test.js apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js apps/agents-manager/jetpack-ai-sidebar-preview-gate.js apps/agents-manager/jetpack-ai-sidebar.js apps/agents-manager/jetpack-ai-sidebar.provider.mjs packages/agents-manager/src/components/agents-manager.tsx packages/agents-manager/src/components/headless-agent-initializer.tsx packages/agents-manager/src/global.d.ts packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts packages/agents-manager/src/utils/create-agent-config.ts packages/agents-manager/src/utils/load-external-providers.ts`
* `yarn typecheck-apps` was attempted but failed on unrelated missing generated declarations and pre-existing app/package type errors in apps such as Odyssey Stats, Happy Blocks, and Notifications.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
