### PR TITLE
Plans: gate Downgrade button on available_for_downgrade

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -435,8 +435,34 @@ describe( 'useGenerateActionHook', () => {
 	} );
 
 	it( 'should handle downgrade actions', () => {
+		( useSelector as jest.Mock ).mockImplementation( ( selector ) =>
+			selector( {
+				ui: {},
+				sites: {
+					items: [],
+					plans: {
+						[ mockSiteId ]: {
+							data: [
+								{
+									productSlug: PLAN_PERSONAL,
+									availableForDowngrade: true,
+								},
+							],
+						},
+					},
+				},
+				route: {
+					query: {
+						current: {
+							get_domain: null,
+						},
+					},
+				},
+			} )
+		);
+
 		const { result } = renderHook( () =>
-			useGenerateActionHook( { isInSignup: false, isLaunchPage: false } )
+			useGenerateActionHook( { siteId: mockSiteId, isInSignup: false, isLaunchPage: false } )
 		);
 
 		const action = result.current( { planSlug: PLAN_PERSONAL, availableForPurchase: false } );

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -27,6 +27,7 @@ import {
 	FREE_HOSTING_TRIAL_ENABLED,
 	isUserEligibleForFreeHostingTrial,
 } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
+import { getSitePlan } from 'calypso/state/sites/plans/selectors';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors/is-current-user-current-plan-owner';
 import isCurrentPlanPaid from 'calypso/state/sites/selectors/is-current-plan-paid';
 import { IAppState } from 'calypso/state/types';
@@ -136,6 +137,12 @@ export default function useGenerateActionHook( {
 		planTitle,
 		pricing,
 	}: UseActionHookProps ): GridAction => {
+		const availableForDowngrade = useSelector( ( state: IAppState ) =>
+			siteId
+				? ( getSitePlan( state, siteId, planSlug ) as { availableForDowngrade?: boolean } | null )
+						?.availableForDowngrade
+				: undefined
+		);
 		// Get renewal pricing text - this will be used as postButtonText if available
 		const renewalPricingText = useRenewalPricingPostButtonText( {
 			planSlug,
@@ -213,6 +220,7 @@ export default function useGenerateActionHook( {
 			priceString,
 			sitePlanSlug,
 			availableForPurchase,
+			availableForDowngrade,
 			domainFromHomeUpsellFlow,
 			canUserManageCurrentPlan,
 			isPlanExpired,
@@ -413,6 +421,7 @@ function getLoggedInPlansAction( {
 	priceString,
 	sitePlanSlug,
 	availableForPurchase,
+	availableForDowngrade,
 	domainFromHomeUpsellFlow,
 	canUserManageCurrentPlan,
 	isPlanExpired,
@@ -432,6 +441,7 @@ function getLoggedInPlansAction( {
 	isLoading: boolean;
 	setIsLoading: ( value: boolean ) => void;
 	plansIntent?: PlansIntent | null;
+	availableForDowngrade?: boolean;
 } & UseActionHookProps ): GridAction {
 	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
 	// This allows monthly/yearly versions of the same plan to be considered "current"
@@ -509,14 +519,19 @@ function getLoggedInPlansAction( {
 		return createLoggedInPlansAction( translate( 'View plan' ), 'secondary' );
 	}
 
-	// Downgrade action if the plan is not available for purchase
+	// Downgrade action if the plan is not available for purchase and is available for downgrade
 	if ( ! availableForPurchase ) {
-		return createLoggedInPlansAction(
-			translate( 'Downgrade', { context: 'verb' } ),
-			'secondary',
-			undefined,
-			canUserManageCurrentPlan ? undefined : 'disabled'
-		);
+		if ( availableForDowngrade ) {
+			return createLoggedInPlansAction(
+				translate( 'Downgrade', { context: 'verb' } ),
+				'secondary',
+				undefined,
+				canUserManageCurrentPlan ? undefined : 'disabled'
+			);
+		}
+		// Not purchasable and not downgradeable — return a disabled no-op to avoid
+		// falling through to the upgrade button path.
+		return createLoggedInPlansAction( '', 'secondary', undefined, 'disabled' );
 	}
 
 	/**

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -238,7 +238,12 @@ const ActionButton = ( {
 
 	return (
 		<div className="plans-grid-next-action-button">
-			<div className="plans-grid-next-action-button__content">{ actionButton }</div>
+			<div
+				className="plans-grid-next-action-button__content"
+				style={ ! text ? { visibility: 'hidden' } : undefined }
+			>
+				{ actionButton }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2188/

## Proposed changes

This gates the "Downgrade" button on `available_for_downgrade: true` from the `/sites/%s/plans` endpoint, so the button no longer appears when the server has explicitly said the plan is not downgradeable.

## Screenshots

> [!IMPORTANT]
> These screenshots are contrived by hacking the API response so that `available_for_downgrade` is false. The wpcom plans shown here are actually eligible for downgrades.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1382" height="457" alt="Screenshot 2026-06-24 at 6 16 14 PM" src="https://github.com/user-attachments/assets/1fec31ae-1318-42de-9ea4-4e649bd1f63a" /> | <img width="1371" height="456" alt="Screenshot 2026-06-24 at 6 25 07 PM" src="https://github.com/user-attachments/assets/e0eebae7-a384-437f-9ede-354517360485" />
<img width="1197" height="680" alt="Screenshot 2026-06-24 at 6 30 51 PM" src="https://github.com/user-attachments/assets/dd2cc40d-118b-4295-a705-67b90cde973b" /> | <img width="1204" height="699" alt="Screenshot 2026-06-24 at 6 30 13 PM" src="https://github.com/user-attachments/assets/fcc6e437-2081-4e49-b49b-bb9a316fa10a" />


## Why are these changes being made?

Previously, `available_for_downgrade` in the site plans API response only gated confirmation modals shown *after* clicking Downgrade (the refund-window modal, the end-of-term scheduling modal, etc.) — it had no effect on whether the button itself appeared. The button label was controlled entirely by `available_for_upgrade`: any plan where `available_for_upgrade: false` would show a "Downgrade" button, regardless of what the server said about downgrade availability. (This predates the recent work adding self-serve downgrade flows.)

This meant that if the server returned `available_for_downgrade: false` for every plan — which it uses as a signal that no downgrades should be offered — the Downgrade button still rendered on the plans page. 

This was a regression from https://github.com/Automattic/wp-calypso/pull/111404 which added the property but failed to use it.

This PR closes the gap so that `available_for_upgrade` controls the "Upgrade" button and `available_for_downgrade` controls the "Downgrade" button, as the API intends.

## Testing instructions

* On a site where the plans API returns `available_for_downgrade: false` for all plans, navigate to the Plans page (`/plans/:site`)
* Confirm no "Downgrade" button appears for any plan
* On a site where the API returns `available_for_downgrade: true` for a lower-tier plan, confirm the "Downgrade" button still appears for that plan
* Confirm that plans where `available_for_upgrade: true` continue to show the "Upgrade" button unaffected

