### PR TITLE
Fix backup actions popover

### DIFF
--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { omit } from '@automattic/js-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { Component, Children } from 'react';
+import { Component, Children, createRef } from 'react';
 
 import './style.scss';
 
@@ -13,11 +13,15 @@ class FormButton extends Component {
 		type: 'submit',
 	};
 
+	buttonRef = createRef();
+
 	getDefaultButtonAction = () => {
 		return this.props.isSubmitting
 			? this.props.translate( 'Saving…' )
 			: this.props.translate( 'Save Settings' );
 	};
+
+	getDOMNode = () => this.buttonRef.current;
 
 	render() {
 		const { children, className, isPrimary, ...props } = this.props;
@@ -26,6 +30,7 @@ class FormButton extends Component {
 		return (
 			<Button
 				{ ...omit( props, [ 'isSubmitting', 'moment', 'numberFormat', 'translate' ] ) }
+				ref={ this.buttonRef }
 				primary={ isPrimary }
 				className={ buttonClasses }
 			>

--- a/client/components/forms/form-button/test/index.jsx
+++ b/client/components/forms/form-button/test/index.jsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import FormButton from '../';
+
+describe( 'FormButton', () => {
+	test( 'exposes the rendered button element', () => {
+		const buttonRef = createRef();
+
+		render( <FormButton ref={ buttonRef }>Actions</FormButton> );
+
+		expect( buttonRef.current.getDOMNode() ).toBe(
+			screen.getByRole( 'button', { name: 'Actions' } )
+		);
+	} );
+
+	test( 'exposes the rendered link element', () => {
+		const linkRef = createRef();
+
+		render(
+			<FormButton ref={ linkRef } href="/backup/example.com">
+				Open backup
+			</FormButton>
+		);
+
+		expect( linkRef.current.getDOMNode() ).toBe(
+			screen.getByRole( 'link', { name: 'Open backup' } )
+		);
+	} );
+} );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `Icon`: Remove component. Use `Icon` from `@wordpress/ui` instead.
 
+## 3.0.5
+
+- Fix popover positioning for contexts that expose DOM nodes through `getDOMNode()` (#111903).
+
 ## 3.0.4
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "3.0.4",
+	"version": "3.0.5",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -26,8 +26,18 @@ function getDOMNode( context ) {
 		return context;
 	}
 
+	if ( typeof context?.getDOMNode === 'function' ) {
+		const node = context.getDOMNode();
+		return isDOMElement( node ) ? node : null;
+	}
+
 	if ( isDOMElement( context?.current ) ) {
 		return context.current;
+	}
+
+	if ( typeof context?.current?.getDOMNode === 'function' ) {
+		const node = context.current.getDOMNode();
+		return isDOMElement( node ) ? node : null;
 	}
 
 	return null;
@@ -461,11 +471,19 @@ function Popover( { isVisible = false, showDelay = 0, hideArrow = false, ...prop
 	);
 }
 
-// We accept DOM elements and React refs as the `context` prop.
+// We accept DOM elements, React refs, and explicit getDOMNode accessors as the `context` prop.
 const PropTypeElement = PropTypes.oneOfType( [
 	PropTypes.instanceOf( DOMElement ),
 	PropTypes.shape( {
 		current: PropTypes.instanceOf( DOMElement ),
+	} ),
+	PropTypes.shape( {
+		getDOMNode: PropTypes.func,
+	} ),
+	PropTypes.shape( {
+		current: PropTypes.shape( {
+			getDOMNode: PropTypes.func,
+		} ),
 	} ),
 ] );
 


### PR DESCRIPTION
Fixes BACKUP-415

## Proposed Changes

* Allow the shared Popover context resolver to use explicit `getDOMNode()` accessors, in addition to DOM elements and React refs.
* Expose the rendered `@automattic/components` Button node from `FormButton` through `getDOMNode()`.
* Add coverage for `FormButton` exposing its rendered button/link element.

## Why are these changes being made?

* The React 19-safe popover change removed `findDOMNode()`, which means a popover context must now resolve to a real DOM element.
* The backup Actions button passes a localized `FormButton` ref as the popover context. Without an explicit DOM accessor, the menu has no usable context and clicking Actions does not open the menu.

## Testing Instructions

* `yarn test-client client/components/forms/form-button/test/index.jsx`
* `yarn test-client client/components/activity-card/toolbar/test/actions-button.jsx`
* `yarn typecheck-client` currently fails on existing dashboard errors unrelated to this change: missing `@automattic/omnibar`, missing `@automattic/date-range-picker`, and `userNotificationsSettingsMutation` export/type errors.
* Manual browser check: started Calypso locally, opened the reported backup page, clicked the bottom Actions button, and confirmed the popover opens with Restore and Download actions.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?