### PR TITLE
CODEOWNERS: add YOLO team for desktop/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -147,3 +147,6 @@
 
 # Grid package
 /packages/grid @youknowriad
+
+# Desktop app
+/desktop @Automattic/yolo


### PR DESCRIPTION
## Proposed Changes

* Add `@Automattic/yolo` as a code owner for the `/desktop` directory in `.github/CODEOWNERS`.

## Why are these changes being made?

The desktop app code under `/desktop` had no CODEOWNERS entry, so the YOLO team wasn't being looped in on changes. As the file header notes, this signals interest (keeping the team in the loop), not enforced ownership. The team is referenced as `@Automattic/yolo` to match existing usages elsewhere in the file.

## Testing Instructions

* Verify the new entry in `.github/CODEOWNERS`:
  ```
  # Desktop app
  /desktop @Automattic/yolo
  ```
* GitHub should now request review from `@Automattic/yolo` on PRs touching `/desktop`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?