### PR TITLE
Legacy contact: fetch access key from view contact endpoint

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -8,6 +8,7 @@ import {
 	domainQuery,
 	geoLocationQuery,
 	isAutomatticianQuery,
+	legacyContactQuery,
 	legacyContactsQuery,
 	monetizeSubscriptionsQuery,
 	plansQuery,
@@ -888,6 +889,14 @@ export const securityLegacyContactPrintRoute = createRoute( {
 	} ),
 	getParentRoute: () => securityLegacyContactRoute,
 	path: '/print',
+	loader: async () => {
+		const [ contact ] = await queryClient.ensureQueryData( legacyContactsQuery() );
+		if ( contact ) {
+			// The access key shown on this page is only returned by the
+			// single-contact endpoint, so prefetch it here.
+			await queryClient.ensureQueryData( legacyContactQuery( contact.legacy_contact_id ) );
+		}
+	},
 } ).lazy( () =>
 	import( '../../me/security-legacy-contact/print' ).then( ( d ) =>
 		createLazyRoute( 'security-legacy-contact-print' )( {

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -35,7 +35,7 @@ export default function SecurityLegacyContact() {
 								<Text>
 									{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
 									{ createInterpolateElement( 'Your legacy contact is <contactEmail />.', {
-										contactEmail: <strong>{ contact.email }</strong>,
+										contactEmail: <strong>{ contact.contact_email }</strong>,
 									} ) }
 								</Text>
 								<ButtonStack justify="flex-start">

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -1,4 +1,4 @@
-import { legacyContactsQuery } from '@automattic/api-queries';
+import { legacyContactQuery, legacyContactsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -11,12 +11,49 @@ import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
 import './style.scss';
 
-export default function SecurityLegacyContactPrint() {
-	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
+function LegacyContactDetails( { id }: { id: number } ) {
+	// The access key is only returned by the single-contact endpoint, so fetch
+	// the full contact here rather than relying on the listing response.
+	const { data: contact } = useSuspenseQuery( legacyContactQuery( id ) );
 
 	const handlePrint = () => {
 		window.print();
 	};
+
+	return (
+		<VStack spacing={ 6 }>
+			<VStack spacing={ 2 }>
+				<Text>
+					Keep this information somewhere safe. After your death, your legacy contact can give this
+					key to WordPress.com to request access to your account.
+				</Text>
+			</VStack>
+
+			<VStack spacing={ 1 } alignment="flex-start">
+				<Text upperCase variant="muted" size={ 11 }>
+					Legacy contact email
+				</Text>
+				<Text size={ 15 }>{ contact.contact_email }</Text>
+			</VStack>
+
+			<VStack spacing={ 1 } alignment="flex-start">
+				<Text upperCase variant="muted" size={ 11 }>
+					Access key
+				</Text>
+				<div className="legacy-contact-print__key">{ contact.access_key }</div>
+			</VStack>
+
+			<ButtonStack justify="flex-start" className="legacy-contact-print__actions">
+				<Button variant="primary" onClick={ handlePrint }>
+					Print
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+}
+
+export default function SecurityLegacyContactPrint() {
+	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
 
 	return (
 		<PageLayout
@@ -29,34 +66,7 @@ export default function SecurityLegacyContactPrint() {
 				<CardBody>
 					{ /* TODO: translate these strings once the legacy contact UI is finalized. */ }
 					{ contact ? (
-						<VStack spacing={ 6 }>
-							<VStack spacing={ 2 }>
-								<Text>
-									Keep this information somewhere safe. After your death, your legacy contact can
-									give this key to WordPress.com to request access to your account.
-								</Text>
-							</VStack>
-
-							<VStack spacing={ 1 } alignment="flex-start">
-								<Text upperCase variant="muted" size={ 11 }>
-									Legacy contact email
-								</Text>
-								<Text size={ 15 }>{ contact.email }</Text>
-							</VStack>
-
-							<VStack spacing={ 1 } alignment="flex-start">
-								<Text upperCase variant="muted" size={ 11 }>
-									Access key
-								</Text>
-								<div className="legacy-contact-print__key">{ contact.token }</div>
-							</VStack>
-
-							<ButtonStack justify="flex-start" className="legacy-contact-print__actions">
-								<Button variant="primary" onClick={ handlePrint }>
-									Print
-								</Button>
-							</ButtonStack>
-						</VStack>
+						<LegacyContactDetails id={ contact.legacy_contact_id } />
 					) : (
 						<VStack spacing={ 4 } alignment="flex-start">
 							<Text>You don’t have a legacy contact set up yet.</Text>

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -11,10 +11,10 @@ import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
 import './style.scss';
 
-function LegacyContactDetails( { id }: { id: number } ) {
+function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } ) {
 	// The access key is only returned by the single-contact endpoint, so fetch
 	// the full contact here rather than relying on the listing response.
-	const { data: contact } = useSuspenseQuery( legacyContactQuery( id ) );
+	const { data: contact } = useSuspenseQuery( legacyContactQuery( legacyContactId ) );
 
 	const handlePrint = () => {
 		window.print();
@@ -66,7 +66,7 @@ export default function SecurityLegacyContactPrint() {
 				<CardBody>
 					{ /* TODO: translate these strings once the legacy contact UI is finalized. */ }
 					{ contact ? (
-						<LegacyContactDetails id={ contact.legacy_contact_id } />
+						<LegacyContactDetails legacyContactId={ contact.legacy_contact_id } />
 					) : (
 						<VStack spacing={ 4 } alignment="flex-start">
 							<Text>You don’t have a legacy contact set up yet.</Text>

--- a/packages/api-core/src/me-legacy-contacts/fetchers.ts
+++ b/packages/api-core/src/me-legacy-contacts/fetchers.ts
@@ -8,9 +8,11 @@ export async function fetchLegacyContacts(): Promise< LegacyContact[] > {
 	} );
 }
 
-export async function fetchLegacyContact( id: number ): Promise< LegacyContactWithAccessKey > {
+export async function fetchLegacyContact(
+	legacyContactId: number
+): Promise< LegacyContactWithAccessKey > {
 	return wpcom.req.get( {
-		path: `/me/legacy-contacts/${ id }`,
+		path: `/me/legacy-contacts/${ legacyContactId }`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }

--- a/packages/api-core/src/me-legacy-contacts/fetchers.ts
+++ b/packages/api-core/src/me-legacy-contacts/fetchers.ts
@@ -1,9 +1,16 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { LegacyContact } from './types';
+import type { LegacyContact, LegacyContactWithAccessKey } from './types';
 
 export async function fetchLegacyContacts(): Promise< LegacyContact[] > {
 	return wpcom.req.get( {
 		path: '/me/legacy-contacts',
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function fetchLegacyContact( id: number ): Promise< LegacyContactWithAccessKey > {
+	return wpcom.req.get( {
+		path: `/me/legacy-contacts/${ id }`,
 		apiNamespace: 'wpcom/v2',
 	} );
 }

--- a/packages/api-core/src/me-legacy-contacts/types.ts
+++ b/packages/api-core/src/me-legacy-contacts/types.ts
@@ -1,4 +1,9 @@
 export interface LegacyContact {
-	email: string;
-	token: string;
+	legacy_contact_id: number;
+	contact_email: string;
+	created_at: string;
+}
+
+export interface LegacyContactWithAccessKey extends LegacyContact {
+	access_key: string;
 }

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -1,11 +1,18 @@
-import { fetchLegacyContacts } from '@automattic/api-core';
+import { fetchLegacyContact, fetchLegacyContacts } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
 export const legacyContactsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'legacy-contacts' ],
 		queryFn: fetchLegacyContacts,
-		// Each contact carries a sensitive `token`, so keep this response out of
-		// the persisted (localStorage) query cache to limit its exposure.
+		meta: { persist: false },
+	} );
+
+export const legacyContactQuery = ( id: number ) =>
+	queryOptions( {
+		queryKey: [ 'me', 'legacy-contacts', id ],
+		queryFn: () => fetchLegacyContact( id ),
+		// The response carries a sensitive `access_key`, so keep it out of the
+		// persisted (localStorage) query cache to limit its exposure.
 		meta: { persist: false },
 	} );

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -7,10 +7,10 @@ export const legacyContactsQuery = () =>
 		queryFn: fetchLegacyContacts,
 	} );
 
-export const legacyContactQuery = ( id: number ) =>
+export const legacyContactQuery = ( legacyContactId: number ) =>
 	queryOptions( {
-		queryKey: [ 'me', 'legacy-contacts', id ],
-		queryFn: () => fetchLegacyContact( id ),
+		queryKey: [ 'me', 'legacy-contacts', legacyContactId ],
+		queryFn: () => fetchLegacyContact( legacyContactId ),
 		// The response carries a sensitive `access_key`, so keep it out of the
 		// persisted (localStorage) query cache to limit its exposure.
 		meta: { persist: false },

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -5,7 +5,7 @@ export const legacyContactsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'legacy-contacts' ],
 		queryFn: fetchLegacyContacts,
-		// The response carries personal data (contact emails + ids), so keep it
+		// The response carries personal data (legacy contact email), so keep it
 		// out of the persisted (localStorage) query cache to limit its exposure.
 		meta: { persist: false },
 	} );

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -5,7 +5,6 @@ export const legacyContactsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'legacy-contacts' ],
 		queryFn: fetchLegacyContacts,
-		meta: { persist: false },
 	} );
 
 export const legacyContactQuery = ( id: number ) =>

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -5,6 +5,9 @@ export const legacyContactsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'legacy-contacts' ],
 		queryFn: fetchLegacyContacts,
+		// The response carries personal data (contact emails + ids), so keep it
+		// out of the persisted (localStorage) query cache to limit its exposure.
+		meta: { persist: false },
 	} );
 
 export const legacyContactQuery = ( legacyContactId: number ) =>


### PR DESCRIPTION
Fixes RSM-4325

## Proposed Changes

The `GET /me/legacy-contacts` listing endpoint no longer returns the access key. The Dashboard view/print page now fetches the individual contact from `GET /me/legacy-contacts/:id`, which includes the `access_key`.

* `@automattic/api-core`: added `fetchLegacyContact( id )`, updated `LegacyContact` to the backend shape (`legacy_contact_id`, `contact_email`, `created_at`), and added `LegacyContactWithAccessKey`.
* `@automattic/api-queries`: added `legacyContactQuery( id )`, kept out of the persisted cache (`meta.persist: false`) since it carries the sensitive `access_key`.
* The `/print` page reads the id from the listing, then fetches the single contact for the email and access key; its route loader prefetches to avoid a request waterfall.

## Why are these changes being made?

The access key was removed from the listing endpoint, so the UI must read it from the single-contact endpoint instead.

## Testing Instructions

* Navigate to Me → Security → Legacy contact (requires the `me/legacy-contact` feature flag).
* With a legacy contact set up, click **View printable details**.
* Confirm the email and access key render, and that the request hits `GET /me/legacy-contacts/:id`.
* Confirm the listing/summary pages still show the contact and the “Legacy contact added” badge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
