### PR TITLE
Plans: Prevent showing "Change plan" for non-downgradable plans

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -298,6 +298,7 @@ export const purchaseSettingsRoute = createRoute( {
 		cancelled?: true;
 		downgraded?: true;
 		plan_changed?: true;
+		delayed_downgrade_scheduled?: true;
 		intent?: 'auto-renew';
 	} => {
 		const isRefunded = search.refunded === true || search.refunded === 'true';
@@ -305,6 +306,8 @@ export const purchaseSettingsRoute = createRoute( {
 		const isCancelled = search.cancelled === true || search.cancelled === 'true';
 		const isDowngraded = search.downgraded === true || search.downgraded === 'true';
 		const isPlanChanged = search.plan_changed === true || search.plan_changed === 'true';
+		const isDelayedDowngradeScheduled =
+			search.delayed_downgrade_scheduled === true || search.delayed_downgrade_scheduled === 'true';
 		const intent = search.intent === 'auto-renew' ? ( 'auto-renew' as const ) : undefined;
 		return {
 			...( isRefunded ? { refunded: true } : {} ),
@@ -312,6 +315,7 @@ export const purchaseSettingsRoute = createRoute( {
 			...( isCancelled ? { cancelled: true } : {} ),
 			...( isDowngraded ? { downgraded: true } : {} ),
 			...( isPlanChanged ? { plan_changed: true } : {} ),
+			...( isDelayedDowngradeScheduled ? { delayed_downgrade_scheduled: true } : {} ),
 			...( intent ? { intent } : {} ),
 		};
 	},

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -471,14 +471,13 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
  *   - active downgradable plan (delayed downgrade) — `plans/delayed-downgrade`
  */
 function shouldShowChangePlan( purchase: Purchase ): boolean {
+	if ( ! purchase.is_plan || ! purchase.is_plan_type_downgradable ) {
+		return false;
+	}
 	const expiredOrRefundDowngrade =
 		config.isEnabled( 'plans/expired-downgrade' ) &&
-		( ( purchase.is_past_expiry_date && purchase.is_plan ) ||
-			isWithinRefundWindowDowngradeEligible( purchase ) );
-	const delayedDowngrade =
-		config.isEnabled( 'plans/delayed-downgrade' ) &&
-		purchase.is_plan &&
-		purchase.is_plan_type_downgradable;
+		( purchase.is_past_expiry_date || isWithinRefundWindowDowngradeEligible( purchase ) );
+	const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
 	return expiredOrRefundDowngrade || delayedDowngrade;
 }
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -464,19 +464,22 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 }
 
 /**
- * Whether the "Change plan" action should be offered for this purchase: either
- * the plan is past expiry (downgrade-to-checkout) or still within its refund
- * window (instant downgrade). Gated by the `plans/expired-downgrade` flag.
+ * Whether the "Change plan" action should be offered for this purchase. Covers
+ * three downgrade flows, each gated by its own flag:
+ *   - past expiry (downgrade-to-checkout) — `plans/expired-downgrade`
+ *   - within refund window (instant downgrade) — `plans/expired-downgrade`
+ *   - active downgradable plan (delayed downgrade) — `plans/delayed-downgrade`
  */
 function shouldShowChangePlan( purchase: Purchase ): boolean {
-	if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
-		return false;
-	}
-	return (
-		( purchase.is_past_expiry_date && purchase.is_plan ) ||
-		isWithinRefundWindowDowngradeEligible( purchase ) ||
-		( purchase.is_plan && purchase.is_plan_type_downgradable )
-	);
+	const expiredOrRefundDowngrade =
+		config.isEnabled( 'plans/expired-downgrade' ) &&
+		( ( purchase.is_past_expiry_date && purchase.is_plan ) ||
+			isWithinRefundWindowDowngradeEligible( purchase ) );
+	const delayedDowngrade =
+		config.isEnabled( 'plans/delayed-downgrade' ) &&
+		purchase.is_plan &&
+		purchase.is_plan_type_downgradable;
+	return expiredOrRefundDowngrade || delayedDowngrade;
 }
 
 function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -474,7 +474,8 @@ function shouldShowChangePlan( purchase: Purchase ): boolean {
 	}
 	return (
 		( purchase.is_past_expiry_date && purchase.is_plan ) ||
-		isWithinRefundWindowDowngradeEligible( purchase )
+		isWithinRefundWindowDowngradeEligible( purchase ) ||
+		( purchase.is_plan && purchase.is_plan_type_downgradable )
 	);
 }
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -658,6 +658,15 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 	}
 
 	const isPastExpiryDowngrade = purchase.is_past_expiry_date && purchase.is_plan;
+	const mode = ( () => {
+		if ( isPastExpiryDowngrade ) {
+			return 'expired';
+		}
+		if ( isWithinRefundWindowDowngradeEligible( purchase ) ) {
+			return 'refund-window';
+		}
+		return 'delayed-downgrade';
+	} )();
 
 	return (
 		<ActionList.ActionItem
@@ -670,7 +679,7 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_purchases_change_plan_click', {
 							product_slug: purchase.product_slug,
-							mode: isPastExpiryDowngrade ? 'expired' : 'refund-window',
+							mode,
 						} );
 						window.location.href = getExpiredNewPlanUrl( purchase );
 					} }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -209,7 +209,10 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		);
 	}
 
-	// Persistent warning notice when a delayed downgrade is pending.
+	// Persistent warning notice when a delayed downgrade is pending. Left ungated
+	// by `plans/delayed-downgrade` so a scheduled downgrade (and its cancel
+	// button) always stays visible, even if the flag is turned off as a kill
+	// switch while a downgrade is pending.
 	if ( purchase.is_delayed_downgrade_pending ) {
 		const slug = purchase.delayed_downgrade_to_product_slug;
 		const planNames = getPlanNames() as Record< string, string | undefined >;

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -57,6 +57,7 @@ import type { Purchase } from '@automattic/api-core';
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const locale = useLocale();
+	const { recordTracksEvent } = useAnalytics();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const {
 		refunded,
@@ -129,7 +130,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			} );
 		}
 	}, [ delayed_downgrade_scheduled, navigate ] );
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { mutate: cancelDelayedDowngrade, isPending: isCancellingDelayedDowngrade } = useMutation(
 		setDelayedDowngradeMutation()
 	);
@@ -255,7 +256,10 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 					<Button
 						variant="secondary"
 						size="compact"
-						onClick={ () =>
+						onClick={ () => {
+							recordTracksEvent( 'calypso_purchases_cancel_delayed_downgrade_click', {
+								purchase_id: purchase.ID,
+							} );
 							cancelDelayedDowngrade(
 								{ purchaseId: purchase.ID, enabled: false },
 								{
@@ -263,9 +267,16 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 										createSuccessNotice( __( 'Your scheduled downgrade has been cancelled.' ), {
 											type: 'snackbar',
 										} ),
+									onError: () =>
+										createErrorNotice(
+											__(
+												'There was a problem cancelling your scheduled downgrade. Please try again later or contact support.'
+											),
+											{ type: 'snackbar' }
+										),
 								}
-							)
-						}
+							);
+						} }
 						disabled={ isCancellingDelayedDowngrade }
 						isBusy={ isCancellingDelayedDowngrade }
 					>

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -15,8 +15,10 @@ import {
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { differenceInCalendarDays } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
@@ -125,6 +127,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			} );
 		}
 	}, [ delayed_downgrade_scheduled, navigate ] );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { mutate: cancelDelayedDowngrade, isPending: isCancellingDelayedDowngrade } = useMutation(
 		setDelayedDowngradeMutation()
 	);
@@ -217,10 +220,15 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 						variant="secondary"
 						size="compact"
 						onClick={ () =>
-							cancelDelayedDowngrade( {
-								purchaseId: purchase.ID,
-								enabled: false,
-							} )
+							cancelDelayedDowngrade(
+								{ purchaseId: purchase.ID, enabled: false },
+								{
+									onSuccess: () =>
+										createSuccessNotice( __( 'Your scheduled downgrade has been cancelled.' ), {
+											type: 'snackbar',
+										} ),
+								}
+							)
 						}
 						disabled={ isCancellingDelayedDowngrade }
 						isBusy={ isCancellingDelayedDowngrade }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,4 +1,9 @@
