### PR TITLE
Emails: use sentence case for Add email forwarder title

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -239,7 +239,7 @@ export const addEmailForwarderRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Add Email Forwarder' ),
+				title: __( 'Add email forwarder' ),
 			},
 		],
 	} ),


### PR DESCRIPTION
## Proposed Changes

* Update the "Add Email Forwarder" page title to sentence case ("Add email forwarder").

## Why are these changes being made?

* The title-cased header was inconsistent with the dashboard's sentence-case convention and with the surrounding copy on the same page.

## Testing Instructions

* Visit the Add Email Forwarder screen (e.g. `/emails/add-forwarder`).
* Confirm the page title / breadcrumb reads "Add email forwarder".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
