### PR TITLE
Notifications: lighten note titles in dark mode

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -119,6 +119,11 @@
 	@include ui-mixins.when-dark-theme {
 		@include dark-unread-note-list-item;
 
+		// The note title reads --wpds-color-fg-content-neutral, whose light-mode
+		// default (#1e1e1e) is near-black and unreadable on the dark surface. Point
+		// it at a light foreground for dark mode.
+		--wpds-color-fg-content-neutral: #f0f0f0;
+
 		// $gray-700 (#757575) is a light-mode literal — it fails WCAG AA on the
 		// dark surface and the accent tints (~1.8–2.7:1). Use a light muted that
 		// clears 4.5:1 on every row state, including the stronger selected tint.


### PR DESCRIPTION
Follow-up to #111867 (DOTMSD-1322 · DOTMSD-1294).

## Proposed Changes

- In dark mode, set `--wpds-color-fg-content-neutral` to `#f0f0f0` on the redesigned notifications list, so note titles are readable on the dark panel surface.

| Before | After |
|-|-|
|<img width="452" height="140" alt="image" src="https://github.com/user-attachments/assets/325e9091-b01f-4c64-b1d6-41e47136dcdd" />|<img width="455" height="141" alt="image" src="https://github.com/user-attachments/assets/86008ec7-d922-4ffb-8c70-b9b09089408b" />|

## Why are these changes being made?

Review feedback on #111867 flagged that note titles are too dark in dark mode. The title inherits `--wpds-color-fg-content-neutral`, whose light-mode default (`#1e1e1e`) is near-black against the dark surface. The dark-theme block already re-colors the muted info row but never touched the title, so it stayed unreadable.

## Testing Instructions

1. Open the notifications panel (bell) with the `notifications/redesign` flag enabled, in dark mode (`:root[data-theme="dark"]`, or system dark with `data-theme="system"`).
2. Confirm note titles read as light text, clearly legible against the dark surface.
3. Confirm light mode is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
