### PR TITLE
Reader: make Quick Post editor minimizable again

### DIFF
--- a/client/reader/components/quick-post/constants.ts
+++ b/client/reader/components/quick-post/constants.ts
@@ -1,0 +1,1 @@
+export const READER_QUICK_POST_MINIMIZED_PREFERENCE = 'reader_quick_post_minimized';

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -30,6 +30,7 @@ import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getMostRecentlySelectedSiteId, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { READER_QUICK_POST_MINIMIZED_PREFERENCE } from './constants';
 import { savePostMutation } from './hooks/use-post-mutation';
 import type { AppState } from 'calypso/types';
 
@@ -75,7 +76,7 @@ const QUICK_POST_EDITOR_DARK_STYLES = `
 	}
 `;
 
-export const READER_QUICK_POST_MINIMIZED_PREFERENCE = 'reader_quick_post_minimized';
+export { READER_QUICK_POST_MINIMIZED_PREFERENCE };
 
 export default function QuickPost(): JSX.Element | null {
 	const translate = useTranslate();

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -246,6 +246,7 @@ export default function QuickPost(): JSX.Element | null {
 					className="quick-post-minimize-toggle"
 					icon={ isMinimized ? chevronDown : chevronUp }
 					onClick={ toggleMinimized }
+					aria-expanded={ ! isMinimized }
 					label={
 						isMinimized
 							? translate( 'Expand the quick post editor' )

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -12,7 +12,9 @@ import * as heading from '@wordpress/block-library/build-module/heading';
 import { createBlock, parse, serialize } from '@wordpress/blocks';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, type JSX } from 'react';
 import SitesDropdown from 'calypso/components/sites-dropdown';
@@ -20,6 +22,7 @@ import { DEFAULT_SCHEME, PREFERENCE_KEY, isColorScheme } from 'calypso/lib/color
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice, warningNotice } from 'calypso/state/notices/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -72,6 +75,8 @@ const QUICK_POST_EDITOR_DARK_STYLES = `
 	}
 `;
 
+export const READER_QUICK_POST_MINIMIZED_PREFERENCE = 'reader_quick_post_minimized';
+
 export default function QuickPost(): JSX.Element | null {
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -95,6 +100,11 @@ export default function QuickPost(): JSX.Element | null {
 	const isReaderDarkMode =
 		colorScheme === 'dark' || ( colorScheme === 'system' && systemPrefersDark );
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
+	const isMinimized = Boolean(
+		useSelector( ( state: AppState ) =>
+			getPreference( state, READER_QUICK_POST_MINIMIZED_PREFERENCE )
+		)
+	);
 	const siteId = selectedSiteId || mostRecentlySelectedSiteId || primarySiteId || undefined;
 	const siteAdminUrl = useSelector( ( state ) =>
 		siteId ? getSiteAdminUrl( state, siteId ) : null
@@ -190,6 +200,14 @@ export default function QuickPost(): JSX.Element | null {
 		dispatch( setSelectedSiteId( siteId ) );
 	};
 
+	const toggleMinimized = () => {
+		const nextMinimized = ! isMinimized;
+		dispatch( savePreference( READER_QUICK_POST_MINIMIZED_PREFERENCE, nextMinimized ) );
+		recordReaderTracksEvent(
+			nextMinimized ? 'calypso_reader_quick_post_minimized' : 'calypso_reader_quick_post_expanded'
+		);
+	};
+
 	const handleFullEditorClick = () => {
 		recordReaderTracksEvent( 'calypso_reader_quick_post_full_editor_opened' );
 
@@ -220,48 +238,66 @@ export default function QuickPost(): JSX.Element | null {
 	}
 
 	return (
-		<div className="quick-post">
-			<SitesDropdown
-				selectedSiteId={ siteId }
-				onSiteSelect={ handleSiteSelect }
-				isPlaceholder={ ! hasLoaded }
-			/>
-
-			<div className="verbum-editor-wrapper">
-				<Editor
-					key={ editorKey }
-					focusOnMount={ false }
-					initialContent={ postContent }
-					onChange={ setPostContent }
-					isRTL={ isLocaleRtl( locale ) ?? false }
-					isDarkMode={ isReaderDarkMode }
-					customStyles={ `${
-						isReaderDarkMode ? QUICK_POST_EDITOR_DARK_STYLES : ''
-					}${ QUICK_POST_EDITOR_BASE_STYLES }` }
+		<div className={ clsx( 'quick-post', { 'is-minimized': isMinimized } ) }>
+			<HStack className="quick-post-header" justify="space-between">
+				<span className="quick-post-title">{ translate( 'Write a quick post' ) }</span>
+				<Button
+					className="quick-post-minimize-toggle"
+					icon={ isMinimized ? chevronDown : chevronUp }
+					onClick={ toggleMinimized }
+					label={
+						isMinimized
+							? translate( 'Expand the quick post editor' )
+							: translate( 'Minimize the quick post editor' )
+					}
 				/>
-			</div>
-
-			<HStack className="quick-post-actions" justify="flex-end">
-				<Button
-					variant="tertiary"
-					onClick={ handleFullEditorClick }
-					title={ translate( 'Edit using the full editor.' ) }
-					disabled={ isPublishing }
-					isBusy={ isSavingDraft }
-				>
-					<span>{ isSavingDraft ? translate( 'Saving…' ) : translate( 'Edit' ) }</span>
-					<span>{ isLocaleRtl( locale ) ? '\u2196' : '\u2197' }</span>
-				</Button>
-
-				<Button
-					variant="primary"
-					onClick={ handlePublish }
-					disabled={ isPublishing || isSavingDraft }
-					isBusy={ isPublishing }
-				>
-					{ isPublishing ? translate( 'Posting…' ) : translate( 'Post' ) }
-				</Button>
 			</HStack>
+
+			{ ! isMinimized && (
+				<>
+					<SitesDropdown
+						selectedSiteId={ siteId }
+						onSiteSelect={ handleSiteSelect }
+						isPlaceholder={ ! hasLoaded }
+					/>
+
+					<div className="verbum-editor-wrapper">
+						<Editor
+							key={ editorKey }
+							focusOnMount={ false }
+							initialContent={ postContent }
+							onChange={ setPostContent }
+							isRTL={ isLocaleRtl( locale ) ?? false }
+							isDarkMode={ isReaderDarkMode }
+							customStyles={ `${
+								isReaderDarkMode ? QUICK_POST_EDITOR_DARK_STYLES : ''
+							}${ QUICK_POST_EDITOR_BASE_STYLES }` }
+						/>
+					</div>
+
+					<HStack className="quick-post-actions" justify="flex-end">
+						<Button
+							variant="tertiary"
+							onClick={ handleFullEditorClick }
+							title={ translate( 'Edit using the full editor.' ) }
+							disabled={ isPublishing }
+							isBusy={ isSavingDraft }
+						>
+							<span>{ isSavingDraft ? translate( 'Saving…' ) : translate( 'Edit' ) }</span>
+							<span>{ isLocaleRtl( locale ) ? '\u2196' : '\u2197' }</span>
+						</Button>
+
+						<Button
+							variant="primary"
+							onClick={ handlePublish }
+							disabled={ isPublishing || isSavingDraft }
+							isBusy={ isPublishing }
+						>
+							{ isPublishing ? translate( 'Posting…' ) : translate( 'Post' ) }
+						</Button>
+					</HStack>
+				</>
+			) }
 		</div>
 	);
 }

--- a/client/reader/components/quick-post/skeleton/index.tsx
+++ b/client/reader/components/quick-post/skeleton/index.tsx
@@ -1,8 +1,28 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useSelector } from 'calypso/state';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { READER_QUICK_POST_MINIMIZED_PREFERENCE } from '../constants';
 import type { JSX } from 'react';
+
 import './style.scss';
 
 export function QuickPostSkeleton(): JSX.Element {
+	// Match the collapsed editor's height when the user has minimized it, so the
+	// skeleton doesn't flash the full-height editor before the bundle loads and
+	// collapses it. `getPreference` returns null until remote preferences load,
+	// which falls back to the expanded skeleton — the same as the default state.
+	const isMinimized = Boolean(
+		useSelector( ( state ) => getPreference( state, READER_QUICK_POST_MINIMIZED_PREFERENCE ) )
+	);
+
+	if ( isMinimized ) {
+		return (
+			<VStack className="quick-post-skeleton" spacing={ 4 }>
+				<span style={ { width: '160px', height: '36px' } }></span>
+			</VStack>
+		);
+	}
+
 	return (
 		<VStack className="quick-post-skeleton" spacing={ 4 }>
 			<span style={ { width: '60px', height: '54px' } }></span>

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -99,6 +99,20 @@
 		}
 	}
 
+	.quick-post-header {
+		.quick-post-title {
+			font-weight: 600;
+		}
+
+		.quick-post-minimize-toggle {
+			color: var( --color-text-subtle );
+		}
+	}
+
+	&:not( .is-minimized ) .quick-post-header {
+		margin-block-end: 14px;
+	}
+
 	.sites-dropdown__wrapper {
 		width: 200px;
 

--- a/client/reader/components/quick-post/test/index.test.tsx
+++ b/client/reader/components/quick-post/test/index.test.tsx
@@ -304,7 +304,7 @@ describe( 'QuickPost', () => {
 
 		expect( screen.getByRole( 'textbox', { name: 'Quick post editor' } ) ).toBeVisible();
 		expect(
-			screen.getByRole( 'button', { name: 'Minimize the quick post editor' } )
+			screen.getByRole( 'button', { name: 'Minimize the quick post editor', expanded: true } )
 		).toBeVisible();
 	} );
 
@@ -317,7 +317,9 @@ describe( 'QuickPost', () => {
 			screen.queryByRole( 'textbox', { name: 'Quick post editor' } )
 		).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Post' } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Expand the quick post editor' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Expand the quick post editor', expanded: false } )
+		).toBeVisible();
 	} );
 
 	it( 'saves the minimized preference and tracks the event when minimizing', async () => {

--- a/client/reader/components/quick-post/test/index.test.tsx
+++ b/client/reader/components/quick-post/test/index.test.tsx
@@ -9,6 +9,7 @@ import nock from 'nock';
 import { DEFAULT_SCHEME, PREFERENCE_KEY } from 'calypso/lib/color-scheme';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -16,7 +17,7 @@ import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getMostRecentlySelectedSiteId, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import QuickPost from '../index';
+import QuickPost, { READER_QUICK_POST_MINIMIZED_PREFERENCE } from '../index';
 
 jest.mock( 'calypso/state/notices/actions', () => ( {
 	successNotice: jest.fn( () => ( {
@@ -85,6 +86,9 @@ jest.mock( 'calypso/state/current-user/selectors', () => ( {
 jest.mock( 'calypso/state/preferences/selectors', () => ( {
 	getPreference: jest.fn(),
 } ) );
+jest.mock( 'calypso/state/preferences/actions', () => ( {
+	savePreference: jest.fn( ( key, value ) => ( { type: 'SAVE_PREFERENCE', key, value } ) ),
+} ) );
 jest.mock( 'calypso/state/selectors/get-primary-site-id', () => ( {
 	__esModule: true,
 	default: jest.fn(),
@@ -120,6 +124,16 @@ describe( 'QuickPost', () => {
 	const mockEditor = Editor as jest.Mock;
 	const getLastEditorProps = () => mockEditor.mock.calls[ mockEditor.mock.calls.length - 1 ][ 0 ];
 
+	// `getPreference` is read for both the color scheme and the minimized state, so
+	// resolve each call by its preference key rather than a single return value.
+	const mockPreferences = ( {
+		colorScheme = DEFAULT_SCHEME,
+		minimized = false,
+	}: { colorScheme?: string; minimized?: boolean } = {} ) =>
+		( getPreference as jest.Mock ).mockImplementation( ( _state, key ) =>
+			key === READER_QUICK_POST_MINIMIZED_PREFERENCE ? minimized : colorScheme
+		);
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 		localStorage.clear();
@@ -138,7 +152,7 @@ describe( 'QuickPost', () => {
 		( getPrimarySiteId as jest.Mock ).mockReturnValue( null );
 		( hasLoadedSites as jest.Mock ).mockReturnValue( true );
 		( getSiteAdminUrl as jest.Mock ).mockReturnValue( 'https://example.com/wp-admin' );
-		( getPreference as jest.Mock ).mockReturnValue( DEFAULT_SCHEME );
+		mockPreferences();
 		( useMediaQuery as jest.Mock ).mockReturnValue( false );
 	} );
 
@@ -148,7 +162,7 @@ describe( 'QuickPost', () => {
 	} );
 
 	it( 'passes dark mode props to the editor when the saved preference is dark', () => {
-		( getPreference as jest.Mock ).mockReturnValue( 'dark' );
+		mockPreferences( { colorScheme: 'dark' } );
 
 		renderWithProvider( <QuickPost /> );
 
@@ -162,7 +176,7 @@ describe( 'QuickPost', () => {
 	} );
 
 	it( 'passes dark mode props to the editor when the system preference resolves to dark', () => {
-		( getPreference as jest.Mock ).mockReturnValue( 'system' );
+		mockPreferences( { colorScheme: 'system' } );
 		( useMediaQuery as jest.Mock ).mockReturnValue( true );
 
 		renderWithProvider( <QuickPost /> );
@@ -176,7 +190,7 @@ describe( 'QuickPost', () => {
 	} );
 
 	it( 'keeps light editor props when the system preference resolves to light', () => {
-		( getPreference as jest.Mock ).mockReturnValue( 'system' );
+		mockPreferences( { colorScheme: 'system' } );
 		( useMediaQuery as jest.Mock ).mockReturnValue( false );
 
 		renderWithProvider( <QuickPost /> );
@@ -283,5 +297,53 @@ describe( 'QuickPost', () => {
 				'calypso_reader_quick_post_full_editor_opened'
 			);
 		} );
+	} );
+
+	it( 'renders the editor expanded by default with a minimize control', () => {
+		renderWithProvider( <QuickPost /> );
+
+		expect( screen.getByRole( 'textbox', { name: 'Quick post editor' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Minimize the quick post editor' } )
+		).toBeVisible();
+	} );
+
+	it( 'hides the editor and shows an expand control when the minimized preference is set', () => {
+		mockPreferences( { minimized: true } );
+
+		renderWithProvider( <QuickPost /> );
+
+		expect(
+			screen.queryByRole( 'textbox', { name: 'Quick post editor' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Post' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Expand the quick post editor' } ) ).toBeVisible();
+	} );
+
+	it( 'saves the minimized preference and tracks the event when minimizing', async () => {
+		const mockTrackEvent = jest.fn();
+		( useRecordReaderTracksEvent as jest.Mock ).mockReturnValue( mockTrackEvent );
+
+		renderWithProvider( <QuickPost /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Minimize the quick post editor' } )
+		);
+
+		expect( savePreference ).toHaveBeenCalledWith( READER_QUICK_POST_MINIMIZED_PREFERENCE, true );
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'calypso_reader_quick_post_minimized' );
+	} );
+
+	it( 'saves the expanded preference and tracks the event when expanding', async () => {
+		mockPreferences( { minimized: true } );
+		const mockTrackEvent = jest.fn();
+		( useRecordReaderTracksEvent as jest.Mock ).mockReturnValue( mockTrackEvent );
+
+		renderWithProvider( <QuickPost /> );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Expand the quick post editor' } ) );
+
+		expect( savePreference ).toHaveBeenCalledWith( READER_QUICK_POST_MINIMIZED_PREFERENCE, false );
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'calypso_reader_quick_post_expanded' );
 	} );
 } );

--- a/client/reader/components/quick-post/test/skeleton.test.tsx
+++ b/client/reader/components/quick-post/test/skeleton.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { READER_QUICK_POST_MINIMIZED_PREFERENCE } from '../constants';
+import { QuickPostSkeleton } from '../skeleton';
+
+jest.mock( 'calypso/state/preferences/selectors', () => ( {
+	getPreference: jest.fn(),
+} ) );
+
+describe( 'QuickPostSkeleton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the full expanded skeleton by default', () => {
+		( getPreference as jest.Mock ).mockReturnValue( null );
+
+		const { container } = renderWithProvider( <QuickPostSkeleton /> );
+
+		expect( container.querySelectorAll( '.quick-post-skeleton span' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'renders a single collapsed bar when the editor is minimized', () => {
+		( getPreference as jest.Mock ).mockImplementation( ( _state, key ) =>
+			key === READER_QUICK_POST_MINIMIZED_PREFERENCE ? true : null
+		);
+
+		const { container } = renderWithProvider( <QuickPostSkeleton /> );
+
+		expect( container.querySelectorAll( '.quick-post-skeleton span' ) ).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
Part of READ-565

## Proposed Changes

- Re-add a minimize/expand control to the Quick Post editor on the Reader Recent screen. A header bar ("Write a quick post") with a chevron toggle is always shown; collapsing hides the site dropdown, editor, and action buttons so the editor no longer pushes feed content below the fold.
- Persist the minimized state via the Calypso preferences API (`reader_quick_post_minimized`), so the choice survives navigation between feeds and syncs across devices — the same pattern used by the Reader onboarding dismissal (#111888) and the Following view toggle.
- Default to **expanded** to preserve the discoverability the redesign was aiming for; minimizing is opt-in and remembered.
- Add `calypso_reader_quick_post_minimized` / `calypso_reader_quick_post_expanded` Tracks events so we can measure how often users collapse it.

<img width="817" height="222" alt="Screenshot 2026-06-23 at 1 45 44 PM" src="https://github.com/user-attachments/assets/68c30261-2b6a-40c7-9447-90b28d4026c5" />


## Why are these changes being made?

The Quick Post redesign (#108367) removed the editor's collapsible panel to keep it always visible. On laptop-sized screens this pushes the feed below the fold — when switching Recent feeds, users can't tell the feed changed because the editor occupies the top of the screen (READ-565).

Usage analysis (posted on READ-565) shows Quick Post is a low-penetration feature — roughly 1–2% of Reader users post in a given month — so the always-open editor costs above-the-fold space for the ~98% who don't. Restoring minimize fixes the fold problem for them while keeping the editor expanded by default (and the new Tracks events let us measure the impact, as discussed in the issue thread).

## Testing Instructions

1. Go to `/reader` with an account that has at least one site (so Quick Post renders).
2. Confirm the Quick Post editor is expanded by default with a "Write a quick post" header and a chevron (minimize) control.
3. Click the chevron to minimize — the editor, site dropdown, and Post/Edit buttons collapse to just the header bar; feed posts move up.
4. Navigate into a specific feed and back — it stays minimized.
5. Reload the page (and/or open Reader on another device) — the minimized choice persists.
6. Click the chevron again to expand; confirm any in-progress draft text is preserved.
8. Check Tracks: `calypso_reader_quick_post_minimized` fires on collapse, `calypso_reader_quick_post_expanded` on expand.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)