### PR TITLE
Minor refactor: Use helper to order suggestions

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -206,6 +206,12 @@ function getReservedSuggestions< T extends { id: string } >( suggestions: T[] ):
 		.filter( Boolean ) as T[];
 }
 
+/** Rank a suggestion id by its position in the priority list; unranked ids sort last. */
+function priorityRank( id: string ): number {
+	const index = LIMITED_BLOCK_SUGGESTION_PRIORITY.indexOf( id );
+	return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
 function applySuggestionLimit< T extends { id: string } >(
 	suggestions: T[],
 	maxSuggestions?: number
@@ -232,13 +238,7 @@ function applySuggestionLimit< T extends { id: string } >(
 		.filter(
 			( suggestion ) => ! reservedSuggestions.some( ( reserved ) => reserved.id === suggestion.id )
 		)
-		.sort( ( a, b ) => {
-			const aPriority = LIMITED_BLOCK_SUGGESTION_PRIORITY.indexOf( a.id );
-			const bPriority = LIMITED_BLOCK_SUGGESTION_PRIORITY.indexOf( b.id );
-			const normalizedAPriority = aPriority === -1 ? Number.MAX_SAFE_INTEGER : aPriority;
-			const normalizedBPriority = bPriority === -1 ? Number.MAX_SAFE_INTEGER : bPriority;
-			return normalizedAPriority - normalizedBPriority;
-		} );
+		.sort( ( a, b ) => priorityRank( a.id ) - priorityRank( b.id ) );
 
 	const reservedSlots = Math.min( reservedSuggestions.length, limit );
 	return [


### PR DESCRIPTION
## Proposed Changes

* `packages/jetpack-ai-sidebar`: extract a `priorityRank()` helper and collapse the duplicated `indexOf` / `Number.MAX_SAFE_INTEGER` normalization in `applySuggestionLimit`'s sort comparator into a single expression. Pure refactor — no behavior change.

## Why are these changes being made?

* The comparator computed the identical `-1 → MAX_SAFE_INTEGER` rank for each operand inline; the helper removes the duplication and makes the ordering intent (priority-list position, unranked last) read at a glance.

## Testing Instructions

* Refactor only — no functional change. Locally: `tsc --build` clean, ESLint clean, and the `@automattic/jetpack-ai-sidebar` suite (154 tests) passes.

Regression:
1. Install on sandbox using `install-plugin.sh am update/ai-editorial-review-minor-refactor`
2. Goto draft post and trigger AER
3. Validate it works as expected

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes? — refactor only; existing `applySuggestionLimit` tests cover the behavior.
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites? — will verify via the CI build.
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode? — no UI change.
- [ ] Have you tested accessibility for your changes? — no UI change.
- [ ] Have you used memoizing on expensive computations? — N/A.
- [ ] Have we added the "[Status] String Freeze" label? — no new strings.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label? — no data or activity change.
