### PR TITLE
Reader Spaces: Persist list data in cache

### DIFF
--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -57,7 +57,8 @@ early if it shouldn't drift between fetches.
 
 All paths are under `https://public-api.wordpress.com/wpcom/v2/reader/spaces`.
 Every mutation returns the **full updated detail**, so the client writes that
-straight to the caches — no follow-up GET.
+straight to the caches for an immediate UI update, then invalidates the affected
+queries for a canonical refresh.
 
 | #   | Method & path                                | Body                                                                   | Returns               | Wired as                  |
 | --- | -------------------------------------------- | ---------------------------------------------------------------------- | --------------------- | ------------------------- |
@@ -116,14 +117,14 @@ surfaces should map the relevant codes as they adopt the mutations.
 
 ## Caching
 
-Both `readSpacesQuery` and `readSpaceQuery` use `staleTime: Infinity` +
-`meta: { persist: false }`. Every mutation returns the full detail and writes it
-back (the detail cache gets the returned space; the list gets its summary), so
-the caches stay authoritative without refetch churn — `staleTime: Infinity` only
-suppresses refetching already-cached data, so a space's detail still loads the
-first time its modal opens. `persist: false` keeps the layout (random-until-set)
-out of the persisted cache, so a reload refetches fresh rather than rehydrating
-stale colours.
+Both `readSpacesQuery` and `readSpaceQuery` use `staleTime: Infinity`,
+`refetchOnMount: 'always'`, `placeholderData: keepPreviousData`, and
+`meta: { persist: true }`. The persisted cache lets the sidebar and space views
+render immediately after reload, while mount-time refetch refreshes the
+canonical server state in the background. Every mutation returns the full detail
+and writes it back (the detail cache gets the returned space; the list gets its
+summary), then invalidates the affected queries so active consumers refetch and
+inactive consumers refresh the next time they mount.
 
 The Sources tab (`customize-modal/sources-tab.tsx`) only mounts while it is the
 active `TabPanel` tab, so its `useSiteSubscriptions` query (which paginates all

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -118,10 +118,13 @@ surfaces should map the relevant codes as they adopt the mutations.
 ## Caching
 
 Both `readSpacesQuery` and `readSpaceQuery` use `staleTime: Infinity`,
-`refetchOnMount: 'always'`, `placeholderData: keepPreviousData`, and
-`meta: { persist: true }`. The persisted cache lets the sidebar and space views
-render immediately after reload, while mount-time refetch refreshes the
-canonical server state in the background. Every mutation returns the full detail
+`refetchOnMount: 'always'`, and `meta: { persist: true }`. The persisted cache
+lets the sidebar and space views render immediately after reload, while
+mount-time refetch refreshes the canonical server state in the background. The
+list query (`readSpacesQuery`) also sets `placeholderData: keepPreviousData`
+because its key is stable; the detail query (`readSpaceQuery`) deliberately omits
+it so a `spaceId` change never flashes the previous space's name/sources. Every
+mutation returns the full detail
 and writes it back (the detail cache gets the returned space; the list gets its
 summary), then invalidates the affected queries so active consumers refetch and
 inactive consumers refresh the next time they mount.

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -86,12 +86,15 @@ describe( 'read spaces mutations', () => {
 			expect( options.refetchOnMount ).toBe( 'always' );
 		} );
 
-		it( 'persists and keeps previous data for space detail queries', () => {
+		it( 'persists space detail queries without bleeding the previous space', () => {
 			const options = readSpaceQuery( '3' );
 
 			expect( options.queryKey ).toEqual( [ 'read', 'spaces', 'detail', '3' ] );
 			expect( options.meta ).toEqual( { persist: true } );
-			expect( options.placeholderData ).toBe( keepPreviousData );
+			// No keepPreviousData on the detail query: a spaceId change must not flash
+			// the previous space's name/sources. Persisted cache + refetchOnMount keep
+			// the same space visible during refetch.
+			expect( options.placeholderData ).toBeUndefined();
 			expect( options.refetchOnMount ).toBe( 'always' );
 		} );
 	} );

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -1,4 +1,9 @@
-import { QueryClient, QueryClientProvider, useMutation } from '@tanstack/react-query';
+import {
+	keepPreviousData,
+	QueryClient,
+	QueryClientProvider,
+	useMutation,
+} from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 import nock from 'nock';
 import {
@@ -71,9 +76,30 @@ const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
 describe( 'read spaces mutations', () => {
 	afterEach( () => nock.cleanAll() );
 
+	describe( 'queries', () => {
+		it( 'persists and keeps previous data for the spaces list query', () => {
+			const options = readSpacesQuery();
+
+			expect( options.queryKey ).toEqual( [ 'read', 'spaces', 'list' ] );
+			expect( options.meta ).toEqual( { persist: true } );
+			expect( options.placeholderData ).toBe( keepPreviousData );
+			expect( options.refetchOnMount ).toBe( 'always' );
+		} );
+
+		it( 'persists and keeps previous data for space detail queries', () => {
+			const options = readSpaceQuery( '3' );
+
+			expect( options.queryKey ).toEqual( [ 'read', 'spaces', 'detail', '3' ] );
+			expect( options.meta ).toEqual( { persist: true } );
+			expect( options.placeholderData ).toBe( keepPreviousData );
+			expect( options.refetchOnMount ).toBe( 'always' );
+		} );
+	} );
+
 	describe( 'createReadSpaceMutation', () => {
 		it( 'appends the summary to the list and seeds the detail cache', async () => {
 			const client = newClient();
+			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
 			nock( BASE )
 				.post( '/wpcom/v2/reader/spaces' )
 				.reply( 201, detailResponse( { id: 99, title: 'New' } ) );
@@ -92,12 +118,19 @@ describe( 'read spaces mutations', () => {
 					tags: [],
 				}
 			);
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpacesQuery().queryKey,
+			} );
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpaceQuery( '99' ).queryKey,
+			} );
 		} );
 	} );
 
 	describe( 'updateReadSpaceMutation', () => {
 		it( 'refreshes the matching list summary and the detail cache', async () => {
 			const client = newClient();
+			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
 			client.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, [
 				{ id: '3', name: 'Old', layout: { color: 'blue', icon: 'inbox' } },
 			] );
@@ -124,6 +157,12 @@ describe( 'read spaces mutations', () => {
 			expect(
 				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )
 			).toMatchObject( { id: '3', name: 'New name', tags: [ 'x' ] } );
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpacesQuery().queryKey,
+			} );
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpaceQuery( '3' ).queryKey,
+			} );
 		} );
 
 		it( "resets the space's posts feed so it reloads after a tag/feed edit", async () => {
@@ -147,6 +186,7 @@ describe( 'read spaces mutations', () => {
 	describe( 'deleteReadSpaceMutation', () => {
 		it( 'removes the deleted space from the list and discards its detail cache', async () => {
 			const client = newClient();
+			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
 			const keep: ReadSpace = { id: 'keep', name: 'Keep', layout: { color: 'red', icon: 'box' } };
 			client.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, [
 				keep,
@@ -163,13 +203,17 @@ describe( 'read spaces mutations', () => {
 			expect(
 				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )
 			).toBeUndefined();
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpacesQuery().queryKey,
+			} );
 		} );
 	} );
 
 	describe( 'feed (source) mutations', () => {
 		it( 'writes the returned detail to the cache after adding a feed', async () => {
 			const client = newClient();
-			const spy = jest.spyOn( client, 'resetQueries' );
+			const resetQueries = jest.spyOn( client, 'resetQueries' );
+			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
 			nock( BASE )
 				.post( '/wpcom/v2/reader/spaces/3/feeds' )
 				.reply(
@@ -203,13 +247,17 @@ describe( 'read spaces mutations', () => {
 					siteIcon: null,
 				},
 			] );
-			expect( spy ).toHaveBeenCalledWith( {
+			expect( resetQueries ).toHaveBeenCalledWith( {
 				queryKey: getStreamInfiniteQueryKeyPrefix( 'space:3' ),
+			} );
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpaceQuery( '3' ).queryKey,
 			} );
 		} );
 
 		it( 'writes the returned detail to the cache after removing a feed', async () => {
 			const client = newClient();
+			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
 			nock( BASE )
 				.delete( '/wpcom/v2/reader/spaces/3/feeds/456' )
 				.reply( 200, detailResponse( { follows: [] } ) );
@@ -222,6 +270,9 @@ describe( 'read spaces mutations', () => {
 			expect(
 				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )?.sources
 			).toEqual( [] );
+			expect( invalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: readSpaceQuery( '3' ).queryKey,
+			} );
 		} );
 
 		it( 'leaves the detail cache untouched when the add request fails', async () => {

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -61,7 +61,10 @@ export const readSpaceQuery = ( spaceId: string ) =>
 		queryFn: () => fetchReadSpace( spaceId ),
 		staleTime: Infinity,
 		refetchOnMount: 'always',
-		placeholderData: keepPreviousData,
+		// No `placeholderData: keepPreviousData` here: when `spaceId` changes the
+		// detail view (or a still-mounted Sources modal) must not flash the previous
+		// space's name/sources. The persisted cache + mount-time refetch already keep
+		// the *same* space's data visible while it refreshes.
 		meta: { persist: true },
 	} );
 

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -12,7 +12,12 @@ import {
 	type ReadSpaceSourceMutationParams,
 	type UpdateReadSpaceParams,
 } from '@automattic/api-core';
-import { mutationOptions, queryOptions, type QueryClient } from '@tanstack/react-query';
+import {
+	keepPreviousData,
+	mutationOptions,
+	queryOptions,
+	type QueryClient,
+} from '@tanstack/react-query';
 import { getStreamInfiniteQueryKeyPrefix } from './read-streams';
 
 const readSpacesListKey = [ 'read', 'spaces', 'list' ] as const;
@@ -42,13 +47,12 @@ export const readSpacesQuery = () =>
 		queryKey: readSpacesListKey,
 		queryFn: () => fetchReadSpaces(),
 		// Every mutation returns the full detail and writes it back to these caches,
-		// so they stay authoritative without refetch churn — hold refetches off.
-		// (First load still fetches; staleTime only suppresses refetching fresh data.)
+		// then invalidates them for a canonical refresh. Persisted data can render
+		// immediately after reload while the active query refreshes in the background.
 		staleTime: Infinity,
-		// Keep the list out of Calypso's persisted query cache: layout_color/icon
-		// are random-until-set server-side, so a dehydrated copy could show stale
-		// colours across reloads. A reload refetches fresh instead.
-		meta: { persist: false },
+		refetchOnMount: 'always',
+		placeholderData: keepPreviousData,
+		meta: { persist: true },
 	} );
 
 export const readSpaceQuery = ( spaceId: string ) =>
@@ -56,7 +60,9 @@ export const readSpaceQuery = ( spaceId: string ) =>
 		queryKey: readSpaceDetailKey( spaceId ),
 		queryFn: () => fetchReadSpace( spaceId ),
 		staleTime: Infinity,
-		meta: { persist: false },
+		refetchOnMount: 'always',
+		placeholderData: keepPreviousData,
+		meta: { persist: true },
 	} );
 
 // The summary (list) shape is the detail minus its `sources` and `tags`.
@@ -71,8 +77,21 @@ const toSummary = ( space: ReadSpaceDetails ): ReadSpace => {
 // from the consuming component.
 //
 // Every mutation returns the full updated detail, so we write that straight into
-// the caches (no follow-up GET, no optimistic patch/rollback): the detail cache
-// gets the returned space, and the list cache gets its summary.
+// the caches for an immediate UI update. We then invalidate the affected queries
+// so active consumers refetch the canonical server state and inactive consumers
+// refresh the next time they mount.
+
+const invalidateReadSpacesList = ( queryClient: QueryClient ) =>
+	queryClient.invalidateQueries( { queryKey: readSpacesQuery().queryKey } );
+
+const invalidateReadSpaceDetail = ( queryClient: QueryClient, spaceId: string ) =>
+	queryClient.invalidateQueries( { queryKey: readSpaceQuery( spaceId ).queryKey } );
+
+const invalidateReadSpaceListAndDetail = ( queryClient: QueryClient, spaceId: string ) =>
+	Promise.all( [
+		invalidateReadSpacesList( queryClient ),
+		invalidateReadSpaceDetail( queryClient, spaceId ),
+	] ).then( () => undefined );
 
 export const createReadSpaceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
@@ -85,6 +104,7 @@ export const createReadSpaceMutation = ( queryClient: QueryClient ) =>
 				toSummary( space ),
 			] );
 			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
+			return invalidateReadSpaceListAndDetail( queryClient, space.id );
 		},
 	} );
 
