### PR TITLE
composite-checkout: Render single payment method without radio button

### DIFF
--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -1,4 +1,4 @@
-@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
 
 img.payment-method-image {
 	vertical-align: middle;
@@ -15,6 +15,11 @@ img.payment-method-image {
 }
 
 .payment-method-selector__content {
+	// The Dashboard's payment method form fields use 12px of inline padding (see
+	// `.credit-card-fields` / `.paypal-fields` below), so align the single,
+	// pre-selected payment method's label to match.
+	--checkout-single-payment-method-label-inline-padding: 12px;
+
 	@include ui-mixins.when-dark-theme {
 		.checkout-steps__submit-button-wrapper {
 			background: var( --dashboard-surface__background-color );

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -255,7 +255,6 @@ function PaymentMethod( {
 			onChange={ onClick ? () => onClick( id ) : undefined }
 			ariaLabel={ ariaLabel }
 			label={ label }
-			hideRadioButton={ isSinglePaymentMethod }
 		>
 			{ activeContent && activeContent }
 		</RadioButton>

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -79,7 +79,13 @@ const SinglePaymentMethodWrapper = styled.div`
 
 const SinglePaymentMethodLabel = styled.div`
 	padding-block: 16px;
-	padding-inline: 12px;
+	/*
+	 * Align the label with the inline padding of the payment method's form
+	 * fields below it. That padding differs between surfaces (24px in checkout,
+	 * 12px in the Dashboard), so consumers can override this custom property to
+	 * match their form.
+	 */
+	padding-inline: var( --checkout-single-payment-method-label-inline-padding, 24px );
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -70,6 +70,34 @@ const PaymentMethodsContainer = styled.div< { isLoading: boolean } >`
 	opacity: ${ ( props ) => ( props.isLoading ? 0.3 : 1 ) };
 `;
 
+const SinglePaymentMethodWrapper = styled.div`
+	position: relative;
+	border-radius: 3px;
+	box-sizing: border-box;
+	width: 100%;
+`;
+
+const SinglePaymentMethodLabel = styled.div`
+	padding-block: 16px;
+	padding-inline: 12px;
+	box-sizing: border-box;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	justify-content: center;
+	align-items: flex-start;
+	font-size: 14px;
+	min-height: 72px;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
+		flex-direction: row;
+		align-items: center;
+		justify-content: space-between;
+		gap: 7px;
+	}
+`;
+
 export default function CheckoutPaymentMethods( {
 	summary,
 	isComplete,
@@ -202,6 +230,18 @@ function PaymentMethod( {
 
 	if ( summary ) {
 		return <>{ inactiveContent && inactiveContent }</>;
+	}
+
+	// When there is only a single available payment method and it is already
+	// selected, there is nothing to choose between, so render it as a plain
+	// container rather than an interactive radio button.
+	if ( isSinglePaymentMethod && checked ) {
+		return (
+			<SinglePaymentMethodWrapper>
+				<SinglePaymentMethodLabel>{ label }</SinglePaymentMethodLabel>
+				{ activeContent && activeContent }
+			</SinglePaymentMethodWrapper>
+		);
 	}
 
 	return (

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -8,7 +8,6 @@ interface RadioButtonWrapperProps {
 	disabled?: boolean;
 	isFocused?: boolean;
 	checked?: boolean;
-	hideRadioButton?: boolean;
 	highlighted?: boolean;
 }
 
@@ -25,7 +24,6 @@ const RadioButtonWrapper = styled.div<
 	pointer-events: ${ ( props ) => ( props.disabled && props.highlighted ? 'none' : 'auto' ) };
 
 	${ ( props ) =>
-		! props.hideRadioButton &&
 		`
 		::before {
 			display: ${ props.hidden ? 'none' : 'block' };
@@ -112,7 +110,6 @@ const Radio = styled.input`
 interface LabelProps {
 	disabled?: boolean;
 	checked?: boolean;
-	hideRadioButton?: boolean;
 	compact?: boolean;
 }
 
@@ -126,7 +123,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		if ( props.compact ) {
 			return '12px 12px 12px 43px';
 		}
-		return props.hideRadioButton ? '16px 24px' : '16px 14px 16px 56px';
+		return '16px 14px 16px 56px';
 	} };
 	border-radius: 3px;
 	box-sizing: border-box;
@@ -146,7 +143,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 			if ( props.compact ) {
 				return '12px';
 			}
-			return props.hideRadioButton ? '16px 24px' : '16px 56px 16px 14px';
+			return '16px 56px 16px 14px';
 		} };
 	}
 
@@ -155,7 +152,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	}
 
 	::before {
-		display: ${ ( props ) => ( props.hideRadioButton ? 'none' : 'block' ) };
+		display: block;
 		width: 16px;
 		height: 16px;
 		content: '';
@@ -175,7 +172,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	}
 
 	::after {
-		display: ${ ( props ) => ( props.hideRadioButton ? 'none' : 'block' ) };
+		display: block;
 		width: 8px;
 		height: 8px;
 		content: '';
@@ -222,7 +219,6 @@ export default function RadioButton( {
 	hidden,
 	id,
 	ariaLabel,
-	hideRadioButton,
 	highlighted,
 	compact,
 	...otherProps
@@ -234,8 +230,7 @@ export default function RadioButton( {
 			isFocused={ isFocused }
 			checked={ checked }
 			hidden={ hidden }
-			hideRadioButton={ hideRadioButton }
-			className={ `${ checked ? 'is-checked' : '' }${ ! hideRadioButton ? ' has-highlight' : '' }` }
+			className={ `${ checked ? 'is-checked' : '' } has-highlight` }
 			highlighted={ highlighted }
 		>
 			<Radio
@@ -256,13 +251,7 @@ export default function RadioButton( {
 				aria-label={ ariaLabel }
 				{ ...otherProps }
 			/>
-			<Label
-				checked={ checked }
-				htmlFor={ id }
-				disabled={ disabled }
-				hideRadioButton={ hideRadioButton }
-				compact={ compact }
-			>
+			<Label checked={ checked } htmlFor={ id } disabled={ disabled } compact={ compact }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -281,7 +270,6 @@ interface RadioButtonProps {
 	onChange?: () => void;
 	ariaLabel?: string;
 	children?: React.ReactNode;
-	hideRadioButton?: boolean;
 	highlighted?: boolean;
 	compact?: boolean;
 }
@@ -374,14 +362,12 @@ function getGrayscaleValue( { checked }: { checked?: boolean } ) {
 function getOutline( {
 	isFocused,
 	theme,
-	hideRadioButton,
 }: {
 	isFocused?: boolean;
 	checked?: boolean;
 	theme: Theme;
-	hideRadioButton?: boolean;
 } ) {
-	if ( isFocused && ! hideRadioButton ) {
+	if ( isFocused ) {
 		return theme.colors.outline + ' solid 2px';
 	}
 	return '0';

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -119,13 +119,16 @@ describe( 'Checkout', () => {
 				expect( getAllByText( mockMethod.inactiveContent )[ 0 ] ).toBeVisible();
 			} );
 
-			it( 'renders the second payment method label as selected if the first is disabled', async () => {
-				const { getByText, getAllByText, findByLabelText } = render( <MyCheckout /> );
+			it( 'renders the second payment method as the selected single method if the first is disabled', async () => {
+				const { getByText, getAllByText, queryByText, findByText } = render( <MyCheckout /> );
 				const user = userEvent.setup();
 				await user.click( getAllByText( 'Continue' )[ 0 ] );
 				await user.click( getByText( 'Disable Payment Method' ) );
-				const paymentMethod = await findByLabelText( mockMethod2.inactiveContent );
-				expect( paymentMethod ).toBeChecked();
+				// Only one payment method remains available, so it is rendered as a
+				// plain selected container (not a radio button): its label is visible
+				// while the disabled method is hidden.
+				expect( await findByText( mockMethod2.inactiveContent ) ).toBeVisible();
+				expect( queryByText( mockMethod.inactiveContent ) ).not.toBeVisible();
 			} );
 
 			it( 'renders the payment method activeContent', () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2177/

## Proposed changes

When a payment method is the only one available and is already selected, this renders it as a plain, non-interactive container instead of a radio button, and removes the now-unused `hideRadioButton` affordance from `RadioButton`.

Before             |  After
:-------------------------:|:-------------------------:
<img width="687" height="309" alt="Screenshot 2026-06-22 at 1 05 31 PM" src="https://github.com/user-attachments/assets/38338457-558c-4b7b-87be-7998bdd5dc05" /> | <img width="683" height="309" alt="Screenshot 2026-06-22 at 1 05 10 PM" src="https://github.com/user-attachments/assets/c1f37446-10da-4548-ad97-50577be3d969" />


## Why are these changes being made?

On the Add payment method flow (`/me/billing/payment-methods/add`) there is only one payment method — "Credit or debit card" — and it is selected by default. It was still rendered as a radio button, so the cursor showed a pointer and the row looked clickable, but clicking did nothing (it was already the only, selected option).

A previous fix (#102959) hid the radio dot for a lone method via a `hideRadioButton` prop, but the element was still a radio button: interactive, with hover/click affordances and a hidden radio input. Also the styles that hid the button's padding in that case were not being applied in the dashboard.

Rather than partially disguising a radio button, this renders the lone selected method as what it actually is — a static container — removing the misleading interactivity entirely. With that path in place, `hideRadioButton` is only ever reachable for a single method that isn't selected, which never happens with current callers (both `PaymentMethodSelector`s preselect, and checkout uses `selectFirstAvailablePaymentMethod`), so the prop and its styles are removed to keep `RadioButton` a straightforward radio button.

The change lives in the shared `CheckoutPaymentMethods`/`RadioButton` components, so both the classic (`client/me/purchases`) and Dashboard (`client/dashboard`) `PaymentMethodSelector`s — and the checkout payment step — benefit consistently.

## Testing instructions

* In the Multi-site Dashboard, go to http://my.localhost:3000/me/billing/payment-methods/add
* Confirm the "Credit or debit card" method is shown as a plain container (no radio dot, no bordered/hoverable radio row) with the card form expanded below it, and that the label's left edge lines up with the form fields.
* Confirm the cursor is no longer a pointer over the method label.
* Go to a purchase with multiple assignable payment methods (start at http://my.localhost:3000/me/billing/purchases/ and click to change the payment method attached to an existing subscription). Confirm methods still render as radio buttons with dots, that selecting one expands its content and collapses the others, and that the focus outline and hover highlight still work.
* Repeat the above in calypso's purchase management pages. They should be unchanged.
* Run through checkout's payment step and confirm payment method selection still behaves normally.

