### PR TITLE
Notifications: keep the poll/refresh window fixed instead of growing to 100

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -8,6 +8,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
+import getFilteredLoading from '../../panel/state/selectors/get-filtered-loading';
 import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import { getIsNoteRead } from '../../panel/state/selectors/get-is-note-read';
@@ -70,6 +71,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	const visibleNotes = notes.filter( ( note ) => hiddenNoteIds[ note.id ] !== true );
 
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
+	const filteredLoading = useSelector( ( state ) => getFilteredLoading( state ) );
 	const { client } = useAppContext();
 
 	// DataViews 14 binds its infinite-scroll listener in an effect that runs
@@ -180,9 +182,10 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	// mid-load leaves scrolling dead. In-flight loading uses the `empty` slot.
 	const showInitialLoader = ! hasRenderedDataViews.current;
 
-	// Spinner instead of an empty message while the view may still be filling —
-	// more cache pages to search, or the Unread fetch in flight.
-	const showEmptyLoader = hasMoreNotes || ( filterName === 'unread' && isLoading );
+	// Spinner instead of an empty message while the view may still be filling: more
+	// cache pages to search, or the Unread fetch in flight. Unread keys off the
+	// in-flight filter, not the shared `isLoading` the background poll also toggles.
+	const showEmptyLoader = hasMoreNotes || ( filterName === 'unread' && !! filteredLoading?.unread );
 
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -57,10 +57,34 @@ describe( 'NoteList loading state', () => {
 
 		// A filtered fetch begins: loading is true while the data is still empty.
 		act( () => {
-			store.dispatch( actions.ui.loadNotes() );
+			store.dispatch( actions.ui.loadNotes( { filter: { unread: 1 } } ) );
 		} );
 
 		// The "all caught up" message must not show until the fetch settles.
+		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
+	} );
+
+	// Regression: the always-running unfiltered background poll clears the shared
+	// loading flag, but it must not expose the Unread empty message while a
+	// filtered fetch is still in flight (the "loading → empty → list" flash).
+	it( 'keeps the loader when the background poll clears shared loading mid-fetch', () => {
+		const store = initStore();
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderUnread( store );
+		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
+
+		// The Unread fetch begins.
+		act( () => {
+			store.dispatch( actions.ui.loadNotes( { filter: { unread: 1 } } ) );
+		} );
+		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
+
+		// A background all-notes poll completes and clears the shared loading flag
+		// while the filtered fetch is still in flight: the message must stay hidden.
+		act( () => {
+			store.dispatch( actions.ui.loadedNotes() );
+		} );
 		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
 		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
 	} );
