### PR TITLE
MSD Plugins: show "No plugins found." empty state for no-results search (DOTMSD-1343)

### DIFF
--- a/client/dashboard/components/switcher/switcher-content.scss
+++ b/client/dashboard/components/switcher/switcher-content.scss
@@ -1,0 +1,4 @@
+.switcher-content__no-results {
+	display: block;
+	padding: 8px 12px;
+}

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -8,8 +8,11 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, type JSX, type PropsWithChildren } from 'react';
 import RouterLinkMenuItem from '../router-link-menu-item';
+import { Text } from '../text';
 import { RenderItem } from './types';
 import type { View, Field } from '@wordpress/dataviews';
+
+import './switcher-content.scss';
 
 export default function SwitcherContent< T >( {
 	itemClassName,
@@ -27,6 +30,7 @@ export default function SwitcherContent< T >( {
 	onItemClick,
 	filter,
 	filterField,
+	noResultsText = __( 'No results found.' ),
 }: PropsWithChildren< {
 	itemClassName?: string | ( ( item: T ) => string );
 	items?: T[];
@@ -42,6 +46,7 @@ export default function SwitcherContent< T >( {
 	onItemClick?: () => void;
 	filter?: JSX.Element;
 	filterField?: Field< T >;
+	noResultsText?: string;
 } > ) {
 	const fields = useMemo( () => {
 		const allFields = searchableFields.map( ( searchableField ) => ( {
@@ -89,26 +94,32 @@ export default function SwitcherContent< T >( {
 				) }
 			</MenuGroup>
 			<MenuGroup hideSeparator>
-				{ filteredData.map( ( item ) => {
-					const itemUrl = getItemUrl( item );
-					const className =
-						typeof itemClassName === 'function' ? itemClassName( item ) : itemClassName;
-					return (
-						<RouterLinkMenuItem
-							className={ className }
-							key={ itemUrl }
-							to={ itemUrl }
-							style={ { height: 'fit-content', minHeight: '40px' } }
-							onClick={ () => {
-								onClose();
-								onItemClick?.();
-							} }
-							resetScroll={ resetScroll }
-						>
-							{ renderItem( { item, context: 'list' } ) }
-						</RouterLinkMenuItem>
-					);
-				} ) }
+				{ filteredData.length === 0 ? (
+					<Text variant="muted" className="switcher-content__no-results">
+						{ noResultsText }
+					</Text>
+				) : (
+					filteredData.map( ( item ) => {
+						const itemUrl = getItemUrl( item );
+						const className =
+							typeof itemClassName === 'function' ? itemClassName( item ) : itemClassName;
+						return (
+							<RouterLinkMenuItem
+								className={ className }
+								key={ itemUrl }
+								to={ itemUrl }
+								style={ { height: 'fit-content', minHeight: '40px' } }
+								onClick={ () => {
+									onClose();
+									onItemClick?.();
+								} }
+								resetScroll={ resetScroll }
+							>
+								{ renderItem( { item, context: 'list' } ) }
+							</RouterLinkMenuItem>
+						);
+					} )
+				) }
 			</MenuGroup>
 			{ children }
 		</NavigableMenu>

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -16,6 +16,11 @@
 	width: fit-content;
 }
 
+// Align the empty-state message with the search box and the plugin rows.
+.plugin-switcher-card-body .switcher-content__no-results {
+	padding: calc(4px * 4) calc(4px * 6);
+}
+
 .plugin-switcher-item {
 	border-top: 1px solid #f0f0f0;
 	border-radius: 0;

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -147,6 +147,7 @@ export const PluginSwitcher = ( {
 					getItemUrl={ ( item ) => pluginRoute.to.replace( '$pluginId', item.slug ) }
 					renderItem={ renderItem }
 					searchableFields={ searchableFields }
+					noResultsText={ __( 'No plugins found.' ) }
 					onClose={ () => {} }
 					width="auto"
 					filter={

--- a/client/dashboard/plugins/manage/components/test/plugin-switcher.test.tsx
+++ b/client/dashboard/plugins/manage/components/test/plugin-switcher.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { PluginSwitcher } from '../plugin-switcher';
+import type { PluginListRow } from '../../types';
+import type { Field, View } from '@wordpress/dataviews';
+
+const searchableFields: Field< PluginListRow >[] = [
+	{ id: 'name', getValue: ( { item } ) => item.name },
+	{ id: 'slug', getValue: ( { item } ) => item.slug },
+];
+
+const akismet = {
+	id: 'akismet/akismet',
+	slug: 'akismet',
+	name: 'Akismet Anti-spam: Spam Protection',
+	sitesWithPluginUpdate: [] as number[],
+} as PluginListRow;
+
+const baseView: View = {
+	type: 'list',
+	page: 1,
+	perPage: 100,
+	sort: { field: 'name', direction: 'asc' },
+};
+
+describe( '<PluginSwitcher> – no-results empty state (DOTMSD-1343)', () => {
+	test( 'shows a "No plugins found." empty state when the search matches nothing', () => {
+		render(
+			<PluginSwitcher
+				pluginsWithIcon={ [ akismet ] }
+				searchableFields={ searchableFields }
+				view={ { ...baseView, search: 'zzznotarealplugin' } }
+				onChangeView={ () => {} }
+				paginationInfo={ { totalItems: 0, totalPages: 0 } }
+			/>
+		);
+
+		expect( screen.getByText( 'No plugins found.' ) ).toBeVisible();
+		// The non-matching plugin must not be rendered in the list.
+		expect( screen.queryByText( akismet.name ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the empty state when there are no plugins at all', () => {
+		render(
+			<PluginSwitcher
+				pluginsWithIcon={ [] }
+				searchableFields={ searchableFields }
+				view={ baseView }
+				onChangeView={ () => {} }
+				paginationInfo={ { totalItems: 0, totalPages: 0 } }
+			/>
+		);
+
+		expect( screen.getByText( 'No plugins found.' ) ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Fixes DOTMSD-1343

## Proposed Changes

In **Manage plugins** (`/plugins/manage`), searching the left plugin list for a term that matches nothing (e.g. `zzznotarealplugin`) left the list **completely blank** — there was no empty state to tell the user nothing matched.

- **`components/switcher/switcher-content.tsx`** — render a muted empty-state message when the filtered list is empty, via a new optional `noResultsText` prop (default `"No results found."`, so every consumer of the switcher gets a sensible empty state).
- **`plugins/manage/components/plugin-switcher.tsx`** — pass `noResultsText={ __( 'No plugins found.' ) }`.
- Added a regression test for the empty-state behavior.

The right-hand detail panel is **intentionally left unchanged**. The "Plugin not found" card it shows for an unmatched/empty selection was introduced in DOTCOM-15563 and is the expected behavior, not a regression — so this PR only addresses the missing empty state on the left list.

| Before | After |
|--------|--------|
| <img width="979" height="502" alt="Screenshot 2026-06-24 at 11 53 56" src="https://github.com/user-attachments/assets/ab08d56f-5194-4405-81ce-0da37b415719" />| <img width="941" height="464" alt="Screenshot 2026-06-24 at 11 53 48" src="https://github.com/user-attachments/assets/74761b8b-bddf-4b47-abf5-c9e5c76f6626" />| 

## Why are these changes being made?

The shared `SwitcherContent` mapped the filtered list with no fallback, so a no-match search rendered nothing at all and the left column appeared broken. This adds a proper empty state.

## Testing Instructions

1. `yarn start-dashboard` and open `/plugins/manage`.
2. In the left plugin search, type a string that matches nothing, e.g. `zzznotarealplugin`.
   - **Before:** the left list goes completely blank.
   - **After:** the left list shows a **"No plugins found."** empty state (the search box stays editable). The right detail panel is unchanged.
3. Clear the search → the full list returns.
4. Type a partial match (e.g. `Blaze`) → the list filters and the detail panel shows the matching plugin.

Automated: `yarn test-client client/dashboard/plugins`, `yarn typecheck-client`.

Note: this is a client-side rendering fix in the dashboard and is environment-agnostic. New translatable strings added: `No plugins found.` and `No results found.` — needs the **[Status] String Freeze** label before merge.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
