### PR TITLE
Plugins: keep tab underline aligned when switching plugins (DOTMSD-1335)

### DIFF
--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -65,7 +65,15 @@ export function PluginTabs( {
 			selectedTabId={ activeTab }
 			onSelect={ ( tabId: 'installed' | 'available' ) => setActiveTab( tabId ) }
 		>
-			<Tabs.TabList className="plugin-tabs-list">
+			{ /*
+			 * The "Installed on N sites" label changes width when the selected
+			 * plugin changes, which shifts the sibling "Available on" tab. The
+			 * WordPress Tabs indicator only re-measures on a selected-tab resize
+			 * or tab-index change — not when a sibling reflows — so its underline
+			 * gets left behind. Keying the tab list on the label remounts it,
+			 * forcing a fresh measurement so the indicator stays aligned.
+			 */ }
+			<Tabs.TabList key={ sitesWithThisPluginExcludingDeleted.length } className="plugin-tabs-list">
 				<Tabs.Tab tabId="installed">
 					<SectionHeader
 						level={ 3 }


### PR DESCRIPTION
Fixes DOTMSD-1335

## Proposed Changes

In **Manage plugins** (`/plugins/manage`), the active-tab underline in the plugin detail panel could end up misaligned: select a plugin, switch to the **Available on** tab, then select a different plugin — the **Installed on N sites** label changes width, which shifts the **Available on** tab sideways, but the underline stayed at its old position.

- **`client/dashboard/plugins/plugin/index.tsx`** — key `Tabs.TabList` on the install count so the tab strip remounts and re-measures the indicator whenever the variable-width label changes.

## Why are these changes being made?

The `@wordpress/components` `Tabs` indicator is positioned from JS-measured offsets that only refresh when the *selected* tab resizes or its index changes — not when a *sibling* tab reflows and shifts the selected tab's position. Switching plugins changes the width of the "Installed on N sites" tab, shifting the selected "Available on" tab, which the indicator doesn't detect. Remounting the tab list forces a fresh measurement. It's scoped to the tab strip, so the open tab and the sites tables aren't disturbed.

## Testing Instructions

1. `yarn start-dashboard` and open `/plugins/manage`.
2. Select a plugin installed on many sites (e.g. one showing "Installed on 18 sites").
3. Switch to the **Available on** tab.
4. Select a different plugin with a different install count (e.g. "1 site").
   - **Before:** the underline stays under the old position and is misaligned with "Available on".
   - **After:** the underline stays correctly aligned under "Available on".
5. Confirm clicking between the two tabs still positions/animates the underline correctly.

Verified manually across 18 → 1 → 11 site transitions. No automated test is included: the bug is the indicator's measured pixel position, which jsdom can't reproduce (`getBoundingClientRect` returns zeros).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