@@ -81,7 +105,7 @@ describe( 'NoteList loading state', () => {
 		// the request is in flight.
 		act( () => {
 			store.dispatch( actions.notes.setUnreadNoteIds( [] ) );
-			store.dispatch( actions.ui.loadNotes() );
+			store.dispatch( actions.ui.loadNotes( { filter: { unread: 1 } } ) );
 		} );
 
 		// The same DataViews node is still mounted — it was not swapped for the

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -131,7 +131,6 @@ export interface Client {
 	isShowing: boolean;
 	lastSeenTime: number;
 	filter: Record< string, unknown > | null;
-	filteredRequestLimit: number;
 	filteredHasMore: boolean;
 	gettingFilteredNotes: boolean;
 	retries: number;

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -130,7 +130,6 @@ export interface Client {
 	isVisible: boolean;
 	isShowing: boolean;
 	lastSeenTime: number;
-	noteRequestLimit: number;
 	filter: Record< string, unknown > | null;
 	filteredRequestLimit: number;
 	filteredHasMore: boolean;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -432,6 +432,9 @@ function getFilteredNotes( before ) {
 	}
 	this.gettingFilteredNotes = true;
 	const generation = this.filterGeneration;
+	// Tag this fetch's loading dispatches with its filter, stable even if the
+	// active filter changes mid-flight.
+	const filter = this.filter;
 
 	const unreadIds = getUnreadNoteIds( store.getState() );
 
@@ -443,7 +446,7 @@ function getFilteredNotes( before ) {
 			? Math.min( settings.increment_limit, settings.max_limit - unreadIds.length )
 			: settings.initial_limit,
 		locale: this.locale,
-		...this.filter,
+		...filter,
 	};
 	if ( before ) {
 		parameters.before = before;
@@ -453,16 +456,16 @@ function getFilteredNotes( before ) {
 	// is empty) and while paging older notes (`before` → the list's load-more
 	// indicator); a steady-state refresh of a non-empty list stays silent.
 	if ( before || unreadIds.length === 0 ) {
-		store.dispatch( actions.ui.loadNotes() );
+		store.dispatch( actions.ui.loadNotes( { filter } ) );
 	}
 
 	listNotes( parameters, ( error, data ) => {
 		this.gettingFilteredNotes = false;
-		store.dispatch( actions.ui.loadedNotes() );
 
 		if ( error ) {
 			// Leave the polling path's state untouched; it will recover on its
 			// own schedule. A retry happens when the user re-enters the tab.
+			store.dispatch( actions.ui.loadedNotes( { filter } ) );
 			return;
 		}
 
@@ -471,7 +474,10 @@ function getFilteredNotes( before ) {
 		// setFilter's own fetch was skipped while this request held the lock.
 		if ( generation !== this.filterGeneration ) {
 			if ( this.filter && this.isVisible ) {
+				// The refetch keeps the loading state; don't clear it here.
 				this.getFilteredNotes();
+			} else {
+				store.dispatch( actions.ui.loadedNotes( { filter } ) );
 			}
 			return;
 		}
@@ -518,6 +524,10 @@ function getFilteredNotes( before ) {
 						: this.filteredHasMore ) && merged.length < settings.max_limit;
 			}
 		}
+
+		// Clear loading only after the notes and ids are in the store, so the list
+		// never flashes empty between "loaded" and the ids landing.
+		store.dispatch( actions.ui.loadedNotes( { filter } ) );
 	} );
 }
 

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -31,7 +31,6 @@ export function Client() {
 	// Active tab's server-side filter (e.g. `{ unread: 1 }`), or null for the
 	// unfiltered "all" list. When set, getFilteredNotes fetches matching notes.
 	this.filter = null;
-	this.filteredRequestLimit = settings.initial_limit;
 	this.filteredHasMore = false;
 	this.gettingFilteredNotes = false;
 	// Bumped on every setFilter so an in-flight fetch whose filter was reset
@@ -406,7 +405,6 @@ function getNotesList() {
  */
 function setFilter( filter ) {
 	this.filter = filter ?? null;
-	this.filteredRequestLimit = settings.initial_limit;
 	this.filteredHasMore = false;
 	this.filterGeneration++;
 
@@ -437,11 +435,11 @@ function getFilteredNotes( before ) {
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		// No `before`: re-request the authoritative top window. With it: page an
-		// older slice, capped to what's left under max_limit.
+		// No `before`: re-request a small fixed head window. With it: page an older
+		// slice, capped to what's left under max_limit.
 		number: before
 			? Math.min( settings.increment_limit, settings.max_limit - unreadIds.length )
-			: this.filteredRequestLimit,
+			: settings.initial_limit,
 		locale: this.locale,
 		...this.filter,
 	};
@@ -450,7 +448,7 @@ function getFilteredNotes( before ) {
 	}
 
 	// Only show the full-panel spinner for the first page; later pages stream in.
-	if ( ! before && this.filteredRequestLimit === settings.initial_limit ) {
+	if ( ! before && unreadIds.length === 0 ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
 
@@ -496,13 +494,24 @@ function getFilteredNotes( before ) {
 					data.notes.length >= parameters.number &&
 					appended.length < settings.max_limit;
 			} else {
-				// The top window is authoritative, so replace the id list — notes the
-				// server no longer returns (read/deleted elsewhere) drop from the view.
-				store.dispatch( actions.notes.setUnreadNoteIds( pageIds ) );
+				// Merge the head over the list, keeping the older paged-in tail. Drop
+				// within-head ids the server no longer returns (read/deleted elsewhere).
+				const current = getUnreadNoteIds( store.getState() );
+				const serverIdSet = new Set( pageIds );
+				const oldestServerId = pageIds[ pageIds.length - 1 ];
+				const boundary = current.findIndex( ( id ) => id === oldestServerId );
+				const tail = (
+					boundary >= 0 ? current.slice( boundary + 1 ) : current.slice( pageIds.length )
+				).filter( ( id ) => ! serverIdSet.has( id ) );
+				const merged = pageIds.concat( tail );
+				store.dispatch( actions.notes.setUnreadNoteIds( merged ) );
 
-				// A full page back implies the server may have more matching notes.
+				// First page: a full head implies more older notes. Later refreshes keep
+				// the load-more exhaustion state instead of resetting it from the head.
 				this.filteredHasMore =
-					data.notes.length >= parameters.number && this.filteredRequestLimit < settings.max_limit;
+					( current.length === 0
+						? data.notes.length >= parameters.number
+						: this.filteredHasMore ) && merged.length < settings.max_limit;
 			}
 		}
 	} );
@@ -674,11 +683,6 @@ function loadMore() {
 		if ( this.gettingFilteredNotes || ! this.filteredHasMore ) {
 			return;
 		}
-		// Grow the refresh window so the poll keeps covering paged-in notes.
-		this.filteredRequestLimit = Math.min(
-			this.filteredRequestLimit + settings.increment_limit,
-			settings.max_limit
-		);
 		// Page older notes additively, anchored on the view's oldest. `before` is
 		// epoch seconds, not the ISO timestamp.
 		const unreadIds = getUnreadNoteIds( store.getState() );

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -26,7 +26,6 @@ export function Client() {
 	this.isVisible = false;
 	this.isShowing = false;
 	this.lastSeenTime = 0;
-	this.noteRequestLimit = settings.initial_limit;
 	// Latches once the server has no older notes left, so load-more stops paging.
 	this.allNotesLoaded = false;
 	// Active tab's server-side filter (e.g. `{ unread: 1 }`), or null for the
@@ -197,18 +196,18 @@ function getNotes( before ) {
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		// Older pages only request what's left under max_limit, so an additive
-		// page can't push the loaded count past the cap.
+		// Older pages request what's left under the cap; the no-`before` refresh
+		// requests a small fixed head window.
 		number: before
 			? Math.min( settings.increment_limit, settings.max_limit - loaded )
-			: this.noteRequestLimit,
+			: settings.initial_limit,
 		locale: this.locale,
 	};
 	if ( before ) {
 		parameters.before = before;
 	}
 
-	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
+	if ( ! notes.length || settings.initial_limit > notes.length ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
 
@@ -245,6 +244,7 @@ function getNotes( before ) {
 			this.allNotesLoaded = true;
 		}
 
+		let removedIds = [];
 		if ( before ) {
 			// Stop when an older page adds nothing new (an inclusive `before` can
 			// echo back just the anchor). Compare against the view's own window so
@@ -255,30 +255,42 @@ function getNotes( before ) {
 				this.allNotesLoaded = true;
 			}
 		} else {
-			// Authoritative top window: prune notes the server dropped. A prune
-			// means newer notes pushed older ones below the window, so let
-			// load-more re-fetch them. The additive `before` path never prunes.
-			const oldIds = getAllNotes( store.getState() ).map( ( { id } ) => id );
-			const newIds = data.notes.map( ( n ) => n.id );
-			const notesToRemove = oldIds.filter( ( id ) => ! newIds.includes( id ) );
+			// Prune only within the head window: drop notes missing from it that
+			// are newer than the oldest one returned; keep older paged-in notes.
+			const headFloor = data.notes.length
+				? Date.parse( data.notes[ data.notes.length - 1 ].timestamp )
+				: -Infinity;
+			const newIds = new Set( data.notes.map( ( n ) => n.id ) );
+			const stale = getAllNotes( store.getState() )
+				.filter( ( n ) => Date.parse( n.timestamp ) >= headFloor && ! newIds.has( n.id ) )
+				.map( ( n ) => n.id );
 			// Skip pruning while a server-side filter is active: the filtered fetch
 			// loads notes outside this top window, and pruning would remove them
 			// from under the filtered view. Pruning resumes on the unfiltered tab.
-			if ( notesToRemove.length && ! this.filter ) {
+			if ( stale.length && ! this.filter ) {
 				this.allNotesLoaded = false;
-				store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+				store.dispatch( actions.notes.removeNotes( stale ) );
+				removedIds = stale;
 			}
 		}
 
-		// The lightweight id/hash list the polling diff compares against: a fresh
-		// top window replaces it; an older page appends to it.
+		// The lightweight id/hash list the polling diff compares against.
 		const pageList = data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) );
-		this.noteList = before ? this.noteList.concat( pageList ) : pageList;
+		if ( before ) {
+			// An older page appends to the window.
+			this.noteList = this.noteList.concat( pageList );
+		} else {
+			// Merge the head over the window, keeping the older paged-in tail.
+			const headIds = new Set( pageList.map( ( n ) => n.id ) );
+			const removed = new Set( removedIds );
+			const tail = this.noteList.filter( ( n ) => ! headIds.has( n.id ) && ! removed.has( n.id ) );
+			this.noteList = pageList.concat( tail );
+		}
 
 		store.dispatch( actions.notes.addNotes( data.notes ) );
 		this.updateLastSeenTime( Number( data.last_seen_time ) );
 
-		if ( parameters.number === settings.max_limit ) {
+		if ( this.allNotesLoaded ) {
 			/*
 			 * Since we store note data in a local cache, we want to purge the
 			 * data if the notes no longer exist, but only once we've loaded all
@@ -313,7 +325,7 @@ function getNotesList() {
 
 	const parameters = {
 		fields: 'id,note_hash',
-		number: this.noteRequestLimit,
+		number: settings.initial_limit,
 	};
 
 	listNotes( parameters, ( error, data ) => {
@@ -344,8 +356,19 @@ function getNotesList() {
 			serverIds.some( ( sId ) => ! localIds.includes( sId ) ) ||
 			serverHashes.some( ( sHash ) => ! localHashes.includes( sHash ) );
 
-		/* Actually remove the notes from the local copy */
-		const notesToRemove = localIds.filter( ( local ) => ! serverIds.includes( local ) );
+		// Prune only within the polled head window: a local note is stale only if
+		// it sits at or above the oldest returned id yet is missing. Older paged-in
+		// notes are kept. (No timestamps here, so the edge is by id position.)
+		const serverIdSet = new Set( serverIds );
+		const oldestServerId = serverIds[ serverIds.length - 1 ];
+		const boundary = this.noteList.findIndex( ( note ) => note.id === oldestServerId );
+		const headLocal =
+			boundary >= 0
+				? this.noteList.slice( 0, boundary + 1 )
+				: this.noteList.slice( 0, serverIds.length );
+		const notesToRemove = headLocal
+			.map( ( note ) => note.id )
+			.filter( ( id ) => ! serverIdSet.has( id ) );
 
 		// Don't prune while a filter is active: the filtered view shares this cache,
 		// and a note that fell out of the unfiltered window could be dropped from it
@@ -356,8 +379,12 @@ function getNotesList() {
 			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
 		}
 
-		/* Update our local copy of the note list */
-		this.noteList = data.notes;
+		// Merge the head over the window, keeping the older paged-in tail.
+		const removed = new Set( this.filter ? [] : notesToRemove );
+		const tail = this.noteList.filter(
+			( note ) => ! serverIdSet.has( note.id ) && ! removed.has( note.id )
+		);
+		this.noteList = data.notes.concat( tail );
 		this.updateLastSeenTime( Number( data.last_seen_time ) );
 
 		// Clean out stored reply texts that are older than a day
@@ -679,14 +706,6 @@ function loadMore() {
 	if ( ! oldest ) {
 		return;
 	}
-
-	// Grow the polling window so getNotes()/getNotesList() keep covering every
-	// note we've paged in; their diff treats the response as the full set, so a
-	// shorter window would prune the older notes back out.
-	this.noteRequestLimit = Math.min(
-		this.noteRequestLimit + settings.increment_limit,
-		settings.max_limit
-	);
 
 	// The endpoint's `before` cursor is UNIX epoch seconds, not the note's ISO
 	// timestamp; a raw string is ignored and load-more would refetch page one.

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -449,8 +449,10 @@ function getFilteredNotes( before ) {
 		parameters.before = before;
 	}
 
-	// Only show the full-panel spinner for the first page; later pages stream in.
-	if ( ! before && unreadIds.length === 0 ) {
+	// Loading state on the first page (the full-panel spinner shows while the list
+	// is empty) and while paging older notes (`before` → the list's load-more
+	// indicator); a steady-state refresh of a non-empty list stays silent.
+	if ( before || unreadIds.length === 0 ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
 

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -206,7 +206,9 @@ function getNotes( before ) {
 		parameters.before = before;
 	}
 
-	if ( ! notes.length || settings.initial_limit > notes.length ) {
+	// Show the loading state while paging older notes (`before`) and until the
+	// first head window has filled; a steady-state background poll stays silent.
+	if ( before || notes.length < settings.initial_limit ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
 

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -4,6 +4,7 @@
 import { store } from '../../state';
 import actions from '../../state/actions';
 import getAllNotes from '../../state/selectors/get-all-notes';
+import getFilteredLoading from '../../state/selectors/get-filtered-loading';
 import getIsLoading from '../../state/selectors/get-is-loading';
 import getUnreadNoteIds from '../../state/selectors/get-unread-note-ids';
 import Client from '../index';
@@ -561,6 +562,52 @@ describe( 'RestClient', () => {
 
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } );
 			expect( getIsLoading( store.getState() ) ).toBe( false );
+		} );
+
+		// Regression: clearing the loading state before the unread ids land makes
+		// the list render an empty frame between "loaded" and the ids ("small
+		// loading → empty → list"). Loading must clear only once the ids are set.
+		it( 'sets the unread ids before clearing the loading state', () => {
+			client.setFilter( { unread: 1 } );
+			expect( getIsLoading( store.getState() ) ).toBe( true );
+
+			const frames = [];
+			const unsubscribe = store.subscribe( () =>
+				frames.push( {
+					isLoading: getIsLoading( store.getState() ),
+					unreadCount: getUnreadNoteIds( store.getState() ).length,
+				} )
+			);
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 50 ), last_seen_time: 0 } );
+			unsubscribe();
+
+			// No frame may show "done loading" over a still-empty list.
+			expect( frames.some( ( f ) => ! f.isLoading && f.unreadCount === 0 ) ).toBe( false );
+			expect( getIsLoading( store.getState() ) ).toBe( false );
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 10 );
+		} );
+
+		// Regression: the always-running unfiltered poll shares the global loading
+		// flag. When it lands while a filtered (Unread) fetch is still in flight, it
+		// clears the shared flag — but the filtered loading state must hold its
+		// filter, or the Unread tab flashes its empty message before the ids land.
+		it( 'keeps the filtered loading state set when a background poll lands mid-fetch', () => {
+			// A full head window is already loaded, so the poll stays silent on start
+			// yet still clears the shared loading flag when it lands.
+			store.dispatch( actions.notes.addNotes( fullPage( 10, 100 ) ) );
+			client.noteList = fullPage( 10, 100 ).map( ( { id, note_hash } ) => ( { id, note_hash } ) );
+
+			client.setFilter( { unread: 1 } ); // filtered fetch A in flight
+			expect( getFilteredLoading( store.getState() ) ).toEqual( { unread: 1 } );
+			getCalls.length = 0;
+
+			client.getNotes(); // background poll B
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } );
+
+			// B cleared the shared flag, but A is still in flight — the filter holds.
+			expect( getIsLoading( store.getState() ) ).toBe( false );
+			expect( getFilteredLoading( store.getState() ) ).toEqual( { unread: 1 } );
+			expect( client.gettingFilteredNotes ).toBe( true );
 		} );
 	} );
 } );

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -548,5 +548,19 @@ describe( 'RestClient', () => {
 			client.getNotes();
 			expect( getIsLoading( store.getState() ) ).toBe( false );
 		} );
+
+		// The filtered (Unread) tab gets the same load-more indicator as the others.
+		it( 'flips loading on while paging older unread notes', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+			getCalls.length = 0;
+			expect( getIsLoading( store.getState() ) ).toBe( false );
+
+			client.loadMore();
+			expect( getIsLoading( store.getState() ) ).toBe( true );
+
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } );
+			expect( getIsLoading( store.getState() ) ).toBe( false );
+		} );
 	} );
 } );

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -206,6 +206,55 @@ describe( 'RestClient', () => {
 		} );
 	} );
 
