### PR TITLE
Add editor support and AI chat entry points

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -40,13 +40,72 @@ jest.mock( '@wordpress/data', () => ( {
 	} ),
 	useSelect: () => mockAgentsManagerState,
 } ) );
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		className,
+		id,
+		label,
+		onClick,
+		'data-agents-manager-react-handler': reactHandler,
+	}: {
+		className?: string;
+		id?: string;
+		label?: string;
+		onClick?: () => void;
+		'data-agents-manager-react-handler'?: string;
+	} ) => (
+		<button
+			className={ className }
+			data-agents-manager-react-handler={ reactHandler }
+			id={ id }
+			onClick={ onClick }
+		>
+			{ label }
+		</button>
+	),
+	DropdownMenu: ( {
+		controls = [],
+		label,
+		onToggle,
+		toggleProps,
+	}: {
+		controls?:
+			| { title?: string; onClick?: () => void }[]
+			| { title?: string; onClick?: () => void }[][];
+		label?: string;
+		onToggle?: () => void;
+		toggleProps?: { id?: string };
+	} ) => {
+		const flattenedControls = controls.flat();
+		return (
+			<div data-testid="editor-help-entry">
+				<button id={ toggleProps?.id } onClick={ onToggle }>
+					{ label }
+				</button>
+				{ flattenedControls.map( ( control ) =>
+					control.title ? (
+						<button key={ control.title } onClick={ control.onClick }>
+							{ control.title }
+						</button>
+					) : null
+				) }
+			</div>
+		);
+	},
+	Fill: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
 jest.mock( '@wordpress/icons', () => ( {
+	backup: 'backup',
 	columns: 'columns',
 	comment: 'comment',
 	drawerRight: 'drawerRight',
+	help: 'help',
 	lineSolid: 'lineSolid',
 	login: 'login',
+	page: 'page',
+	rss: 'rss',
+	video: 'video',
 } ) );
 jest.mock( '../../contexts', () => ( {
 	useAgentsManagerContext: () => mockContext,
@@ -57,6 +116,8 @@ jest.mock( '../../utils/tracks', () => ( {
 } ) );
 jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
 	__esModule: true,
+	AI_CHAT_ENTRY_BUTTON_ID: 'wp-admin-bar-agents-manager-ai-chat',
+	EDITOR_HELP_ENTRY_BUTTON_ID: 'agents-manager-editor-help',
 	default: () => mockHasAdminBar,
 } ) );
 jest.mock( '../../hooks/use-agent-layout-manager', () => ( options: unknown ) => {
@@ -71,6 +132,7 @@ jest.mock( '../../hooks/use-agent-layout-manager', () => ( options: unknown ) =>
 		createAgentPortal: ( children: React.ReactNode ) => children,
 	};
 } );
+jest.mock( '../icons', () => ( { AI: () => null } ) );
 jest.mock( '../../hooks/custom-actions', () => ( {
 	useSetupCustomActions: () => {},
 } ) );
