### PR TITLE
Plans: Prevent showing "Change plan" for non-downgradable plans

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -471,14 +471,13 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
  *   - active downgradable plan (delayed downgrade) — `plans/delayed-downgrade`
  */
 function shouldShowChangePlan( purchase: Purchase ): boolean {
+	if ( ! purchase.is_plan || ! purchase.is_plan_type_downgradable ) {
+		return false;
+	}
 	const expiredOrRefundDowngrade =
 		config.isEnabled( 'plans/expired-downgrade' ) &&
-		( ( purchase.is_past_expiry_date && purchase.is_plan ) ||
-			isWithinRefundWindowDowngradeEligible( purchase ) );
-	const delayedDowngrade =
-		config.isEnabled( 'plans/delayed-downgrade' ) &&
-		purchase.is_plan &&
-		purchase.is_plan_type_downgradable;
+		( purchase.is_past_expiry_date || isWithinRefundWindowDowngradeEligible( purchase ) );
+	const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
 	return expiredOrRefundDowngrade || delayedDowngrade;
 }
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -658,6 +658,15 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 	}
 
 	const isPastExpiryDowngrade = purchase.is_past_expiry_date && purchase.is_plan;
+	const mode = ( () => {
+		if ( isPastExpiryDowngrade ) {
+			return 'expired';
+		}
+		if ( isWithinRefundWindowDowngradeEligible( purchase ) ) {
+			return 'refund-window';
+		}
+		return 'delayed-downgrade';
+	} )();
 
 	return (
 		<ActionList.ActionItem
@@ -670,7 +679,7 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_purchases_change_plan_click', {
 							product_slug: purchase.product_slug,
-							mode: isPastExpiryDowngrade ? 'expired' : 'refund-window',
+							mode,
 						} );
 						window.location.href = getExpiredNewPlanUrl( purchase );
 					} }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -728,6 +728,7 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
  */
 export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
 	return (
+		purchase.is_plan_type_downgradable &&
 		purchase.is_plan &&
 		purchase.is_within_initial_refund_window &&
 		! isExpired( purchase ) &&

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -617,12 +617,14 @@ class ManagePurchase extends Component<
 		if ( ! purchase || ! isPlan( purchase ) ) {
 			return false;
 		}
+		if ( ! purchase.isPlanTypeDowngradable ) {
+			return false;
+		}
 		const expiredOrRefundDowngrade =
 			config.isEnabled( 'plans/expired-downgrade' ) &&
 			( isInExpirationGracePeriod( purchase ) ||
 				isWithinRefundWindowDowngradeEligible( purchase ) );
-		const delayedDowngrade =
-			config.isEnabled( 'plans/delayed-downgrade' ) && purchase.isPlanTypeDowngradable;
+		const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
 		return expiredOrRefundDowngrade || delayedDowngrade;
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2185/

## Proposed changes

This gates the "Change plan" action on `is_plan_type_downgradable` so that non-downgradeable plans never show the option, regardless of which feature flag path is active.

* Add an early-return guard for `! is_plan_type_downgradable` in `shouldShowChangePlan` (Dashboard) and the equivalent method in Calypso, covering all paths (expired, refund-window, delayed-downgrade)
* Add `is_plan_type_downgradable` to `isWithinRefundWindowDowngradeEligible` so the helper is self-contained
* Fix the `calypso_purchases_change_plan_click` Tracks event to include `'delayed-downgrade'` as a valid `mode` value (previously only `'expired'` or `'refund-window'` were tracked)

## Why are these changes being made?

When the `plans/delayed-downgrade` flag is enabled, the previous logic checked `is_plan_type_downgradable` only for that flag's branch. The `plans/expired-downgrade` path didn't enforce it, and the two conditions were evaluated independently. This meant users on plans that can't be downgraded could still see the "Change plan" action under certain circumstances.

Pulling `is_plan_type_downgradable` up to an early guard makes it a universal pre-condition rather than a per-branch check, which is both clearer and correct. The Tracks fix is a related cleanup: the event was missing the `'delayed-downgrade'` mode entirely, so downgrade events fired via that path were being misclassified as `'refund-window'`.

## Testing instructions

* Use a WordPress.com account with a plan that has `is_plan_type_downgradable: false` (e.g. a plan that doesn't support downgrades)
* Confirm the "Change plan" action does not appear in the purchase settings (Dashboard: `/sites/me/billing-purchases`, Calypso: `/me/purchases`)
* Use an account with a downgradable plan and confirm "Change plan" still appears and clicking it fires the `calypso_purchases_change_plan_click` event with the correct `mode` value (`expired`, `refund-window`, or `delayed-downgrade` as appropriate)