+	describe( 'polling window', () => {
+		// Load-more pages with `before`; the poll/refresh must keep requesting a small
+		// fixed head window instead of growing to cover everything paged in (which
+		// ballooned the request to number=100 with no `before`).
+		it( 'keeps the poll window fixed after paging many notes in', () => {
+			seedFirstWindow(); // ids 100..91
+
+			// Page two more windows in (ids 90..71), growing the loaded list to 30.
+			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } );
+			getCalls.length = 0;
+
+			client.getNotesList();
+			expect( getCalls ).toHaveLength( 1 );
+			// Small fixed window, not the 30 (or eventual 100) notes loaded.
+			expect( getCalls[ 0 ].query.number ).toBe( 10 );
+			expect( getCalls[ 0 ].query ).not.toHaveProperty( 'before' );
+		} );
+
+		it( 'does not prune older paged-in notes when the poll only returns the head', () => {
+			seedFirstWindow(); // ids 100..91
+			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 20, 90 ), last_seen_time: 0 } ); // 90..71
+			getCalls.length = 0;
+
+			// A poll returns only the authoritative top window (ids 100..91).
+			client.getNotesList();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } );
+
+			// The older paged-in notes are outside the head window, not deleted.
+			const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
+			expect( ids ).toContain( 71 );
+			expect( ids ).toContain( 90 );
+		} );
+
+		it( 'still prunes a note dropped from within the head window', () => {
+			seedFirstWindow(); // ids 100..91
+
+			// The poll's top window no longer includes 95 (read/deleted elsewhere); the
+			// freed slot is filled by an older note (90), so 95 fell out of the head.
+			client.getNotesList();
+			const polled = [ 100, 99, 98, 97, 96, 94, 93, 92, 91, 90 ].map( makeNote );
+			getCalls[ 0 ].callback( null, { notes: polled, last_seen_time: 0 } );
+
+			const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
+			expect( ids ).not.toContain( 95 );
+		} );
+	} );
+
 	describe( 'server-side (unread) filtering', () => {
 		it( 'sends unread=1 to the server and adds the returned notes', () => {
 			client.setFilter( { unread: 1 } );

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -485,5 +485,44 @@ describe( 'RestClient', () => {
 			// 99 stays in the store so the Unread view can still resolve it.
 			expect( getAllNotes( store.getState() ).map( ( note ) => note.id ) ).toContain( 99 );
 		} );
+
+		// The filtered refresh/poll must keep a small fixed window too, instead of
+		// growing to cover everything paged into the Unread tab.
+		it( 'keeps the filtered poll window fixed after paging unread notes in', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
+			getCalls.length = 0;
+			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } ); // 199..190
+			getCalls.length = 0;
+
+			// A poll-driven refresh (no `before`) requests the small fixed window, not
+			// the 20 unread notes loaded.
+			client.getFilteredNotes();
+			expect( getCalls ).toHaveLength( 1 );
+			expect( getCalls[ 0 ].query.number ).toBe( 10 );
+			expect( getCalls[ 0 ].query ).not.toHaveProperty( 'before' );
+			expect( getCalls[ 0 ].query.unread ).toBe( 1 );
+		} );
+
+		it( 'keeps older paged-in unread notes on a head-only refresh', () => {
+			client.setFilter( { unread: 1 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
+			getCalls.length = 0;
+			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } ); // 199..190
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 20 );
+			getCalls.length = 0;
+
+			// The refresh returns only the head window (209..200); the older paged-in
+			// ids (199..190) are outside it and must survive.
+			client.getFilteredNotes();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+
+			const unread = getUnreadNoteIds( store.getState() );
+			expect( unread ).toHaveLength( 20 );
+			expect( unread ).toContain( 209 ); // head kept
+			expect( unread ).toContain( 190 ); // older paged-in id kept
+		} );
 	} );
 } );

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -4,6 +4,7 @@
 import { store } from '../../state';
 import actions from '../../state/actions';
 import getAllNotes from '../../state/selectors/get-all-notes';
