### PR TITLE
Global Nav 2026: point Calypso at the live experiment

### DIFF
--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -36,11 +36,11 @@ type Nav2026Options = {
 // the wpcom assignments controller allowlists it so the /assignments/calypso
 // endpoint returns it here too, giving every surface consistent bucketing.
 // Keep in sync with the PHP constant WPCOM_Global_Nav_Helpers::NAV_2026_EXPERIMENT.
-const NAV_2026_EXPERIMENT = 'calypso_lossless_revert';
+const NAV_2026_EXPERIMENT = 'wpcom_global_navigation_202606';
 
 const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
-	treatment_1: 1,
-	treatment_2: 2,
+	showcase_products: 1,
+	showcase_products_and_ai: 2,
 };
 
 /**
@@ -52,8 +52,8 @@ const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
  * 1. Minimal universal headers are not eligible for Nav 2026.
  * 2. `nav-redesign/2026` config flag — manual force-on for staff/dev. Variant
  *    follows the existing `nav-redesign/2026-variant-2` flag.
- * 3. The NAV_2026_EXPERIMENT assignment — `treatment_1`/`treatment_2` map to
- *    variants 1/2; everything else (control, null) → old nav.
+ * 3. The NAV_2026_EXPERIMENT assignment — `showcase_products`/`showcase_products_and_ai`
+ *    map to variants 1/2; everything else (control, null) → old nav.
  *    While the assignment is still loading for logged-in users, return a
  *    temporary className that hides the old nav until the assignment resolves.
  */

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -38,7 +38,7 @@ type Nav2026Options = {
 // Keep in sync with the PHP constant WPCOM_Global_Nav_Helpers::NAV_2026_EXPERIMENT.
 const NAV_2026_EXPERIMENT = 'wpcom_global_navigation_202606';
 
-const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
+const VARIATION_TO_VARIANT: Partial< Record< string, 1 | 2 > > = {
 	showcase_products: 1,
 	showcase_products_and_ai: 2,
 };


### PR DESCRIPTION
Part of WPBRAND-402

## Proposed Changes

* Point the Calypso Global Nav 2026 hook at the live `wpcom_global_navigation_202606` ExPlat experiment, mapping the `showcase_products` / `showcase_products_and_ai` arms to nav variants 1 / 2.

## Why are these changes being made?

* The live experiment is `wpcom_global_navigation_202606`, shared across the logged-out homepage, the Landpack landing pages, and the Calypso front end, so every surface buckets visitors the same way. The wpcom side is in 224197-ghe-Automattic/wpcom.

## Testing Instructions

* Visit a Calypso nav surface (e.g. `/themes`, `/plugins`, `/patterns`) logged out.
* With the `nav-redesign/2026` feature flag on, confirm the redesigned nav still renders (`nav-redesign/2026-variant-2` selects variant 2). This path is unchanged.
* Once the `wpcom_global_navigation_202606` experiment is live in ExPlat, confirm an assigned arm (`showcase_products` / `showcase_products_and_ai`) renders the corresponding nav variant and control / no assignment keeps the current nav.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
