### PR TITLE
Write On: create sites as Coming Soon (private by default)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -11,6 +11,7 @@ import {
 	isNewsletterFlow,
 	isReadymadeFlow,
 	isStartWritingFlow,
+	isWriteOnFlow,
 	isOnboardingFlow,
 	Step,
 	isNewSiteMigrationFlow,
@@ -164,6 +165,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		isOnboardingFlow( flow ) ||
 		isCopySiteFlow( flow ) ||
 		isStartWritingFlow( flow ) ||
+		isWriteOnFlow( flow ) ||
 		isNewHostedSiteCreationFlow( flow ) ||
 		isReadymadeFlow( flow ) ||
 		wooFlows.includes( flow || '' ) ||

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -107,6 +107,10 @@ export const isStartWritingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ START_WRITING_FLOW ].includes( flowName ) );
 };
 
+export const isWriteOnFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ WRITE_ON_FLOW ].includes( flowName ) );
+};
+
 export const isOnboardingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ ONBOARDING_FLOW ].includes( flowName ) );
 };

--- a/packages/onboarding/src/utils/test/flows.ts
+++ b/packages/onboarding/src/utils/test/flows.ts
@@ -1,0 +1,15 @@
+import { WRITE_ON_FLOW, START_WRITING_FLOW, isWriteOnFlow } from '../flows';
+
+describe( 'isWriteOnFlow', () => {
+	test( 'returns true for the write-on flow', () => {
+		expect( isWriteOnFlow( WRITE_ON_FLOW ) ).toBe( true );
+	} );
+
+	test( 'returns false for a different flow', () => {
+		expect( isWriteOnFlow( START_WRITING_FLOW ) ).toBe( false );
+	} );
+
+	test( 'returns false for null', () => {
+		expect( isWriteOnFlow( null ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Part of READ-568 (follow-up to READ-559)

## Proposed Changes

* Add `isWriteOnFlow` helper to `packages/onboarding` (mirrors `isStartWritingFlow`).
* Add the `write-on` flow to the create-site step's "Coming Soon" condition, so it creates sites as `PublicNotIndexed` instead of inheriting the default `PublicIndexed`.
* Add a unit test for `isWriteOnFlow`.

## Why are these changes being made?

See pe7F0s-3NU-p2#comment-4399

## Testing Instructions

1. With the `calypso/write-on-flow` feature flag on, set an anon draft in localStorage and go to `/setup/write-on` as a logged-out user (incognito).
2. Complete signup + site creation.
3. Confirm the new site is **Coming Soon** (private until launched), not public/indexed — check site visibility settings, or that the front end shows the Coming Soon screen to logged-out visitors.
4. Confirm the transferred post can be published from the editor without an email-verification block.
5. `yarn jest -c=test/packages/jest.config.js packages/onboarding/src/utils/test/flows.ts`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?