### PR TITLE
Domains: Prevent enabling DNSSEC when NS records don't point to WordPress.com

### DIFF
--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -1,6 +1,5 @@
 import { domainDnssecMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -10,10 +9,8 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
-import { domainNameServersRoute } from '../../app/router/domains';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
-import { Notice } from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
 import { DnsSecRecordTextarea } from './dnssec-record-textarea';
 import type { Domain } from '@automattic/api-core';
@@ -89,23 +86,6 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 						<Text>{ __( 'DNSSEC is not supported for this domain.' ) }</Text>
 					) : (
 						<VStack spacing={ 4 }>
-							{ isEnablingDisabled && (
-								<Notice
-									variant="warning"
-									title={ __( 'Your domain is using external name servers' ) }
-								>
-									{ createInterpolateElement(
-										__(
-											'DNSSEC can only be enabled when your domain is using WordPress.com name servers. <updateNameServersLink>You can update your name servers here</updateNameServersLink>'
-										),
-										{
-											updateNameServersLink: (
-												<Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />
-											),
-										}
-									) }
-								</Notice>
-							) }
 							<HStack alignment="left">
 								<ToggleControl
 									__nextHasNoMarginBottom

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -1,5 +1,6 @@
 import { domainDnssecMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -9,8 +10,10 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { domainNameServersRoute } from '../../app/router/domains';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
+import { Notice } from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
 import { DnsSecRecordTextarea } from './dnssec-record-textarea';
 import type { Domain } from '@automattic/api-core';
@@ -34,6 +37,12 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 	} );
 
 	const { isPending } = mutation;