@@ -160,6 +222,18 @@ function useWpAdminAgent() {
 		sectionName: 'wp-admin',
 		agentConfig: {
 			agentId: 'wp-orchestrator',
+		},
+		getActiveSessionId: () => 'session-123',
+		resumeActiveChat: mockResumeActiveChat,
+	} as unknown as Partial< AgentsManagerContextType >;
+}
+
+function useDollySiteEditorAgent() {
+	mockContext = {
+		siteKey: 'site-1',
+		sectionName: 'site-editor',
+		agentConfig: {
+			agentId: 'dolly',
 		},
 		getActiveSessionId: () => 'session-123',
 		resumeActiveChat: mockResumeActiveChat,
@@ -268,6 +342,39 @@ describe( 'AgentDock', () => {
 
 		expect( mockResumeActiveChat ).not.toHaveBeenCalled();
 		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/support-guides' );
+	} );
+
+	it( 'keeps support guides available for Dolly site-editor opt-in', () => {
+		useDollySiteEditorAgent();
+
+		renderAgentDock( '/support-guides' );
+
+		expect( screen.getByTestId( 'support-guides' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/support-guides' );
+	} );
+
+	it( 'renders the editor Help entry point for Dolly site-editor opt-in', () => {
+		useDollySiteEditorAgent();
+		mockAgentsManagerState = { isOpen: false, isDocked: false };
+
+		renderAgentDock();
+		fireEvent.click( screen.getByText( 'Support guides' ) );
+
+		expect( screen.getByText( 'Help' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/support-guides' );
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( true, true );
+	} );
+
+	it( 'renders an editor AI chat entry point for Dolly site-editor opt-in', () => {
+		useDollySiteEditorAgent();
+		mockAgentsManagerState = { isOpen: false, isDocked: false };
+
+		renderAgentDock();
+		fireEvent.click( screen.getByText( 'Ask AI' ) );
+
+		expect( document.getElementById( 'wp-admin-bar-agents-manager-ai-chat' ) ).toBeInTheDocument();
+		expect( mockResumeActiveChat ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( true, true );
 	} );
 
 	it( 'hides the support guides list without the WP admin bar trigger', () => {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -22,6 +22,7 @@ import { persistLastActivity } from '../../utils/persist-last-activity';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
+import EditorHelpCenterEntryPoint from '../editor-help-center-entry-point';
 import OrchestratorChat from '../orchestrator-chat';
 import SupportGuide from '../support-guide';
 import SupportGuides from '../support-guides';
@@ -77,7 +78,8 @@ export default function AgentDock( {
 	useCheckpoint,
 	capabilities,
 }: Props ) {
-	const { siteKey, agentConfig } = useAgentsManagerContext();
+	const { siteKey, agentConfig, sectionName, currentRoute, resumeActiveChat } =
+		useAgentsManagerContext();
 
 	const [ isCompactMode, setIsCompactMode ] = useState(
 		window.__agentsManagerActions?.isCompactMode ?? false
@@ -111,6 +113,16 @@ export default function AgentDock( {
 	// detect it to hide docking options and skip persisting open/close state to
 	// the logged-in REST endpoint.
 	const isReaderChat = isReaderChatAgent( agentId );
+	const isEditorContext =
+		sectionName === 'gutenberg' ||
+		sectionName === 'site-editor' ||
+		!! currentRoute?.includes( 'site-editor.php' ) ||
+		!! currentRoute?.includes( 'post.php' ) ||
+		!! currentRoute?.includes( 'post-new.php' ) ||
+		document.body?.classList.contains( 'site-editor-php' ) ||
+		document.body?.classList.contains( 'post-php' ) ||
+		document.body?.classList.contains( 'post-new-php' );
+	const showEditorHelpEntry = ! isReaderChat && isEditorContext;
 
 	const setOpenState = useCallback(
 		( isOpen: boolean ) => setIsOpen( isOpen, ! isReaderChat ),
@@ -152,33 +164,38 @@ export default function AgentDock( {
 		}
 	};
 
-	// WP admin bar integration. Returns whether the AI chat entry button is present.
-	const hasAiChatEntry = useAdminBarIntegration( {
+	const openChatPanel = useCallback( () => {
+		if ( isMinimized ) {
+			setIsMinimized( false );
+		}
+		// Skip a redundant save when the chat is already open.
+		if ( ! isPersistedOpen ) {
+			if ( isDocked ) {
+				openSidebar();
+			} else {
+				setOpenState( true );
+			}
+		}
+	}, [ isDocked, isMinimized, isPersistedOpen, openSidebar, setIsMinimized, setOpenState ] );
+
+	// WP admin bar integration. Returns whether an external entry point is present.
+	const hasAdminBarEntry = useAdminBarIntegration( {
 		closeChat: handleClose,
 		// Open/un-minimize the chat panel, leaving the route unchanged.
-		maybeOpenChat: () => {
-			if ( isMinimized ) {
-				setIsMinimized( false );
-			}
-			// Skip a redundant save when the chat is already open.
-			if ( ! isPersistedOpen ) {
-				if ( isDocked ) {
-					openSidebar();
-				} else {
-					setOpenState( true );
-				}
-			}
-		},
+		maybeOpenChat: openChatPanel,
 	} );
+	const hasAgentsManagerEntry = hasAdminBarEntry || showEditorHelpEntry;
 
 	// Route visibility. All are hidden in reader chat (public blog frontends);
 	// some add a further requirement, noted below. Ordered to match the routes.
 	//
 	// `/zendesk` also needs the unified agent or using Woo AI.
 	const showZendeskChat = shouldUseUnifiedAgent && ! isReaderChat;
-	// `/support-guides` (the list) also needs the unified agent, and is only
-	// reachable from the AI chat entry button (WP admin bar or Calypso masterbar).
-	const showSupportGuides = shouldUseUnifiedAgent && ! isReaderChat && hasAiChatEntry;
+	// `/support-guides` (the list) is reached from the Help menu. Host-level
+	// opt-ins, such as Dolly in the editor, can expose that menu without turning
+	// on the full unified Help Center experience for every screen.
+	const showSupportGuides =
+		! isReaderChat && ( showEditorHelpEntry || ( shouldUseUnifiedAgent && hasAdminBarEntry ) );
 	// `/post` (the viewer) opens a guide or link from in-chat links and sources,
 	// so unlike the list it isn't tied to the admin bar.
 	const showSupportGuide = ! isReaderChat;
@@ -296,10 +313,10 @@ export default function AgentDock( {
 
 	const chatHeaderOptions = getChatHeaderOptions();
 
-	// With the AI chat entry button, the chat hides on close and can minimize to
-	// the bar. Without one, it stays mounted and collapses to a button instead.
-	const isChatVisible = isPersistedOpen || ! hasAiChatEntry;
-	const isMinimizedActive = hasAiChatEntry && isMinimized;
+	// With an external entry point, the chat can hide on close and reopen from it.
+	// Without one, it stays mounted and collapses to a button instead.
+	const isChatVisible = isPersistedOpen || ! hasAgentsManagerEntry;
+	const isMinimizedActive = hasAgentsManagerEntry && isMinimized;
 	const chatIsOpen = isPersistedOpen && ! isMinimizedActive;
 
 	const OrchestratorChatRoute = (
@@ -371,18 +388,35 @@ export default function AgentDock( {
 	);
 
 	return (
-		shouldRenderChat &&
-		isChatVisible &&
-		createAgentPortal(
-			// NOTE: Use route state to pass data that needs to be accessed throughout the app.
-			<Routes>
-				<Route path="/chat" element={ OrchestratorChatRoute } />
-				{ showZendeskChat && <Route path="/zendesk" element={ ZendeskChatRoute } /> }
-				{ showSupportGuides && <Route path="/support-guides" element={ SupportGuidesRoute } /> }
-				{ showSupportGuide && <Route path="/post" element={ SupportGuideRoute } /> }
-				{ showChatHistory && <Route path="/history" element={ HistoryRoute } /> }
-				<Route path="*" element={ <Navigate to="/chat" state={ { isNewChat: true } } replace /> } />
-			</Routes>
+		shouldRenderChat && (
+			<>
+				{ showEditorHelpEntry && (
+					<EditorHelpCenterEntryPoint
+						isChatVisible={ chatIsOpen }
+						onOpen={ openChatPanel }
+						onClose={ handleClose }
+						onResumeChat={ resumeActiveChat }
+						sectionName={ sectionName }
+					/>
+				) }
+				{ isChatVisible &&
+					createAgentPortal(
+						// NOTE: Use route state to pass data that needs to be accessed throughout the app.
+						<Routes>
+							<Route path="/chat" element={ OrchestratorChatRoute } />
+							{ showZendeskChat && <Route path="/zendesk" element={ ZendeskChatRoute } /> }
+							{ showSupportGuides && (
+								<Route path="/support-guides" element={ SupportGuidesRoute } />
+							) }
+							{ showSupportGuide && <Route path="/post" element={ SupportGuideRoute } /> }
+							{ showChatHistory && <Route path="/history" element={ HistoryRoute } /> }
+							<Route
+								path="*"
+								element={ <Navigate to="/chat" state={ { isNewChat: true } } replace /> }
+							/>
+						</Routes>
+					) }
+			</>
 		)
 	);
 }

--- a/packages/agents-manager/src/components/editor-help-center-entry-point/index.tsx
+++ b/packages/agents-manager/src/components/editor-help-center-entry-point/index.tsx
@@ -1,0 +1,166 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button, Fill, DropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { backup, comment, help, page, rss, video } from '@wordpress/icons';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+	AI_CHAT_ENTRY_BUTTON_ID,
+	EDITOR_HELP_ENTRY_BUTTON_ID,
+} from '../../hooks/use-admin-bar-integration';
+import { AI } from '../icons';
+import type { ComponentProps } from 'react';
+
+type DropdownControls = ComponentProps< typeof DropdownMenu >[ 'controls' ];
+
+interface Props {
+	/** Whether the current chat route is expanded and visible. */
+	isChatVisible: boolean;
+	/** Opens or expands the chat without changing the current route. */
+	onOpen: () => void;
+	/** Closes the chat panel. */
+	onClose: () => void;
+	/** Resumes the active chat session and routes to `/chat`. */
+	onResumeChat: () => void;
+	/** Current section name for Tracks events. */
+	sectionName?: string;
+}
+
+export default function EditorHelpCenterEntryPoint( {
+	isChatVisible,
+	onOpen,
+	onClose,
+	onResumeChat,
+	sectionName,
+}: Props ) {
+	const navigate = useNavigate();
+	const { pathname } = useLocation();
+	const eventSection = sectionName || 'gutenberg-editor';
+
+	const handleAiChatClick = () => {
+		recordTracksEvent( 'calypso_admin_bar_agents_manager_ai_chat_clicked', {
+			section: eventSection,
+			action: isChatVisible ? 'close' : 'open',
+		} );
+
+		if ( isChatVisible ) {
+			onClose();
+			return;
+		}
+
+		onResumeChat();
+		onOpen();
+	};
+
+	const trackIconInteraction = () => {
+		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
+			is_help_center_visible: isChatVisible,
+			section: eventSection,
+			is_menu_panel_enabled: true,
+			is_assignment_loaded: true,
+		} );
+	};
+
+	const handleRouteClick = ( route: string, destination: string, onRoute?: () => void ) => {
+		const isClosing = isChatVisible && pathname === route;
+		recordTracksEvent( 'calypso_dashboard_help_center_menu_panel_click', {
+			section: eventSection,
+			destination,
+			action: isClosing ? 'close' : 'open',
+		} );
+
+		if ( isClosing ) {
+			recordTracksEvent( 'calypso_inlinehelp_close', {
+				force_site_id: true,
+				location: 'help-center',
+				section: eventSection,
+			} );
+			onClose();
+			return;
+		}
+
+		onRoute?.();
+		onOpen();
+		recordTracksEvent( 'calypso_inlinehelp_show', {
+			force_site_id: true,
+			location: 'help-center',
+			section: eventSection,
+			destination,
+		} );
+	};
+
+	const handleExternalClick = ( destination: string ) => {
+		recordTracksEvent( 'calypso_dashboard_help_center_menu_panel_click', {
+			section: eventSection,
+			destination,
+			action: 'open',
+		} );
+		window.open( destination, '_blank', 'noopener,noreferrer' );
+	};
+
+	const menuControls: DropdownControls = [
+		[
+			{
+				title: __( 'Chat support', '__i18n_text_domain__' ),
+				icon: comment,
+				onClick: () => handleRouteClick( '/chat', 'agents-manager-chat', onResumeChat ),
+			},
+			{
+				title: __( 'Chat history', '__i18n_text_domain__' ),
+				icon: backup,
+				onClick: () =>
+					handleRouteClick( '/history', 'agents-manager-history', () => navigate( '/history' ) ),
+			},
+		],
+		[
+			{
+				title: __( 'Support guides', '__i18n_text_domain__' ),
+				icon: page,
+				onClick: () =>
+					handleRouteClick( '/support-guides', 'agents-manager-support-guides', () =>
+						navigate( '/support-guides' )
+					),
+			},
+			{
+				title: __( 'Courses', '__i18n_text_domain__' ),
+				icon: video,
+				onClick: () =>
+					handleExternalClick( localizeUrl( 'https://wordpress.com/support/courses/' ) ),
+			},
+			{
+				title: __( 'Product updates', '__i18n_text_domain__' ),
+				icon: rss,
+				onClick: () =>
+					handleExternalClick(
+						localizeUrl( 'https://wordpress.com/blog/category/product-features/' )
+					),
+			},
+		],
+	];
+
+	return (
+		<Fill name="PinnedItems/core">
+			<DropdownMenu
+				className="agents-manager-editor-help-center"
+				controls={ menuControls }
+				icon={ help }
+				label={ __( 'Help', '__i18n_text_domain__' ) }
+				onToggle={ trackIconInteraction }
+				popoverProps={ { position: 'bottom left' } }
+				toggleProps={ {
+					id: EDITOR_HELP_ENTRY_BUTTON_ID,
+					size: 'compact',
+				} }
+			/>
+			<Button
+				className="agents-manager-editor-ai-chat"
+				data-agents-manager-react-handler="true"
+				id={ AI_CHAT_ENTRY_BUTTON_ID }
+				icon={ <AI /> }
+				label={ __( 'Ask AI', '__i18n_text_domain__' ) }
+				onClick={ handleAiChatClick }
+				size="compact"
+			/>
+		</Fill>
+	);
+}

--- a/packages/agents-manager/src/hooks/__tests__/use-admin-bar-integration.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-admin-bar-integration.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
+
+import {
+	AI_CHAT_ENTRY_BUTTON_ID,
+	EDITOR_HELP_ENTRY_BUTTON_ID,
+	hasAgentsManagerEntryPoint,
+	hasAgentsManagerHelpMenu,
+	hasAiChatEntryButton,
+} from '../use-admin-bar-integration';
+
+function appendElement( options: { id?: string; className?: string } ) {
+	const element = document.createElement( 'div' );
+	if ( options.id ) {
+		element.id = options.id;
+	}
+	if ( options.className ) {
+		element.className = options.className;
+	}
+	document.body.appendChild( element );
+	return element;
+}
+
+describe( 'use-admin-bar-integration entry detection', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'detects the wp-admin AI chat button as an AI chat entry', () => {
+		appendElement( { id: AI_CHAT_ENTRY_BUTTON_ID } );
+
+		expect( hasAiChatEntryButton() ).toBe( true );
+		expect( hasAgentsManagerEntryPoint() ).toBe( true );
+	} );
+
+	it( 'detects the Calypso masterbar AI chat button as an AI chat entry', () => {
+		appendElement( { className: 'masterbar__item-agents-manager-ai-chat' } );
+
+		expect( hasAiChatEntryButton() ).toBe( true );
+		expect( hasAgentsManagerEntryPoint() ).toBe( true );
+	} );
+
+	it( 'detects the Help menu as an Agents Manager entry point', () => {
+		appendElement( { id: 'wp-admin-bar-agents-manager' } );
+
+		expect( hasAgentsManagerHelpMenu() ).toBe( true );
+		expect( hasAiChatEntryButton() ).toBe( false );
+		expect( hasAgentsManagerEntryPoint() ).toBe( true );
+	} );
+
+	it( 'detects the editor Help button as an Agents Manager entry point', () => {
+		appendElement( { id: EDITOR_HELP_ENTRY_BUTTON_ID } );
+
+		expect( hasAgentsManagerHelpMenu() ).toBe( true );
+		expect( hasAiChatEntryButton() ).toBe( false );
+		expect( hasAgentsManagerEntryPoint() ).toBe( true );
+	} );
+
+	it( 'returns false when no Agents Manager entry point is present', () => {
+		expect( hasAgentsManagerHelpMenu() ).toBe( false );
+		expect( hasAiChatEntryButton() ).toBe( false );
+		expect( hasAgentsManagerEntryPoint() ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -12,10 +12,11 @@ const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
 const ADMIN_BAR_CHAT_ITEM_ID = 'wp-admin-bar-agents-manager-chat-support';
 const ADMIN_BAR_HISTORY_ITEM_ID = 'wp-admin-bar-agents-manager-chat-history';
 const ADMIN_BAR_GUIDES_ITEM_ID = 'wp-admin-bar-agents-manager-support-guides';
+export const EDITOR_HELP_ENTRY_BUTTON_ID = 'agents-manager-editor-help';
 
 // The standalone AI chat button — the chat's entry point, separate from the Help
-// menu. The wp-admin bar exposes it by ID; Calypso's masterbar by class.
-const ADMIN_BAR_AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
+// menu. The wp-admin bar and editor toolbar expose it by ID; Calypso's masterbar by class.
+export const AI_CHAT_ENTRY_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
 const MASTERBAR_AI_CHAT_BUTTON_SELECTOR = '.masterbar__item-agents-manager-ai-chat';
 
 /**
@@ -24,9 +25,26 @@ const MASTERBAR_AI_CHAT_BUTTON_SELECTOR = '.masterbar__item-agents-manager-ai-ch
  */
 export function hasAiChatEntryButton(): boolean {
 	return (
-		!! document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID ) ||
+		!! document.getElementById( AI_CHAT_ENTRY_BUTTON_ID ) ||
 		!! document.querySelector( MASTERBAR_AI_CHAT_BUTTON_SELECTOR )
 	);
+}
+
+/**
+ * Whether the Agents Manager Help menu is present in the wp-admin bar.
+ */
+export function hasAgentsManagerHelpMenu(): boolean {
+	return (
+		!! document.getElementById( ADMIN_BAR_BUTTON_ID ) ||
+		!! document.getElementById( EDITOR_HELP_ENTRY_BUTTON_ID )
+	);
+}
+
+/**
+ * Whether there is an external Agents Manager entry point that can reopen the chat.
+ */
+export function hasAgentsManagerEntryPoint(): boolean {
+	return hasAiChatEntryButton() || hasAgentsManagerHelpMenu();
 }
 
 // CSS class name
@@ -50,7 +68,7 @@ interface UseAdminBarIntegrationOptions {
  * - Click outside to close the menu
  * - Menu item and AI chat button click handlers with tracking
  *
- * Returns whether the AI chat entry button is present on the page.
+ * Returns whether an external Agents Manager entry point is present on the page.
  */
 export default function useAdminBarIntegration( {
 	maybeOpenChat,
@@ -72,8 +90,8 @@ export default function useAdminBarIntegration( {
 	const resumeActiveChatRef = useRef( resumeActiveChat );
 	resumeActiveChatRef.current = resumeActiveChat;
 
-	// Whether the AI chat entry button is present (captured once on mount).
-	const [ hasAiChatEntry ] = useState( hasAiChatEntryButton );
+	// Whether an external Agents Manager entry point is present (captured once on mount).
+	const [ hasAgentsManagerEntry ] = useState( hasAgentsManagerEntryPoint );
 
 	// Whether the chat is visible (open and not minimized), read inside the
 	// one-time DOM click handlers below to decide whether a click opens or closes.
@@ -133,8 +151,8 @@ export default function useAdminBarIntegration( {
 	// The standalone AI button toggles the chat: close it if it's already showing,
 	// otherwise resume the active conversation and open it.
 	useEffect( () => {
-		const aiChatButton = document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID );
-		if ( ! aiChatButton ) {
+		const aiChatButton = document.getElementById( AI_CHAT_ENTRY_BUTTON_ID );
+		if ( ! aiChatButton || aiChatButton.dataset.agentsManagerReactHandler === 'true' ) {
 			return;
 		}
 
@@ -210,5 +228,5 @@ export default function useAdminBarIntegration( {
 		};
 	}, [ navigate, sectionName ] );
 
-	return hasAiChatEntry;
+	return hasAgentsManagerEntry;
 }

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -307,6 +307,96 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
+	it( 'renders `EscalationButton` from live data-only handoff messages', () => {
+		const message = createMessage( {
+			content: [
+				{
+					type: 'data',
+					data: { flags: { forward_to_human_support: true } },
+				},
+			],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: EscalationButton,
+		} );
+	} );
+
+	it.each( [
+		[
+			'root flags',
+			{
+				flags: { forward_to_human_support: true },
+			},
+		],
+		[
+			'data flags',
+			{
+				data: { flags: { forward_to_human_support: true } },
+			},
+		],
+		[
+			'context flags',
+			{
+				context: { flags: { forward_to_human_support: true } },
+			},
+		],
+	] )( 'renders `EscalationButton` from parsed handoff messages with %s', ( _name, data ) => {
+		const message = createMessage( {
+			content: [ { type: 'text', text: JSON.stringify( data ) } ],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: EscalationButton,
+		} );
+	} );
+
+	it( 'renders `EscalationButton` from completed support handoff outcome messages', () => {
+		const message = createMessage( {
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify( {
+						final_text: 'This conversation has been forwarded to non-AI support (chat/forums)',
+						outcome: {
+							type: 'handoff_required',
+							handoff_target: 'human_support',
+							reason: 'support_workflow_handoff',
+						},
+						sources: [
+							{
+								title: 'Contact WordPress.com support',
+								url: 'https://en.support.wordpress.com/help-support-options/',
+							},
+						],
+					} ),
+				},
+			],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: EscalationButton,
+		} );
+	} );
+
 	it( 'filters out unhandled tool messages', () => {
 		const result = convertWithDefaults( {
 			messages: [ createToolMessage( 'other_tool' ) ],

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -20,6 +20,44 @@ interface Options {
 	onSubmit: UseAgentChatReturn[ 'onSubmit' ];
 }
 
+const isRecord = ( value: unknown ): value is Record< string, unknown > =>
+	typeof value === 'object' && value !== null;
+
+const isHumanSupportHandoff = ( value: unknown ): boolean => {
+	if ( ! isRecord( value ) ) {
+		return false;
+	}
+
+	const flags = value.flags;
+	if ( isRecord( flags ) && 'forward_to_human_support' in flags ) {
+		return true;
+	}
+
+	const outcome = value.outcome;
+	if (
+		isRecord( outcome ) &&
+		outcome.type === 'handoff_required' &&
+		outcome.handoff_target === 'human_support'
+	) {
+		return true;
+	}
+
+	return isHumanSupportHandoff( value.data ) || isHumanSupportHandoff( value.context );
+};
+
+const createEscalationMessage = ( message: UIMessage ): AgentsManagerUIMessage => ( {
+	...message,
+	content: [
+		{
+			type: 'component',
+			component: EscalationButton as React.ComponentType,
+			componentProps: {
+				messageId: message.id,
+			},
+		},
+	],
+} );
+
 /**
  * Converts tool-related messages to component messages.
  */
@@ -30,35 +68,23 @@ export default function convertToolMessagesToComponents( {
 	onSubmit,
 }: Options ): AgentsManagerUIMessage[] {
 	return messages.flatMap( ( message, index, array ) => {
-		const firstContentText = message.content?.[ 0 ]?.text;
-
 		// @ts-expect-error -- `assistant` comes from Big Sky messages
-		if ( ( message.role !== 'agent' && message.role !== 'assistant' ) || ! firstContentText ) {
+		if ( message.role !== 'agent' && message.role !== 'assistant' ) {
 			return [ message ];
 		}
 
 		// The user asked for human support
 		if (
 			message.content.find(
-				( content ) =>
-					content.type === 'data' &&
-					content.data?.flags &&
-					typeof content.data.flags === 'object' &&
-					'forward_to_human_support' in content.data.flags
+				( content ) => content.type === 'data' && isHumanSupportHandoff( content.data )
 			)
 		) {
-			return {
-				...message,
-				content: [
-					{
-						type: 'component',
-						component: EscalationButton as React.ComponentType,
-						componentProps: {
-							messageId: message.id,
-						},
-					},
-				],
-			};
+			return createEscalationMessage( message );
+		}
+
+		const firstContentText = message.content?.[ 0 ]?.text;
+		if ( ! firstContentText ) {
+			return [ message ];
 		}
 
 		// The tool message is a JSON string. Try to parse it, falling back to the original if invalid
@@ -67,6 +93,10 @@ export default function convertToolMessagesToComponents( {
 			textData = JSON.parse( firstContentText );
 		} catch ( _error ) {
 			return [ message ];
+		}
+
+		if ( isHumanSupportHandoff( textData ) ) {
+			return createEscalationMessage( message );
 		}
 
 		// Handle `show-component` tool message


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

* Add Agents Manager editor toolbar entry points for the site/Gutenberg editor when an agent such as Dolly opts in.
* Render a Help questionmark menu in the editor toolbar with Chat support, Chat history, Support guides, Courses, and Product updates.
* Render a separate Ask AI toolbar button using the same AI chat entry id used by wp-admin, so minimized/hidden chat behavior is consistent with the unified support/AI chat IA.
* Allow the Support guides route when the editor Help entry point is available, without adding client-side legacy Help Center suppression.

## Why are these changes being made?

The unified AI chat experience and newer wp-admin IA separate Help/support navigation from the direct AI chat entry. The editor-specific Agents Manager opt-in path needs the same shape: legacy Help Center is disabled server-side when unified chat is active, and Dolly can opt in to Agents Manager in the editor without relying on the legacy Help Center bundle to render the questionmark.

This keeps the editor consistent with wp-admin by giving users both a Help menu and a direct Ask AI entry point, while preserving the normal unified chat/server-side legacy Help Center behavior.

## Testing Instructions

* Turn on unified chat. This disables the legacy Help Center server-side.
* Test with wpcom PR 223822. 
* Run `yarn dev --sync`.
* Sandbox `widgets.wp.com`.
* Sandbox a Simple site.
* Sandbox the public API with wpcom PR 223822.
* Open the site editor and confirm the Help questionmark appears in the editor toolbar.
* Confirm the Ask AI button appears to the right of the questionmark.
* Confirm Help menu items open the expected Agents Manager views: Chat support, Chat history, and Support guides.
* Confirm closing/minimizing the chat leaves the editor toolbar Ask AI entry available to reopen it.

Automated checks run locally:

* `yarn jest -c test/packages/jest.config.js --testPathPattern='agents-manager/src/(components/__tests__/agent-dock.test.tsx|hooks/__tests__/use-admin-bar-integration.test.ts)' --runInBand`
* `yarn eslint packages/agents-manager/src/components/editor-help-center-entry-point/index.tsx packages/agents-manager/src/components/agent-dock/index.tsx packages/agents-manager/src/components/__tests__/agent-dock.test.tsx packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx packages/agents-manager/src/hooks/__tests__/use-admin-bar-integration.test.ts`
* `yarn typecheck-packages`
* `git diff --cached --check`
* `git diff --check HEAD~1 HEAD`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
