### PR TITLE
Harden two flaky unit tests (TESTOPS-193)

### DIFF
--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -123,24 +123,39 @@ describe( '<Sites>', () => {
 		} );
 		startSiteCollisionListener( queryClient );
 
-		// The collision listener (started by test-utils) should auto-detect the
-		// Jetpack site and fix the wpcom site's slug without manual intervention.
-		const links = await screen.findAllByRole( 'link', { name: /WPcom Site/ } );
-		for ( const link of links ) {
-			expect( link ).toHaveAttribute(
-				'href',
-				expect.stringMatching( /\/sites\/wpcomsite.wordpress\.com$/ )
-			);
-		}
+		// <Sites> uses a suspense query; wait for the table to render before
+		// asserting.
+		await screen.findByRole( 'table' );
+
+		// The collision listener rewrites the wpcom site's slug asynchronously, so
+		// poll until the rewrite lands instead of racing it. Scope the link lookup
+		// to the table (so a link rendered elsewhere can't satisfy the assertion)
+		// and re-query the table each poll so a re-render replacing the node leaves
+		// no stale reference.
+		await waitFor( () => {
+			const links = within( screen.getByRole( 'table' ) ).getAllByRole( 'link', {
+				name: /WPcom Site/,
+			} );
+			for ( const link of links ) {
+				expect( link ).toHaveAttribute(
+					'href',
+					expect.stringMatching( /\/sites\/wpcomsite\.wordpress\.com$/ )
+				);
+			}
+		} );
 
 		// The Jetpack site's links should remain unchanged.
