### PR TITLE
Dashboard: add payment method: require country to be set

### DIFF
--- a/client/dashboard/components/tax-location-form.tsx
+++ b/client/dashboard/components/tax-location-form.tsx
@@ -22,12 +22,15 @@ function getFields( {
 			id: 'country_code',
 			label: __( 'Country' ),
 			Edit: 'select',
-			elements: countryList
-				.filter( ( countryItem ) => countryItem.name )
-				.map( ( countryItem ) => ( {
-					label: countryItem.name,
-					value: countryItem.code,
-				} ) ),
+			elements: [
+				{ label: __( 'Select Country' ), value: '' },
+				...countryList
+					.filter( ( countryItem ) => countryItem.name )
+					.map( ( countryItem ) => ( {
+						label: countryItem.name,
+						value: countryItem.code,
+					} ) ),
+			],
 		},
 		{
 			id: 'postal_code',

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -6,8 +6,10 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { Fragment, useState } from 'react';
 import InlineSupportLink from '../../../components/inline-support-link';
 import { TaxLocationForm, defaultTaxLocation } from '../../../components/tax-location-form';
@@ -200,6 +202,7 @@ function CreditCardSubmitButton( {
 	getCardElement: () => StripeCardNumberElement | undefined;
 } ) {
 	const { formStatus } = useFormStatus();
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const handleButtonPress = () => {
 		if ( ! onClick ) {
@@ -209,6 +212,11 @@ function CreditCardSubmitButton( {
 		}
 		const formData = getFormData();
 		const cardElement = getCardElement();
+
+		if ( ! formData.taxLocation.country_code ) {
+			createErrorNotice( __( 'Please select a country.' ), { type: 'snackbar' } );
+			return;
+		}
 
 		onClick( {
 			name: formData.cardholderName,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2178/

## Proposed changes

This fixes the Dashboard "Add payment method" form, where the country `<select>` defaulted to the first country (Australia) while the underlying value was empty, causing invalid data to be sent to Stripe and a cryptic error to be returned. It adds a "Select Country" placeholder option so the displayed and stored values agree, and adds client-side validation that blocks submission with a clear message when no country is selected.

* Prepend a `{ label: 'Select Country', value: '' }` placeholder option to the country field in `tax-location-form.tsx`, matching the Calypso checkout behavior.
* Guard `CreditCardSubmitButton` submission on an empty `country_code`, showing a "Please select a country." error notice instead of calling the payment processor.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1512" height="828" alt="Screenshot 2026-06-22 at 1 51 37 PM" src="https://github.com/user-attachments/assets/1be2c0ff-5b6d-4a33-9433-1f636672675b" /> | <img width="1512" height="831" alt="Screenshot 2026-06-22 at 2 02 38 PM" src="https://github.com/user-attachments/assets/09797b1d-9324-40a2-839c-59207036e5fd" />


## Why are these changes being made?

The Dashboard country selector built its `<option>` list directly from the country list with no leading empty option. A native `<select>` with no empty option auto-selects its first option, so the field *displayed* "Australia" even though the form's `country_code` defaulted to `''` (see `defaultTaxLocation`). The displayed value and the stored value disagreed.

When the form was submitted with the empty `country_code`, the invalid data was passed through to `POST https://api.stripe.com/v1/setup_intents/.../confirm`, which rejected it with a cryptic, non-user-friendly error. The Calypso counterpart (`client/me/purchases/add-payment-method`) avoids this by rendering a "Select Country" placeholder and validating the form before calling the payment processor.

This change mirrors that behavior: the placeholder makes the empty state explicit and visible, and the submit-time guard catches the empty selection client-side with an actionable message, so invalid data never reaches Stripe.

## Testing instructions

* Run the Dashboard locally (`yarn start-dashboard`) and open `/me/billing/payment-methods/add`.
* Confirm the Country dropdown shows "Select Country" by default rather than "Australia".
* Fill in valid card details but leave the country unselected, then click "Save card". Confirm submission is blocked and a "Please select a country." notice appears (no request is sent to Stripe).
* Select a country and complete the form. Confirm the card saves successfully.

