### PR TITLE
Reader: clear the floating 2026 nav on the logged-out hero

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -513,6 +513,16 @@ body.is-section-reader {
 		}
 	}
 
+	// The 2026 global nav is fixed and floats over this dark hero band, so add its
+	// height on top of the hero's own top padding to keep the heading clear of the nav.
+	&:has( .x-nav--2026-redesign ) .layout__header-section-content {
+		padding-top: calc( 24px + var( --nav-2026-height ) );
+
+		@include break-medium {
+			padding-top: calc( 48px + var( --nav-2026-height ) );
+		}
+	}
+
 	.masterbar {
 		border-bottom: none;
 		background: transparent;


### PR DESCRIPTION
Fixes #

## Proposed Changes

* On the logged-out Reader landing page, add the new Global Nav 2026 bar's height on top of the hero's existing top padding, so the hero heading clears the floating nav instead of sitting underneath it.
* The adjustment only applies when the 2026 nav is active; the legacy nav is unaffected.
<img width="480" alt="Screenshot 2026-06-24 at 11 49 06" src="https://github.com/user-attachments/assets/6f041e64-fd39-4d53-9a0e-23db37b622da" />
<img width="240" alt="Screenshot 2026-06-24 at 15 07 26" src="https://github.com/user-attachments/assets/fb6ad8ac-5654-42de-9230-4fd758c15faf" />


## Why are these changes being made?

* With the Global Nav 2026 experiment live, the new nav is fixed and floats over the Reader hero's dark band. The hero heading sat too close to the top and visually clashed with the nav. The showcase pages (Themes, Patterns, Plugins) already account for the floating nav in their heroes; this brings the Reader hero in line.

## Testing Instructions

* Visit the logged-out Reader landing page (Discover) with the Global Nav 2026 redesign active (?flags=nav-redesign/2026)
* Confirm the hero heading sits clearly below the floating nav with comfortable spacing, on both mobile and desktop widths.
<img width="480" alt="Screenshot 2026-06-24 at 15 06 58" src="https://github.com/user-attachments/assets/0965309e-77d8-4839-96e6-774a94020259" />
<img width="240" alt="Screenshot 2026-06-24 at 15 07 19" src="https://github.com/user-attachments/assets/53d7f39c-ed03-4ed2-abbf-834745259e29" />


* Visit the same page with the legacy nav and confirm the hero spacing is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
