### PR TITLE
Legacy contact: implement remove contact button

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,8 +1,9 @@
 import { legacyContactsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -11,9 +12,11 @@ import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
 import LegacyContactForm from './legacy-contact-form';
+import RemoveContactDialog from './remove-contact-dialog';
 
 export default function SecurityLegacyContact() {
 	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
+	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 
 	return (
 		<PageLayout
@@ -44,7 +47,19 @@ export default function SecurityLegacyContact() {
 										{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
 										View printable details
 									</RouterLinkButton>
+									<Button
+										variant="secondary"
+										isDestructive
+										onClick={ () => setIsRemoveDialogOpen( true ) }
+									>
+										{ __( 'Remove legacy contact' ) }
+									</Button>
 								</ButtonStack>
+								<RemoveContactDialog
+									contact={ contact }
+									isOpen={ isRemoveDialogOpen }
+									onClose={ () => setIsRemoveDialogOpen( false ) }
+								/>
 							</>
 						) : (
 							<LegacyContactForm />

--- a/client/dashboard/me/security-legacy-contact/remove-contact-dialog.tsx
+++ b/client/dashboard/me/security-legacy-contact/remove-contact-dialog.tsx
@@ -1,0 +1,54 @@
+import { deleteLegacyContactMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import ConfirmModal from '../../components/confirm-modal';
+import type { LegacyContact } from '@automattic/api-core';
+
+interface RemoveContactDialogProps {
+	contact: LegacyContact;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export default function RemoveContactDialog( {
+	contact,
+	isOpen,
+	onClose,
+}: RemoveContactDialogProps ) {
+	const mutation = useMutation( {
+		...deleteLegacyContactMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'Legacy contact removed.' ),
+				error: __( 'Failed to remove legacy contact.' ),
+			},
+		},
+	} );
+
+	const handleRemove = () => {
+		mutation.mutate( contact.legacy_contact_id, {
+			onSuccess: () => {
+				onClose();
+			},
+		} );
+	};
+
+	return (
+		<ConfirmModal
+			isOpen={ isOpen }
+			// Keep the dialog in place while the request is in flight so the
+			// confirmation UI can't be dismissed mid-removal.
+			isDismissible={ ! mutation.isPending }
+			confirmButtonProps={ {
+				label: __( 'Remove' ),
+				isBusy: mutation.isPending,
+				disabled: mutation.isPending,
+				isDestructive: true,
+			} }
+			onCancel={ onClose }
+			onConfirm={ handleRemove }
+		>
+			{ __( 'Are you sure you want to remove your legacy contact?' ) }
+		</ConfirmModal>
+	);
+}

--- a/client/dashboard/me/security-legacy-contact/test/index.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/index.test.tsx
@@ -1,0 +1,94 @@
+/** @jest-environment jsdom */
+import { queryClient } from '@automattic/api-queries';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import SecurityLegacyContact from '../index';
+
+const API = 'https://public-api.wordpress.com';
+const CONTACT = {
+	legacy_contact_id: 123,
+	contact_email: 'trusted@example.com',
+	created_at: '2026-01-01T00:00:00+00:00',
+};
+
+const interceptContacts = ( contacts: Array< typeof CONTACT > ) =>
+	nock( API ).get( '/wpcom/v2/me/legacy-contacts' ).query( true ).reply( 200, contacts );
+
+const removeButton = () => screen.findByRole( 'button', { name: 'Remove legacy contact' } );
+const confirmDialog = () => screen.queryByRole( 'dialog' );
+const confirmRemoveButton = () => screen.findByRole( 'button', { name: 'Remove' } );
+const cancelButton = () => screen.findByRole( 'button', { name: 'Cancel' } );
+
+// The remove mutation reads/writes the shared api-queries query client, so the
+// component must render against that same client (rather than a throwaway one)
+// for the cache updates to be reflected in the UI.
+const renderScreen = () => render( <SecurityLegacyContact />, { queryClient } );
+
+describe( '<SecurityLegacyContact />', () => {
+	beforeEach( () => {
+		queryClient.clear();
+	} );
+
+	test( 'shows the existing contact and a remove button', async () => {
+		interceptContacts( [ CONTACT ] );
+
+		renderScreen();
+
+		expect( await screen.findByText( CONTACT.contact_email ) ).toBeVisible();
+		expect( await removeButton() ).toBeVisible();
+	} );
+
+	test( 'opens a confirmation dialog when removing', async () => {
+		interceptContacts( [ CONTACT ] );
+
+		renderScreen();
+
+		await userEvent.click( await removeButton() );
+
+		expect( confirmDialog() ).toBeVisible();
+		expect(
+			screen.getByText( 'Are you sure you want to remove your legacy contact?' )
+		).toBeVisible();
+	} );
+
+	test( 'removes the contact and returns to the empty state on confirm', async () => {
+		interceptContacts( [ CONTACT ] );
+		const removeScope = nock( API )
+			.delete( `/wpcom/v2/me/legacy-contacts/${ CONTACT.legacy_contact_id }` )
+			.query( true )
+			.reply( 200, {} );
+		// The mutation invalidates the list, triggering a refetch that now returns
+		// no contacts.
+		interceptContacts( [] );
+
+		renderScreen();
+
+		await userEvent.click( await removeButton() );
+		await userEvent.click( await confirmRemoveButton() );
+
+		await waitFor( () => expect( removeScope.isDone() ).toBe( true ) );
+
+		// The empty state renders the set-up form.
+		expect( await screen.findByRole( 'button', { name: 'Set up legacy contact' } ) ).toBeVisible();
+	} );
+
+	test( 'does not remove the contact when the dialog is cancelled', async () => {
+		interceptContacts( [ CONTACT ] );
+		const removeScope = nock( API )
+			.delete( `/wpcom/v2/me/legacy-contacts/${ CONTACT.legacy_contact_id }` )
+			.query( true )
+			.reply( 200, {} );
+
+		renderScreen();
+
+		await userEvent.click( await removeButton() );
+		await userEvent.click( await cancelButton() );
+
+		await waitFor( () => expect( confirmDialog() ).not.toBeInTheDocument() );
+		expect( removeScope.isDone() ).toBe( false );
+		// The contact is still shown.
+		expect( screen.getByText( CONTACT.contact_email ) ).toBeVisible();
+	} );
+} );

--- a/packages/api-core/src/me-legacy-contacts/mutators.ts
+++ b/packages/api-core/src/me-legacy-contacts/mutators.ts
@@ -10,3 +10,11 @@ export async function addLegacyContact( email: string ): Promise< LegacyContact 
 		{ email }
 	);
 }
+
+export async function deleteLegacyContact( legacyContactId: number ): Promise< void > {
+	return wpcom.req.post( {
+		path: `/me/legacy-contacts/${ legacyContactId }`,
+		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
+	} );
+}

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -1,6 +1,12 @@
-import { addLegacyContact, fetchLegacyContact, fetchLegacyContacts } from '@automattic/api-core';
+import {
+	addLegacyContact,
+	deleteLegacyContact,
+	fetchLegacyContact,
+	fetchLegacyContacts,
+} from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
+import type { LegacyContact } from '@automattic/api-core';
 
 export const legacyContactsQuery = () =>
 	queryOptions( {
@@ -25,5 +31,24 @@ export const addLegacyContactMutation = () =>
 		mutationFn: ( email: string ) => addLegacyContact( email ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( legacyContactsQuery() );
+		},
+	} );
+
+export const deleteLegacyContactMutation = () =>
+	mutationOptions( {
+		mutationFn: ( legacyContactId: number ) => deleteLegacyContact( legacyContactId ),
+		onSuccess: ( _data, legacyContactId ) => {
+			// Drop the contact from the cached list right away so the UI returns to
+			// the empty state immediately, rather than showing the removed contact
+			// until the invalidation refetch below completes.
+			queryClient.setQueryData< LegacyContact[] >(
+				legacyContactsQuery().queryKey,
+				( contacts ) =>
+					contacts?.filter( ( contact ) => contact.legacy_contact_id !== legacyContactId )
+			);
+			queryClient.invalidateQueries( legacyContactsQuery() );
+			// Drop the single-contact query from the cache; it holds a sensitive
+			// `access_key` that should not linger after the contact is removed.
+			queryClient.removeQueries( { queryKey: legacyContactQuery( legacyContactId ).queryKey } );
 		},
 	} );


### PR DESCRIPTION
Fixes RSM-4291

## Proposed Changes

* Add a "Remove legacy contact" button to `/me/security/legacy-contact`, shown when the user already has a legacy contact configured.
* Clicking it opens an "are you sure?" confirmation dialog before removing the contact.
* Confirming calls `DELETE /me/legacy-contacts/:legacy_contact_id` and invalidates the legacy contacts query so the page returns to the empty state.
* Adds the `deleteLegacyContact` mutator to `@automattic/api-core` and the `deleteLegacyContactMutation` to `@automattic/api-queries`.
* Surfaces success/error feedback via snackbars.
* 
<img width="714" height="245" alt="Screenshot 2026-06-26 at 14 40 49" src="https://github.com/user-attachments/assets/604045c4-f81e-4e5c-821e-2e4fc249806d" />
<img width="465" height="214" alt="Screenshot 2026-06-26 at 14 40 58" src="https://github.com/user-attachments/assets/65d924bb-eece-4fae-a693-cace8b60f106" />

## Why are these changes being made?

Users who have set up a legacy contact had no way to remove it from the dashboard. This adds the removal flow, guarded by a confirmation dialog to prevent accidental removal of a sensitive account-access setting.

## Testing Instructions

* Run the dashboard (`yarn start-dashboard`) and navigate to `/me/security/legacy-contact` with an account that already has a legacy contact set up.
* Confirm the "Remove legacy contact" button appears.
* Click it and verify the confirmation dialog appears.
* Click "Cancel" and verify nothing changes.
* Click "Remove" and verify the contact is removed, a success snackbar appears, and the page returns to the "Set up legacy contact" empty state.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