+import getIsLoading from '../../state/selectors/get-is-loading';
 import getUnreadNoteIds from '../../state/selectors/get-unread-note-ids';
 import Client from '../index';
 import { init } from '../wpcom';
@@ -523,6 +524,29 @@ describe( 'RestClient', () => {
 			expect( unread ).toHaveLength( 20 );
 			expect( unread ).toContain( 209 ); // head kept
 			expect( unread ).toContain( 190 ); // older paged-in id kept
+		} );
+	} );
+
+	describe( 'loading state', () => {
+		// Regression: with the fixed head window, paging older notes must still flip
+		// the loading state on, so the UI shows its load-more indicator.
+		it( 'flips loading on while paging older notes and off when the page lands', () => {
+			seedFirstWindow(); // 10 notes loaded; settles loading to false
+			expect( getIsLoading( store.getState() ) ).toBe( false );
+
+			client.loadMore();
+			expect( getIsLoading( store.getState() ) ).toBe( true );
+
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 90 ), last_seen_time: 0 } );
+			expect( getIsLoading( store.getState() ) ).toBe( false );
+		} );
+
+		// A steady-state poll (no `before`, a full window already loaded) must not
+		// flash the loading state.
+		it( 'stays silent on a steady-state refresh once a full window is loaded', () => {
+			seedFirstWindow(); // 10 notes loaded, loading false
+			client.getNotes();
+			expect( getIsLoading( store.getState() ) ).toBe( false );
 		} );
 	} );
 } );

