### PR TITLE
Agents Manager: Preserve empty view suggestions after clearing the input

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.69",
+		"@automattic/agenttic-ui": "^0.1.71",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.69",
-		"@automattic/agenttic-ui": "^0.1.69",
+		"@automattic/agenttic-client": "^0.1.71",
+		"@automattic/agenttic-ui": "^0.1.71",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -71,9 +71,11 @@ jest.mock( '../agent-chat', () => ( {
 	default: ( {
 		onSuggestionClick,
 		onSubmit,
+		emptyViewSuggestions = [],
 	}: {
 		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
 		onSubmit: ( message: string ) => void;
+		emptyViewSuggestions?: Suggestion[];
 	} ) => (
 		<>
 			<button
@@ -91,6 +93,11 @@ jest.mock( '../agent-chat', () => ( {
 				Click string suggestion
 			</button>
 			<button onClick={ () => onSubmit( 'Describe these images' ) }>Submit with images</button>
+			<ul data-testid="empty-view-suggestions">
+				{ emptyViewSuggestions.map( ( suggestion ) => (
+					<li key={ suggestion.id }>{ suggestion.label }</li>
+				) ) }
+			</ul>
 		</>
 	),
 } ) );
@@ -217,6 +224,80 @@ describe( 'OrchestratorChat', () => {
 		);
 
 		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
+	} );
+
+	it( 'keeps showing the provider suggestions in the empty view after the store is cleared', () => {
+		// Reproduces the regression where clicking a suggestion calls
+		// clearSuggestions() (emptying the store) and the empty view then falls
+		// back to the static defaults instead of the persistent provider list.
+		const customSuggestions: Suggestion[] = [
+			{ id: 'attention', label: 'What needs my attention today?', prompt: 'attention' },
+		];
+		const staticDefaults: Suggestion[] = [
+			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
+		];
+		const useSuggestions = jest.fn( () => ( { suggestions: customSuggestions } ) );
+
+		// Store is empty (as it is right after clearSuggestions()), no messages,
+		// and the input is empty — the empty-view fallback branch.
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ staticDefaults }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'What needs my attention today?' ) ).toBeTruthy();
+		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
+	} );
+
+	it( 'falls back to the static empty-view suggestions when the provider has none', () => {
+		const staticDefaults: Suggestion[] = [
+			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
+		];
+		const useSuggestions = jest.fn( () => ( { suggestions: [] } ) );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ staticDefaults }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Getting started with WordPress' ) ).toBeTruthy();
 	} );
 
 	it( 'fires file_upload_success after images upload on send, with the uploaded media count', async () => {

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -30,6 +30,7 @@ import type { UseImageUploadResult } from '../../hooks/use-image-upload';
 import type { ExternalContextCard, ExternalContextCardAction } from '../../utils/external-context';
 import type { Message, NoticeConfig } from '@automattic/agenttic-ui/dist/types';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
+import type { ComponentProps } from 'react';
 
 interface Props {
 	/** Chat messages to display. */
@@ -53,7 +54,7 @@ interface Props {
 	/** Indicates if the chat is expanded (floating mode). */
 	isOpen: boolean;
 	/** Called when the user submits a message. */
-	onSubmit: ( message: string, files?: File[] ) => Promise< void > | void;
+	onSubmit: ComponentProps< typeof AgentUI.Container >[ 'onSubmit' ];
 	/** Called when the user aborts the current request. */
 	onAbort: () => void;
 	/** Called when the chat is closed. */

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -543,7 +543,14 @@ export default function OrchestratorChat( {
 	if ( suggestions.length > 0 ) {
 		displayedEmptyViewSuggestions = suggestions;
 	} else if ( displayedMessages.length === 0 && inputValue.length === 0 ) {
-		displayedEmptyViewSuggestions = emptyViewSuggestions;
+		// Read straight from the live `useSuggestions` output rather than the
+		// registered store. Clicking a suggestion calls `clearSuggestions()`,
+		// which empties the store, and the re-registration effect is keyed on
+		// the (unchanged) hook output so it won't restore it. Persistent
+		// empty-view chips must survive that clear; fall back to the static
+		// defaults only when the hook genuinely has none.
+		displayedEmptyViewSuggestions =
+			dynamicSuggestionsList.length > 0 ? dynamicSuggestionsList : emptyViewSuggestions;
 	}
 
 	return (

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.69",
+		"@automattic/agenttic-client": "^0.1.71",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.69",
-		"@automattic/agenttic-ui": "^0.1.69",
+		"@automattic/agenttic-client": "^0.1.71",
+		"@automattic/agenttic-ui": "^0.1.71",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.69",
+		"@automattic/agenttic-client": "^0.1.71",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.69",
+		"@automattic/agenttic-ui": "^0.1.71",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.69"
-    "@automattic/agenttic-ui": "npm:^0.1.69"
+    "@automattic/agenttic-client": "npm:^0.1.71"
+    "@automattic/agenttic-ui": "npm:^0.1.71"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,9 +180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.69":
-  version: 0.1.69
-  resolution: "@automattic/agenttic-client@npm:0.1.69"
+"@automattic/agenttic-client@npm:^0.1.71":
+  version: 0.1.71
+  resolution: "@automattic/agenttic-client@npm:0.1.71"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -196,13 +196,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: ba07edc8d44edc09eb419658d809b41b206fe4a82fb91db47eade626a8f2c776bd860cd3ec65a03538d1ac12c013a418f09e63298c4612d954d3a402593a3f91
+  checksum: ac50a45413b7e37a0b28f0e14ed40a183dc0a9ec1918b8f3866a0c714729830bd1902877ac294d0da47ffe5cf0ae1eb62ebd2742a0e9632175fe334e465e7d2e
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.69":
-  version: 0.1.69
-  resolution: "@automattic/agenttic-ui@npm:0.1.69"
+"@automattic/agenttic-ui@npm:^0.1.71":
+  version: 0.1.71
+  resolution: "@automattic/agenttic-ui@npm:0.1.71"
   dependencies:
     "@automattic/charts": "npm:>=0.58.0 <1.0.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -228,7 +228,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 997ae168a36257f01efe2163117b2b4ab10d724c703c61ac5dcc0dbccb130a4b98f717473d30b4c4695ab1213f74d010d40f106a70229e44b5c5007354e1ee9b
+  checksum: e7a13895a22be7cd240303953e9a0ca817931a49df03d3cb5ca5698585b6aece599c15bdf7b74f1602ada135e126b388cb89a4fcc33e435a252aee2bea83a906
   languageName: node
   linkType: hard
 
@@ -345,7 +345,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.69"
+    "@automattic/agenttic-client": "npm:^0.1.71"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1523,8 +1523,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.69"
-    "@automattic/agenttic-ui": "npm:^0.1.69"
+    "@automattic/agenttic-client": "npm:^0.1.71"
+    "@automattic/agenttic-ui": "npm:^0.1.71"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1619,7 +1619,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.69"
+    "@automattic/agenttic-client": "npm:^0.1.71"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1881,7 +1881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.69"
+    "@automattic/agenttic-ui": "npm:^0.1.71"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14335,7 +14335,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.69"
+    "@automattic/agenttic-ui": "npm:^0.1.71"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
Part of WOOAI-644.

## Proposed Changes

This PR fixes a problem where typing after seeing customized suggestions and then removing the content reverted the suggestions to their default state. 

It will be later used to upgrade `@automattic/agenttic-{chat,ui}` once we merge the PR there.

## Testing Instructions

See https://github.com/woocommerce/woocommerce-ai/pull/252.