### PR TITLE
image-studio: lazy-load the modal's generate-mode layout (spike)

### DIFF
--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -7,7 +7,16 @@ import {
 } from '@wordpress/components';
 import { useMediaQuery, withInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	lazy,
+	memo,
+	Suspense,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAgentConfig } from '../hooks/use-agent-config';
 import { useAnnotation } from '../hooks/use-annotation';
@@ -44,13 +53,20 @@ import { type ActionButton, ConfirmationDialog } from './confirmation-dialog';
 import { EditLayout } from './edit-layout';
 import { ExperimentalBadge } from './experimental-badge';
 import { Footer } from './footer';
-import { GenerateLayout } from './generate-layout';
 import { Header } from './header';
 import LoadingSpinner from './loading-spinner';
 import { ImageStudioNotice } from './notice';
 import { ImageStudioAltTextSidebar } from './sidebar';
 import { StylePicker } from './style-picker';
 import './style.scss';
+
+// GenerateLayout is the modal's generate-mode UI; it renders only when the modal
+// is open in generate mode. Load it as a separate chunk so its generate/video
+// weight stays out of the bundle every block editor boots, and only loads when a
+// user actually opens generate mode.
+const GenerateLayout = lazy( () =>
+	import( './generate-layout' ).then( ( module ) => ( { default: module.GenerateLayout } ) )
+);
 
 /** Content for one flavor of the modal's close-confirmation dialog. */
 type CloseDialogConfig = {
@@ -657,13 +673,15 @@ const ImageStudioContent = withInstanceId(
 								originalAttachmentId={ originalAttachmentId }
 							/>
 						) : (
-							<GenerateLayout
-								isAiProcessing={ isAiProcessing }
-								isPromptSent={ isPromptSent }
-								videoUrl={ isVideoMode ? currentVideoUrl : null }
-								onFeedback={ handleFeedback }
-								onSubmitFeedbackText={ handleSubmitFeedbackText }
-							/>
+							<Suspense fallback={ <LoadingSpinner /> }>
+								<GenerateLayout
+									isAiProcessing={ isAiProcessing }
+									isPromptSent={ isPromptSent }
+									videoUrl={ isVideoMode ? currentVideoUrl : null }
+									onFeedback={ handleFeedback }
+									onSubmitFeedbackText={ handleSubmitFeedbackText }
+								/>
+							</Suspense>
 						) }
 
 						<Footer


### PR DESCRIPTION
**Spike — do not merge until validated on a build + sandbox.** Came out of the Agents Manager loading retro / FORNO-368.

## What

`GenerateLayout` (the modal's generate-mode UI, plus its generate/video subtree) was statically imported into `components/index.tsx`, so it ships in `image-studio.min.js` and loads on every block-editor boot — even though it only renders when a user opens generate mode. This loads it as a `lazy()` chunk behind a `Suspense` fallback so it stays out of the boot bundle and only loads on demand.

`EditLayout` and `StylePicker` are intentionally untouched — `StylePicker` renders in every mode, so it isn't generate-only.

## Why

Per the retro: the `image-studio` bundle loads on every block editor, and the generate/video code is the bulk of it. Surface-scoping the enqueue isn't safe (image-gen UI is GA on all block editors via global `editor.BlockEdit` / `editor.MediaUpload` filters), so "defer until invoked" is the lever. This is the first slice.

## Validation needed (why this is a spike)

- [ ] **Builds + typechecks** (CI).
- [ ] **Async chunk loads from `widgets.wp.com`.** There is no explicit `publicPath` and this bundle has never had an async chunk, so it relies on webpack 5's `auto`. Confirm on a sandbox that opening generate mode fetches the chunk with no 404. If it fails, `publicPath` needs wiring first.
- [ ] **No regression.** Image generation, Edit-with-AI, and Clips still work on Media Library + post editor across Simple / Atomic / Jetpack.
- [ ] **Bundle delta.** Confirm the boot-time `image-studio.min.js` drops by roughly the `GenerateLayout` subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
