### PR TITLE
Dashboard: Make phone number country code field searchable

### DIFF
--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -1,6 +1,11 @@
 import { smsCountryCodesQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { __experimentalHStack as HStack, privateApis, SelectControl } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	privateApis,
+	ComboboxControl,
+	Disabled,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
@@ -38,7 +43,7 @@ export default function PhoneNumberInput( {
 			value: countryCode.code,
 		} ) ) ?? [];
 
-	const onChangeCountryCode = ( value: string ) => {
+	const onChangeCountryCode = ( value: string | null | undefined ) => {
 		const countryCode = smsCountryCodes?.find( ( countryCode ) => countryCode.code === value );
 		if ( ! countryCode ) {
 			return;
@@ -53,16 +58,19 @@ export default function PhoneNumberInput( {
 
 	return (
 		<HStack className="phone-number-input">
-			<SelectControl
-				label={ __( 'Country code' ) }
-				value={ data.countryCode ?? '' }
-				options={ countryCodes }
-				onChange={ onChangeCountryCode }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				disabled={ isDisabled }
-				className="phone-number-input__country-code-input"
-			/>
+			<div className="phone-number-input__country-code-input">
+				<Disabled isDisabled={ isDisabled }>
+					<ComboboxControl
+						label={ __( 'Country code' ) }
+						value={ data.countryCode ?? '' }
+						options={ countryCodes }
+						onChange={ onChangeCountryCode }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						expandOnFocus={ false }
+					/>
+				</Disabled>
+			</div>
 			<ValidatedInputControl
 				customValidity={ customValidity }
 				__next40pxDefaultSize

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -67,7 +67,6 @@ export default function PhoneNumberInput( {
 						onChange={ onChangeCountryCode }
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						expandOnFocus={ false }
 					/>
 				</Disabled>
 			</div>

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -57,7 +57,7 @@ export default function PhoneNumberInput( {
 	};
 
 	return (
-		<HStack className="phone-number-input">
+		<HStack className="phone-number-input" spacing={ 4 }>
 			<div className="phone-number-input__country-code-input">
 				<Disabled isDisabled={ isDisabled }>
 					<ComboboxControl

--- a/client/dashboard/components/phone-number-input/style.scss
+++ b/client/dashboard/components/phone-number-input/style.scss
@@ -5,5 +5,4 @@
 	.components-validated-control {
 		width: 100%;
 	}
-
 }

--- a/client/dashboard/components/phone-number-input/style.scss
+++ b/client/dashboard/components/phone-number-input/style.scss
@@ -1,6 +1,5 @@
 .phone-number-input {
 	align-items: baseline;
-	gap: calc( 4px * 4 );
 
 	.phone-number-input__country-code-input {
 		width: 35%;

--- a/client/dashboard/components/phone-number-input/style.scss
+++ b/client/dashboard/components/phone-number-input/style.scss
@@ -1,11 +1,9 @@
 .phone-number-input {
 	align-items: baseline;
 
-	.phone-number-input__country-code-input {
-		width: 35%;
+	.phone-number-input__country-code-input,
+	.components-validated-control {
+		width: 100%;
 	}
 
-	.components-validated-control {
-		width: 65%;
-	}
 }

--- a/client/dashboard/components/phone-number-input/test/index.test.tsx
+++ b/client/dashboard/components/phone-number-input/test/index.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import PhoneNumberInput, { type SecuritySMSNumber } from '../index';
+
+// ComboboxControl scrolls the highlighted option into view; jsdom doesn't implement it.
+Element.prototype.scrollIntoView = jest.fn();
+
+const SMS_COUNTRY_CODES = [
+	{ code: 'US', country_name: 'United States', name: 'United States (+1)', numeric_code: '+1' },
+	{ code: 'DE', country_name: 'Germany', name: 'Germany (+49)', numeric_code: '+49' },
+];
+
+const emptyData: SecuritySMSNumber = {
+	phoneNumber: '',
+	countryCode: '',
+	countryNumericCode: '',
+};
+
+describe( '<PhoneNumberInput>', () => {
+	test( 'lets the user filter the country code list by typing and reports the selection', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( '/rest/v1.1/meta/sms-country-codes/' )
+			.reply( 200, SMS_COUNTRY_CODES );
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render( <PhoneNumberInput data={ emptyData } onChange={ onChange } /> );
+
+		const countryCode = await screen.findByRole( 'combobox', { name: 'Country code' } );
+		await user.type( countryCode, 'Germany' );
+
+		// Typing filters out the non-matching country, leaving only the match selectable.
+		expect(
+			screen.queryByRole( 'option', { name: 'United States (+1)' } )
+		).not.toBeInTheDocument();
+		await user.click( screen.getByRole( 'option', { name: 'Germany (+49)' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( { countryCode: 'DE', countryNumericCode: '+49' } )
+		);
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* Replace the native `SelectControl` used for the phone-number **country code** field with a filterable `ComboboxControl` — the same searchable component the contact-info **Country** field already uses. Users can now type to filter the country list (by any letter) instead of scrolling a long native dropdown.
* `ComboboxControl` has no `disabled` prop, so the disabled-while-pending behavior is preserved by wrapping it in a `Disabled` component. The `35%` width layout class moves to an outer wrapper `<div>` because `Disabled` only applies its own `className` when actually disabled.
* Widen `onChangeCountryCode` to accept `string | null | undefined` to match `ComboboxControl`'s `onChange` signature (it can emit `null` on reset).



| Before | After |
|--------|--------|
| <img width="750" height="484" alt="Screenshot 2026-06-22 at 17 15 11" src="https://github.com/user-attachments/assets/0986c702-b66d-4234-b4f9-a2170c3d1f67" /> | <img width="849" height="551" alt="image" src="https://github.com/user-attachments/assets/60fdb4ce-14b4-4dd0-800c-08c13433d3de" /> | 




This is a shared component (`client/dashboard/components/phone-number-input`), so the searchable behavior now also applies to the **Two-step auth SMS setup** and **Account recovery SMS** screens, not just domain contact info.

## Why are these changes being made?

The new contact details screen (`/domains/<domain>/contact-info`) lets users filter the **Country** field by typing any letter. The adjacent **Country code** field was still a plain native `<select>`, which is hard to navigate given the long list of countries. This brings the country code field to parity with that searchable UX.

## Testing Instructions

* Go to a site's domain contact info screen (`/domains/<domain>/contact-info`).
* Locate the phone number **Country code** field.
* **Before:** native dropdown, no filtering.
* **After:** click the field and type part of a country name (e.g. "ger") — the list filters down. Select an entry and confirm the dial code / number behaves as before.
* Verify the same field on **Me → Security → Two-step auth (SMS setup)** and **Account recovery (SMS)**.
* Confirm the field is disabled while a submit is pending.
* Check dark mode and keyboard navigation.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
