### PR TITLE
Masterbar: white grouped submenu background in global-sidebar context

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -53,8 +53,8 @@ $brand-text: "SF Pro Text", $sans;
 		--color-masterbar-icon: #fff; // From "Modern" color scheme.
 		--color-masterbar-submenu-text: var(--color-sidebar-text);
 		--color-masterbar-submenu-hover-text: var(--color-accent);
-		--color-global-masterbar-submenu-background: var(--studio-white);
 		--color-masterbar-submenu-group-background: var(--studio-white);
+		--color-global-masterbar-submenu-background: var(--studio-white);
 		--color-global-masterbar-submenu-hover-background: var(--studio-white);
 		--color-global-masterbar-site-info-background: #{$gray-100};
 		--color-global-masterbar-site-info-badge-background: #{$gray-300};

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -54,6 +54,7 @@ $brand-text: "SF Pro Text", $sans;
 		--color-masterbar-submenu-text: var(--color-sidebar-text);
 		--color-masterbar-submenu-hover-text: var(--color-accent);
 		--color-global-masterbar-submenu-background: var(--studio-white);
+		--color-masterbar-submenu-group-background: var(--studio-white);
 		--color-global-masterbar-submenu-hover-background: var(--studio-white);
 		--color-global-masterbar-site-info-background: #{$gray-100};
 		--color-global-masterbar-site-info-badge-background: #{$gray-300};


### PR DESCRIPTION
Fixes: DOTMSD-1339 follow-up

## Proposed Changes

* In the global-sidebar (my-sites) masterbar context, re-declare `--color-masterbar-submenu-group-background` to `var(--studio-white)` so grouped (`--odd`) submenu items match the white submenu surface instead of rendering as a grey strip.

## Why are these changes being made?

* Follow-up to #111864. That PR added `--color-masterbar-submenu-group-background`, defined in the default scheme **by reference** to `--color-sidebar-submenu-background`. CSS custom properties resolve `var()` at their declaration site and inherit the already-resolved value, so the token resolves once at the root to the dark wp-admin grey (`#32373c`) and inherits that everywhere.
* The `.is-global-sidebar-visible` context re-skins the masterbar to a white submenu, but only overrides `--color-sidebar-submenu-background` / `--color-global-masterbar-submenu-background`. Because the group token was already substituted to grey at the root, overriding the sidebar token does **not** re-resolve it — so regular submenu items go white while grouped items keep the stale grey.
* The grey is correct in real wp-admin (`ul.ab-sub-secondary` is genuinely grey there), but wrong in the Calypso my-sites context where the whole submenu is white. This scoped override fixes it without touching the per-scheme values, since this block already hard-resets the masterbar to a fixed skin regardless of the user's admin color scheme.

## Testing Instructions

* Open the my-sites view with the global sidebar on a default-theme site.
* Open the user/profile dropdown in the masterbar.
* Confirm the grouped (`--odd`) items render with a white background matching the rest of the submenu, not a grey strip.
* Spot-check other admin color schemes to confirm their grouped masterbar/wp-admin submenu backgrounds are unchanged.
* Ran `yarn stylelint client/my-sites/sidebar/style.scss`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)