### PR TITLE
Reuse escalation transfer metadata for human chats

### DIFF
--- a/packages/agents-manager/src/components/__tests__/escalation-button.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/escalation-button.test.tsx
@@ -4,35 +4,33 @@
 /* eslint-disable import/order -- jest.mock calls must precede imports */
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { MouseEventHandler, ReactNode } from 'react';
-import type { ZendeskConversation } from '../../types';
 
 const mockGetActiveSessionId = jest.fn();
 const mockNavigate = jest.fn();
-const mockUseGetZendeskConversations = jest.fn();
 
-jest.mock( '@automattic/components', () => ( {
-	SummaryButton: ( {
-		title,
-		description,
-		onClick,
-		disabled,
-	}: {
-		title: ReactNode;
-		description?: ReactNode;
-		onClick?: MouseEventHandler;
-		disabled?: boolean;
-	} ) => (
-		<button type="button" onClick={ onClick } disabled={ disabled }>
-			<span>{ title }</span>
-			{ description && <span>{ description }</span> }
-		</button>
-	),
-	TimeSince: ( { date }: { date: string } ) => <time dateTime={ date }>2h ago</time>,
-} ) );
-
-jest.mock( '@automattic/zendesk-client', () => ( {
-	useGetZendeskConversations: ( enabled: boolean ) => mockUseGetZendeskConversations( enabled ),
-} ) );
+jest.mock(
+	'@automattic/components',
+	() => ( {
+		SummaryButton: ( {
+			title,
+			description,
+			onClick,
+			disabled,
+		}: {
+			title: ReactNode;
+			description?: ReactNode;
+			onClick?: MouseEventHandler;
+			disabled?: boolean;
+		} ) => (
+			<button type="button" onClick={ onClick } disabled={ disabled }>
+				<span>{ title }</span>
+				{ description && <span>{ description }</span> }
+			</button>
+		),
+		TimeSince: ( { date }: { date: string } ) => <time dateTime={ date }>2h ago</time>,
+	} ),
+	{ virtual: true }
+);
 
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
 
@@ -46,38 +44,22 @@ jest.mock( '../../contexts', () => ( {
 	} ),
 } ) );
 
-import { EscalationButton, findConversationByChatSessionId } from '../escalation-button';
-
-function createConversation(
-	id: string,
-	chatSessionId: string,
-	placement: 'metadata' | 'top-level' = 'metadata'
-) {
-	return {
-		id,
-		...( placement === 'metadata'
-			? { metadata: { chat_session_id: chatSessionId, createdAt: 1718193600000 } }
-			: { chat_session_id: chatSessionId } ),
-	} as unknown as ZendeskConversation;
-}
+import { EscalationButton } from '../escalation-button';
 
 describe( 'EscalationButton', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockGetActiveSessionId.mockReturnValue( 'ai-chat-123' );
-		mockUseGetZendeskConversations.mockReturnValue( {
-			conversations: [],
-			isLoading: false,
-		} );
 	} );
 
