### PR TITLE
Launchpad: drop unused and trivially-replaceable dependencies

### DIFF
--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -39,7 +39,6 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
-		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
@@ -49,11 +48,9 @@
 		"@wordpress/base-styles": "^9.1.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/icons": "^13.3.0",
-		"@wordpress/url": "^4.48.0",
 		"clsx": "^2.1.1",
 		"social-logos": "^3.1.18",
 		"tslib": "^2.8.1",
-		"utility-types": "^3.10.0",
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"devDependencies": {

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,9 +1,13 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
-import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LaunchpadTaskActionsProps, Task } from './types';
+
+const addQueryArg = ( url: string, key: string, value: string ): string => {
+	const separator = url.includes( '?' ) ? '&' : '?';
+	return `${ url }${ separator }${ encodeURIComponent( key ) }=${ encodeURIComponent( value ) }`;
+};
 
 const TASKS_TO_COMPLETE_ON_CLICK = [
 	'add_about_page',
@@ -39,7 +43,7 @@ export const setUpActionsForTasks = ( {
 
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			if ( task.id === 'drive_traffic' && ! isMobile() && hasCalypsoPath ) {
-				task.calypso_path = addQueryArgs( task.calypso_path, { tour: 'marketingConnectionsTour' } );
+				task.calypso_path = addQueryArg( task.calypso_path, 'tour', 'marketingConnectionsTour' );
 			}
 
 			// Enable task in 'calypso' context

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -37,8 +37,9 @@ export const setUpActionsForTasks = ( {
 		const hasCalypsoPath = task.calypso_path !== undefined;
 
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
-			if ( task.id === 'drive_traffic' && ! isMobile() && task.calypso_path !== undefined ) {
-				const [ path, query ] = task.calypso_path.split( '?' );
+			const { calypso_path } = task;
+			if ( task.id === 'drive_traffic' && ! isMobile() && calypso_path !== undefined ) {
+				const [ path, query ] = calypso_path.split( '?' );
 				const params = new URLSearchParams( query );
 				params.set( 'tour', 'marketingConnectionsTour' );
 				task.calypso_path = `${ path }?${ params }`;

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -39,10 +39,12 @@ export const setUpActionsForTasks = ( {
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			const { calypso_path } = task;
 			if ( task.id === 'drive_traffic' && ! isMobile() && calypso_path !== undefined ) {
-				const [ path, query ] = calypso_path.split( '?' );
+				// Split off any fragment first so the added query arg stays before the `#`.
+				const [ pathAndQuery, fragment ] = calypso_path.split( /#(.*)/s );
+				const [ path, query ] = pathAndQuery.split( '?' );
 				const params = new URLSearchParams( query );
 				params.set( 'tour', 'marketingConnectionsTour' );
-				task.calypso_path = `${ path }?${ params }`;
+				task.calypso_path = `${ path }?${ params }${ fragment ? `#${ fragment }` : '' }`;
 			}
 
 			// Enable task in 'calypso' context

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -39,12 +39,10 @@ export const setUpActionsForTasks = ( {
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			const { calypso_path } = task;
 			if ( task.id === 'drive_traffic' && ! isMobile() && calypso_path !== undefined ) {
-				// Split off any fragment first so the added query arg stays before the `#`.
-				const [ pathAndQuery, fragment ] = calypso_path.split( /#(.*)/s );
-				const [ path, query ] = pathAndQuery.split( '?' );
-				const params = new URLSearchParams( query );
-				params.set( 'tour', 'marketingConnectionsTour' );
-				task.calypso_path = `${ path }?${ params }${ fragment ? `#${ fragment }` : '' }`;
+				// Base is a throwaway just to parse the relative path; only the path/query/fragment are kept.
+				const url = new URL( calypso_path, 'http://example.com' );
+				url.searchParams.set( 'tour', 'marketingConnectionsTour' );
+				task.calypso_path = url.pathname + url.search + url.hash;
 			}
 
 			// Enable task in 'calypso' context

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -4,6 +4,8 @@ import { isMobile } from '@automattic/viewport';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
+// Local helper for the single query-arg append we need, preferred over pulling
+// in a dependency just for this.
 const addQueryArg = ( url: string, key: string, value: string ): string => {
 	const separator = url.includes( '?' ) ? '&' : '?';
 	return `${ url }${ separator }${ encodeURIComponent( key ) }=${ encodeURIComponent( value ) }`;

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -37,7 +37,7 @@ export const setUpActionsForTasks = ( {
 		const hasCalypsoPath = task.calypso_path !== undefined;
 
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
-			if ( task.id === 'drive_traffic' && ! isMobile() && hasCalypsoPath ) {
+			if ( task.id === 'drive_traffic' && ! isMobile() && task.calypso_path !== undefined ) {
 				const [ path, query ] = task.calypso_path.split( '?' );
 				const params = new URLSearchParams( query );
 				params.set( 'tour', 'marketingConnectionsTour' );

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -4,13 +4,6 @@ import { isMobile } from '@automattic/viewport';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
-// Local helper for the single query-arg append we need, preferred over pulling
-// in a dependency just for this.
-const addQueryArg = ( url: string, key: string, value: string ): string => {
-	const separator = url.includes( '?' ) ? '&' : '?';
-	return `${ url }${ separator }${ encodeURIComponent( key ) }=${ encodeURIComponent( value ) }`;
-};
-
 const TASKS_TO_COMPLETE_ON_CLICK = [
 	'add_about_page',
 	'add_first_subscribers',
@@ -45,7 +38,9 @@ export const setUpActionsForTasks = ( {
 
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			if ( task.id === 'drive_traffic' && ! isMobile() && hasCalypsoPath ) {
-				task.calypso_path = addQueryArg( task.calypso_path, 'tour', 'marketingConnectionsTour' );
+				// Append the tour query arg locally to avoid a dependency just for this.
+				const separator = task.calypso_path.includes( '?' ) ? '&' : '?';
+				task.calypso_path += `${ separator }tour=marketingConnectionsTour`;
 			}
 
 			// Enable task in 'calypso' context

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -39,10 +39,12 @@ export const setUpActionsForTasks = ( {
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			const { calypso_path } = task;
 			if ( task.id === 'drive_traffic' && ! isMobile() && calypso_path !== undefined ) {
-				// Base is a throwaway just to parse the relative path; only the path/query/fragment are kept.
-				const url = new URL( calypso_path, 'http://example.com' );
-				url.searchParams.set( 'tour', 'marketingConnectionsTour' );
-				task.calypso_path = url.pathname + url.search + url.hash;
+				// Merge the query via a throwaway base, but keep the original string as the base so
+				// absolute origins survive, then re-append any fragment.
+				const params = new URL( calypso_path, 'http://example.com' ).searchParams;
+				params.set( 'tour', 'marketingConnectionsTour' );
+				const [ baseAndQuery, fragment = '' ] = calypso_path.split( /(#.*)/s );
+				task.calypso_path = `${ baseAndQuery.split( '?' )[ 0 ] }?${ params }${ fragment }`;
 			}
 
 			// Enable task in 'calypso' context

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -38,9 +38,10 @@ export const setUpActionsForTasks = ( {
 
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			if ( task.id === 'drive_traffic' && ! isMobile() && hasCalypsoPath ) {
-				// Append the tour query arg locally to avoid a dependency just for this.
-				const separator = task.calypso_path.includes( '?' ) ? '&' : '?';
-				task.calypso_path += `${ separator }tour=marketingConnectionsTour`;
+				const [ path, query ] = task.calypso_path.split( '?' );
+				const params = new URLSearchParams( query );
+				params.set( 'tour', 'marketingConnectionsTour' );
+				task.calypso_path = `${ path }?${ params }`;
 			}
 
 			// Enable task in 'calypso' context

--- a/packages/launchpad/src/test/setup-actions.ts
+++ b/packages/launchpad/src/test/setup-actions.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { setUpActionsForTasks } from '../setup-actions';
+import type { LaunchpadTaskActionsProps } from '../types';
+
+jest.mock( '@automattic/viewport', () => ( { isMobile: jest.fn( () => false ) } ) );
+jest.mock( '@automattic/data-stores', () => ( { updateLaunchpadSettings: jest.fn() } ) );
+
+const runDriveTraffic = ( calypso_path: string ) => {
+	const props: LaunchpadTaskActionsProps = {
+		siteSlug: 'example.wordpress.com',
+		tasks: [ { id: 'drive_traffic', completed: false, disabled: false, calypso_path } ],
+		tracksData: {
+			checklistSlug: 'test',
+			launchpadContext: 'test',
+			recordTracksEvent: jest.fn(),
+			tasklistCompleted: false,
+		},
+		extraActions: {},
+		uiContext: 'calypso',
+	};
+	return setUpActionsForTasks( props )[ 0 ].calypso_path;
+};
+
+describe( 'setUpActionsForTasks: drive_traffic tour query arg', () => {
+	it( 'appends the tour arg to a relative path', () => {
+		expect( runDriveTraffic( '/marketing/connections/example.wordpress.com' ) ).toBe(
+			'/marketing/connections/example.wordpress.com?tour=marketingConnectionsTour'
+		);
+	} );
+
+	it( 'preserves the origin and existing query of an absolute URL', () => {
+		expect( runDriveTraffic( 'https://example.com/wp-admin/admin.php?page=jetpack-social' ) ).toBe(
+			'https://example.com/wp-admin/admin.php?page=jetpack-social&tour=marketingConnectionsTour'
+		);
+	} );
+
+	it( 'keeps the fragment after the query', () => {
+		expect( runDriveTraffic( '/marketing/connections/example.wordpress.com#section' ) ).toBe(
+			'/marketing/connections/example.wordpress.com?tour=marketingConnectionsTour#section'
+		);
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,7 +1702,6 @@ __metadata:
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
-    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -1715,7 +1714,6 @@ __metadata:
     "@wordpress/base-styles": "npm:^9.1.0"
     "@wordpress/components": "npm:^35.0.0"
     "@wordpress/icons": "npm:^13.3.0"
-    "@wordpress/url": "npm:^4.48.0"
     clsx: "npm:^2.1.1"
     msw: "npm:^2.1.7"
     msw-storybook-addon: "npm:2.0.7"
@@ -1726,7 +1724,6 @@ __metadata:
     storybook: "npm:^9.1.20"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
-    utility-types: "npm:^3.10.0"
     webpack: "npm:^5.99.8"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

Remove three runtime dependencies from `@automattic/launchpad`:

* `@automattic/calypso-config` — not referenced anywhere in the package.
* `utility-types` — not referenced anywhere in the package.
* `@wordpress/url` — used only for a single `addQueryArgs` call; replaced with a small local helper that appends one query arg (handling an existing query string and URL-encoding the key/value).

## Why are these changes being made?

Trims the package's dependency surface. The two unused packages were pure dead weight, and the single `@wordpress/url` usage didn't justify the dependency when a few lines of local code cover the need.

## Testing Instructions

* `yarn install`
* `yarn typecheck-packages`
* `yarn test-packages` (launchpad)
* Smoke-check the Launchpad `drive_traffic` task on a desktop viewport: its `calypso_path` should still gain `?tour=marketingConnectionsTour`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
