### PR TITLE
Plugins: resolve the detail panel immediately for an empty search (DOTMSD-1301)

### DIFF
--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -39,9 +39,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	const availableIcon = useMarketplaceSearchIcon( pluginSlug );
 	const { queries } = useAppContext();
 	const locale = useLocale();
-	// When the plugin search returns no results, there is no selected plugin to
-	// look up. Skip the queries and resolve immediately so the detail panel shows
-	// its empty state without a loading flash.
+	// No slug to look up — resolve immediately to avoid a loading flash.
 	const hasPluginSlug = !! pluginSlug;
 	const {
 		data: sitesPlugins,

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -39,6 +39,10 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	const availableIcon = useMarketplaceSearchIcon( pluginSlug );
 	const { queries } = useAppContext();
 	const locale = useLocale();
+	// When the plugin search returns no results, there is no selected plugin to
+	// look up. Skip the queries and resolve immediately so the detail panel shows
+	// its empty state without a loading flash.
+	const hasPluginSlug = !! pluginSlug;
 	const {
 		data: sitesPlugins,
 		isLoading: isLoadingSitesPlugins,
@@ -51,7 +55,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	const isMarketplacePlugin = !! marketplacePlugins?.results[ pluginSlug ];
 	const { data: wpOrgPlugin, isLoading: isLoadingWpOrgPlugin } = useQuery( {
 		...wpOrgPluginQuery( pluginSlug, locale ),
-		enabled: ! availableIcon,
+		enabled: ! availableIcon && hasPluginSlug,
 	} );
 	// Query needed to get the action_links
 	const sitePluginQueryResults = useQueries( {
@@ -142,11 +146,12 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 
 	return {
 		isLoading:
-			isLoadingSitesPlugins ||
-			isLoadingSites ||
-			isLoadingWpOrgPlugin ||
-			isLoadingMarketplacePlugins ||
-			isLoadingSitePlugins,
+			hasPluginSlug &&
+			( isLoadingSitesPlugins ||
+				isLoadingSites ||
+				isLoadingWpOrgPlugin ||
+				isLoadingMarketplacePlugins ||
+				isLoadingSitePlugins ),
 		isFetching: isFetchingSitePlugins,
 		pluginBySiteId,
 		sitesWithThisPlugin,

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -57,9 +57,11 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	} );
 	// Query needed to get the action_links
 	const sitePluginQueryResults = useQueries( {
-		queries: Object.keys( sitesPlugins?.sites || {} ).map( ( id ) =>
-			sitePluginQuery( Number( id ), pluginSlug )
-		),
+		queries: hasPluginSlug
+			? Object.keys( sitesPlugins?.sites || {} ).map( ( id ) =>
+					sitePluginQuery( Number( id ), pluginSlug )
+			  )
+			: [],
 	} );
 	const isLoadingSitePlugins = sitePluginQueryResults.some( ( query ) => query.isLoading );
 


### PR DESCRIPTION
Fixes DOTMSD-1301

## Proposed Changes

In **Manage plugins** (`/plugins/manage`), when the left search returns no results, the right detail panel showed a loading state for a few seconds before settling on **"Plugin not found"**. Since there is no plugin to look up, the panel should resolve immediately.

- **`client/dashboard/plugins/plugin/use-plugin.ts`** — short-circuit when there is no selected plugin slug: skip the wordpress.org plugin lookup and report `isLoading` as `false`, so the detail panel renders its empty state right away.

## Why are these changes being made?

With an empty search, the selected plugin slug is empty, but `usePlugin` still fired the wordpress.org lookup for that empty slug and reported `isLoading: true` until it resolved — producing the loading flash before "Plugin not found". When there is no slug there is nothing to load, so the hook can resolve immediately.

## Testing Instructions

You can test on the **Calypso live link** generated for this PR (see the live-link comment/check on the PR), or run locally with `yarn start-dashboard` and open `/plugins/manage`.

1. Open **Manage plugins** with the two-column (desktop) layout.
2. In the left plugin search, type a string that matches nothing, e.g. `zzznotarealplugin`.
   - **Before:** the right panel shows a loading state (placeholder icon / blurred title) for a few seconds, then "Plugin not found".
   - **After:** the right panel shows "Plugin not found" immediately, with no loading flash.
3. Clear the search (or select a plugin) and confirm a real plugin still loads its details normally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
