### PR TITLE
Reader Spaces: reload the space feed after tag/feed edits

### DIFF
--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -10,6 +10,7 @@ import {
 	readSpacesQuery,
 	updateReadSpaceMutation,
 } from '../read-spaces';
+import { getStreamInfiniteQueryKeyPrefix } from '../read-streams';
 import type { ReadSpace, ReadSpaceDetails, SiteSubscriptionItem } from '@automattic/api-core';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -124,6 +125,23 @@ describe( 'read spaces mutations', () => {
 				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )
 			).toMatchObject( { id: '3', name: 'New name', tags: [ 'x' ] } );
 		} );
+
+		it( "resets the space's posts feed so it reloads after a tag/feed edit", async () => {
+			const client = newClient();
+			const spy = jest.spyOn( client, 'resetQueries' );
+			nock( BASE )
+				.put( '/wpcom/v2/reader/spaces/3' )
+				.reply( 200, detailResponse( { id: 3, tags: [ 'x' ] } ) );
+
+			await runMutation( client, updateReadSpaceMutation( client ), {
+				spaceId: '3',
+				params: { tags: [ 'x' ] },
+			} );
+
+			expect( spy ).toHaveBeenCalledWith( {
+				queryKey: getStreamInfiniteQueryKeyPrefix( 'space:3' ),
+			} );
+		} );
 	} );
 
 	describe( 'deleteReadSpaceMutation', () => {
@@ -151,6 +169,7 @@ describe( 'read spaces mutations', () => {
 	describe( 'feed (source) mutations', () => {
 		it( 'writes the returned detail to the cache after adding a feed', async () => {
 			const client = newClient();
+			const spy = jest.spyOn( client, 'resetQueries' );
 			nock( BASE )
 				.post( '/wpcom/v2/reader/spaces/3/feeds' )
 				.reply(
@@ -184,6 +203,9 @@ describe( 'read spaces mutations', () => {
 					siteIcon: null,
 				},
 			] );
+			expect( spy ).toHaveBeenCalledWith( {
+				queryKey: getStreamInfiniteQueryKeyPrefix( 'space:3' ),
+			} );
 		} );
 
 		it( 'writes the returned detail to the cache after removing a feed', async () => {

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -13,10 +13,29 @@ import {
 	type UpdateReadSpaceParams,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions, type QueryClient } from '@tanstack/react-query';
+import { getStreamInfiniteQueryKeyPrefix } from './read-streams';
 
 const readSpacesListKey = [ 'read', 'spaces', 'list' ] as const;
 
 const readSpaceDetailKey = ( spaceId: string ) => [ 'read', 'spaces', 'detail', spaceId ] as const;
+
+// A space's posts feed is served under the `space:<id>` stream key, built
+// server-side from the space's followed feeds and tags. Editing either changes
+// which posts appear, so the feed list has to reload.
+//
+// The feed is a cursor-paginated `useInfiniteQuery`, so a plain
+// `invalidateQueries` is not enough: it refetches each cached page using the
+// cursor (`before`/`offset`) it was originally loaded with, and those cursors
+// were derived from the *old* post set. After the tags/feeds change the page
+// boundaries no longer line up, so the reloaded list can show stale, duplicated
+// or gapped posts. `resetQueries` discards the cached pages and their cursors
+// and refetches the active stream from the first page — a clean reload. This
+// mirrors the stream "force refresh" pattern in
+// `client/reader/stream/use-stream-pending-posts.ts`.
+const reloadReadSpaceStream = ( queryClient: QueryClient, spaceId: string ) =>
+	queryClient.resetQueries( {
+		queryKey: getStreamInfiniteQueryKeyPrefix( `space:${ spaceId }` ),
+	} );
 
 export const readSpacesQuery = () =>
 	queryOptions( {
@@ -86,6 +105,8 @@ export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
 				( previous ) => previous?.map( ( item ) => ( item.id === space.id ? summary : item ) )
 			);
 			queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
+			// Tags/feeds may have changed, so reload the space's posts feed.
+			reloadReadSpaceStream( queryClient, space.id );
 		},
 	} );
 
@@ -109,8 +130,11 @@ export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 // Add/remove a followed feed. Both endpoints return the updated detail, so we
 // write it straight to the detail cache (the list summary is unaffected by
 // feeds). `subscription` carries the feed id/url the api-core mutator sends.
-const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails ) =>
+const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails ) => {
 	queryClient.setQueryData< ReadSpaceDetails >( readSpaceQuery( space.id ).queryKey, space );
+	// Adding/removing a feed changes the space's posts feed, so reload it too.
+	reloadReadSpaceStream( queryClient, space.id );
+};
 
 export const addReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {


### PR DESCRIPTION
Part of RSM-4494

## Proposed Changes

* Reset the `space:<id>` posts stream in `updateReadSpaceMutation` so the feed list reloads after a space's tags (or name) are edited and saved.
* Reset the same stream in the add/remove followed-feed mutations (`writeReadSpaceDetail`), since changing sources also changes which posts the space shows.
* Use `resetQueries` rather than `invalidateQueries`: the space feed is a cursor-paginated infinite query, and invalidation only refetches each cached page using the cursor (`before`/`offset`) it was loaded with — cursors derived from the *old* post set. After the tags/feeds change those page boundaries no longer line up, so the reloaded list could show stale, duplicated, or gapped posts. `resetQueries` discards the cached pages and their cursors and refetches the active stream from the first page — a clean reload, mirroring the stream "force refresh" pattern in `use-stream-pending-posts.ts`.
* Added regression tests asserting the stream is reset on tag edit and on feed add.

## Why are these changes being made?

A space's posts feed is built server-side from its followed feeds and tags. Previously the update/feed mutations only wrote the space detail cache, leaving the cached `space:<id>` stream stale — users kept seeing the old feed until a manual reload or re-navigation.

## Testing Instructions

### Scenario 1 - Editing tags reloads the feed:
- Go to `/reader` and open one of your spaces
- Open the space's Customize modal, change its tags, and save
- Check if the space's feed list reloads to reflect the updated tags (no manual refresh needed)

### Scenario 2 - Adding/removing a feed reloads the feed:
- Open a space and add or remove a followed feed (source)
- Check if the space's feed list reloads to reflect the changed sources

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