-		const jpLinks = await screen.findAllByRole( 'link', { name: /Jetpack Site/ } );
-		for ( const jpLink of jpLinks ) {
-			expect( jpLink ).toHaveAttribute(
-				'href',
-				expect.stringMatching( /\/sites\/shared-domain\.com$/ )
-			);
-		}
+		await waitFor( () => {
+			const jpLinks = within( screen.getByRole( 'table' ) ).getAllByRole( 'link', {
+				name: /Jetpack Site/,
+			} );
+			for ( const jpLink of jpLinks ) {
+				expect( jpLink ).toHaveAttribute(
+					'href',
+					expect.stringMatching( /\/sites\/shared-domain\.com$/ )
+				);
+			}
+		} );
 	} );
 
 	test( 'renders DataViews when the user has sites', async () => {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -123,15 +123,8 @@ describe( '<Sites>', () => {
 		} );
 		startSiteCollisionListener( queryClient );
 
-		// <Sites> uses a suspense query; wait for the table to render before
-		// asserting.
-		await screen.findByRole( 'table' );
-
-		// The collision listener rewrites the wpcom site's slug asynchronously, so
-		// poll until the rewrite lands instead of racing it. Scope the link lookup
-		// to the table (so a link rendered elsewhere can't satisfy the assertion)
-		// and re-query the table each poll so a re-render replacing the node leaves
-		// no stale reference.
+		// Slug rewrite is async; poll until it lands. Re-query the table each pass
+		// to avoid a stale node after a re-render.
 		await waitFor( () => {
 			const links = within( screen.getByRole( 'table' ) ).getAllByRole( 'link', {
 				name: /WPcom Site/,
@@ -144,18 +137,16 @@ describe( '<Sites>', () => {
 			}
 		} );
 
-		// The Jetpack site's links should remain unchanged.
-		await waitFor( () => {
-			const jpLinks = within( screen.getByRole( 'table' ) ).getAllByRole( 'link', {
-				name: /Jetpack Site/,
-			} );
-			for ( const jpLink of jpLinks ) {
-				expect( jpLink ).toHaveAttribute(
-					'href',
-					expect.stringMatching( /\/sites\/shared-domain\.com$/ )
-				);
-			}
+		// The Jetpack site's links are never rewritten; the table is settled now.
+		const jpLinks = within( screen.getByRole( 'table' ) ).getAllByRole( 'link', {
+			name: /Jetpack Site/,
 		} );
+		for ( const jpLink of jpLinks ) {
+			expect( jpLink ).toHaveAttribute(
+				'href',
+				expect.stringMatching( /\/sites\/shared-domain\.com$/ )
+			);
+		}
 	} );
 
 	test( 'renders DataViews when the user has sites', async () => {

--- a/packages/webpack-inline-constant-exports-plugin/test/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/index.js
@@ -1,5 +1,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { promisify } = require( 'util' );
 const rimraf = require( 'rimraf' );
 const webpack = require( 'webpack' );
 const InlineConstantExportsPlugin = require( '..' );
@@ -16,51 +17,40 @@ describe( 'webpack-inline-constant-exports-plugin', () => {
 		rimraf.sync( buildDirectory );
 	} );
 
-	test( 'should produce expected output', () => {
-		return new Promise( ( resolve, reject ) => {
-			const inputDirectory = path.join( fixturesDirectory, 'basic' );
-			const outputDirectory = path.join( buildDirectory, 'basic' );
-			const config = {
-				context: inputDirectory,
-				entry: './index.js',
-				mode: 'production',
-				optimization: {
-					runtimeChunk: true,
-					moduleIds: 'named',
-					chunkIds: 'named',
-					minimize: false,
-				},
-				output: {
-					path: outputDirectory,
-					globalObject: 'window',
-				},
-				plugins: [
-					new InlineConstantExportsPlugin( [
-						/\/actions\.js$/,
-						/\/plans\.js$/,
-						/\/constants\.js$/,
-						/\/constants2\.js$/,
-						/\/export\.js$/,
-					] ),
-				],
-			};
+	test( 'should produce expected output', async () => {
+		const inputDirectory = path.join( fixturesDirectory, 'basic' );
+		const outputDirectory = path.join( buildDirectory, 'basic' );
+		const config = {
+			context: inputDirectory,
+			entry: './index.js',
+			mode: 'production',
+			optimization: {
+				runtimeChunk: true,
+				moduleIds: 'named',
+				chunkIds: 'named',
+				minimize: false,
+			},
+			output: {
+				path: outputDirectory,
+				globalObject: 'window',
+			},
+			plugins: [
+				new InlineConstantExportsPlugin( [
+					/\/actions\.js$/,
+					/\/plans\.js$/,
+					/\/constants\.js$/,
+					/\/constants2\.js$/,
+					/\/export\.js$/,
+				] ),
+			],
+		};
 
-			webpack( config, ( err ) => {
-				// Resolve/reject explicitly: throwing inside this callback would
-				// otherwise leave the Promise pending and hang until the timeout
-				// instead of failing fast on the assertion.
-				try {
-					expect( err ).toBeNull();
+		// promisify rejects on webpack's error-first callback arg; assertions run
+		// in the async body, so a failure fails fast instead of hanging.
+		await promisify( webpack )( config );
 
-					const outputFile = path.join( outputDirectory, 'main.js' );
-					const outputFileContent = fs.readFileSync( outputFile, 'utf8' );
-					expect( outputFileContent ).toMatchSnapshot( 'Output bundle should match snapshot' );
-
-					resolve();
-				} catch ( error ) {
-					reject( error );
-				}
-			} );
-		} );
+		const outputFile = path.join( outputDirectory, 'main.js' );
+		const outputFileContent = fs.readFileSync( outputFile, 'utf8' );
+		expect( outputFileContent ).toMatchSnapshot( 'Output bundle should match snapshot' );
 	}, 30000 );
 } );

--- a/packages/webpack-inline-constant-exports-plugin/test/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/index.js
@@ -47,7 +47,10 @@ describe( 'webpack-inline-constant-exports-plugin', () => {
 
 		// promisify rejects on webpack's error-first callback arg; assertions run
 		// in the async body, so a failure fails fast instead of hanging.
-		await promisify( webpack )( config );
+		const stats = await promisify( webpack )( config );
+		// Compilation errors surface via stats, not the callback err arg, so a
+		// broken build would otherwise snapshot silently.
+		expect( stats.hasErrors() ).toBe( false );
 
 		const outputFile = path.join( outputDirectory, 'main.js' );
 		const outputFileContent = fs.readFileSync( outputFile, 'utf8' );

--- a/packages/webpack-inline-constant-exports-plugin/test/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/index.js
@@ -17,7 +17,7 @@ describe( 'webpack-inline-constant-exports-plugin', () => {
 	} );
 
 	test( 'should produce expected output', () => {
-		return new Promise( ( done ) => {
+		return new Promise( ( resolve, reject ) => {
 			const inputDirectory = path.join( fixturesDirectory, 'basic' );
 			const outputDirectory = path.join( buildDirectory, 'basic' );
 			const config = {
@@ -46,14 +46,21 @@ describe( 'webpack-inline-constant-exports-plugin', () => {
 			};
 
 			webpack( config, ( err ) => {
-				expect( err ).toBeNull();
+				// Resolve/reject explicitly: throwing inside this callback would
+				// otherwise leave the Promise pending and hang until the timeout
+				// instead of failing fast on the assertion.
+				try {
+					expect( err ).toBeNull();
 
-				const outputFile = path.join( outputDirectory, 'main.js' );
-				const outputFileContent = fs.readFileSync( outputFile, 'utf8' );
-				expect( outputFileContent ).toMatchSnapshot( 'Output bundle should match snapshot' );
+					const outputFile = path.join( outputDirectory, 'main.js' );
+					const outputFileContent = fs.readFileSync( outputFile, 'utf8' );
+					expect( outputFileContent ).toMatchSnapshot( 'Output bundle should match snapshot' );
 
-				done();
+					resolve();
+				} catch ( error ) {
+					reject( error );
+				}
 			} );
 		} );
-	} );
+	}, 30000 );
 } );


### PR DESCRIPTION
Part of [TESTOPS-193](https://linear.app/a8c/issue/TESTOPS-193).

## Proposed Changes

Two pre-existing flaky unit tests; both pass locally but fail intermittently in CI under load. Found while working on [TESTOPS-193](https://linear.app/a8c/issue/TESTOPS-193), unrelated to the PRs they surfaced on. Test files only, no product or source code touched.

- `client/dashboard/sites/test/index.test.tsx` (collision-listener test): anchor on the rendered table, then poll the slug-rewrite assertions with `waitFor` instead of a single `findAllByRole` that raced both the suspense render and the async `setQueryData` rewrite. Link lookups are scoped to the table, and the table is re-queried each poll so a re-render that replaces the node leaves no stale reference.
- `packages/webpack-inline-constant-exports-plugin/test/index.js`: add a 30s per-test timeout so the cold production webpack compile doesn't exceed the default 5s under CI agent contention. The Promise also gets a reject path, so an assertion failure fails fast instead of hanging to the timeout.

## Why are these changes being made?

Both fail intermittently in CI under load: a render-timing race in the first, a slow-compile timeout in the second. Neither reproduces locally, so this is hardening rather than a guaranteed-repro fix; the real signal is CI stability.

## Testing Instructions

Both run green 20x locally (`nvm use` first):

```
for i in $(seq 20); do yarn test-client client/dashboard/sites/test/index.test.tsx --testNamePattern="collision listener" 2>&1 | grep "Tests:"; done
for i in $(seq 20); do yarn jest --config=test/packages/jest.config.js packages/webpack-inline-constant-exports-plugin 2>&1 | grep "Tests:"; done
```

The real check is CI staying green across repeated runs.
