### PR TITLE
Nav 2026: hide the nav from SSR until the assignment resolves

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -574,8 +574,7 @@ body.is-mobile-app-view {
 }
 
 .is-nav-2026-assignment-loading {
-	visibility: hidden;
-	pointer-events: none;
+	display: none;
 }
 
 // Source of truth for the fixed 2026 nav's geometry; everything that clears or sticks

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -5,7 +5,6 @@ import {
 	getCurrentUser,
 	getCurrentUserDisplayName,
 	getCurrentUserEmail,
-	isUserLoggedIn,
 } from 'calypso/state/current-user/selectors';
 import type { HeaderProps } from '@automattic/wpcom-template-parts';
 
@@ -45,8 +44,8 @@ const VARIATION_TO_VARIANT: Partial< Record< string, 1 | 2 > > = {
 
 /**
  * Props to spread onto `UniversalNavbarHeader` to opt into the 2026 Global Nav.
- * Returns a temporary loading class while a logged-in assignment is pending,
- * otherwise returns `{}` when the nav stays on the old design.
+ * Returns a temporary loading class while the assignment is pending, otherwise
+ * returns `{}` when the nav stays on the old design.
  *
  * Resolution order:
  * 1. Minimal universal headers are not eligible for Nav 2026.
@@ -54,13 +53,13 @@ const VARIATION_TO_VARIANT: Partial< Record< string, 1 | 2 > > = {
  *    follows the existing `nav-redesign/2026-variant-2` flag.
  * 3. The NAV_2026_EXPERIMENT assignment — `showcase_products`/`showcase_products_and_ai`
  *    map to variants 1/2; everything else (control, null) → old nav.
- *    While the assignment is still loading for logged-in users, return a
- *    temporary className that hides the old nav until the assignment resolves.
+ *    While the assignment is still loading, return a temporary className that
+ *    hides the old nav until the assignment resolves, avoiding the old-nav→new-nav
+ *    flash on navigation.
  */
 export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
 	const isHeaderEligible = options.variant !== 'minimal';
 	const forcedOn = isHeaderEligible && config.isEnabled( 'nav-redesign/2026' );
-	const isLoggedIn = useSelector( isUserLoggedIn );
 	const userAvatar = useSelector( ( state ) => getCurrentUser( state )?.avatar_URL );
 	const userName = useSelector( getCurrentUserDisplayName );
 	const userEmail = useSelector( getCurrentUserEmail );
@@ -80,7 +79,12 @@ export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
 		variant = VARIATION_TO_VARIANT[ experimentAssignment.variationName ];
 	}
 
-	if ( isLoggedIn && isLoadingExperiment && ! forcedOn ) {
+	// Hide the old nav while the client-side assignment is still pending, then let
+	// it render once we know the variant. This avoids the brief old-nav→new-nav
+	// flash when navigating between logged-out marketing surfaces. The nav stays in
+	// the server HTML (only `visibility` is toggled), so crawlers still see it and
+	// its links — the hide is purely client-side and visual.
+	if ( isLoadingExperiment && ! forcedOn ) {
 		return { className: 'is-nav-2026-assignment-loading' };
 	}
 

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -53,9 +53,10 @@ const VARIATION_TO_VARIANT: Partial< Record< string, 1 | 2 > > = {
  *    follows the existing `nav-redesign/2026-variant-2` flag.
  * 3. The NAV_2026_EXPERIMENT assignment — `showcase_products`/`showcase_products_and_ai`
  *    map to variants 1/2; everything else (control, null) → old nav.
- *    While the assignment is still loading, return a temporary className that
- *    hides the old nav until the assignment resolves, avoiding the old-nav→new-nav
- *    flash on navigation.
+ *    Until the variant is resolved — from the server render through the client
+ *    loading window — return a temporary className that hides the nav, then reveal
+ *    it once resolved. Hiding from SSR (not just after hydration) is what prevents
+ *    the old-nav→new-nav flash.
  */
 export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
 	const isHeaderEligible = options.variant !== 'minimal';
@@ -79,12 +80,18 @@ export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
 		variant = VARIATION_TO_VARIANT[ experimentAssignment.variationName ];
 	}
 
-	// Hide the old nav while the client-side assignment is still pending, then let
-	// it render once we know the variant. This avoids the brief old-nav→new-nav
-	// flash when navigating between logged-out marketing surfaces. The nav stays in
-	// the server HTML (only `visibility` is toggled), so crawlers still see it and
-	// its links — the hide is purely client-side and visual.
-	if ( isLoadingExperiment && ! forcedOn ) {
+	// Hide the nav until the variant is resolved, then reveal it. The assignment is
+	// only available client-side, so we hide from the server render onwards (SSR:
+	// `window` is undefined; client: until the experiment finishes loading) and let
+	// the client reveal the resolved nav once known. Hiding from SSR — rather than
+	// only after hydration — is what actually prevents the old-nav→new-nav flash, and
+	// keeps the server and first client render in sync (no hydration mismatch).
+	//
+	// The nav markup and its links stay in the DOM; only `visibility` is toggled. A
+	// no-JS client (including crawlers) never runs the reveal, so it keeps the nav
+	// hidden — an accepted trade-off, pending SEO sign-off.
+	const isVariantResolved = forcedOn || ( typeof window !== 'undefined' && ! isLoadingExperiment );
+	if ( isHeaderEligible && ! forcedOn && ! isVariantResolved ) {
 		return { className: 'is-nav-2026-assignment-loading' };
 	}
 


### PR DESCRIPTION
Fixes p1782298166556859-slack-C09UDBAANDS

## Proposed Changes

* Hide the nav until the Global Nav 2026 experiment variant is resolved, then reveal it — removing the old-nav→new-nav flash on logged-out marketing pages (homepage → Themes / Patterns / Plugins).
* The hide is applied from the **server render** onwards (through the client loading window), not only after hydration. Hiding only after hydration — the earlier approach — left the old nav visible during the HTML-paint→JS-load window, so the flash remained.
* Reuses the existing `is-nav-2026-assignment-loading` hide (now `display:none` to avoid a layout shift while the nav resolves); no new markup, document, or CSP changes.

## Why are these changes being made?

* The 2026 nav variant is resolved client-side (ExPlat has no server-side path), so the server ships the old nav and the client swaps to the new one once the variant is known — a visible flash. Hiding the nav from the server render until the variant resolves removes the flash, and keeps the server and first client render in sync (no hydration mismatch).
* The nav markup and its links stay in the DOM; the nav wrapper is `display:none` while unresolved. A no-JS client / crawler never runs the reveal, so it keeps the nav hidden — an accepted trade-off, pending SEO sign-off.
* If the assignment fails, ExPlat resolves to a fallback, so the nav is never left hidden for a JS client.

## Testing Instructions

* With the Global Nav 2026 experiment active, navigate as a logged-out visitor to Themes, Patterns, or Plugins.
* Confirm the old nav no longer flashes — the nav is hidden from first paint, then appears once the variant resolves, without a layout jump.
* View source / curl the page and confirm the nav markup and links are present, with `is-nav-2026-assignment-loading` on the nav wrapper.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
