### PR TITLE
Reader Spaces: prefetch a space's feed on sidebar hover

### DIFF
--- a/client/reader/sidebar/spaces/index.tsx
+++ b/client/reader/sidebar/spaces/index.tsx
@@ -1,9 +1,12 @@
+import { readSpaceQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { Icon, category } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import { useSpaces } from 'calypso/reader/data/spaces';
+import { prefetchInfiniteStream } from 'calypso/reader/data/stream';
 import { AddMenuItem } from 'calypso/reader/sidebar/menu';
 import { CreateSpaceModal } from 'calypso/reader/spaces/create-modal';
 import { getSpacePath, SPACES_BASE_PATH } from 'calypso/reader/spaces/routes';
@@ -29,6 +32,7 @@ function getActiveSpaceId( path: string ): string | null {
 export function ReaderSidebarSpaces( { path }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
 	const spaces = useSpaces();
 
 	const activeId = getActiveSpaceId( path );
@@ -45,6 +49,20 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 
 	const recordSpaceClick = ( id: string ) => {
 		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_space_clicked', { space: id } ) );
+	};
+
+	// Warm the feed on hover/focus so the view paints from cache on click. The
+	// stream query's 5-minute staleTime makes repeated hovers cheap no-ops.
+	const prefetchSpace = ( id: string ) => {
+		// Skip the space we're already viewing — its data is loaded (or loading).
+		if ( id === activeId ) {
+			return;
+		}
+		void prefetchInfiniteStream( queryClient, dispatch, {
+			streamKey: `space:${ id }`,
+			enabled: true,
+		} );
+		void queryClient.prefetchQuery( readSpaceQuery( id ) );
 	};
 
 	const handleAddSpaceClick = () => {
@@ -76,6 +94,7 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 						space={ space }
 						isSelected={ activeId === space.id }
 						onClick={ () => recordSpaceClick( space.id ) }
+						onPrefetch={ () => prefetchSpace( space.id ) }
 					/>
 				) ) }
 				<AddMenuItem label={ translate( 'Add a space' ) } onClick={ handleAddSpaceClick } />

--- a/client/reader/sidebar/spaces/menu-item.tsx
+++ b/client/reader/sidebar/spaces/menu-item.tsx
@@ -8,9 +8,11 @@ interface Props {
 	space: ReadSpace;
 	isSelected: boolean;
 	onClick: () => void;
+	/** Warm the space's feed cache when the user hovers or focuses the row. */
+	onPrefetch?: () => void;
 }
 
-export function SpaceMenuItem( { space, isSelected, onClick }: Props ) {
+export function SpaceMenuItem( { space, isSelected, onClick, onPrefetch }: Props ) {
 	// Fall back to a generic icon when the API returns an icon key the UI
 	// doesn't recognize, so the item still renders a glyph.
 	const icon = SPACE_ICONS[ space.layout.icon ] ?? rss;
@@ -24,6 +26,8 @@ export function SpaceMenuItem( { space, isSelected, onClick }: Props ) {
 				className="sidebar__menu-link sidebar-spaces__link"
 				href={ getSpacePath( space.id ) }
 				onClick={ onClick }
+				onMouseEnter={ onPrefetch }
+				onFocus={ onPrefetch }
 			>
 				<span className="sidebar-spaces__icon" aria-hidden="true">
 					<Icon icon={ icon } size={ 18 } />

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -132,6 +132,44 @@ describe( 'ReaderSidebarSpaces', () => {
 		);
 	} );
 
+	it( 'prefetches the feed and detail of a space on hover', async () => {
+		const user = userEvent.setup();
+		const HOVERED = SPACES[ 1 ]; // Not the active space.
+		const postsScope = nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/reader/spaces/${ HOVERED.id }/posts` )
+			.query( true )
+			.reply( 200, { posts: [] } );
+		const detailScope = nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/reader/spaces/${ HOVERED.id }` )
+			.reply( 200, { ...HOVERED, follows: [], tags: [] } );
+
+		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
+
+		await user.hover( screen.getByRole( 'link', { name: new RegExp( HOVERED.name ) } ) );
+
+		await waitFor( () => expect( postsScope.isDone() ).toBe( true ) );
+		await waitFor( () => expect( detailScope.isDone() ).toBe( true ) );
+	} );
+
+	it( 'does not prefetch the space that is already open', async () => {
+		const user = userEvent.setup();
+		// Interceptors for the active space; they must stay pending (never called).
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/reader/spaces/${ FIRST_SPACE.id }/posts` )
+			.query( true )
+			.reply( 200, { posts: [] } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/reader/spaces/${ FIRST_SPACE.id }` )
+			.reply( 200, { ...FIRST_SPACE, follows: [], tags: [] } );
+
+		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
+
+		await user.hover( screen.getByRole( 'link', { name: new RegExp( FIRST_SPACE.name ) } ) );
+
+		// The guard short-circuits synchronously, so no request goes out.
+		expect( nock.pendingMocks() ).toHaveLength( 2 );
+	} );
+
 	it( 'does not render the sources modal from the sidebar', () => {
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
 

--- a/client/reader/sidebar/spaces/test/menu-item.test.tsx
+++ b/client/reader/sidebar/spaces/test/menu-item.test.tsx
@@ -78,6 +78,23 @@ describe( 'SpaceMenuItem', () => {
 		expect( onClick ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'invokes onPrefetch when the link is hovered', async () => {
+		const user = userEvent.setup();
+		const onPrefetch = jest.fn();
+		render(
+			<SpaceMenuItem
+				space={ SPACE }
+				isSelected={ false }
+				onClick={ jest.fn() }
+				onPrefetch={ onPrefetch }
+			/>
+		);
+
+		await user.hover( screen.getByRole( 'link', { name: new RegExp( SPACE.name ) } ) );
+
+		expect( onPrefetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'marks the row as selected and tags it with the space colour modifier', () => {
 		const { container } = render(
 			<SpaceMenuItem space={ SPACE } isSelected onClick={ jest.fn() } />


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Prefetch a Reader Space's posts feed (the `space:<id>` stream) and its detail query when the user hovers or focuses the space's row in the sidebar, so the feed view paints from cache on click instead of showing a loading state.
* Reuse the existing `prefetchInfiniteStream` helper and `readSpaceQuery`; the currently-open space is skipped and the stream's 5-minute `staleTime` keeps repeated hovers as cheap no-ops.
* Added regression tests covering prefetch-on-hover, the active-space skip, and `onPrefetch` wiring on the menu item.

## Why are these changes being made?

Today the space feed only starts fetching after the user clicks and `SpaceFeed` mounts, so every navigation into a space shows a loading spinner. Warming the cache on hover/focus hides most of that latency for a faster perceived load, while staying low-risk by leaning on infrastructure that already exists.

## Testing Instructions

### Scenario 1 - Feed preloads on hover:
- Go to `/reader` and expand the **Spaces** section in the sidebar.
- Open the browser Network tab and filter for `spaces`.
- Hover (or keyboard-focus) a space you have not visited yet.
- Check that a request to `/wpcom/v2/reader/spaces/<id>/posts` (and the space detail request) fires on hover, before any click.

### Scenario 2 - Cached feed opens instantly:
- After hovering as above, click that same space.
- Check that the feed renders its posts with little or no loading spinner.
- Hover the same space again within a few minutes and check that no new posts request is sent.

### Scenario 3 - Active space is not refetched:
- While viewing a space at `/reader/spaces/<id>`, hover that same space's row in the sidebar.
- Check that no additional feed or detail request is made for it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
