### PR TITLE
Notifications: restore code block styling in v3 panel

### DIFF
--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -200,6 +200,37 @@
 	li {
 		margin: auto;
 	}
+
+	// Monospaced, boxed styling for inline code and code blocks.
+	code,
+	pre {
+		font-family: $font-family-mono;
+		font-size: 90%;
+		background: var( --wpnc-code__background-color, #{$gray-100} );
+		border: 1px solid var( --wpnc-code__border-color, #{$gray-300} );
+		border-radius: 4px;
+	}
+
+	code {
+		padding: 0 4px;
+		color: var( --wpnc-code__text-color, #{$gray-700} );
+	}
+
+	pre {
+		padding: 8px;
+		// Preserve the source's line breaks/indentation while still wrapping
+		// long lines so code can't overflow the narrow panel horizontally.
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+
+		// A <code> nested inside <pre> shouldn't double up the box.
+		code {
+			padding: 0;
+			border: none;
+			background: none;
+			color: inherit;
+		}
+	}
 }
 
 .comment-reply-input__textarea {
@@ -340,6 +371,12 @@
 		--wpnc-quote__border-color: var( --wp-components-color-gray-600, #758095 );
 		--wpnc-quote__text-color: var( --wp-components-color-gray-700, #9aa2b1 );
 		--wpnc-divider__color: var( --wp-components-color-gray-400, #424855 );
+
+		// Code blocks: a subtly raised surface against the dark panel, with a
+		// neutral border and light text that keeps AA contrast.
+		--wpnc-code__background-color: var( --wp-components-color-gray-800, #2c3338 );
+		--wpnc-code__border-color: var( --wp-components-color-gray-600, #758095 );
+		--wpnc-code__text-color: var( --wp-components-color-gray-100, #f0f0f1 );
 
 		// Two frame-level dividers miss the dashboard's border handling:
 		//   - the action-block CardFooter (above Like/Reply) — the dark card

--- a/apps/notifications/src/panel/indices-to-html/test/index.test.js
+++ b/apps/notifications/src/panel/indices-to-html/test/index.test.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import { html } from '../index';
+
+describe( 'indices-to-html rich content parsing', () => {
+	// Notification bodies from non-Gutenberg P2s lean on these range types for
+	// code. The redesigned panel must keep parsing them into real <code>/<pre>
+	// elements (with their wpnc__ classes) so the restored styling has something
+	// to target. See DOTMSD-1325.
+	it( 'wraps an inline `code` range in <code class="wpnc__code">', () => {
+		const output = html( {
+			text: 'run yarn start',
+			ranges: [ { type: 'code', indices: [ 4, 14 ] } ],
+		} );
+
+		expect( output ).toContain( '<code class="wpnc__code">yarn start</code>' );
+	} );
+
+	it( 'wraps a `pre` range in <pre class="wpnc__pre">', () => {
+		const output = html( {
+			text: 'const a = 1;',
+			ranges: [ { type: 'pre', indices: [ 0, 12 ] } ],
+		} );
+
+		expect( output ).toContain( '<pre class="wpnc__pre">' );
+		expect( output ).toContain( 'const a = 1;' );
+	} );
+
+	it( 'keeps a `code` range nested inside a `pre` block', () => {
+		const output = html( {
+			text: 'const a = 1;',
+			ranges: [
+				{ id: 0, type: 'pre', indices: [ 0, 12 ] },
+				{ id: 1, parent: 0, type: 'code', indices: [ 0, 12 ] },
+			],
+		} );
+
+		expect( output ).toContain( '<pre class="wpnc__pre">' );
+		expect( output ).toContain( '<code class="wpnc__code">' );
+	} );
+} );


### PR DESCRIPTION
Fixes DOTMSD-1325

## Proposed Changes

* Restore monospace + boxed styling for inline `code` and `pre` code blocks in the redesigned (v3) notifications panel's note body, including dark-mode tokens.

| Before | After |
| - | - |
|<img width="447" height="366" alt="image" src="https://github.com/user-attachments/assets/562afb49-878a-488a-bb53-c43217cf26be" />|<img width="450" height="376" alt="image" src="https://github.com/user-attachments/assets/2a4ace16-832d-476a-b703-1366c0231b69" />|

## Why are these changes being made?

A report on the notifications redesign noted that a notification containing a code block no longer rendered richly — relevant for older P2s with Gutenberg disabled, where comments/posts carry raw `<code>`/`<pre>`.

Investigation: the redesign **kept** the custom content parser (`indices-to-html`), so note bodies still emit real `<code>`/`<pre>` elements. What was lost is the **CSS**. The legacy panel styled `pre`/`code` (monospace, background, border); the v3 stylesheet ported styles for blockquotes, lists, headings, etc. but not code — and its `reset.scss` strips the default monospace. Net effect: code blocks rendered as plain, run-together text. So the "no functionality removed" claim was partially inaccurate; this restores the missing styling.

## Testing Instructions

* Open the notifications panel (v3 / redesign enabled) and open a notification whose comment or post body contains a code block — an inline `` `snippet` `` and/or a fenced ```` ``` ```` block (most reproducible on a Gutenberg-disabled P2).
* Before this change the code shows as plain sans-serif text; after, it renders monospaced inside a subtle box.
* Verify in both light and dark mode.

## Considerations

* Targets bare `pre`/`code` element selectors so it covers both code paths (range-based and the fence/backtick text parsing) the panel produces.
* Uses `$font-family-mono` and grays from `@wordpress/base-styles` (no `@automattic/typography` dependency); colors are routed through `--wpnc-code__*` custom properties so the existing dark-mode block can override them.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?