+
+	const isDnssecEnabled = domain.is_dnssec_enabled ?? false;
+	// DNSSEC can only be enabled when the domain uses WordPress.com name servers.
+	// Prevent enabling it otherwise, since the request would fail server-side with
+	// `domain_does_not_use_wpcom_ns`. Disabling an already-enabled record stays allowed.
+	const isEnablingDisabled = ! domain.has_wpcom_nameservers && ! isDnssecEnabled;
 
 	const handleToggleChange = ( enabled: boolean ) => {
 		// Track the toggle action
@@ -80,18 +89,33 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 						<Text>{ __( 'DNSSEC is not supported for this domain.' ) }</Text>
 					) : (
 						<VStack spacing={ 4 }>
+							{ isEnablingDisabled && (
+								<Notice
+									variant="warning"
+									title={ __( 'Your domain is using external name servers' ) }
+								>
+									{ createInterpolateElement(
+										__(
+											'DNSSEC can only be enabled when your domain is using WordPress.com name servers. <updateNameServersLink>You can update your name servers here</updateNameServersLink>'
+										),
+										{
+											updateNameServersLink: (
+												<Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />
+											),
+										}
+									) }
+								</Notice>
+							) }
 							<HStack alignment="left">
 								<ToggleControl
 									__nextHasNoMarginBottom
-									checked={ domain.is_dnssec_enabled ?? false }
+									checked={ isDnssecEnabled }
 									onChange={ ( checked ) => handleToggleChange( checked ) }
-									disabled={ isPending }
-									label={
-										domain.is_dnssec_enabled ? __( 'Disable DNSSEC' ) : __( 'Enable DNSSEC' )
-									}
+									disabled={ isPending || isEnablingDisabled }
+									label={ isDnssecEnabled ? __( 'Disable DNSSEC' ) : __( 'Enable DNSSEC' ) }
 								/>
 							</HStack>
-							{ domain.is_dnssec_enabled && (
+							{ isDnssecEnabled && (
 								<VStack spacing={ 3 }>
 									{ domain.dnssec_records?.dnskey?.map( ( dnskey, index ) => (
 										<DnsSecRecordTextarea

--- a/client/dashboard/domains/domain-security/index.tsx
+++ b/client/dashboard/domains/domain-security/index.tsx
@@ -9,6 +9,7 @@ import PageLayout from '../../components/page-layout';
 import { isTldInMaintenance } from '../../utils/domain';
 import { TLDMaintenanceNotice } from '../maintenance-notice';
 import DnsSec from './dnssec';
+import { DnsSecNameserversNotice } from './notice';
 import SslCertificate from './ssl-certificate';
 
 export default function DomainSecurity() {
@@ -33,6 +34,7 @@ export default function DomainSecurity() {
 		>
 			{ ! isInMaintenance && (
 				<>
+					<DnsSecNameserversNotice domainName={ domainName } domain={ domain } />
 					<SslCertificate domainName={ domainName } domain={ domain } sslDetails={ sslDetails } />
 					<DnsSec domainName={ domainName } domain={ domain } />
 				</>

--- a/client/dashboard/domains/domain-security/notice.tsx
+++ b/client/dashboard/domains/domain-security/notice.tsx
@@ -1,0 +1,40 @@
+import { Link } from '@tanstack/react-router';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { domainNameServersRoute } from '../../app/router/domains';
+import { Notice } from '../../components/notice';
+import type { Domain } from '@automattic/api-core';
+
+interface DnsSecNameserversNoticeProps {
+	domainName: string;
+	domain: Domain;
+}
+
+/**
+ * Warns that DNSSEC can't be enabled while the domain uses external name servers.
+ *
+ * DNSSEC can only be enabled when the domain uses WordPress.com name servers;
+ * otherwise the request fails server-side with `domain_does_not_use_wpcom_ns`.
+ * Returns `null` when DNSSEC is unsupported, already enabled, or the domain
+ * already uses WordPress.com name servers.
+ */
+export const DnsSecNameserversNotice = ( { domainName, domain }: DnsSecNameserversNoticeProps ) => {
+	if ( ! domain.is_dnssec_supported || domain.has_wpcom_nameservers || domain.is_dnssec_enabled ) {
+		return null;
+	}
+
+	return (
+		<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
+			{ createInterpolateElement(
+				__(
+					'DNSSEC can only be enabled when your domain is using WordPress.com name servers. <updateNameServersLink>You can update your name servers here</updateNameServersLink>'
+				),
+				{
+					updateNameServersLink: (
+						<Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />
+					),
+				}
+			) }
+		</Notice>
+	);
+};

--- a/client/dashboard/domains/domain-security/test/dnssec.test.tsx
+++ b/client/dashboard/domains/domain-security/test/dnssec.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import DnsSec from '../dnssec';
+import type { Domain } from '@automattic/api-core';
+
+const domainName = 'example.com';
+
+const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
+	return {
+		domain: domainName,
+		is_dnssec_supported: true,
+		is_dnssec_enabled: false,
+		has_wpcom_nameservers: true,
+		...customProps,
+	} as Domain;
+};
+
+describe( '<DnsSec>', () => {
+	test( 'shows external name servers notice and disables the toggle when the domain uses external name servers', () => {
+		const domain = getMockedDomainData( {
+			has_wpcom_nameservers: false,
+			is_dnssec_enabled: false,
+		} );
+
+		render( <DnsSec domainName={ domainName } domain={ domain } /> );
+
+		expect( screen.getByText( /your domain is using external name servers/i ) ).toBeVisible();
+		expect( screen.getByRole( 'checkbox', { name: /enable dnssec/i } ) ).toBeDisabled();
+	} );
+
+	test( 'enables the toggle and hides the notice when the domain uses WordPress.com name servers', () => {
+		const domain = getMockedDomainData( {
+			has_wpcom_nameservers: true,
+			is_dnssec_enabled: false,
+		} );
+
+		render( <DnsSec domainName={ domainName } domain={ domain } /> );
+
+		expect(
+			screen.queryByText( /your domain is using external name servers/i )
+		).not.toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox', { name: /enable dnssec/i } ) ).toBeEnabled();
+	} );
+
+	test( 'allows disabling DNSSEC even when the domain uses external name servers', () => {
+		const domain = getMockedDomainData( {
+			has_wpcom_nameservers: false,
+			is_dnssec_enabled: true,
+		} );
+
+		render( <DnsSec domainName={ domainName } domain={ domain } /> );
+
+		expect(
+			screen.queryByText( /your domain is using external name servers/i )
+		).not.toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox', { name: /disable dnssec/i } ) ).toBeEnabled();
+	} );
+} );

--- a/client/dashboard/domains/domain-security/test/dnssec.test.tsx
+++ b/client/dashboard/domains/domain-security/test/dnssec.test.tsx
@@ -19,7 +19,7 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
 };
 
 describe( '<DnsSec>', () => {
-	test( 'shows external name servers notice and disables the toggle when the domain uses external name servers', () => {
+	test( 'disables the toggle when the domain uses external name servers and DNSSEC is off', () => {
 		const domain = getMockedDomainData( {
 			has_wpcom_nameservers: false,
 			is_dnssec_enabled: false,
@@ -27,11 +27,10 @@ describe( '<DnsSec>', () => {
 
 		render( <DnsSec domainName={ domainName } domain={ domain } /> );
 
-		expect( screen.getByText( /your domain is using external name servers/i ) ).toBeVisible();
 		expect( screen.getByRole( 'checkbox', { name: /enable dnssec/i } ) ).toBeDisabled();
 	} );
 
-	test( 'enables the toggle and hides the notice when the domain uses WordPress.com name servers', () => {
+	test( 'enables the toggle when the domain uses WordPress.com name servers', () => {
 		const domain = getMockedDomainData( {
 			has_wpcom_nameservers: true,
 			is_dnssec_enabled: false,
@@ -39,9 +38,6 @@ describe( '<DnsSec>', () => {
 
 		render( <DnsSec domainName={ domainName } domain={ domain } /> );
 
-		expect(
-			screen.queryByText( /your domain is using external name servers/i )
-		).not.toBeInTheDocument();
 		expect( screen.getByRole( 'checkbox', { name: /enable dnssec/i } ) ).toBeEnabled();
 	} );
 
@@ -53,9 +49,6 @@ describe( '<DnsSec>', () => {
 
 		render( <DnsSec domainName={ domainName } domain={ domain } /> );
 
-		expect(
-			screen.queryByText( /your domain is using external name servers/i )
-		).not.toBeInTheDocument();
 		expect( screen.getByRole( 'checkbox', { name: /disable dnssec/i } ) ).toBeEnabled();
 	} );
 } );

--- a/client/dashboard/domains/domain-security/test/notice.test.tsx
+++ b/client/dashboard/domains/domain-security/test/notice.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { DnsSecNameserversNotice } from '../notice';
+import type { Domain } from '@automattic/api-core';
+
+const domainName = 'example.com';
+
+const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
+	return {
+		domain: domainName,
+		is_dnssec_supported: true,
+		is_dnssec_enabled: false,
+		has_wpcom_nameservers: true,
+		...customProps,
+	} as Domain;
+};
+
+describe( '<DnsSecNameserversNotice>', () => {
+	test( 'shows the warning when DNSSEC is supported, off, and the domain uses external name servers', () => {
+		const domain = getMockedDomainData( { has_wpcom_nameservers: false } );
+
+		render( <DnsSecNameserversNotice domainName={ domainName } domain={ domain } /> );
+
+		expect( screen.getByText( /your domain is using external name servers/i ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'link', { name: /you can update your name servers here/i } )
+		).toBeVisible();
+	} );
+
+	test( 'renders nothing when the domain uses WordPress.com name servers', () => {
+		const domain = getMockedDomainData( { has_wpcom_nameservers: true } );
+
+		render( <DnsSecNameserversNotice domainName={ domainName } domain={ domain } /> );
+
+		expect(
+			screen.queryByText( /your domain is using external name servers/i )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing when DNSSEC is already enabled', () => {
+		const domain = getMockedDomainData( {
+			has_wpcom_nameservers: false,
+			is_dnssec_enabled: true,
+		} );
+
+		render( <DnsSecNameserversNotice domainName={ domainName } domain={ domain } /> );
+
+		expect(
+			screen.queryByText( /your domain is using external name servers/i )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing when DNSSEC is not supported', () => {
+		const domain = getMockedDomainData( {
+			is_dnssec_supported: false,
+			has_wpcom_nameservers: false,
+		} );
+
+		render( <DnsSecNameserversNotice domainName={ domainName } domain={ domain } /> );
+
+		expect(
+			screen.queryByText( /your domain is using external name servers/i )
+		).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Part of DOMENG-731

## Proposed Changes

* In the Multi-site Dashboard domain security screen, when a domain's NS records do not point to WordPress.com (`has_wpcom_nameservers === false`), show the standard **"Your domain is using external name servers"** warning notice and disable the **Enable DNSSEC** toggle.
* Disabling an already-enabled DNSSEC record is still allowed — only *enabling* is blocked.
* Added unit tests covering the three states (external NS → notice + disabled toggle; WordPress.com NS → no notice + enabled toggle; already-enabled + external NS → can still disable).

## Why are these changes being made?

Users could attempt to enable DNSSEC even when the domain's NS records were not pointing to WordPress.com. The attempt failed with a 400 response from `POST /domains/dnssec/<domain>` and the error `domain_does_not_use_wpcom_ns`. The UI now prevents this up front, matching the validator already used on the DNS records and Domain Forwarding screens.

## Testing Instructions

* Open the dashboard for a registered domain whose name servers are **not** WordPress.com, and go to the domain's **Security** screen.
* Confirm the DNSSEC section shows the "Your domain is using external name servers" warning notice and the Enable DNSSEC toggle is disabled.
* Repeat with a domain using WordPress.com name servers: the notice is absent and the toggle is enabled.
* Run the unit tests: `yarn test-client client/dashboard/domains/domain-security/test/dnssec.test.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)