### PR TITLE
Reader onboarding - add key to stream preview subscribe button

### DIFF
--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -255,6 +255,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 												</span>
 											</div>
 											<ReaderFollowButton
+												// Remount per previewed site so the follow mutation's
+												// pending state (which lingers while follow-sensitive
+												// caches refetch) can't disable the button for the next
+												// site the user previews.
+												key={ selectedSite.feed_ID }
 												siteUrl={ selectedFollowUrl }
 												feedId={ selectedSite.feed_ID }
 												siteId={ selectedSite.site_ID }

--- a/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
@@ -66,9 +66,26 @@ jest.mock( 'calypso/blocks/site-icon', () => ( {
 	SiteIcon: () => null,
 } ) );
 
+// Track each mount of the preview follow button (keyed by feedId) so a test
+// can assert that switching previews remounts it. The `key={ feed_ID }` on the
+// real button is what forces this remount, which resets the follow mutation's
+// lingering `isPending` state so it can't disable the button for the next site.
+const mockFollowButtonMounts: number[] = [];
+
+function MockFollowButton( { feedId }: { feedId: number } ) {
+	React.useEffect( () => {
+		mockFollowButtonMounts.push( feedId );
+		// Empty deps: only count true mounts. A dependency on `feedId` would also
+		// fire on prop updates, which would defeat the remount assertion (the
+		// no-`key` regression updates props on a persistent instance).
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+	return null;
+}
+
 jest.mock( 'calypso/reader/follow-button', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: MockFollowButton,
 } ) );
 
 jest.mock( 'calypso/reader/controller-helper', () => ( {
@@ -168,6 +185,33 @@ describe( 'SubscribeModal – site preview analytics', () => {
 		jest.mocked( recordTracksEvent ).mockClear();
 		jest.mocked( prefetchInfiniteStream ).mockClear();
 		mockedRecommendationsHook.mockReturnValue( defaultRecommendationsHookValue );
+		mockFollowButtonMounts.length = 0;
+	} );
+
+	it( 'remounts the preview follow button when a different site is previewed', async () => {
+		const user = userEvent.setup();
+		const recommendations = [ makeRecommendation( 0 ), makeRecommendation( 1 ) ];
+		mockedRecommendationsHook.mockReturnValue( {
+			...defaultRecommendationsHookValue,
+			combinedRecommendations: recommendations,
+			recommendations,
+		} );
+
+		renderWithProvider( <SubscribeModal onFinish={ jest.fn() } promptVerification={ false } /> );
+
+		// The first recommendation is auto-selected on mount.
+		expect( mockFollowButtonMounts ).toEqual( [ 100 ] );
+
+		// Previewing a different site must remount the follow button (via its
+		// `key`) rather than reusing the persistent instance — otherwise a
+		// lingering follow-mutation pending state would disable it for the new
+		// site. A fresh mount appends the newly selected feedId.
+		await user.click( screen.getByTestId( 'reader-list-item-101' ) );
+		expect( mockFollowButtonMounts ).toEqual( [ 100, 101 ] );
+
+		// Returning to the first site remounts it again.
+		await user.click( screen.getByTestId( 'reader-list-item-100' ) );
+		expect( mockFollowButtonMounts ).toEqual( [ 100, 101, 100 ] );
 	} );
 
 	it( 'records discover_modal_site_previewed when the user picks a different site in the list', async () => {


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # a bug i just found while sandboxing async jobs and having slow responses

## Proposed Changes

* Adds a key to the subscribe button used here for the preview.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On slow networks, there is currently a bug where we subscribe to one site -> preview the next site -> and the subscribe button in the preview is still disabled. Adding the key based on the preview site to fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* May not be able to repro original issue on normal network - i saw this while sandboxing async jobs
* Load reader onboarding at `*/reader?flags=reader/force-onboarding`.
* on the last step, subscribe to a site using the subscribe button in the preview header.
* select another site in the list, try to subscribe in the preview header and confirm it isn't disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
