### PR TITLE
Handle multi step requests from Dolly agent

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -90,7 +90,7 @@ function isShowComponentMessage( message: Pick< UIMessage, 'content' > ): boolea
 
 function getShowComponentIdentity( message: Pick< UIMessage, 'content' > ): string | undefined {
 	const toolData = getToolMessageData( message );
-	if ( ! isShowComponentTool( toolData?.toolId ) ) {
+	if ( ! toolData || ! isShowComponentTool( toolData.toolId ) ) {
 		return undefined;
 	}
 
@@ -334,11 +334,7 @@ export default function OrchestratorChat( {
 
 			debugShowComponentMessages( 'useConversation onSuccess loading messages', {
 				serverSessionId,
-				messageIds: loadedMessages.map( ( message ) => message.id ),
-				showComponents: loadedMessages.filter( isShowComponentMessage ).map( ( message ) => ( {
-					id: message.id,
-					tool: getToolMessageData( message ),
-				} ) ),
+				messageCount: loadedMessages.length,
 			} );
 
 			// Update the UI with the loaded messages
@@ -631,9 +627,9 @@ export default function OrchestratorChat( {
 			const deleteDecisions = msgs.map( ( msg ) => {
 				const messageFromRequest = msg as Pick< UIMessage, 'id' > &
 					Partial< Pick< UIMessage, 'content' > >;
-				const fullMessage =
-					( messageFromRequest.content ? messageFromRequest : undefined ) ??
-					messagesRef.current.find( ( message ) => message.id === msg.id );
+				const fullMessage = messageFromRequest.content
+					? ( messageFromRequest as UIMessage )
+					: messagesRef.current.find( ( message ) => message.id === msg.id );
 				const isShowComponent = !! fullMessage && isShowComponentMessage( fullMessage );
 
 				return {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1,11 +1,11 @@
-import { getAgentManager, useAgentChat } from '@automattic/agenttic-client';
+import { getAgentManager, useAgentChat, type UIMessage } from '@automattic/agenttic-client';
 import {
 	type Suggestion,
 	type MarkdownComponents,
 	type MarkdownExtensions,
 } from '@automattic/agenttic-ui';
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback, useMemo, useEffect } from '@wordpress/element';
+import { useState, useCallback, useMemo, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
@@ -34,6 +34,7 @@ import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
+import { isShowComponentTool } from '../../utils/show-component-tools';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
@@ -54,6 +55,87 @@ import type {
  */
 function formatSuggestionIds( suggestions: Suggestion[] ): string {
 	return '|' + suggestions.map( ( s ) => s.id ).join( '|' ) + '|';
+}
+
+function getToolMessageData( message: Pick< UIMessage, 'content' > ):
+	| {
+			toolId?: string;
+			toolCallId?: string;
+			componentType?: string;
+			summary?: string;
+	  }
+	| undefined {
+	const firstText = message.content?.[ 0 ]?.text;
+	if ( ! firstText ) {
+		return undefined;
+	}
+
+	try {
+		const parsed = JSON.parse( firstText );
+		return {
+			toolId: parsed?.tool_id,
+			toolCallId: parsed?.tool_call_id,
+			componentType: parsed?.data?.type,
+			summary: parsed?.data?.summary,
+		};
+	} catch ( _error ) {
+		return undefined;
+	}
+}
+
+function isShowComponentMessage( message: Pick< UIMessage, 'content' > ): boolean {
+	const toolData = getToolMessageData( message );
+	return isShowComponentTool( toolData?.toolId );
+}
+
+function getShowComponentIdentity( message: Pick< UIMessage, 'content' > ): string | undefined {
+	const toolData = getToolMessageData( message );
+	if ( ! isShowComponentTool( toolData?.toolId ) ) {
+		return undefined;
+	}
+
+	return [ toolData.toolCallId, toolData.componentType, toolData.summary ]
+		.filter( Boolean )
+		.join( '|' );
+}
+
+function isShowComponentDebugEnabled(): boolean {
+	return window.localStorage?.getItem( 'agents-manager-debug-show-components' ) === 'true';
+}
+
+function debugShowComponentMessages( message: string, data?: unknown ): void {
+	if ( ! isShowComponentDebugEnabled() ) {
+		return;
+	}
+
+	// eslint-disable-next-line no-console
+	console.debug( `[AgentsManager show-component] ${ message }`, data ?? '' );
+}
+
+function debugShowComponentTrace( message: string, data?: unknown ): void {
+	if ( ! isShowComponentDebugEnabled() ) {
+		return;
+	}
+
+	// eslint-disable-next-line no-console
+	console.trace( `[AgentsManager show-component] ${ message }`, data ?? '' );
+}
+
+function convertBigSkyMessageToUIMessage( message: BigSkyMessage ): UIMessage {
+	const uiMessage = {
+		// Keep Big Sky message properties without explicit mapping to keep linter happy.
+		// Big Sky messages sometimes have a `context` field used by the site build to
+		// show the progress indicator.
+		...message,
+		id: message.id,
+		role: message.role === 'assistant' ? 'agent' : 'user',
+		content: message.content,
+		timestamp: message.created_at ? message.created_at * 1000 : Date.now(),
+		archived: message.archived ?? false,
+		showIcon: message.showIcon ?? true,
+	} as UIMessage;
+
+	return uiMessage;
 }
 
 interface Props {
@@ -120,6 +202,9 @@ export default function OrchestratorChat( {
 	const [ thinkingMessage, setThinkingMessage ] = useState< string | null >( null );
 	const [ isBuildingSite, setIsBuildingSite ] = useState( false );
 	const [ deletedMessageIds, setDeletedMessageIds ] = useState< Set< string > >( new Set() );
+	const [ retainedShowComponentMessages, setRetainedShowComponentMessages ] = useState<
+		Map< string, UIMessage >
+	>( new Map() );
 	const [ hasUserSentMessage, setHasUserSentMessage ] = useState( false );
 	const currentPostId = useSelect( ( select ) => {
 		return ( select( 'core/editor' ) as { getCurrentPostId?: () => number } )?.getCurrentPostId?.();
@@ -139,6 +224,96 @@ export default function OrchestratorChat( {
 		registerMessageActions,
 		progressMessage,
 	} = useAgentChat( agentConfig! );
+	const messagesRef = useRef( messages );
+	const previousMessagesRef = useRef( messages );
+	const previousShowComponentIdsRef = useRef< string[] >( [] );
+	const showComponentOrderRef = useRef< Map< string, number > >( new Map() );
+	const nextShowComponentOrderRef = useRef( 0 );
+	messagesRef.current = messages;
+
+	const getShowComponentOrder = useCallback( ( message: UIMessage ): number | undefined => {
+		const identity = getShowComponentIdentity( message );
+		if ( ! identity ) {
+			return undefined;
+		}
+
+		const existingOrder = showComponentOrderRef.current.get( identity );
+		if ( existingOrder !== undefined ) {
+			return existingOrder;
+		}
+
+		const nextOrder = nextShowComponentOrderRef.current++;
+		showComponentOrderRef.current.set( identity, nextOrder );
+		return nextOrder;
+	}, [] );
+
+	useEffect( () => {
+		const previousMessages = previousMessagesRef.current;
+		messages.filter( isShowComponentMessage ).forEach( getShowComponentOrder );
+
+		const currentShowComponentIdentities = new Set(
+			messages.filter( isShowComponentMessage ).map( getShowComponentIdentity ).filter( Boolean )
+		);
+		const retainedCandidates = previousMessages.filter( ( previousMessage ) => {
+			const identity = getShowComponentIdentity( previousMessage );
+			return !! identity && ! currentShowComponentIdentities.has( identity );
+		} );
+
+		if ( retainedCandidates.length > 0 ) {
+			setRetainedShowComponentMessages( ( previousRetainedMessages ) => {
+				const nextRetainedMessages = new Map( previousRetainedMessages );
+				let changed = false;
+
+				for ( const message of retainedCandidates ) {
+					const identity = getShowComponentIdentity( message );
+					const retainedId = `${ message.id }-retained-${ identity }`;
+					if ( ! nextRetainedMessages.has( retainedId ) ) {
+						nextRetainedMessages.set( retainedId, { ...message, id: retainedId } );
+						changed = true;
+					}
+				}
+
+				debugShowComponentMessages( 'retained replaced show-component messages', {
+					retained: retainedCandidates.map( ( message ) => ( {
+						id: message.id,
+						retainedId: `${ message.id }-retained-${ getShowComponentIdentity( message ) }`,
+						tool: getToolMessageData( message ),
+					} ) ),
+				} );
+
+				return changed ? nextRetainedMessages : previousRetainedMessages;
+			} );
+		}
+
+		const showComponents = messages.filter( isShowComponentMessage ).map( ( message ) => ( {
+			id: message.id,
+			role: message.role,
+			archived: message.archived,
+			tool: getToolMessageData( message ),
+		} ) );
+		const showComponentIds = showComponents.map( ( message ) => message.id );
+		const removedShowComponentIds = previousShowComponentIdsRef.current.filter(
+			( id ) => ! showComponentIds.includes( id )
+		);
+
+		debugShowComponentMessages( 'agenttic messages changed', {
+			messageIds: messages.map( ( message ) => message.id ),
+			showComponents,
+			removedShowComponentIds,
+		} );
+
+		if ( removedShowComponentIds.length > 0 ) {
+			debugShowComponentTrace( 'show-component disappeared from agenttic messages', {
+				removedShowComponentIds,
+				previousShowComponentIds: previousShowComponentIdsRef.current,
+				currentShowComponentIds: showComponentIds,
+				currentMessageIds: messages.map( ( message ) => message.id ),
+			} );
+		}
+
+		previousShowComponentIdsRef.current = showComponentIds;
+		previousMessagesRef.current = messages;
+	}, [ getShowComponentOrder, messages ] );
 
 	// Reader-chat sessions are short (usually < 50 messages) — don't waste
 	// time paginating 10 pages deep. One page covers typical use.
@@ -156,6 +331,15 @@ export default function OrchestratorChat( {
 			if ( isReaderChat && ( hasUserSentMessage || messages.length > 0 || isProcessing ) ) {
 				return;
 			}
+
+			debugShowComponentMessages( 'useConversation onSuccess loading messages', {
+				serverSessionId,
+				messageIds: loadedMessages.map( ( message ) => message.id ),
+				showComponents: loadedMessages.filter( isShowComponentMessage ).map( ( message ) => ( {
+					id: message.id,
+					tool: getToolMessageData( message ),
+				} ) ),
+			} );
 
 			// Update the UI with the loaded messages
 			loadMessages( loadedMessages );
@@ -421,29 +605,62 @@ export default function OrchestratorChat( {
 	// The hook is stable as `OrchestratorChat` only renders after external providers have been loaded.
 	useAbilitiesSetup?.( {
 		addMessage: ( message: BigSkyMessage ) => {
-			// Transform Big Sky message format to `UIMessage` format and add to chat
-			addMessage( {
-				// Keep Big Sky message properties without explicit mapping to keep linter happy
-				// Big Sky messages sometimes have a `context` field used by the
-				// site build to show the progress indicator
-				...message,
-				id: message.id,
-				role: message.role === 'assistant' ? 'agent' : 'user',
-				content: message.content,
-				timestamp: message.created_at ? message.created_at * 1000 : Date.now(),
-				archived: message.archived ?? false,
-				showIcon: message.showIcon ?? true,
+			// Transform Big Sky message format to `UIMessage` format and add to chat.
+			const uiMessage = convertBigSkyMessageToUIMessage( message );
+			debugShowComponentMessages( 'addMessage called', {
+				incomingId: message.id,
+				uiId: uiMessage.id,
+				role: uiMessage.role,
+				tool: getToolMessageData( uiMessage ),
+				isShowComponent: isShowComponentMessage( uiMessage ),
 			} );
+			addMessage( uiMessage );
 		},
-		clearMessages: () => loadMessages( [] ),
+		clearMessages: () => {
+			debugShowComponentTrace( 'clearMessages called' );
+			loadMessages( [] );
+		},
 		clearSuggestions,
 		getAgentManager,
 		isProcessing,
 		setIsThinking,
 		deleteMarkedMessages: ( msgs ) => {
-			setDeletedMessageIds(
-				( prevIds ) => new Set( [ ...prevIds, ...msgs.map( ( msg ) => msg.id ) ] )
+			debugShowComponentTrace( 'deleteMarkedMessages stack trace', {
+				requestedIds: msgs.map( ( msg ) => msg.id ),
+			} );
+			const deleteDecisions = msgs.map( ( msg ) => {
+				const messageFromRequest = msg as Pick< UIMessage, 'id' > &
+					Partial< Pick< UIMessage, 'content' > >;
+				const fullMessage =
+					( messageFromRequest.content ? messageFromRequest : undefined ) ??
+					messagesRef.current.find( ( message ) => message.id === msg.id );
+				const isShowComponent = !! fullMessage && isShowComponentMessage( fullMessage );
+
+				return {
+					id: msg.id,
+					foundMessage: !! fullMessage,
+					isShowComponent,
+					tool: fullMessage ? getToolMessageData( fullMessage ) : undefined,
+					shouldDelete: fullMessage ? ! isShowComponent : false,
+				};
+			} );
+			debugShowComponentMessages( 'deleteMarkedMessages called', deleteDecisions );
+
+			const deletableMessages = msgs.filter(
+				( msg ) => deleteDecisions.find( ( decision ) => decision.id === msg.id )?.shouldDelete
 			);
+			if ( deletableMessages.length === 0 ) {
+				return;
+			}
+
+			setDeletedMessageIds( ( prevIds ) => {
+				const nextIds = new Set( [ ...prevIds, ...deletableMessages.map( ( msg ) => msg.id ) ] );
+				debugShowComponentMessages( 'deletedMessageIds updated', {
+					previous: [ ...prevIds ],
+					next: [ ...nextIds ],
+				} );
+				return nextIds;
+			} );
 		},
 		// This ensures the same session ID is used between Big Sky and Calypso agents,
 		// so that messages will be stored in the same conversation.
@@ -454,12 +671,57 @@ export default function OrchestratorChat( {
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		let currentMessages: AgentsManagerUIMessage[] = messages;
+		debugShowComponentMessages( 'displayedMessages start', {
+			messageIds: currentMessages.map( ( message ) => message.id ),
+			showComponentIds: currentMessages
+				.filter( isShowComponentMessage )
+				.map( ( message ) => message.id ),
+			deletedMessageIds: [ ...deletedMessageIds ],
+			isBuildingSite,
+		} );
 
 		currentMessages = currentMessages.filter(
 			( message ) =>
 				! deletedMessageIds.has( message.id ) &&
 				! message.content?.some( ( content ) => content?.text === LOCAL_TOOL_RUNNING_MESSAGE )
 		);
+
+		currentMessages.filter( isShowComponentMessage ).forEach( getShowComponentOrder );
+
+		const currentShowComponentIdentities = new Set(
+			currentMessages
+				.filter( isShowComponentMessage )
+				.map( getShowComponentIdentity )
+				.filter( Boolean )
+		);
+		const retainedMessagesToDisplay = [ ...retainedShowComponentMessages.values() ].filter(
+			( message ) => {
+				const identity = getShowComponentIdentity( message );
+				return !! identity && ! currentShowComponentIdentities.has( identity );
+			}
+		);
+		if ( retainedMessagesToDisplay.length > 0 ) {
+			retainedMessagesToDisplay.forEach( getShowComponentOrder );
+			currentMessages = [ ...currentMessages, ...retainedMessagesToDisplay ].sort(
+				( messageA, messageB ) => {
+					const orderA = getShowComponentOrder( messageA );
+					const orderB = getShowComponentOrder( messageB );
+
+					if ( orderA !== undefined && orderB !== undefined && orderA !== orderB ) {
+						return orderA - orderB;
+					}
+
+					return ( messageA.timestamp ?? 0 ) - ( messageB.timestamp ?? 0 );
+				}
+			);
+		}
+
+		debugShowComponentMessages( 'after local filter', {
+			messageIds: currentMessages.map( ( message ) => message.id ),
+			showComponentIds: currentMessages
+				.filter( isShowComponentMessage )
+				.map( ( message ) => message.id ),
+		} );
 
 		// Group site-build messages only when needed
 		const hasBuildMessages = siteBuildUtils?.hasSiteBuildMessages( currentMessages );
@@ -471,6 +733,12 @@ export default function OrchestratorChat( {
 				currentMessages,
 				isBuildingSite ? thinkingMessage : null
 			);
+			debugShowComponentMessages( 'after groupSiteBuildMessages', {
+				messageIds: currentMessages.map( ( message ) => message.id ),
+				showComponentIds: currentMessages
+					.filter( isShowComponentMessage )
+					.map( ( message ) => message.id ),
+			} );
 		}
 
 		currentMessages = convertToolMessagesToComponents( {
@@ -478,6 +746,15 @@ export default function OrchestratorChat( {
 			getChatComponent,
 			currentPostId,
 			onSubmit: onSubmitWithImages,
+		} );
+
+		debugShowComponentMessages( 'after convertToolMessagesToComponents', {
+			messageIds: currentMessages.map( ( message ) => message.id ),
+			componentMessages: currentMessages
+				.filter(
+					( message ) => message.content?.some( ( content ) => content.type === 'component' )
+				)
+				.map( ( message ) => ( { id: message.id, disabled: message.disabled } ) ),
 		} );
 
 		currentMessages = currentMessages.map( ( message ) => {
@@ -511,10 +788,12 @@ export default function OrchestratorChat( {
 		deletedMessageIds,
 		getChatComponent,
 		getCopyActionsForMessage,
+		getShowComponentOrder,
 		getFeedbackActionsForMessage,
 		isBuildingSite,
 		messages,
 		onSubmitWithImages,
+		retainedShowComponentMessages,
 		siteBuildUtils,
 		thinkingMessage,
 	] );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -99,28 +99,6 @@ function getShowComponentIdentity( message: Pick< UIMessage, 'content' > ): stri
 		.join( '|' );
 }
 
-function isShowComponentDebugEnabled(): boolean {
-	return window.localStorage?.getItem( 'agents-manager-debug-show-components' ) === 'true';
-}
-
-function debugShowComponentMessages( message: string, data?: unknown ): void {
-	if ( ! isShowComponentDebugEnabled() ) {
-		return;
-	}
-
-	// eslint-disable-next-line no-console
-	console.debug( `[AgentsManager show-component] ${ message }`, data ?? '' );
-}
-
-function debugShowComponentTrace( message: string, data?: unknown ): void {
-	if ( ! isShowComponentDebugEnabled() ) {
-		return;
-	}
-
-	// eslint-disable-next-line no-console
-	console.trace( `[AgentsManager show-component] ${ message }`, data ?? '' );
-}
-
 function convertBigSkyMessageToUIMessage( message: BigSkyMessage ): UIMessage {
 	const uiMessage = {
 		// Keep Big Sky message properties without explicit mapping to keep linter happy.
@@ -226,7 +204,6 @@ export default function OrchestratorChat( {
 	} = useAgentChat( agentConfig! );
 	const messagesRef = useRef( messages );
 	const previousMessagesRef = useRef( messages );
-	const previousShowComponentIdsRef = useRef< string[] >( [] );
 	const showComponentOrderRef = useRef< Map< string, number > >( new Map() );
 	const nextShowComponentOrderRef = useRef( 0 );
 	messagesRef.current = messages;
@@ -273,45 +250,10 @@ export default function OrchestratorChat( {
 					}
 				}
 
-				debugShowComponentMessages( 'retained replaced show-component messages', {
-					retained: retainedCandidates.map( ( message ) => ( {
-						id: message.id,
-						retainedId: `${ message.id }-retained-${ getShowComponentIdentity( message ) }`,
-						tool: getToolMessageData( message ),
-					} ) ),
-				} );
-
 				return changed ? nextRetainedMessages : previousRetainedMessages;
 			} );
 		}
 
-		const showComponents = messages.filter( isShowComponentMessage ).map( ( message ) => ( {
-			id: message.id,
-			role: message.role,
-			archived: message.archived,
-			tool: getToolMessageData( message ),
-		} ) );
-		const showComponentIds = showComponents.map( ( message ) => message.id );
-		const removedShowComponentIds = previousShowComponentIdsRef.current.filter(
-			( id ) => ! showComponentIds.includes( id )
-		);
-
-		debugShowComponentMessages( 'agenttic messages changed', {
-			messageIds: messages.map( ( message ) => message.id ),
-			showComponents,
-			removedShowComponentIds,
-		} );
-
-		if ( removedShowComponentIds.length > 0 ) {
-			debugShowComponentTrace( 'show-component disappeared from agenttic messages', {
-				removedShowComponentIds,
-				previousShowComponentIds: previousShowComponentIdsRef.current,
-				currentShowComponentIds: showComponentIds,
-				currentMessageIds: messages.map( ( message ) => message.id ),
-			} );
-		}
-
-		previousShowComponentIdsRef.current = showComponentIds;
 		previousMessagesRef.current = messages;
 	}, [ getShowComponentOrder, messages ] );
 
@@ -331,11 +273,6 @@ export default function OrchestratorChat( {
 			if ( isReaderChat && ( hasUserSentMessage || messages.length > 0 || isProcessing ) ) {
 				return;
 			}
-
-			debugShowComponentMessages( 'useConversation onSuccess loading messages', {
-				serverSessionId,
-				messageCount: loadedMessages.length,
-			} );
 
 			// Update the UI with the loaded messages
 			loadMessages( loadedMessages );
@@ -602,28 +539,14 @@ export default function OrchestratorChat( {
 	useAbilitiesSetup?.( {
 		addMessage: ( message: BigSkyMessage ) => {
 			// Transform Big Sky message format to `UIMessage` format and add to chat.
-			const uiMessage = convertBigSkyMessageToUIMessage( message );
-			debugShowComponentMessages( 'addMessage called', {
-				incomingId: message.id,
-				uiId: uiMessage.id,
-				role: uiMessage.role,
-				tool: getToolMessageData( uiMessage ),
-				isShowComponent: isShowComponentMessage( uiMessage ),
-			} );
-			addMessage( uiMessage );
+			addMessage( convertBigSkyMessageToUIMessage( message ) );
 		},
-		clearMessages: () => {
-			debugShowComponentTrace( 'clearMessages called' );
-			loadMessages( [] );
-		},
+		clearMessages: () => loadMessages( [] ),
 		clearSuggestions,
 		getAgentManager,
 		isProcessing,
 		setIsThinking,
 		deleteMarkedMessages: ( msgs ) => {
-			debugShowComponentTrace( 'deleteMarkedMessages stack trace', {
-				requestedIds: msgs.map( ( msg ) => msg.id ),
-			} );
 			const deleteDecisions = msgs.map( ( msg ) => {
 				const messageFromRequest = msg as Pick< UIMessage, 'id' > &
 					Partial< Pick< UIMessage, 'content' > >;
@@ -640,7 +563,6 @@ export default function OrchestratorChat( {
 					shouldDelete: fullMessage ? ! isShowComponent : false,
 				};
 			} );
-			debugShowComponentMessages( 'deleteMarkedMessages called', deleteDecisions );
 
 			const deletableMessages = msgs.filter(
 				( msg ) => deleteDecisions.find( ( decision ) => decision.id === msg.id )?.shouldDelete
@@ -649,14 +571,9 @@ export default function OrchestratorChat( {
 				return;
 			}
 
-			setDeletedMessageIds( ( prevIds ) => {
-				const nextIds = new Set( [ ...prevIds, ...deletableMessages.map( ( msg ) => msg.id ) ] );
-				debugShowComponentMessages( 'deletedMessageIds updated', {
-					previous: [ ...prevIds ],
-					next: [ ...nextIds ],
-				} );
-				return nextIds;
-			} );
+			setDeletedMessageIds(
+				( prevIds ) => new Set( [ ...prevIds, ...deletableMessages.map( ( msg ) => msg.id ) ] )
+			);
 		},
 		// This ensures the same session ID is used between Big Sky and Calypso agents,
 		// so that messages will be stored in the same conversation.
@@ -667,14 +584,6 @@ export default function OrchestratorChat( {
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		let currentMessages: AgentsManagerUIMessage[] = messages;
-		debugShowComponentMessages( 'displayedMessages start', {
-			messageIds: currentMessages.map( ( message ) => message.id ),
-			showComponentIds: currentMessages
-				.filter( isShowComponentMessage )
-				.map( ( message ) => message.id ),
-			deletedMessageIds: [ ...deletedMessageIds ],
-			isBuildingSite,
-		} );
 
 		currentMessages = currentMessages.filter(
 			( message ) =>
@@ -712,13 +621,6 @@ export default function OrchestratorChat( {
 			);
 		}
 
-		debugShowComponentMessages( 'after local filter', {
-			messageIds: currentMessages.map( ( message ) => message.id ),
-			showComponentIds: currentMessages
-				.filter( isShowComponentMessage )
-				.map( ( message ) => message.id ),
-		} );
-
 		// Group site-build messages only when needed
 		const hasBuildMessages = siteBuildUtils?.hasSiteBuildMessages( currentMessages );
 
@@ -729,12 +631,6 @@ export default function OrchestratorChat( {
 				currentMessages,
 				isBuildingSite ? thinkingMessage : null
 			);
-			debugShowComponentMessages( 'after groupSiteBuildMessages', {
-				messageIds: currentMessages.map( ( message ) => message.id ),
-				showComponentIds: currentMessages
-					.filter( isShowComponentMessage )
-					.map( ( message ) => message.id ),
-			} );
 		}
 
 		currentMessages = convertToolMessagesToComponents( {
@@ -742,15 +638,6 @@ export default function OrchestratorChat( {
 			getChatComponent,
 			currentPostId,
 			onSubmit: onSubmitWithImages,
-		} );
-
-		debugShowComponentMessages( 'after convertToolMessagesToComponents', {
-			messageIds: currentMessages.map( ( message ) => message.id ),
-			componentMessages: currentMessages
-				.filter(
-					( message ) => message.content?.some( ( content ) => content.type === 'component' )
-				)
-				.map( ( message ) => ( { id: message.id, disabled: message.disabled } ) ),
 		} );
 
 		currentMessages = currentMessages.map( ( message ) => {

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -1,5 +1,4 @@
 import { EscalationButton } from '../../components/escalation-button';
-import NextStepButton from '../../components/next-step-button';
 import UnavailableToolMessage from '../../components/unavailable-tool-message';
 import convertToolMessagesToComponents from '../convert-tool-messages-to-components';
 import { isEditorPage } from '../is-editor-page';
@@ -76,6 +75,19 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [ message ] );
 	} );
 
+	it( 'filters out context-only messages', () => {
+		const message = createMessage( {
+			content: [ { type: 'text', text: 'This is only context for the model.' } ],
+			context: { flags: { context_only: true } },
+		} as Partial< UIMessage > );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toEqual( [] );
+	} );
+
 	it( 'renders tool messages as components', () => {
 		const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
 			type: 'my-component',
@@ -127,6 +139,22 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
+	it( 'does not suppress the thinking indicator for component messages with follow-up tasks', () => {
+		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
+			type: 'my-component',
+			followUpTasks: true,
+			isCurrent: true,
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ].suppressThinking ).toBe( false );
+	} );
+
 	it( 'filters out unregistered components', () => {
 		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
 			type: 'unknown-component',
@@ -141,7 +169,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [] );
 	} );
 
-	it( 'appends `NextStepButton` with `onSubmit` as `onMoveToNextStep` only to the last active message with follow-up tasks', () => {
+	it( 'does not append a move-to-next-step button for active messages with follow-up tasks', () => {
 		const data = { type: 'my-component', followUpTasks: true, isCurrent: true };
 		const actions = [
 			{ id: 'action-1', label: 'Do something', onClick: jest.fn() },
@@ -156,16 +184,10 @@ describe( 'convertToolMessagesToComponents', () => {
 			getChatComponent,
 		} );
 
-		expect( result ).toHaveLength( 3 );
-		expect( result[ 0 ].id ).toBe( 'msg-1' );
-		expect( result[ 1 ].id ).toBe( 'msg-2' );
-		expect( result[ 2 ].id ).toBe( 'msg-2-next-step' );
-		expect( result[ 2 ].content[ 0 ] ).toMatchObject( {
-			type: 'component',
-			component: NextStepButton,
-			componentProps: { onMoveToNextStep: mockOnSubmit },
-		} );
-		expect( result[ 2 ].actions ).toBeUndefined();
+		expect( result ).toHaveLength( 2 );
+		expect( result.map( ( message ) => message.id ) ).toEqual( [ 'msg-1', 'msg-2' ] );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( { component: MockComponent } );
+		expect( result[ 1 ].content[ 0 ] ).toMatchObject( { component: MockComponent } );
 	} );
 
 	it( 'renders `UnavailableToolMessage` when not on an editor page', () => {
@@ -269,6 +291,39 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result[ 0 ].suppressThinking ).toBe( true );
 	} );
 
+	it( 'hides intermediate apply-block-edits summaries when a later tool response exists in the same turn', () => {
+		const intermediateMessage = createToolMessage(
+			'big_sky__apply_block_edits',
+			{
+				followUpTasks: true,
+				summary: 'Updated the heading.',
+			},
+			{ id: 'tool-1' }
+		);
+		const finalMessage = createToolMessage(
+			LEGACY_SHOW_COMPONENT_TOOL_ID,
+			{
+				type: 'color-picker',
+				summary: 'Pick a blue palette.',
+				isCurrent: true,
+			},
+			{ id: 'tool-2' }
+		);
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ intermediateMessage, finalMessage ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'tool-2' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: 'Pick a blue palette.',
+		} );
+	} );
+
 	it( 'renders update-theme structured result message as plain text', () => {
 		const message = createToolMessage( 'big_sky__apply_update_theme', {
 			result: {
@@ -316,6 +371,28 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 
 		expect( result ).toEqual( [] );
+	} );
+
+	it( 'filters out a plain-text agent message that duplicates an adjacent show-component summary', () => {
+		const summary = 'Pick a palette from beyond the grave.';
+		const toolMessage = createToolMessage(
+			SHOW_COMPONENT_TOOL_ID,
+			{ type: 'color-picker', summary, isCurrent: true },
+			{ id: 'tool-1' }
+		);
+		const prose = createMessage( {
+			id: 'prose-1',
+			content: [ { type: 'text', text: summary } ],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolMessage, prose ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'tool-1' );
 	} );
 
 	it( 'keeps a plain-text agent message that does not match any adjacent tool summary', () => {

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -50,6 +50,11 @@ function getShowComponentSummary( message: UIMessage ): string | undefined {
 	}
 }
 
+function hasAgentRole( message: UIMessage ): boolean {
+	const role = message.role as string;
+	return role === 'agent' || role === 'assistant';
+}
+
 function isDuplicateAdjacentShowComponentSummary(
 	message: UIMessage,
 	messages: UIMessage[],
@@ -78,8 +83,7 @@ function hasLaterAgentToolMessageInSameTurn(
 			return false;
 		}
 
-		// @ts-expect-error -- `assistant` comes from Big Sky messages
-		if ( laterMessage.role !== 'agent' && laterMessage.role !== 'assistant' ) {
+		if ( ! hasAgentRole( laterMessage ) ) {
 			continue;
 		}
 
@@ -111,8 +115,7 @@ export default function convertToolMessagesToComponents( {
 
 		const firstContentText = message.content?.[ 0 ]?.text;
 
-		// @ts-expect-error -- `assistant` comes from Big Sky messages
-		if ( ( message.role !== 'agent' && message.role !== 'assistant' ) || ! firstContentText ) {
+		if ( ! hasAgentRole( message ) || ! firstContentText ) {
 			return [ message ];
 		}
 

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -1,5 +1,4 @@
 import { EscalationButton } from '../components/escalation-button';
-import NextStepButton from '../components/next-step-button';
 import UnavailableToolMessage from '../components/unavailable-tool-message';
 import { isEditorPage } from './is-editor-page';
 import { isShowComponentTool } from './show-component-tools';
@@ -20,21 +19,105 @@ interface Options {
 	onSubmit: UseAgentChatReturn[ 'onSubmit' ];
 }
 
+type MessageWithContextFlags = UIMessage & {
+	context?: {
+		flags?: {
+			context_only?: boolean;
+		};
+	};
+};
+
+function isContextOnlyMessage( message: UIMessage ): boolean {
+	return ( message as MessageWithContextFlags ).context?.flags?.context_only === true;
+}
+
+function getShowComponentSummary( message: UIMessage ): string | undefined {
+	const firstText = message.content?.[ 0 ]?.text;
+	if ( ! firstText ) {
+		return undefined;
+	}
+
+	try {
+		const parsed = JSON.parse( firstText );
+		if ( ! isShowComponentTool( parsed?.tool_id ) ) {
+			return undefined;
+		}
+
+		const summary = parsed?.data?.summary;
+		return typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
+	} catch ( _error ) {
+		return undefined;
+	}
+}
+
+function isDuplicateAdjacentShowComponentSummary(
+	message: UIMessage,
+	messages: UIMessage[],
+	index: number
+): boolean {
+	const text = message.content?.[ 0 ]?.text?.trim();
+	if ( ! text ) {
+		return false;
+	}
+
+	const adjacentMessages = [ messages[ index - 1 ], messages[ index + 1 ] ].filter( Boolean );
+	return adjacentMessages.some(
+		( adjacentMessage ) => getShowComponentSummary( adjacentMessage ) === text
+	);
+}
+
 /**
  * Converts tool-related messages to component messages.
  */
+function hasLaterAgentToolMessageInSameTurn(
+	messages: UIMessage[],
+	currentIndex: number
+): boolean {
+	for ( const laterMessage of messages.slice( currentIndex + 1 ) ) {
+		if ( laterMessage.role === 'user' ) {
+			return false;
+		}
+
+		// @ts-expect-error -- `assistant` comes from Big Sky messages
+		if ( laterMessage.role !== 'agent' && laterMessage.role !== 'assistant' ) {
+			continue;
+		}
+
+		const laterText = laterMessage.content?.[ 0 ]?.text;
+		if ( ! laterText ) {
+			continue;
+		}
+
+		try {
+			const laterData = JSON.parse( laterText );
+			if ( typeof laterData?.tool_id === 'string' ) {
+				return true;
+			}
+		} catch ( _error ) {}
+	}
+
+	return false;
+}
+
 export default function convertToolMessagesToComponents( {
 	messages,
 	getChatComponent,
 	currentPostId,
-	onSubmit,
 }: Options ): AgentsManagerUIMessage[] {
 	return messages.flatMap( ( message, index, array ) => {
+		if ( isContextOnlyMessage( message ) ) {
+			return [];
+		}
+
 		const firstContentText = message.content?.[ 0 ]?.text;
 
 		// @ts-expect-error -- `assistant` comes from Big Sky messages
 		if ( ( message.role !== 'agent' && message.role !== 'assistant' ) || ! firstContentText ) {
 			return [ message ];
+		}
+
+		if ( isDuplicateAdjacentShowComponentSummary( message, array, index ) ) {
+			return [];
 		}
 
 		// The user asked for human support
@@ -99,14 +182,11 @@ export default function convertToolMessagesToComponents( {
 			const summaryText =
 				typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
 
-			// Whether this is the last message in the array.
-			const isLastMessage = index === array.length - 1;
-
 			// In the site editor, React-Query caching keeps past conversations alive when the
 			// user navigates to a different page. Compare the picker's `postId` with the
 			// current editor page to disable pickers that no longer belong to this page.
 			const isPageChanged = !! postId && !! currentPostId && postId !== currentPostId;
-			const isStale = ! isLastMessage || ! isCurrent || isPageChanged;
+			const isStale = ! isCurrent || isPageChanged;
 
 			const componentMessage: AgentsManagerUIMessage = {
 				...message,
@@ -130,37 +210,27 @@ export default function convertToolMessagesToComponents( {
 					},
 				],
 				disabled: isStale,
-				suppressThinking: true,
+				suppressThinking: followUpTasks !== true,
 			};
 
-			// Only show `next-step-button` when the component is active and has follow-up tasks.
-			if ( isStale || ! followUpTasks ) {
-				return [ componentMessage ];
-			}
-
-			// Omit `actions` so the parent message's actions don't leak into the next-step message.
-			const { actions, content, ...baseMessage } = message;
-
-			return [
-				componentMessage,
-				{
-					...baseMessage,
-					id: `${ message.id }-next-step`,
-					content: [
-						{
-							type: 'component' as const,
-							component: NextStepButton as React.ComponentType,
-							componentProps: { onMoveToNextStep: onSubmit },
-						},
-					],
-				},
-			];
+			return [ componentMessage ];
 		}
 
 		// Handle agent-facing Big Sky tool result summaries.
 		if ( isDisplayableToolMessageTool( textData.tool_id ) ) {
 			const summary = getDisplayMessageFromToolData( textData.data );
 			if ( ! summary ) {
+				return [];
+			}
+
+			// Tool summaries with follow-up tasks are intermediate status updates. When
+			// rehydrating history, a later tool message in the same user turn (for example,
+			// a color picker) should be the visible response instead of replaying this
+			// intermediate confirmation.
+			if (
+				( textData.data as { followUpTasks?: unknown } )?.followUpTasks === true &&
+				hasLaterAgentToolMessageInSameTurn( array, index )
+			) {
 				return [];
 			}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

* Improve Agents Manager handling for multi-step tool responses that show interactive picker components.
* Keep previous live `show_component` picker messages visible when Agenttic replaces the streaming agent message with the next picker.
* Preserve the live picker order so multi-step requests render in the order requested, e.g. color picker, font picker, button picker.
* Remove the automatic move-to-next-step button from component responses.
* Avoid disabling older picker components solely because a newer message was sent.
* Hide duplicate/context-only summary messages so picker summaries are not repeated as separate chat messages.
* Keep the thinking indicator visible when a component response has follow-up tasks still running.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Multi-step requests can emit several picker components in one response. During live rendering, Agenttic reuses/replaces the streaming agent message, which caused earlier pickers to disappear or appear out of order until page refresh.
* Component summaries could also be persisted as plain text context messages, causing duplicate visible responses after sending a follow-up message or refreshing.
* These changes make live chat rendering match persisted conversation history more closely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run:
  * `yarn test-packages packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts --runInBand`
* In the editor with Agents Manager enabled, send a multi-step request such as:
  * `show purple colors, spooky fonts, square buttons`
* Confirm the pickers remain visible during the live response and stay ordered as:
  * color picker
  * font picker
  * button picker
* Send a follow-up message after a picker appears.
* Confirm the picker summary is not duplicated as a separate plain text bot message.
* Refresh the page and confirm the persisted conversation renders the same picker sequence.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
