### PR TITLE
Calypso E2E: fix untracked failing specs: invite, advertising, dark-mode (TESTOPS-193)

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -42,10 +42,8 @@ export class AdvertisingPage {
 	 * @returns The heading element for the Advertising page.
 	 */
 	get advertisingHeading(): Locator {
-		// On WordPress.com the Tools > Advertising page heading is "Blaze". Only the
-		// standalone Blaze Ads Jetpack plugin (is_running_in_blaze_plugin) renders
-		// "Blaze Ads", and Calypso E2E never runs in that build, so assert the exact
-		// WordPress.com label.
+		// Only the standalone Blaze Ads Jetpack plugin renders "Blaze Ads"; WordPress.com,
+		// where E2E runs, uses the exact label "Blaze".
 		return this.page.getByRole( 'heading', { name: 'Blaze', exact: true } );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -42,7 +42,11 @@ export class AdvertisingPage {
 	 * @returns The heading element for the Advertising page.
 	 */
 	get advertisingHeading(): Locator {
-		return this.page.getByRole( 'heading', { name: /^Blaze( Ads)?$/ } );
+		// On WordPress.com the Tools > Advertising page heading is "Blaze". Only the
+		// standalone Blaze Ads Jetpack plugin (is_running_in_blaze_plugin) renders
+		// "Blaze Ads", and Calypso E2E never runs in that build, so assert the exact
+		// WordPress.com label.
+		return this.page.getByRole( 'heading', { name: 'Blaze', exact: true } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -42,7 +42,7 @@ export class AdvertisingPage {
 	 * @returns The heading element for the Advertising page.
 	 */
 	get advertisingHeading(): Locator {
-		return this.page.getByRole( 'heading', { name: 'Dashboard' } );
+		return this.page.getByRole( 'heading', { name: /^Blaze( Ads)?$/ } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -30,7 +30,11 @@ export class BlazeCampaignPage {
 	 * @returns The heading element for the Blaze Campaign page.
 	 */
 	get makeMostOfYourBlazeCampaignHeading(): Locator {
-		return this.page.getByRole( 'heading', { name: 'Make the most of your Blaze campaign' } );
+		// The campaign wizard is rendered by the external BlazePress widget, which
+		// rebranded "Blaze" to "Blaze Ads" in its copy. Match either form.
+		return this.page.getByRole( 'heading', {
+			name: /^Make the most of your Blaze( Ads)? campaign$/,
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -30,8 +30,7 @@ export class BlazeCampaignPage {
 	 * @returns The heading element for the Blaze Campaign page.
 	 */
 	get makeMostOfYourBlazeCampaignHeading(): Locator {
-		// The campaign wizard is rendered by the external BlazePress widget, which
-		// rebranded "Blaze" to "Blaze Ads" in its copy. Match either form.
+		// The external BlazePress widget rebranded "Blaze" to "Blaze Ads"; match either.
 		return this.page.getByRole( 'heading', {
 			name: /^Make the most of your Blaze( Ads)? campaign$/,
 		} );

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -168,11 +168,12 @@ export class PeoplePage {
 			throw new Error( 'username is required' );
 		}
 
-		// Trim a trailing slash off baseURL so the joined path doesn't become
-		// `host//people/edit/...` (a double slash breaks page.js route matching).
-		await this.page.goto(
-			`${ baseURL.replace( /\/+$/, '' ) }/people/edit/${ siteURL }/${ username }`
-		);
+		// Join via new URL with a host-absolute path rather than string concatenation:
+		// baseURL often carries a trailing slash (getCalypsoURL( '' ) returns one), and
+		// concatenating would produce `host//people/edit/...`, whose double slash breaks
+		// page.js routing. The leading slash also ignores any path on baseURL, so the
+		// route always resolves against the host root.
+		await this.page.goto( new URL( `/people/edit/${ siteURL }/${ username }`, baseURL ).href );
 		await this.page.getByRole( 'button', { name: 'Remove' } ).waitFor( { state: 'visible' } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -168,11 +168,8 @@ export class PeoplePage {
 			throw new Error( 'username is required' );
 		}
 
-		// Join via new URL with a host-absolute path rather than string concatenation:
-		// baseURL often carries a trailing slash (getCalypsoURL( '' ) returns one), and
-		// concatenating would produce `host//people/edit/...`, whose double slash breaks
-		// page.js routing. The leading slash also ignores any path on baseURL, so the
-		// route always resolves against the host root.
+		// baseURL may carry a trailing slash; new URL with a leading-slash path avoids the
+		// `host//people/...` double slash that breaks page.js routing.
 		await this.page.goto( new URL( `/people/edit/${ siteURL }/${ username }`, baseURL ).href );
 		await this.page.getByRole( 'button', { name: 'Remove' } ).waitFor( { state: 'visible' } );
 	}

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -168,7 +168,11 @@ export class PeoplePage {
 			throw new Error( 'username is required' );
 		}
 
-		await this.page.goto( `${ baseURL }/people/edit/${ siteURL }/${ username }` );
+		// Trim a trailing slash off baseURL so the joined path doesn't become
+		// `host//people/edit/...` (a double slash breaks page.js route matching).
+		await this.page.goto(
+			`${ baseURL.replace( /\/+$/, '' ) }/people/edit/${ siteURL }/${ username }`
+		);
 		await this.page.getByRole( 'button', { name: 'Remove' } ).waitFor( { state: 'visible' } );
 	}
 }

--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -407,7 +407,7 @@ test.describe( 'Dashboard dark-mode surface', { tag: [ tags.DASHBOARD_PR ] }, ()
 
 		await test.step( 'Then the Sites route renders in dark mode', async () => {
 			await pageDashboard.visitPath( 'sites' );
-			await page.getByRole( 'main' ).waitFor();
+			await expect( page.getByRole( 'main' ) ).toBeVisible( { timeout: 30_000 } );
 			await expectDarkModeRoot( page );
 			await expectSharedDarkTokens( page );
 			await expectNoObviousLightSurface( page.getByRole( 'main' ) );
@@ -422,7 +422,7 @@ test.describe( 'Dashboard dark-mode surface', { tag: [ tags.DASHBOARD_PR ] }, ()
 
 		await test.step( 'And the site overview route renders in dark mode', async () => {
 			await pageDashboard.visitPath( `sites/${ siteSlug }` );
-			await page.getByRole( 'main' ).waitFor();
+			await expect( page.getByRole( 'main' ) ).toBeVisible( { timeout: 30_000 } );
 			await expectDarkModeRoot( page );
 			await expectSharedDarkTokens( page );
 			await expectNoObviousLightSurface( page.getByRole( 'main' ) );

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -61,7 +61,10 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 			// site we invited the user to. Fail loudly if the URL is not the expected
 			// `/people/team/<slug>` list route.
 			const peopleUrl = new URL( page.url() );
-			const slugMatch = peopleUrl.pathname.match( /^\/people\/team\/([^/?#]+\.[^/?#]+)/ );
+			// Capture the first path segment after /people/team/. The route is
+			// /people/team/:site_id and :site_id accepts any non-slash value, so do not
+			// require a dot: mapped/dotless slugs are valid and must not throw here.
+			const slugMatch = peopleUrl.pathname.match( /^\/people\/team\/([^/?#]+)/ );
 			if ( ! slugMatch ) {
 				throw new Error(
 					`Could not determine the invited site slug from the people URL: ${ peopleUrl.href }`

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -54,6 +54,20 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'When I navigate to Users > All Users', async function () {
 			await componentSidebar.navigate( 'Users', 'All Users' );
+			// Capture the slug of the site authenticate() landed on, which is the site
+			// the invite below is sent to (not necessarily testSites.primary on the
+			// shared pre-release account). Reading it from the All Users URL now, before
+			// the invite and signup round-trip, makes the later removal act on the exact
+			// site we invited the user to. Fail loudly if the URL is not the expected
+			// `/people/team/<slug>` list route.
+			const peopleUrl = new URL( page.url() );
+			const slugMatch = peopleUrl.pathname.match( /^\/people\/team\/([^/?#]+\.[^/?#]+)/ );
+			if ( ! slugMatch ) {
+				throw new Error(
+					`Could not determine the invited site slug from the people URL: ${ peopleUrl.href }`
+				);
+			}
+			invitedSiteSlug = slugMatch[ 1 ];
 		} );
 
 		await test.step( `And I invite a new user with role ${ role }`, async function () {
@@ -139,20 +153,6 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'When I navigate back to Users > All Users', async function () {
 			await componentSidebar.navigate( 'Users', 'All Users' );
-			// The invite was sent to whichever site is currently selected (the site
-			// authenticate() landed on), which is not necessarily testSites.primary on
-			// the shared pre-release account. Capture that site's slug from the people
-			// URL so the removal acts on the same site we actually invited the user to.
-			// Match the site fragment (a domain-like segment) after the people filter
-			// and fail loudly if the URL isn't the expected `/people/<filter>/<slug>`.
-			const peopleUrl = new URL( page.url() );
-			const slugMatch = peopleUrl.pathname.match( /\/people\/[^/]+\/([^/?#]+\.[^/?#]+)/ );
-			if ( ! slugMatch ) {
-				throw new Error(
-					`Could not determine the invited site slug from the people URL: ${ peopleUrl.href }`
-				);
-			}
-			invitedSiteSlug = slugMatch[ 1 ];
 		} );
 
 		await test.step( 'Then I can see the invited user part of the team', async function () {

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -20,6 +20,7 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 	let userManagementRevampFeature = false;
 	let acceptInviteLink: string;
+	let invitedSiteSlug: string;
 
 	// Accounts created during the run, closed via API in afterAll as a guaranteed
 	// teardown. The in-body UI close below stays as product coverage; the API close
@@ -138,13 +139,27 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'When I navigate back to Users > All Users', async function () {
 			await componentSidebar.navigate( 'Users', 'All Users' );
+			// The invite was sent to whichever site is currently selected (the site
+			// authenticate() landed on), which is not necessarily testSites.primary on
+			// the shared pre-release account. Capture that site's slug from the people
+			// URL so the removal acts on the same site we actually invited the user to.
+			// Match the site fragment (a domain-like segment) after the people filter
+			// and fail loudly if the URL isn't the expected `/people/<filter>/<slug>`.
+			const peopleUrl = new URL( page.url() );
+			const slugMatch = peopleUrl.pathname.match( /\/people\/[^/]+\/([^/?#]+\.[^/?#]+)/ );
+			if ( ! slugMatch ) {
+				throw new Error(
+					`Could not determine the invited site slug from the people URL: ${ peopleUrl.href }`
+				);
+			}
+			invitedSiteSlug = slugMatch[ 1 ];
 		} );
 
 		await test.step( 'Then I can see the invited user part of the team', async function () {
 			// Use direct navigation to avoid finding the user when there are over 100 team members piled up.
 			await pagePeople.visitTeamMemberUserDetails(
 				helperData.getCalypsoURL(),
-				accountPreRelease.credentials.testSites?.primary?.url as string,
+				invitedSiteSlug,
 				signedUpUsername
 			);
 		} );

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -54,16 +54,10 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'When I navigate to Users > All Users', async function () {
 			await componentSidebar.navigate( 'Users', 'All Users' );
-			// Capture the slug of the site authenticate() landed on, which is the site
-			// the invite below is sent to (not necessarily testSites.primary on the
-			// shared pre-release account). Reading it from the All Users URL now, before
-			// the invite and signup round-trip, makes the later removal act on the exact
-			// site we invited the user to. Fail loudly if the URL is not the expected
-			// `/people/team/<slug>` list route.
+			// Capture the site authenticate() landed on (not necessarily testSites.primary
+			// on the shared pre-release account) so the later removal targets the invited
+			// site. site_id accepts any non-slash value, so dotless/mapped slugs are valid.
 			const peopleUrl = new URL( page.url() );
-			// Capture the first path segment after /people/team/. The route is
-			// /people/team/:site_id and :site_id accepts any non-slash value, so do not
-			// require a dot: mapped/dotless slugs are valid and must not throw here.
 			const slugMatch = peopleUrl.pathname.match( /^\/people\/team\/([^/?#]+)/ );
 			if ( ! slugMatch ) {
 				throw new Error(


### PR DESCRIPTION
Fixes [TESTOPS-193](https://linear.app/a8c/issue/TESTOPS-193)

## Proposed Changes

Four E2E specs were failing in the matrix with no tracking issue or PR. Only two were actually flaky; the other two were broken outright. Per spec:

- **`advertising__promote`**: the Blaze page header was redesigned in #111173, so the h1 is now "Blaze", and the campaign wizard (rendered by the external BlazePress widget) now reads "Blaze Ads campaign". Both POM locators still looked for the old "Dashboard" / "Make the most of your Blaze campaign" text, so the spec failed on every run. Updated both.
- **`invite__new-user`**: `visitTeamMemberUserDetails` removed the user from `testSites.primary`, but the invite is sent to whichever site `authenticate()` lands on. On the shared pre-release account those have drifted apart, so the user was never on the removal site and the route fell back to the "Select a site" picker, where there's no Remove button. The spec now captures the slug of the site it actually invited to and removes from that. Also trimmed a trailing slash that produced a `//people/edit` double slash.
- **`dark-mode-surfaces`** (Dashboard surface): the sites and site-overview routes can take longer than the default 10s to render `<main>` on a cold load, so the wait timed out while it was still hidden. Bumped to a 30s web-first assertion, same as the Themes step in #111920.
- **`i18n__editor`**: no change in this PR; #111920 already fixed it (the `.global-sidebar` Global Nav case, plus skipping the sidebar wait). Listed for completeness since it was in the same batch.

## Why are these changes being made?

These specs fail on unrelated PRs and add noise to the matrix. The ticket called them "flaky", but the CI history disagrees: `invite__new-user` failed 300/300 over two days with zero passes, and `advertising__promote` has failed since #111173 landed. That's consistent product/data drift, not timing. The two genuine timing cases (dark-mode, i18n) are handled by waiting on the real condition instead of a short fixed timeout.

## Testing Instructions

Run against staging by pointing `CALYPSO_BASE_URL` at the staging Calypso, then (substitute the spec path):

```
CALYPSO_BASE_URL=<staging> NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests playwright test specs/users/invite__new-user.spec.ts --project=pixel --repeat-each=5
```

Results so far:

- `advertising__promote`: 5/5 pass.
- `invite__new-user`: 5/5 pass.
- `i18n__editor`: passes for all 17 locales.
- `dark-mode-surfaces` (Dashboard): can't be run against staging, the dashboard specs need a real dashboard URL (`DASHBOARD_BASE_URL`) that only CI provides per-PR. Confirmed green on this PR's CI, in the Dashboard E2E Tests (PR) build [18298089](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Dashboard_E2E_Playwright_Test_Matrix/18298089).

