### PR TITLE
Renewal pricing: switch to the new experiment id

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -135,7 +135,7 @@ describe( 'useRenewalPricingExperiment', () => {
 			renderHook( () => useRenewalPricingExperiment() );
 			expect( useExperiment ).toHaveBeenNthCalledWith(
 				1,
-				'wpcom_renewal_pricing_increase_v2_usd_202604_v1',
+				'wpcom_renewal_pricing_increase_v2_usd_202604_v2',
 				expect.objectContaining( { isEligible: false } )
 			);
 		} );
@@ -201,7 +201,7 @@ describe( 'useRenewalPricingExperiment', () => {
 			renderHook( () => useRenewalPricingExperiment() );
 			expect( useExperiment ).toHaveBeenNthCalledWith(
 				1,
-				'wpcom_renewal_pricing_increase_v2_usd_202604_v1',
+				'wpcom_renewal_pricing_increase_v2_usd_202604_v2',
 				expect.objectContaining( { isEligible: false } )
 			);
 		} );
@@ -212,7 +212,7 @@ describe( 'useRenewalPricingExperiment', () => {
 			renderHook( () => useRenewalPricingExperiment() );
 			expect( useExperiment ).toHaveBeenNthCalledWith(
 				1,
-				'wpcom_renewal_pricing_increase_v2_usd_202604_v1',
+				'wpcom_renewal_pricing_increase_v2_usd_202604_v2',
 				expect.objectContaining( { isEligible: false } )
 			);
 			expect( useExperiment ).toHaveBeenNthCalledWith(

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -8,7 +8,7 @@ import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 
-const RENEWAL_PRICING_EXPERIMENT_V2_EN_USD = 'wpcom_renewal_pricing_increase_v2_usd_202604_v1';
+const RENEWAL_PRICING_EXPERIMENT_V2_EN_USD = 'wpcom_renewal_pricing_increase_v2_usd_202604_v2';
 const RENEWAL_PRICING_EXPERIMENT_V2_NON_USD = 'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1';
 
 function useCurrencyFromPlans(): string | undefined {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Update the experiment id

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To restart the experiment with fresh assignments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
