### PR TITLE
Reuse existing escalation chats

### DIFF
--- a/packages/agents-manager/src/components/__tests__/escalation-button.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/escalation-button.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { MouseEventHandler, ReactNode } from 'react';
+import type { ZendeskConversation } from '../../types';
+
+const mockGetActiveSessionId = jest.fn();
+const mockNavigate = jest.fn();
+const mockUseGetZendeskConversations = jest.fn();
+
+jest.mock( '@automattic/components', () => ( {
+	SummaryButton: ( {
+		title,
+		description,
+		onClick,
+		disabled,
+	}: {
+		title: ReactNode;
+		description?: ReactNode;
+		onClick?: MouseEventHandler;
+		disabled?: boolean;
+	} ) => (
+		<button type="button" onClick={ onClick } disabled={ disabled }>
+			<span>{ title }</span>
+			{ description && <span>{ description }</span> }
+		</button>
+	),
+	TimeSince: ( { date }: { date: string } ) => <time dateTime={ date }>2h ago</time>,
+} ) );
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useGetZendeskConversations: ( enabled: boolean ) => mockUseGetZendeskConversations( enabled ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: () => ( {
+		getActiveSessionId: mockGetActiveSessionId,
+	} ),
+} ) );
+
+import { EscalationButton, findConversationByChatSessionId } from '../escalation-button';
+
+function createConversation(
+	id: string,
+	chatSessionId: string,
+	placement: 'metadata' | 'top-level' = 'metadata'
+) {
+	return {
+		id,
+		...( placement === 'metadata'
+			? { metadata: { chat_session_id: chatSessionId, createdAt: 1718193600000 } }
+			: { chat_session_id: chatSessionId } ),
+	} as unknown as ZendeskConversation;
+}
+
+describe( 'EscalationButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetActiveSessionId.mockReturnValue( 'ai-chat-123' );
+		mockUseGetZendeskConversations.mockReturnValue( {
+			conversations: [],
+			isLoading: false,
+		} );
+	} );
+
+	it( 'continues an existing Zendesk conversation for the active AI chat', () => {
+		mockUseGetZendeskConversations.mockReturnValue( {
+			conversations: [ createConversation( 'conversation-1', 'ai-chat-123' ) ],
+			isLoading: false,
+		} );
+
+		render( <EscalationButton messageId="message-1" /> );
+
+		expect( screen.getByText( 'Continue existing chat' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Continue chat started 2h ago' );
+
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( '/zendesk', {
+			state: { conversationId: 'conversation-1' },
+		} );
+	} );
+
+	it( 'starts a new Zendesk conversation when no active AI chat match exists', () => {
+		mockUseGetZendeskConversations.mockReturnValue( {
+			conversations: [ createConversation( 'conversation-1', 'other-ai-chat' ) ],
+			isLoading: false,
+		} );
+
+		render( <EscalationButton messageId="message-1" /> );
+
+		expect( screen.getByText( 'Switch to Happiness Engineer' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'A new chat will start' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( '/zendesk', {
+			state: { startedFromChatId: 'ai-chat-123', startedFromMessageId: 'message-1' },
+		} );
+	} );
+
+	it( 'disables the button while Zendesk conversations are loading', () => {
+		mockUseGetZendeskConversations.mockReturnValue( {
+			conversations: [],
+			isLoading: true,
+		} );
+
+		render( <EscalationButton messageId="message-1" /> );
+
+		expect( screen.getByRole( 'button' ) ).toBeDisabled();
+	} );
+
+	it( 'matches conversations with metadata or top-level chat_session_id values', () => {
+		const conversations = [
+			createConversation( 'metadata-conversation', 'metadata-chat' ),
+			createConversation( 'top-level-conversation', 'top-level-chat', 'top-level' ),
+		];
+
+		expect( findConversationByChatSessionId( conversations, 'metadata-chat' )?.id ).toBe(
+			'metadata-conversation'
+		);
+		expect( findConversationByChatSessionId( conversations, 'top-level-chat' )?.id ).toBe(
+			'top-level-conversation'
+		);
+	} );
+} );

--- a/packages/agents-manager/src/components/escalation-button/index.tsx
+++ b/packages/agents-manager/src/components/escalation-button/index.tsx
@@ -1,21 +1,116 @@
-import { SummaryButton } from '@automattic/components';
+import { SummaryButton, TimeSince } from '@automattic/components';
+import { useGetZendeskConversations } from '@automattic/zendesk-client';
+import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import type { ZendeskConversation } from '../../types';
 import './style.scss';
+
+function getConversationChatSessionId( conversation: ZendeskConversation ) {
+	const metadataChatSessionId = conversation.metadata?.chat_session_id;
+	const { chat_session_id: conversationChatSessionId } = conversation as ZendeskConversation & {
+		chat_session_id?: unknown;
+	};
+
+	if ( typeof conversationChatSessionId === 'string' ) {
+		return conversationChatSessionId;
+	}
+
+	return typeof metadataChatSessionId === 'string' ? metadataChatSessionId : undefined;
+}
+
+function getTimestampInMilliseconds( timestamp: unknown ) {
+	if ( typeof timestamp === 'number' && Number.isFinite( timestamp ) ) {
+		return timestamp > 9999999999 ? timestamp : timestamp * 1000;
+	}
+
+	if ( typeof timestamp === 'string' ) {
+		const parsedTimestamp = Number( timestamp );
+		if ( Number.isFinite( parsedTimestamp ) ) {
+			return parsedTimestamp > 9999999999 ? parsedTimestamp : parsedTimestamp * 1000;
+		}
+	}
+
+	return undefined;
+}
+
+function getConversationStartedAt( conversation: ZendeskConversation ) {
+	const createdAt = getTimestampInMilliseconds( conversation.metadata?.createdAt );
+	if ( createdAt ) {
+		return new Date( createdAt ).toISOString();
+	}
+
+	const firstMessageReceivedAt = getTimestampInMilliseconds(
+		conversation.messages?.[ 0 ]?.received
+	);
+	if ( firstMessageReceivedAt ) {
+		return new Date( firstMessageReceivedAt ).toISOString();
+	}
+
+	const lastUpdatedAt = getTimestampInMilliseconds( conversation.lastUpdatedAt );
+	return lastUpdatedAt ? new Date( lastUpdatedAt ).toISOString() : undefined;
+}
+
+export function findConversationByChatSessionId(
+	conversations: ZendeskConversation[],
+	chatSessionId: string
+) {
+	if ( ! chatSessionId ) {
+		return undefined;
+	}
+
+	return conversations.find(
+		( conversation ) => getConversationChatSessionId( conversation ) === chatSessionId
+	);
+}
+
+function getExistingConversationButtonDescription( startedAt?: string ) {
+	if ( ! startedAt ) {
+		return __( 'Return to your human chat' );
+	}
+
+	return createInterpolateElement( __( 'Continue chat started <time></time>' ), {
+		time: <TimeSince className="agents-manager__escalation-button-time" date={ startedAt } />,
+	} );
+}
 
 export function EscalationButton( { messageId }: { messageId: string } ) {
 	const { getActiveSessionId } = useAgentsManagerContext();
 	const navigate = useNavigate();
+	const activeSessionId = getActiveSessionId();
+	const { conversations, isLoading } = useGetZendeskConversations( !! activeSessionId );
+	const existingConversation = useMemo(
+		() => findConversationByChatSessionId( conversations, activeSessionId ),
+		[ conversations, activeSessionId ]
+	);
+	const existingConversationStartedAt = existingConversation
+		? getConversationStartedAt( existingConversation )
+		: undefined;
 
 	return (
 		<SummaryButton
 			className="agents-manager__escalation-button"
-			title={ __( 'Switch to Happiness Engineer' ) }
-			description={ __( 'A new chat will start' ) }
+			title={
+				existingConversation ? __( 'Continue existing chat' ) : __( 'Switch to Happiness Engineer' )
+			}
+			description={
+				existingConversation
+					? getExistingConversationButtonDescription( existingConversationStartedAt )
+					: __( 'A new chat will start' )
+			}
+			disabled={ isLoading }
 			onClick={ () => {
+				const currentChatSessionId = getActiveSessionId();
+				const currentExistingConversation = findConversationByChatSessionId(
+					conversations,
+					currentChatSessionId
+				);
+
 				navigate( '/zendesk', {
-					state: { startedFromChatId: getActiveSessionId(), startedFromMessageId: messageId },
+					state: currentExistingConversation
+						? { conversationId: currentExistingConversation.id }
+						: { startedFromChatId: currentChatSessionId, startedFromMessageId: messageId },
 				} );
 			} }
 		/>

--- a/packages/agents-manager/src/components/escalation-button/style.scss
+++ b/packages/agents-manager/src/components/escalation-button/style.scss
@@ -11,4 +11,8 @@
 	.summary-button-title {
 		color: var( --color-foreground );
 	}
+
+	.agents-manager__escalation-button-time {
+		color: inherit;
+	}
 }

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -17,6 +17,9 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useGetZendeskConversations: () => ( { conversations: [], isLoading: false } ),
+} ) );
 jest.mock( '../is-editor-page' );
 
 const MockComponent = jest.fn();


