### PR TITLE
client/site-profiler: React-18-safe cleanups extracted from the React 19 spike

### DIFF
--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -102,3 +102,5 @@ export const BasicMetrics = forwardRef(
 		);
 	}
 );
+
+BasicMetrics.displayName = 'BasicMetrics';

--- a/client/site-profiler/components/metrics-section/index.tsx
+++ b/client/site-profiler/components/metrics-section/index.tsx
@@ -99,3 +99,5 @@ export const MetricsSection = forwardRef< HTMLObjectElement, MetricsSectionProps
 		);
 	}
 );
+
+MetricsSection.displayName = 'MetricsSection';

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -122,7 +122,11 @@ export default function SiteProfilerV2( props: Props ) {
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
 		// URL param is the source of truth
-		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
+		if ( value ) {
+			page( `/site-profiler/${ value }` );
+		} else {
+			page( '/site-profiler' );
+		}
 	};
 
 	const { is_wpcom: isWpCom = false, is_wordpress: isWordPress = false } = performanceMetrics ?? {};

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -110,7 +110,11 @@ export default function SiteProfiler( props: Props ) {
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
 		// URL param is the source of truth
-		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
+		if ( value ) {
+			page( `/site-profiler/${ value }` );
+		} else {
+			page( '/site-profiler' );
+		}
 	};
 
 	return (

--- a/client/site-profiler/hooks/use-is-menu-section-visible.ts
+++ b/client/site-profiler/hooks/use-is-menu-section-visible.ts
@@ -12,7 +12,9 @@ export function useIsMenuSectionVisible( ref: React.RefObject< HTMLObjectElement
 			{ rootMargin: `-${ calculateMetricsSectionScrollOffset() + 1 }px` } // the additional pixel triggers the tab change
 		);
 
-		ref?.current && observer.observe( ref.current );
+		if ( ref?.current ) {
+			observer.observe( ref.current );
+		}
 
 		return () => {
 			observer.disconnect();


### PR DESCRIPTION
Part of DOTCOM-17400

## Proposed Changes

While splitting the React 19 validation spike (#111325) into forward-compatible `client/` slices, I found that the remaining substantive `client/` retypes (`client/site-profiler/` ref types and `client/dashboard/components/responsive-menu/`) are **React-19-only** and cannot be landed ahead of the version flip — see below.

What this PR keeps are the parts of the spike's `client/site-profiler/` changes that compile under **both React 18 and React 19**:

- Replace expression-statement ternaries with `if`/`else` in `updateDomainRouteParam` (`site-profiler.tsx`, `site-profiler-v2.tsx`).
- Replace the short-circuit `ref?.current && observer.observe( … )` with an `if` guard (`use-is-menu-section-visible.ts`).
- Add `displayName` to the `BasicMetrics` and `MetricsSection` `forwardRef` components.

No behavior change.

### Why the rest was dropped (deferred to the version flip)

Under the React 18 `@types/react` on trunk, the spike's substantive retypes fail `type_check_client`, because React 18 and 19 have incompatible type semantics that no single annotation satisfies:

- **`RefObject`**: React 18 is `{ current: T | null }`, React 19 is `{ current: T }`. The spike widens the site-profiler section refs to `RefObject<HTMLElement | null>` and feeds them into `forwardRef<HTMLElement>` components — valid on React 19, rejected on React 18.
- **Event handlers / `child.props`**: the responsive-menu rewrite casts `child.props` to `ComponentProps<typeof RouterLinkMenuItem>`, whose `onClick` requires an event arg and whose `children` may be a render-prop — incompatible with the `onClick?.()` call sites and `<span>{ children }</span>`.

These belong in the version-flip PR (the spike), alongside `client/package.json`'s `react`/`react-dom`/`@types/react` bump and the theme test snapshot (React 19 render output).

## Why are these changes being made?

To migrate Calypso to React 19 incrementally. The forward-compatible cleanups can land now; the version-coupled retypes ride with the flip.

## Testing Instructions

- `git diff trunk...HEAD` — confirm changes are limited to `client/site-profiler/` and are behavior-preserving control-flow / `displayName` edits.
- CI `type_check_client` is the gate (this worktree has no local `node_modules`).
- Smoke test Site Profiler (`/site-profiler`): the section nav still scrolls to and highlights each metrics section.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)