### PR TITLE
Dashboard: force-redirect rolled-out users from Calypso HD to MSD

### DIFF
--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -30,12 +30,12 @@ export function getHostingDashboardEnrollment(
 		return { enrolled: false };
 	}
 
-	if ( preference?.value === 'opt-in' ) {
-		return { enrolled: true, reason: 'opt-in' };
-	}
-
 	if ( preference?.value === 'forced-opt-in' || isInRolloutCohort( userId ) ) {
 		return { enrolled: true, reason: 'forced' };
+	}
+
+	if ( preference?.value === 'opt-in' ) {
+		return { enrolled: true, reason: 'opt-in' };
 	}
 
 	return { enrolled: false };

--- a/client/me/controller.jsx
+++ b/client/me/controller.jsx
@@ -193,7 +193,7 @@ export const maybeRedirectToDashboard = ( context, next ) => {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
-			window.location.replace( dashboardLink( '/me/profile' ) );
+			window.location.replace( dashboardLink( '/me' ) );
 			return;
 		}
 		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -16,7 +16,7 @@ export default function () {
 		'/me',
 		controller.maybeRedirectToDashboard,
 		setupPreferences,
-		maybeRedirectToMultiSiteDashboard( '/me/profile' ),
+		maybeRedirectToMultiSiteDashboard( '/me' ),
 		controller.sidebar,
 		setSelectedSiteIdByOrigin,
 		controller.profile,


### PR DESCRIPTION
Fixes DOTMSD-1300

## Proposed Changes

Redirects users in the rollout cohort from Calypso HD pages to the equivalent pages in MSD.

It turns out this mechanism already exists; I only need to fix the precedence between `opt-in` and `isInRolloutCohort()` rule.

I also fixed the outdated redirection from `/me`.

## Why are these changes being made?

We want those users to only be able to access MSD.

## Testing Instructions

It's easiest to test this locally. First, checkout this branch and apply this diff:

```diff
diff --git i/client/dashboard/utils/hosting-dashboard-enrollment.ts w/client/dashboard/utils/hosting-dashboard-enrollment.ts
index 2db50ae7392..c381b81a4cf 100644
--- i/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ w/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -7,11 +7,7 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
  * in analytics queries; nothing is ever persisted.
  */
 function isInRolloutCohort( userId: number | undefined ): boolean {
-       return (
-               config.isEnabled( 'dashboard/enable-percentage-rollout' ) &&
-               userId !== undefined &&
-               userId % 100 < 50
-       );
+       return true;
 }

 type HostingDashboardEnrollment =
```

Then, run `yarn start`. Then:

1. Visit `wordpress.com/sites` (old Calypso HD).
2. Open any site, then navigate to any page.
3. Replace `https://wordpress.com` with `http://calypso.localhost:3000`.
4. Verify you are redirected to `http://my.localhost:3000/*` with the equivalent page.
5. Repeat as necessary.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)