### PR TITLE
SHILL-2181: Offer to finish checkout without a VAT ID when VAT validation is unavailable

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -924,9 +924,17 @@ export default function CheckoutMainContent( {
 									} catch ( error ) {
 										reduxDispatch( removeNotice( 'vat_info_notice' ) );
 										if ( shouldDisplayValidationErrors ) {
-											reduxDispatch(
-												errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
-											);
+											const vatError = error as { error?: string; message: string };
+											// `invalid_vat` means the VAT ID could not be validated right now
+											// (service down/busy), so the shopper can still finish without one.
+											const vatErrorMessage =
+												vatError.error === 'invalid_vat'
+													? `${ vatError.message } ${ translate(
+															'You can uncheck “Add VAT details” to finish your purchase now without a VAT ID.',
+															{ textOnly: true }
+													  ) }`
+													: vatError.message;
+											reduxDispatch( errorNotice( vatErrorMessage, { id: 'vat_info_notice' } ) );
 										}
 										return false;
 									}

--- a/client/my-sites/checkout/src/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/src/test/checkout-vat-form.tsx
@@ -9,6 +9,7 @@ import { dispatch } from '@wordpress/data';
 import nock from 'nock';
 import { useCheckoutHelpCenter } from 'calypso/my-sites/checkout/src/hooks/use-checkout-help-center';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
@@ -43,6 +44,15 @@ jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
+// Spy on errorNotice so we can assert the message text; keep every other
+// notices action real so the rest of the suite behaves normally.
+jest.mock( 'calypso/state/notices/actions', () => {
+	const actual = jest.requireActual( 'calypso/state/notices/actions' );
+	return {
+		...actual,
+		errorNotice: jest.fn( actual.errorNotice ),
+	};
+} );
 
 // These tests seem to be particularly slow (it might be because of using
 // it.each; it's not clear but the timeout might apply to the whole loop
@@ -768,5 +778,68 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue to payment' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
+	} );
+
+	it( 'tells the shopper they can finish without a VAT ID when validation is temporarily unavailable', async () => {
+		const vatId = '12345';
+		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
+		const countryCode = 'GB';
+		// `invalid_vat` is the "could not validate right now" bucket (service down/busy).
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/me/vat-info' ).reply( 400, {
+			error: 'invalid_vat',
+			message:
+				'VAT validation for this country is temporarily unavailable. Please try again later.',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		( errorNotice as jest.Mock ).mockClear();
+		await user.click( screen.getByText( 'Continue to payment' ) );
+		await waitFor( () =>
+			expect( errorNotice ).toHaveBeenCalledWith(
+				expect.stringContaining( 'finish your purchase now without a VAT ID' ),
+				expect.anything()
+			)
+		);
+	} );
+
+	it( 'does not suggest skipping VAT when the VAT number is actually invalid', async () => {
+		const vatId = '12345';
+		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
+		const countryCode = 'GB';
+		// `validation_failed` means the number is genuinely wrong, so the shopper should fix it.
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/me/vat-info' ).reply( 400, {
+			error: 'validation_failed',
+			message: 'Your VAT details are not valid. Please check each field and try again.',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		( errorNotice as jest.Mock ).mockClear();
+		await user.click( screen.getByText( 'Continue to payment' ) );
+		await waitFor( () =>
+			expect( errorNotice ).toHaveBeenCalledWith(
+				expect.stringContaining( 'not valid' ),
+				expect.anything()
+			)
+		);
+		expect( errorNotice ).not.toHaveBeenCalledWith(
+			expect.stringContaining( 'finish your purchase now without a VAT ID' ),
+			expect.anything()
+		);
 	} );
 } );


### PR DESCRIPTION
Part of SHILL-2181
Related to 225134-ghe-Automattic/wpcom (reworded VAT validation messages).

## Proposed Changes

* `checkout-main-content.tsx`: when saving VAT details fails with error code `invalid_vat` (VAT validation couldn't complete - service down/busy/timeout), append a hint to the error notice: **"You can uncheck "Add VAT details" to finish your purchase now without a VAT ID."** Any other error code shows the message unchanged.
* `checkout-vat-form.tsx`: two tests - hint shown for `invalid_vat`, hint absent for `validation_failed`.

## Why are these changes being made?

When VAT validation can't complete at checkout, a customer who entered a VAT ID was stuck - they couldn't validate it and couldn't move on. They can actually finish without a VAT ID (uncheck the box, request a VAT refund later if eligible). This tells them so.

It only shows for the "couldn't validate right now" bucket (`invalid_vat`), not for a genuinely invalid number (`validation_failed`) - there the right advice is "fix the number," not "skip it." The two already come back as distinct error codes from `/me/vat-info`, so no backend change was needed for the scoping.

| Scenario | Error code | Toast |
|----------|-----------|-------|
| VIES down / busy / timeout | `invalid_vat` | message + "You can uncheck Add VAT details..." hint |
| Number is genuinely invalid | `validation_failed` | message only, no hint |

## New Translation
You can uncheck "Add VAT details" to finish your purchase now without a VAT ID.

## Screenshots

Service unavailable (`invalid_vat`) - message + hint:

<img width="1679" alt="shill-2181-hint-invalid-vat-banner" src="https://github.com/user-attachments/assets/dd341f4f-3f88-4b60-a38c-aaef43267de5" />

Invalid number (`validation_failed`) - message only, no hint:

<img width="1679" alt="shill-2181-no-hint-validation-failed-banner" src="https://github.com/user-attachments/assets/55b5d850-4bae-4b5d-a466-fce47862b0cf" />

## Testing Instructions

This does not depend on 225134-ghe-Automattic/wpcom (reworded VAT validation messages), but that change adjusts the error message in the first sentence.   This PR only adds the second sentence and can be tested locally and deployed without 225134-ghe-Automattic/wpcom (reworded VAT validation messages).

**Environment:**
- Enable Store Sandbox mode
- `public-api.wordpress.com` sandboxed to a sandbox that has the paired wpcom change (so the backend message matches)

```
yarn test-client client/my-sites/checkout/src/test/checkout-vat-form.tsx -t VAT
```
Proves both branches: hint appended for `invalid_vat`, absent for `validation_failed`.

**Steps:**
1. Open checkout for a paid product, e.g. `/checkout/jetpack/jetpack_security_t1_yearly`
2. At "Billing information" click Edit, set Country to Germany. Check "Add VAT details", fill Organization / VAT ID / Address.
3. Force a VIES service fault: temporarily add `throw new \SoapFault( 'Server', 'MS_UNAVAILABLE' );` at the top of `validate_vat_details` in the wpcom `vies-vat-validator.php` on sandbox - fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sovyyvatqnqql%2Sfep%2Sgnk%2Sivrf%2Qing%2Qinyvqngbe.cuc%2328-og. Or, with DevTools, override the `POST /me/vat-info` response to `400 {"error":"invalid_vat","message":"VAT validation for this country is temporarily unavailable. Please try again later."}`.
4. Click "Continue to payment". Verify the toast reads the message **plus** "You can uncheck "Add VAT details" to finish your purchase now without a VAT ID."
5. Now enter a well-formed but invalid number instead: Germany + VAT ID `123456789`, click Continue. Verify the toast reads "Your VAT details are not valid. Please check each field and try again." with **no** "uncheck" hint.
6. Test a valid VAT ID - found [here](https://viesapi.eu/test-vies-api/).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.