### PR TITLE
Launchpad: drop @automattic/viewport dependency

### DIFF
--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -43,7 +43,6 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/typography": "workspace:^",
-		"@automattic/viewport": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/base-styles": "^9.1.0",
 		"@wordpress/components": "^35.0.0",

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,8 +1,13 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isMobile } from '@automattic/viewport';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LaunchpadTaskActionsProps, Task } from './types';
+
+// Matches the mobile breakpoint ( max-width: 480px ); resolves to false during SSR.
+const isMobile = () =>
+	typeof window !== 'undefined' &&
+	typeof window.matchMedia === 'function' &&
+	window.matchMedia( '(max-width: 480px)' ).matches;
 
 const TASKS_TO_COMPLETE_ON_CLICK = [
 	'add_about_page',

--- a/packages/launchpad/src/test/setup-actions.ts
+++ b/packages/launchpad/src/test/setup-actions.ts
@@ -4,7 +4,6 @@
 import { setUpActionsForTasks } from '../setup-actions';
 import type { LaunchpadTaskActionsProps } from '../types';
 
-jest.mock( '@automattic/viewport', () => ( { isMobile: jest.fn( () => false ) } ) );
 jest.mock( '@automattic/data-stores', () => ( { updateLaunchpadSettings: jest.fn() } ) );
 
 const runDriveTraffic = ( calypso_path: string ) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,7 +1708,6 @@ __metadata:
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/typography": "workspace:^"
-    "@automattic/viewport": "workspace:^"
     "@storybook/addon-a11y": "npm:^9.1.20"
     "@tanstack/react-query": "npm:^5.83.0"
     "@wordpress/base-styles": "npm:^9.1.0"


### PR DESCRIPTION
## Proposed Changes

* Drop the `@automattic/viewport` dependency from `@automattic/launchpad`.
* Its only use was `isMobile()`; replace it with a small local `matchMedia` helper.

## Why are these changes being made?

`@automattic/launchpad` is published and consumed outside this repo, so trimming dependencies it doesn't really need keeps its install/bundle footprint smaller. `@automattic/viewport` was a direct dependency used in a single spot, and `isMobile()` is a one-line wrapper over `matchMedia`, so inlining it removes the dependency with no behavior change (it still resolves to `false` during SSR, matching the previous behavior).

## Testing Instructions

* Run the package tests: `yarn jest -c=test/packages/jest.config.js packages/launchpad` — all pass.
* Confirm the mobile-specific behavior is unchanged for the `drive_traffic` task (no `tour` query arg / mobile path on viewports ≤ 480px wide).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