--- a/apps/notifications/src/panel/state/selectors/get-filtered-loading.js
+++ b/apps/notifications/src/panel/state/selectors/get-filtered-loading.js
@@ -1,0 +1,7 @@
+import getUi from './get-ui';
+
+// The filter fragment whose fetch is currently loading (e.g. `{ unread: 1 }`),
+// or null. See the `filteredLoading` reducer.
+export const getFilteredLoading = ( uiState ) => uiState.filteredLoading;
+
+export default ( state ) => getFilteredLoading( getUi( state ) );

--- a/apps/notifications/src/panel/state/ui/actions.js
+++ b/apps/notifications/src/panel/state/ui/actions.js
@@ -19,12 +19,22 @@ export const closePanel = () => ( {
 	type: CLOSE_PANEL,
 } );
 
-export const loadNotes = () => ( {
+// Pass the in-flight filter fragment (e.g. `{ unread: 1 }`) for a filtered fetch,
+// or nothing for the unfiltered poll. See the `filteredLoading` reducer.
+/**
+ * @param {{ filter?: Object | null }} [options]
+ */
+export const loadNotes = ( { filter = null } = {} ) => ( {
 	type: NOTES_LOADING,
+	filter,
 } );
 
-export const loadedNotes = () => ( {
+/**
+ * @param {{ filter?: Object | null }} [options]
+ */
+export const loadedNotes = ( { filter = null } = {} ) => ( {
 	type: NOTES_LOADED,
+	filter,
 } );
 
 export const selectNote = ( noteId ) => ( {

--- a/apps/notifications/src/panel/state/ui/reducer.js
+++ b/apps/notifications/src/panel/state/ui/reducer.js
@@ -21,6 +21,30 @@ export const isLoading = ( state = true, { type } ) => {
 	return state;
 };
 
+// The filter fragment whose fetch is currently loading (e.g. `{ unread: 1 }`), or
+// null. Only load actions tagged with a `filter` touch it, so the unfiltered
+// background poll can't clear it mid-fetch (which would flash a filtered tab's
+// empty message). Reset on SET_FILTER so a tab switch starts clean.
+export const filteredLoading = ( state = null, { type, filter } ) => {
+	if ( SET_FILTER === type ) {
+		return null;
+	}
+
+	if ( ! filter ) {
+		return state;
+	}
+
+	if ( NOTES_LOADING === type ) {
+		return filter;
+	}
+
+	if ( NOTES_LOADED === type ) {
+		return null;
+	}
+
+	return state;
+};
+
 export const isPanelOpen = ( state = false, { type, isShowing } ) =>
 	SET_IS_SHOWING === type ? isShowing : state;
 
@@ -73,6 +97,7 @@ export const shortcutsPopoverIsOpen = ( state = false, { type } ) => {
 
 export default combineReducers( {
 	isLoading,
+	filteredLoading,
 	isPanelOpen,
 	selectedNoteId,
 	lastSelectedNoteId,


### PR DESCRIPTION
## Proposed Changes

Two related fixes in the REST client shared by the classic (v1) and redesigned (v2) notification panels.

**Keep the poll/refresh window fixed instead of growing to 100.** Load-more and the background refresh shared one request limit that grew on every scroll, up to 100. After a few pages, every poll fetched 100 notes with no cursor — for the rest of the session. Now load-more still pages older notes with a cursor, but the refresh always requests a small fixed window and merges it over the already-loaded tail; pruning is bounded to that window so older paged-in notes survive.

**Stop the Unread tab flashing "You're all caught up!" mid-fetch.** The Unread tab chose between spinner and empty message using a loading flag shared with the always-running background poll. A poll finishing while the Unread fetch was still in flight cleared that flag over an empty list, flashing the empty message before the notes landed. The Unread tab now tracks its own in-flight fetch, so the poll can't clear it.

## Why are these changes being made?

- The growing window made the panel silently escalate to fetching 100 notes on every poll after any scrolling — wasted bandwidth and server work for the life of the client. The window only grew so a refresh wouldn't drop notes paged in by load-more; bounding pruning to the head window removes that need.
- The Unread flash was a visible "loading → empty → list" flicker on every tab open, caused by two concurrent fetches sharing one loading flag.

Trade-off (window change): with a small refresh window, edits to notes below the top window reconcile on load-more or panel re-open rather than on every poll.

## Testing Instructions

- `yarn test-apps apps/notifications` — all suites pass, including new cases for the fixed refresh window, a regression test that the Unread loading state survives a background poll landing mid-fetch, and a component test that the empty message stays hidden while a fetch is in flight.
- Manually: open the panel and scroll several pages, watching the network tab on both All and Unread — poll/refresh requests should stay small instead of climbing to 100. Then open the Unread tab a few times: it should go spinner → list, never flashing "You're all caught up!" first.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
