### PR TITLE
Suppress intermediate tool summaries when final response exist

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -256,6 +256,51 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
+	it( 'suppresses displayable tool summaries when a later agent text message exists in the same turn', () => {
+		const toolMessage = createToolMessage(
+			'big_sky__apply_block_edits',
+			{ summary: 'Updated the heading.' },
+			{ id: 'tool-1' }
+		);
+		const finalMessage = createMessage( {
+			id: 'final-1',
+			content: [ { type: 'text', text: 'Done — the heading is updated.' } ],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ toolMessage, finalMessage ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'final-1' );
+	} );
+
+	it( 'keeps displayable tool summaries when the later agent text message is context-only', () => {
+		const toolMessage = createToolMessage(
+			'big_sky__apply_block_edits',
+			{ summary: 'Updated the heading.' },
+			{ id: 'tool-1' }
+		);
+		const contextOnlyMessage = createMessage( {
+			id: 'context-only-1',
+			content: [
+				{ type: 'text', text: 'Updated the heading.' },
+				{ type: 'data', data: { flags: { context_only: true } } },
+			],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ toolMessage, contextOnlyMessage ],
+		} );
+
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 0 ].id ).toBe( 'tool-1' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: 'Updated the heading.',
+		} );
+	} );
+
 	it( 'suppresses transient thinking for converted apply-block-edits messages', () => {
 		const message = createToolMessage( 'big_sky__apply_block_edits', {
 			followUpTasks: true,

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -20,6 +20,58 @@ interface Options {
 	onSubmit: UseAgentChatReturn[ 'onSubmit' ];
 }
 
+function isAgentMessage( message: UIMessage ): boolean {
+	// @ts-expect-error -- `assistant` comes from Big Sky messages.
+	return message.role === 'agent' || message.role === 'assistant';
+}
+
+function hasContextOnlyFlag( message: UIMessage ): boolean {
+	return message.content.some(
+		( content ) =>
+			content.type === 'data' &&
+			content.data?.flags &&
+			typeof content.data.flags === 'object' &&
+			'context_only' in content.data.flags &&
+			content.data.flags.context_only === true
+	);
+}
+
+function isJsonToolMessageText( text: string ): boolean {
+	try {
+		const data = JSON.parse( text );
+		return typeof data?.tool_id === 'string';
+	} catch ( _error ) {
+		return false;
+	}
+}
+
+function hasLaterRenderableAgentTextMessage(
+	messages: UIMessage[],
+	currentIndex: number
+): boolean {
+	for ( let index = currentIndex + 1; index < messages.length; index++ ) {
+		const message = messages[ index ];
+
+		if ( message.role === 'user' ) {
+			return false;
+		}
+
+		if ( ! isAgentMessage( message ) || hasContextOnlyFlag( message ) ) {
+			continue;
+		}
+
+		const text = message.content.find(
+			( content ) => content.type === 'text' && content.text.trim()
+		)?.text;
+
+		if ( text && ! isJsonToolMessageText( text ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /**
  * Converts tool-related messages to component messages.
  */
@@ -32,8 +84,7 @@ export default function convertToolMessagesToComponents( {
 	return messages.flatMap( ( message, index, array ) => {
 		const firstContentText = message.content?.[ 0 ]?.text;
 
-		// @ts-expect-error -- `assistant` comes from Big Sky messages
-		if ( ( message.role !== 'agent' && message.role !== 'assistant' ) || ! firstContentText ) {
+		if ( ! isAgentMessage( message ) || ! firstContentText ) {
 			return [ message ];
 		}
 
@@ -157,8 +208,14 @@ export default function convertToolMessagesToComponents( {
 			];
 		}
 
-		// Handle agent-facing Big Sky tool result summaries.
+		// Handle agent-facing Big Sky tool result summaries. If a later renderable
+		// agent text message exists in this turn, suppress the intermediate tool
+		// summary so refresh matches the live final-response view.
 		if ( isDisplayableToolMessageTool( textData.tool_id ) ) {
+			if ( hasLaterRenderableAgentTextMessage( array, index ) ) {
+				return [];
+			}
+
 			const summary = getDisplayMessageFromToolData( textData.data );
 			if ( ! summary ) {
 				return [];

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -61,10 +61,11 @@ function hasLaterRenderableAgentTextMessage(
 		}
 
 		const text = message.content.find(
-			( content ) => content.type === 'text' && content.text.trim()
+			( content ) =>
+				content.type === 'text' && typeof content.text === 'string' && content.text.trim()
 		)?.text;
 
-		if ( text && ! isJsonToolMessageText( text ) ) {
+		if ( typeof text === 'string' && text.trim() && ! isJsonToolMessageText( text ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Related to AI-1020

## Proposed Changes

* Suppress intermediate displayable tool-result summaries when a later renderable agent text response exists in the same turn.
* Keep tool-result summaries visible when the later agent text message is `context_only`, since in that case the summary is the user-visible response.
* Add coverage for both cases in `convertToolMessagesToComponents` tests.

## Why are these changes being made?

* On refresh, Agents Manager rebuilds the transcript from server history. Some turns include both a displayable tool summary (for example `big_sky__apply_block_edits`) and a later final agent response.
* Without this change, both messages render after refresh, so users see an intermediate tool summary duplicated before the final response.
* This keeps refreshed transcripts aligned with the live chat experience while preserving summaries for turns where the later agent message is context-only.

## Testing Instructions

* Run the targeted unit test:
  * `yarn test-packages packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts --runInBand`
* Verify a refreshed Agents Manager conversation that has a displayable tool summary followed by a final agent text response only shows the final response.
* Verify a conversation whose later agent message has `context.flags.context_only: true` still shows the displayable tool summary.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
