### PR TITLE
Notifications: add achievements notifications toggle to /me/notifications

### DIFF
--- a/client/me/notification-settings/achievements-notification-settings/index.tsx
+++ b/client/me/notification-settings/achievements-notification-settings/index.tsx
@@ -4,14 +4,17 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import { recordAction } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 
 import './style.scss';
 
 export default function AchievementsNotificationSettings() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 
 	const { data: savedNotifications, isLoading } = useQuery(
 		userPreferenceQuery( 'achievements-global-notifications' )
@@ -40,6 +43,11 @@ export default function AchievementsNotificationSettings() {
 						{ duration: 4000 }
 					)
 				);
+				recordAction( `set_achievements_notifications_${ newNotifications }` );
+				recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
+					setting: 'me-achievements-notifications',
+					value: newNotifications,
+				} );
 			},
 			onError() {
 				dispatch(

--- a/client/me/notification-settings/achievements-notification-settings/index.tsx
+++ b/client/me/notification-settings/achievements-notification-settings/index.tsx
@@ -1,0 +1,71 @@
+import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automattic/api-queries';
+import { Card } from '@automattic/components';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+
+import './style.scss';
+
+export default function AchievementsNotificationSettings() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { data: savedNotifications, isLoading } = useQuery(
+		userPreferenceQuery( 'achievements-global-notifications' )
+	);
+	const { mutate: setNotifications } = useMutation(
+		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
+	);
+
+	// Local state for immediate toggle feedback. Synced from query data on load.
+	const [ notifications, setLocalNotifications ] = useState( savedNotifications ?? 'enabled' );
+	useEffect(
+		() => setLocalNotifications( savedNotifications ?? 'enabled' ),
+		[ savedNotifications ]
+	);
+
+	const handleSetNotifications = ( checked: boolean ) => {
+		const newNotifications = checked ? 'enabled' : 'disabled';
+		setLocalNotifications( newNotifications );
+		setNotifications( newNotifications, {
+			onSuccess() {
+				dispatch(
+					successNotice(
+						newNotifications === 'enabled'
+							? translate( 'Achievements notifications are now enabled.' )
+							: translate( 'Achievements notifications are now disabled.' ),
+						{ duration: 4000 }
+					)
+				);
+			},
+			onError() {
+				dispatch(
+					errorNotice( translate( 'Failed to save the achievements notifications settings.' ), {
+						duration: 4000,
+					} )
+				);
+			},
+		} );
+	};
+
+	return (
+		<Card
+			id="achievements"
+			className="notification-settings-achievements-notification-settings__settings"
+		>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				checked={ notifications !== 'disabled' }
+				disabled={ isLoading }
+				help={ translate(
+					'Receive notifications when you unlock new achievements. This setting overrides site-level settings.'
+				) }
+				label={ translate( 'Achievements' ) }
+				onChange={ handleSetNotifications }
+			/>
+		</Card>
+	);
+}

--- a/client/me/notification-settings/achievements-notification-settings/style.scss
+++ b/client/me/notification-settings/achievements-notification-settings/style.scss
@@ -1,0 +1,4 @@
+.card.notification-settings-achievements-notification-settings__settings {
+	position: relative;
+	margin-top: 1em;
+}

--- a/client/me/notification-settings/achievements-notification-settings/test/index.test.tsx
+++ b/client/me/notification-settings/achievements-notification-settings/test/index.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { rawUserPreferencesQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import AchievementsNotificationSettings from '../index';
+
+const mockMutationFn = jest.fn().mockResolvedValue( {} );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	...jest.requireActual( '@automattic/api-queries' ),
+	userPreferenceOptimisticMutation: () => ( { mutationFn: mockMutationFn } ),
+} ) );
+
+function setup( savedValue?: 'enabled' | 'disabled' ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+	} );
+	if ( savedValue !== undefined ) {
+		queryClient.setQueryData( rawUserPreferencesQuery().queryKey, {
+			'achievements-global-notifications': savedValue,
+		} );
+	}
+	return {
+		user: userEvent.setup(),
+		...renderWithProvider( <AchievementsNotificationSettings />, { queryClient } ),
+	};
+}
+
+describe( 'AchievementsNotificationSettings', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the toggle checked when notifications are enabled', () => {
+		setup( 'enabled' );
+		expect( screen.getByRole( 'checkbox', { name: 'Achievements' } ) ).toBeChecked();
+	} );
+
+	it( 'renders the toggle unchecked when notifications are disabled', () => {
+		setup( 'disabled' );
+		expect( screen.getByRole( 'checkbox', { name: 'Achievements' } ) ).not.toBeChecked();
+	} );
+
+	it( 'saves the disabled value when toggled off', async () => {
+		const { user } = setup( 'enabled' );
+		await user.click( screen.getByRole( 'checkbox', { name: 'Achievements' } ) );
+		expect( mockMutationFn ).toHaveBeenCalledWith( 'disabled' );
+		expect( screen.getByRole( 'checkbox', { name: 'Achievements' } ) ).not.toBeChecked();
+	} );
+} );

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -12,6 +12,7 @@ import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
+import AchievementsNotificationSettings from './achievements-notification-settings';
 import BlogsSettings from './blogs-settings';
 import Navigation from './navigation';
 import OnThisDayNotificationSettings from './on-this-day-notification-settings';
@@ -65,6 +66,7 @@ class NotificationSettings extends Component {
 				<Navigation path={ this.props.path } />
 				<PushNotificationSettings pushNotifications={ this.props.pushNotifications } />
 				<OnThisDayNotificationSettings />
+				<AchievementsNotificationSettings />
 				<BlogsSettings
 					settings={ this.props.settings }
 					hasUnsavedChanges={ this.props.hasUnsavedChanges }


### PR DESCRIPTION
Part of CMM-2096

## Proposed Changes

* Add an "Achievements" notifications toggle to `/me/notifications`, alongside the existing "On this day" toggle.
* The toggle reads and writes the `achievements-global-notifications` user preference (via `@automattic/api-queries`), the same preference exposed in the Reader Achievements screen.
* Includes a unit test covering the checked/unchecked states and the save-on-toggle behavior.

## Why are these changes being made?

* The global achievements notifications toggle previously lived only in the Reader Achievements screen, which is hard to discover. `/me/notifications` is the more visible and appropriate home for a notification preference, so this surfaces it there too.

## Testing Instructions

* Go to `/me/notifications`.
* Confirm an "Achievements" toggle appears below "On this day", with the help text "Receive notifications when you unlock new achievements. This setting overrides site-level settings."
* Toggle it off and on; confirm a success notice appears and the value persists across reloads.
* Confirm the value stays in sync with the toggle in the Reader Achievements screen after reload.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
