### PR TITLE
Global Nav 2026: drop the "New" badge from AI website builder

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -48,7 +48,6 @@ export function getNav2026Menus( {
 				label: __( 'AI website builder', __i18n_text_domain__ ),
 				url: localizeUrl( '//wordpress.com/ai-website-builder/?ref=topnav' ),
 				target: '_self',
-				badge: __( 'New', __i18n_text_domain__ ),
 			},
 		],
 	};
@@ -122,7 +121,6 @@ export function getNav2026Menus( {
 						label: __( 'AI website builder', __i18n_text_domain__ ),
 						url: localizeUrl( '//wordpress.com/ai-website-builder/?ref=topnav' ),
 						target: '_self',
-						badge: __( 'New', __i18n_text_domain__ ),
 					},
 				],
 			},


### PR DESCRIPTION
Related to 6315496e8e23 (Dotcom Global Nav Redesign 2026)

## Proposed Changes

* Remove the "New" badge from the AI website builder item in the redesigned global navigation, so it no longer renders a pill next to the link in the desktop and mobile dropdowns.

## Why are these changes being made?

* The "New" label has run its course for the AI website builder entry and is being retired from the nav. This is a small copy/polish change to the 2026 nav redesign.

## Testing Instructions

* Check out this branch and load the redesigned nav (variant 1 and variant 2).
* Open the menu containing **AI website builder** on both desktop and mobile.
* Confirm the link still appears and works, with no "New" pill next to it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
