### PR TITLE
MSD Plans: restore vertical spacing between features in plan-upgrade flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -40,10 +40,6 @@
 		padding: 0;
 	}
 
-	.is-last-feature .plan-features-2023-grid__item {
-		padding-bottom: 0;
-	}
-
 	// Style the inline `start with a free plan` CTA inside Step.Heading subText
 	// to look like a link instead of a default borderless button. The legacy
 	// <PlansPageSubheader> applied equivalent styles to the same button via its


### PR DESCRIPTION
Fixes DOTMSD-1329

## Proposed Changes

* Remove the `.is-last-feature .plan-features-2023-grid__item { padding-bottom: 0; }` rule from the unified-plans step stylesheet (`client/landing/stepper/.../unified-plans/style.scss`), so plan feature rows in the plan-upgrade stepper flow keep their 12px bottom spacing.

| Before | Header |
|--------|--------|
|<img width="1651" height="1220" alt="Screenshot 2026-06-22 at 17 34 18" src="https://github.com/user-attachments/assets/9f875729-2654-4f69-bef8-99bd0e29c27e" />|<img width="1657" height="1206" alt="Screenshot 2026-06-22 at 17 34 28" src="https://github.com/user-attachments/assets/7088cc89-13d1-459e-980c-e9590b7d59fa" />|

## Why are these changes being made?

In the MSD plan-upgrade flow (`/setup/plan-upgrade/plans`), the plan feature lists rendered with no vertical spacing between items, looking cramped/unstyled compared to the classic `/plans` grid.

The cause was a rule added in #110297 that zeroed `padding-bottom` on `.is-last-feature .plan-features-2023-grid__item`. The intent was to trim only the trailing space below the *last* feature. However, `@automattic/plans-grid-next` applies the `is-last-feature` class to **every** feature item (not just the last one), so the rule collapsed the spacing between *all* features. The override is scoped to `.step-container-v2`, which is why the classic `/plans` grid was never affected.

Removing the rule lets the stepper feature list inherit the shared `padding: 0 20px 12px` from `plans-grid-next`, matching the classic `/plans` grid.

## Testing Instructions

* Run the MSD locally (`yarn start-dashboard`) and open the plan-upgrade flow: `http://my.localhost:3000/setup/plan-upgrade/plans?siteSlug=<your-test-site>`. You can also test using the live link.
* **Before:** feature rows (e.g. "Unlimited pages, posts, users, and visitors", "Ad-free browsing experience…") are bunched together with no gap; computed `padding-bottom` on `.plan-features-2023-grid__item` is `0px`.
* **After:** feature rows have clear vertical spacing; computed `padding-bottom` is `12px`, matching the classic `/plans` grid.
* Verify desktop and mobile (the removed rule applied to both).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)