### PR TITLE
Fix response actions

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -213,13 +213,14 @@ export default function OrchestratorChat( {
 	useCheckpointAction( registerMessageActions, checkpoint );
 
 	// Register thumbs-up/down feedback actions on agent messages.
-	const { showFeedbackInput, submitFeedbackText, resetFeedback } = useFeedbackAction( {
-		registerMessageActions,
-		messages,
-	} );
+	const { showFeedbackInput, submitFeedbackText, resetFeedback, getFeedbackActionsForMessage } =
+		useFeedbackAction( {
+			registerMessageActions,
+			messages,
+		} );
 
-	// Register a "Copy" action on plain-text agent messages.
-	useCopyAction( registerMessageActions );
+	// Add a "Copy" action on plain-text agent messages.
+	const getCopyActionsForMessage = useCopyAction();
 
 	// Register zoom-in/zoom-out actions on agent messages.
 	useZoomAction( registerMessageActions );
@@ -479,11 +480,38 @@ export default function OrchestratorChat( {
 			onSubmit: onSubmitWithImages,
 		} );
 
+		currentMessages = currentMessages.map( ( message ) => {
+			if ( message.id.endsWith( '-next-step' ) ) {
+				return message;
+			}
+
+			const directActions = [
+				...getFeedbackActionsForMessage( message ),
+				...getCopyActionsForMessage( message ),
+			];
+			if ( directActions.length === 0 ) {
+				return message;
+			}
+
+			const existingActions = message.actions?.filter(
+				( action ) => ! action.id.startsWith( 'feedback-' ) && action.id !== 'copy'
+			);
+
+			return {
+				...message,
+				actions: [ ...( existingActions ?? [] ), ...directActions ].sort(
+					( actionA, actionB ) => ( actionA.order ?? Infinity ) - ( actionB.order ?? Infinity )
+				),
+			};
+		} );
+
 		return currentMessages;
 	}, [
 		currentPostId,
 		deletedMessageIds,
 		getChatComponent,
+		getCopyActionsForMessage,
+		getFeedbackActionsForMessage,
 		isBuildingSite,
 		messages,
 		onSubmitWithImages,

--- a/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { createFeedbackActions } from '@automattic/agenttic-ui';
 import { renderHook, act } from '@testing-library/react';
 import { useAgentsManagerContext } from '../../contexts';
 import { recordAgentsManagerTracksEvent, recordBigSkyTracksEvent } from '../../utils/tracks';
@@ -43,6 +44,7 @@ const mockUseAgentsManagerContext = useAgentsManagerContext as jest.MockedFuncti
 const mockFetch = jest.fn().mockResolvedValue( { ok: true } );
 globalThis.fetch = mockFetch;
 
+const mockCreateFeedbackActions = createFeedbackActions as jest.Mock;
 const mockRegisterMessageActions = jest.fn();
 const mockRecordBigSkyTracksEvent = recordBigSkyTracksEvent as jest.MockedFunction<
 	typeof recordBigSkyTracksEvent
@@ -101,18 +103,18 @@ describe( 'useFeedbackAction', () => {
 	};
 
 	describe( 'initialization', () => {
-		it( 'registers feedback actions on mount', () => {
+		it( 'creates feedback actions on mount', () => {
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 
-			expect( mockRegisterMessageActions ).toHaveBeenCalledWith(
+			expect( mockCreateFeedbackActions ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					id: 'agents-manager-feedback',
-					actions: expect.any( Function ),
+					onFeedback: expect.any( Function ),
+					condition: expect.any( Function ),
 				} )
 			);
 		} );
 
-		it( 'does not register feedback actions when user is not logged in', () => {
+		it( 'does not create feedback actions when user is not logged in', () => {
 			mockUseAgentsManagerContext.mockReturnValue( {
 				agentConfig: defaultAgentConfig,
 				isLoggedIn: false,
@@ -121,17 +123,17 @@ describe( 'useFeedbackAction', () => {
 
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 
-			expect( mockRegisterMessageActions ).not.toHaveBeenCalled();
+			expect( mockCreateFeedbackActions ).not.toHaveBeenCalled();
 		} );
 
-		it( 'only registers once across rerenders', () => {
+		it( 'only creates feedback actions once across rerenders', () => {
 			const { rerender } = renderHook( () => useFeedbackAction( defaultConfig ) );
 			rerender();
 
-			expect( mockRegisterMessageActions ).toHaveBeenCalledTimes( 1 );
+			expect( mockCreateFeedbackActions ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'resets registration when session changes', () => {
+		it( 'recreates feedback actions when session changes', () => {
 			const { rerender } = renderHook( ( props ) => useFeedbackAction( props ), {
 				initialProps: defaultConfig,
 			} );
@@ -147,7 +149,7 @@ describe( 'useFeedbackAction', () => {
 
 			rerender( defaultConfig );
 
-			expect( mockRegisterMessageActions ).toHaveBeenCalledTimes( 2 );
+			expect( mockCreateFeedbackActions ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'passes condition that filters to agent messages only', () => {

--- a/packages/agents-manager/src/hooks/use-copy-action.ts
+++ b/packages/agents-manager/src/hooks/use-copy-action.ts
@@ -1,12 +1,11 @@
-import { useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import CopyActionButton from '../components/copy-action-button';
 import {
 	getDisplayMessageFromToolData,
 	isDisplayableToolMessageTool,
 } from '../utils/tool-message-utils';
-import type { UseAgentChatReturn, UIMessage } from '@automattic/agenttic-client';
-
-type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
+import type { UIMessage } from '@automattic/agenttic-client';
+import type { MessageAction } from '@automattic/agenttic-ui/dist/types';
 
 /**
  * Extracts copyable text from a message. For tool messages, only known tools with
@@ -53,33 +52,28 @@ function getCopyableText( message: UIMessage ): string {
 }
 
 /**
- * Registers a copy action on agent messages that copies the text content to the clipboard.
+ * Returns a copy action for agent messages that have copyable text content.
  */
-export default function useCopyAction( registerMessageActions: RegisterMessageActions ): void {
-	useEffect( () => {
-		registerMessageActions( {
-			id: 'agents-manager-copy',
-			actions: ( message: UIMessage ) => {
-				if ( message.role !== 'agent' ) {
-					return [];
-				}
+export default function useCopyAction(): ( message: UIMessage ) => MessageAction[] {
+	return useCallback( ( message: UIMessage ) => {
+		if ( message.role !== 'agent' ) {
+			return [];
+		}
 
-				const text = getCopyableText( message );
+		const text = getCopyableText( message );
 
-				if ( ! text ) {
-					return [];
-				}
+		if ( ! text ) {
+			return [];
+		}
 
-				return [
-					{
-						type: 'component',
-						id: 'copy',
-						component: CopyActionButton,
-						componentProps: { text },
-						order: 4,
-					},
-				];
+		return [
+			{
+				type: 'component',
+				id: 'copy',
+				component: CopyActionButton,
+				componentProps: { text },
+				order: 4,
 			},
-		} );
-	}, [ registerMessageActions ] );
+		];
+	}, [] );
 }

--- a/packages/agents-manager/src/hooks/use-feedback-action.ts
+++ b/packages/agents-manager/src/hooks/use-feedback-action.ts
@@ -1,10 +1,17 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
-import { createElement, useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import {
+	createElement,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
 import { recordAgentsManagerTracksEvent, recordBigSkyTracksEvent } from '../utils/tracks';
 import type { AuthProvider, UseAgentChatReturn } from '@automattic/agenttic-client';
-import type { Message } from '@automattic/agenttic-ui/dist/types';
+import type { Message, MessageAction } from '@automattic/agenttic-ui/dist/types';
 
 const FEEDBACK_API_BASE = 'https://public-api.wordpress.com/wpcom/v2/ai/feedback';
 
@@ -17,6 +24,7 @@ export interface UseFeedbackActionReturn {
 	showFeedbackInput: boolean;
 	submitFeedbackText: ( feedbackText: string ) => Promise< void >;
 	resetFeedback: () => void;
+	getFeedbackActionsForMessage: ( message: Message ) => MessageAction[];
 }
 
 export async function rateMessage(
@@ -159,7 +167,6 @@ function getPreviousMessages( messages: Message[], targetMessageId: string ): Pr
 }
 
 export default function useFeedbackAction( {
-	registerMessageActions,
 	messages,
 }: UseFeedbackActionConfig ): UseFeedbackActionReturn {
 	const { agentConfig, isLoggedIn, getActiveSessionId } = useAgentsManagerContext();
@@ -209,13 +216,13 @@ export default function useFeedbackAction( {
 		[ getActiveSessionId ]
 	);
 
-	useEffect( () => {
-		// Only register feedback actions for logged-in users.
+	const feedbackManager = useMemo( () => {
+		// Only provide feedback actions for logged-in users.
 		if ( ! isLoggedIn ) {
-			return;
+			return null;
 		}
 
-		const feedbackManager = createFeedbackActions( {
+		return createFeedbackActions( {
 			onFeedback: handleFeedback,
 			condition: ( message: Message ) => message.role === 'agent',
 			icons: {
@@ -223,27 +230,38 @@ export default function useFeedbackAction( {
 				down: createElement( ThumbsDownIcon, { className: 'agents-manager-message-action-icon' } ),
 			},
 		} );
+	}, [ handleFeedback, isLoggedIn ] );
 
-		const feedbackRegistration = {
-			id: 'agents-manager-feedback',
-			actions: ( message: Message ) =>
-				feedbackManager.getActionsForMessage( message ).map( ( action, index ) => ( {
-					...action,
-					order: 2 + index,
-				} ) ),
-		};
+	const [ feedbackActionsVersion, setFeedbackActionsVersion ] = useState( 0 );
 
-		registerMessageActions( feedbackRegistration );
+	useEffect( () => {
+		if ( ! feedbackManager ) {
+			return;
+		}
 
 		const handleFeedbackChange = () => {
-			registerMessageActions( { ...feedbackRegistration } );
+			setFeedbackActionsVersion( ( version ) => version + 1 );
 		};
 		feedbackManager.onChange( handleFeedbackChange );
 
 		return () => {
 			feedbackManager.offChange( handleFeedbackChange );
 		};
-	}, [ registerMessageActions, handleFeedback, isLoggedIn ] );
+	}, [ feedbackManager ] );
+
+	const getFeedbackActionsForMessage = useCallback(
+		( message: Message ) => {
+			void feedbackActionsVersion;
+
+			return (
+				feedbackManager?.getActionsForMessage( message ).map( ( action, index ) => ( {
+					...action,
+					order: 2 + index,
+				} ) ) ?? []
+			);
+		},
+		[ feedbackActionsVersion, feedbackManager ]
+	);
 
 	const resetFeedback = useCallback( () => {
 		setShowFeedbackInput( false );
@@ -291,5 +309,6 @@ export default function useFeedbackAction( {
 		showFeedbackInput,
 		submitFeedbackText: handleSubmitFeedbackText,
 		resetFeedback,
+		getFeedbackActionsForMessage,
 	};
 }


### PR DESCRIPTION
Fixes AI-1017

## Proposed Changes

* Avoid registering Agents Manager feedback and copy actions through Agenttic's message-action registration path.
* Add feedback and copy actions directly to the displayed messages after tool/component conversion.
* Preserve the existing response action behavior and ordering: thumbs up, thumbs down, copy.
* Keep feedback button pressed state local to the feedback action manager without rebuilding Agenttic UI messages.
* Update feedback action tests for the new action creation flow.

## Why are these changes being made?

Agent responses that render components could duplicate after clicking a feedback button. The previous feedback action flow re-registered message actions when feedback state changed, which caused Agenttic to rebuild UI messages from conversation history. For component/tool responses, that rebuild could leave a duplicated/stale component message in the UI.

This change avoids that rebuild path for feedback and copy actions while keeping the same user-facing functionality.

## Testing Instructions

* Open Agents Manager in an editor context that can return a component response.
* Send a prompt that produces an agent response with an embedded component.
* Click thumbs up on the component response.
	* Confirm the message does not duplicate.
	* Confirm the original component message does not become disabled/stale.
	* Confirm the thumbs up button shows as active.
	* Confirm the action order is thumbs up, thumbs down, copy.
* Repeat with thumbs down.
	* Confirm the feedback text input appears.
	* Confirm the message does not duplicate or flash into a stale duplicate.
* Confirm the copy action still copies the response text for copyable responses.
* Run:

```bash
yarn jest packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts --runInBand
```

* Targeted lint was run on the changed Agents Manager files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
