### PR TITLE
Dashboard: remove Blocked Sites from me-sidebar

### DIFF
--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -6,15 +6,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	bell,
-	buttons,
-	commentAuthorAvatar,
-	lock,
-	notAllowed,
-	payment,
-	settings,
-} from '@wordpress/icons';
+import { bell, buttons, commentAuthorAvatar, lock, payment, settings } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import type { AppConfig, MeSupports } from '../../app/context';
@@ -74,11 +66,6 @@ function MeMenuSidebar() {
 			{ supports.notifications && (
 				<SidebarMenuItem icon={ bell } to="/me/notifications">
 					{ __( 'Notifications' ) }
-				</SidebarMenuItem>
-			) }
-			{ supports.reader && (
-				<SidebarMenuItem icon={ notAllowed } to="/me/blocked-sites">
-					{ __( 'Blocked sites' ) }
 				</SidebarMenuItem>
 			) }
 			{ hasAppSupport( supports, 'apps' ) && (


### PR DESCRIPTION
Fixes DOTMSD-1331

## Proposed Changes

Remove Blocked Sites from MSD `/me` sidebar.

## Why are these changes being made?

It was moved under Preferences in https://github.com/Automattic/wp-calypso/pull/109317 but we forgot to remove it from the old sidebar location.

## Testing Instructions

| Before | After | 
| - | - | 
| <img width="780" height="480" alt="image" src="https://github.com/user-attachments/assets/4f22b4b1-dd8d-484c-9a31-ed00ec9163ea" /> | <img width="780" height="480" alt="image" src="https://github.com/user-attachments/assets/5d63c601-4f13-4ade-bdd6-027879ca4f88" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