-import { DomainProductSlugs, DotcomPlans, WooHostedPlans } from '@automattic/api-core';
+import {
+	DomainProductSlugs,
+	DotcomPlans,
+	WooHostedPlans,
+	getPlanNames,
+} from '@automattic/api-core';
 import {
 	purchaseQuery,
 	sitePurchasesQuery,
@@ -203,14 +208,15 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 
 	// Transient success notice after scheduling a delayed downgrade.
 	if ( showDelayedDowngradeScheduledNotice ) {
-		const targetPlanName = purchase.delayed_downgrade_to_product_slug ?? null;
+		const slug = purchase.delayed_downgrade_to_product_slug;
+		const targetPlanName = slug ? getPlanNames()[ slug ] ?? null : null;
 		return (
 			<Notice variant="success" onClose={ () => setShowDelayedDowngradeScheduledNotice( false ) }>
 				{ targetPlanName
 					? sprintf(
-							// translators: %s is the name of the plan, e.g. "WordPress.com Personal"
+							// translators: %s is the name of the plan, e.g. "Personal"
 							__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
-							String( targetPlanName )
+							targetPlanName
 					  )
 					: __( 'Your plan downgrade has been scheduled for your next renewal.' ) }
 			</Notice>
@@ -219,13 +225,15 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 
 	// Persistent warning notice when a delayed downgrade is pending.
 	if ( purchase.is_delayed_downgrade_pending ) {
-		const targetPlanName = purchase.delayed_downgrade_to_product_slug ?? null;
+		const slug = purchase.delayed_downgrade_to_product_slug;
+		const targetPlanName = slug ? getPlanNames()[ slug ] ?? null : null;
 		return (
 			<Notice
 				variant="warning"
 				actions={
 					<Button
-						variant="tertiary"
+						variant="secondary"
+						size="compact"
 						onClick={ () =>
 							cancelDelayedDowngrade( {
 								purchaseId: purchase.ID,
@@ -241,9 +249,9 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			>
 				{ targetPlanName
 					? sprintf(
-							// translators: %s is the name of the plan, e.g. "WordPress.com Personal"
+							// translators: %s is the name of the plan, e.g. "Personal"
 							__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
-							String( targetPlanName )
+							targetPlanName
 					  )
 					: __( 'Your plan is scheduled to downgrade at your next renewal.' ) }
 			</Notice>

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -112,10 +112,8 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			} );
 		}
 	}, [ plan_changed, navigate ] );
-	// Transient success notice shown after scheduling a delayed downgrade.
-	const [ showDelayedDowngradeScheduledNotice, setShowDelayedDowngradeScheduledNotice ] = useState(
-		Boolean( delayed_downgrade_scheduled )
-	);
+	// Strip ?delayed_downgrade_scheduled from the URL on mount so refresh
+	// doesn't re-trigger anything; the persistent warning notice handles display.
 	useEffect( () => {
 		if ( delayed_downgrade_scheduled ) {
 			navigate( {
@@ -206,27 +204,11 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		);
 	}
 
-	// Transient success notice after scheduling a delayed downgrade.
-	if ( showDelayedDowngradeScheduledNotice ) {
-		const slug = purchase.delayed_downgrade_to_product_slug;
-		const targetPlanName = slug ? getPlanNames()[ slug ] ?? null : null;
-		return (
-			<Notice variant="success" onClose={ () => setShowDelayedDowngradeScheduledNotice( false ) }>
-				{ targetPlanName
-					? sprintf(
-							// translators: %s is the name of the plan, e.g. "Personal"
-							__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
-							targetPlanName
-					  )
-					: __( 'Your plan downgrade has been scheduled for your next renewal.' ) }
-			</Notice>
-		);
-	}
-
 	// Persistent warning notice when a delayed downgrade is pending.
 	if ( purchase.is_delayed_downgrade_pending ) {
 		const slug = purchase.delayed_downgrade_to_product_slug;
-		const targetPlanName = slug ? getPlanNames()[ slug ] ?? null : null;
+		const planNames = getPlanNames() as Record< string, string | undefined >;
+		const targetPlanName = slug ? planNames[ slug ] ?? null : null;
 		return (
 			<Notice
 				variant="warning"

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -90,7 +90,12 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	// Transient success notice shown after a change-plan checkout (upgrade or
 	// downgrade) redirects back here with `?plan_changed=true`. The param is
 	// stripped immediately so it doesn't survive a refresh or back navigation.
-	const [ showPlanChangedNotice, setShowPlanChangedNotice ] = useState( Boolean( plan_changed ) );
+	// Suppress the plan-changed notice when a delayed-downgrade notice is also
+	// present: plan_changed=true comes from the redirect_to template and is a
+	// red herring in that flow — the delayed-downgrade notice is the right one.
+	const [ showPlanChangedNotice, setShowPlanChangedNotice ] = useState(
+		Boolean( plan_changed ) && ! delayed_downgrade_scheduled
+	);
 	useEffect( () => {
 		if ( plan_changed ) {
 			navigate( {

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -5,6 +5,7 @@ import {
 	siteBySlugQuery,
 	userPreferenceMutation,
 	userPreferenceQuery,
+	setDelayedDowngradeMutation,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
@@ -48,8 +49,15 @@ import type { Purchase } from '@automattic/api-core';
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
-	const { refunded, upgraded, cancelled, downgraded, plan_changed, intent } =
-		purchaseSettingsRoute.useSearch();
+	const {
+		refunded,
+		upgraded,
+		cancelled,
+		downgraded,
+		plan_changed,
+		delayed_downgrade_scheduled,
+		intent,
+	} = purchaseSettingsRoute.useSearch();
 	const navigate = purchaseSettingsRoute.useNavigate();
 	// Show the transient cancelled success notice once after a cancel redirects
 	// here. The URL search param is cleared immediately so that a refresh / back
@@ -94,6 +102,24 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			} );
 		}
 	}, [ plan_changed, navigate ] );
+	// Transient success notice shown after scheduling a delayed downgrade.
+	const [ showDelayedDowngradeScheduledNotice, setShowDelayedDowngradeScheduledNotice ] = useState(
+		Boolean( delayed_downgrade_scheduled )
+	);
+	useEffect( () => {
+		if ( delayed_downgrade_scheduled ) {
+			navigate( {
+				search: ( prev: Record< string, unknown > ) => {
+					const { delayed_downgrade_scheduled: _delayed_downgrade_scheduled, ...rest } = prev;
+					return rest;
+				},
+				replace: true,
+			} );
+		}
+	}, [ delayed_downgrade_scheduled, navigate ] );
+	const { mutate: cancelDelayedDowngrade, isPending: isCancellingDelayedDowngrade } = useMutation(
+		setDelayedDowngradeMutation()
+	);
 	const { data: purchaseAttachedTo } = useQuery( {
 		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
 		enabled: Boolean( purchase.attached_to_purchase_id ),
@@ -166,6 +192,55 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 					__( 'Your plan has been updated to %s.' ),
 					purchase.product_name
 				) }
+			</Notice>
+		);
+	}
+
+	// Transient success notice after scheduling a delayed downgrade.
+	if ( showDelayedDowngradeScheduledNotice ) {
+		const targetPlanName = purchase.delayed_downgrade_to_product_slug ?? null;
+		return (
+			<Notice variant="success" onClose={ () => setShowDelayedDowngradeScheduledNotice( false ) }>
+				{ targetPlanName
+					? sprintf(
+							// translators: %s is the name of the plan, e.g. "WordPress.com Personal"
+							__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
+							String( targetPlanName )
+					  )
+					: __( 'Your plan downgrade has been scheduled for your next renewal.' ) }
+			</Notice>
+		);
+	}
+
+	// Persistent warning notice when a delayed downgrade is pending.
+	if ( purchase.is_delayed_downgrade_pending ) {
+		const targetPlanName = purchase.delayed_downgrade_to_product_slug ?? null;
+		return (
+			<Notice
+				variant="warning"
+				actions={
+					<Button
+						variant="tertiary"
+						onClick={ () =>
+							cancelDelayedDowngrade( {
+								purchaseId: purchase.ID,
+								enabled: false,
+							} )
+						}
+						disabled={ isCancellingDelayedDowngrade }
+						isBusy={ isCancellingDelayedDowngrade }
+					>
+						{ __( 'Cancel downgrade' ) }
+					</Button>
+				}
+			>
+				{ targetPlanName
+					? sprintf(
+							// translators: %s is the name of the plan, e.g. "WordPress.com Personal"
+							__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
+							String( targetPlanName )
+					  )
+					: __( 'Your plan is scheduled to downgrade at your next renewal.' ) }
 			</Notice>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -224,7 +224,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			if ( targetPlanName && renewalDate ) {
 				return sprintf(
 					// translators: %1$s is the name of the plan, e.g. "Personal"; %2$s is a date, e.g. "January 1, 2026"
-					__( 'Your plan is scheduled to downgrade to %1$s on %2$s.' ),
+					__( 'Your plan is scheduled to downgrade to %1$s at your next renewal on %2$s.' ),
 					targetPlanName,
 					renewalDate
 				);
@@ -232,7 +232,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			if ( renewalDate ) {
 				return sprintf(
 					// translators: %s is a date, e.g. "January 1, 2026"
-					__( 'Your plan is scheduled to downgrade on %s.' ),
+					__( 'Your plan is scheduled to downgrade at your next renewal on %s.' ),
 					renewalDate
 				);
 			}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -23,9 +23,10 @@ import { differenceInCalendarDays } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
+import { useLocale } from '../../../app/locale';
 import { changePaymentMethodRoute, purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
-import { getRelativeTimeString } from '../../../utils/datetime';
+import { formatDate, getRelativeTimeString } from '../../../utils/datetime';
 import { wpcomLink } from '../../../utils/link';
 import {
 	isExpired,
@@ -55,6 +56,7 @@ import type { Purchase } from '@automattic/api-core';
 
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
+	const locale = useLocale();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const {
 		refunded,
@@ -212,6 +214,37 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		const slug = purchase.delayed_downgrade_to_product_slug;
 		const planNames = getPlanNames() as Record< string, string | undefined >;
 		const targetPlanName = slug ? planNames[ slug ] ?? null : null;
+		// `renew_date` is the next auto-renewal attempt date, which for annual
+		// plans is up to 30 days before expiry. The downgrade takes effect on
+		// that renewal, so it's the accurate date to show the customer.
+		const renewalDate = purchase.renew_date
+			? formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } )
+			: null;
+		const getDelayedDowngradeMessage = () => {
+			if ( targetPlanName && renewalDate ) {
+				return sprintf(
+					// translators: %1$s is the name of the plan, e.g. "Personal"; %2$s is a date, e.g. "January 1, 2026"
+					__( 'Your plan is scheduled to downgrade to %1$s on %2$s.' ),
+					targetPlanName,
+					renewalDate
+				);
+			}
+			if ( renewalDate ) {
+				return sprintf(
+					// translators: %s is a date, e.g. "January 1, 2026"
+					__( 'Your plan is scheduled to downgrade on %s.' ),
+					renewalDate
+				);
+			}
+			if ( targetPlanName ) {
+				return sprintf(
+					// translators: %s is the name of the plan, e.g. "Personal"
+					__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
+					targetPlanName
+				);
+			}
+			return __( 'Your plan is scheduled to downgrade at your next renewal.' );
+		};
 		return (
 			<Notice
 				variant="warning"
@@ -237,13 +270,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 					</Button>
 				}
 			>
-				{ targetPlanName
-					? sprintf(
-							// translators: %s is the name of the plan, e.g. "Personal"
-							__( 'Your plan is scheduled to downgrade to %s at your next renewal.' ),
-							targetPlanName
-					  )
-					: __( 'Your plan is scheduled to downgrade at your next renewal.' ) }
+				{ getDelayedDowngradeMessage() }
 			</Notice>
 		);
 	}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -728,6 +728,7 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
  */
 export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
 	return (
+		purchase.is_plan_type_downgradable &&
 		purchase.is_plan &&
 		purchase.is_within_initial_refund_window &&
 		! isExpired( purchase ) &&

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -617,12 +617,14 @@ class ManagePurchase extends Component<
 		if ( ! purchase || ! isPlan( purchase ) ) {
 			return false;
 		}
+		if ( ! purchase.isPlanTypeDowngradable ) {
+			return false;
+		}
 		const expiredOrRefundDowngrade =
 			config.isEnabled( 'plans/expired-downgrade' ) &&
 			( isInExpirationGracePeriod( purchase ) ||
 				isWithinRefundWindowDowngradeEligible( purchase ) );
-		const delayedDowngrade =
-			config.isEnabled( 'plans/delayed-downgrade' ) && purchase.isPlanTypeDowngradable;
+		const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
 		return expiredOrRefundDowngrade || delayedDowngrade;
 	}
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -614,17 +614,16 @@ class ManagePurchase extends Component<
 
 	shouldRenderDowngradeOption(): boolean {
 		const { purchase } = this.props;
-		if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
-			return false;
-		}
 		if ( ! purchase || ! isPlan( purchase ) ) {
 			return false;
 		}
-		return (
-			isInExpirationGracePeriod( purchase ) ||
-			isWithinRefundWindowDowngradeEligible( purchase ) ||
-			purchase.isPlanTypeDowngradable
-		);
+		const expiredOrRefundDowngrade =
+			config.isEnabled( 'plans/expired-downgrade' ) &&
+			( isInExpirationGracePeriod( purchase ) ||
+				isWithinRefundWindowDowngradeEligible( purchase ) );
+		const delayedDowngrade =
+			config.isEnabled( 'plans/delayed-downgrade' ) && purchase.isPlanTypeDowngradable;
+		return expiredOrRefundDowngrade || delayedDowngrade;
 	}
 
 	renderChangePlanNavItem() {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -620,13 +620,11 @@ class ManagePurchase extends Component<
 		if ( ! purchase || ! isPlan( purchase ) ) {
 			return false;
 		}
-		if (
-			! isInExpirationGracePeriod( purchase ) &&
-			! isWithinRefundWindowDowngradeEligible( purchase )
-		) {
-			return false;
-		}
-		return true;
+		return (
+			isInExpirationGracePeriod( purchase ) ||
+			isWithinRefundWindowDowngradeEligible( purchase ) ||
+			purchase.isPlanTypeDowngradable
+		);
 	}
 
 	renderChangePlanNavItem() {

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1558,10 +1558,13 @@ class PurchaseNotice extends Component<
 			return planChangedRedirectNotice;
 		}
 
-		// Transient success notice after scheduling a delayed downgrade.
-		const delayedDowngradeScheduledNotice = this.renderDelayedDowngradeScheduledNotice();
-		if ( delayedDowngradeScheduledNotice ) {
-			return delayedDowngradeScheduledNotice;
+		// Transient success notice after scheduling — only shown when the
+		// persistent warning isn't available yet (e.g. data still loading).
+		if ( ! purchase.isDelayedDowngradePending ) {
+			const delayedDowngradeScheduledNotice = this.renderDelayedDowngradeScheduledNotice();
+			if ( delayedDowngradeScheduledNotice ) {
+				return delayedDowngradeScheduledNotice;
+			}
 		}
 
 		// Persistent warning notice when a delayed downgrade is pending.

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -122,9 +122,12 @@ class PurchaseNotice extends Component<
 		showDowngradedRedirectNotice:
 			typeof window !== 'undefined' &&
 			new URLSearchParams( window.location.search ).get( 'downgraded' ) === 'true',
+		// Suppressed when delayed_downgrade_scheduled is also present: plan_changed=true
+		// comes from the redirect_to template and is a red herring in that flow.
 		showPlanChangedRedirectNotice:
 			typeof window !== 'undefined' &&
-			new URLSearchParams( window.location.search ).get( 'plan_changed' ) === 'true',
+			new URLSearchParams( window.location.search ).get( 'plan_changed' ) === 'true' &&
+			new URLSearchParams( window.location.search ).get( 'delayed_downgrade_scheduled' ) !== 'true',
 		// Seeded from `?delayed_downgrade_scheduled=true` on first render.
 		// The URL param is cleared in componentDidMount.
 		showDelayedDowngradeScheduledNotice:

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -17,11 +17,10 @@ import {
 import page from '@automattic/calypso-router';
 import { minBy } from '@automattic/js-utils';
 import { useMutation } from '@tanstack/react-query';
-import { localize } from 'i18n-calypso';
-import { isEmpty, merge } from 'lodash';
+import { localize, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice, { NoticeStatus } from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -56,6 +55,7 @@ import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getAddNewPaymentMethodPath } from '../utils';
 import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -775,7 +775,7 @@ class PurchaseNotice extends Component<
 		const otherRenewableSitePurchases = renewableSitePurchases.filter(
 			( otherPurchase ) => otherPurchase.id !== currentPurchase.id
 		);
-		if ( isEmpty( otherRenewableSitePurchases ) ) {
+		if ( ! otherRenewableSitePurchases.length ) {
 			return null;
 		}
 
@@ -1085,15 +1085,17 @@ class PurchaseNotice extends Component<
 				noticeText = creditCardHasAlreadyExpired( currentPurchase )
 					? translate(
 							'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
-							merge( translateOptions, {
+							{
+								...translateOptions,
 								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
-							} )
+							}
 					  )
 					: translate(
 							'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
-							merge( translateOptions, {
+							{
+								...translateOptions,
 								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
-							} )
+							}
 					  );
 			}
 		}
@@ -1220,15 +1222,17 @@ class PurchaseNotice extends Component<
 				noticeText = creditCardHasAlreadyExpired( currentPurchase )
 					? translate(
 							'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
-							merge( translateOptions, {
+							{
+								...translateOptions,
 								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
-							} )
+							}
 					  )
 					: translate(
 							'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
-							merge( translateOptions, {
+							{
+								...translateOptions,
 								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
-							} )
+							}
 					  );
 			}
 		}
@@ -1690,11 +1694,36 @@ const ConnectedPurchaseNotice = connect( null, { recordTracksEvent } )(
 
 function PurchaseNoticeWithExperiment( props: PurchaseNoticeProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const { mutate: cancelDelayedDowngrade, isPending: isCancellingDelayedDowngrade } = useMutation(
 		setDelayedDowngradeMutation()
 	);
 	const onCancelDelayedDowngrade = () => {
-		cancelDelayedDowngrade( { purchaseId: props.purchase.id, enabled: false } );
+		dispatch(
+			recordTracksEvent( 'calypso_purchases_cancel_delayed_downgrade_click', {
+				purchase_id: props.purchase.id,
+			} )
+		);
+		cancelDelayedDowngrade(
+			{ purchaseId: props.purchase.id, enabled: false },
+			{
+				onSuccess: () =>
+					dispatch(
+						successNotice( translate( 'Your scheduled downgrade has been cancelled.' ), {
+							duration: 5000,
+						} )
+					),
+				onError: () =>
+					dispatch(
+						errorNotice(
+							translate(
+								'There was a problem cancelling your scheduled downgrade. Please try again later or contact support.'
+							)
+						)
+					),
+			}
+		);
 	};
 	return (
 		<ConnectedPurchaseNotice

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1607,6 +1607,11 @@ class PurchaseNotice extends Component<
 			return planChangedRedirectNotice;
 		}
 
+		// These delayed-downgrade notices are intentionally left ungated by
+		// `plans/delayed-downgrade` so a scheduled downgrade (and its cancel
+		// button) always stays visible, even if the flag is turned off as a kill
+		// switch while a downgrade is pending.
+		//
 		// Transient success notice after scheduling — only shown when the
 		// persistent warning isn't available yet (e.g. data still loading).
 		if ( ! purchase.isDelayedDowngradePending ) {

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1,3 +1,4 @@
+import { setDelayedDowngradeMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import {
 	getPlan,
@@ -15,6 +16,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { minBy } from '@automattic/js-utils';
+import { useMutation } from '@tanstack/react-query';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge } from 'lodash';
 import moment from 'moment';
@@ -83,6 +85,10 @@ export interface PurchaseNoticeProps {
 	renewableSitePurchases: Purchase[];
 	selectedSite: SiteDetails | null | undefined;
 	willAtomicSiteRevert?: boolean;
+	/** Called when the user clicks the cancel button on the pending delayed-downgrade notice. */
+	onCancelDelayedDowngrade?: () => void;
+	/** True while the cancel-delayed-downgrade API call is in flight. */
+	isCancellingDelayedDowngrade?: boolean;
 }
 
 export interface PurchaseNoticeConnectedProps {
@@ -119,6 +125,11 @@ class PurchaseNotice extends Component<
 		showPlanChangedRedirectNotice:
 			typeof window !== 'undefined' &&
 			new URLSearchParams( window.location.search ).get( 'plan_changed' ) === 'true',
+		// Seeded from `?delayed_downgrade_scheduled=true` on first render.
+		// The URL param is cleared in componentDidMount.
+		showDelayedDowngradeScheduledNotice:
+			typeof window !== 'undefined' &&
+			new URLSearchParams( window.location.search ).get( 'delayed_downgrade_scheduled' ) === 'true',
 	};
 
 	componentDidMount() {
@@ -140,6 +151,10 @@ class PurchaseNotice extends Component<
 			params.delete( 'plan_changed' );
 			changed = true;
 		}
+		if ( params.get( 'delayed_downgrade_scheduled' ) === 'true' ) {
+			params.delete( 'delayed_downgrade_scheduled' );
+			changed = true;
+		}
 		if ( changed ) {
 			const newSearch = params.toString();
 			const newUrl =
@@ -159,6 +174,56 @@ class PurchaseNotice extends Component<
 	dismissPlanChangedRedirectNotice = () => {
 		this.setState( { showPlanChangedRedirectNotice: false } );
 	};
+
+	dismissDelayedDowngradeScheduledNotice = () => {
+		this.setState( { showDelayedDowngradeScheduledNotice: false } );
+	};
+
+	/**
+	 * Persistent notice shown when a delayed downgrade is pending on this
+	 * purchase. Includes a cancel button. Suppressed by transient notices.
+	 */
+	renderDelayedDowngradePendingNotice() {
+		const { purchase, translate, onCancelDelayedDowngrade, isCancellingDelayedDowngrade } =
+			this.props;
+
+		if ( ! purchase.isDelayedDowngradePending ) {
+			return null;
+		}
+
+		const targetPlanName = purchase.delayedDowngradeToProductSlug
+			? getPlan( purchase.delayedDowngradeToProductSlug )?.getTitle() ??
+			  purchase.delayedDowngradeToProductSlug
+			: null;
+
+		const noticeText = targetPlanName
+			? translate(
+					'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
+					{
+						args: { targetPlanName: String( targetPlanName ) },
+						comment:
+							'Warning notice shown when a plan downgrade is scheduled for the end of the billing term',
+					}
+			  )
+			: translate( 'Your plan is scheduled to downgrade at your next renewal.' );
+
+		return (
+			<Notice
+				className="manage-purchase__delayed-downgrade-pending-notice"
+				showDismiss={ false }
+				status="is-warning"
+				text={ noticeText }
+			>
+				{ onCancelDelayedDowngrade && (
+					<NoticeAction onClick={ onCancelDelayedDowngrade }>
+						{ isCancellingDelayedDowngrade
+							? translate( 'Cancelling…' )
+							: translate( 'Cancel downgrade' ) }
+					</NoticeAction>
+				) }
+			</Notice>
+		);
+	}
 
 	/**
 	 * Transient success notice shown after a cancel-flow redirect. Suppresses
@@ -271,6 +336,36 @@ class PurchaseNotice extends Component<
 				text={ translate( 'Your plan has been updated to %(planName)s.', {
 					args: { planName: getName( purchase ) },
 				} ) }
+			/>
+		);
+	}
+
+	renderDelayedDowngradeScheduledNotice() {
+		const { purchase, translate } = this.props;
+		if ( ! this.state.showDelayedDowngradeScheduledNotice || ! purchase ) {
+			return null;
+		}
+		const targetPlanName = purchase.delayedDowngradeToProductSlug
+			? getPlan( purchase.delayedDowngradeToProductSlug )?.getTitle() ??
+			  purchase.delayedDowngradeToProductSlug
+			: null;
+		const text = targetPlanName
+			? translate(
+					'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
+					{
+						args: { targetPlanName: String( targetPlanName ) },
+						comment:
+							'Success notice shown after scheduling a plan downgrade for end of billing term',
+					}
+			  )
+			: translate( 'Your plan downgrade has been scheduled for your next renewal.' );
+		return (
+			<Notice
+				className="manage-purchase__purchase-expiring-notice"
+				showDismiss
+				onDismissClick={ this.dismissDelayedDowngradeScheduledNotice }
+				status="is-success"
+				text={ text }
 			/>
 		);
 	}
@@ -1460,6 +1555,18 @@ class PurchaseNotice extends Component<
 			return planChangedRedirectNotice;
 		}
 
+		// Transient success notice after scheduling a delayed downgrade.
+		const delayedDowngradeScheduledNotice = this.renderDelayedDowngradeScheduledNotice();
+		if ( delayedDowngradeScheduledNotice ) {
+			return delayedDowngradeScheduledNotice;
+		}
+
+		// Persistent warning notice when a delayed downgrade is pending.
+		const delayedDowngradePendingNotice = this.renderDelayedDowngradePendingNotice();
+		if ( delayedDowngradePendingNotice ) {
+			return delayedDowngradePendingNotice;
+		}
+
 		if ( purchase.asyncPendingPaymentBlockIsSet ) {
 			return this.renderAsyncPendingPaymentNotice();
 		}
@@ -1523,10 +1630,18 @@ const ConnectedPurchaseNotice = connect( null, { recordTracksEvent } )(
 
 function PurchaseNoticeWithExperiment( props: PurchaseNoticeProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
+	const { mutate: cancelDelayedDowngrade, isPending: isCancellingDelayedDowngrade } = useMutation(
+		setDelayedDowngradeMutation()
+	);
+	const onCancelDelayedDowngrade = () => {
+		cancelDelayedDowngrade( { purchaseId: props.purchase.id, enabled: false } );
+	};
 	return (
 		<ConnectedPurchaseNotice
 			{ ...props }
 			isSplitCancelRemoveEnabled={ isSplitCancelRemoveEnabled }
+			onCancelDelayedDowngrade={ onCancelDelayedDowngrade }
+			isCancellingDelayedDowngrade={ isCancellingDelayedDowngrade }
 		/>
 	);
 }

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -208,17 +208,20 @@ class PurchaseNotice extends Component<
 		let noticeText;
 		if ( targetPlanName && renewalDate ) {
 			noticeText = translate(
-				'Your plan is scheduled to downgrade to %(targetPlanName)s on %(renewalDate)s.',
+				'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal on %(renewalDate)s.',
 				{
 					args: { targetPlanName: String( targetPlanName ), renewalDate },
 					comment: 'Warning notice shown when a plan downgrade is scheduled for a renewal date',
 				}
 			);
 		} else if ( renewalDate ) {
-			noticeText = translate( 'Your plan is scheduled to downgrade on %(renewalDate)s.', {
-				args: { renewalDate },
-				comment: 'Warning notice shown when a plan downgrade is scheduled for a renewal date',
-			} );
+			noticeText = translate(
+				'Your plan is scheduled to downgrade at your next renewal on %(renewalDate)s.',
+				{
+					args: { renewalDate },
+					comment: 'Warning notice shown when a plan downgrade is scheduled for a renewal date',
+				}
+			);
 		} else if ( targetPlanName ) {
 			noticeText = translate(
 				'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
@@ -383,17 +386,20 @@ class PurchaseNotice extends Component<
 		let text;
 		if ( targetPlanName && renewalDate ) {
 			text = translate(
-				'Your plan is scheduled to downgrade to %(targetPlanName)s on %(renewalDate)s.',
+				'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal on %(renewalDate)s.',
 				{
 					args: { targetPlanName: String( targetPlanName ), renewalDate },
 					comment: 'Success notice shown after scheduling a plan downgrade for a renewal date',
 				}
 			);
 		} else if ( renewalDate ) {
-			text = translate( 'Your plan is scheduled to downgrade on %(renewalDate)s.', {
-				args: { renewalDate },
-				comment: 'Success notice shown after scheduling a plan downgrade for a renewal date',
-			} );
+			text = translate(
+				'Your plan is scheduled to downgrade at your next renewal on %(renewalDate)s.',
+				{
+					args: { renewalDate },
+					comment: 'Success notice shown after scheduling a plan downgrade for a renewal date',
+				}
+			);
 		} else if ( targetPlanName ) {
 			text = translate(
 				'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -198,17 +198,39 @@ class PurchaseNotice extends Component<
 			? getPlan( purchase.delayedDowngradeToProductSlug )?.getTitle() ??
 			  purchase.delayedDowngradeToProductSlug
 			: null;
+		// `renewDate` is the next auto-renewal attempt date, which for annual
+		// plans is up to 30 days before expiry. The downgrade takes effect on
+		// that renewal, so it's the accurate date to show the customer.
+		const renewalDate = purchase.renewDate
+			? this.props.moment( purchase.renewDate ).format( 'LL' )
+			: null;
 
-		const noticeText = targetPlanName
-			? translate(
-					'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
-					{
-						args: { targetPlanName: String( targetPlanName ) },
-						comment:
-							'Warning notice shown when a plan downgrade is scheduled for the end of the billing term',
-					}
-			  )
-			: translate( 'Your plan is scheduled to downgrade at your next renewal.' );
+		let noticeText;
+		if ( targetPlanName && renewalDate ) {
+			noticeText = translate(
+				'Your plan is scheduled to downgrade to %(targetPlanName)s on %(renewalDate)s.',
+				{
+					args: { targetPlanName: String( targetPlanName ), renewalDate },
+					comment: 'Warning notice shown when a plan downgrade is scheduled for a renewal date',
+				}
+			);
+		} else if ( renewalDate ) {
+			noticeText = translate( 'Your plan is scheduled to downgrade on %(renewalDate)s.', {
+				args: { renewalDate },
+				comment: 'Warning notice shown when a plan downgrade is scheduled for a renewal date',
+			} );
+		} else if ( targetPlanName ) {
+			noticeText = translate(
+				'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
+				{
+					args: { targetPlanName: String( targetPlanName ) },
+					comment:
+						'Warning notice shown when a plan downgrade is scheduled for the end of the billing term',
+				}
+			);
+		} else {
+			noticeText = translate( 'Your plan is scheduled to downgrade at your next renewal.' );
+		}
 
 		return (
 			<Notice
@@ -352,16 +374,37 @@ class PurchaseNotice extends Component<
 			? getPlan( purchase.delayedDowngradeToProductSlug )?.getTitle() ??
 			  purchase.delayedDowngradeToProductSlug
 			: null;
-		const text = targetPlanName
-			? translate(
-					'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
-					{
-						args: { targetPlanName: String( targetPlanName ) },
-						comment:
-							'Success notice shown after scheduling a plan downgrade for end of billing term',
-					}
-			  )
-			: translate( 'Your plan downgrade has been scheduled for your next renewal.' );
+		// `renewDate` is the next auto-renewal attempt date (up to 30 days before
+		// expiry for annual plans) — the date the scheduled downgrade takes effect.
+		const renewalDate = purchase.renewDate
+			? this.props.moment( purchase.renewDate ).format( 'LL' )
+			: null;
+
+		let text;
+		if ( targetPlanName && renewalDate ) {
+			text = translate(
+				'Your plan is scheduled to downgrade to %(targetPlanName)s on %(renewalDate)s.',
+				{
+					args: { targetPlanName: String( targetPlanName ), renewalDate },
+					comment: 'Success notice shown after scheduling a plan downgrade for a renewal date',
+				}
+			);
+		} else if ( renewalDate ) {
+			text = translate( 'Your plan is scheduled to downgrade on %(renewalDate)s.', {
+				args: { renewalDate },
+				comment: 'Success notice shown after scheduling a plan downgrade for a renewal date',
+			} );
+		} else if ( targetPlanName ) {
+			text = translate(
+				'Your plan is scheduled to downgrade to %(targetPlanName)s at your next renewal.',
+				{
+					args: { targetPlanName: String( targetPlanName ) },
+					comment: 'Success notice shown after scheduling a plan downgrade for end of billing term',
+				}
+			);
+		} else {
+			text = translate( 'Your plan downgrade has been scheduled for your next renewal.' );
+		}
 		return (
 			<Notice
 				className="manage-purchase__purchase-expiring-notice"

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
@@ -9,6 +10,7 @@ import PurchaseNotice from '../notices';
 
 describe( 'PurchaseNotice', () => {
 	const store = createReduxStore();
+	const queryClient = new QueryClient();
 	const futureYearDate = new Date();
 	futureYearDate.setFullYear( futureYearDate.getFullYear() + 10 );
 	const pastYearDate = new Date();
@@ -40,12 +42,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -58,7 +62,9 @@ describe( 'PurchaseNotice', () => {
 	it( 'renders nothing when data is still loading', () => {
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice isDataLoading renewableSitePurchases={ [] } />
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice isDataLoading renewableSitePurchases={ [] } />
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.container ).toBeFalsy();
@@ -68,7 +74,9 @@ describe( 'PurchaseNotice', () => {
 		const purchase = { product_slug: 'domain_transfer' };
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice purchase={ purchase } renewableSitePurchases={ [] } />
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice purchase={ purchase } renewableSitePurchases={ [] } />
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.container ).toBeFalsy();
@@ -78,11 +86,13 @@ describe( 'PurchaseNotice', () => {
 		const purchase = { product_slug: 'something_else' };
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner={ false }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner={ false }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -94,7 +104,9 @@ describe( 'PurchaseNotice', () => {
 		const purchase = { product_slug: 'concierge-session', expiryStatus: 'expired' };
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice purchase={ purchase } isProductOwner renewableSitePurchases={ [] } />
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice purchase={ purchase } isProductOwner renewableSitePurchases={ [] } />
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.getByText( 'This session has been used.' ) ).toBeInTheDocument();
@@ -112,12 +124,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -146,12 +160,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -185,13 +201,15 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					purchaseAttachedTo={ plan }
-					isProductOwner
-					renewableSitePurchases={ [] }
-					selectedSite={ { slug: 'testingsite' } }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						purchaseAttachedTo={ plan }
+						isProductOwner
+						renewableSitePurchases={ [] }
+						selectedSite={ { slug: 'testingsite' } }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.getByText( 'Premium plan' ) ).toBeInTheDocument();
@@ -210,12 +228,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -233,12 +253,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -257,12 +279,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -281,12 +305,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.container ).toBeFalsy();
@@ -303,12 +329,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.container ).toBeFalsy();
@@ -335,13 +363,15 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					purchaseAttachedTo={ plan }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						purchaseAttachedTo={ plan }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.getByText( 'Premium plan' ) ).toBeInTheDocument();
@@ -362,12 +392,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -388,12 +420,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -413,12 +447,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect(
@@ -449,12 +485,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.getByText( /Your VISA ending in 1111 expired/ ) ).toBeInTheDocument();
@@ -483,12 +521,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.container ).toBeFalsy();
@@ -516,12 +556,14 @@ describe( 'PurchaseNotice', () => {
 		};
 		render(
 			<ReduxProvider store={ store }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isProductOwner
-					selectedSite={ { slug: 'testingsite' } }
-					renewableSitePurchases={ [] }
-				/>
+				<QueryClientProvider client={ queryClient }>
+					<PurchaseNotice
+						purchase={ purchase }
+						isProductOwner
+						selectedSite={ { slug: 'testingsite' } }
+						renewableSitePurchases={ [] }
+					/>
+				</QueryClientProvider>
 			</ReduxProvider>
 		);
 		expect( screen.container ).toBeFalsy();

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -23,6 +23,11 @@ interface DowngradeConfirmationModalProps {
 	 * performed immediately. The confirm button reflects the scheduled nature.
 	 */
 	isDelayedDowngrade?: boolean;
+	/**
+	 * Pre-formatted, localized date of the next renewal (e.g. "January 1, 2026"),
+	 * when the scheduled downgrade will take effect. Shown for delayed downgrades.
+	 */
+	renewalDate?: string;
 	/** Pre-formatted, localized refund amount (e.g. "$48.00"). */
 	refundText?: string;
 	/** When true, the confirm action is in flight; disable buttons and show a spinner. */
@@ -38,6 +43,7 @@ function ModalBody( {
 	lostFeatures,
 	isInstantDowngrade,
 	isDelayedDowngrade,
+	renewalDate,
 	refundText,
 }: {
 	isLoading: boolean;
@@ -46,6 +52,7 @@ function ModalBody( {
 	lostFeatures: { feature_id: string; title: string }[];
 	isInstantDowngrade?: boolean;
 	isDelayedDowngrade?: boolean;
+	renewalDate?: string;
 	refundText?: string;
 } ) {
 	const translate = useTranslate();
@@ -62,14 +69,27 @@ function ModalBody( {
 		return (
 			<>
 				<p className="downgrade-confirmation-modal__description">
-					{ translate(
-						'Your plan will change from %(currentPlan)s to %(targetPlan)s at your next renewal. Until then you’ll continue using %(currentPlan)s.',
-						{
-							args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
-							comment:
-								'Message shown when scheduling a plan downgrade for end of the current billing term',
-						}
-					) }
+					{ renewalDate
+						? translate(
+								'Your plan will change from %(currentPlan)s to %(targetPlan)s on %(renewalDate)s. Until then you’ll continue using %(currentPlan)s.',
+								{
+									args: {
+										currentPlan: currentPlanName,
+										targetPlan: targetPlanName,
+										renewalDate,
+									},
+									comment:
+										'Message shown when scheduling a plan downgrade for a specific renewal date',
+								}
+						  )
+						: translate(
+								'Your plan will change from %(currentPlan)s to %(targetPlan)s at your next renewal. Until then you’ll continue using %(currentPlan)s.',
+								{
+									args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
+									comment:
+										'Message shown when scheduling a plan downgrade for end of the current billing term',
+								}
+						  ) }
 				</p>
 				{ lostFeatures.length > 0 && (
 					<>
@@ -165,6 +185,7 @@ const DowngradeConfirmationModal = ( {
 	purchaseId,
 	isInstantDowngrade,
 	isDelayedDowngrade,
+	renewalDate,
 	refundText,
 	isConfirming,
 	onClose,
@@ -225,6 +246,7 @@ const DowngradeConfirmationModal = ( {
 				lostFeatures={ lostFeatures }
 				isInstantDowngrade={ isInstantDowngrade }
 				isDelayedDowngrade={ isDelayedDowngrade }
+				renewalDate={ renewalDate }
 				refundText={ refundText }
 			/>
 			<div className="downgrade-confirmation-modal__buttons">

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -18,6 +18,11 @@ interface DowngradeConfirmationModalProps {
 	 * confirm button reflects the refund.
 	 */
 	isInstantDowngrade?: boolean;
+	/**
+	 * When true, the downgrade is scheduled for end-of-term rather than
+	 * performed immediately. The confirm button reflects the scheduled nature.
+	 */
+	isDelayedDowngrade?: boolean;
 	/** Pre-formatted, localized refund amount (e.g. "$48.00"). */
 	refundText?: string;
 	/** When true, the confirm action is in flight; disable buttons and show a spinner. */
@@ -32,6 +37,7 @@ function ModalBody( {
 	targetPlanName,
 	lostFeatures,
 	isInstantDowngrade,
+	isDelayedDowngrade,
 	refundText,
 }: {
 	isLoading: boolean;
@@ -39,6 +45,7 @@ function ModalBody( {
 	targetPlanName: string;
 	lostFeatures: { feature_id: string; title: string }[];
 	isInstantDowngrade?: boolean;
+	isDelayedDowngrade?: boolean;
 	refundText?: string;
 } ) {
 	const translate = useTranslate();
@@ -48,6 +55,50 @@ function ModalBody( {
 			<div className="downgrade-confirmation-modal__loading">
 				<Spinner />
 			</div>
+		);
+	}
+
+	if ( isDelayedDowngrade ) {
+		return (
+			<>
+				<p className="downgrade-confirmation-modal__description">
+					{ translate(
+						'Your plan will change from %(currentPlan)s to %(targetPlan)s at your next renewal. Until then you’ll continue using %(currentPlan)s.',
+						{
+							args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
+							comment:
+								'Message shown when scheduling a plan downgrade for end of the current billing term',
+						}
+					) }
+				</p>
+				{ lostFeatures.length > 0 && (
+					<>
+						<p className="downgrade-confirmation-modal__description">
+							{ translate( 'When the change takes effect, here’s what you’ll lose:', {
+								comment:
+									'Intro line before the list of features that will be lost at the delayed downgrade',
+							} ) }
+						</p>
+						<ul className="downgrade-confirmation-modal__feature-list">
+							{ lostFeatures.map( ( feature ) => (
+								<li
+									key={ feature.feature_id }
+									className="downgrade-confirmation-modal__feature-item"
+								>
+									<Gridicon
+										icon="cross-small"
+										size={ 24 }
+										className="downgrade-confirmation-modal__feature-icon"
+									/>
+									<span className="downgrade-confirmation-modal__feature-text">
+										{ feature.title }
+									</span>
+								</li>
+							) ) }
+						</ul>
+					</>
+				) }
+			</>
 		);
 	}
 
@@ -113,6 +164,7 @@ const DowngradeConfirmationModal = ( {
 	targetPlanSlug,
 	purchaseId,
 	isInstantDowngrade,
+	isDelayedDowngrade,
 	refundText,
 	isConfirming,
 	onClose,
@@ -137,9 +189,33 @@ const DowngradeConfirmationModal = ( {
 
 	const lostFeatures = cancelFeaturesData?.features ?? [];
 
+	const title = isDelayedDowngrade
+		? String( translate( 'Schedule downgrade' ) )
+		: String( translate( 'Confirm downgrade' ) );
+
+	const confirmButtonLabel = ( () => {
+		if ( isDelayedDowngrade ) {
+			return translate( 'Schedule downgrade to %(planName)s', {
+				args: { planName: targetPlanName },
+				comment: 'Button label to confirm scheduling a plan downgrade for end of billing term',
+			} );
+		}
+		if ( isInstantDowngrade && refundText ) {
+			return translate( 'Downgrade and refund %(refundText)s', {
+				args: { refundText },
+				comment:
+					'Button label to confirm an instant downgrade that issues a refund of the given amount',
+			} );
+		}
+		return translate( 'Downgrade to %(planName)s', {
+			args: { planName: targetPlanName },
+			comment: 'Button label to confirm downgrading to a lower-tier plan',
+		} );
+	} )();
+
 	return (
 		<Modal
-			title={ String( translate( 'Confirm downgrade' ) ) }
+			title={ title }
 			onRequestClose={ onClose }
 			className="downgrade-confirmation-modal"
 			size="medium"
@@ -150,6 +226,7 @@ const DowngradeConfirmationModal = ( {
 				targetPlanName={ targetPlanName }
 				lostFeatures={ lostFeatures }
 				isInstantDowngrade={ isInstantDowngrade }
+				isDelayedDowngrade={ isDelayedDowngrade }
 				refundText={ refundText }
 			/>
 			<div className="downgrade-confirmation-modal__buttons">
@@ -171,16 +248,7 @@ const DowngradeConfirmationModal = ( {
 					isBusy={ isConfirming }
 					disabled={ isConfirming }
 				>
-					{ isInstantDowngrade && refundText
-						? translate( 'Downgrade and refund %(refundText)s', {
-								args: { refundText },
-								comment:
-									'Button label to confirm an instant downgrade that issues a refund of the given amount',
-						  } )
-						: translate( 'Downgrade to %(planName)s', {
-								args: { planName: targetPlanName },
-								comment: 'Button label to confirm downgrading to a lower-tier plan',
-						  } ) }
+					{ confirmButtonLabel }
 				</Button>
 			</div>
 		</Modal>

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -71,7 +71,7 @@ function ModalBody( {
 				<p className="downgrade-confirmation-modal__description">
 					{ renewalDate
 						? translate(
-								'Your plan will change from %(currentPlan)s to %(targetPlan)s on %(renewalDate)s. Until then you’ll continue using %(currentPlan)s.',
+								'Your plan will change from %(currentPlan)s to %(targetPlan)s at your next renewal on %(renewalDate)s. Until then you’ll continue using %(currentPlan)s.',
 								{
 									args: {
 										currentPlan: currentPlanName,

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -1,7 +1,7 @@
 import { purchaseCancelFeaturesQuery } from '@automattic/api-queries';
 import { Gridicon, Spinner } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
@@ -32,6 +32,13 @@ interface DowngradeConfirmationModalProps {
 	refundText?: string;
 	/** When true, the confirm action is in flight; disable buttons and show a spinner. */
 	isConfirming?: boolean;
+	/**
+	 * When false and isDelayedDowngrade is true, shows a notice that a rechargeable
+	 * payment method is required and disables the confirm button.
+	 */
+	isRechargeable?: boolean;
+	/** URL to the change payment method page, linked from the rechargeable payment notice. */
+	changePaymentMethodUrl?: string;
 	onClose: () => void;
 	onConfirm: () => void;
 }
@@ -45,6 +52,8 @@ function ModalBody( {
 	isDelayedDowngrade,
 	renewalDate,
 	refundText,
+	isRechargeable,
+	changePaymentMethodUrl,
 }: {
 	isLoading: boolean;
 	currentPlanName: string;
@@ -54,6 +63,8 @@ function ModalBody( {
 	isDelayedDowngrade?: boolean;
 	renewalDate?: string;
 	refundText?: string;
+	isRechargeable?: boolean;
+	changePaymentMethodUrl?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -68,6 +79,27 @@ function ModalBody( {
 	if ( isDelayedDowngrade ) {
 		return (
 			<>
+				{ isRechargeable === false && (
+					<Notice
+						status="warning"
+						isDismissible={ false }
+						className="downgrade-confirmation-modal__payment-notice"
+					>
+						{ translate( 'Scheduling a downgrade requires a rechargeable payment method.', {
+							comment: 'Notice shown when the subscription has no rechargeable payment method',
+						} ) }
+						{ changePaymentMethodUrl && (
+							<>
+								<br />
+								<a href={ changePaymentMethodUrl }>
+									{ translate( 'Add or change payment method', {
+										comment: 'Link to the change payment method page',
+									} ) }
+								</a>
+							</>
+						) }
+					</Notice>
+				) }
 				<p className="downgrade-confirmation-modal__description">
 					{ renewalDate
 						? translate(
@@ -188,6 +220,8 @@ const DowngradeConfirmationModal = ( {
 	renewalDate,
 	refundText,
 	isConfirming,
+	isRechargeable,
+	changePaymentMethodUrl,
 	onClose,
 	onConfirm,
 }: DowngradeConfirmationModalProps ) => {
@@ -248,6 +282,8 @@ const DowngradeConfirmationModal = ( {
 				isDelayedDowngrade={ isDelayedDowngrade }
 				renewalDate={ renewalDate }
 				refundText={ refundText }
+				isRechargeable={ isRechargeable }
+				changePaymentMethodUrl={ changePaymentMethodUrl }
 			/>
 			<div className="downgrade-confirmation-modal__buttons">
 				<span className="downgrade-confirmation-modal__plan-transition">
@@ -272,7 +308,7 @@ const DowngradeConfirmationModal = ( {
 						variant="primary"
 						onClick={ onConfirm }
 						isBusy={ isConfirming }
-						disabled={ isConfirming }
+						disabled={ isConfirming || ( isDelayedDowngrade && isRechargeable === false ) }
 					>
 						{ confirmButtonLabel }
 					</Button>

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -195,8 +195,7 @@ const DowngradeConfirmationModal = ( {
 
 	const confirmButtonLabel = ( () => {
 		if ( isDelayedDowngrade ) {
-			return translate( 'Schedule downgrade to %(planName)s', {
-				args: { planName: targetPlanName },
+			return translate( 'Schedule downgrade', {
 				comment: 'Button label to confirm scheduling a plan downgrade for end of billing term',
 			} );
 		}
@@ -207,8 +206,7 @@ const DowngradeConfirmationModal = ( {
 					'Button label to confirm an instant downgrade that issues a refund of the given amount',
 			} );
 		}
-		return translate( 'Downgrade to %(planName)s', {
-			args: { planName: targetPlanName },
+		return translate( 'Downgrade', {
 			comment: 'Button label to confirm downgrading to a lower-tier plan',
 		} );
 	} )();
@@ -230,26 +228,33 @@ const DowngradeConfirmationModal = ( {
 				refundText={ refundText }
 			/>
 			<div className="downgrade-confirmation-modal__buttons">
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ onClose }
-					disabled={ isConfirming }
-				>
-					{ translate( 'Keep %(planName)s', {
-						args: { planName: currentPlanName },
-						comment: 'Button label to dismiss the downgrade modal and keep the current plan',
+				<span className="downgrade-confirmation-modal__plan-transition">
+					{ translate( '%(currentPlan)s → %(targetPlan)s', {
+						args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
+						comment: 'Plan transition summary shown above the downgrade confirm/cancel buttons',
 					} ) }
-				</Button>
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					onClick={ onConfirm }
-					isBusy={ isConfirming }
-					disabled={ isConfirming }
-				>
-					{ confirmButtonLabel }
-				</Button>
+				</span>
+				<div className="downgrade-confirmation-modal__button-row">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+						disabled={ isConfirming }
+					>
+						{ translate( 'Keep plan', {
+							comment: 'Button label to dismiss the downgrade modal and keep the current plan',
+						} ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ onConfirm }
+						isBusy={ isConfirming }
+						disabled={ isConfirming }
+					>
+						{ confirmButtonLabel }
+					</Button>
+				</div>
 			</div>
 		</Modal>
 	);

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -6,6 +6,10 @@
 	padding: 16px 0;
 }
 
+.downgrade-confirmation-modal__payment-notice {
+	margin-block-end: 16px;
+}
+
 .downgrade-confirmation-modal__description {
 	font-size: $font-body-small;
 	margin-block-end: 8px;

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -44,6 +44,7 @@
 
 .downgrade-confirmation-modal__buttons {
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: flex-end;
 	gap: 8px;
 	margin-block-start: 24px;

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -44,8 +44,18 @@
 
 .downgrade-confirmation-modal__buttons {
 	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-end;
-	gap: 8px;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 12px;
 	margin-block-start: 24px;
+}
+
+.downgrade-confirmation-modal__plan-transition {
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+}
+
+.downgrade-confirmation-modal__button-row {
+	display: flex;
+	gap: 8px;
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -487,8 +487,14 @@ const PlansFeaturesMain = ( {
 					// confirmation message.
 					const redirectTarget = redirectTo ?? getQueryArg( window.location.href, 'redirect_to' );
 					if ( typeof redirectTarget === 'string' ) {
-						const sep = redirectTarget.includes( '?' ) ? '&' : '?';
-						window.location.href = `${ redirectTarget }${ sep }delayed_downgrade_scheduled=true`;
+						// :purchaseId is a placeholder normally filled by the checkout
+						// pending page; substitute it here since we skip checkout.
+						const resolved = redirectTarget.replace(
+							':purchaseId',
+							String( currentPlanPurchaseId )
+						);
+						const sep = resolved.includes( '?' ) ? '&' : '?';
+						window.location.href = `${ resolved }${ sep }delayed_downgrade_scheduled=true`;
 						return;
 					}
 					window.location.href = siteSlug

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -64,6 +64,7 @@ import QueryActivePromotions from 'calypso/components/data/query-active-promotio
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
@@ -270,6 +271,7 @@ const PlansFeaturesMain = ( {
 		number | null
 	>( null );
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
 
 	const [ isRenewalPricingExperimentLoading, renewalPricingVariation ] =
@@ -338,6 +340,13 @@ const PlansFeaturesMain = ( {
 		currentPurchase && downgradeRefundAmount > 0
 			? formatCurrency( downgradeRefundAmount, currentPurchase.currency_code )
 			: undefined;
+
+	// The date a delayed downgrade will take effect. `renew_date` is the next
+	// auto-renewal attempt date, which for annual plans is up to 30 days before
+	// expiry; the downgrade happens on that renewal, so it's the accurate date.
+	const downgradeRenewalDate = currentPurchase?.renew_date
+		? moment( currentPurchase.renew_date ).format( 'LL' )
+		: undefined;
 
 	// Ignore dismiss requests (X/Escape/overlay) while an instant downgrade is in
 	// flight so the loader stays visible until the redirect.
@@ -1228,6 +1237,7 @@ const PlansFeaturesMain = ( {
 					purchaseId={ currentPlan?.purchaseId }
 					isInstantDowngrade={ downgradeMode === 'instant' }
 					isDelayedDowngrade={ downgradeMode === 'delayed' }
+					renewalDate={ downgradeRenewalDate }
 					refundText={ downgradeRefundText }
 					isConfirming={ cancelAndRefundMutation.isPending || isDowngrading }
 					onClose={ closeDowngradeModal }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -65,6 +65,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
@@ -1243,6 +1244,14 @@ const PlansFeaturesMain = ( {
 					renewalDate={ downgradeRenewalDate }
 					refundText={ downgradeRefundText }
 					isConfirming={ cancelAndRefundMutation.isPending || isDowngrading }
+					isRechargeable={ currentPurchase?.is_rechargeable ?? false }
+					changePaymentMethodUrl={
+						currentPlanPurchaseId
+							? dashboardLink(
+									`/me/billing/purchases/${ currentPlanPurchaseId }/payment-method/change`
+							  )
+							: undefined
+					}
 					onClose={ closeDowngradeModal }
 					onConfirm={ confirmDowngrade }
 				/>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -2,6 +2,7 @@ import {
 	cancelAndRefundPurchaseMutation,
 	purchaseCancelFeaturesQuery,
 	purchaseQuery,
+	setDelayedDowngradeMutation,
 	userPurchasesQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
@@ -291,6 +292,10 @@ const PlansFeaturesMain = ( {
 	const reduxDispatch = useReduxDispatch();
 	const queryClient = useQueryClient();
 	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
+	const delayedDowngradeMutation = useMutation( setDelayedDowngradeMutation() );
+	// Fire-and-forget: cancel any pending delayed downgrade without blocking
+	// the main action. Used when the user takes any other plan action.
+	const cancelDelayedDowngradeMutation = useMutation( setDelayedDowngradeMutation() );
 	// Stays true from the moment the instant downgrade is confirmed until the page
 	// navigates away, so the dialog can keep showing a loader across the mutation
 	// AND the subsequent purchases refetch (the mutation's own isPending clears
@@ -306,7 +311,18 @@ const PlansFeaturesMain = ( {
 		!! currentPurchase &&
 		currentPurchase.is_within_initial_refund_window &&
 		! currentPurchase.is_past_expiry_date;
-	const downgradeMode: 'instant' | 'checkout' = isWithinRefundWindow ? 'instant' : 'checkout';
+	// Three downgrade modes:
+	//   'instant'  — within refund window: cancel+refund via the cancel endpoint
+	//   'checkout' — expired plan: route to checkout to purchase the new plan
+	//   'delayed'  — active plan, not in refund window: schedule downgrade at renewal
+	let downgradeMode: 'instant' | 'checkout' | 'delayed';
+	if ( isWithinRefundWindow ) {
+		downgradeMode = 'instant';
+	} else if ( isPlanExpired ) {
+		downgradeMode = 'checkout';
+	} else {
+		downgradeMode = 'delayed';
+	}
 
 	// The product the user is downgrading to, and the refund specific to that
 	// downgrade target. `refund_options` carries the per-target refund amount,
@@ -332,6 +348,19 @@ const PlansFeaturesMain = ( {
 		setPendingDowngradePlanSlug( null );
 	};
 
+	// Cancel any pending delayed downgrade before performing a different plan
+	// action. Fire-and-forget: the subscription is changing anyway so we don't
+	// need to wait for confirmation. Only called when a delayed downgrade is
+	// actually pending to avoid unnecessary API calls.
+	const cancelPendingDelayedDowngrade = () => {
+		if ( currentPlanPurchaseId && currentPurchase?.is_delayed_downgrade_pending ) {
+			cancelDelayedDowngradeMutation.mutate( {
+				purchaseId: currentPlanPurchaseId,
+				enabled: false,
+			} );
+		}
+	};
+
 	// Refund-window mode: perform the downgrade instantly via the cancel endpoint.
 	const confirmInstantDowngrade = () => {
 		const toProductId = downgradeTargetProductId;
@@ -344,6 +373,7 @@ const PlansFeaturesMain = ( {
 			mode: 'instant',
 		} );
 		recordTracksEvent( 'calypso_purchases_downgrade_form_submit' );
+		cancelPendingDelayedDowngrade();
 		const blogId = currentPurchase?.blog_id;
 		// Keep the dialog open with its loader until the redirect; only reset on error.
 		setIsDowngrading( true );
@@ -409,6 +439,7 @@ const PlansFeaturesMain = ( {
 			return;
 		}
 		closeDowngradeModal();
+		cancelPendingDelayedDowngrade();
 		recordTracksEvent( 'calypso_plan_features_downgrade_click', {
 			current_plan: sitePlanSlug,
 			downgrading_to: pendingDowngradePlanSlug,
@@ -435,8 +466,55 @@ const PlansFeaturesMain = ( {
 		window.location.href = addQueryArgs( checkoutQuery, `/checkout/${ siteSlug }/${ planPath }` );
 	};
 
-	const confirmDowngrade = () =>
-		downgradeMode === 'instant' ? confirmInstantDowngrade() : confirmCheckoutDowngrade();
+	// Delayed mode: schedule the downgrade for end-of-term via the API.
+	const confirmDelayedDowngrade = () => {
+		const toProductId = downgradeTargetProductId;
+		if ( ! currentPlanPurchaseId || ! toProductId ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_plan_features_downgrade_click', {
+			current_plan: sitePlanSlug,
+			downgrading_to: pendingDowngradePlanSlug,
+			mode: 'delayed',
+		} );
+		setIsDowngrading( true );
+		delayedDowngradeMutation.mutate(
+			{ purchaseId: currentPlanPurchaseId, enabled: true, toProductId },
+			{
+				onSuccess: () => {
+					// Redirect back to the purchase settings page (or the caller's
+					// redirect_to) with a param so the notice layer can show a
+					// confirmation message.
+					const redirectTarget = redirectTo ?? getQueryArg( window.location.href, 'redirect_to' );
+					if ( typeof redirectTarget === 'string' ) {
+						const sep = redirectTarget.includes( '?' ) ? '&' : '?';
+						window.location.href = `${ redirectTarget }${ sep }delayed_downgrade_scheduled=true`;
+						return;
+					}
+					window.location.href = siteSlug
+						? `${ managePurchase(
+								siteSlug,
+								currentPlanPurchaseId
+						  ) }?delayed_downgrade_scheduled=true`
+						: `/plans/${ siteSlug }?delayed_downgrade_scheduled=true`;
+				},
+				onError: ( error: Error ) => {
+					setIsDowngrading( false );
+					reduxDispatch( errorNotice( error.message ) );
+				},
+			}
+		);
+	};
+
+	const confirmDowngrade = () => {
+		if ( downgradeMode === 'instant' ) {
+			return confirmInstantDowngrade();
+		}
+		if ( downgradeMode === 'delayed' ) {
+			return confirmDelayedDowngrade();
+		}
+		return confirmCheckoutDowngrade();
+	};
 
 	const userCanUpgradeToPersonalPlan = useSelector(
 		( state: IAppState ) => siteId && canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
@@ -637,6 +715,24 @@ const PlansFeaturesMain = ( {
 			await openDowngradeModal( planSlug );
 			return true;
 		}
+
+		// For active paid plans (not expired, not in refund window), intercept
+		// paid-plan downgrades to schedule the downgrade at end-of-term instead.
+		if (
+			config.isEnabled( 'plans/expired-downgrade' ) &&
+			! isPlanExpired &&
+			! isWithinRefundWindow &&
+			currentPurchase?.is_plan_type_downgradable &&
+			! isFreePlan( planSlug ) &&
+			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
+		) {
+			setPendingDowngradePlanSlug( planSlug );
+			return true;
+		}
+
+		// The user is selecting an upgrade (or a lateral plan change). Cancel any
+		// pending delayed downgrade since they've expressed intent to change plans.
+		cancelPendingDelayedDowngrade();
 
 		setLastClickedPlan( planSlug );
 
@@ -1125,6 +1221,7 @@ const PlansFeaturesMain = ( {
 					targetPlanSlug={ pendingDowngradePlanSlug }
 					purchaseId={ currentPlan?.purchaseId }
 					isInstantDowngrade={ downgradeMode === 'instant' }
+					isDelayedDowngrade={ downgradeMode === 'delayed' }
 					refundText={ downgradeRefundText }
 					isConfirming={ cancelAndRefundMutation.isPending || isDowngrading }
 					onClose={ closeDowngradeModal }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -313,6 +313,9 @@ const PlansFeaturesMain = ( {
 		!! currentPurchase &&
 		currentPurchase.is_within_initial_refund_window &&
 		! currentPurchase.is_past_expiry_date;
+	// The delayed-downgrade flow (schedule a downgrade at renewal for an active
+	// plan) is gated separately from the launched expired/refund downgrade flow.
+	const isDelayedDowngradeEnabled = config.isEnabled( 'plans/delayed-downgrade' );
 	// Three downgrade modes:
 	//   'instant'  — within refund window: cancel+refund via the cancel endpoint
 	//   'checkout' — expired plan: route to checkout to purchase the new plan
@@ -320,10 +323,10 @@ const PlansFeaturesMain = ( {
 	let downgradeMode: 'instant' | 'checkout' | 'delayed';
 	if ( isWithinRefundWindow ) {
 		downgradeMode = 'instant';
-	} else if ( isPlanExpired ) {
-		downgradeMode = 'checkout';
-	} else {
+	} else if ( isDelayedDowngradeEnabled && ! isPlanExpired ) {
 		downgradeMode = 'delayed';
+	} else {
+		downgradeMode = 'checkout';
 	}
 
 	// The product the user is downgrading to, and the refund specific to that
@@ -734,7 +737,7 @@ const PlansFeaturesMain = ( {
 		// For active paid plans (not expired, not in refund window), intercept
 		// paid-plan downgrades to schedule the downgrade at end-of-term instead.
 		if (
-			config.isEnabled( 'plans/expired-downgrade' ) &&
+			isDelayedDowngradeEnabled &&
 			! isPlanExpired &&
 			! isWithinRefundWindow &&
 			currentPurchase?.is_plan_type_downgradable &&

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -45,6 +45,7 @@
 		"me/legacy-contact": true,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -40,6 +40,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -40,7 +40,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
-		"plans/delayed-downgrade": true,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -37,6 +37,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -37,7 +37,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
-		"plans/delayed-downgrade": true,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -37,6 +37,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/development.json
+++ b/config/development.json
@@ -173,6 +173,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"performance/apm": true,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -124,6 +124,7 @@
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"performance/apm": true,
-		"plans/delayed-downgrade": true,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,6 +122,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"performance/apm": true,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,6 +84,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/post-checkout-ai-step": false,
 		"onboarding/woo-hosting-post-purchase-setup-choice": false,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -129,6 +129,7 @@
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -129,7 +129,7 @@
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
-		"plans/delayed-downgrade": true,
+		"plans/delayed-downgrade": false,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -343,9 +343,10 @@ export const getDataCenterOptions = (): Record< DataCenterOption, string > => ( 
 } );
 
 export const getPlanNames = () => ( {
+	[ DotcomPlans.PERSONAL ]: __( 'Personal' ),
+	[ DotcomPlans.PREMIUM ]: __( 'Premium' ),
 	[ DotcomPlans.BUSINESS ]: __( 'Business' ),
 	[ DotcomPlans.ECOMMERCE ]: __( 'Commerce' ),
-	[ DotcomPlans.PREMIUM ]: __( 'Premium' ),
 } );
 
 export const PaymentPartners = {

--- a/packages/api-core/src/upgrades/mutators.ts
+++ b/packages/api-core/src/upgrades/mutators.ts
@@ -97,6 +97,17 @@ export async function cancelAndRefundPurchase(
 	} );
 }
 
+export async function setDelayedDowngrade(
+	purchaseId: number,
+	params: { enabled: true; to_product_id: number } | { enabled: false }
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/delayed-downgrade`,
+		apiVersion: '1.1',
+		body: params,
+	} );
+}
+
 export async function extendPurchaseWithFreeMonth(
 	purchaseId: number
 ): Promise< { status: string; message: string } > {

--- a/packages/api-core/src/upgrades/mutators.ts
+++ b/packages/api-core/src/upgrades/mutators.ts
@@ -97,10 +97,19 @@ export async function cancelAndRefundPurchase(
 	} );
 }
 
+export interface DelayedDowngradeState {
+	is_pending: boolean;
+	to_product_id: number | null;
+	requested_at: number | null;
+}
+
 export async function setDelayedDowngrade(
 	purchaseId: number,
 	params: { enabled: true; to_product_id: number } | { enabled: false }
-): Promise< { success: boolean } > {
+): Promise< { success: boolean; delayed_downgrade: DelayedDowngradeState } > {
+	// The endpoint resolves with `{ success: true, delayed_downgrade: … }` on
+	// success and rejects (throws) on any failure, so `success` is always true
+	// here; the resulting downgrade state is carried in `delayed_downgrade`.
 	return wpcom.req.post( {
 		path: `/upgrades/${ purchaseId }/delayed-downgrade`,
 		apiVersion: '1.1',

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -485,6 +485,19 @@ export interface Purchase {
 	 * number.
 	 */
 	cancellation_offer_notice_discount_percentage: number | null;
+
+	/**
+	 * True when a delayed downgrade has been scheduled for this subscription.
+	 * The plan will be downgraded at the next renewal rather than immediately.
+	 * See `delayed_downgrade_to_product_slug` for the target plan.
+	 */
+	is_delayed_downgrade_pending: boolean;
+
+	/**
+	 * The product slug of the plan this subscription will downgrade to at
+	 * renewal, or null when no delayed downgrade is scheduled.
+	 */
+	delayed_downgrade_to_product_slug: string | null;
 }
 
 export type RawPurchase = Purchase & {

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -360,6 +360,16 @@ export interface Purchase {
 	refund_period_in_days: number;
 	regular_price_text: string;
 	regular_price_integer: number;
+
+	/**
+	 * The date this subscription will next attempt to auto-renew (ISO 8601).
+	 *
+	 * For active/auto-renewing subscriptions this is the next *renewal attempt*
+	 * date, NOT the expiry date: WordPress.com begins attempting renewals before
+	 * a subscription expires (e.g. non-monthly WordPress.com plans first attempt
+	 * ~30 days before `expiry_date`). For subscriptions that are not renewing
+	 * (expiring, manual-renew, etc.) it falls back to the expiry date.
+	 */
 	renew_date: string;
 
 	sale_amount?: number;

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -10,6 +10,7 @@ import {
 	fetchUserTransferredPurchases,
 	fetchSitePurchases,
 	fetchCancellationFeatures,
+	setDelayedDowngrade,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -113,5 +114,23 @@ export const extendPurchaseWithFreeMonthMutation = () =>
 		mutationFn: ( purchaseId: number ) => extendPurchaseWithFreeMonth( purchaseId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( userPurchasesQuery() );
+		},
+	} );
+
+export const setDelayedDowngradeMutation = () =>
+	mutationOptions( {
+		mutationFn: (
+			params: { purchaseId: number } & (
+				| { enabled: true; toProductId: number }
+				| { enabled: false }
+			)
+		) =>
+			setDelayedDowngrade(
+				params.purchaseId,
+				params.enabled ? { enabled: true, to_product_id: params.toProductId } : { enabled: false }
+			),
+		onSuccess: ( _data, params ) => {
+			queryClient.invalidateQueries( userPurchasesQuery() );
+			queryClient.invalidateQueries( purchaseQuery( params.purchaseId ) );
 		},
 	} );

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -61,6 +61,7 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		isHundredYearDomain: Boolean( purchase.is_hundred_year_domain ),
 		isLocked: Boolean( purchase.is_locked ),
 		isInAppPurchase: Boolean( purchase.is_iap_purchase ),
+		isPlanTypeDowngradable: Boolean( purchase.is_plan_type_downgradable ),
 		isRechargeable: Boolean( purchase.is_rechargeable ),
 		isRefundable: Boolean( purchase.is_refundable ),
 		isWithinInitialRefundWindow: Boolean( purchase.is_within_initial_refund_window ),

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -122,6 +122,8 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		isAutoRenewEnabled: purchase.is_auto_renew_enabled,
 		isJetpackPlanOrProduct: purchase.is_jetpack_plan_or_product,
 		isAttachedToHoldingSite: Boolean( purchase.is_attached_to_holding_site ),
+		isDelayedDowngradePending: Boolean( purchase.is_delayed_downgrade_pending ),
+		delayedDowngradeToProductSlug: purchase.delayed_downgrade_to_product_slug ?? null,
 	};
 
 	if ( isCreditCardPurchase( purchase ) ) {

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -65,6 +65,7 @@ export interface Purchase {
 	isHundredYearDomain?: boolean;
 	isInAppPurchase: boolean;
 	isLocked: boolean;
+	isPlanTypeDowngradable: boolean;
 	isRechargeable: boolean;
 	isRefundable: boolean;
 	isWithinInitialRefundWindow: boolean;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -135,6 +135,15 @@ export interface Purchase {
 	 */
 	regularPriceInteger: number;
 
+	/**
+	 * The date this subscription will next attempt to auto-renew (ISO 8601).
+	 *
+	 * For active/auto-renewing subscriptions this is the next *renewal attempt*
+	 * date, NOT the expiry date: WordPress.com begins attempting renewals before
+	 * a subscription expires (e.g. non-monthly WordPress.com plans first attempt
+	 * ~30 days before `expiryDate`). For subscriptions that are not renewing
+	 * (expiring, manual-renew, etc.) it falls back to the expiry date.
+	 */
 	renewDate: string;
 	saleAmount?: number;
 	saleAmountInteger?: number;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -196,6 +196,18 @@ export interface Purchase {
 
 	isJetpackPlanOrProduct: boolean;
 	isAttachedToHoldingSite: boolean;
+
+	/**
+	 * True when a delayed downgrade has been scheduled for this subscription.
+	 * See `delayedDowngradeToProductSlug` for the target plan.
+	 */
+	isDelayedDowngradePending: boolean;
+
+	/**
+	 * The product slug of the plan this subscription will downgrade to at
+	 * renewal, or null when no delayed downgrade is scheduled.
+	 */
+	delayedDowngradeToProductSlug: string | null;
 }
 
 export interface PurchasePriceTier {


### PR DESCRIPTION
- **Purchases: add delayed-downgrade fields and API mutation**
- **Plans: add delayed downgrade flow to the plans page**
- **Purchases (classic): show pending delayed-downgrade notice**
- **Purchases (Dashboard): show pending delayed-downgrade notice**
- **Purchases: show 'Change plan' button for delayed-downgrade eligible plans**
- **Plans (downgrade modal): move plan names out of buttons**
- **Plans: fix delayed-downgrade redirect when redirect_to contains :purchaseId**
- **Purchases: suppress plan-changed notice when delayed-downgrade notice is present**
- **Purchases (Dashboard): fix delayed-downgrade notice layout and plan name**
- **Purchases: show cancel button immediately after scheduling delayed downgrade**
- **Purchases (Dashboard): show snackbar after cancelling delayed downgrade**
- **Fix purchase management tests to use QueryClientProvider**
- **Purchases: show the renewal date in delayed-downgrade UI**
- **Add docs for renew_date type**
- **Purchases: clarify the downgrade date is the next renewal date**
- **Plans: gate delayed-downgrade flow behind plans/delayed-downgrade flag**
- **Purchases: return delayed_downgrade state from setDelayedDowngrade mutator**
- **Purchases (Dashboard): add error notice and Tracks event to cancel-downgrade button**
- **Purchases (classic): add notices and Tracks event to cancel-downgrade button**
- **Plans: block delayed downgrade when no rechargeable payment method**
- **Disable in horizon wpcalypso and staging**
- **Purchases: prevent showing "Change plan" for non-downgradeable plans**
- **Purchases: make sure Change plan tracks event has delayed-downgrade**

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
