### PR TITLE
Ensure env badge does not obstruct pagination controls

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -6,8 +6,8 @@ $z-index: 999;
 .environment-badge {
 	padding: 0;
 	position: fixed;
-	bottom: 27px;
-	right: 86px;
+	bottom: 5px;
+	right: 5px;
 	z-index: $z-index;
 
 	// The hovered class is toggled in load-dev-helpers/index.js
@@ -128,8 +128,6 @@ html[dir="rtl"] .environment-badge,
 
 @include breakpoint-deprecated( "<960px" ) {
 	.environment-badge {
-		right: 20px;
-
 		&.hovered {
 			display: flex;
 			flex-wrap: wrap-reverse;

--- a/client/lib/store-sandbox-helper/style.scss
+++ b/client/lib/store-sandbox-helper/style.scss
@@ -10,6 +10,7 @@
 	display: block;
 	position: absolute;
 	bottom: 100%;
+	right: 0;
 	padding: 12px;
 	background: var(--color-surface);
 	box-shadow: 0 0 0 1px var(--color-border-subtle);


### PR DESCRIPTION
Fixes DOTMSD-1259

## Proposed Changes

Move the env badge to the position where it does not cover the main DataViews pagination controls at the bottom of the page.

|Before|After|
|-|-|
|<img width="256" height="78" alt="image" src="https://github.com/user-attachments/assets/7251e44b-cea8-4a07-a0bc-456ffc65e901" />|<img width="267" height="80" alt="image" src="https://github.com/user-attachments/assets/83f8febe-51b2-4c45-b87f-734d5db2056f" />|


## Testing Instructions

Go to `/sites` (Calypso HD or MSD), verify you can still use the pagination comfortably.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
