### PR TITLE
add reader onboarding dismissal option

### DIFF
--- a/client/reader/onboarding-rsm/constants.tsx
+++ b/client/reader/onboarding-rsm/constants.tsx
@@ -1,5 +1,6 @@
 export const READER_ONBOARDING_PREFERENCE_KEY = 'has_completed_reader_onboarding';
 export const READER_ONBOARDING_SEEN_PREFERENCE_KEY = 'has_seen_reader_onboarding';
+export const READER_ONBOARDING_DISMISSED_PREFERENCE_KEY = 'has_dismissed_reader_onboarding';
 export const READER_ONBOARDING_TRACKS_EVENT_PREFIX = 'calypso_reader_onboarding_';
 
 // Minimum followed counts that mark the interests/discover checklist tasks

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -503,7 +503,7 @@ const ReaderOnboardingRsm = ( {
 						<Button variant="tertiary" onClick={ handleDismissCancel }>
 							{ __( 'Cancel' ) }
 						</Button>
-						<Button variant="primary" onClick={ handleDismissConfirm }>
+						<Button variant="primary" isDestructive onClick={ handleDismissConfirm }>
 							{ __( 'Dismiss' ) }
 						</Button>
 					</DialogFooter>

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -7,16 +7,18 @@ import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronLeft } from '@wordpress/icons';
+import { chevronLeft, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
+import { ConfirmDialog, DialogContent, DialogFooter } from 'calypso/components/confirm-dialog';
 import { useSiteSubscriptions as useCachedSiteSubscriptions } from 'calypso/reader/data/site-subscriptions';
 import { useFollowedTags } from 'calypso/reader/data/tags';
 import {
 	READER_ONBOARDING_ELIGIBLE_REGISTRATION_DATE,
 	READER_ONBOARDING_MIN_FOLLOWED_SITES,
 	READER_ONBOARDING_MIN_FOLLOWED_TAGS,
+	READER_ONBOARDING_DISMISSED_PREFERENCE_KEY,
 	READER_ONBOARDING_SEEN_PREFERENCE_KEY,
 	READER_ONBOARDING_PREFERENCE_KEY,
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
@@ -107,6 +109,9 @@ const ReaderOnboardingRsm = ( {
 	const hasSeenOnboarding: boolean | null = useSelector( ( state ) =>
 		getPreference( state, READER_ONBOARDING_SEEN_PREFERENCE_KEY )
 	);
+	const hasDismissedOnboarding: boolean | null = useSelector( ( state ) =>
+		getPreference( state, READER_ONBOARDING_DISMISSED_PREFERENCE_KEY )
+	);
 
 	const hasFollowedTags = ( followedTags?.length ?? 0 ) >= READER_ONBOARDING_MIN_FOLLOWED_TAGS;
 	const hasFollowedSites = nonSelfSubscriptionsCount >= READER_ONBOARDING_MIN_FOLLOWED_SITES;
@@ -128,6 +133,7 @@ const ReaderOnboardingRsm = ( {
 	const [ currentStep, setCurrentStep ] = useState< Step | null >( null );
 	const [ hasFinished, setHasFinished ] = useState( false );
 	const [ hasFollowedInInterestsStep, setHasFollowedInInterestsStep ] = useState( false );
+	const [ isDismissConfirmOpen, setIsDismissConfirmOpen ] = useState( false );
 	const markFollowedInInterestsStep = () => setHasFollowedInInterestsStep( true );
 
 	// Stable blog map for the interests step — initialized lazily the first
@@ -202,7 +208,8 @@ const ReaderOnboardingRsm = ( {
 	const forceShow = ! hasFinished && startingForceShow === true;
 
 	const shouldShowOnboarding =
-		forceShow || isEnabled( 'reader/force-onboarding' ) || !! meetsEligibility;
+		isEnabled( 'reader/force-onboarding' ) ||
+		( ! hasDismissedOnboarding && ( forceShow || !! meetsEligibility ) );
 
 	const shouldRenderOnboarding = shouldShowOnboarding && ! isSuppressed;
 
@@ -335,6 +342,27 @@ const ReaderOnboardingRsm = ( {
 		task?.actionDispatch?.();
 	};
 
+	const handleDismissClick = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_click` );
+		setIsDismissConfirmOpen( true );
+	};
+
+	const handleDismissCancel = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_cancel` );
+		setIsDismissConfirmOpen( false );
+	};
+
+	const handleDismissConfirm = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_confirm` );
+		if ( currentStep ) {
+			recordStepClose( currentStep );
+			runStepSideEffects( currentStep );
+			setCurrentStep( null );
+		}
+		dispatch( savePreference( READER_ONBOARDING_DISMISSED_PREFERENCE_KEY, true ) );
+		setIsDismissConfirmOpen( false );
+	};
+
 	// Track if user viewed Reader Onboarding.
 	useEffect( () => {
 		if ( shouldRenderOnboarding ) {
@@ -425,6 +453,13 @@ const ReaderOnboardingRsm = ( {
 	return (
 		<>
 			<div className="reader-onboarding">
+				<Button
+					size="compact"
+					className="reader-onboarding__dismiss-button"
+					icon={ close }
+					label={ __( 'Dismiss onboarding checklist' ) }
+					onClick={ handleDismissClick }
+				/>
 				<div className="reader-onboarding__intro-column">
 					<CircularProgressBar
 						size={ 40 }
@@ -447,6 +482,30 @@ const ReaderOnboardingRsm = ( {
 					</Checklist>
 				</div>
 			</div>
+
+			{ isDismissConfirmOpen && (
+				<ConfirmDialog
+					onRequestClose={ handleDismissCancel }
+					title={ translate( 'Dismiss Reader onboarding?' ) }
+					className="reader-onboarding__dismiss-confirm-dialog"
+				>
+					<DialogContent>
+						<p>
+							{ translate(
+								'You will not be able to access the Reader onboarding flow again. Are you sure you want to dismiss it?'
+							) }
+						</p>
+					</DialogContent>
+					<DialogFooter>
+						<Button variant="tertiary" onClick={ handleDismissCancel }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button variant="primary" onClick={ handleDismissConfirm }>
+							{ __( 'Dismiss' ) }
+						</Button>
+					</DialogFooter>
+				</ConfirmDialog>
+			) }
 
 			{ currentStep && (
 				<Modal

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -456,21 +456,25 @@ const ReaderOnboardingRsm = ( {
 	return (
 		<>
 			<div className="reader-onboarding">
-				<Button
-					size="compact"
-					className="reader-onboarding__dismiss-button"
-					icon={ close }
-					label={ __( 'Dismiss onboarding checklist' ) }
-					onClick={ handleDismissClick }
-				/>
 				<div className="reader-onboarding__intro-column">
-					<CircularProgressBar
-						size={ 40 }
-						enableDesktopScaling
-						numberOfSteps={ tasks.length }
-						currentStep={ tasks.filter( ( task ) => task.completed ).length }
-					/>
-					<h2>{ translate( 'Your personal reading adventure' ) }</h2>
+					<div className="reader-onboarding__header">
+						<h2>{ translate( 'Your personal reading adventure' ) }</h2>
+						<div className="reader-onboarding__header-actions">
+							<CircularProgressBar
+								size={ 40 }
+								enableDesktopScaling
+								numberOfSteps={ tasks.length }
+								currentStep={ tasks.filter( ( task ) => task.completed ).length }
+							/>
+							<Button
+								size="compact"
+								className="reader-onboarding__dismiss-button"
+								icon={ close }
+								label={ __( 'Dismiss onboarding checklist' ) }
+								onClick={ handleDismissClick }
+							/>
+						</div>
+					</div>
 					<p>{ translate( 'Tailor your feed, connect with your favorite topics.' ) }</p>
 				</div>
 				<div className="reader-onboarding__steps-column">

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -122,19 +122,21 @@ const ReaderOnboardingRsm = ( {
 	//
 	// - `currentStep`: which onboarding modal body is mounted, or `null` when
 	//   the modal is closed.
-	// - `hasFinished`: latched on Finish in the discover step so `forceShow`
-	//   stays off for the rest of the session even before subscription
-	//   queries refresh.
+	// - `hasHiddenOnboardingThisSession`: latched when the user finishes the
+	//   discover step or permanently dismisses the checklist so onboarding
+	//   stays hidden for the rest of the browser session — including under
+	//   `reader/force-onboarding` and before subscription queries refresh.
 	// - `hasFollowedInInterestsStep`: tracks any subscribe action (tag follow
 	//   or pack subscribe) inside the interests step. Owned here so it
 	//   persists across remounts of `InterestsModal` — without that, a user
 	//   could subscribe to a tagless pack, advance to discover, click Back,
 	//   and find the relaxed Continue gate forgotten on the fresh modal.
 	const [ currentStep, setCurrentStep ] = useState< Step | null >( null );
-	const [ hasFinished, setHasFinished ] = useState( false );
+	const [ hasHiddenOnboardingThisSession, setHasHiddenOnboardingThisSession ] = useState( false );
 	const [ hasFollowedInInterestsStep, setHasFollowedInInterestsStep ] = useState( false );
 	const [ isDismissConfirmOpen, setIsDismissConfirmOpen ] = useState( false );
 	const markFollowedInInterestsStep = () => setHasFollowedInInterestsStep( true );
+	const hideOnboardingThisSession = () => setHasHiddenOnboardingThisSession( true );
 
 	// Stable blog map for the interests step — initialized lazily the first
 	// time the onboarding modal is actually shown, so the random blog selection
@@ -205,10 +207,10 @@ const ReaderOnboardingRsm = ( {
 		setStartingForceShow( ! hasNonSelfSubscriptions );
 	}, [ startingForceShow, subscriptionsLoading, hasNonSelfSubscriptions ] );
 
-	const forceShow = ! hasFinished && startingForceShow === true;
+	const forceShow = ! hasHiddenOnboardingThisSession && startingForceShow === true;
 
 	const shouldShowOnboarding =
-		isEnabled( 'reader/force-onboarding' ) ||
+		( isEnabled( 'reader/force-onboarding' ) && ! hasHiddenOnboardingThisSession ) ||
 		( ! hasDismissedOnboarding && ( forceShow || !! meetsEligibility ) );
 
 	const shouldRenderOnboarding = shouldShowOnboarding && ! isSuppressed;
@@ -332,7 +334,7 @@ const ReaderOnboardingRsm = ( {
 		recordOnboardingCompleted();
 		runStepSideEffects( 'discover' );
 		setCurrentStep( null );
-		setHasFinished( true );
+		hideOnboardingThisSession();
 	};
 
 	const itemClickHandler = ( task: Task ) => {
@@ -361,6 +363,7 @@ const ReaderOnboardingRsm = ( {
 		}
 		dispatch( savePreference( READER_ONBOARDING_DISMISSED_PREFERENCE_KEY, true ) );
 		setIsDismissConfirmOpen( false );
+		hideOnboardingThisSession();
 	};
 
 	// Track if user viewed Reader Onboarding.

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -6,7 +6,6 @@ import { SubscriptionManager } from '@automattic/data-stores';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { chevronLeft, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
@@ -438,7 +437,7 @@ const ReaderOnboardingRsm = ( {
 				className="reader-onboarding-modal__back-button"
 				onClick={ handleInterestsBack }
 				icon={ chevronLeft }
-				label={ __( 'Back' ) }
+				label={ translate( 'Back' ) }
 			/>
 		);
 	} else if ( currentStep === 'discover' ) {
@@ -448,7 +447,7 @@ const ReaderOnboardingRsm = ( {
 				className="reader-onboarding-modal__back-button"
 				onClick={ handleDiscoverBack }
 				icon={ chevronLeft }
-				label={ __( 'Back' ) }
+				label={ translate( 'Back' ) }
 			/>
 		);
 	}
@@ -470,7 +469,7 @@ const ReaderOnboardingRsm = ( {
 								size="compact"
 								className="reader-onboarding__dismiss-button"
 								icon={ close }
-								label={ __( 'Dismiss onboarding checklist' ) }
+								label={ translate( 'Dismiss onboarding checklist' ) }
 								onClick={ handleDismissClick }
 							/>
 						</div>
@@ -505,10 +504,10 @@ const ReaderOnboardingRsm = ( {
 					</DialogContent>
 					<DialogFooter>
 						<Button variant="tertiary" onClick={ handleDismissCancel }>
-							{ __( 'Cancel' ) }
+							{ translate( 'Cancel' ) }
 						</Button>
 						<Button variant="primary" isDestructive onClick={ handleDismissConfirm }>
-							{ __( 'Dismiss' ) }
+							{ translate( 'Dismiss' ) }
 						</Button>
 					</DialogFooter>
 				</ConfirmDialog>

--- a/client/reader/onboarding-rsm/style.scss
+++ b/client/reader/onboarding-rsm/style.scss
@@ -1,9 +1,16 @@
 .reader-onboarding {
+	position: relative;
 	background-color: var( --color-surface-1 );
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
 	box-shadow: rgba( 0, 0, 0, 0.05 ) 0 0 0 1px inset;
 	margin-bottom: 24px;
 	padding: 20px 20px 5px 20px;
+
+	&__dismiss-button {
+		position: absolute;
+		top: 12px;
+		inset-inline-end: 12px;
+	}
 
 	h2 {
 		font-weight: 600;

--- a/client/reader/onboarding-rsm/style.scss
+++ b/client/reader/onboarding-rsm/style.scss
@@ -1,25 +1,37 @@
 .reader-onboarding {
-	position: relative;
 	background-color: var( --color-surface-1 );
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
 	box-shadow: rgba( 0, 0, 0, 0.05 ) 0 0 0 1px inset;
 	margin-bottom: 24px;
 	padding: 20px 20px 5px 20px;
 
+	&__header {
+		display: flex;
+		align-items: center;
+	}
+
+	&__header h2 {
+		flex: 1;
+	}
+
+	&__header-actions {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 20px;
+		flex-shrink: 0;
+	}
+
 	&__dismiss-button {
-		position: absolute;
-		top: 12px;
-		inset-inline-end: 12px;
+		align-items: center;
+		display: flex;
+		padding: 0;
+		height: 24px;
 	}
 
 	h2 {
 		font-weight: 600;
 		clear: initial;
-	}
-
-	.circular__progress-bar {
-		float: right;
-		margin: 5px 5px 5px 10px;
 	}
 }
 

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -143,7 +143,7 @@ jest.mock( 'calypso/state/preferences/selectors', () => ( {
 } ) );
 
 jest.mock( 'calypso/state/preferences/actions', () => ( {
-	savePreference: jest.fn( () => ( { type: 'PREFERENCES_SAVE' } ) ),
+	savePreference: jest.fn( () => () => Promise.resolve() ),
 } ) );
 
 jest.mock( 'calypso/state/current-user/selectors', () => ( {
@@ -1229,7 +1229,7 @@ describe( 'ReaderOnboardingRsm – permanent checklist dismiss', () => {
 					prefKey === READER_ONBOARDING_DISMISSED_PREFERENCE_KEY ? value : null
 				);
 			}
-			return { type: 'PREFERENCES_SAVE' };
+			return () => Promise.resolve();
 		} );
 
 		const onRender = jest.fn();

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -3,12 +3,14 @@
  */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {
+	READER_ONBOARDING_DISMISSED_PREFERENCE_KEY,
 	READER_ONBOARDING_ELIGIBLE_REGISTRATION_DATE,
 	READER_ONBOARDING_PREFERENCE_KEY,
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
@@ -185,12 +187,28 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
 
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn();
+	const isEnabledMock = jest.fn( () => false );
+	return {
+		__esModule: true,
+		default: Object.assign( config, { isEnabled: isEnabledMock } ),
+		isEnabled: isEnabledMock,
+	};
+} );
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 beforeEach( () => {
 	mockRefreshFollowingStreams.mockClear();
 	jest.mocked( savePreference ).mockClear();
 	jest.mocked( recordTracksEvent ).mockClear();
+	jest.mocked( isEnabled ).mockReturnValue( false );
+
+	const { getPreference } = jest.requireMock( 'calypso/state/preferences/selectors' ) as {
+		getPreference: jest.Mock;
+	};
+	getPreference.mockReturnValue( null );
 
 	const { useFollowedTags } = jest.requireMock( 'calypso/reader/data/tags' ) as {
 		useFollowedTags: jest.Mock;
@@ -1096,5 +1114,179 @@ describe( 'ReaderOnboardingRsm – interests-step "has followed" state lifted to
 			'data-disabled',
 			'true'
 		);
+	} );
+} );
+
+describe( 'ReaderOnboardingRsm – permanent checklist dismiss', () => {
+	const getPreferenceMock = () => {
+		const { getPreference } = jest.requireMock( 'calypso/state/preferences/selectors' ) as {
+			getPreference: jest.Mock;
+		};
+		return getPreference;
+	};
+
+	const overrideMocks = ( {
+		nonSelfSubscriptionsCount = 0,
+		tags = { data: [] as Array< { slug: string } >, isPending: false },
+		hasDismissedOnboarding = false,
+	}: {
+		nonSelfSubscriptionsCount?: number;
+		tags?: { data?: Array< { slug: string } >; isPending?: boolean };
+		hasDismissedOnboarding?: boolean;
+	} = {} ) => {
+		const { useFollowedTags } = jest.requireMock( 'calypso/reader/data/tags' ) as {
+			useFollowedTags: jest.Mock;
+		};
+		const { useSiteSubscriptions } = jest.requireMock(
+			'../../following/use-site-subscriptions'
+		) as { useSiteSubscriptions: jest.Mock };
+
+		useFollowedTags.mockImplementation( () => ( {
+			data: tags.data ?? [],
+			isPending: tags.isPending ?? false,
+		} ) );
+		useSiteSubscriptions.mockImplementation( () => ( {
+			isLoading: false,
+			hasNonSelfSubscriptions: nonSelfSubscriptionsCount > 0,
+			nonSelfSubscriptionsCount,
+		} ) );
+		getPreferenceMock().mockImplementation( ( _state: unknown, key: string ) => {
+			if ( key === READER_ONBOARDING_DISMISSED_PREFERENCE_KEY ) {
+				return hasDismissedOnboarding;
+			}
+			return null;
+		} );
+	};
+
+	it( 'renders the dismiss button when onboarding is visible', async () => {
+		overrideMocks();
+
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		expect(
+			await screen.findByRole( 'button', { name: 'Dismiss onboarding checklist' } )
+		).toBeVisible();
+	} );
+
+	it( 'opens the confirm modal and records dismiss_click when the dismiss button is clicked', async () => {
+		overrideMocks();
+		const user = userEvent.setup();
+
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await user.click(
+			await screen.findByRole( 'button', { name: 'Dismiss onboarding checklist' } )
+		);
+
+		expect(
+			screen.getByText(
+				'You will not be able to access the Reader onboarding flow again. Are you sure you want to dismiss it?'
+			)
+		).toBeVisible();
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_click`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_confirm`
+		);
+	} );
+
+	it( 'closes the confirm modal on cancel without saving and records dismiss_cancel', async () => {
+		overrideMocks();
+		const user = userEvent.setup();
+
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await user.click(
+			await screen.findByRole( 'button', { name: 'Dismiss onboarding checklist' } )
+		);
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect(
+			screen.queryByText(
+				'You will not be able to access the Reader onboarding flow again. Are you sure you want to dismiss it?'
+			)
+		).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Dismiss onboarding checklist' } ) ).toBeVisible();
+		expect( savePreference ).not.toHaveBeenCalledWith(
+			READER_ONBOARDING_DISMISSED_PREFERENCE_KEY,
+			true
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_cancel`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_confirm`
+		);
+	} );
+
+	it( 'permanently dismisses onboarding on confirm, closes open step modals, and records dismiss_confirm', async () => {
+		overrideMocks();
+		const getPreference = getPreferenceMock();
+		jest.mocked( savePreference ).mockImplementation( ( key, value ) => {
+			if ( key === READER_ONBOARDING_DISMISSED_PREFERENCE_KEY ) {
+				getPreference.mockImplementation( ( _state: unknown, prefKey: string ) =>
+					prefKey === READER_ONBOARDING_DISMISSED_PREFERENCE_KEY ? value : null
+				);
+			}
+			return { type: 'PREFERENCES_SAVE' };
+		} );
+
+		const onRender = jest.fn();
+		const user = userEvent.setup();
+		const { rerender } = renderWithProvider( <ReaderOnboardingRsm onRender={ onRender } /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Dismiss onboarding checklist' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
+
+		expect( savePreference ).toHaveBeenCalledWith(
+			READER_ONBOARDING_DISMISSED_PREFERENCE_KEY,
+			true
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }checklist_dismiss_confirm`
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_close`
+		);
+		expect( screen.queryByTestId( 'welcome-modal-content' ) ).not.toBeInTheDocument();
+
+		rerender( <ReaderOnboardingRsm onRender={ onRender } /> );
+
+		await waitFor( () => {
+			expect( onRender ).toHaveBeenLastCalledWith( false );
+		} );
+		expect(
+			screen.queryByRole( 'button', { name: 'Dismiss onboarding checklist' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render onboarding when the dismissed preference is set, even if otherwise eligible', async () => {
+		overrideMocks( { hasDismissedOnboarding: true } );
+		const onRender = jest.fn();
+
+		renderWithProvider( <ReaderOnboardingRsm onRender={ onRender } /> );
+
+		await waitFor( () => {
+			expect( onRender ).toHaveBeenCalled();
+		} );
+		expect( onRender ).toHaveBeenLastCalledWith( false );
+		expect( screen.queryByTestId( 'welcome-modal-content' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Dismiss onboarding checklist' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'still renders onboarding when reader/force-onboarding is enabled even if dismissed', async () => {
+		overrideMocks( { hasDismissedOnboarding: true } );
+		jest
+			.mocked( isEnabled )
+			.mockImplementation( ( flag: string ) => flag === 'reader/force-onboarding' );
+
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		expect( await screen.findByTestId( 'welcome-modal-content' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Dismiss onboarding checklist' } ) ).toBeVisible();
 	} );
 } );

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -985,7 +985,7 @@ describe( 'ReaderOnboardingRsm – forceShow snapshot', () => {
 		expect( screen.getByTestId( 'welcome-modal-content' ) ).toBeVisible();
 	} );
 
-	it( 'disables forceShow after the user clicks Finish on the subscribe step', async () => {
+	it( 'hides onboarding for the session after the user clicks Finish on the subscribe step', async () => {
 		seedAboveEligibilityThresholds();
 		const useSiteSubscriptions = getUseSiteSubscriptionsMock();
 		useSiteSubscriptions.mockImplementation( () => ( {
@@ -1019,8 +1019,8 @@ describe( 'ReaderOnboardingRsm – forceShow snapshot', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
 
-		// Modal is closed, and forceShow is now off — onRender should report false
-		// even though hasNonSelfSubscriptions is still false.
+		// Modal is closed, and the session hide latch is set — onRender should
+		// report false even though hasNonSelfSubscriptions is still false.
 		await waitFor( () => {
 			expect( onRender ).toHaveBeenLastCalledWith( false );
 		} );
@@ -1278,7 +1278,7 @@ describe( 'ReaderOnboardingRsm – permanent checklist dismiss', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'still renders onboarding when reader/force-onboarding is enabled even if dismissed', async () => {
+	it( 'still renders onboarding when reader/force-onboarding is enabled even if permanently dismissed', async () => {
 		overrideMocks( { hasDismissedOnboarding: true } );
 		jest
 			.mocked( isEnabled )
@@ -1288,5 +1288,28 @@ describe( 'ReaderOnboardingRsm – permanent checklist dismiss', () => {
 
 		expect( await screen.findByTestId( 'welcome-modal-content' ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Dismiss onboarding checklist' } ) ).toBeVisible();
+	} );
+
+	it( 'hides onboarding for the session when dismissed under reader/force-onboarding', async () => {
+		overrideMocks( { hasDismissedOnboarding: true } );
+		jest
+			.mocked( isEnabled )
+			.mockImplementation( ( flag: string ) => flag === 'reader/force-onboarding' );
+
+		const onRender = jest.fn();
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm onRender={ onRender } /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Dismiss onboarding checklist' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
+
+		await waitFor( () => {
+			expect( onRender ).toHaveBeenLastCalledWith( false );
+		} );
+		expect( screen.queryByTestId( 'welcome-modal-content' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Dismiss onboarding checklist' } )
+		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # https://linear.app/a8c/issue/READ-566/reader-onboarding-make-checklist-permanently-dismissable

## Proposed Changes

* Add a permanent Dismiss control (an X button) to the Reader onboarding (RSM) checklist card, grouped with the progress counter in the card header.
* Clicking the X opens a confirmation dialog warning that the action is permanent; confirming saves a new `has_dismissed_reader_onboarding` user preference so the checklist stays hidden on future visits.
* The `reader/force-onboarding` dev flag still overrides the permanent dismiss so the flow remains testable. Dismissing (or finishing) under that flag hides the checklist for the rest of the browser session (until refresh) via a session-only latch.
* Add Tracks events: `calypso_reader_onboarding_checklist_dismiss_click`, `…_dismiss_cancel`, `…_dismiss_confirm`.
* Update checklist header layout so the dismiss X and the progress counter no longer overlap (matches the Customer Home launchpad flex-header pattern).

<img width="760" height="308" alt="Screenshot 2026-06-23 at 11 36 07 AM" src="https://github.com/user-attachments/assets/c47150b6-ce1d-40e3-a14a-d06fce64d645" />
<img width="637" height="281" alt="Screenshot 2026-06-23 at 11 36 11 AM" src="https://github.com/user-attachments/assets/54fcf221-69ac-4692-8cf3-1a79824175ca" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Reader onboarding checklist had no way to permanently remove it... (the new `has_dismissed_reader_onboarding` preference is intentionally separate from `has_completed_reader_onboarding`).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the reader onboarding dismissal in various states.
* New user / hasnt completed onboarding - dismiss from the checklist, reload and verify it doesn't show.
* New user + completed onboarding  + hasn't dismissed - remove your tag follows to <3 or non-self site follows <4 and reload, onboarding should appear, dismiss the onboarding. Reload it should not reappear.
* Legacy user / flag test (onboarding completed, dismissed or not) - add the `?flags=reader/force-onboarding` to see the checklist again. Dismiss the onboarding and it should be gone from the session. Reload with the flag, it should re-appear.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
