### PR TITLE
Run Build Calypso Apps only on trunk

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -7,8 +7,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
@@ -77,15 +75,6 @@ object CalypsoApps: BuildType({
 	features {
 		perfmon {
 		}
-		pullRequests {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			provider = github {
-				authType = token {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
-			}
-		}
 		commitStatusPublisher {
 			vcsRootExtId = "${Settings.WpCalypso.id}"
 			publisher = github {
@@ -99,10 +88,7 @@ object CalypsoApps: BuildType({
 
 	triggers {
 		vcs {
-			branchFilter = """
-				+:*
-				-:pull*
-			""".trimIndent()
+			branchFilter = "+:<default>"
 			triggerRules = """
 				-:test/e2e/**
 				-:docs/**.md


### PR DESCRIPTION
See pgle0O-1us-p2

## Proposed Changes

* Remove PR discovery from the Build Calypso Apps TeamCity build type.
* Restrict its VCS trigger branch filter to `+:<default>`.

## Why are these changes being made?

* Build Calypso Apps publishes Calypso app release artifacts and should run after changes land on the default branch, not as a PR check.

## Testing Instructions

* Confirmed the committed diff only changes `.teamcity/_self/projects/WPComPlugins.kt`.
* Ran `git diff --check origin/trunk...HEAD -- .teamcity/_self/projects/WPComPlugins.kt`.
* Attempted `mvn -q -f .teamcity/pom.xml teamcity-configs:generate`, but `mvn` is not installed in this local environment.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?