### PR TITLE
Calypso E2E: navigate to post edit URL instead of clicking row title in PostsPage

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/posts-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/posts-page.ts
@@ -164,11 +164,14 @@ export class PostsPage {
 		const locator = this.page.locator(
 			`${ selectors.postRow } a.row-title:has-text("${ title }")`
 		);
+		// Navigate via href instead of click(): some wp-admin column widgets (e.g. jetpack_seo_schema)
+		// overlay the row and intercept pointer events, causing click() to time out.
+		await locator.waitFor( { state: 'visible' } );
 		const href = await locator.getAttribute( 'href' );
 		if ( ! href ) {
 			throw new Error( `No href found on row-title for post "${ title }"` );
 		}
-		await this.page.goto( href );
+		await this.page.goto( href, { waitUntil: 'domcontentloaded', timeout: 30 * 1000 } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/posts-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/posts-page.ts
@@ -161,8 +161,14 @@ export class PostsPage {
 	async clickPost( title: string ): Promise< void > {
 		await this.ensurePostShown( title );
 
-		const locator = this.page.locator( `${ selectors.postRow } ${ selectors.postItem( title ) }` );
-		await locator.click();
+		const locator = this.page.locator(
+			`${ selectors.postRow } a.row-title:has-text("${ title }")`
+		);
+		const href = await locator.getAttribute( 'href' );
+		if ( ! href ) {
+			throw new Error( `No href found on row-title for post "${ title }"` );
+		}
+		await this.page.goto( href );
 	}
 
 	/**


### PR DESCRIPTION
Related: p1782188227834769-slack-C020H2DD6MD

## Proposed Changes

* `PostsPage.clickPost` reads `href` from `a.row-title` and calls `page.goto()` instead of `locator.click()`
* `waitFor({ state: 'visible' })` added before `getAttribute` to confirm the element's there before reading it
* `page.goto` gets `{ waitUntil: 'domcontentloaded', timeout: 30 * 1000 }`, matching the other `goto` calls in the same file

## Why are these changes being made?

A new `jetpack_seo_schema` column in the wp-admin posts list intercepts pointer events over the row; `locator.click()` times out on every attempt. Reading the `href` and navigating directly avoids the interception. The editor still loads or fails at that URL, so the test's actual assertions (content, publish, draft) aren't affected.

## Testing Instructions

`specs/editor/editor__post-advanced-flow.ts` against staging; all 18 tests pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?