### PR TITLE
Fix Zendesk chat transfer link

### DIFF
--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -318,6 +318,7 @@ export const useManagedZendeskChat = () => {
 
 	const agentticMessages = useMemo( () => {
 		const rawMessages = sortMessagesByTimestamp( conversation?.messages ?? [] );
+		const chatSessionId = conversation?.metadata?.chat_session_id;
 		const ratingMessage = rawMessages.find( ( msg ) => msg.metadata?.rated === true );
 		const hasRated = ratingMessage !== undefined;
 		let score: 'GOOD' | 'BAD' | null = null;
@@ -446,10 +447,7 @@ export const useManagedZendeskChat = () => {
 				],
 			} );
 		}
-		if (
-			conversation?.metadata?.started_from === 'chat' &&
-			conversation?.metadata?.chat_session_id
-		) {
+		if ( conversation?.metadata?.started_from === 'chat' && chatSessionId ) {
 			messages.unshift( {
 				id: 'transfer_message',
 				role: 'agent',
@@ -465,11 +463,7 @@ export const useManagedZendeskChat = () => {
 									{ createInterpolateElement(
 										__( 'Started from <a>another chat</a>', '__i18n_text_domain__' ),
 										{
-											a: (
-												<Link
-													to={ `/chat?sessionId=${ conversation?.metadata?.chat_session_id }` }
-												/>
-											),
+											a: <Link to="/chat" state={ { sessionId: chatSessionId } } />,
 										}
 									) }
 								</div>


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Pass the originating AI chat session through React Router state when linking from Zendesk transfer messages back to `/chat`.
* Reuse `chatSessionId` from conversation metadata for the link guard and state payload.

## Why are these changes being made?

* The Agents Manager chat view restores non-reader conversations from `useLocation().state.sessionId`. The Zendesk transfer message was putting the session ID in the query string, so clicking "another chat" navigated to `/chat` without restoring the intended conversation.

## Testing Instructions

* `yarn workspace @automattic/zendesk-client build`
* `env ESLINT_USE_FLAT_CONFIG=false yarn eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json --cache packages/zendesk-client/src/use-managed-zendesk-chat.tsx` (passes with 4 existing warnings in this file)
* `yarn typecheck-packages`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
