### PR TITLE
Global Nav 2026: add reason to mobile menu open Tracks events

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -94,7 +94,9 @@ const UniversalNavbarHeader = ( {
 	const activeCategory = nav2026Menus.find( ( menu ) => menu.name === currentDropdown );
 
 	const closeMobileMenu = useCallback(
-		( reason = 'close_button' ) => {
+		// `reason` is required (no default) so a new close path that forgets to
+		// label itself fails the type-check instead of silently logging a wrong reason.
+		( reason: string ) => {
 			setMobileMenuOpen( ( open ) => {
 				if ( open && nav2026 ) {
 					recordMobileMenuClose( isScrolledRef.current, reason );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -36,7 +36,7 @@ interface Nav2026MobileMenuProps {
 	variant: 'default' | 'minimal';
 	mobilePlatform: 'ios' | 'android' | null;
 	mobileFooterRef: React.RefObject< HTMLDivElement >;
-	closeMobileMenu: ( reason?: string ) => void;
+	closeMobileMenu: ( reason: string ) => void;
 	setCurrentDropdown: ( name: string | null ) => void;
 }
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts
@@ -76,11 +76,12 @@ describe( 'nav-2026 tracks', () => {
 	} );
 
 	describe( 'mobile menu open/close', () => {
-		it( 'fires mobile_menu_open with burger_menu start type + viewport width', () => {
+		it( 'fires mobile_menu_open with burger_menu reason + start type + viewport width', () => {
 			recordMobileMenuOpen( false );
 			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_mobile_menu_open', {
 				is_2026: true,
 				is_floating: false,
+				reason: 'burger_menu',
 				start_type: 'burger_menu',
 				viewport_width: window.innerWidth,
 			} );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -36,6 +36,9 @@ export function recordSubmenuHide( isFloating: boolean, name: string ): void {
 
 export function recordMobileMenuOpen( isFloating: boolean ): void {
 	record( 'calypso_global_nav_mobile_menu_open', isFloating, {
+		// The hamburger is the only way to open the menu, so `reason` is constant
+		// for now; it's recorded for parity with the close event's `reason`.
+		reason: 'burger_menu',
 		start_type: 'burger_menu',
 		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
 	} );
@@ -115,6 +118,7 @@ function recordLegacy( name: string, props: TracksProps = {} ): void {
 
 export function recordLegacyMobileMenuOpen(): void {
 	recordLegacy( 'calypso_global_nav_mobile_menu_open', {
+		reason: 'burger_menu',
 		start_type: 'burger_menu',
 		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
 	} );


### PR DESCRIPTION
## Proposed Changes

* **Open events** now record a `reason` property on `calypso_global_nav_mobile_menu_open` (both the 2026 and legacy navs), set to a constant `burger_menu` since the hamburger is the only way to open the menu.
* **Close reason is now required**: `closeMobileMenu`'s `reason` argument has no default, so a new close path that forgets to label itself fails the type-check instead of silently logging a wrong reason. Existing reachable reasons (`close_button`, `overlay`, `escape`) are unchanged.
* Updates the unit test for the open-event property.

## Why are these changes being made?

* The registered Tracks definitions for the mobile menu events declare a `reason` property. The close event already sent it, but the open event did not, leaving the metric incomplete.
* Making the close `reason` required keeps the metric trustworthy: every dismissal path is forced to label itself at compile time, so we can't ship a close path that logs a misleading reason.

## Testing Instructions

* Run the unit test: `yarn test-packages packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts`
* On a narrow viewport, open the 2026 nav mobile menu via the hamburger and confirm the `*_mobile_menu_open` Tracks event carries `reason: "burger_menu"`.
* Close it via the X, the overlay, and Escape and confirm `*_mobile_menu_close` carries `close_button`, `overlay`, and `escape` respectively.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