@@ -107,6 +127,7 @@ export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
 			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
 			// Tags/feeds may have changed, so reload the space's posts feed.
 			reloadReadSpaceStream( queryClient, space.id );
+			return invalidateReadSpaceListAndDetail( queryClient, space.id );
 		},
 	} );
 
@@ -124,6 +145,7 @@ export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 			);
 			// ...and discard its now-defunct detail cache.
 			queryClient.removeQueries( { queryKey: readSpaceQuery( spaceId ).queryKey } );
+			return invalidateReadSpacesList( queryClient );
 		},
 	} );
 
@@ -134,6 +156,7 @@ const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails
 	queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
 	// Adding/removing a feed changes the space's posts feed, so reload it too.
 	reloadReadSpaceStream( queryClient, space.id );
+	return invalidateReadSpaceDetail( queryClient, space.id );
 };
 
 export const addReadSpaceSourceMutation = ( queryClient: QueryClient ) =>

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -104,7 +104,9 @@ export const createReadSpaceMutation = ( queryClient: QueryClient ) =>
 				toSummary( space ),
 			] );
 			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
-			return invalidateReadSpaceListAndDetail( queryClient, space.id );
+			// Reconcile in the background — don't await the refetch so the consumer's
+			// own onSuccess (close modal, redirect) fires immediately off the cache write.
+			void invalidateReadSpaceListAndDetail( queryClient, space.id );
 		},
 	} );
 
