### PR TITLE
Speed Test: add copy-link button to share popover

### DIFF
--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -1,8 +1,8 @@
 import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { Icon, mobile, desktop, share } from '@wordpress/icons';
+import { Icon, mobile, desktop, share, link, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import WPcomBadge from 'calypso/assets/images/performance-profiler/wpcom-badge.svg';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -47,10 +47,25 @@ const SocialServices = [
 export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 	const translate = useTranslate();
 	const [ showPopoverMenu, setPopoverMenu ] = useState( false );
+	const [ linkCopied, setLinkCopied ] = useState( false );
 	const popoverButtonRef = useRef( null );
 	const { url, activeTab, onTabChange, showNavigationTabs, timestamp, showWPcomBadge, shareLink } =
 		props;
 	const urlParts = new URL( url );
+
+	useEffect( () => {
+		if ( ! linkCopied ) {
+			return;
+		}
+
+		const timeoutId = setTimeout( () => setLinkCopied( false ), 2000 );
+		return () => clearTimeout( timeoutId );
+	}, [ linkCopied ] );
+
+	const onCopyLink = () => {
+		navigator.clipboard.writeText( shareLink );
+		setLinkCopied( true );
+	};
 
 	const renderTimestampAndBadge = () => (
 		<>
@@ -140,6 +155,14 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 										position="top"
 										onClose={ () => setPopoverMenu( false ) }
 									>
+										<Button
+											className="copy-link-button"
+											onClick={ onCopyLink }
+											label={ linkCopied ? translate( 'Copied!' ) : translate( 'Copy link' ) }
+											showTooltip
+										>
+											<Icon icon={ linkCopied ? check : link } size={ 28 } />
+										</Button>
 										{ SocialServices.map( ( item ) => (
 											<ShareButton
 												key={ item.service }

--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -1,4 +1,4 @@
-import { Popover } from '@automattic/components';
+import { Button as AutomatticButton, Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, mobile, desktop, share, link, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -19,7 +19,7 @@ type HeaderProps = {
 	showNavigationTabs?: boolean;
 	timestamp?: string;
 	showWPcomBadge?: boolean;
-	shareLink: string;
+	shareLink?: string;
 };
 
 export const TabTypes = {
@@ -63,6 +63,10 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 	}, [ linkCopied ] );
 
 	const onCopyLink = () => {
+		if ( ! shareLink ) {
+			return;
+		}
+
 		navigator.clipboard.writeText( shareLink );
 		setLinkCopied( true );
 	};
@@ -155,14 +159,6 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 										position="top"
 										onClose={ () => setPopoverMenu( false ) }
 									>
-										<Button
-											className="copy-link-button"
-											onClick={ onCopyLink }
-											label={ linkCopied ? translate( 'Copied!' ) : translate( 'Copy link' ) }
-											showTooltip
-										>
-											<Icon icon={ linkCopied ? check : link } size={ 28 } />
-										</Button>
 										{ SocialServices.map( ( item ) => (
 											<ShareButton
 												key={ item.service }
@@ -172,6 +168,15 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 												service={ item.service }
 											/>
 										) ) }
+										<AutomatticButton
+											className="copy-link-button"
+											onClick={ onCopyLink }
+											disabled={ ! shareLink }
+											title={ linkCopied ? translate( 'Copied!' ) : translate( 'Copy link' ) }
+											borderless
+										>
+											<Icon icon={ linkCopied ? check : link } size={ 28 } />
+										</AutomatticButton>
 									</Popover>
 								</>
 							) }

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -262,10 +262,21 @@
 		padding: 3px 10px 0;
 		border-radius: 8px;
 		border-width: 0;
+		display: flex;
+		align-items: center;
 
 		button {
 			padding-right: 4px;
 			padding-left: 4px;
+		}
+
+		.copy-link-button {
+			height: auto;
+			min-width: 0;
+
+			svg {
+				fill: var( --color-text );
+			}
 		}
 	}
 	.popover__arrow {

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -270,13 +270,8 @@
 			padding-left: 4px;
 		}
 
-		.copy-link-button {
-			height: auto;
-			min-width: 0;
-
-			svg {
-				fill: var( --color-text );
-			}
+		.copy-link-button svg {
+			fill: var( --color-text );
 		}
 	}
 	.popover__arrow {


### PR DESCRIPTION
Fixes DOTDEV-135

## Proposed Changes

* Add a copy-link button as the last item in the speed test results share popover, alongside the existing X / LinkedIn / Facebook / Tumblr icons.
* Clicking it copies the report shortlink (`share_link`) to the clipboard and briefly swaps the link icon for a checkmark with a “Copied!” tooltip (resets after 2s).

## Why are these changes being made?

<!-- It's easy to see what a PR does but much harder to find out why it was made. -->

* The share popover only let users post results to a social network. To get a plain shareable link, you had to start a post somewhere and copy the URL out of it. This adds a one-click way to copy the shortlink, matching the pattern of common share sheets.

<img width="2374" height="1570" alt="CleanShot 2026-06-23 at 17 43 14@2x" src="https://github.com/user-attachments/assets/097dcdb0-bbe2-4287-b682-61d449e05346" />

## Testing Instructions

* Run `yarn start` or use Calypso Live URL
* Open `http://calypso.localhost:3000/speed-test-tool?url=YOUR_SITE_URL` link
* Wait for the results dashboard.
* Click **Share** (top-right of the results nav).
* The popover shows the new link icon last, just after the social icons.
* Click the link icon → it swaps to a checkmark with a “Copied!” tooltip; paste to confirm the shortlink was copied.
* Note: the copy button only appears once a report has finished (gated on the report timestamp), and clipboard copy requires a secure context (localhost qualifies).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?