### PR TITLE
Lodash: replace reject(), flow(), defaults() and concat()

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.tsx
+++ b/client/components/domains/registrant-extra-info/fr-form.tsx
@@ -1,4 +1,5 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
+import { defaults } from '@automattic/js-utils';
 import { DomainContactDetails } from '@automattic/shopping-cart';
 import {
 	DomainContactDetailsErrors,
@@ -6,7 +7,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { LocalizeProps, TranslateResult, localize } from 'i18n-calypso';
-import { defaults, get, isEmpty, map, set } from 'lodash';
+import { get, isEmpty, map, set } from 'lodash';
 import { PureComponent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';

--- a/client/components/line-chart/index.jsx
+++ b/client/components/line-chart/index.jsx
@@ -5,7 +5,6 @@ import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
 import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } from 'd3-shape';
-import { concat } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import D3Base from 'calypso/components/d3-base';
@@ -424,7 +423,7 @@ class LineChart extends Component {
 		const newWidth = node.offsetWidth;
 		const newHeight = newWidth / aspectRatio;
 
-		const concatData = concat( ...data );
+		const concatData = [].concat( ...data );
 
 		return {
 			height: newHeight,

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -1,5 +1,5 @@
-import { sortBy } from '@automattic/js-utils';
-import { concat, filter, flow, map } from 'lodash';
+import { flow, sortBy } from '@automattic/js-utils';
+import { filter, map } from 'lodash';
 import { PureComponent } from 'react';
 import PaymentLogo, { POSSIBLE_TYPES } from '../index';
 
@@ -8,7 +8,7 @@ const genVendors = flow(
 	( arr ) => filter( arr, ( type ) => type !== 'placeholder' ),
 
 	( arr ) => map( arr, ( type ) => ( { type, isCompact: false } ) ),
-	( arr ) => concat( arr, [ { type: 'paypal', isCompact: true } ] ),
+	( arr ) => arr.concat( [ { type: 'paypal', isCompact: true } ] ),
 	( arr ) => sortBy( arr, [ 'type', 'isCompact' ] )
 );
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -1,11 +1,11 @@
 import page from '@automattic/calypso-router';
 import { getUrlParts, getUrlFromParts, determineUrlType, format } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
+import { flow } from '@automattic/js-utils';
 import Search from '@automattic/search';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { flow } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { safeImageUrl as safeImageUrlFake } from '@automattic/calypso-url';
-import { flow } from 'lodash';
+import { flow } from '@automattic/js-utils';
 import detectMedia from '../rule-content-detect-media';
 import detectPolls from '../rule-content-detect-polls';
 import detectSurveys from '../rule-content-detect-surveys';

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { pick } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { translate } from 'i18n-calypso';
-import { filter, find, forEach, isEmpty, reject, reduce } from 'lodash';
+import { filter, find, forEach, isEmpty, reduce } from 'lodash';
 import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -380,7 +380,8 @@ export default class SignupFlowController {
 			( { stepName } ) => currentSteps.includes( stepName )
 		);
 		const allStepsSubmitted =
-			reject( signupProgress, { status: 'in-progress' } ).length === currentSteps.length;
+			signupProgress.filter( ( step ) => step.status !== 'in-progress' ).length ===
+			currentSteps.length;
 		const allowUnauthenticated =
 			getSignupDependencyStore( this._reduxStore.getState() )?.allowUnauthenticated ?? false;
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -5,11 +5,11 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { capitalize } from '@automattic/js-utils';
+import { capitalize, flow } from '@automattic/js-utils';
 import { Icon, upload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { flow, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -1,6 +1,5 @@
 import { ScreenReaderText, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { reject } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -21,7 +20,7 @@ class RemoveButton extends PureComponent {
 			return;
 		}
 
-		const items = reject( selectedItems, ( item ) => item.ID === itemId );
+		const items = selectedItems.filter( ( item ) => item.ID !== itemId );
 
 		this.props.selectMediaItems( siteId, items );
 	};

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -1,5 +1,6 @@
+import { flow } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { flow, get, isEmpty, some } from 'lodash';
+import { get, isEmpty, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/reader/data/post/normalization/index.js
+++ b/client/reader/data/post/normalization/index.js
@@ -1,4 +1,4 @@
-import { flow } from 'lodash';
+import { flow } from '@automattic/js-utils';
 import addImageWrapperElement from 'calypso/lib/post-normalizer/rule-add-image-wrapper-element';
 import addMinutesToRead from 'calypso/lib/post-normalizer/rule-add-minutes-to-read';
 import convertVideoPressBlocks from 'calypso/lib/post-normalizer/rule-content-convert-videopress-blocks';

--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -1,8 +1,7 @@
 import { open } from 'fs/promises';
 import path from 'path';
-import { groupBy } from '@automattic/js-utils';
+import { defaults, groupBy } from '@automattic/js-utils';
 import asyncHandler from 'express-async-handler';
-import { defaults } from 'lodash';
 
 const ASSETS_PATH = path.resolve( __dirname, '../../../build' );
 const ASSETS_FILE = path.join( ASSETS_PATH, `assets.json` );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -6,7 +6,7 @@ import {
 } from '@automattic/design-picker';
 import { DOMAIN_FOR_GRAVATAR_FLOW, isDomainForGravatarFlow } from '@automattic/onboarding';
 import { isURL } from '@wordpress/url';
-import { get, reject } from 'lodash';
+import { get } from 'lodash';
 import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { getOnboardingPostCheckoutDestination } from 'calypso/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination';
@@ -325,7 +325,7 @@ const Flows = {
 
 		return {
 			...flow,
-			steps: reject( flow.steps, ( stepName ) => Flows.excludedSteps.includes( stepName ) ),
+			steps: flow.steps.filter( ( stepName ) => ! Flows.excludedSteps.includes( stepName ) ),
 		};
 	},
 

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,7 +1,7 @@
 import { omit, orderBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { filter, has, map, reject, get } from 'lodash';
+import { filter, has, map, get } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,
@@ -122,7 +122,7 @@ export function items( state = {}, action ) {
 		case COMMENTS_DELETE:
 			return {
 				...state,
-				[ stateKey ]: reject( state[ stateKey ], { ID: commentId } ),
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).filter( ( comment ) => comment.ID !== commentId ),
 			};
 		case COMMENTS_LIKE:
 			return {

--- a/client/state/connected-applications/reducer.js
+++ b/client/state/connected-applications/reducer.js
@@ -1,5 +1,4 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { reject } from 'lodash';
 import {
 	CONNECTED_APPLICATION_DELETE_SUCCESS,
 	CONNECTED_APPLICATIONS_RECEIVE,
@@ -10,7 +9,7 @@ import schema from './schema';
 const reducer = ( state = null, action ) => {
 	switch ( action.type ) {
 		case CONNECTED_APPLICATION_DELETE_SUCCESS:
-			return reject( state, { ID: action.appId } );
+			return ( state ?? [] ).filter( ( app ) => app.ID !== action.appId );
 		case CONNECTED_APPLICATIONS_RECEIVE:
 			return action.apps;
 		default:

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -1,6 +1,6 @@
 import { pick } from '@automattic/js-utils';
 import update from 'immutability-helper';
-import { filter, find, matches, reject, some } from 'lodash';
+import { filter, find, matches, some } from 'lodash';
 import {
 	DOMAINS_DNS_ADD,
 	DOMAINS_DNS_ADD_COMPLETED,
@@ -122,9 +122,7 @@ function deleteDns( state, domainName, record ) {
 		[ domainName ]: {
 			records: {
 				$apply: ( records ) => {
-					const deleted = reject( records, ( _, current ) => {
-						return index === current;
-					} );
+					const deleted = records.filter( ( _, current ) => index !== current );
 
 					return addMissingWpcomRecords( domainName, deleted );
 				},

--- a/client/state/posts/utils/apply-post-edits.js
+++ b/client/state/posts/utils/apply-post-edits.js
@@ -1,4 +1,4 @@
-import { cloneDeep, find, map, mergeWith, reduce, reject } from 'lodash';
+import { cloneDeep, find, map, mergeWith, reduce } from 'lodash';
 
 /*
  * Applies a metadata edit operation (either update or delete) to an existing array of
@@ -19,7 +19,7 @@ function applyMetadataEdit( metadata, edit ) {
 			// return unmodified original value.
 			const { key } = edit;
 			if ( find( metadata, { key } ) ) {
-				return reject( metadata, { key } );
+				return ( Array.isArray( metadata ) ? metadata : [] ).filter( ( m ) => m.key !== key );
 			}
 			return metadata;
 		}

--- a/client/state/posts/utils/merge-post-edits.js
+++ b/client/state/posts/utils/merge-post-edits.js
@@ -1,8 +1,8 @@
-import { cloneDeep, find, mergeWith, reduce, reject } from 'lodash';
+import { cloneDeep, find, mergeWith, reduce } from 'lodash';
 
 function mergeMetadataEdits( edits, nextEdits ) {
 	// remove existing edits that get updated in `nextEdits`
-	const newEdits = reject( edits, ( edit ) => find( nextEdits, { key: edit.key } ) );
+	const newEdits = ( edits ?? [] ).filter( ( edit ) => ! find( nextEdits, { key: edit.key } ) );
 	// append the new edits at the end
 	return newEdits.concat( nextEdits );
 }

--- a/client/state/posts/utils/normalize-post-for-display.js
+++ b/client/state/posts/utils/normalize-post-for-display.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
-import { cloneDeep, flow } from 'lodash';
+import { flow } from '@automattic/js-utils';
+import { cloneDeep } from 'lodash';
 import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import decodeEntities from 'calypso/lib/post-normalizer/rule-decode-entities';
 import pickCanonicalImage from 'calypso/lib/post-normalizer/rule-pick-canonical-image';

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -26,6 +26,8 @@ const JS_UTILS_NAMES = [
 	'random',
 	'range',
 	'truncate',
+	'flow',
+	'defaults',
 ];
 
 // The js-utils case converters cover ASCII identifiers/keys, not lodash's full
@@ -81,6 +83,11 @@ const PARTITION_MESSAGE =
 const SORT_MESSAGE =
 	'Please use `sortBy`/`orderBy` from `@automattic/js-utils`. They support function and ' +
 	'property-path iteratees (and arrays of those) but not lodash object-match shorthands.';
+const REJECT_MESSAGE =
+	'Please use native `array.filter( ( item ) => ! … )` instead of lodash `reject` ' +
+	'(expand object-match shorthands to a predicate, and guard nullable collections with `?? []`).';
+const CONCAT_MESSAGE =
+	'Please use native `array.concat( … )` (or `[].concat( ...arrays )`) instead of lodash `concat`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -104,6 +111,8 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'maxBy', 'minBy' ], message: EXTREMUM_MESSAGE },
 	{ name: 'lodash', importNames: [ 'partition' ], message: PARTITION_MESSAGE },
 	{ name: 'lodash', importNames: [ 'sortBy', 'orderBy' ], message: SORT_MESSAGE },
+	{ name: 'lodash', importNames: [ 'reject' ], message: REJECT_MESSAGE },
+	{ name: 'lodash', importNames: [ 'concat' ], message: CONCAT_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -129,6 +138,8 @@ const patterns = [
 	{ group: [ 'lodash/maxBy', 'lodash/minBy' ], message: EXTREMUM_MESSAGE },
 	{ group: [ 'lodash/partition' ], message: PARTITION_MESSAGE },
 	{ group: [ 'lodash/sortBy', 'lodash/orderBy' ], message: SORT_MESSAGE },
+	{ group: [ 'lodash/reject' ], message: REJECT_MESSAGE },
+	{ group: [ 'lodash/concat' ], message: CONCAT_MESSAGE },
 ];
 
 module.exports = { paths, patterns };

--- a/packages/js-utils/src/defaults.ts
+++ b/packages/js-utils/src/defaults.ts
@@ -1,0 +1,52 @@
+function defaults< T extends object, S extends object >( object: T, source: S ): T & S;
+function defaults< T extends object, S1 extends object, S2 extends object >(
+	object: T,
+	source1: S1,
+	source2: S2
+): T & S1 & S2;
+function defaults< T extends object >(
+	object: T,
+	...sources: Array< object | null | undefined >
+): T;
+
+/**
+ * Assigns own enumerable properties of the source objects to `object` for every
+ * destination property that is `undefined`, matching lodash `defaults`. Earlier
+ * sources take precedence, `object` always wins over sources, and `object` is
+ * mutated and returned.
+ * @param object  The destination object (mutated).
+ * @param sources The source objects.
+ * @returns `object`.
+ */
+function defaults(
+	object: Record< string, unknown > | null | undefined,
+	...sources: Array< object | null | undefined >
+): object {
+	const objectProto = Object.prototype as Record< string, unknown >;
+	const hasOwn = Object.prototype.hasOwnProperty;
+
+	// `Object()` coerces a nullish destination to `{}`, like lodash.
+	const target = Object( object ) as Record< string, unknown >;
+	for ( const source of sources ) {
+		if ( source == null ) {
+			continue;
+		}
+		// Iterate own and inherited enumerable keys (lodash uses `keysIn`).
+		// eslint-disable-next-line guard-for-in
+		for ( const key in source ) {
+			const value = target[ key ];
+			// Assign when the destination resolves to `undefined`, or to an
+			// inherited `Object.prototype` value that isn't an own property (e.g.
+			// `constructor`, `toString`) — matching lodash `customDefaultsAssignIn`.
+			if (
+				value === undefined ||
+				( value === objectProto[ key ] && ! hasOwn.call( target, key ) )
+			) {
+				target[ key ] = ( source as Record< string, unknown > )[ key ];
+			}
+		}
+	}
+	return target;
+}
+
+export default defaults;

--- a/packages/js-utils/src/flow.ts
+++ b/packages/js-utils/src/flow.ts
@@ -1,0 +1,32 @@
+// Variadic function composition is inherently loosely typed; like lodash's own
+// types, the runtime is untyped and consumers rely on inference at the call.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunction = ( ...args: any[] ) => any;
+
+/**
+ * Creates a function that runs the given functions left-to-right, passing the
+ * result of each to the next, matching lodash `flow`. Functions may be passed
+ * variadically and/or in arrays (flattened one level); the first receives all
+ * arguments, the rest a single value. `this` is forwarded.
+ * @param funcs The functions to compose.
+ * @returns The composed function.
+ */
+const flow = ( ...funcs: Array< AnyFunction | readonly AnyFunction[] > ): AnyFunction => {
+	const fns = funcs.flat() as AnyFunction[];
+	// Validate up front, like lodash, rather than failing on first invocation.
+	for ( const fn of fns ) {
+		if ( typeof fn !== 'function' ) {
+			throw new TypeError( 'Expected a function' );
+		}
+	}
+	return function ( this: unknown, ...args ) {
+		let index = 0;
+		let result = fns.length ? fns[ 0 ].apply( this, args ) : args[ 0 ];
+		while ( ++index < fns.length ) {
+			result = fns[ index ].call( this, result );
+		}
+		return result;
+	};
+};
+
+export default flow;

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -1,7 +1,9 @@
 export { default as camelCase } from './camel-case';
 export { default as camelToSnakeCase } from './camel-to-snake-case';
 export { default as capitalize } from './capitalize';
+export { default as defaults } from './defaults';
 export { default as escapeRegExp } from './escape-reg-exp';
+export { default as flow } from './flow';
 export { default as groupBy } from './group-by';
 export { default as isError } from './is-error';
 export { default as kebabCase } from './kebab-case';

--- a/packages/js-utils/src/test/defaults.ts
+++ b/packages/js-utils/src/test/defaults.ts
@@ -1,0 +1,46 @@
+import defaults from '../defaults';
+
+describe( 'defaults', () => {
+	it( 'fills only undefined destination properties', () => {
+		expect( defaults( { a: 1 }, { a: 9, b: 2 } ) ).toEqual( { a: 1, b: 2 } );
+	} );
+
+	it( 'gives earlier sources precedence', () => {
+		expect( defaults( {}, { a: 1 }, { a: 2, b: 3 } ) ).toEqual( { a: 1, b: 3 } );
+	} );
+
+	it( 'lets a later source fill a key whose earlier source value was undefined', () => {
+		expect( defaults( {}, { a: undefined, b: 2 }, { a: 5 } ) ).toEqual( { a: 5, b: 2 } );
+	} );
+
+	it( 'skips nullish sources', () => {
+		expect( defaults( { a: 1 }, null, undefined, { b: 2 } ) ).toEqual( { a: 1, b: 2 } );
+	} );
+
+	it( 'mutates and returns the destination object', () => {
+		const target = { a: 1 };
+		const result = defaults( target, { b: 2 } );
+		expect( result ).toBe( target );
+		expect( target ).toEqual( { a: 1, b: 2 } );
+	} );
+
+	it( 'coerces a nullish destination to a new object, like lodash', () => {
+		// @ts-expect-error -- exercises runtime tolerance of a nullish destination.
+		expect( defaults( null, { a: 1 } ) ).toEqual( { a: 1 } );
+		// @ts-expect-error -- see above.
+		expect( defaults( undefined, { b: 2 } ) ).toEqual( { b: 2 } );
+	} );
+
+	it( 'copies inherited enumerable source properties, like lodash', () => {
+		const source = Object.create( { inherited: 9 } );
+		source.own = 1;
+		expect( defaults( {}, source ) ).toEqual( { own: 1, inherited: 9 } );
+	} );
+
+	it( 'fills keys that resolve through Object.prototype, like lodash', () => {
+		const result = defaults( {}, { constructor: 'x', toString: 'y', own: 1 } );
+		expect( result.constructor ).toBe( 'x' );
+		expect( result.toString ).toBe( 'y' );
+		expect( result.own ).toBe( 1 );
+	} );
+} );

--- a/packages/js-utils/src/test/flow.ts
+++ b/packages/js-utils/src/test/flow.ts
@@ -1,0 +1,60 @@
+import flow from '../flow';
+
+describe( 'flow', () => {
+	it( 'runs functions left-to-right', () => {
+		const composed = flow(
+			( x: number ) => x + 1,
+			( x: number ) => x * 2
+		);
+		expect( composed( 3 ) ).toBe( 8 );
+	} );
+
+	it( 'accepts an array of functions', () => {
+		const composed = flow( [ ( x: number ) => x + 1, ( x: number ) => x * 2 ] );
+		expect( composed( 3 ) ).toBe( 8 );
+	} );
+
+	it( 'flattens mixed array and variadic arguments one level', () => {
+		const composed = flow(
+			[ ( x: number ) => x + 1 ],
+			( x: number ) => x * 2,
+			( x: number ) => x - 3
+		);
+		expect( composed( 3 ) ).toBe( 5 );
+	} );
+
+	it( 'passes all arguments to the first function only', () => {
+		const composed = flow(
+			( a: number, b: number ) => a + b,
+			( x: number ) => x * 10
+		);
+		expect( composed( 2, 3 ) ).toBe( 50 );
+	} );
+
+	it( 'returns the first argument when no functions are given', () => {
+		expect( flow()( 42 ) ).toBe( 42 );
+	} );
+
+	it( 'throws up front when a composed value is not a function, like lodash', () => {
+		// @ts-expect-error -- exercises runtime validation of non-function values.
+		expect( () => flow( [ ( x: number ) => x, undefined ] ) ).toThrow( 'Expected a function' );
+		// @ts-expect-error -- see above.
+		expect( () => flow( ( x: number ) => x, 'nope' ) ).toThrow( TypeError );
+	} );
+
+	it( 'forwards `this` to the composed functions', () => {
+		const object = {
+			factor: 10,
+			scale: flow(
+				function ( this: { factor: number }, x: number ) {
+					return x + 1;
+				},
+				function ( this: { factor: number }, x: number ) {
+					return x * this.factor;
+				}
+			),
+		};
+		// ( 2 + 1 ) * this.factor; both functions receive `this` === object.
+		expect( object.scale( 2 ) ).toBe( 30 );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

Part of the incremental lodash removal. Migrates four more functions off `lodash`:

- **`flow`** and **`defaults`** move to new `@automattic/js-utils` helpers. `flow` composes functions left-to-right (variadic and array forms, flattened one level, `this` forwarded); `defaults` fills only `undefined` destination properties from own and inherited enumerable source keys, earlier sources winning, tolerating a nullish destination — mutating and returning it, like lodash.
- **`reject`** becomes `array.filter( ( item ) => ! … )` (object-match shorthands expanded to predicates; nullable collections guarded with `?? []`).
- **`concat`** becomes native `array.concat( … )` / `[].concat( ...arrays )`.

Adds the matching `no-restricted-imports` guard entries (named and deep `lodash/<fn>` imports) to prevent reintroduction. (It does not catch namespace/CJS access such as `_.reject` from `require( 'lodash' )` — e.g. the existing build-tools usage — which is outside `no-restricted-imports` and would need a separate member-expression rule.)

## Why are these changes being made?

Reducing the codebase's dependency on lodash, one small, low-risk batch at a time, replacing it with native JS or shared, tested helpers.

## Testing Instructions

- CI green: `yarn typecheck-client`, `yarn typecheck-packages`, lint, and unit tests all pass.
- The new helpers were validated against lodash as an oracle (flow: variadic/array/mixed/multi-arg; defaults: undefined-fill, multiple sources, nullish source/destination, inherited source props) with zero mismatches, and have unit tests under `packages/js-utils/src/test/`.
- No behavior change is expected at any usage; conversions preserve the prior semantics.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

