### PR TITLE
Calypso E2E: fix sidebar init and test stability for Global Nav 2026

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -49,10 +49,8 @@ export class SidebarComponent {
 		if ( await this.sidebarIsCollapsed() ) {
 			const sidebarCollapseToggle = this.page.locator( selectors.linkWithText( 'Collapse menu' ) );
 			// Wait until the collapsed sidebar CSS is detached from DOM, ie. it is no longer collapsed.
-			await Promise.all( [
-				this.page.waitForSelector( selectors.collapsedSidebar, { state: 'detached' } ),
-				sidebarCollapseToggle.click(),
-			] );
+			await sidebarCollapseToggle.click();
+			await this.page.locator( selectors.collapsedSidebar ).waitFor( { state: 'detached' } );
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -37,7 +37,7 @@ export class SidebarComponent {
 	 * Waits for the WordPress.com Calypso sidebar to be ready on the page.
 	 */
 	async waitForSidebarInitialization(): Promise< void > {
-		const sidebarLocator = this.page.locator( selectors.sidebar );
+		const sidebarLocator = this.page.locator( `${ selectors.sidebar }, .global-sidebar` ).first();
 
 		await Promise.all( [
 			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -51,7 +51,7 @@ export class SidebarComponent {
 			// Wait until the collapsed sidebar CSS is detached from DOM, ie. it is no longer collapsed.
 			await Promise.all( [
 				this.page.waitForSelector( selectors.collapsedSidebar, { state: 'detached' } ),
-				sidebarCollapseToggle.dispatchEvent( 'click' ),
+				sidebarCollapseToggle.click(),
 			] );
 		}
 	}

--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -515,9 +515,9 @@ test.describe( 'Themes dark-mode surfaces', { tag: [ tags.CALYPSO_PR ] }, () => 
 
 		await test.step( 'Then the Themes listing renders in dark mode', async () => {
 			await pageThemes.visitShowcase();
-			await page
-				.getByRole( 'heading', { name: /Find the perfect theme/ } )
-				.waitFor( { timeout: 30_000 } );
+			await expect( page.getByRole( 'heading', { name: /Find the perfect theme/ } ) ).toBeVisible( {
+				timeout: 30_000,
+			} );
 			await expectDarkModeRoot( page, {
 				bodyClasses: [ 'is-themes-dark-mode' ],
 				expectColorSchemeBodyClass: true,

--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -515,7 +515,9 @@ test.describe( 'Themes dark-mode surfaces', { tag: [ tags.CALYPSO_PR ] }, () => 
 
 		await test.step( 'Then the Themes listing renders in dark mode', async () => {
 			await pageThemes.visitShowcase();
-			await page.getByRole( 'heading', { name: /Find the perfect theme/ } ).waitFor();
+			await page
+				.getByRole( 'heading', { name: /Find the perfect theme/ } )
+				.waitFor( { timeout: 30_000 } );
 			await expectDarkModeRoot( page, {
 				bodyClasses: [ 'is-themes-dark-mode' ],
 				expectColorSchemeBodyClass: true,

--- a/test/e2e/specs/i18n/i18n__editor.spec.ts
+++ b/test/e2e/specs/i18n/i18n__editor.spec.ts
@@ -30,7 +30,7 @@ test.describe( 'I18N: Editor', { tag: [ tags.I18N, tags.DESKTOP_ONLY ] }, () => 
 			pageEditor,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accounti18n.accountName }'`, async function () {
-				await accounti18n.authenticate( page );
+				await accounti18n.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( `And I update my locale settings to ${ locale }`, async function () {


### PR DESCRIPTION
Part of [TESTOPS-193](https://linear.app/a8c/issue/TESTOPS-193)

## Proposed Changes

- `SidebarComponent.waitForSidebarInitialization()`: extend locator to match `.sidebar, .global-sidebar` with `.first()` to avoid Playwright strict-mode throws when both are present simultaneously (Global Nav 2026 renders `.global-sidebar` wrapping `.sidebar` on reader, me, and sites-dashboard routes)
- `i18n__editor.spec.ts`: skip sidebar stability wait — the test navigates to the editor immediately after auth, so the sidebar ready-check is unnecessary and was timing out under the new nav
- `dark-mode-surfaces.spec.ts`: extend Themes heading wait to 30s (pixel config was consistently timing out at 10s); replace `locator.waitFor()` with `expect().toBeVisible()` for auto-retry and better failure output
- `sidebar-component.ts`: replace `dispatchEvent('click')` with `click()` on the collapse toggle to restore Playwright actionability checks

## Why are these changes being made?

The Global Nav 2026 experiment launched on trunk today. Accounts enrolled in it land on routes where `.global-sidebar` renders instead of `.sidebar`. `waitForSidebarInitialization()` waited for `.sidebar` only, causing 20s timeouts. The fix is made at the page-object level so all callers are covered without per-test workarounds.

## Testing Instructions

All changed specs verified against staging (wpcalypso.wordpress.com), 5 runs each:

- `specs/i18n/i18n__editor.spec.ts`: 5 × 18 passed
- `specs/color-scheme/dark-mode-surfaces.spec.ts`: 5 × 7 passed, 2 consistent pre-existing failures in `@dashboard-pr` suite (requires a local dev server, unrelated to this change)