### PR TITLE
Checkout: update the copy for the terms and conditions popup

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
+++ b/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
@@ -2,7 +2,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows';
 import CheckoutTermsModal from './checkout-terms-modal';
@@ -91,28 +91,53 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 			<Divider />
 
 			<LegalNotice>
-				{ translate(
-					'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}Read more{{/readmore}}',
-					{
-						components: {
-							tos: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							pp: (
-								<a
-									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
-						},
-					}
-				) }
+				{ i18n.fixMe( {
+					text: 'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+					newCopy: translate(
+						'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+						{
+							components: {
+								tos: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								pp: (
+									<a
+										href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
+							},
+						}
+					),
+					oldCopy: translate(
+						'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}Read more{{/readmore}}',
+						{
+							components: {
+								tos: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								pp: (
+									<a
+										href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
+							},
+						}
+					),
+				} ) }
 			</LegalNotice>
 
 			<CheckoutTermsModal


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17584

## Proposed Changes

* Change the "Read more" link to "View billing and renewal details" to make it easier to understand the purpose of the link.

**Before**
<img width="404" height="174" alt="Screenshot 2026-06-22 at 18 54 43" src="https://github.com/user-attachments/assets/8b69bb50-3928-41a7-9e72-9ee2ed2f7c3c" />

**After**
<img width="404" height="174" alt="Screenshot 2026-06-22 at 18 30 54" src="https://github.com/user-attachments/assets/ca2d602c-c829-4a47-a268-638f992b06e9" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Feedback from testing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to checkout page and confirm that the new text appears in the sidebar.
* Switch to a non-English locale and confirm that the old text appears as a fallback.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
