### PR TITLE
Desktop: Default Windows signing to Azure Artifact Signing

### DIFF
--- a/.buildkite/commands/build-desktop-windows-nsis.ps1
+++ b/.buildkite/commands/build-desktop-windows-nsis.ps1
@@ -91,9 +91,7 @@ Write-Output "--- :windows: Building signed NSIS installer"
 Invoke-Checked { yarn run build:main }
 Invoke-Checked { yarn electron-builder --config electron-builder.json build --publish never }
 
-# Fail loud on any unsigned binary rather than shipping it: verify every packed
-# *.exe/*.node/*.dll (signed by win.sign + the afterPack native pass) before the
-# unpacked trees are dropped, then the installer itself below.
+# Fail loud on any unsigned binary rather than shipping it.
 function Assert-Signed {
     param([Parameter(Mandatory)][System.IO.FileInfo[]]$Binaries, [Parameter(Mandatory)][string]$Label)
     if ($Binaries.Count -eq 0) {

--- a/.buildkite/commands/build-desktop-windows-nsis.ps1
+++ b/.buildkite/commands/build-desktop-windows-nsis.ps1
@@ -8,9 +8,11 @@
     direct-download path: it is code-signed and keeps the in-app
     electron-updater enabled, so existing users auto-update to it.
 
-    This is the PFX-signed "bridge" build of the PFX -> Azure Trusted Signing
-    migration (AINFRA-2237): it must stay PFX-signed and ship while the Sectigo
-    cert is still valid (before 2026-07-05) so existing installs accept it.
+    Signs via Azure Trusted Signing by default (AINFRA-2237). The org Sectigo
+    PFX is retained as a fallback, selected by setting FORCE_PFX_SIGNING, until
+    the Azure-signed build is confirmed in distribution. The signer choice here
+    only decides which env vars are populated; electron-builder's `win.sign`
+    callback (bin/windows-sign.js) routes on them.
 #>
 
 # PowerShell does not abort on a failed *native* command, only on failed cmdlets.
@@ -53,29 +55,74 @@ $env:PLAYWRIGHT_SKIP_DOWNLOAD = 'true'
 Write-Output "--- :yarn: Installing desktop dependencies"
 Invoke-Checked { yarn install --immutable --inline-builds }
 
-# Materialize the org Windows signing certificate from AWS Secrets Manager
-# (writes certificate.pfx). Provided by the CI Toolkit Buildkite plugin and used
-# by every a8c Windows-signing app; WINDOWS_CODE_SIGNING_CERT_PASSWORD is the
-# matching cert password, already on the windows queue.
-Write-Output "--- :lock: Configuring Windows code signing (CI Toolkit cert)"
-Invoke-Checked { & 'setup_windows_code_signing.ps1' }
+if ($env:FORCE_PFX_SIGNING) {
+    # Fallback: materialize the org Sectigo cert from AWS Secrets Manager (writes
+    # certificate.pfx; WINDOWS_CODE_SIGNING_CERT_PASSWORD is the matching
+    # password, already on the windows queue). bin/windows-sign.js signs with
+    # signtool /f /p, so locate signtool from the Windows 10 SDK on the AMI.
+    Write-Output "--- :lock: Configuring Windows code signing (PFX fallback)"
+    Invoke-Checked { & 'setup_windows_code_signing.ps1' }
 
-if ([string]::IsNullOrEmpty($env:WINDOWS_CODE_SIGNING_CERT_PASSWORD)) {
-    throw "WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set on this agent."
+    if ([string]::IsNullOrEmpty($env:WINDOWS_CODE_SIGNING_CERT_PASSWORD)) {
+        throw "WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set on this agent."
+    }
+    $env:WIN_CSC_LINK = (Convert-Path '.\certificate.pfx')
+    $env:WIN_CSC_KEY_PASSWORD = $env:WINDOWS_CODE_SIGNING_CERT_PASSWORD
+
+    $signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin' -Recurse -Filter 'signtool.exe' -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+        Sort-Object FullName | Select-Object -Last 1
+    if (-not $signtool) {
+        throw "signtool.exe not found under the Windows 10 SDK - cannot PFX-sign."
+    }
+    $env:SIGNTOOL_PATH = $signtool.FullName
+} else {
+    # Default: Azure Trusted Signing. Sets AZURE_CODE_SIGNING_DLIB,
+    # AZURE_METADATA_JSON, and SIGNTOOL_PATH for bin/windows-sign.js.
+    Write-Output "--- :lock: Configuring Windows code signing (Azure Trusted Signing)"
+    Invoke-Checked { & 'setup_azure_trusted_signing.ps1' }
 }
-$certPath = (Convert-Path '.\certificate.pfx')
-$env:WIN_CSC_LINK = $certPath
-$env:WIN_CSC_KEY_PASSWORD = $env:WINDOWS_CODE_SIGNING_CERT_PASSWORD
+
 # electron-builder skips signing on CI PR builds unless this is set - needed to
 # exercise signing here. Gate to trunk/release before production.
 $env:CSC_FOR_PULL_REQUEST = 'true'
-# Workaround (per simplenote-electron): import the cert so the signer finds it.
-Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root `
-    -Password (ConvertTo-SecureString -String $env:WINDOWS_CODE_SIGNING_CERT_PASSWORD -AsPlainText -Force) | Out-Null
 
 Write-Output "--- :windows: Building signed NSIS installer"
 Invoke-Checked { yarn run build:main }
 Invoke-Checked { yarn electron-builder --config electron-builder.json build --publish never }
+
+# Fail loud on any unsigned binary rather than shipping it: verify every packed
+# *.exe/*.node/*.dll (signed by win.sign + the afterPack native pass) before the
+# unpacked trees are dropped, then the installer itself below.
+function Assert-Signed {
+    param([Parameter(Mandatory)][System.IO.FileInfo[]]$Binaries, [Parameter(Mandatory)][string]$Label)
+    if ($Binaries.Count -eq 0) {
+        throw "No binaries to verify for ${Label} - did the packaged layout change?"
+    }
+    $failures = @()
+    foreach ($binary in $Binaries) {
+        & $env:SIGNTOOL_PATH verify /pa /q $binary.FullName
+        if ($LASTEXITCODE -ne 0) {
+            # Re-run without /q so the reason lands in the log instead of forcing
+            # an operator to RDP into the worker.
+            Write-Output "[!] Not signed: $($binary.FullName)"
+            & $env:SIGNTOOL_PATH verify /pa /v $binary.FullName
+            $failures += $binary.FullName
+        }
+    }
+    if ($failures.Count -gt 0) {
+        Write-Output "^^^ +++"
+        throw "$($failures.Count) of $($Binaries.Count) ${Label} binaries are NOT signed."
+    }
+    Write-Output "Verified all $($Binaries.Count) ${Label} binaries are signed."
+}
+
+Write-Output "--- :mag: Verifying signatures on packed binaries"
+$unpacked = @(Get-ChildItem -Path release -Directory -Filter 'win*-unpacked')
+foreach ($dir in $unpacked) {
+    $binaries = @(Get-ChildItem -Path $dir.FullName -Recurse -Include '*.exe', '*.node', '*.dll' -File)
+    Assert-Signed -Binaries $binaries -Label $dir.Name
+}
 
 # Drop the unpacked trees so the artifact upload doesn't ferry thousands of
 # loose files; keep the installer, its blockmap, and the electron-updater feed.
@@ -85,5 +132,7 @@ $exe = @(Get-ChildItem -Path release -Filter '*.exe' -ErrorAction SilentlyContin
 if (-not $exe) {
     throw "No .exe produced in desktop/release - the NSIS build did not emit an installer."
 }
+Assert-Signed -Binaries $exe -Label 'installer'
+
 Write-Output "--- :white_check_mark: Built $($exe.Count) installer(s):"
 $exe | ForEach-Object { Write-Output "  $($_.Name)" }

--- a/.buildkite/commands/build-desktop-windows-nsis.ps1
+++ b/.buildkite/commands/build-desktop-windows-nsis.ps1
@@ -77,8 +77,8 @@ if ($env:FORCE_PFX_SIGNING) {
     }
     $env:SIGNTOOL_PATH = $signtool.FullName
 } else {
-    # Default: Azure Trusted Signing. Sets AZURE_CODE_SIGNING_DLIB,
-    # AZURE_METADATA_JSON, and SIGNTOOL_PATH for bin/windows-sign.js.
+    # Sets AZURE_CODE_SIGNING_DLIB, AZURE_METADATA_JSON,
+    # and SIGNTOOL_PATH for bin/windows-sign.js.
     Write-Output "--- :lock: Configuring Windows code signing (Azure Trusted Signing)"
     Invoke-Checked { & 'setup_azure_trusted_signing.ps1' }
 }

--- a/.buildkite/commands/build-desktop-windows-nsis.ps1
+++ b/.buildkite/commands/build-desktop-windows-nsis.ps1
@@ -8,7 +8,7 @@
     direct-download path: it is code-signed and keeps the in-app
     electron-updater enabled, so existing users auto-update to it.
 
-    Signs via Azure Trusted Signing by default (AINFRA-2237). The org Sectigo
+    Signs via Azure Artifact Signing by default (AINFRA-2237). The org Sectigo
     PFX is retained as a fallback, selected by setting FORCE_PFX_SIGNING, until
     the Azure-signed build is confirmed in distribution. The signer choice here
     only decides which env vars are populated; electron-builder's `win.sign`
@@ -79,7 +79,7 @@ if ($env:FORCE_PFX_SIGNING) {
 } else {
     # Sets AZURE_CODE_SIGNING_DLIB, AZURE_METADATA_JSON,
     # and SIGNTOOL_PATH for bin/windows-sign.js.
-    Write-Output "--- :lock: Configuring Windows code signing (Azure Trusted Signing)"
+    Write-Output "--- :lock: Configuring Windows code signing (Azure Artifact Signing)"
     Invoke-Checked { & 'setup_azure_trusted_signing.ps1' }
 }
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
       - desktop/release/*.appx
 
   # Signed NSIS direct-download installer — the auto-update path (electron-
-  # updater stays enabled). Signs via Azure Trusted Signing by default, with the
+  # updater stays enabled). Signs via Azure Artifact Signing by default, with the
   # org Sectigo PFX as a fallback behind FORCE_PFX_SIGNING (AINFRA-2237).
   - label: ":windows: Build desktop (windows nsis, signed)"
     branches: ainfra-*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,10 +73,8 @@ steps:
       - desktop/release/*.appx
 
   # Signed NSIS direct-download installer — the auto-update path (electron-
-  # updater stays enabled). Signed with the org cert the CI Toolkit plugin
-  # pulls from AWS Secrets Manager (setup_windows_code_signing.ps1) using
-  # WINDOWS_CODE_SIGNING_CERT_PASSWORD. This is the PFX→Azure handover bridge
-  # build.
+  # updater stays enabled). Signs via Azure Trusted Signing by default, with the
+  # org Sectigo PFX as a fallback behind FORCE_PFX_SIGNING (AINFRA-2237).
   - label: ":windows: Build desktop (windows nsis, signed)"
     branches: ainfra-*
     notify:

--- a/desktop/bin/after_pack_hook.js
+++ b/desktop/bin/after_pack_hook.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-// `afterPack` hook for electron-builder. Signs the packed binaries it won't:
-// *.node/*.dll (never routed through `win.sign`) and nested *.exe (its
-// asar:false signApp signs only the top-level app exe). The top-level exe is
-// left to electron-builder — signing it here would corrupt its rcedit+sign pass.
+// `afterPack` hook for electron-builder. Signs the packaged native binaries
+// (*.node, *.dll) that the `win.sign` callback never sees because electron-builder
+// routes only *.exe through it. Runs before the app exe and installer are
+// signed, so the whole tree is covered by the time the installer is built.
 
-const { signPackagedBinaries } = require( './windows-signing-core' );
+const { signNativeBinaries } = require( './windows-signing-core' );
 
 module.exports = async function ( context ) {
 	// Gate to CI Windows builds: matches the win.sign callback, and keeps local
@@ -13,5 +13,5 @@ module.exports = async function ( context ) {
 	if ( context.electronPlatformName !== 'win32' || ! process.env.CI ) {
 		return;
 	}
-	await signPackagedBinaries( context.appOutDir );
+	await signNativeBinaries( context.appOutDir );
 };

--- a/desktop/bin/after_pack_hook.js
+++ b/desktop/bin/after_pack_hook.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-// electron-builder `afterPack` hook. Signs the packaged native binaries
-// (*.node, *.dll) that the `win.sign` callback never sees — electron-builder
+// `afterPack` hook for electron-builder. Signs the packaged native binaries
+// (*.node, *.dll) that the `win.sign` callback never sees because electron-builder
 // routes only *.exe through it. Runs before the app exe and installer are
 // signed, so the whole tree is covered by the time the installer is built.
 

--- a/desktop/bin/after_pack_hook.js
+++ b/desktop/bin/after_pack_hook.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-// `afterPack` hook for electron-builder. Signs every packed binary (*.exe,
-// *.node, *.dll) so none ship unsigned: under `asar: false` electron-builder's
-// signApp signs only the top-level app exe, and it never routes *.node/*.dll
-// through `win.sign`. Runs before signApp and the installer build, so the whole
-// tree is covered by the time the installer is built.
+// `afterPack` hook for electron-builder. Signs the packed binaries it won't:
+// *.node/*.dll (never routed through `win.sign`) and nested *.exe (its
+// asar:false signApp signs only the top-level app exe). The top-level exe is
+// left to electron-builder — signing it here would corrupt its rcedit+sign pass.
 
 const { signPackagedBinaries } = require( './windows-signing-core' );
 

--- a/desktop/bin/after_pack_hook.js
+++ b/desktop/bin/after_pack_hook.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-// `afterPack` hook for electron-builder. Signs the packaged native binaries
-// (*.node, *.dll) that the `win.sign` callback never sees because electron-builder
-// routes only *.exe through it. Runs before the app exe and installer are
-// signed, so the whole tree is covered by the time the installer is built.
+// `afterPack` hook for electron-builder. Signs every packed binary (*.exe,
+// *.node, *.dll) so none ship unsigned: under `asar: false` electron-builder's
+// signApp signs only the top-level app exe, and it never routes *.node/*.dll
+// through `win.sign`. Runs before signApp and the installer build, so the whole
+// tree is covered by the time the installer is built.
 
-const { signNativeBinaries } = require( './windows-signing-core' );
+const { signPackagedBinaries } = require( './windows-signing-core' );
 
 module.exports = async function ( context ) {
 	// Gate to CI Windows builds: matches the win.sign callback, and keeps local
@@ -13,5 +14,5 @@ module.exports = async function ( context ) {
 	if ( context.electronPlatformName !== 'win32' || ! process.env.CI ) {
 		return;
 	}
-	await signNativeBinaries( context.appOutDir );
+	await signPackagedBinaries( context.appOutDir );
 };

--- a/desktop/bin/after_pack_hook.js
+++ b/desktop/bin/after_pack_hook.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// electron-builder `afterPack` hook. Signs the packaged native binaries
+// (*.node, *.dll) that the `win.sign` callback never sees — electron-builder
+// routes only *.exe through it. Runs before the app exe and installer are
+// signed, so the whole tree is covered by the time the installer is built.
+
+const { signNativeBinaries } = require( './windows-signing-core' );
+
+module.exports = async function ( context ) {
+	// Gate to CI Windows builds: matches the win.sign callback, and keeps local
+	// dev / Mac / Linux packing untouched.
+	if ( context.electronPlatformName !== 'win32' || ! process.env.CI ) {
+		return;
+	}
+	await signNativeBinaries( context.appOutDir );
+};

--- a/desktop/bin/windows-sign.js
+++ b/desktop/bin/windows-sign.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // `win.sign` callback for electron-builder. Invoked for every Windows .exe (the
-// app exe, nested exes, and the NSIS installer). Signs via Azure Trusted
+// app exe, nested exes, and the NSIS installer). Signs via Azure.
 
 const { resolveSigner, signFile } = require( './windows-signing-core' );
 

--- a/desktop/bin/windows-sign.js
+++ b/desktop/bin/windows-sign.js
@@ -7,7 +7,7 @@ const { resolveSigner, signFile } = require( './windows-signing-core' );
 
 module.exports = async function ( configuration ) {
 	// electron-builder iterates its default sha1 + sha256 hashes and calls this
-	// once per hash. Azure Trusted Signing is SHA256-only, so skip the sha1 pass.
+	// once per hash. Azure Artifact Signing is SHA256-only, so skip the sha1 pass.
 	if ( configuration.hash === 'sha1' ) {
 		console.log( `[windows-sign] Skipping ${ configuration.path } for SHA1 (SHA256-only)` );
 		return;

--- a/desktop/bin/windows-sign.js
+++ b/desktop/bin/windows-sign.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// electron-builder `win.sign` callback. Invoked for every Windows .exe (the
+// app exe, nested exes, and the NSIS installer). Signs via Azure Trusted
+// Signing by default, falling back to the org PFX when no Azure env is present.
+
+const { resolveSigner, signFile } = require( './windows-signing-core' );
+
+module.exports = async function ( configuration ) {
+	// electron-builder iterates its default sha1 + sha256 hashes and calls this
+	// once per hash. Azure Trusted Signing is SHA256-only, so skip the sha1 pass.
+	if ( configuration.hash === 'sha1' ) {
+		console.log( `[windows-sign] Skipping ${ configuration.path } for SHA1 (SHA256-only)` );
+		return;
+	}
+	await signFile( resolveSigner(), configuration.path );
+};

--- a/desktop/bin/windows-sign.js
+++ b/desktop/bin/windows-sign.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
-// electron-builder `win.sign` callback. Invoked for every Windows .exe (the
+// `win.sign` callback for electron-builder. Invoked for every Windows .exe (the
 // app exe, nested exes, and the NSIS installer). Signs via Azure Trusted
-// Signing by default, falling back to the org PFX when no Azure env is present.
 
 const { resolveSigner, signFile } = require( './windows-signing-core' );
 

--- a/desktop/bin/windows-signing-core.js
+++ b/desktop/bin/windows-signing-core.js
@@ -14,10 +14,15 @@ const TIMESTAMP_DIGEST = 'SHA256';
 const AZURE_TIMESTAMP_SERVER = 'http://timestamp.acs.microsoft.com';
 const PFX_TIMESTAMP_SERVER = 'http://timestamp.sectigo.com';
 
-// electron-builder routes *.exe through the sign callback but not these, so
-// native binaries ship unsigned without an explicit afterPack pass — and
-// Windows Smart App Control blocks an app that loads unsigned ones.
-const NATIVE_BINARY_EXTENSIONS = new Set( [ '.node', '.dll' ] );
+// afterPack signs every packed binary so the verify gate can't trip on an
+// unsigned one. electron-builder signs only the top-level app .exe under
+// `asar: false` (its signApp returns before walking the rest of the tree),
+// leaving two gaps this fills:
+//   - *.node/*.dll: native modules it never signs — Smart App Control blocks
+//     an app that loads unsigned ones.
+//   - *.exe nested below the top level (e.g. bundled by production node_modules).
+// Re-signing the top-level .exe here is harmless: signApp re-signs it afterward.
+const SIGNABLE_EXTENSIONS = new Set( [ '.exe', '.node', '.dll' ] );
 
 // Resolve the active signer from the environment, or throw naming exactly what
 // is missing. Azure takes precedence; the PFX fallback engages only when no
@@ -111,19 +116,19 @@ function signFile( signer, file ) {
 	} );
 }
 
-function collectNativeBinaries( dir, acc = [] ) {
+function collectSignableBinaries( dir, acc = [] ) {
 	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
 		const full = path.join( dir, entry.name );
 		// Skip symlinks to avoid following workspace links / cycles; the packaged
-		// output dereferences them, so real native binaries are still visited.
+		// output dereferences them, so real binaries are still visited.
 		if ( entry.isSymbolicLink() ) {
 			continue;
 		}
 		if ( entry.isDirectory() ) {
-			collectNativeBinaries( full, acc );
+			collectSignableBinaries( full, acc );
 		} else if (
 			entry.isFile() &&
-			NATIVE_BINARY_EXTENSIONS.has( path.extname( entry.name ).toLowerCase() )
+			SIGNABLE_EXTENSIONS.has( path.extname( entry.name ).toLowerCase() )
 		) {
 			acc.push( full );
 		}
@@ -131,15 +136,17 @@ function collectNativeBinaries( dir, acc = [] ) {
 	return acc;
 }
 
-async function signNativeBinaries( appOutDir, env = process.env ) {
+async function signPackagedBinaries( appOutDir, env = process.env ) {
 	const signer = resolveSigner( env );
-	const binaries = collectNativeBinaries( appOutDir );
+	const binaries = collectSignableBinaries( appOutDir );
 	if ( binaries.length === 0 ) {
-		console.log( `[windows-sign] No native binaries (*.node, *.dll) under ${ appOutDir }` );
+		console.log(
+			`[windows-sign] No signable binaries (*.exe, *.node, *.dll) under ${ appOutDir }`
+		);
 		return;
 	}
 	console.log(
-		`[windows-sign] Signing ${ binaries.length } native binaries (*.node, *.dll) under ${ appOutDir }`
+		`[windows-sign] Signing ${ binaries.length } packed binaries (*.exe, *.node, *.dll) under ${ appOutDir }`
 	);
 	for ( const binary of binaries ) {
 		await signFile( signer, binary );
@@ -150,6 +157,6 @@ module.exports = {
 	resolveSigner,
 	buildSignToolArgs,
 	signFile,
-	signNativeBinaries,
-	collectNativeBinaries,
+	signPackagedBinaries,
+	collectSignableBinaries,
 };

--- a/desktop/bin/windows-signing-core.js
+++ b/desktop/bin/windows-signing-core.js
@@ -14,15 +14,9 @@ const TIMESTAMP_DIGEST = 'SHA256';
 const AZURE_TIMESTAMP_SERVER = 'http://timestamp.acs.microsoft.com';
 const PFX_TIMESTAMP_SERVER = 'http://timestamp.sectigo.com';
 
-// afterPack signs every packed binary so the verify gate can't trip on an
-// unsigned one. electron-builder signs only the top-level app .exe under
-// `asar: false` (its signApp returns before walking the rest of the tree),
-// leaving two gaps this fills:
-//   - *.node/*.dll: native modules it never signs — Smart App Control blocks
-//     an app that loads unsigned ones.
-//   - *.exe nested below the top level (e.g. bundled by production node_modules).
-// Re-signing the top-level .exe here is harmless: signApp re-signs it afterward.
-const SIGNABLE_EXTENSIONS = new Set( [ '.exe', '.node', '.dll' ] );
+// Native modules electron-builder never signs — Smart App Control blocks an app
+// that loads unsigned ones — so afterPack signs these at every depth.
+const NATIVE_BINARY_EXTENSIONS = new Set( [ '.node', '.dll' ] );
 
 // Resolve the active signer from the environment, or throw naming exactly what
 // is missing. Azure takes precedence; the PFX fallback engages only when no
@@ -116,7 +110,7 @@ function signFile( signer, file ) {
 	} );
 }
 
-function collectSignableBinaries( dir, acc = [] ) {
+function collectSignableBinaries( dir, rootDir = dir, acc = [] ) {
 	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
 		const full = path.join( dir, entry.name );
 		// Skip symlinks to avoid following workspace links / cycles; the packaged
@@ -125,12 +119,19 @@ function collectSignableBinaries( dir, acc = [] ) {
 			continue;
 		}
 		if ( entry.isDirectory() ) {
-			collectSignableBinaries( full, acc );
-		} else if (
-			entry.isFile() &&
-			SIGNABLE_EXTENSIONS.has( path.extname( entry.name ).toLowerCase() )
-		) {
-			acc.push( full );
+			collectSignableBinaries( full, rootDir, acc );
+		} else if ( entry.isFile() ) {
+			const ext = path.extname( entry.name ).toLowerCase();
+			// Take *.exe only below the top level. electron-builder signs the
+			// top-level app exe itself (rcedit then signtool); pre-signing it here
+			// breaks that pass — rcedit rewrites resources on the already-signed PE
+			// and signtool then rejects it with 0x800700C1 (bad exe format). Its
+			// asar:false signApp never reaches nested exes, so those are ours.
+			if ( NATIVE_BINARY_EXTENSIONS.has( ext ) ) {
+				acc.push( full );
+			} else if ( ext === '.exe' && dir !== rootDir ) {
+				acc.push( full );
+			}
 		}
 	}
 	return acc;

--- a/desktop/bin/windows-signing-core.js
+++ b/desktop/bin/windows-signing-core.js
@@ -4,7 +4,7 @@ const { spawn } = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 
-// Azure Trusted Signing is SHA256-only. The PFX path matches it so both modes
+// Azure Artifact Signing is SHA256-only. The PFX path matches it so both modes
 // emit a single SHA256 signature.
 const FILE_DIGEST = 'SHA256';
 const TIMESTAMP_DIGEST = 'SHA256';
@@ -38,7 +38,7 @@ function resolveSigner( env = process.env ) {
 		);
 		if ( missing.length ) {
 			throw new Error(
-				`Azure Trusted Signing selected but missing: ${ missing.join(
+				`Azure Artifact Signing selected but missing: ${ missing.join(
 					', '
 				) }. Did setup_azure_trusted_signing.ps1 run?`
 			);

--- a/desktop/bin/windows-signing-core.js
+++ b/desktop/bin/windows-signing-core.js
@@ -1,16 +1,4 @@
 // Shared Windows code-signing helpers for the Buildkite NSIS build.
-//
-// Azure Trusted Signing is the default path; the org Sectigo PFX is retained as
-// a fallback until the Azure-signed build is confirmed in distribution. Both
-// paths drive `signtool` directly so a single electron-builder `win.sign`
-// callback covers them (electron-builder 24 has no native Azure support).
-//
-// Env vars come from the CI Toolkit Buildkite plugin (6.1.0+):
-//   - setup_azure_trusted_signing.ps1 → AZURE_CODE_SIGNING_DLIB,
-//     AZURE_METADATA_JSON, SIGNTOOL_PATH
-//   - setup_windows_code_signing.ps1  → certificate.pfx, surfaced by the build
-//     script as WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD (SIGNTOOL_PATH located from
-//     the Windows SDK in the same branch)
 
 const { spawn } = require( 'child_process' );
 const fs = require( 'fs' );
@@ -80,7 +68,6 @@ function resolveSigner( env = process.env ) {
 	);
 }
 
-// Build the `signtool sign` argument vector for the resolved signer.
 function buildSignToolArgs( signer, file ) {
 	const common = [
 		'sign',

--- a/desktop/bin/windows-signing-core.js
+++ b/desktop/bin/windows-signing-core.js
@@ -1,0 +1,168 @@
+// Shared Windows code-signing helpers for the Buildkite NSIS build.
+//
+// Azure Trusted Signing is the default path; the org Sectigo PFX is retained as
+// a fallback until the Azure-signed build is confirmed in distribution. Both
+// paths drive `signtool` directly so a single electron-builder `win.sign`
+// callback covers them (electron-builder 24 has no native Azure support).
+//
+// Env vars come from the CI Toolkit Buildkite plugin (6.1.0+):
+//   - setup_azure_trusted_signing.ps1 → AZURE_CODE_SIGNING_DLIB,
+//     AZURE_METADATA_JSON, SIGNTOOL_PATH
+//   - setup_windows_code_signing.ps1  → certificate.pfx, surfaced by the build
+//     script as WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD (SIGNTOOL_PATH located from
+//     the Windows SDK in the same branch)
+
+const { spawn } = require( 'child_process' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+// Azure Trusted Signing is SHA256-only. The PFX path matches it so both modes
+// emit a single SHA256 signature.
+const FILE_DIGEST = 'SHA256';
+const TIMESTAMP_DIGEST = 'SHA256';
+
+// HTTPS against the Azure timestamp endpoint currently fails; HTTP is the
+// working protocol (Beeper hit the same, AINFRA-2275).
+const AZURE_TIMESTAMP_SERVER = 'http://timestamp.acs.microsoft.com';
+const PFX_TIMESTAMP_SERVER = 'http://timestamp.sectigo.com';
+
+// electron-builder routes *.exe through the sign callback but not these, so
+// native binaries ship unsigned without an explicit afterPack pass — and
+// Windows Smart App Control blocks an app that loads unsigned ones.
+const NATIVE_BINARY_EXTENSIONS = new Set( [ '.node', '.dll' ] );
+
+// Resolve the active signer from the environment, or throw naming exactly what
+// is missing. Azure takes precedence; the PFX fallback engages only when no
+// Azure env is present. A partially-configured mode is an error, not a reason
+// to fall through to the other.
+function resolveSigner( env = process.env ) {
+	const azureIntended = !! ( env.AZURE_CODE_SIGNING_DLIB || env.AZURE_METADATA_JSON );
+	const pfxIntended = !! ( env.WIN_CSC_LINK || env.WIN_CSC_KEY_PASSWORD );
+
+	if ( azureIntended ) {
+		const missing = [ 'AZURE_CODE_SIGNING_DLIB', 'AZURE_METADATA_JSON', 'SIGNTOOL_PATH' ].filter(
+			( name ) => ! env[ name ]
+		);
+		if ( missing.length ) {
+			throw new Error(
+				`Azure Trusted Signing selected but missing: ${ missing.join(
+					', '
+				) }. Did setup_azure_trusted_signing.ps1 run?`
+			);
+		}
+		return {
+			kind: 'azure',
+			signtoolPath: env.SIGNTOOL_PATH,
+			dlib: env.AZURE_CODE_SIGNING_DLIB,
+			metadata: env.AZURE_METADATA_JSON,
+			timestampServer: env.AZURE_TIMESTAMP_SERVER || AZURE_TIMESTAMP_SERVER,
+		};
+	}
+
+	if ( pfxIntended ) {
+		const missing = [ 'WIN_CSC_LINK', 'WIN_CSC_KEY_PASSWORD', 'SIGNTOOL_PATH' ].filter(
+			( name ) => ! env[ name ]
+		);
+		if ( missing.length ) {
+			throw new Error( `PFX fallback selected but missing: ${ missing.join( ', ' ) }.` );
+		}
+		return {
+			kind: 'pfx',
+			signtoolPath: env.SIGNTOOL_PATH,
+			pfx: env.WIN_CSC_LINK,
+			password: env.WIN_CSC_KEY_PASSWORD,
+			timestampServer: env.PFX_TIMESTAMP_SERVER || PFX_TIMESTAMP_SERVER,
+		};
+	}
+
+	throw new Error(
+		'No Windows signing configuration found: set Azure (AZURE_CODE_SIGNING_DLIB, AZURE_METADATA_JSON, SIGNTOOL_PATH) or PFX (WIN_CSC_LINK, WIN_CSC_KEY_PASSWORD, SIGNTOOL_PATH) env vars.'
+	);
+}
+
+// Build the `signtool sign` argument vector for the resolved signer.
+function buildSignToolArgs( signer, file ) {
+	const common = [
+		'sign',
+		'/v',
+		// /debug surfaces Azure.CodeSigning.Dlib diagnostics (account/cert
+		// selection, token acquisition, timestamp round-trips); without it a
+		// remote failure collapses to a generic "SignTool Error".
+		'/debug',
+		'/fd',
+		FILE_DIGEST,
+		'/tr',
+		signer.timestampServer,
+		'/td',
+		TIMESTAMP_DIGEST,
+	];
+
+	if ( signer.kind === 'azure' ) {
+		return [ ...common, '/dlib', signer.dlib, '/dmdf', signer.metadata, file ];
+	}
+	return [ ...common, '/f', signer.pfx, '/p', signer.password, file ];
+}
+
+function signFile( signer, file ) {
+	const args = buildSignToolArgs( signer, file );
+	console.log( `[windows-sign] Signing (${ signer.kind }) ${ file }` );
+
+	return new Promise( ( resolve, reject ) => {
+		const proc = spawn( signer.signtoolPath, args, { stdio: 'inherit' } );
+		proc.on( 'error', ( err ) =>
+			reject( new Error( `signtool spawn failed for ${ file }: ${ err.message }` ) )
+		);
+		proc.on( 'exit', ( code, signal ) => {
+			if ( signal ) {
+				reject( new Error( `signtool killed by signal ${ signal } for ${ file }` ) );
+			} else if ( code !== 0 ) {
+				reject( new Error( `signtool failed for ${ file } (exit ${ code })` ) );
+			} else {
+				resolve();
+			}
+		} );
+	} );
+}
+
+function collectNativeBinaries( dir, acc = [] ) {
+	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+		const full = path.join( dir, entry.name );
+		// Skip symlinks to avoid following workspace links / cycles; the packaged
+		// output dereferences them, so real native binaries are still visited.
+		if ( entry.isSymbolicLink() ) {
+			continue;
+		}
+		if ( entry.isDirectory() ) {
+			collectNativeBinaries( full, acc );
+		} else if (
+			entry.isFile() &&
+			NATIVE_BINARY_EXTENSIONS.has( path.extname( entry.name ).toLowerCase() )
+		) {
+			acc.push( full );
+		}
+	}
+	return acc;
+}
+
+async function signNativeBinaries( appOutDir, env = process.env ) {
+	const signer = resolveSigner( env );
+	const binaries = collectNativeBinaries( appOutDir );
+	if ( binaries.length === 0 ) {
+		console.log( `[windows-sign] No native binaries (*.node, *.dll) under ${ appOutDir }` );
+		return;
+	}
+	console.log(
+		`[windows-sign] Signing ${ binaries.length } native binaries (*.node, *.dll) under ${ appOutDir }`
+	);
+	for ( const binary of binaries ) {
+		await signFile( signer, binary );
+	}
+}
+
+module.exports = {
+	resolveSigner,
+	buildSignToolArgs,
+	signFile,
+	signNativeBinaries,
+	collectNativeBinaries,
+};

--- a/desktop/bin/windows-signing-core.js
+++ b/desktop/bin/windows-signing-core.js
@@ -14,8 +14,9 @@ const TIMESTAMP_DIGEST = 'SHA256';
 const AZURE_TIMESTAMP_SERVER = 'http://timestamp.acs.microsoft.com';
 const PFX_TIMESTAMP_SERVER = 'http://timestamp.sectigo.com';
 
-// Native modules electron-builder never signs — Smart App Control blocks an app
-// that loads unsigned ones — so afterPack signs these at every depth.
+// electron-builder routes *.exe through the sign callback but not these, so
+// native binaries ship unsigned without an explicit afterPack pass — and
+// Windows Smart App Control blocks an app that loads unsigned ones.
 const NATIVE_BINARY_EXTENSIONS = new Set( [ '.node', '.dll' ] );
 
 // Resolve the active signer from the environment, or throw naming exactly what
@@ -110,44 +111,35 @@ function signFile( signer, file ) {
 	} );
 }
 
-function collectSignableBinaries( dir, rootDir = dir, acc = [] ) {
+function collectNativeBinaries( dir, acc = [] ) {
 	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
 		const full = path.join( dir, entry.name );
 		// Skip symlinks to avoid following workspace links / cycles; the packaged
-		// output dereferences them, so real binaries are still visited.
+		// output dereferences them, so real native binaries are still visited.
 		if ( entry.isSymbolicLink() ) {
 			continue;
 		}
 		if ( entry.isDirectory() ) {
-			collectSignableBinaries( full, rootDir, acc );
-		} else if ( entry.isFile() ) {
-			const ext = path.extname( entry.name ).toLowerCase();
-			// Take *.exe only below the top level. electron-builder signs the
-			// top-level app exe itself (rcedit then signtool); pre-signing it here
-			// breaks that pass — rcedit rewrites resources on the already-signed PE
-			// and signtool then rejects it with 0x800700C1 (bad exe format). Its
-			// asar:false signApp never reaches nested exes, so those are ours.
-			if ( NATIVE_BINARY_EXTENSIONS.has( ext ) ) {
-				acc.push( full );
-			} else if ( ext === '.exe' && dir !== rootDir ) {
-				acc.push( full );
-			}
+			collectNativeBinaries( full, acc );
+		} else if (
+			entry.isFile() &&
+			NATIVE_BINARY_EXTENSIONS.has( path.extname( entry.name ).toLowerCase() )
+		) {
+			acc.push( full );
 		}
 	}
 	return acc;
 }
 
-async function signPackagedBinaries( appOutDir, env = process.env ) {
+async function signNativeBinaries( appOutDir, env = process.env ) {
 	const signer = resolveSigner( env );
-	const binaries = collectSignableBinaries( appOutDir );
+	const binaries = collectNativeBinaries( appOutDir );
 	if ( binaries.length === 0 ) {
-		console.log(
-			`[windows-sign] No signable binaries (*.exe, *.node, *.dll) under ${ appOutDir }`
-		);
+		console.log( `[windows-sign] No native binaries (*.node, *.dll) under ${ appOutDir }` );
 		return;
 	}
 	console.log(
-		`[windows-sign] Signing ${ binaries.length } packed binaries (*.exe, *.node, *.dll) under ${ appOutDir }`
+		`[windows-sign] Signing ${ binaries.length } native binaries (*.node, *.dll) under ${ appOutDir }`
 	);
 	for ( const binary of binaries ) {
 		await signFile( signer, binary );
@@ -158,6 +150,6 @@ module.exports = {
 	resolveSigner,
 	buildSignToolArgs,
 	signFile,
-	signPackagedBinaries,
-	collectSignableBinaries,
+	signNativeBinaries,
+	collectNativeBinaries,
 };

--- a/desktop/electron-builder.json
+++ b/desktop/electron-builder.json
@@ -42,6 +42,7 @@
 	},
 	"win": {
 		"publisherName": [ "Automattic, Inc.", "Automattic Inc." ],
+		"sign": "./bin/windows-sign.js",
 		"icon": "./resource/icon.ico",
 		"target": [
 			{
@@ -70,5 +71,6 @@
 		"depends": [ "gconf2", "gconf-service", "libnotify4", "libxtst6", "libnss3" ],
 		"artifactName": "wordpress.com-linux-deb-${version}.${ext}"
 	},
+	"afterPack": "./bin/after_pack_hook.js",
 	"afterSign": "./bin/after_sign_hook.js"
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -31,7 +31,8 @@
 		"build:secrets": "node bin/build-desktop-secrets.js",
 		"ci:github:add-review": "node bin/github/add-review.js",
 		"ci:github:dismiss-review": "node bin/github/dismiss-review.js",
-		"test:e2e": "jest -c test/e2e/config/jest.config.js"
+		"test:e2e": "jest -c test/e2e/config/jest.config.js",
+		"test:unit": "jest -c test/unit/jest.config.js"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",

--- a/desktop/test/unit/jest.config.js
+++ b/desktop/test/unit/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rootDir: '../..',
+	testMatch: [ '<rootDir>/test/unit/**/*.test.js' ],
+	testEnvironment: 'node',
+};

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -1,0 +1,85 @@
+const { resolveSigner, buildSignToolArgs } = require( '../../bin/windows-signing-core' );
+
+const AZURE_ENV = {
+	AZURE_CODE_SIGNING_DLIB: 'C:\\dlib\\Azure.CodeSigning.Dlib.dll',
+	AZURE_METADATA_JSON: 'C:\\meta\\metadata.json',
+	SIGNTOOL_PATH: 'C:\\sdk\\signtool.exe',
+};
+
+const PFX_ENV = {
+	WIN_CSC_LINK: 'C:\\certs\\certificate.pfx',
+	WIN_CSC_KEY_PASSWORD: 'hunter2',
+	SIGNTOOL_PATH: 'C:\\sdk\\signtool.exe',
+};
+
+describe( 'resolveSigner', () => {
+	it( 'selects Azure when its env is present', () => {
+		expect( resolveSigner( AZURE_ENV ) ).toMatchObject( {
+			kind: 'azure',
+			dlib: AZURE_ENV.AZURE_CODE_SIGNING_DLIB,
+		} );
+	} );
+
+	it( 'falls back to PFX when only PFX env is present', () => {
+		expect( resolveSigner( PFX_ENV ) ).toMatchObject( { kind: 'pfx', pfx: PFX_ENV.WIN_CSC_LINK } );
+	} );
+
+	it( 'prefers Azure over PFX when both are present', () => {
+		expect( resolveSigner( { ...AZURE_ENV, ...PFX_ENV } ).kind ).toBe( 'azure' );
+	} );
+
+	it( 'throws naming the missing var for a partial Azure config', () => {
+		const { SIGNTOOL_PATH, ...partial } = AZURE_ENV;
+		expect( () => resolveSigner( partial ) ).toThrow( /SIGNTOOL_PATH/ );
+	} );
+
+	it( 'throws naming the missing var for a partial PFX config', () => {
+		const { WIN_CSC_KEY_PASSWORD, ...partial } = PFX_ENV;
+		expect( () => resolveSigner( partial ) ).toThrow( /WIN_CSC_KEY_PASSWORD/ );
+	} );
+
+	it( 'throws when no signing config is present', () => {
+		expect( () => resolveSigner( {} ) ).toThrow( /No Windows signing configuration/ );
+	} );
+} );
+
+describe( 'buildSignToolArgs', () => {
+	it( 'builds an Azure dlib invocation, SHA256, file last', () => {
+		const args = buildSignToolArgs( resolveSigner( AZURE_ENV ), 'app.exe' );
+		expect( args ).toEqual(
+			expect.arrayContaining( [
+				'/dlib',
+				AZURE_ENV.AZURE_CODE_SIGNING_DLIB,
+				'/dmdf',
+				AZURE_ENV.AZURE_METADATA_JSON,
+			] )
+		);
+		expect( args ).not.toContain( '/f' );
+		expect( args[ args.length - 1 ] ).toBe( 'app.exe' );
+		expect( args ).toEqual( expect.arrayContaining( [ '/fd', 'SHA256' ] ) );
+	} );
+
+	it( 'builds a PFX invocation with cert + password, file last', () => {
+		const args = buildSignToolArgs( resolveSigner( PFX_ENV ), 'app.exe' );
+		expect( args ).toEqual(
+			expect.arrayContaining( [ '/f', PFX_ENV.WIN_CSC_LINK, '/p', PFX_ENV.WIN_CSC_KEY_PASSWORD ] )
+		);
+		expect( args ).not.toContain( '/dlib' );
+		expect( args[ args.length - 1 ] ).toBe( 'app.exe' );
+	} );
+} );
+
+describe( 'win.sign callback', () => {
+	it( 'skips the SHA1 pass without signing', async () => {
+		jest.resetModules();
+		jest.doMock( '../../bin/windows-signing-core', () => ( {
+			resolveSigner: jest.fn(),
+			signFile: jest.fn(),
+		} ) );
+		const core = require( '../../bin/windows-signing-core' );
+		const sign = require( '../../bin/windows-sign' );
+		await sign( { path: 'app.exe', hash: 'sha1' } );
+		expect( core.signFile ).not.toHaveBeenCalled();
+		jest.dontMock( '../../bin/windows-signing-core' );
+	} );
+} );

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -1,4 +1,11 @@
-const { resolveSigner, buildSignToolArgs } = require( '../../bin/windows-signing-core' );
+const fs = require( 'fs' );
+const os = require( 'os' );
+const path = require( 'path' );
+const {
+	resolveSigner,
+	buildSignToolArgs,
+	collectSignableBinaries,
+} = require( '../../bin/windows-signing-core' );
 
 const AZURE_ENV = {
 	AZURE_CODE_SIGNING_DLIB: 'C:\\dlib\\Azure.CodeSigning.Dlib.dll',
@@ -66,6 +73,51 @@ describe( 'buildSignToolArgs', () => {
 		);
 		expect( args ).not.toContain( '/dlib' );
 		expect( args[ args.length - 1 ] ).toBe( 'app.exe' );
+	} );
+} );
+
+describe( 'collectSignableBinaries', () => {
+	let root;
+
+	beforeEach( () => {
+		root = fs.mkdtempSync( path.join( os.tmpdir(), 'sign-collect-' ) );
+	} );
+
+	afterEach( () => {
+		fs.rmSync( root, { recursive: true, force: true } );
+	} );
+
+	it( 'collects nested *.exe, *.node and *.dll and skips other files', () => {
+		fs.writeFileSync( path.join( root, 'WordPress.com.exe' ), '' );
+		fs.writeFileSync( path.join( root, 'ffmpeg.dll' ), '' );
+		fs.writeFileSync( path.join( root, 'app.txt' ), '' );
+		const nested = path.join( root, 'resources', 'app', 'node_modules', 'pkg' );
+		fs.mkdirSync( nested, { recursive: true } );
+		fs.writeFileSync( path.join( nested, 'helper.exe' ), '' );
+		fs.writeFileSync( path.join( nested, 'binding.node' ), '' );
+		fs.writeFileSync( path.join( nested, 'readme.md' ), '' );
+
+		const found = collectSignableBinaries( root )
+			.map( ( f ) => path.relative( root, f ) )
+			.sort();
+
+		expect( found ).toEqual(
+			[
+				'WordPress.com.exe',
+				'ffmpeg.dll',
+				path.join( 'resources', 'app', 'node_modules', 'pkg', 'binding.node' ),
+				path.join( 'resources', 'app', 'node_modules', 'pkg', 'helper.exe' ),
+			].sort()
+		);
+	} );
+
+	it( 'skips symlinks', () => {
+		fs.writeFileSync( path.join( root, 'real.exe' ), '' );
+		fs.symlinkSync( path.join( root, 'real.exe' ), path.join( root, 'link.exe' ) );
+
+		const found = collectSignableBinaries( root ).map( ( f ) => path.basename( f ) );
+
+		expect( found ).toEqual( [ 'real.exe' ] );
 	} );
 } );
 

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -1,11 +1,4 @@
-const fs = require( 'fs' );
-const os = require( 'os' );
-const path = require( 'path' );
-const {
-	resolveSigner,
-	buildSignToolArgs,
-	collectSignableBinaries,
-} = require( '../../bin/windows-signing-core' );
+const { resolveSigner, buildSignToolArgs } = require( '../../bin/windows-signing-core' );
 
 const AZURE_ENV = {
 	AZURE_CODE_SIGNING_DLIB: 'C:\\dlib\\Azure.CodeSigning.Dlib.dll',
@@ -73,54 +66,6 @@ describe( 'buildSignToolArgs', () => {
 		);
 		expect( args ).not.toContain( '/dlib' );
 		expect( args[ args.length - 1 ] ).toBe( 'app.exe' );
-	} );
-} );
-
-describe( 'collectSignableBinaries', () => {
-	let root;
-
-	beforeEach( () => {
-		root = fs.mkdtempSync( path.join( os.tmpdir(), 'sign-collect-' ) );
-	} );
-
-	afterEach( () => {
-		fs.rmSync( root, { recursive: true, force: true } );
-	} );
-
-	it( 'signs *.node/*.dll at any depth and *.exe only below the top level', () => {
-		// electron-builder signs the top-level app exe itself, so afterPack must skip it.
-		fs.writeFileSync( path.join( root, 'WordPress.com.exe' ), '' );
-		fs.writeFileSync( path.join( root, 'ffmpeg.dll' ), '' );
-		fs.writeFileSync( path.join( root, 'app.txt' ), '' );
-		const nested = path.join( root, 'resources', 'app', 'node_modules', 'pkg' );
-		fs.mkdirSync( nested, { recursive: true } );
-		fs.writeFileSync( path.join( nested, 'helper.exe' ), '' );
-		fs.writeFileSync( path.join( nested, 'binding.node' ), '' );
-		fs.writeFileSync( path.join( nested, 'readme.md' ), '' );
-
-		const found = collectSignableBinaries( root )
-			.map( ( f ) => path.relative( root, f ) )
-			.sort();
-
-		expect( found ).toEqual(
-			[
-				'ffmpeg.dll',
-				path.join( 'resources', 'app', 'node_modules', 'pkg', 'binding.node' ),
-				path.join( 'resources', 'app', 'node_modules', 'pkg', 'helper.exe' ),
-			].sort()
-		);
-		expect( found ).not.toContain( 'WordPress.com.exe' );
-	} );
-
-	it( 'skips symlinks', () => {
-		const nested = path.join( root, 'resources' );
-		fs.mkdirSync( nested );
-		fs.writeFileSync( path.join( nested, 'real.exe' ), '' );
-		fs.symlinkSync( path.join( nested, 'real.exe' ), path.join( nested, 'link.exe' ) );
-
-		const found = collectSignableBinaries( root ).map( ( f ) => path.basename( f ) );
-
-		expect( found ).toEqual( [ 'real.exe' ] );
 	} );
 } );
 

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -87,7 +87,8 @@ describe( 'collectSignableBinaries', () => {
 		fs.rmSync( root, { recursive: true, force: true } );
 	} );
 
-	it( 'collects nested *.exe, *.node and *.dll and skips other files', () => {
+	it( 'signs *.node/*.dll at any depth and *.exe only below the top level', () => {
+		// electron-builder signs the top-level app exe itself, so afterPack must skip it.
 		fs.writeFileSync( path.join( root, 'WordPress.com.exe' ), '' );
 		fs.writeFileSync( path.join( root, 'ffmpeg.dll' ), '' );
 		fs.writeFileSync( path.join( root, 'app.txt' ), '' );
@@ -103,17 +104,19 @@ describe( 'collectSignableBinaries', () => {
 
 		expect( found ).toEqual(
 			[
-				'WordPress.com.exe',
 				'ffmpeg.dll',
 				path.join( 'resources', 'app', 'node_modules', 'pkg', 'binding.node' ),
 				path.join( 'resources', 'app', 'node_modules', 'pkg', 'helper.exe' ),
 			].sort()
 		);
+		expect( found ).not.toContain( 'WordPress.com.exe' );
 	} );
 
 	it( 'skips symlinks', () => {
-		fs.writeFileSync( path.join( root, 'real.exe' ), '' );
-		fs.symlinkSync( path.join( root, 'real.exe' ), path.join( root, 'link.exe' ) );
+		const nested = path.join( root, 'resources' );
+		fs.mkdirSync( nested );
+		fs.writeFileSync( path.join( nested, 'real.exe' ), '' );
+		fs.symlinkSync( path.join( nested, 'real.exe' ), path.join( nested, 'link.exe' ) );
 
 		const found = collectSignableBinaries( root ).map( ( f ) => path.basename( f ) );
 


### PR DESCRIPTION
Part of [AINFRA-2237](https://linear.app/a8c/issue/AINFRA-2237).

Adds Azure Artifact Signing as the default code sign mode for WordPress Desktop. The PFX mode is still available as a fallback via env var, but I hope we won't have to use it.

<details>
<summary>AI-generated details</summary>

## Proposed Changes

- Cut the signed Windows NSIS direct-download build over to **Azure Trusted Signing by default**, retaining the org Sectigo PFX as a fallback behind `FORCE_PFX_SIGNING` until the Azure-signed build is confirmed in distribution.
- electron-builder 24 has no native Azure support, so a custom `win.sign` callback drives `signtool` for both paths and routes on whichever env the Buildkite script populates. A partially-configured mode throws naming the missing var.
- `win.sign` only sees `*.exe`, so an `afterPack` pass signs packaged `*.node`/`*.dll` too (Smart App Control blocks an app loading unsigned native binaries). The build script then `signtool verify`s every packed binary and the installer, failing loud on any unsigned one.

## Why are these changes being made?

The Sectigo PFX cert expires **2026-07-05**; this moves Windows signing onto Azure Trusted Signing before then. The dual `win.publisherName` handover already shipped in `desktop-v8.2.0`, so the cert CN change won't break `electron-updater` for existing users.

## Testing Instructions

- Local (routing/arg logic): `cd desktop && yarn test:unit`.
- CI (real signing): this branch matches `ainfra-*`, so the `:windows: Build desktop (windows nsis, signed)` step runs the Azure path end-to-end and the verify gate. Watch that step is green.
- The PFX fallback can be exercised by setting `FORCE_PFX_SIGNING` on the step.


</details>