### PR TITLE
Lodash: replace clone(), property(), range() and random()

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -1,10 +1,11 @@
 import { FormLabel } from '@automattic/components';
+import { range } from '@automattic/js-utils';
 import { AutoSizer, List } from '@automattic/react-virtualized';
 import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { filter, map, memoize, range, reduce } from 'lodash';
+import { filter, map, memoize, reduce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/components/infinite-list/test/scroll-helper.js
+++ b/client/components/infinite-list/test/scroll-helper.js
@@ -1,4 +1,4 @@
-import { range } from 'lodash';
+import { range } from '@automattic/js-utils';
 import ScrollHelper from '../scroll-helper';
 
 function getItemRef( item ) {

--- a/client/components/line-chart/docs/example.jsx
+++ b/client/components/line-chart/docs/example.jsx
@@ -1,5 +1,5 @@
 import { Card, FormLabel } from '@automattic/components';
-import { range, random } from 'lodash';
+import { random, range } from '@automattic/js-utils';
 import moment from 'moment';
 import { Component } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';

--- a/client/lib/analytics/ad-tracking/criteo.js
+++ b/client/lib/analytics/ad-tracking/criteo.js
@@ -1,5 +1,5 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import { clone, cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS } from './constants';
 import { loadTrackingScripts } from './load-tracking-scripts';
@@ -31,7 +31,7 @@ export async function recordInCriteo( eventName, eventProps ) {
 		events.push( { event: 'setEmail', email: [ currentUser.hashedPii.email ] } );
 	}
 
-	const conversionEvent = clone( eventProps );
+	const conversionEvent = { ...eventProps };
 	conversionEvent.event = eventName;
 	events.push( conversionEvent );
 

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -1,7 +1,7 @@
 import { camelCase, mapValues, pickBy } from '@automattic/js-utils';
 import { debounce } from '@wordpress/compose';
 import update from 'immutability-helper';
-import { filter, isEmpty, map, property, some } from 'lodash';
+import { filter, isEmpty, map, some } from 'lodash';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {
@@ -269,7 +269,7 @@ function getFieldErrorMessages( formState, fieldName ) {
 }
 
 function getFieldsValidating( formState ) {
-	return pickBy( formState, property( 'isValidating' ) );
+	return pickBy( formState, ( field ) => field?.isValidating );
 }
 
 function isInitialized( field ) {

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,6 +1,6 @@
 import { omit } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { clone, get, map, reduce } from 'lodash';
+import { get, map, reduce } from 'lodash';
 import QueryKey from './key';
 
 /**
@@ -269,7 +269,7 @@ export default class QueryManager {
 					// Did not exist previously or has changed
 					if ( memo === this.data.items ) {
 						// Create a copy of memo, as we don't want to mutate the original items set
-						memo = clone( memo );
+						memo = { ...memo };
 					}
 
 					memo[ receivedItemKey ] = mergedItem;
@@ -373,7 +373,7 @@ export default class QueryManager {
 						if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
 							// Create a copy of the original details to avoid mutating
 							if ( memo[ queryKey ] === queryDetails ) {
-								memo[ queryKey ] = clone( queryDetails );
+								memo[ queryKey ] = { ...queryDetails };
 							}
 
 							// Omit item by slicing previous and next
@@ -393,7 +393,7 @@ export default class QueryManager {
 
 						// Create a copy of the original details to avoid mutating
 						if ( memo[ queryKey ] === queryDetails ) {
-							memo[ queryKey ] = clone( queryDetails );
+							memo[ queryKey ] = { ...queryDetails };
 						}
 
 						// Increment found count for query

--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -1,5 +1,5 @@
-import { omit } from '@automattic/js-utils';
-import { cloneDeep, range } from 'lodash';
+import { omit, range } from '@automattic/js-utils';
+import { cloneDeep } from 'lodash';
 import QueryManager from '../';
 import { DEFAULT_PAGINATED_QUERY, PAGINATION_QUERY_KEYS } from './constants';
 import PaginatedQueryKey from './key';

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -1,5 +1,5 @@
 import { withRtl } from 'i18n-calypso';
-import { clone, filter } from 'lodash';
+import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, Component } from 'react';
 import { connect } from 'react-redux';
@@ -97,7 +97,7 @@ export class MediaLibraryList extends Component {
 		if ( this.props.single ) {
 			selectedItems = filter( this.props.selectedItems, { ID: item.ID } );
 		} else {
-			selectedItems = clone( this.props.selectedItems );
+			selectedItems = [ ...this.props.selectedItems ];
 		}
 
 		const selectedItemsIndex = selectedItems.findIndex( ( i ) => i.ID === item.ID );

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { CompactCard, Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { range } from '@automattic/js-utils';
 import {
 	JETPACK_CONTACT_SUPPORT,
 	JETPACK_SERVICE_AKISMET,
@@ -8,7 +9,7 @@ import {
 	JETPACK_SUPPORT,
 } from '@automattic/urls';
 import { localize, fixMe } from 'i18n-calypso';
-import { filter, get, range } from 'lodash';
+import { filter, get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';

--- a/client/reader/data/stream/build-query-params.js
+++ b/client/reader/data/stream/build-query-params.js
@@ -1,5 +1,5 @@
+import { random } from '@automattic/js-utils';
 import i18n from 'i18n-calypso';
-import { random } from 'lodash';
 import { getTagsFromStreamKey } from 'calypso/reader/discover/helper';
 import { getStreamType } from 'calypso/reader/utils';
 import {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -13,7 +13,7 @@ import * as oauthToken from '@automattic/oauth-token';
 import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
 import isEqual from 'fast-deep-equal/es6';
-import { clone, find, get, isEmpty, map } from 'lodash';
+import { find, get, isEmpty, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -557,7 +557,7 @@ class Signup extends Component {
 		const currentStepIndex = flowSteps.indexOf( stepName );
 		const stepsToProcess =
 			currentStepIndex >= 0 ? flowSteps.slice( 0, currentStepIndex + 1 ) : flowSteps;
-		const previouslyExcludedSteps = clone( flows.excludedSteps );
+		const previouslyExcludedSteps = [ ...flows.excludedSteps ];
 		map( previouslyExcludedSteps, ( flowStepName ) => {
 			if ( stepsToProcess.includes( flowStepName ) ) {
 				this.processFulfilledSteps( flowStepName, nextProps );

--- a/client/state/automated-transfer/eligibility/reducer.js
+++ b/client/state/automated-transfer/eligibility/reducer.js
@@ -1,4 +1,4 @@
-import { property, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 import { AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE } from 'calypso/state/action-types';
 import { withPersistence } from 'calypso/state/utils';
 
@@ -14,7 +14,7 @@ export default withPersistence( ( state = initialState, action ) => {
 		case AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE:
 			return {
 				eligibilityHolds: sortBy( action.eligibilityHolds ),
-				eligibilityWarnings: sortBy( action.eligibilityWarnings, property( 'name' ) ),
+				eligibilityWarnings: sortBy( action.eligibilityWarnings, ( warning ) => warning?.name ),
 				lastUpdate: action.lastUpdate,
 			};
 	}

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/delays.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/delays.js
@@ -11,7 +11,7 @@
  * @module state/data-layer/wpcom-http/pipeline/retry-on-failure/delays
  */
 
-import { random } from 'lodash';
+import { random } from '@automattic/js-utils';
 
 /**
  * Computes "decorrelated jitter" delay

--- a/client/state/selectors/test/get-past-billing-transaction.js
+++ b/client/state/selectors/test/get-past-billing-transaction.js
@@ -1,4 +1,3 @@
-import { clone } from 'lodash';
 import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
 
 describe( 'getPastBillingTransaction()', () => {
@@ -52,7 +51,7 @@ describe( 'getPastBillingTransaction()', () => {
 			date: '2017-01-01T11:22:33+0000',
 		};
 
-		const testState = clone( state );
+		const testState = { ...state };
 		testState.billingTransactions.individualTransactions = {
 			999999: { data: individualTransaction },
 		};
@@ -68,7 +67,7 @@ describe( 'getPastBillingTransaction()', () => {
 			tax_state: 'OH',
 		};
 
-		const testState = clone( state );
+		const testState = { ...state };
 		testState.billingTransactions.individualTransactions = {
 			12345678: { data: individualTransaction },
 		};
@@ -81,7 +80,7 @@ describe( 'getPastBillingTransaction()', () => {
 	} );
 
 	test( 'should keep tax metadata from past transaction when individually fetched transaction omits it', () => {
-		const testState = clone( state );
+		const testState = { ...state };
 		testState.billingTransactions.items.past[ 0 ] = {
 			...testState.billingTransactions.items.past[ 0 ],
 			tax_is_for_business: true,
@@ -102,7 +101,7 @@ describe( 'getPastBillingTransaction()', () => {
 	} );
 
 	test( 'should keep business tax flag from past transaction when individually fetched transaction defaults it to false', () => {
-		const testState = clone( state );
+		const testState = { ...state };
 		testState.billingTransactions.items.past[ 0 ] = {
 			...testState.billingTransactions.items.past[ 0 ],
 			tax_is_for_business: true,
@@ -124,7 +123,7 @@ describe( 'getPastBillingTransaction()', () => {
 	} );
 
 	test( 'should return null for individual transaction that is being fetched', () => {
-		const testState = clone( state );
+		const testState = { ...state };
 		testState.billingTransactions.individualTransactions = {
 			999999: { requesting: true },
 		};
@@ -134,7 +133,7 @@ describe( 'getPastBillingTransaction()', () => {
 	} );
 
 	test( 'should return null for individual transaction that failed to fetch', () => {
-		const testState = clone( state );
+		const testState = { ...state };
 		testState.billingTransactions.individualTransactions = {
 			999999: { error: true },
 		};

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -1,4 +1,4 @@
-import { map, property } from 'lodash';
+import { map } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { fetchThemesList as fetchWporgThemesList } from 'calypso/lib/wporg';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -104,7 +104,7 @@ export function requestThemes( siteId, query = {}, locale ) {
 						tier: query.tier,
 						response_time_in_ms: responseTime,
 						result_count: found,
-						results_first_page: themes.map( property( 'id' ) ).join(),
+						results_first_page: themes.map( ( theme ) => theme?.id ).join(),
 					} );
 					dispatch( trackShowcaseSearch );
 

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -23,6 +23,8 @@ const JS_UTILS_NAMES = [
 	'escapeRegExp',
 	'once',
 	'isError',
+	'random',
+	'range',
 ];
 
 // The js-utils case converters cover ASCII identifiers/keys, not lodash's full
@@ -58,6 +60,10 @@ const FINDKEY_MESSAGE =
 	'Please use `Object.keys( obj ).find( ( key ) => … )` instead of lodash `findKey`.';
 const FINDINDEX_MESSAGE =
 	'Please use native `array.findIndex( ( item ) => … )` instead of lodash `findIndex`.';
+const CLONE_MESSAGE =
+	'Please use a spread copy (`{ ...obj }` / `[ ...arr ]`) instead of lodash `clone`.';
+const PROPERTY_MESSAGE =
+	'Please use an arrow function (`( obj ) => obj.key`) instead of lodash `property`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -76,6 +82,8 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'isNumber' ], message: ISNUMBER_MESSAGE },
 	{ name: 'lodash', importNames: [ 'findKey' ], message: FINDKEY_MESSAGE },
 	{ name: 'lodash', importNames: [ 'findIndex' ], message: FINDINDEX_MESSAGE },
+	{ name: 'lodash', importNames: [ 'clone' ], message: CLONE_MESSAGE },
+	{ name: 'lodash', importNames: [ 'property' ], message: PROPERTY_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -96,6 +104,8 @@ const patterns = [
 	{ group: [ 'lodash/isNumber' ], message: ISNUMBER_MESSAGE },
 	{ group: [ 'lodash/findKey' ], message: FINDKEY_MESSAGE },
 	{ group: [ 'lodash/findIndex' ], message: FINDINDEX_MESSAGE },
+	{ group: [ 'lodash/clone' ], message: CLONE_MESSAGE },
+	{ group: [ 'lodash/property' ], message: PROPERTY_MESSAGE },
 ];
 
 module.exports = { paths, patterns };

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -14,6 +14,8 @@ export { default as omitBy } from './omit-by';
 export { default as once } from './once';
 export { default as pick } from './pick';
 export { default as pickBy } from './pick-by';
+export { default as random } from './random';
+export { default as range } from './range';
 export { default as shuffle } from './shuffle';
 export { default as snakeCase } from './snake-case';
 export { default as snakeToCamelCase } from './snake-to-camel-case';

--- a/packages/js-utils/src/random.ts
+++ b/packages/js-utils/src/random.ts
@@ -1,0 +1,59 @@
+import toFinite from './to-finite';
+
+function random( floating?: boolean ): number;
+function random( upper: number, floating?: boolean ): number;
+function random( lower: number, upper: number, floating?: boolean ): number;
+
+/**
+ * Produces a random number between `lower` and `upper` (inclusive). An integer
+ * is returned unless either bound is fractional or `floating` is `true`, in
+ * which case a floating-point number is returned — mirroring lodash `random`.
+ *
+ * If only one numeric argument is provided it is treated as the upper bound
+ * (with `0` as the lower bound); with no numeric arguments a number between `0`
+ * and `1` is returned. Bounds are coerced to finite numbers (numeric strings
+ * work) and swapped when `lower` is greater than `upper`. A single boolean
+ * argument, or a boolean in place of `upper`, is treated as `floating`.
+ * @param lower The lower bound (or the upper bound, if `upper` is omitted).
+ * @param upper The upper bound.
+ * @param floating Whether to return a floating-point number.
+ * @returns The random number.
+ */
+function random( lower?: number | boolean, upper?: number | boolean, floating?: boolean ): number {
+	if ( floating === undefined ) {
+		if ( typeof upper === 'boolean' ) {
+			floating = upper;
+			upper = undefined;
+		} else if ( typeof lower === 'boolean' ) {
+			floating = lower;
+			lower = undefined;
+		}
+	}
+
+	let low: number;
+	let high: number;
+	if ( lower === undefined && upper === undefined ) {
+		low = 0;
+		high = 1;
+	} else if ( upper === undefined ) {
+		low = 0;
+		high = toFinite( lower );
+	} else {
+		low = toFinite( lower );
+		high = toFinite( upper );
+	}
+
+	if ( low > high ) {
+		[ low, high ] = [ high, low ];
+	}
+
+	if ( floating || low % 1 || high % 1 ) {
+		const rand = Math.random();
+		const epsilon = parseFloat( '1e-' + ( String( rand ).length - 1 ) );
+		return Math.min( low + rand * ( high - low + epsilon ), high );
+	}
+
+	return low + Math.floor( Math.random() * ( high - low + 1 ) );
+}
+
+export default random;

--- a/packages/js-utils/src/range.ts
+++ b/packages/js-utils/src/range.ts
@@ -1,0 +1,40 @@
+import toFinite from './to-finite';
+
+/**
+ * Creates an array of numbers progressing from `start` up to, but not
+ * including, `end`. A `step` of `-1` is used if a negative `start` is specified
+ * without an `end` or `step`. If `end` is not specified, it's set to `start`
+ * with `start` then set to `0`. Bounds are coerced to finite numbers, matching
+ * lodash.
+ * @param start The start of the range (or the end, if `end` is omitted).
+ * @param end   The end of the range (exclusive).
+ * @param step  The value to increment or decrement by.
+ * @returns The range of numbers.
+ */
+const range = ( start: number, end?: number, step?: number ): number[] => {
+	start = toFinite( start );
+	if ( end === undefined ) {
+		end = start;
+		start = 0;
+	} else {
+		end = toFinite( end );
+	}
+	if ( step === undefined ) {
+		step = start < end ? 1 : -1;
+	} else {
+		step = toFinite( step );
+	}
+
+	let length = Math.max( Math.ceil( ( end - start ) / ( step || 1 ) ), 0 );
+	const result = new Array< number >( length );
+
+	let index = 0;
+	while ( length-- ) {
+		result[ index++ ] = start;
+		start += step;
+	}
+
+	return result;
+};
+
+export default range;

--- a/packages/js-utils/src/test/random.ts
+++ b/packages/js-utils/src/test/random.ts
@@ -1,0 +1,84 @@
+import random from '../random';
+
+describe( 'random', () => {
+	afterEach( () => {
+		jest.spyOn( Math, 'random' ).mockRestore();
+	} );
+
+	const mockRandom = ( value: number ) => jest.spyOn( Math, 'random' ).mockReturnValue( value );
+
+	it( 'should return an integer between 0 and a single argument (inclusive)', () => {
+		mockRandom( 0 );
+		expect( random( 5 ) ).toBe( 0 );
+		mockRandom( 0.999999 );
+		expect( random( 5 ) ).toBe( 5 );
+	} );
+
+	it( 'should return an integer between lower and upper (inclusive)', () => {
+		mockRandom( 0 );
+		expect( random( 2, 8 ) ).toBe( 2 );
+		mockRandom( 0.999999 );
+		expect( random( 2, 8 ) ).toBe( 8 );
+	} );
+
+	it( 'should swap the bounds when lower is greater than upper', () => {
+		mockRandom( 0 );
+		expect( random( 8, 2 ) ).toBe( 2 );
+		mockRandom( 0.999999 );
+		expect( random( 8, 2 ) ).toBe( 8 );
+	} );
+
+	it( 'should coerce numeric-string bounds to numbers', () => {
+		mockRandom( 0 );
+		// @ts-expect-error -- exercises lenient coercion for untyped (e.g. form) callers.
+		expect( random( '10', '50' ) ).toBe( 10 );
+		mockRandom( 0.999999 );
+		// @ts-expect-error -- see above.
+		expect( random( '10', '50' ) ).toBe( 50 );
+	} );
+
+	it( 'should return an in-range float when a bound is fractional', () => {
+		mockRandom( 0.999999 );
+		const value = random( 1.2, 1.5 );
+		expect( Number.isInteger( value ) ).toBe( false );
+		expect( value ).toBeGreaterThanOrEqual( 1.2 );
+		expect( value ).toBeLessThanOrEqual( 1.5 );
+	} );
+
+	it( 'should return a float when the floating flag is set on integer bounds', () => {
+		mockRandom( 0.5 );
+		const value = random( 0, 10, true );
+		expect( Number.isInteger( value ) ).toBe( false );
+		expect( value ).toBeGreaterThanOrEqual( 0 );
+		expect( value ).toBeLessThanOrEqual( 10 );
+	} );
+
+	it( 'should return 0 or 1 when called with no arguments', () => {
+		mockRandom( 0 );
+		expect( random() ).toBe( 0 );
+		mockRandom( 0.999999 );
+		expect( random() ).toBe( 1 );
+	} );
+
+	it( 'should stay within the inclusive bounds across many samples', () => {
+		for ( let i = 0; i < 1000; i++ ) {
+			const value = random( 3, 6 );
+			expect( Number.isInteger( value ) ).toBe( true );
+			expect( value ).toBeGreaterThanOrEqual( 3 );
+			expect( value ).toBeLessThanOrEqual( 6 );
+		}
+	} );
+
+	it( 'should treat a symbol bound as 0 instead of throwing', () => {
+		mockRandom( 0.999999 );
+		// @ts-expect-error -- lodash coerces non-numeric bounds rather than throwing.
+		expect( random( Symbol( 'x' ) ) ).toBe( 0 );
+	} );
+
+	it( 'should produce a huge finite range for an Infinity bound', () => {
+		mockRandom( 0.999999 );
+		const value = random( 0, Infinity );
+		expect( Number.isFinite( value ) ).toBe( true );
+		expect( value ).toBeGreaterThan( 1e300 );
+	} );
+} );

--- a/packages/js-utils/src/test/range.ts
+++ b/packages/js-utils/src/test/range.ts
@@ -1,0 +1,48 @@
+import range from '../range';
+
+describe( 'range', () => {
+	it( 'should create a range from 0 up to a single argument', () => {
+		expect( range( 4 ) ).toEqual( [ 0, 1, 2, 3 ] );
+	} );
+
+	it( 'should create a range between start and end', () => {
+		expect( range( 1, 5 ) ).toEqual( [ 1, 2, 3, 4 ] );
+	} );
+
+	it( 'should support a custom step', () => {
+		expect( range( 0, 20, 5 ) ).toEqual( [ 0, 5, 10, 15 ] );
+	} );
+
+	it( 'should descend when start is greater than end', () => {
+		expect( range( 4, 1 ) ).toEqual( [ 4, 3, 2 ] );
+		expect( range( 0, -4 ) ).toEqual( [ 0, -1, -2, -3 ] );
+	} );
+
+	it( 'should return an empty array for an empty range', () => {
+		expect( range( 0 ) ).toEqual( [] );
+		expect( range( 3, 3 ) ).toEqual( [] );
+	} );
+
+	it( 'should coerce numeric-string and non-finite bounds like lodash', () => {
+		// @ts-expect-error -- exercises lenient coercion for untyped callers.
+		expect( range( '1', '5' ) ).toEqual( [ 1, 2, 3, 4 ] );
+		expect( range( 0, NaN ) ).toEqual( [] );
+		// @ts-expect-error -- see above.
+		expect( range( 0, undefined ) ).toEqual( [] );
+	} );
+
+	it( 'should treat a symbol bound as 0, like lodash', () => {
+		// @ts-expect-error -- lodash coerces non-numeric bounds rather than throwing.
+		expect( range( Symbol( 'x' ) ) ).toEqual( [] );
+	} );
+
+	it( 'should repeat the start value when step is 0', () => {
+		expect( range( 0, 5, 0 ) ).toEqual( [ 0, 0, 0, 0, 0 ] );
+	} );
+
+	it( 'should throw on an Infinity bound, like lodash', () => {
+		// lodash coerces Infinity to MAX_INTEGER, so the resulting array length
+		// is invalid for both implementations.
+		expect( () => range( 0, Infinity ) ).toThrow( RangeError );
+	} );
+} );

--- a/packages/js-utils/src/test/to-finite.ts
+++ b/packages/js-utils/src/test/to-finite.ts
@@ -1,0 +1,55 @@
+import toFinite from '../to-finite';
+
+describe( 'toFinite', () => {
+	// Expected values verified against lodash `toFinite`.
+	it.each( [
+		[ 'integer', 5, 5 ],
+		[ 'negative', -5, -5 ],
+		[ 'float', 3.14, 3.14 ],
+		[ 'zero', 0, 0 ],
+		[ 'NaN', NaN, 0 ],
+		[ 'Infinity', Infinity, 1.7976931348623157e308 ],
+		[ '-Infinity', -Infinity, -1.7976931348623157e308 ],
+		[ 'numeric string', '10', 10 ],
+		[ 'padded numeric string', '  10  ', 10 ],
+		[ 'exponential string', '1e3', 1000 ],
+		[ 'binary string', '0b101', 5 ],
+		[ 'octal string', '0o17', 15 ],
+		[ 'hex string', '0x1f', 31 ],
+		[ 'signed hex string', '-0x1f', 0 ],
+		[ 'bad hex string', '0xzz', 0 ],
+		[ 'non-numeric string', 'abc', 0 ],
+		[ 'empty string', '', 0 ],
+		[ 'null', null, 0 ],
+		[ 'undefined', undefined, 0 ],
+		[ 'true', true, 1 ],
+		[ 'false', false, 0 ],
+		[ 'empty array', [], 0 ],
+		[ 'single-element array', [ 5 ], 5 ],
+		[ 'multi-element array', [ 5, 6 ], 0 ],
+		[ 'plain object', {}, 0 ],
+	] )( 'coerces %s to %p like lodash', ( _label, input, expected ) => {
+		expect( toFinite( input ) ).toBe( expected );
+	} );
+
+	it( 'returns 0 for a symbol instead of throwing', () => {
+		expect( toFinite( Symbol( 'x' ) ) ).toBe( 0 );
+	} );
+
+	it( 'returns 0 for a boxed symbol, like lodash', () => {
+		expect( toFinite( Object( Symbol( 'x' ) ) ) ).toBe( 0 );
+	} );
+
+	it( 'derives object values from valueOf only, like lodash', () => {
+		// `valueOf` returning a primitive is used directly.
+		expect( toFinite( { valueOf: () => 8 } ) ).toBe( 8 );
+		expect( toFinite( { valueOf: () => '8' } ) ).toBe( 8 );
+		// `valueOf` returning an object is stringified — lodash does NOT fall back
+		// to the original object's `toString`, so this is 0 (not 8) like lodash.
+		expect( toFinite( { valueOf: () => ( {} ), toString: () => '8' } ) ).toBe( 0 );
+		// With no custom `valueOf`, the default returns the object, so `toString`
+		// is consulted via stringification.
+		expect( toFinite( { toString: () => '8' } ) ).toBe( 8 );
+		expect( toFinite( new Date( 1000 ) ) ).toBe( 1000 );
+	} );
+} );

--- a/packages/js-utils/src/to-finite.ts
+++ b/packages/js-utils/src/to-finite.ts
@@ -1,0 +1,54 @@
+// lodash's largest finite number; ±Infinity coerce to this in `toFinite`.
+const MAX_INTEGER = 1.7976931348623157e308;
+
+/**
+ * Whether a value is a symbol, including boxed symbols (`Object( Symbol() )`).
+ * Uses the object tag so the check is realm-safe, matching lodash `isSymbol`.
+ */
+const isSymbol = ( value: unknown ): boolean =>
+	typeof value === 'symbol' ||
+	( typeof value === 'object' &&
+		value !== null &&
+		Object.prototype.toString.call( value ) === '[object Symbol]' );
+
+/**
+ * Coerces a value to a number, matching lodash `toNumber`. Notably, the
+ * primitive of an object is derived from `valueOf` only — if `valueOf` returns
+ * another object, that result is stringified (rather than falling back to the
+ * original object's `toString`, as native `Number` would). Symbols become `NaN`.
+ */
+const toNumber = ( value: unknown ): number => {
+	if ( typeof value === 'number' ) {
+		return value;
+	}
+	if ( isSymbol( value ) ) {
+		return NaN;
+	}
+
+	let primitive: unknown = value;
+	if ( value !== null && typeof value === 'object' ) {
+		const valueOf = ( value as { valueOf?: () => unknown } ).valueOf;
+		const other = typeof valueOf === 'function' ? valueOf.call( value ) : value;
+		primitive = other !== null && typeof other === 'object' ? `${ other }` : other;
+	}
+
+	return Number( primitive );
+};
+
+/**
+ * Coerces a value to a finite number, matching lodash `toFinite`: numeric
+ * strings (including binary/octal/hex) are parsed, `±Infinity` clamp to
+ * `±MAX_INTEGER`, and everything non-numeric (symbols, objects, `NaN`, etc.)
+ * becomes `0` — never throwing. Internal helper; not part of the public API.
+ */
+const toFinite = ( value: unknown ): number => {
+	const number = toNumber( value );
+
+	if ( number === Infinity || number === -Infinity ) {
+		return ( number < 0 ? -1 : 1 ) * MAX_INTEGER;
+	}
+
+	return Number.isNaN( number ) ? 0 : number;
+};
+
+export default toFinite;


### PR DESCRIPTION
## Proposed Changes

Part of the incremental lodash removal. Migrates four more functions off `lodash`:

- **`range`** and **`random`** → new `@automattic/js-utils` helpers. Both faithfully reproduce lodash behavior, including bound coercion of numeric strings and (for `random`) floating-point results when a bound is fractional or the `floating` flag is set. They share a small internal `toFinite` helper.
- **`clone`** → shallow spread copy (`{ ...obj }` / `[ ...arr ]`) at each usage.
- **`property`** → inline arrow function.

Adds the matching `no-restricted-imports` guard entries (named and deep `lodash/<fn>` imports) so the functions can't be reintroduced.

## Why are these changes being made?

Reducing the codebase's dependency on lodash, one small, low-risk batch at a time, replacing it with native JS or shared, tested helpers.

## Testing Instructions

- CI green: `yarn typecheck-client`, `yarn typecheck-packages`, lint, and unit tests all pass.
- The new helpers were validated against lodash as an oracle across integer/float/string/edge-case inputs (0 mismatches) and have unit tests under `packages/js-utils/src/test/`.
- No behavior change is expected at any usage; conversions preserve the prior semantics.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