### PR DESCRIPTION
Related issue: none

## Proposed Changes

* Reuse an existing Zendesk Conversation when its `chat_session_id` matches the current AI chat session.
* Route the escalation button to the existing Conversation instead of creating a duplicate human chat.
* Show `Continue chat started <relative time>` in the secondary text for reused chats, based on the Conversation start timestamp.
* Keep the relative-time fragment visually consistent with the rest of the secondary text.
* Add focused tests for the reuse path, fallback creation path, loading state, and `chat_session_id` matching.

## Why are these changes being made?

* Users can click the escalation button more than once from the same AI chat, which could create multiple human chats.
* Reusing the existing Conversation keeps the handoff tied to one human chat and makes the button state clearer.

## Testing Instructions

* `yarn run -T jest -c packages/agents-manager/jest.config.js packages/agents-manager/src/components/__tests__/escalation-button.test.tsx --runInBand`
* `yarn run -T jest -c packages/agents-manager/jest.config.js packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts --runInBand`
* `yarn run -T prettier --check packages/agents-manager/src/components/escalation-button/index.tsx packages/agents-manager/src/components/__tests__/escalation-button.test.tsx`
* `yarn run eslint packages/agents-manager/src/components/escalation-button/index.tsx packages/agents-manager/src/components/__tests__/escalation-button.test.tsx`
* `yarn run -T tsc --noEmit --project packages/agents-manager/tsconfig.json`
* `yarn run -T stylelint packages/agents-manager/src/components/escalation-button/style.scss`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
