### PR TITLE
Desktop: Run e2e tests on Buildkite

### DIFF
--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -9,6 +9,7 @@ export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export NODE_OPTIONS=--max-old-space-size=5120
+# Playwright and Electron use HOME for caches; keep it writable under the propagated UID.
 export HOME=/tmp/buildkite-home
 
 mkdir -p "$HOME"

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -8,9 +8,9 @@ export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export NODE_OPTIONS=--max-old-space-size=5120
 
 cd desktop
-corepack enable
 sudo apt update
 sudo apt-get install -y libsecret-1-dev
 yarn install --immutable --inline-builds

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -9,10 +9,10 @@ export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export NODE_OPTIONS=--max-old-space-size=5120
+export HOME=/tmp/buildkite-home
 
+mkdir -p "$HOME"
 cd desktop
-sudo apt update
-sudo apt-get install -y libsecret-1-dev
 yarn install --immutable --inline-builds
 yarn run build
 

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -11,8 +11,9 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 cd desktop
 corepack enable
+sudo apt update
+sudo apt-get install -y libsecret-1-dev
 yarn install --immutable --inline-builds
-yarn playwright install-deps chromium
 yarn run build
 
 # `-c.linux.target=dir` produces an unpacked `linux-unpacked/` tree. Assert

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -12,6 +12,7 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 cd desktop
 corepack enable
 yarn install --immutable --inline-builds
+yarn playwright install-deps chromium
 yarn run build
 
 # `-c.linux.target=dir` produces an unpacked `linux-unpacked/` tree. Assert

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -23,5 +23,7 @@ if [[ ! -d release/linux-unpacked ]]; then
   exit 1
 fi
 
+yarn run test:e2e
+
 tar -zcf release/linux-unpacked.tar.gz -C release linux-unpacked
 rm -rf release/linux-unpacked

--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -49,6 +49,7 @@ fi
 export APP_STORE_CONNECT_API_KEY_PATH="$ASC_KEY_PATH"
 
 yarn run ci:build-mac
+yarn run test:e2e
 
 # The afterSign hook already notarized and stapled the app; this notarizes and
 # staples the `.dmg` wrapper for offline Gatekeeper checks on first mount.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,8 +56,11 @@ steps:
           context: Desktop / Build (linux, unsigned)
     agents:
       queue: default
+    env:
+      NODE_OPTIONS: --max-old-space-size=5120
     plugins:
-      - automattic/nvm#0.6.0
+      - docker#v5.13.0:
+          image: cimg/node:24.15.0-browsers
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,6 +47,7 @@ steps:
       - desktop/release/*.dmg
       - desktop/release/*.blockmap
       - desktop/release/*.yml
+      - desktop/test/e2e/results/**/*
 
   - label: ":desktop_computer: Build desktop (linux, unsigned)"
     branches: ainfra-*
@@ -60,6 +61,7 @@ steps:
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*
+      - desktop/test/e2e/results/**/*
 
   - label: ":windows: Build desktop (windows store, unsigned)"
     branches: ainfra-*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,6 +61,9 @@ steps:
           image: cimg/node:24.15.0-browsers
           propagate-uid-gid: true
           userns: host
+          environment:
+            - E2EGUTENBERGUSER
+            - E2EPASSWORD
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,6 +59,7 @@ steps:
     plugins:
       - docker#v5.13.0:
           image: cimg/node:24.15.0-browsers
+          propagate-uid-gid: true
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,8 +56,6 @@ steps:
           context: Desktop / Build (linux, unsigned)
     agents:
       queue: default
-    env:
-      NODE_OPTIONS: --max-old-space-size=5120
     plugins:
       - docker#v5.13.0:
           image: cimg/node:24.15.0-browsers

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,7 @@ steps:
       - docker#v5.13.0:
           image: cimg/node:24.15.0-browsers
           propagate-uid-gid: true
+          userns: host
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -37,6 +37,7 @@ const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
 const LAUNCH_ARGS = [ '--disable-http-cache', '--start-maximized' ];
 
+// Linux CI lacks Electron's SUID sandbox setup.
 if ( process.platform === 'linux' ) {
 	LAUNCH_ARGS.push( '--no-sandbox' );
 }

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -35,6 +35,11 @@ const HAR_PATH = path.join( __dirname, '../results/network.har' );
 const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
 
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
+const LAUNCH_ARGS = [ '--disable-http-cache', '--start-maximized' ];
+
+if ( process.platform === 'linux' ) {
+	LAUNCH_ARGS.push( '--no-sandbox' );
+}
 
 const skipIfOAuthLogin = config.oauthLoginEnabled ? it.skip : it;
 const runIfOAuthLogin = config.oauthLoginEnabled ? it : it.skip;
@@ -52,7 +57,7 @@ describe( 'User Can log in', () => {
 
 		electronApp = await electron.launch( {
 			executablePath: APP_PATH,
-			args: [ '--disable-http-cache', '--start-maximized' ],
+			args: LAUNCH_ARGS,
 			timeout: 0,
 			recordHar: {
 				path: HAR_PATH,


### PR DESCRIPTION
See [AINFRA-2545](https://linear.app/a8c/issue/AINFRA-2545/desktop-port-e2e-tests-to-buildkite)

## Proposed Changes

* Run the existing desktop E2E suite in the Buildkite macOS and Linux desktop steps, same as CircleCI.
* Uploads `desktop/test/e2e/results/**/*` from those Buildkite steps for debugging failures.

## Why are these changes being made?

CircleCI currently runs the desktop e2e suite for macOS and Linux. This keeps that coverage in place while the desktop release path moves to Buildkite. Notice I didn't remove the CircleCI steps. They will be removed in one go once we officially switch over.

## Testing Instructions

See Buildkite CI for this PR:

_Linux_
<img width="1445" height="525" alt="image" src="https://github.com/user-attachments/assets/10f051c4-a665-46bc-9a74-e0ab15de44b4" />

_Mac_
<img width="974" height="762" alt="image" src="https://github.com/user-attachments/assets/b50a6acd-4aea-4c73-8584-09954eb73a4a" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

*Posted by Codex (GPT-5) on behalf of @mokagio with approval.*
