### PR TITLE
Dashboard add payment method: Reduce Breadcrumbs to 3 levels

### DIFF
--- a/client/dashboard/me/billing-purchases/add-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/add-payment-method.tsx
@@ -32,7 +32,7 @@ function AddPaymentMethod() {
 				size="small"
 				header={
 					<PageHeader
-						prefix={ <Breadcrumbs length={ 4 } /> }
+						prefix={ <Breadcrumbs length={ 3 } /> }
 						title={ __( 'Add payment method' ) }
 					/>
 				}
@@ -52,7 +52,7 @@ function AddPaymentMethod() {
 				size="small"
 				header={
 					<PageHeader
-						prefix={ <Breadcrumbs length={ 4 } /> }
+						prefix={ <Breadcrumbs length={ 3 } /> }
 						title={ __( 'Add payment method' ) }
 					/>
 				}
@@ -70,7 +70,7 @@ function AddPaymentMethod() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 4 } /> } title={ __( 'Add payment method' ) } />
+				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } title={ __( 'Add payment method' ) } />
 			}
 		>
 			<VStack spacing={ 6 }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-2176/msd-billing-breadcrumb-on-add-payment-method-page-should-be-billing

## Proposed Changes

This PR reduces the number of Breadcrumbs displayed on the "Add payment method" page.

Before             |  After
:-------------------------:|:-------------------------:
<img width="716" height="336" alt="Screenshot 2026-06-22 at 12 25 50 PM" src="https://github.com/user-attachments/assets/31d48cad-bfbd-44a2-b825-1dd7bc4b7038" /> | <img width="711" height="348" alt="Screenshot 2026-06-22 at 12 26 54 PM" src="https://github.com/user-attachments/assets/08041059-eec0-44c3-bf6e-fb76495fd345" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There are many billing pages in the dasboard and their breadcrumbs should all lead back to "Billing". However, the "Add payment method" page has the wrong number of links, instead going all the way back to "Account" which is not really a menu page and therefore should not be in the breadcrumbs.

Note that this is different from the "Change payment method" page which is for the payment method assigned to a subscription. That can be linked by an "Add payment method" button from the purchase settings page and can also have the "Add payment method" heading if no payment method is yet assigned to that subscription, but it's a different page with different Breadcrumbs ("Billing / Active upgrades / example.com").

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://my.localhost:3000/me/billing/payment-methods/add
- Verify that the breadcrumbs links at the top are "Billing / Payment methods" and do not include "Account".
