### PR TITLE
Help Center: hide Smooch crawler-SEO fallback link leaking into wp-admin

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -8,6 +8,13 @@
  *
  * THIS FILE SHOULD NOT CONTAIN ANY COMPONENT SPECIFIC STYLES.
  */
+
+// Hide Smooch's crawler-SEO fallback link, which leaks an unstyled "Powered by
+// Zendesk Sunshine" anchor into the host page for crawler-matching UAs. DOTCOM-17693.
+a[href^='https://smooch.io/live-web-chat'] {
+	display: none !important;
+}
+
 .help-center > div.help-center__container {
 	background-color: var(--color-surface);
 	z-index: $help-center-z-index;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17693/zendesk-widget-leaking-to-wp-admin-page-footers

## Proposed Changes

**Hide the stray “Powered by Zendesk Sunshine” link the Smooch library leaks into the host page.**

- Adds a single global CSS rule to the Help Center styles that hides any `a[href^='https://smooch.io/live-web-chat']`.
- The rule ships with every Help Center bundle (it lives in the general `styles.scss`, imported alongside the `smooch` import), so it covers Calypso, Simple, Atomic, and wp-admin.

## Why are these changes being made?

On some browsers a broken-looking footer reading “Powered by Zendesk Sunshine” (linking to smooch.io) appears at the bottom of new wp-admin pages on Atomic sites — see [DOTCOM-17693](https://linear.app/a8c/issue/DOTCOM-17693). It only showed up in one reporter’s Firefox, never in Chrome.

The cause is inside the third-party `smooch` chat library, not our own code. When Smooch loads, it checks the browser’s user-agent against a built-in “is this a search-engine crawler?” pattern. If it thinks a crawler is visiting, it drops a plain, unstyled “Powered by Zendesk Sunshine” link straight onto the page as an SEO breadcrumb — something a crawler would index but a real visitor would normally never render.

That crawler pattern is very loose (it matches fragments like “obo” and “pide”), so a browser running with a customized or spoofed user-agent — which is what the reporter’s Firefox was doing — trips it and shows the link to a real person. Because the link is meant for crawlers it carries no styling, so it looks like a broken footer bleeding into the page. In our embedded chat experience this link serves no purpose, so the safe fix is to hide it everywhere.

## Testing Instructions

Because the trigger is a crawler-like user-agent, the simplest way to reproduce is to spoof one.

### Calypso

1. Run `yarn start`.
2. Open dev tools and set a user-agent containing a crawler token (e.g. append `Applebot` to the UA string), then reload.
3. Confirm there is **no** “Powered by Zendesk Sunshine” link at the bottom of the page.
4. Revert the UA and confirm the Help Center still works normally.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing) with a spoofed crawler user-agent.
4. Confirm the stray “Powered by Zendesk Sunshine” footer no longer appears, and the Help Center otherwise behaves as before.