@@ -127,7 +129,7 @@ export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
 			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
 			// Tags/feeds may have changed, so reload the space's posts feed.
 			reloadReadSpaceStream( queryClient, space.id );
-			return invalidateReadSpaceListAndDetail( queryClient, space.id );
+			void invalidateReadSpaceListAndDetail( queryClient, space.id );
 		},
 	} );
 
@@ -145,7 +147,7 @@ export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 			);
 			// ...and discard its now-defunct detail cache.
 			queryClient.removeQueries( { queryKey: readSpaceQuery( spaceId ).queryKey } );
-			return invalidateReadSpacesList( queryClient );
+			void invalidateReadSpacesList( queryClient );
 		},
 	} );
 
@@ -156,7 +158,7 @@ const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails
 	queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
 	// Adding/removing a feed changes the space's posts feed, so reload it too.
 	reloadReadSpaceStream( queryClient, space.id );
-	return invalidateReadSpaceDetail( queryClient, space.id );
+	void invalidateReadSpaceDetail( queryClient, space.id );
 };
 
 export const addReadSpaceSourceMutation = ( queryClient: QueryClient ) =>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes RSM-4495

## Proposed Changes

* Persist Reader Spaces list and detail query caches, keeping previous data visible while refetching on mount.
* Keep immediate mutation cache writes, then invalidate affected Spaces queries for a canonical refresh.
* Update Spaces caching docs and add regression coverage for persistence and refetch behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Reader sidebar currently has to wait for the Spaces list after reload because Spaces queries opt out of Calypso's persisted query cache. This keeps the sidebar responsive from rehydrated data while still reconciling with the server after reloads and mutations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Scenario 1 - Sidebar reload cache:
- Go to `/reader`
- Check if the Spaces section shows the user's spaces, then reload and check if the same list remains visible while it refreshes.

### Scenario 2 - Space mutation refresh:
- Go to `/reader`
- Create or edit a space from the Spaces section.
- Check if the sidebar updates immediately and remains in sync after the background refresh.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

