### PR TITLE
Lodash: replace set()

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.tsx
+++ b/client/components/domains/registrant-extra-info/fr-form.tsx
@@ -1,5 +1,5 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
-import { defaults } from '@automattic/js-utils';
+import { defaults, set } from '@automattic/js-utils';
 import { DomainContactDetails } from '@automattic/shopping-cart';
 import {
 	DomainContactDetailsErrors,
@@ -7,7 +7,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { LocalizeProps, TranslateResult, localize } from 'i18n-calypso';
-import { get, isEmpty, map, set } from 'lodash';
+import { get, isEmpty, map } from 'lodash';
 import { PureComponent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';

--- a/client/state/analytics/actions/enhance-with-global-site-view-enabled.ts
+++ b/client/state/analytics/actions/enhance-with-global-site-view-enabled.ts
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { set } from '@automattic/js-utils';
 import { ANALYTICS_EVENT_RECORD } from 'calypso/state/action-types';
 import { isAdminInterfaceWPAdmin } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/state/analytics/actions/enhance-with-site-type.js
+++ b/client/state/analytics/actions/enhance-with-site-type.js
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { set } from '@automattic/js-utils';
 import { ANALYTICS_EVENT_RECORD } from 'calypso/state/action-types';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 

--- a/client/state/analytics/actions/enhance-with-user-is-dev-account.ts
+++ b/client/state/analytics/actions/enhance-with-user-is-dev-account.ts
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { set } from '@automattic/js-utils';
 import { ANALYTICS_EVENT_RECORD } from 'calypso/state/action-types';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import type { AppState } from 'calypso/types';

--- a/client/state/analytics/actions/record-with-client-id.js
+++ b/client/state/analytics/actions/record-with-client-id.js
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { set } from '@automattic/js-utils';
 import { ANALYTICS_EVENT_RECORD } from 'calypso/state/action-types';
 import { getCurrentOAuth2ClientId } from 'calypso/state/oauth2-clients/ui/selectors';
 import { withEnhancers } from 'calypso/state/utils';

--- a/client/state/analytics/test/helpers/analytics-mock.js
+++ b/client/state/analytics/test/helpers/analytics-mock.js
@@ -1,4 +1,5 @@
-import { merge, set } from 'lodash';
+import { set } from '@automattic/js-utils';
+import { merge } from 'lodash';
 
 const analyticsMocks = [
 	'pageView.record',

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,6 +1,6 @@
-import { camelCase, snakeCase } from '@automattic/js-utils';
+import { camelCase, set, snakeCase } from '@automattic/js-utils';
 import { extendAction } from '@automattic/state-utils';
-import { map, reduce, set } from 'lodash';
+import { map, reduce } from 'lodash';
 
 const doBypassDataLayer = {
 	meta: {

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-case-declarations */
 
-import { mapValues, omit, omitBy } from '@automattic/js-utils';
+import { mapValues, omit, omitBy, set } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { set, isEmpty, reduce, merge } from 'lodash';
+import { isEmpty, reduce, merge } from 'lodash';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
 import {

--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -1,6 +1,5 @@
-import { pick } from '@automattic/js-utils';
+import { pick, set } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { set } from 'lodash';
 import { STATS_CHART_COUNTS_REQUEST, STATS_CHART_COUNTS_RECEIVE } from 'calypso/state/action-types';
 import {
 	combineReducers,

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -28,6 +28,7 @@ const JS_UTILS_NAMES = [
 	'truncate',
 	'flow',
 	'defaults',
+	'set',
 ];
 
 // The js-utils case converters cover ASCII identifiers/keys, not lodash's full

--- a/packages/js-utils/src/base-order-by.ts
+++ b/packages/js-utils/src/base-order-by.ts
@@ -1,4 +1,5 @@
 import isSymbol from './is-symbol';
+import castPath from './to-path';
 
 export type Order = 'asc' | 'desc';
 export type Iteratee< T > =
@@ -55,49 +56,6 @@ const compareAscending = ( value: unknown, other: unknown ): number => {
 		}
 	}
 	return 0;
-};
-
-// Property-path resolution, ported from lodash so a string iteratee tokenizes
-// the same way (dot, bracket, and quoted-bracket notation) and a string that is
-// a literal key of the object is used whole rather than split.
-const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
-const reIsPlainProp = /^\w*$/;
-const rePropName =
-	/[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
-const reEscapeChar = /\\(\\)?/g;
-
-const isKey = ( value: unknown, object: unknown ): boolean => {
-	if ( Array.isArray( value ) ) {
-		return false;
-	}
-	const type = typeof value;
-	if ( type === 'number' || type === 'boolean' || value == null || isSymbol( value ) ) {
-		return true;
-	}
-	return (
-		reIsPlainProp.test( value as string ) ||
-		! reIsDeepProp.test( value as string ) ||
-		( object != null && ( value as string ) in Object( object ) )
-	);
-};
-
-const stringToPath = ( string: string ): string[] => {
-	const result: string[] = [];
-	if ( string.charCodeAt( 0 ) === 46 /* . */ ) {
-		result.push( '' );
-	}
-	string.replace( rePropName, ( match, number, quote, substring ) => {
-		result.push( quote ? substring.replace( reEscapeChar, '$1' ) : number || match );
-		return match;
-	} );
-	return result;
-};
-
-const castPath = ( value: string | number | ReadonlyArray< string | number >, object: unknown ) => {
-	if ( Array.isArray( value ) ) {
-		return value;
-	}
-	return isKey( value, object ) ? [ value ] : stringToPath( String( value ) );
 };
 
 const baseGet = (

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -22,6 +22,7 @@ export { default as pick } from './pick';
 export { default as pickBy } from './pick-by';
 export { default as random } from './random';
 export { default as range } from './range';
+export { default as set } from './set';
 export { default as shuffle } from './shuffle';
 export { default as snakeCase } from './snake-case';
 export { default as snakeToCamelCase } from './snake-to-camel-case';

--- a/packages/js-utils/src/set.ts
+++ b/packages/js-utils/src/set.ts
@@ -1,0 +1,93 @@
+import castPath from './to-path';
+
+const MAX_SAFE_INTEGER = 9007199254740991;
+const reIsUint = /^(?:0|[1-9]\d*)$/;
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+const isObject = ( value: unknown ): boolean =>
+	value != null && ( typeof value === 'object' || typeof value === 'function' );
+
+// SameValueZero: like `===` but treats `NaN` as equal to `NaN`.
+const eq = ( value: unknown, other: unknown ): boolean =>
+	value === other || ( Number.isNaN( value as number ) && Number.isNaN( other as number ) );
+
+// Assigns only when the value actually changes, so setters/proxy traps aren't
+// triggered for same-value writes, matching lodash `assignValue`.
+const assignValue = (
+	object: Record< PropertyKey, unknown >,
+	key: PropertyKey,
+	value: unknown
+): void => {
+	const objValue = object[ key ];
+	if (
+		! ( hasOwn.call( object, key ) && eq( objValue, value ) ) ||
+		( value === undefined && ! ( key in object ) )
+	) {
+		object[ key ] = value;
+	}
+};
+
+// Whether a path segment is a valid array index (so the intermediate container
+// created for it should be an array rather than a plain object), like lodash.
+const isIndex = ( value: PropertyKey ): boolean => {
+	const type = typeof value;
+	if ( type !== 'number' && ( type === 'symbol' || ! reIsUint.test( value as string ) ) ) {
+		return false;
+	}
+	const number = Number( value );
+	return number > -1 && number % 1 === 0 && number < MAX_SAFE_INTEGER;
+};
+
+// Converts a path segment to a property key, preserving symbols and mapping
+// negative zero to `'-0'`, like lodash `toKey`.
+const toKey = ( value: PropertyKey ): PropertyKey => {
+	if ( typeof value === 'string' || typeof value === 'symbol' ) {
+		return value;
+	}
+	return Object.is( value, -0 ) ? '-0' : String( value );
+};
+
+/**
+ * Sets the value at `path` of `object`, creating missing intermediate
+ * containers (arrays for index-like segments, objects otherwise), matching
+ * lodash `set`. `object` is mutated and returned; a non-object `object` is
+ * returned unchanged. Assignments to `__proto__`/`constructor`/`prototype` keys
+ * are skipped to avoid prototype pollution.
+ * @param object The object to modify.
+ * @param path   The property path (string with dot/bracket notation, or array of segments).
+ * @param value  The value to set.
+ * @returns `object`.
+ */
+const set = < T >( object: T, path: PropertyKey | readonly PropertyKey[], value: unknown ): T => {
+	if ( ! isObject( object ) ) {
+		return object;
+	}
+
+	const segments = castPath( path, object );
+	const lastIndex = segments.length - 1;
+	let nested = object as Record< PropertyKey, unknown >;
+
+	for ( let index = 0; index <= lastIndex && nested != null; index++ ) {
+		const key = toKey( segments[ index ] );
+		if ( key === '__proto__' || key === 'constructor' || key === 'prototype' ) {
+			return object;
+		}
+
+		if ( index === lastIndex ) {
+			assignValue( nested, key, value );
+		} else {
+			let newValue = nested[ key ];
+			if ( ! isObject( newValue ) ) {
+				newValue = isIndex( segments[ index + 1 ] ) ? [] : {};
+			}
+			assignValue( nested, key, newValue );
+		}
+
+		nested = nested[ key ] as Record< PropertyKey, unknown >;
+	}
+
+	return object;
+};
+
+export default set;

--- a/packages/js-utils/src/test/set.ts
+++ b/packages/js-utils/src/test/set.ts
@@ -1,0 +1,77 @@
+import set from '../set';
+
+describe( 'set', () => {
+	it( 'sets a value at a simple key', () => {
+		expect( set( {}, 'a', 1 ) ).toEqual( { a: 1 } );
+	} );
+
+	it( 'creates intermediate objects for a dotted path', () => {
+		expect( set( {}, 'a.b.c', 5 ) ).toEqual( { a: { b: { c: 5 } } } );
+	} );
+
+	it( 'creates an array for an index-like segment (bracket notation)', () => {
+		expect( set( {}, 'a[0].b', 9 ) ).toEqual( { a: [ { b: 9 } ] } );
+	} );
+
+	it( 'treats numeric array-path segments as indices, like lodash', () => {
+		expect( set( {}, [ 'a', 2 ], 'x' ) ).toEqual( { a: [ undefined, undefined, 'x' ] } );
+	} );
+
+	it( 'sets a value via a single-element array path', () => {
+		expect( set( {}, [ 'newKey' ], 'nv' ) ).toEqual( { newKey: 'nv' } );
+	} );
+
+	it( 'reuses existing intermediate containers and overwrites leaves', () => {
+		expect( set( { a: { b: 1 } }, 'a.c', 2 ) ).toEqual( { a: { b: 1, c: 2 } } );
+		expect( set( { a: 1 }, 'a', 2 ) ).toEqual( { a: 2 } );
+	} );
+
+	it( 'mutates and returns the same object', () => {
+		const object = {};
+		const result = set( object, 'a.b', 1 );
+		expect( result ).toBe( object );
+		expect( object ).toEqual( { a: { b: 1 } } );
+	} );
+
+	it( 'returns a non-object argument unchanged', () => {
+		expect( set( null, 'a', 1 ) ).toBe( null );
+	} );
+
+	it( 'does not pollute the prototype', () => {
+		set( {}, '__proto__.polluted', 'x' );
+		expect( ( {} as Record< string, unknown > ).polluted ).toBeUndefined();
+	} );
+
+	it( 'preserves symbol path segments, like lodash', () => {
+		const sym = Symbol( 's' );
+		const object: Record< PropertyKey, unknown > = {};
+		set( object, [ sym ], 1 );
+		expect( object[ sym ] ).toBe( 1 );
+		set( object, [ 'x', sym ], 2 );
+		expect( ( object.x as Record< PropertyKey, unknown > )[ sym ] ).toBe( 2 );
+	} );
+
+	it( 'maps a negative-zero segment to "-0", like lodash', () => {
+		expect( set( {}, [ -0 ], 9 ) ).toEqual( { '-0': 9 } );
+	} );
+
+	it( 'skips the write for a same-value (SameValueZero) assignment, like lodash', () => {
+		let writes = 0;
+		let stored: unknown = 5;
+		const object = {};
+		Object.defineProperty( object, 'a', {
+			enumerable: true,
+			configurable: true,
+			get: () => stored,
+			set: ( v ) => {
+				writes++;
+				stored = v;
+			},
+		} );
+
+		set( object, 'a', 5 ); // same value → no write
+		expect( writes ).toBe( 0 );
+		set( object, 'a', 6 ); // different value → write
+		expect( writes ).toBe( 1 );
+	} );
+} );

--- a/packages/js-utils/src/to-path.ts
+++ b/packages/js-utils/src/to-path.ts
@@ -1,0 +1,56 @@
+import isSymbol from './is-symbol';
+
+// Property-path parsing, ported from lodash. A string is tokenized into path
+// segments (dot, bracket, and quoted-bracket notation), except a string that is
+// a literal key of the object is used whole rather than split — `castPath` is
+// object-dependent, like lodash. Internal helper; not part of the public API.
+const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
+const reIsPlainProp = /^\w*$/;
+const rePropName =
+	/[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+const reEscapeChar = /\\(\\)?/g;
+
+const isKey = ( value: unknown, object: unknown ): boolean => {
+	if ( Array.isArray( value ) ) {
+		return false;
+	}
+	const type = typeof value;
+	if ( type === 'number' || type === 'boolean' || value == null || isSymbol( value ) ) {
+		return true;
+	}
+	return (
+		reIsPlainProp.test( value as string ) ||
+		! reIsDeepProp.test( value as string ) ||
+		( object != null && ( value as string ) in Object( object ) )
+	);
+};
+
+const stringToPath = ( string: string ): string[] => {
+	const result: string[] = [];
+	if ( string.charCodeAt( 0 ) === 46 /* . */ ) {
+		result.push( '' );
+	}
+	string.replace( rePropName, ( match, number, quote, substring ) => {
+		result.push( quote ? substring.replace( reEscapeChar, '$1' ) : number || match );
+		return match;
+	} );
+	return result;
+};
+
+/**
+ * Casts `value` to a property-path array, resolving a string against `object`
+ * (an existing literal key is used whole), matching lodash `castPath`.
+ */
+const castPath = (
+	value: PropertyKey | readonly PropertyKey[],
+	object: unknown
+): readonly PropertyKey[] => {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+	// Narrowing: `Array.isArray` does not exclude a readonly array, so cast.
+	const key = value as PropertyKey;
+	return isKey( key, object ) ? [ key ] : stringToPath( String( key ) );
+};
+
+export default castPath;


### PR DESCRIPTION
## Proposed Changes

Part of the incremental lodash removal. Migrates lodash `set` to a new `@automattic/js-utils` helper:

- **`set`** — a faithful deep-path setter: resolves the path (string with dot/bracket notation, or an array of segments), creates missing intermediate containers (arrays for index-like segments, objects otherwise), reuses existing containers, preserves symbol and negative-zero path segments, mutates and returns the object, and skips `__proto__`/`constructor`/`prototype` keys to avoid prototype pollution.
- Extracts the shared property-path machinery (`castPath`/`isKey`/`stringToPath`) into an internal `to-path` module, now used by both `set` and the sort helpers' `base-order-by` (no behavior change to the sort helpers).

Adds the matching `no-restricted-imports` guard so `set` can't be reintroduced via named or deep imports.

## Why are these changes being made?

Reducing the codebase's dependency on lodash, one small, low-risk batch at a time, replacing it with shared, tested helpers.

## Testing Instructions

- CI green: `yarn typecheck-client`, `yarn typecheck-packages`, lint, and unit tests all pass.
- The helper was validated against lodash as an oracle across all converted call-site path shapes and edge cases (numeric array paths, bracket indices, deep creation, container reuse, symbol/`-0` segments, prototype-pollution hardening, mutation/identity) with zero mismatches, and has unit tests under `packages/js-utils/src/test/`.
- No behavior change is expected at any usage; conversions preserve the prior semantics.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
