### PR TITLE
Fix two tree-wide calypso-pr e2e failures (SEO category + audio upload)

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/audio-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/audio-block.ts
@@ -1,9 +1,8 @@
-import { Page, ElementHandle } from 'playwright';
+import { Page, ElementHandle, Response } from 'playwright';
 
 const selectors = {
 	block: '.wp-block-audio',
 	fileInput: '.components-form-file-upload input[type="file"]',
-	spinner: '.components-spinner',
 };
 
 /**
@@ -33,8 +32,19 @@ export class AudioBlock {
 	 */
 	async upload( path: string ): Promise< void > {
 		const input = await this.block.waitForSelector( selectors.fileInput, { state: 'attached' } );
-		await input.setInputFiles( path );
-		await this.page.locator( selectors.spinner ).waitFor( { state: 'hidden' } );
+		// Wait for the upload request to complete rather than for a spinner to hide.
+		// The page-level `.components-spinner` also matches the editor's "Uploading…"
+		// snackbar, which can linger after the block itself has finished uploading.
+		// Match the upload POST specifically so an unrelated media GET can't resolve early.
+		await Promise.all( [
+			this.page.waitForResponse(
+				( response: Response ) =>
+					response.request().method() === 'POST' &&
+					response.url().includes( 'media?' ) &&
+					response.ok()
+			),
+			input.setInputFiles( path ),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -9,7 +9,12 @@ const selectors = {
 	listTitle: ( section: string ) => `.plugins-results-header__title:text("${ section }")`,
 	listSubtitle: ( section: string ) => `.plugins-results-header__subtitle:text("${ section }")`,
 	headerTitle: ( section: string ) => `.plugins-results-header__title:text("${ section }")`,
-	pluginTitle: ( plugin: string ) => `.plugins-browser-item__title:text("${ plugin }")`,
+	// A real (non-placeholder) plugin tile title within a given section's list.
+	// Scope to that list so a stale or unrelated list elsewhere on the page can't
+	// satisfy the wait. Placeholders also render `.plugins-browser-item__title`
+	// (with an ellipsis) but carry `.is-placeholder`, so exclude them.
+	categoryPluginResult: ( section: string ) =>
+		`.plugins-browser-list:has(.plugins-results-header__title:text("${ section }")) .plugins-browser-item:not(.is-placeholder) .plugins-browser-item__title`,
 	pluginTitleOnSection: ( section: string, plugin: string ) =>
 		`.plugins-browser-list:has(.plugins-results-header__title:text("${ section }")) :text-is("${ plugin }")`,
 	sectionTitles: '.plugins-results-header__title',
@@ -154,11 +159,16 @@ export class PluginsPage {
 	}
 
 	/**
-	 * Validate category has the plugin
+	 * Validate a category page loads and lists plugin results.
+	 *
+	 * Asserts the category renders its header and at least one real (non-placeholder)
+	 * plugin tile. It deliberately does not assert a specific plugin: which plugins
+	 * appear in a category is driven by the marketplace search ranking, controlled
+	 * server-side, and changes over time.
 	 */
-	async validateHasPluginInCategory( section: string, plugin: string ): Promise< void > {
+	async validateCategoryHasPlugins( section: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.headerTitle( section ) );
-		await this.page.waitForSelector( selectors.pluginTitle( plugin ) );
+		await this.page.waitForSelector( selectors.categoryPluginResult( section ) );
 	}
 
 	/**

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -105,10 +105,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 		await page.waitForURL( new RegExp( `/plugins/browse/seo/${ siteUrl }$` ) );
 	} );
 
-	it.each( [ 'Yoast SEO' ] )(
-		'SEO category should show the %s plugin',
-		async function ( plugin: string ) {
-			await pluginsPage.validateHasPluginInCategory( 'Search Engine Optimization', plugin );
-		}
-	);
+	it( 'SEO category lists plugins', async function () {
+		await pluginsPage.validateCategoryHasPlugins( 'Search Engine Optimization' );
+	} );
 } );


### PR DESCRIPTION
Fixes [TESTOPS-195](https://linear.app/a8c/issue/TESTOPS-195).

Two `calypso-pr` tests fail on every PR regardless of the diff, so they tell you nothing about the change under test.

## Proposed Changes

- `blocks__media.ts` "Audio block: upload audio file": `AudioBlock.upload` waited for the page-global `.components-spinner` to be hidden. The editor's "Uploading…" snackbar keeps a spinner up after the block itself is done, so that wait never resolved and the test timed out. It now waits for the upload `POST .../media?` response, the same approach `FileBlock` already uses for the same endpoint (plus a `POST` guard so a stray media GET can't resolve it early).
- `plugins__browse.ts` "SEO category should show the Yoast SEO plugin": the test asserted a specific third-party tile. Yoast no longer ranks into the marketplace search results for the `seo` filter, so it failed tree-wide. The check is now `validateCategoryHasPlugins`, which waits for the category header plus at least one real (non-placeholder) plugin tile, scoped to the section's list.

## Why are these changes being made?

Both have been red on every recent desktop and mobile build, so they pollute the signal on unrelated PRs. Neither is a product regression:

- The audio upload completes; the `POST .../media?` returns 200 and the media item is created, and the File block uploads the same file and passes. The failure was the over-broad spinner wait, not the backend (unlike the VideoPress test right below it, skipped since 2024 for a real backend issue).
- Yoast dropping out of the SEO category is a server-side marketplace ranking change, not something an e2e test should pin. Asserting a named third-party plugin in a server-ranked category was brittle to begin with (see the stale Automattic/wp-calypso#80541).

## Testing Instructions

Both specs are legacy Jest-runner tests. Run each against staging:

```
cd test/e2e
CALYPSO_BASE_URL=<STAGING_URL> yarn jest specs/plugins/plugins__browse.ts
CALYPSO_BASE_URL=<STAGING_URL> yarn jest specs/blocks/blocks__media.ts
```

Add `VIEWPORT_NAME=mobile` for the mobile run. I ran each spec 5 times on desktop and 5 on mobile against staging; 20/20 green, including the previously-failing "SEO category lists plugins" and "Audio block: upload audio file".
