### PR TITLE
Plugins: explain why core managed plugins can't be deleted (DOTMSD-1304)

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -25,6 +25,11 @@ img.plugin-icon {
 	overflow-y: auto;
 }
 
+.plugin-sites-card-managed-notice {
+	margin-block-end: 16px;
+	margin-inline: 20px;
+}
+
 .plugin-sites-card-header {
 	margin-bottom: 8px;
 	padding-inline-start: 20px;

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -3,12 +3,14 @@ import { createInterpolateElement } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody } from '../../../components/card';
+import { Notice } from '../../../components/notice';
 import { SectionHeader } from '../../../components/section-header';
 import { Text } from '../../../components/text';
 import { TextBlur } from '../../../components/text-blur';
 import { isWebUrl } from '../../../utils/is-web-url';
 import { PluginTabs } from '../../plugin';
 import { usePlugin } from '../../plugin/use-plugin';
+import { getAllowedPluginActions } from '../../plugin/utils/get-allowed-plugin-actions';
 import { PluginIcon } from './plugin-icon';
 
 import './plugin-sites.scss';
@@ -22,6 +24,12 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 		sitesWithThisPlugin,
 		sitesWithoutThisPlugin,
 	} = usePlugin( selectedPluginSlug );
+
+	// Core plugins WordPress.com manages (Jetpack/VaultPress/Akismet) can't be
+	// deleted; surface a notice explaining why instead of leaving the user guessing.
+	const isCoreManagedPlugin = sitesWithThisPlugin.some(
+		( site ) => getAllowedPluginActions( site, selectedPluginSlug ).isAutoManagedPlugin
+	);
 
 	const decoration = () => {
 		if ( icon ) {
@@ -82,6 +90,16 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 					title={ title() }
 					description={ description() }
 				/>
+
+				{ isCoreManagedPlugin && (
+					<div className="plugin-sites-card-managed-notice">
+						<Notice variant="info">
+							{ __(
+								'This plugin is managed by WordPress.com and is required for your site to work properly, so it can’t be removed.'
+							) }
+						</Notice>
+					</div>
+				) }
 
 				<PluginTabs
 					pluginSlug={ selectedPluginSlug }

--- a/client/dashboard/plugins/plugin/utils/get-allowed-plugin-actions.ts
+++ b/client/dashboard/plugins/plugin/utils/get-allowed-plugin-actions.ts
@@ -17,5 +17,8 @@ export const getAllowedPluginActions = ( site: SiteWithPluginData, pluginSlug: s
 		// core plugins (Jetpack/VaultPress/Akismet) stay protected from deletion.
 		canDelete: ! isAutoManagedPlugin && canManagePlugins,
 		isManagedPlugin,
+		// Core plugins WordPress.com manages and keeps active (Jetpack/VaultPress/
+		// Akismet); these are never deletable and warrant an explanatory notice.
+		isAutoManagedPlugin,
 	};
 };

--- a/client/dashboard/plugins/plugin/utils/test/get-allowed-plugin-actions.test.ts
+++ b/client/dashboard/plugins/plugin/utils/test/get-allowed-plugin-actions.test.ts
@@ -58,4 +58,28 @@ describe( 'getAllowedPluginActions', () => {
 			expect( getAllowedPluginActions( site, 'some-plugin' ).canDelete ).toBe( true );
 		} );
 	} );
+
+	// DOTMSD-1304: flags the core plugins that WordPress.com manages so the UI can
+	// explain why they can't be deleted.
+	describe( 'isAutoManagedPlugin', () => {
+		test( 'flags the core plugins on Atomic', () => {
+			const site = makeSite( { isAtomic: true } );
+
+			expect( getAllowedPluginActions( site, 'jetpack' ).isAutoManagedPlugin ).toBe( true );
+			expect( getAllowedPluginActions( site, 'vaultpress' ).isAutoManagedPlugin ).toBe( true );
+			expect( getAllowedPluginActions( site, 'akismet' ).isAutoManagedPlugin ).toBe( true );
+		} );
+
+		test( 'does not flag a regular plugin on Atomic', () => {
+			const site = makeSite( { isAtomic: true, managed: true } );
+
+			expect( getAllowedPluginActions( site, 'some-plugin' ).isAutoManagedPlugin ).toBe( false );
+		} );
+
+		test( 'does not flag core plugins on a non-Atomic site', () => {
+			const site = makeSite( { isAtomic: false, jetpack: true } );
+
+			expect( getAllowedPluginActions( site, 'jetpack' ).isAutoManagedPlugin ).toBe( false );
+		} );
+	} );
 } );


### PR DESCRIPTION
Fixes DOTMSD-1304

## Proposed Changes

The core plugins WordPress.com manages and keeps active — Jetpack, VaultPress, and Akismet — can't be deleted, but nothing in **Manage plugins** (`/plugins/manage`) explained why, leaving users confused about the missing Delete action.

This adds an info notice at the top of the plugin detail panel (under the plugin name, above the tabs) when the viewed plugin is one of these core managed plugins:

> This plugin is managed by WordPress.com and is required for your site to work properly, so it can’t be removed.

- **`get-allowed-plugin-actions.ts`** — expose `isAutoManagedPlugin` so the UI can detect the core managed plugins (single source of truth for the list).
- **`plugin-sites.tsx`** — render the notice when the viewed plugin is a core managed plugin on the site(s) it's installed on.
- Added unit tests for `isAutoManagedPlugin`.

Builds on the previously merged DOTMSD-1304 work that enabled deleting other managed (symlinked) plugins; this covers the remaining "why can't I delete this one?" case for the core plugins.

| Before | After |
|--------|--------|
| <img width="1658" height="1135" alt="Screenshot 2026-06-25 at 10 20 19" src="https://github.com/user-attachments/assets/98715be5-b820-4ed6-b96c-2601b4d3c175" />|<img width="1655" height="1117" alt="Screenshot 2026-06-25 at 10 20 25" src="https://github.com/user-attachments/assets/0bdea1d9-1ca7-40b6-99b9-112687e0a8e3" />|

## Why are these changes being made?

The original report was "I can't delete my plugin, I have no idea why." Deleting was enabled for managed plugins generally, but the core plugins stay protected by design. Communicating that — rather than silently omitting the action — is the remaining part of the issue.

## Testing Instructions

You can test on the **Calypso live link** generated for this PR (see the live-link comment/check on the PR), or run locally with `yarn start-dashboard` and open `/plugins/manage`.

1. Open **Manage plugins** and select **Jetpack** (or Akismet / VaultPress).
   - The detail panel shows an info notice under the plugin name explaining it can't be removed, and the per-site Delete action is absent.
2. Select a regular plugin (e.g. Contact Form 7).
   - No notice is shown, and Delete works as before.

Automated: `yarn test-client client/dashboard/plugins`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
