### PR TITLE
A4A MCP: present setup as a 3-step flow

### DIFF
--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -116,9 +116,9 @@ export default function McpOverview( {
 								</VStack>
 							</HStack>
 							<ToggleControl
-								className="mcp-overview__step-toggle"
 								__nextHasNoMarginBottom
-								label={ __( 'Enable MCP access' ) }
+								label=""
+								aria-label={ __( 'Enable MCP access' ) }
 								checked={ mainEnabled }
 								onChange={ onMainToggle }
 								disabled={ isLoading || isSaving }

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -1,20 +1,35 @@
 import {
 	Icon,
 	ToggleControl,
+	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { plugins, tool } from '@wordpress/icons';
-import { Card, CardBody, CardDivider } from '../../../components/card';
+import { check } from '@wordpress/icons';
+import clsx from 'clsx';
+import { Card, CardBody } from '../../../components/card';
 import SummaryButton from '../../../components/summary-button';
 import type { RecordTracksEvent } from './types';
 import type { McpSettings, McpSettingsUpdate } from '@automattic/api-core';
 import type { MouseEvent } from 'react';
 
+import './style.scss';
+
 const MCP_TOOLS_PATH = '/resources/ai-mcp/tools';
 const MCP_CONNECT_PATH = '/resources/ai-mcp/connect';
+
+function StepNumber( { n, completed }: { n: number; completed?: boolean } ) {
+	return (
+		<span
+			className={ clsx( 'mcp-overview__step-number', { 'is-completed': completed } ) }
+			aria-hidden="true"
+		>
+			{ completed ? <Icon icon={ check } size={ 18 } /> : n }
+		</span>
+	);
+}
 
 interface McpOverviewProps {
 	settings: McpSettings | undefined;
@@ -72,55 +87,66 @@ export default function McpOverview( {
 		<>
 			<Spacer marginBottom={ 8 } style={ { maxWidth: '650px' } }>
 				<Text size={ 15 }>
-					{ __( 'Control how AI assistants interact with your Automattic for Agencies account.' ) }
+					{ __(
+						'Set up AI agent access in three steps. Access won’t work until you complete all three.'
+					) }
 				</Text>
 			</Spacer>
 
 			<VStack spacing={ 4 }>
 				<Card>
 					<CardBody>
-						<VStack spacing={ 3 }>
-							<Text weight={ 600 } size={ 15 }>
-								{ __( 'External AI agent access' ) }
-							</Text>
-							<Text variant="muted">
-								{ __(
-									'Allow external AI agents to access your Automattic for Agencies account via MCP.'
-								) }
-							</Text>
+						<HStack alignment="flex-start" justify="space-between" spacing={ 4 }>
+							<HStack
+								className="mcp-overview__step-heading"
+								alignment="flex-start"
+								justify="flex-start"
+								spacing={ 3 }
+							>
+								<StepNumber n={ 1 } completed={ mainEnabled } />
+								<VStack spacing={ 1 }>
+									<Text weight={ 600 } size={ 15 }>
+										{ __( 'Enable MCP access' ) }
+									</Text>
+									<Text variant="muted">
+										{ __(
+											'Allow external AI agents to access your Automattic for Agencies account via MCP.'
+										) }
+									</Text>
+								</VStack>
+							</HStack>
 							<ToggleControl
+								className="mcp-overview__step-toggle"
 								__nextHasNoMarginBottom
 								label={ __( 'Enable MCP access' ) }
 								checked={ mainEnabled }
 								onChange={ onMainToggle }
 								disabled={ isLoading || isSaving }
 							/>
-						</VStack>
+						</HStack>
 					</CardBody>
-					{ mainEnabled && (
-						<>
-							<CardDivider style={ { borderColor: 'var(--color-neutral-5)' } } />
-							<SummaryButton
-								density="medium"
-								title={ __( 'Available tools' ) }
-								decoration={ <Icon icon={ tool } size={ 24 } /> }
-								badges={ [ availableToolsBadge ] }
-								href={ toolsPath }
-								onClick={ handleNavClick( toolsPath, 'calypso_a4a_ai_mcp_available_tools_click' ) }
-							/>
-						</>
-					) }
 				</Card>
 
-				{ mainEnabled && (
-					<SummaryButton
-						title={ __( 'Connect external AI assistant' ) }
-						description={ __( 'Get instructions for connecting your external AI assistant.' ) }
-						decoration={ <Icon icon={ plugins } size={ 24 } /> }
-						href={ connectPath }
-						onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
-					/>
-				) }
+				<SummaryButton
+					title={ __( 'Select tools' ) }
+					description={ __( 'Choose what AI agents can do in your account.' ) }
+					decoration={ <StepNumber n={ 2 } /> }
+					badges={ [ availableToolsBadge ] }
+					href={ toolsPath }
+					disabled={ ! mainEnabled }
+					onClick={ handleNavClick( toolsPath, 'calypso_a4a_ai_mcp_available_tools_click' ) }
+				/>
+
+				<SummaryButton
+					title={ __( 'Connect your AI agent' ) }
+					description={ __(
+						'Required — add the MCP connection to your AI agent to finish setup.'
+					) }
+					decoration={ <StepNumber n={ 3 } /> }
+					href={ connectPath }
+					disabled={ ! mainEnabled }
+					onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
+				/>
 			</VStack>
 		</>
 	);

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -22,16 +22,6 @@
 	}
 }
 
-.mcp-overview__step-toggle .components-toggle-control__label {
-	position: absolute;
-	clip: rect( 1px, 1px, 1px, 1px );
-	inline-size: 1px;
-	block-size: 1px;
-	margin: -1px;
-	padding: 0;
-	overflow: hidden;
-}
-
 .mcp-connect-agent ol {
 	padding-inline-start: 20px;
 	margin: 0;

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -1,3 +1,37 @@
+.mcp-overview__step-number {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	inline-size: 24px;
+	block-size: 24px;
+	border-radius: 50%;
+	box-shadow: inset 0 0 0 1px var( --color-border-subtle );
+	color: var( --color-text );
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.mcp-overview__step-number.is-completed {
+	box-shadow: inset 0 0 0 1px var( --color-primary );
+	color: var( --color-primary );
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.mcp-overview__step-toggle .components-toggle-control__label {
+	position: absolute;
+	clip: rect( 1px, 1px, 1px, 1px );
+	inline-size: 1px;
+	block-size: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+}
+
 .mcp-connect-agent ol {
 	padding-inline-start: 20px;
 	margin: 0;


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2875/mcp-add-3-step-setup-flow



> Stacked on top of #111380 — base branch is `dashboard-a4a-resources-mcp`, not `trunk`.

## Proposed Changes

Reframe the A4A "AI and MCP" overview (`overview-content.tsx`, shared by the Dashboard client and a8c-for-agencies) as an explicit, numbered **3-step setup flow**:

* **Step 1 — Enable MCP access**: the master toggle, now in a numbered step card.
* **Step 2 — Select tools**: links to the available-tools screen (keeps the `X of Y enabled` badge).
* **Step 3 — Connect your AI agent**: links to the connect instructions, with "Required —…" copy so it never reads as optional.
* Steps 2 and 3 are **disabled until access is enabled**, enforcing the sequence.
* Step 1's indicator becomes a **checkmark** once enabled, signaling the gate is satisfied and the remaining steps are unlocked.

| Before | After |
|--------|--------|
| <img width="1602" height="511" alt="Screenshot 2026-06-23 at 8 20 54 PM" src="https://github.com/user-attachments/assets/7a1f34f9-2779-4003-b79a-1327e529236f" /> | <img width="1591" height="580" alt="Screenshot 2026-06-23 at 8 15 23 PM" src="https://github.com/user-attachments/assets/72b74e89-9284-4336-91c1-6c47649b8a67" /> | 

## Why are these changes being made?

Previously the connect step only appeared after enabling MCP and read as an optional link. A non-technical user could enable the feature, see the tools, and assume it works without ever connecting an external AI agent. Numbering the steps and gating 2–3 behind step 1 makes the required sequence explicit.

## Testing Instructions

* Open **Resources → AI and MCP** (Dashboard) / **AI and MCP** (a8c-for-agencies).
* With access **off**: all three numbered steps are visible; steps 2 and 3 are disabled and not navigable; step 1 shows "1".
* Toggle access **on**: step 1's indicator becomes a checkmark; steps 2 and 3 become enabled and navigable; the tools badge reflects enabled/total counts.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