-	it( 'continues an existing Zendesk conversation for the active AI chat', () => {
-		mockUseGetZendeskConversations.mockReturnValue( {
-			conversations: [ createConversation( 'conversation-1', 'ai-chat-123' ) ],
-			isLoading: false,
-		} );
-
-		render( <EscalationButton messageId="message-1" /> );
+	it( 'continues an existing Zendesk conversation when a Zendesk ticket id is provided', () => {
+		render(
+			<EscalationButton
+				messageId="message-1"
+				zendeskTicketId={ 11368863 }
+				escalatedAt="2026-06-23T11:39:22Z"
+			/>
+		);
 
 		expect( screen.getByText( 'Continue existing chat' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Continue chat started 2h ago' );
@@ -85,16 +67,11 @@ describe( 'EscalationButton', () => {
 		fireEvent.click( screen.getByRole( 'button' ) );
 
 		expect( mockNavigate ).toHaveBeenCalledWith( '/zendesk', {
-			state: { conversationId: 'conversation-1' },
+			state: { zendeskTicketId: 11368863 },
 		} );
 	} );
 
 	it( 'starts a new Zendesk conversation when no active AI chat match exists', () => {
-		mockUseGetZendeskConversations.mockReturnValue( {
-			conversations: [ createConversation( 'conversation-1', 'other-ai-chat' ) ],
-			isLoading: false,
-		} );
-
 		render( <EscalationButton messageId="message-1" /> );
 
 		expect( screen.getByText( 'Switch to Happiness Engineer' ) ).toBeInTheDocument();
@@ -105,30 +82,5 @@ describe( 'EscalationButton', () => {
 		expect( mockNavigate ).toHaveBeenCalledWith( '/zendesk', {
 			state: { startedFromChatId: 'ai-chat-123', startedFromMessageId: 'message-1' },
 		} );
-	} );
-
-	it( 'disables the button while Zendesk conversations are loading', () => {
-		mockUseGetZendeskConversations.mockReturnValue( {
-			conversations: [],
-			isLoading: true,
-		} );
-
-		render( <EscalationButton messageId="message-1" /> );
-
-		expect( screen.getByRole( 'button' ) ).toBeDisabled();
-	} );
-
-	it( 'matches conversations with metadata or top-level chat_session_id values', () => {
-		const conversations = [
-			createConversation( 'metadata-conversation', 'metadata-chat' ),
-			createConversation( 'top-level-conversation', 'top-level-chat', 'top-level' ),
-		];
-
-		expect( findConversationByChatSessionId( conversations, 'metadata-chat' )?.id ).toBe(
-			'metadata-conversation'
-		);
-		expect( findConversationByChatSessionId( conversations, 'top-level-chat' )?.id ).toBe(
-			'top-level-conversation'
-		);
 	} );
 } );

--- a/packages/agents-manager/src/components/escalation-button/index.tsx
+++ b/packages/agents-manager/src/components/escalation-button/index.tsx
@@ -1,69 +1,9 @@
 import { SummaryButton, TimeSince } from '@automattic/components';
-import { useGetZendeskConversations } from '@automattic/zendesk-client';
-import { createInterpolateElement, useMemo } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
-import type { ZendeskConversation } from '../../types';
 import './style.scss';
-
-function getConversationChatSessionId( conversation: ZendeskConversation ) {
-	const metadataChatSessionId = conversation.metadata?.chat_session_id;
-	const { chat_session_id: conversationChatSessionId } = conversation as ZendeskConversation & {
-		chat_session_id?: unknown;
-	};
-
-	if ( typeof conversationChatSessionId === 'string' ) {
-		return conversationChatSessionId;
-	}
-
-	return typeof metadataChatSessionId === 'string' ? metadataChatSessionId : undefined;
-}
-
-function getTimestampInMilliseconds( timestamp: unknown ) {
-	if ( typeof timestamp === 'number' && Number.isFinite( timestamp ) ) {
-		return timestamp > 9999999999 ? timestamp : timestamp * 1000;
-	}
-
-	if ( typeof timestamp === 'string' ) {
-		const parsedTimestamp = Number( timestamp );
-		if ( Number.isFinite( parsedTimestamp ) ) {
-			return parsedTimestamp > 9999999999 ? parsedTimestamp : parsedTimestamp * 1000;
-		}
-	}
-
-	return undefined;
-}
-
-function getConversationStartedAt( conversation: ZendeskConversation ) {
-	const createdAt = getTimestampInMilliseconds( conversation.metadata?.createdAt );
-	if ( createdAt ) {
-		return new Date( createdAt ).toISOString();
-	}
-
-	const firstMessageReceivedAt = getTimestampInMilliseconds(
-		conversation.messages?.[ 0 ]?.received
-	);
-	if ( firstMessageReceivedAt ) {
-		return new Date( firstMessageReceivedAt ).toISOString();
-	}
-
-	const lastUpdatedAt = getTimestampInMilliseconds( conversation.lastUpdatedAt );
-	return lastUpdatedAt ? new Date( lastUpdatedAt ).toISOString() : undefined;
-}
-
-export function findConversationByChatSessionId(
-	conversations: ZendeskConversation[],
-	chatSessionId: string
-) {
-	if ( ! chatSessionId ) {
-		return undefined;
-	}
-
-	return conversations.find(
-		( conversation ) => getConversationChatSessionId( conversation ) === chatSessionId
-	);
-}
 
 function getExistingConversationButtonDescription( startedAt?: string ) {
 	if ( ! startedAt ) {
@@ -75,41 +15,38 @@ function getExistingConversationButtonDescription( startedAt?: string ) {
 	} );
 }
 
-export function EscalationButton( { messageId }: { messageId: string } ) {
+export function EscalationButton( {
+	messageId,
+	zendeskTicketId,
+	escalatedAt,
+}: {
+	messageId: string;
+	zendeskTicketId?: number | string;
+	escalatedAt?: string;
+} ) {
 	const { getActiveSessionId } = useAgentsManagerContext();
 	const navigate = useNavigate();
-	const activeSessionId = getActiveSessionId();
-	const { conversations, isLoading } = useGetZendeskConversations( !! activeSessionId );
-	const existingConversation = useMemo(
-		() => findConversationByChatSessionId( conversations, activeSessionId ),
-		[ conversations, activeSessionId ]
-	);
-	const existingConversationStartedAt = existingConversation
-		? getConversationStartedAt( existingConversation )
-		: undefined;
+	const hasExistingConversation = zendeskTicketId !== undefined && zendeskTicketId !== null;
 
 	return (
 		<SummaryButton
 			className="agents-manager__escalation-button"
 			title={
-				existingConversation ? __( 'Continue existing chat' ) : __( 'Switch to Happiness Engineer' )
+				hasExistingConversation
+					? __( 'Continue existing chat' )
+					: __( 'Switch to Happiness Engineer' )
 			}
 			description={
-				existingConversation
-					? getExistingConversationButtonDescription( existingConversationStartedAt )
+				hasExistingConversation
+					? getExistingConversationButtonDescription( escalatedAt )
 					: __( 'A new chat will start' )
 			}
-			disabled={ isLoading }
 			onClick={ () => {
 				const currentChatSessionId = getActiveSessionId();
-				const currentExistingConversation = findConversationByChatSessionId(
-					conversations,
-					currentChatSessionId
-				);
 
 				navigate( '/zendesk', {
-					state: currentExistingConversation
-						? { conversationId: currentExistingConversation.id }
+					state: hasExistingConversation
+						? { zendeskTicketId }
 						: { startedFromChatId: currentChatSessionId, startedFromMessageId: messageId },
 				} );
 			} }

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -17,9 +17,6 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
-jest.mock( '@automattic/zendesk-client', () => ( {
-	useGetZendeskConversations: () => ( { conversations: [], isLoading: false } ),
-} ) );
 jest.mock( '../is-editor-page' );
 
 const MockComponent = jest.fn();
@@ -290,6 +287,7 @@ describe( 'convertToolMessagesToComponents', () => {
 
 	it( 'renders `EscalationButton` when `forward_to_human_support` flag is set', () => {
 		const message = createMessage( {
+			message_id: 27406875,
 			content: [
 				{ type: 'text', text: 'Hello' },
 				{
@@ -297,16 +295,32 @@ describe( 'convertToolMessagesToComponents', () => {
 					data: { flags: { forward_to_human_support: true } },
 				},
 			],
-		} );
+		} as unknown as Partial< UIMessage > );
+		const escalationFollowUp = createMessage( {
+			id: 'escalation-follow-up',
+			message_id: 27407960,
+			role: 'escalation',
+			content: [ { type: 'text', text: 'This conversation was transferred to human support' } ],
+			context: {
+				zendesk_ticket_id: 11368863,
+				ai_chat_message_id: 27406875,
+			},
+			created_at: '2026-06-23 11:39:22',
+		} as unknown as Partial< UIMessage > );
 
 		const result = convertWithDefaults( {
-			messages: [ message ],
+			messages: [ message, escalationFollowUp ],
 		} );
 
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
 			type: 'component',
 			component: EscalationButton,
+			componentProps: {
+				messageId: message.id,
+				zendeskTicketId: 11368863,
+				escalatedAt: '2026-06-23T11:39:22.000Z',
+			},
 		} );
 	} );
 

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -13,11 +13,99 @@ export type AgentsManagerUIMessage = UIMessage & {
 	suppressThinking?: boolean;
 };
 
+type RawChatMessage = Omit< UIMessage, 'role' > & {
+	role: UIMessage[ 'role' ] | 'assistant' | 'escalation';
+	message_id?: number | string;
+	created_at?: string;
+	ts?: number | string;
+	context?: {
+		ai_chat_message_id?: number | string;
+		zendesk_ticket_id?: number | string;
+	};
+};
+
+type EscalationTransfer = {
+	zendeskTicketId: number | string;
+	escalatedAt?: string;
+};
+
 interface Options {
 	messages: UIMessage[];
 	getChatComponent?: GetChatComponent;
 	currentPostId?: number;
 	onSubmit: UseAgentChatReturn[ 'onSubmit' ];
+}
+
+function normalizeMessageId( messageId: number | string | undefined ) {
+	return messageId === undefined ? undefined : String( messageId );
+}
+
+function getMessageId( message: RawChatMessage ) {
+	return normalizeMessageId( message.message_id ) ?? message.id;
+}
+
+function getTimestampInMilliseconds( timestamp: number | string | undefined ) {
+	if ( typeof timestamp === 'number' && Number.isFinite( timestamp ) ) {
+		return timestamp > 9999999999 ? timestamp : timestamp * 1000;
+	}
+
+	if ( typeof timestamp === 'string' ) {
+		const parsedTimestamp = Number( timestamp );
+		if ( Number.isFinite( parsedTimestamp ) ) {
+			return parsedTimestamp > 9999999999 ? parsedTimestamp : parsedTimestamp * 1000;
+		}
+	}
+
+	return undefined;
+}
+
+function getEscalatedAt( message: RawChatMessage ) {
+	const timestamp = getTimestampInMilliseconds( message.ts );
+	if ( timestamp ) {
+		const date = new Date( timestamp );
+		return Number.isNaN( date.getTime() ) ? undefined : date.toISOString();
+	}
+
+	if ( ! message.created_at ) {
+		return undefined;
+	}
+
+	const createdAt = message.created_at.trim().replace( ' ', 'T' );
+	const createdAtWithTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/.test( createdAt )
+		? createdAt
+		: `${ createdAt }Z`;
+	const date = new Date( createdAtWithTimezone );
+	return Number.isNaN( date.getTime() ) ? undefined : date.toISOString();
+}
+
+export function findEscalationTransferForMessage(
+	messages: UIMessage[],
+	message: UIMessage
+): EscalationTransfer | undefined {
+	const rawMessages = messages as RawChatMessage[];
+	const messageId = getMessageId( message as RawChatMessage );
+
+	const escalationMessage = rawMessages.find(
+		( candidate ) =>
+			candidate.role === 'escalation' &&
+			normalizeMessageId( candidate.context?.ai_chat_message_id ) === messageId &&
+			candidate.context?.zendesk_ticket_id !== undefined &&
+			candidate.context.zendesk_ticket_id !== null
+	);
+
+	if ( ! escalationMessage ) {
+		return undefined;
+	}
+
+	const zendeskTicketId = escalationMessage.context?.zendesk_ticket_id;
+	if ( zendeskTicketId === undefined || zendeskTicketId === null ) {
+		return undefined;
+	}
+
+	return {
+		zendeskTicketId,
+		escalatedAt: getEscalatedAt( escalationMessage ),
+	};
 }
 
 /**
@@ -30,6 +118,10 @@ export default function convertToolMessagesToComponents( {
 	onSubmit,
 }: Options ): AgentsManagerUIMessage[] {
 	return messages.flatMap( ( message, index, array ) => {
+		if ( ( message as RawChatMessage ).role === 'escalation' ) {
+			return [];
+		}
+
 		const firstContentText = message.content?.[ 0 ]?.text;
 
 		// @ts-expect-error -- `assistant` comes from Big Sky messages
@@ -47,6 +139,8 @@ export default function convertToolMessagesToComponents( {
 					'forward_to_human_support' in content.data.flags
 			)
 		) {
+			const escalationTransfer = findEscalationTransferForMessage( array, message );
+
 			return {
 				...message,
 				content: [
@@ -55,6 +149,8 @@ export default function convertToolMessagesToComponents( {
 						component: EscalationButton as React.ComponentType,
 						componentProps: {
 							messageId: message.id,
+							zendeskTicketId: escalationTransfer?.zendeskTicketId,
+							escalatedAt: escalationTransfer?.escalatedAt,
 						},
 					},
 				],

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -60,6 +60,32 @@ function sortMessagesByTimestamp( messages: ZendeskMessage[] ) {
 	} );
 }
 
+function normalizeTicketId( ticketId: unknown ) {
+	return ticketId === undefined || ticketId === null ? undefined : String( ticketId );
+}
+
+function conversationHasTicketId( conversation: ZendeskConversation, ticketId: unknown ) {
+	const normalizedTicketId = normalizeTicketId( ticketId );
+	if ( ! normalizedTicketId ) {
+		return false;
+	}
+
+	const metadataTicketId =
+		conversation.metadata?.zendesk_ticket_id ?? conversation.metadata?.ticket_id;
+	if ( normalizeTicketId( metadataTicketId ) === normalizedTicketId ) {
+		return true;
+	}
+
+	return conversation.messages.some(
+		( message ) =>
+			normalizeTicketId( message.metadata?.zendesk_ticket_id ?? message.metadata?.ticket_id ) ===
+				normalizedTicketId ||
+			!! message.actions?.some(
+				( action ) => normalizeTicketId( action.metadata?.ticket_id ) === normalizedTicketId
+			)
+	);
+}
+
 function useSmooch( enabled = true ) {
 	const queryClient = useQueryClient();
 	const { data: authData, isFetching: isAuthenticatingZendeskMessaging } =
@@ -178,6 +204,7 @@ export const useManagedZendeskChat = () => {
 	const [ attachmentsNotice, setAttachmentNotice ] = useState< NoticeConfig | undefined >();
 	const { state } = useLocation();
 	const conversationId = state?.conversationId;
+	const zendeskTicketId = normalizeTicketId( state?.zendeskTicketId );
 	const startedFromChatId = state?.startedFromChatId;
 	const startedFromMessageId = state?.startedFromMessageId;
 	const [ conversation, setConversation ] = useState< ZendeskConversation | undefined >();
@@ -271,6 +298,16 @@ export const useManagedZendeskChat = () => {
 		if ( conversationId ) {
 			Smooch.getConversationById( conversationId ).then( setConversation );
 			Smooch.loadConversation( conversationId );
+		} else if ( zendeskTicketId ) {
+			const ticketConversation = Smooch.getConversations().find( ( conversation ) =>
+				conversationHasTicketId( conversation, zendeskTicketId )
+			);
+
+			if ( ticketConversation ) {
+				Smooch.getConversationById( ticketConversation.id ).then( setConversation );
+				Smooch.loadConversation( ticketConversation.id );
+				navigate( '/zendesk', { state: { conversationId: ticketConversation.id }, replace: true } );
+			}
 		} else {
 			Smooch.createConversation( {
 				metadata: {
@@ -287,7 +324,16 @@ export const useManagedZendeskChat = () => {
 				Smooch.loadConversation( conversation.id );
 			} );
 		}
-	}, [ Smooch, conversationId, navigate, conversation, Smooch?.render, startedFromChatId ] );
+	}, [
+		Smooch,
+		conversationId,
+		zendeskTicketId,
+		navigate,
+		conversation,
+		Smooch?.render,
+		startedFromChatId,
+		startedFromMessageId,
+	] );
 
 	const currentTypingStatus = typingStatus[ conversation?.id ?? '' ];
 


### PR DESCRIPTION
Related issue: none

## Proposed Changes

* Detect existing human-support transfers from the AI chat messages themselves by matching `role: 'escalation'` follow-up messages whose `context.ai_chat_message_id` matches the original escalation message.
* Pass the matched `context.zendesk_ticket_id` and escalation timestamp into `EscalationButton` so it shows the existing-chat state without scanning Zendesk Conversations in the button.
* Route existing-chat clicks with the Zendesk ticket id and resolve that ticket back to the Smooch Conversation in the Zendesk chat route.
* Keep escalation follow-up messages out of the rendered chat stream after using them as transfer metadata.

## Why are these changes being made?

* The previous approach reused chats by scanning Zendesk Conversations for the AI chat session id. The chat transcript now records a transfer follow-up message with the Zendesk ticket id, so the button can decide whether to continue from the chat data that produced the escalation button.
* This keeps repeated clicks tied to the already-created human chat instead of creating another one.

## Testing Instructions

* `yarn run -T jest -c packages/agents-manager/jest.config.js packages/agents-manager/src/components/__tests__/escalation-button.test.tsx packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts --runInBand`
* `yarn run -T tsc --noEmit --project packages/agents-manager/tsconfig.json`
* `yarn run -T tsc --noEmit --project packages/zendesk-client/tsconfig.json`
* `yarn run -T prettier --check packages/agents-manager/src/components/escalation-button/index.tsx packages/agents-manager/src/components/escalation-button/style.scss packages/agents-manager/src/components/__tests__/escalation-button.test.tsx packages/agents-manager/src/utils/convert-tool-messages-to-components.ts packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts packages/zendesk-client/src/use-managed-zendesk-chat.tsx`
* `yarn run eslint packages/agents-manager/src/components/escalation-button/index.tsx packages/agents-manager/src/components/__tests__/escalation-button.test.tsx packages/agents-manager/src/utils/convert-tool-messages-to-components.ts packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts packages/zendesk-client/src/use-managed-zendesk-chat.tsx`
* `yarn run -T stylelint packages/agents-manager/src/components/escalation-button/style.scss`
* `git diff --check origin/trunk...HEAD`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
