### PR TITLE
Notifications: surface Settings & Keyboard shortcuts as direct icons

### DIFF
--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -1,7 +1,6 @@
-import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
+import { Button, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { moreVertical } from '@wordpress/icons';
-import { useEffect, useState } from 'react';
+import { cog, keyboard } from '@wordpress/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import actions from '../../panel/state/actions';
 import getIsShortcutsPopoverOpen from '../../panel/state/selectors/get-is-shortcuts-popover-open';
@@ -9,52 +8,36 @@ import NoteShortcuts from '../note-shortcuts';
 
 export default function NotePanelActions() {
 	const dispatch = useDispatch();
-
-	const [ isOpen, setIsOpen ] = useState( false );
 	const isShortcutsPopoverOpen = useSelector( getIsShortcutsPopoverOpen );
 
-	useEffect( () => {
-		if ( ! isOpen && isShortcutsPopoverOpen ) {
-			dispatch( actions.ui.closeShortcutsPopover() );
-		}
-	}, [ isOpen, dispatch ] ); // eslint-disable-line react-hooks/exhaustive-deps
-
 	return (
-		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Actions' ) }
-			onToggle={ setIsOpen }
-			open={ isOpen || isShortcutsPopoverOpen }
-			toggleProps={ {
-				size: 'small',
-			} }
-			popoverProps={ {
-				focusOnMount: true,
-			} }
-		>
-			{ ( { onClose } ) =>
-				isShortcutsPopoverOpen ? (
-					<NoteShortcuts />
-				) : (
-					<MenuGroup>
-						<MenuItem
-							onClick={ () => {
-								dispatch( actions.ui.toggleShortcutsPopover() );
-							} }
-						>
-							{ __( 'Keyboard shortcuts' ) }
-						</MenuItem>
-						<MenuItem
-							onClick={ () => {
-								onClose();
-								dispatch( actions.ui.viewSettings() );
-							} }
-						>
-							{ __( 'Settings' ) }
-						</MenuItem>
-					</MenuGroup>
-				)
-			}
-		</DropdownMenu>
+		<>
+			<DropdownMenu
+				icon={ keyboard }
+				label={ __( 'Keyboard shortcuts' ) }
+				// Drive the open state from Redux so the `i` keyboard shortcut
+				// keeps toggling the panel.
+				open={ isShortcutsPopoverOpen }
+				onToggle={ ( willOpen ) => {
+					if ( willOpen !== isShortcutsPopoverOpen ) {
+						dispatch( actions.ui.toggleShortcutsPopover() );
+					}
+				} }
+				toggleProps={ {
+					size: 'small',
+				} }
+				popoverProps={ {
+					focusOnMount: true,
+				} }
+			>
+				{ () => <NoteShortcuts /> }
+			</DropdownMenu>
+			<Button
+				size="small"
+				icon={ cog }
+				label={ __( 'Settings' ) }
+				onClick={ () => dispatch( actions.ui.viewSettings() ) }
+			/>
+		</>
 	);
 }

--- a/apps/notifications/src/app/note-shortcuts/style.scss
+++ b/apps/notifications/src/app/note-shortcuts/style.scss
@@ -1,6 +1,12 @@
 .wpnc__keyboard-shortcuts-popover {
 	width: min-content;
 
+	// The panel is focused on mount to anchor the popover's focus trap, but
+	// it's just an informational list — don't show a focus outline on it.
+	&:focus {
+		outline: none;
+	}
+
 	.shortcut {
 		border: 1px solid #ccc;
 		border-radius: 4px;

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useNavigate } from '@tanstack/react-router';
 import { Button, Dropdown } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -7,6 +6,7 @@ import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
+import { dashboardLink } from '../../utils/link';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
 import { useLocale } from '../locale';
@@ -23,7 +23,6 @@ export default function Notifications( {
 	/** When true, hides the built-in toggle button (the omnibar provides its own). */
 	anchor?: boolean;
 } ) {
-	const navigate = useNavigate();
 	const { user } = useAuth();
 	const locale = useLocale();
 	const isMobileViewport = useViewportMatch( 'small', '<' );
@@ -78,8 +77,8 @@ export default function Notifications( {
 		],
 		VIEW_SETTINGS: [
 			() => {
-				handleClose();
-				navigate( { to: '/me/notifications' } );
+				// Open in a new tab so the current notification state is preserved.
+				window.open( dashboardLink( '/me/notifications' ), '_blank' );
 			},
 		],
 		EDIT_COMMENT: [

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -238,8 +238,8 @@ export class Notifications extends Component {
 		],
 		VIEW_SETTINGS: [
 			() => {
-				this.props.checkToggle();
-				page( '/me/notifications' );
+				// Open in a new tab so the current notification state is preserved.
+				window.open( '/me/notifications', '_blank' );
 			},
 		],
 		EDIT_COMMENT: [

--- a/client/reader/components/header/notifications/index.tsx
+++ b/client/reader/components/header/notifications/index.tsx
@@ -32,8 +32,8 @@ export default function Notifications( { user, className }: { user: User; classN
 		],
 		VIEW_SETTINGS: [
 			() => {
-				handleClose();
-				window.location.assign( dashboardLink( '/me/notifications' ) );
+				// Open in a new tab so the current notification state is preserved.
+				window.open( dashboardLink( '/me/notifications' ), '_blank' );
 			},
 		],
 		EDIT_COMMENT: [


### PR DESCRIPTION
Part of DOTMSD-1324

## Proposed Changes

* Replace the triple-dot (⋮) overflow menu in the notifications panel header with two always-visible icon buttons: **Keyboard shortcuts** (keyboard icon) and **Settings** (cog icon).
* The keyboard shortcuts list now opens in a popover anchored directly to its button.

| Before | After |
| - | - |
|<img width="452" height="101" alt="image" src="https://github.com/user-attachments/assets/ec0673ee-9232-452a-83a4-6cbb90a0713c" />|<img width="455" height="104" alt="image" src="https://github.com/user-attachments/assets/b5a83ad9-f786-4c83-b96f-6042ed9e0792" />|

## Why are these changes being made?

The settings cog was hidden behind a new overflow menu in the notifications panel redesign. It took several intentional attempts to find it, hurting self-discovery for a negligible screen-space saving. Surfacing the entry points directly restores discoverability of these high-value actions.

## Testing Instructions

* Open the notifications panel.
* Confirm the header shows a keyboard-shortcuts icon and a settings (cog) icon directly, with no triple-dot menu.
* Click the cog → notification settings open.
* Click the keyboard icon → the shortcuts popover toggles open/closed; clicking outside or pressing Escape closes it.
* Press `i` → the shortcuts popover still toggles (the button reflects the pressed state).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
