### PR TITLE
Lodash: replace reduce() with native reduce

### DIFF
--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -1,4 +1,4 @@
-import { get, reduce } from 'lodash';
+import { get } from 'lodash';
 
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
 export const GUTENBERG = 'gutenberg-editor';
@@ -87,25 +87,21 @@ function getDismissTimes() {
 export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
 	const dismissTimes = getDismissTimes();
 
-	return reduce(
-		ALLOWED_SECTIONS,
-		( result, section ) => {
-			if ( section === dismissedSection ) {
-				// Dismiss selected section for a longer period.
-				result[ section ] = dismissTimes.longerDuration;
-			} else {
-				// Dismiss all other sections for a shorter period, but make sure that we preserve previous dismiss time
-				// if it was longer than that (e.g. if other section was also dismissed for a month).
-				result[ section ] =
-					get( currentDismissTimes, section, -Infinity ) > dismissTimes.shorterDuration
-						? currentDismissTimes?.[ section ]
-						: dismissTimes.shorterDuration;
-			}
+	return ALLOWED_SECTIONS.reduce( ( result, section ) => {
+		if ( section === dismissedSection ) {
+			// Dismiss selected section for a longer period.
+			result[ section ] = dismissTimes.longerDuration;
+		} else {
+			// Dismiss all other sections for a shorter period, but make sure that we preserve previous dismiss time
+			// if it was longer than that (e.g. if other section was also dismissed for a month).
+			result[ section ] =
+				get( currentDismissTimes, section, -Infinity ) > dismissTimes.shorterDuration
+					? currentDismissTimes?.[ section ]
+					: dismissTimes.shorterDuration;
+		}
 
-			return result;
-		},
-		{}
-	);
+		return result;
+	}, {} );
 }
 
 export const isDismissed = ( dismissedUntil, section ) =>

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -5,7 +5,7 @@ import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { filter, map, memoize, reduce } from 'lodash';
+import { filter, map, memoize } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -217,13 +217,9 @@ class TermTreeSelectorList extends Component {
 			return this.itemHeights[ item.ID ];
 		}
 
-		return reduce(
-			this.getTermChildren( item.ID ),
-			( memo, childItem ) => {
-				return memo + this.getItemHeight( childItem, true );
-			},
-			ITEM_HEIGHT
-		);
+		return this.getTermChildren( item.ID ).reduce( ( memo, childItem ) => {
+			return memo + this.getItemHeight( childItem, true );
+		}, ITEM_HEIGHT );
 	};
 
 	getRowHeight = ( { index } ) => {

--- a/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import validatorFactory from 'is-my-json-valid';
-import { isEmpty, reduce, update } from 'lodash';
+import { isEmpty, update } from 'lodash';
 import validationSchema from './fr-schema';
 
 const validate = validatorFactory( validationSchema, { greedy: true } );
@@ -89,27 +89,20 @@ export default function validateContactDetails( contactDetails ) {
 	const errors = validateWithSirenSiretChecksum( contactDetails );
 	errors && debug( errors );
 
-	return reduce(
-		errors,
-		( accumulatedErrors, { field, message } ) => {
-			// Drop 'data.' prefix
-			const path = String( field ).split( '.' ).slice( 1 );
+	return ( errors ?? [] ).reduce( ( accumulatedErrors, { field, message } ) => {
+		// Drop 'data.' prefix
+		const path = String( field ).split( '.' ).slice( 1 );
 
-			// In order to capture the relationship between the organization
-			// and extra.fr.individualType fields, the rule ends up in the root
-			// path.
-			// We've only got one such case at the moment, so we can insert this
-			// hack, but if we need to tell multiple such rules apart, we're
-			// going to need to add a some magic to map schemas to fields
-			const correctedPath = isEmpty( path ) ? [ 'organization' ] : path;
+		// In order to capture the relationship between the organization
+		// and extra.fr.individualType fields, the rule ends up in the root
+		// path.
+		// We've only got one such case at the moment, so we can insert this
+		// hack, but if we need to tell multiple such rules apart, we're
+		// going to need to add a some magic to map schemas to fields
+		const correctedPath = isEmpty( path ) ? [ 'organization' ] : path;
 
-			const appendThisMessage = ( before ) => [
-				...( before || [] ),
-				ruleNameFromMessage( message ),
-			];
+		const appendThisMessage = ( before ) => [ ...( before || [] ), ruleNameFromMessage( message ) ];
 
-			return update( accumulatedErrors, correctedPath, appendThisMessage );
-		},
-		{}
-	);
+		return update( accumulatedErrors, correctedPath, appendThisMessage );
+	}, {} );
 }

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -30,7 +30,7 @@
 //
 
 import { camelCase, mapKeys, mapValues, snakeCase } from '@automattic/js-utils';
-import { get, map, reduce } from 'lodash';
+import { get, map } from 'lodash';
 
 // Right-to-left composition of unary functions. Kept local so this pure mapping
 // module doesn't take on a dependency it otherwise has no need for.
@@ -66,19 +66,15 @@ export const rawToNative = ( list ) =>
 export const nativeToRaw = compose(
 	// combine adjacent strings
 	( list ) =>
-		reduce(
-			list,
-			( format, piece ) => {
-				const lastPiece = format.at( -1 );
+		list.reduce( ( format, piece ) => {
+			const lastPiece = format.at( -1 );
 
-				if ( lastPiece && 'string' === lastPiece.type && 'string' === piece.type ) {
-					return [ ...format.slice( 0, -1 ), mergeStringPieces( lastPiece, piece ) ];
-				}
+			if ( lastPiece && 'string' === lastPiece.type && 'string' === piece.type ) {
+				return [ ...format.slice( 0, -1 ), mergeStringPieces( lastPiece, piece ) ];
+			}
 
-				return [ ...format, piece ];
-			},
-			[]
-		),
+			return [ ...format, piece ];
+		}, [] ),
 	( list ) =>
 		map( list, ( p ) => ( {
 			type: p.type === 'string' ? 'string' : 'token',

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,5 +1,5 @@
 import { omit } from '@automattic/js-utils';
-import { get, map, reduce } from 'lodash';
+import { get, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
@@ -26,14 +26,10 @@ class SortedGrid extends PureComponent {
 
 		for ( let i = 0; i < this.props.items.length; i += this.props.itemsPerRow ) {
 			const row = this.props.items.slice( i, i + this.props.itemsPerRow );
-			const groups = reduce(
-				map( row, this.props.getItemGroup ),
-				( results, group ) => {
-					results[ group ] = get( results, group, 0 ) + 1;
-					return results;
-				},
-				{}
-			);
+			const groups = map( row, this.props.getItemGroup ).reduce( ( results, group ) => {
+				results[ group ] = get( results, group, 0 ) + 1;
+				return results;
+			}, {} );
 
 			items.push( { isGridLabel: true, id: i, groups }, ...row );
 		}

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -1,5 +1,5 @@
 import { convertFromRaw, convertToRaw } from 'draft-js';
-import { get, map, matchesProperty, reduce } from 'lodash';
+import { get, map, matchesProperty } from 'lodash';
 import { compose } from 'redux';
 
 /*
@@ -169,8 +169,7 @@ const newEntityAt = ( offset, type, tokens, entityGuide ) => ( {
  * @returns {Object} blockMap for use in ContentState
  */
 const buildBlockMap = compose( ( format, tokens ) =>
-	reduce(
-		format,
+	( format ?? [] ).reduce(
 		( [ block, lastIndex, entityGuide ], piece ) => [
 			{
 				...block,

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -1,4 +1,3 @@
-import { reduce } from 'lodash';
 import { domForHtml } from './utils';
 
 export default function createDomTransformRunner( transforms ) {
@@ -9,13 +8,9 @@ export default function createDomTransformRunner( transforms ) {
 
 		const dom = domForHtml( post.content );
 
-		post = reduce(
-			transforms,
-			( memo, transform ) => {
-				return transform( memo, dom );
-			},
-			post
-		);
+		post = transforms.reduce( ( memo, transform ) => {
+			return transform( memo, dom );
+		}, post );
 
 		post.content = dom.innerHTML;
 		dom.innerHTML = '';

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,6 +1,6 @@
 import { omit } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { get, map, reduce } from 'lodash';
+import { get, map } from 'lodash';
 import QueryKey from './key';
 
 /**
@@ -247,38 +247,34 @@ export default class QueryManager {
 			items = [ items ];
 		}
 
-		const nextItems = reduce(
-			items,
-			( memo, receivedItem ) => {
-				const receivedItemKey = receivedItem[ this.options.itemKey ];
-				const item = this.getItem( receivedItemKey );
-				const mergedItem = this.constructor.mergeItem( item, receivedItem, options.patch );
+		const nextItems = items.reduce( ( memo, receivedItem ) => {
+			const receivedItemKey = receivedItem[ this.options.itemKey ];
+			const item = this.getItem( receivedItemKey );
+			const mergedItem = this.constructor.mergeItem( item, receivedItem, options.patch );
 
-				if ( undefined === mergedItem ) {
-					if ( item ) {
-						// `undefined` item is an intended omission from set
-						return omit( memo, receivedItemKey );
-					}
-
-					// Item never existed in set in the first place, skip and
-					// return same memo
-					return memo;
+			if ( undefined === mergedItem ) {
+				if ( item ) {
+					// `undefined` item is an intended omission from set
+					return omit( memo, receivedItemKey );
 				}
 
-				if ( ! item || ! isEqual( mergedItem, item ) ) {
-					// Did not exist previously or has changed
-					if ( memo === this.data.items ) {
-						// Create a copy of memo, as we don't want to mutate the original items set
-						memo = { ...memo };
-					}
-
-					memo[ receivedItemKey ] = mergedItem;
-				}
-
+				// Item never existed in set in the first place, skip and
+				// return same memo
 				return memo;
-			},
-			this.data.items
-		);
+			}
+
+			if ( ! item || ! isEqual( mergedItem, item ) ) {
+				// Did not exist previously or has changed
+				if ( memo === this.data.items ) {
+					// Create a copy of memo, as we don't want to mutate the original items set
+					memo = { ...memo };
+				}
+
+				memo[ receivedItemKey ] = mergedItem;
+			}
+
+			return memo;
+		}, this.data.items );
 
 		let isModified = nextItems !== this.data.items;
 		let nextQueries = this.data.queries;
@@ -339,87 +335,83 @@ export default class QueryManager {
 			}
 		}
 
-		nextQueries = reduce(
-			nextQueries,
-			( memo, queryDetails, queryKey ) => {
-				memo[ queryKey ] = queryDetails;
+		nextQueries = Object.entries( nextQueries ).reduce( ( memo, [ queryKey, queryDetails ] ) => {
+			memo[ queryKey ] = queryDetails;
 
-				const isReceivedQueryKey = receivedQueryKey && receivedQueryKey === queryKey;
-				if ( isReceivedQueryKey && ( isNewlyReceivedQueryKey || ! options.mergeQuery ) ) {
-					// We can save the effort testing against received items in
-					// the current query, since we know they'll match
-					return memo;
-				}
+			const isReceivedQueryKey = receivedQueryKey && receivedQueryKey === queryKey;
+			if ( isReceivedQueryKey && ( isNewlyReceivedQueryKey || ! options.mergeQuery ) ) {
+				// We can save the effort testing against received items in
+				// the current query, since we know they'll match
+				return memo;
+			}
 
-				if ( ! isReceivedQueryKey && options.dontShareQueryResultsWhenQueriesAreDifferent ) {
-					return memo;
-				}
+			if ( ! isReceivedQueryKey && options.dontShareQueryResultsWhenQueriesAreDifferent ) {
+				return memo;
+			}
 
-				// Found counts should not be adjusted for the received query if
-				// merging into existing items
-				const shouldAdjustFoundCount = ! isReceivedQueryKey;
+			// Found counts should not be adjusted for the received query if
+			// merging into existing items
+			const shouldAdjustFoundCount = ! isReceivedQueryKey;
 
-				const query = this.constructor.QueryKey.parse( queryKey );
-				let needsSort = false;
-				items.forEach( ( receivedItem ) => {
-					// Find item in known data for query
-					const receivedItemKey = receivedItem[ this.options.itemKey ];
-					const updatedItem = nextItems[ receivedItemKey ];
-					const index = memo[ queryKey ].itemKeys.indexOf( receivedItemKey );
+			const query = this.constructor.QueryKey.parse( queryKey );
+			let needsSort = false;
+			items.forEach( ( receivedItem ) => {
+				// Find item in known data for query
+				const receivedItemKey = receivedItem[ this.options.itemKey ];
+				const updatedItem = nextItems[ receivedItemKey ];
+				const index = memo[ queryKey ].itemKeys.indexOf( receivedItemKey );
 
-					if ( -1 !== index ) {
-						// Item already exists in query, check to see whether the
-						// updated item is being removed or no longer matches
-						if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
-							// Create a copy of the original details to avoid mutating
-							if ( memo[ queryKey ] === queryDetails ) {
-								memo[ queryKey ] = { ...queryDetails };
-							}
-
-							// Omit item by slicing previous and next
-							memo[ queryKey ].itemKeys = [
-								...memo[ queryKey ].itemKeys.slice( 0, index ),
-								...memo[ queryKey ].itemKeys.slice( index + 1 ),
-							];
-
-							// Decrement found count for query
-							if ( shouldAdjustFoundCount && Number.isFinite( memo[ queryKey ].found ) ) {
-								memo[ queryKey ].found--;
-							}
-						}
-					} else if ( updatedItem && this.constructor.matches( query, updatedItem ) ) {
-						// Item doesn't currently exist in query but is a match, so
-						// insert item into set
-
+				if ( -1 !== index ) {
+					// Item already exists in query, check to see whether the
+					// updated item is being removed or no longer matches
+					if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
 						// Create a copy of the original details to avoid mutating
 						if ( memo[ queryKey ] === queryDetails ) {
 							memo[ queryKey ] = { ...queryDetails };
 						}
 
-						// Increment found count for query
+						// Omit item by slicing previous and next
+						memo[ queryKey ].itemKeys = [
+							...memo[ queryKey ].itemKeys.slice( 0, index ),
+							...memo[ queryKey ].itemKeys.slice( index + 1 ),
+						];
+
+						// Decrement found count for query
 						if ( shouldAdjustFoundCount && Number.isFinite( memo[ queryKey ].found ) ) {
-							memo[ queryKey ].found++;
+							memo[ queryKey ].found--;
 						}
-
-						// A matching item should be inserted into the query set
-						memo[ queryKey ].itemKeys = get( memo, [ queryKey, 'itemKeys' ], [] ).concat(
-							receivedItemKey
-						);
-
-						// The itemKeys will need to be re-sorted after all items are processed
-						needsSort = true;
 					}
-				} );
+				} else if ( updatedItem && this.constructor.matches( query, updatedItem ) ) {
+					// Item doesn't currently exist in query but is a match, so
+					// insert item into set
 
-				if ( needsSort ) {
-					this.constructor.sort( memo[ queryKey ].itemKeys, nextItems, query );
+					// Create a copy of the original details to avoid mutating
+					if ( memo[ queryKey ] === queryDetails ) {
+						memo[ queryKey ] = { ...queryDetails };
+					}
+
+					// Increment found count for query
+					if ( shouldAdjustFoundCount && Number.isFinite( memo[ queryKey ].found ) ) {
+						memo[ queryKey ].found++;
+					}
+
+					// A matching item should be inserted into the query set
+					memo[ queryKey ].itemKeys = get( memo, [ queryKey, 'itemKeys' ], [] ).concat(
+						receivedItemKey
+					);
+
+					// The itemKeys will need to be re-sorted after all items are processed
+					needsSort = true;
 				}
+			} );
 
-				isModified = isModified || memo[ queryKey ] !== queryDetails;
-				return memo;
-			},
-			{}
-		);
+			if ( needsSort ) {
+				this.constructor.sort( memo[ queryKey ].itemKeys, nextItems, query );
+			}
+
+			isModified = isModified || memo[ queryKey ] !== queryDetails;
+			return memo;
+		}, {} );
 
 		if ( ! isModified ) {
 			return this;

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { pick } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { translate } from 'i18n-calypso';
-import { filter, find, forEach, isEmpty, reduce } from 'lodash';
+import { filter, find, forEach, isEmpty } from 'lodash';
 import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -497,9 +497,8 @@ export default class SignupFlowController {
 			( stepName ) => ( steps && steps[ stepName ] && steps[ stepName ].providesDependencies ) || []
 		);
 
-		return reduce(
-			getSignupProgress( this._reduxStore.getState() ),
-			( current, step ) => ( {
+		return Object.entries( getSignupProgress( this._reduxStore.getState() ) ?? {} ).reduce(
+			( current, [ , step ] ) => ( {
 				...current,
 				...pick( step.providedDependencies, requiredDependencies ),
 			} ),

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { get, reduce } from 'lodash';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -29,13 +29,9 @@ export const StatsReach = ( props ) => {
 	const isLoadingFollowData = ! followData;
 	const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
 	const emailFollowCount = get( followData, 'total_email', 0 );
-	const publicizeFollowCount = reduce(
-		publicizeData,
-		( sum, item ) => {
-			return sum + item.value;
-		},
-		0
-	);
+	const publicizeFollowCount = ( publicizeData ?? [] ).reduce( ( sum, item ) => {
+		return sum + item.value;
+	}, 0 );
 
 	const wpData = {
 		value: wpcomFollowCount,

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,6 +1,6 @@
 import { camelCase, set, snakeCase } from '@automattic/js-utils';
 import { extendAction } from '@automattic/state-utils';
-import { map, reduce } from 'lodash';
+import { map } from 'lodash';
 
 const doBypassDataLayer = {
 	meta: {
@@ -24,15 +24,11 @@ export function convertKeysBy( obj, fn ) {
 	}
 
 	if ( typeof obj === 'object' && obj !== null ) {
-		return reduce(
-			obj,
-			( result, value, key ) => {
-				const newKey = fn( key );
-				const newValue = convertKeysBy( value, fn );
-				return set( result, [ newKey ], newValue );
-			},
-			{}
-		);
+		return Object.entries( obj ).reduce( ( result, [ key, value ] ) => {
+			const newKey = fn( key );
+			const newValue = convertKeysBy( value, fn );
+			return set( result, [ newKey ], newValue );
+		}, {} );
 	}
 
 	return obj;

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -1,5 +1,3 @@
-import { reduce } from 'lodash';
-
 import 'calypso/state/jetpack-sync/init';
 
 /**
@@ -79,20 +77,12 @@ function getImmediateSyncProgressPercentage( state, siteId ) {
 	if ( ! progress ) {
 		return 0;
 	}
-	const totalItems = reduce(
-		Object.values( progress ),
-		( sum, syncItem ) => {
-			return syncItem.total ? ( sum += parseInt( syncItem.total ) ) : sum;
-		},
-		0
-	);
-	const totalSent = reduce(
-		Object.values( progress ),
-		( sum, syncItem ) => {
-			return syncItem.sent ? ( sum += parseInt( syncItem.sent ) ) : sum;
-		},
-		0
-	);
+	const totalItems = Object.values( progress ).reduce( ( sum, syncItem ) => {
+		return syncItem.total ? ( sum += parseInt( syncItem.total ) ) : sum;
+	}, 0 );
+	const totalSent = Object.values( progress ).reduce( ( sum, syncItem ) => {
+		return syncItem.sent ? ( sum += parseInt( syncItem.sent ) ) : sum;
+	}, 0 );
 	return Math.ceil( ( totalSent / totalItems ) * 100 );
 }
 
@@ -136,29 +126,17 @@ function getSyncProgressPercentage( state, siteId ) {
 		return 0;
 	}
 
-	const countQueued = reduce(
-		queued,
-		( sum, value ) => {
-			return ( sum += value );
-		},
-		0
-	);
+	const countQueued = Object.values( queued ).reduce( ( sum, value ) => {
+		return ( sum += value );
+	}, 0 );
 
-	const countSent = reduce(
-		sent,
-		( sum, value ) => {
-			return ( sum += value );
-		},
-		0
-	);
+	const countSent = Object.values( sent ).reduce( ( sum, value ) => {
+		return ( sum += value );
+	}, 0 );
 
-	const countTotal = reduce(
-		total,
-		( sum, value ) => {
-			return ( sum += value );
-		},
-		0
-	);
+	const countTotal = Object.values( total ).reduce( ( sum, value ) => {
+		return ( sum += value );
+	}, 0 );
 
 	const percentQueued = ( countQueued / countTotal ) * queuedMultiplier * 100;
 	const percentSent = ( countSent / countTotal ) * sentMultiplier * 100;

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -1,6 +1,5 @@
 import { omit } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
-import { reduce } from 'lodash';
 import { NOTICE_CREATE, NOTICE_REMOVE, ROUTE_SET } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
 
@@ -22,26 +21,22 @@ export const items = ( state = {}, action ) => {
 			return omit( state, noticeId );
 		}
 		case ROUTE_SET: {
-			return reduce(
-				state,
-				( memo, notice, noticeId ) => {
-					if ( ! notice.isPersistent && ! notice.displayOnNextPage ) {
-						return memo;
-					}
-
-					let nextNotice = notice;
-					if ( nextNotice.displayOnNextPage ) {
-						nextNotice = {
-							...nextNotice,
-							displayOnNextPage: false,
-						};
-					}
-
-					memo[ noticeId ] = nextNotice;
+			return Object.entries( state ).reduce( ( memo, [ noticeId, notice ] ) => {
+				if ( ! notice.isPersistent && ! notice.displayOnNextPage ) {
 					return memo;
-				},
-				{}
-			);
+				}
+
+				let nextNotice = notice;
+				if ( nextNotice.displayOnNextPage ) {
+					nextNotice = {
+						...nextNotice,
+						displayOnNextPage: false,
+					};
+				}
+
+				memo[ noticeId ] = nextNotice;
+				return memo;
+			}, {} );
 		}
 	}
 

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,6 +1,6 @@
 import { pick, sortBy } from '@automattic/js-utils';
 import { createSelector } from '@automattic/state-utils';
-import { filter, find, reduce, some } from 'lodash';
+import { filter, find, some } from 'lodash';
 import {
 	getSite,
 	getSiteTitle,
@@ -85,36 +85,32 @@ export function requestPluginsError( state ) {
 }
 
 function getPluginsSelector( state, siteIds, pluginFilter ) {
-	let pluginList = reduce(
-		siteIds,
-		( memo, siteId ) => {
-			if ( isRequesting( state, siteId ) ) {
-				return memo;
-			}
-
-			// We currently support fetching plugins per site and also fetching all plugins
-			// in bulk, aiming to optimize the UX in some flows.
-			if ( isRequestingForAllSites( state ) ) {
-				return memo;
-			}
-
-			const list = state.plugins.installed.plugins[ siteId ] || [];
-			list.forEach( ( item ) => {
-				const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update', 'version' ] );
-
-				memo[ item.slug ] = {
-					...memo[ item.slug ],
-					...item,
-					sites: {
-						...memo[ item.slug ]?.sites,
-						[ siteId ]: sitePluginInfo,
-					},
-				};
-			} );
+	let pluginList = ( siteIds ?? [] ).reduce( ( memo, siteId ) => {
+		if ( isRequesting( state, siteId ) ) {
 			return memo;
-		},
-		{}
-	);
+		}
+
+		// We currently support fetching plugins per site and also fetching all plugins
+		// in bulk, aiming to optimize the UX in some flows.
+		if ( isRequestingForAllSites( state ) ) {
+			return memo;
+		}
+
+		const list = state.plugins.installed.plugins[ siteId ] || [];
+		list.forEach( ( item ) => {
+			const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update', 'version' ] );
+
+			memo[ item.slug ] = {
+				...memo[ item.slug ],
+				...item,
+				sites: {
+					...memo[ item.slug ]?.sites,
+					[ siteId ]: sitePluginInfo,
+				},
+			};
+		} );
+		return memo;
+	}, {} );
 
 	if ( pluginFilter && _filters[ pluginFilter ] ) {
 		pluginList = filter( pluginList, _filters[ pluginFilter ] );

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -2,7 +2,7 @@
 
 import { mapValues, omit, omitBy, set } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { isEmpty, reduce, merge } from 'lodash';
+import { isEmpty, merge } from 'lodash';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
 import {
@@ -49,25 +49,21 @@ import {
 export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case POSTS_RECEIVE: {
-			return reduce(
-				action.posts,
-				( memo, post ) => {
-					const { site_ID: siteId, ID: postId, global_ID: globalId } = post;
-					if ( memo[ globalId ] ) {
-						// We're making an assumption here that the site ID and post ID
-						// corresponding with a global ID will never change
-						return memo;
-					}
-
-					if ( memo === state ) {
-						memo = { ...memo };
-					}
-
-					memo[ globalId ] = [ siteId, postId ];
+			return ( action.posts ?? [] ).reduce( ( memo, post ) => {
+				const { site_ID: siteId, ID: postId, global_ID: globalId } = post;
+				if ( memo[ globalId ] ) {
+					// We're making an assumption here that the site ID and post ID
+					// corresponding with a global ID will never change
 					return memo;
-				},
-				state
-			);
+				}
+
+				if ( memo === state ) {
+					memo = { ...memo };
+				}
+
+				memo[ globalId ] = [ siteId, postId ];
+				return memo;
+			}, state );
 		}
 		case POST_DELETE_SUCCESS: {
 			const globalId = Object.keys( state ).find( ( key ) => {
@@ -157,19 +153,14 @@ const queriesReducer = ( state = {}, action ) => {
 		}
 		case POSTS_RECEIVE: {
 			const { posts } = action;
-			const postsBySiteId = reduce(
-				posts,
-				( memo, post ) => {
-					return Object.assign( memo, {
-						[ post.site_ID ]: [ ...( memo[ post.site_ID ] || [] ), normalizePostForState( post ) ],
-					} );
-				},
-				{}
-			);
+			const postsBySiteId = ( posts ?? [] ).reduce( ( memo, post ) => {
+				return Object.assign( memo, {
+					[ post.site_ID ]: [ ...( memo[ post.site_ID ] || [] ), normalizePostForState( post ) ],
+				} );
+			}, {} );
 
-			return reduce(
-				postsBySiteId,
-				( memo, sitePosts, siteId ) =>
+			return Object.entries( postsBySiteId ).reduce(
+				( memo, [ siteId, sitePosts ] ) =>
 					withQueryManager(
 						memo,
 						siteId,
@@ -316,80 +307,76 @@ export const allSitesQueries = withSchemaValidation(
 export function edits( state = {}, action ) {
 	switch ( action.type ) {
 		case POSTS_RECEIVE:
-			return reduce(
-				action.posts,
-				( memoState, post ) => {
-					// Receive a new version of a post object, in most cases returned in the POST
-					// response after a successful save. Removes the edits that have been applied
-					// and leaves only the ones that are not noops.
-					let postEditsLog = memoState?.[ post.site_ID ]?.[ post.ID ];
+			return ( action.posts ?? [] ).reduce( ( memoState, post ) => {
+				// Receive a new version of a post object, in most cases returned in the POST
+				// response after a successful save. Removes the edits that have been applied
+				// and leaves only the ones that are not noops.
+				let postEditsLog = memoState?.[ post.site_ID ]?.[ post.ID ];
 
-					if ( ! postEditsLog ) {
-						return memoState;
+				if ( ! postEditsLog ) {
+					return memoState;
+				}
+
+				if ( memoState === state ) {
+					memoState = merge( {}, state );
+				}
+
+				// if the action has a save marker, remove the edits before that marker
+				if ( action.saveMarker ) {
+					const markerIndex = postEditsLog.indexOf( action.saveMarker );
+					if ( markerIndex !== -1 ) {
+						postEditsLog = postEditsLog.slice( markerIndex + 1 );
 					}
+				}
 
-					if ( memoState === state ) {
-						memoState = merge( {}, state );
-					}
+				// merge the array of remaining edits into one object
+				const postEdits = mergePostEdits( ...postEditsLog );
+				let newEditsLog = null;
 
-					// if the action has a save marker, remove the edits before that marker
-					if ( action.saveMarker ) {
-						const markerIndex = postEditsLog.indexOf( action.saveMarker );
-						if ( markerIndex !== -1 ) {
-							postEditsLog = postEditsLog.slice( markerIndex + 1 );
+				if ( postEdits ) {
+					// remove the edits that try to set an attribute to a value it already has.
+					// For most attributes, it's a simple `isEqual` deep comparison, but a few
+					// properties are more complicated than that.
+					const unappliedPostEdits = omitBy( postEdits, ( value, key ) => {
+						switch ( key ) {
+							case 'author':
+								return isAuthorEqual( value, post[ key ] );
+							case 'date':
+								return isDateEqual( value, post[ key ] );
+							case 'discussion':
+								return isDiscussionEqual( value, post[ key ] );
+							case 'featured_image':
+								return value === getFeaturedImageId( post );
+							case 'metadata':
+								// omit from unappliedPostEdits, metadata edits will be merged
+								return true;
+							case 'status':
+								return isStatusEqual( value, post[ key ] );
+							case 'terms':
+								return isTermsEqual( value, post[ key ] );
+						}
+						return isEqual( post[ key ], value );
+					} );
+
+					// remove edits that are already applied in the incoming metadata values and
+					// leave only the unapplied ones.
+					if ( postEdits.metadata ) {
+						const unappliedMetadataEdits = getUnappliedMetadataEdits(
+							postEdits.metadata,
+							post.metadata
+						);
+						if ( unappliedMetadataEdits.length > 0 ) {
+							unappliedPostEdits.metadata = unappliedMetadataEdits;
 						}
 					}
 
-					// merge the array of remaining edits into one object
-					const postEdits = mergePostEdits( ...postEditsLog );
-					let newEditsLog = null;
-
-					if ( postEdits ) {
-						// remove the edits that try to set an attribute to a value it already has.
-						// For most attributes, it's a simple `isEqual` deep comparison, but a few
-						// properties are more complicated than that.
-						const unappliedPostEdits = omitBy( postEdits, ( value, key ) => {
-							switch ( key ) {
-								case 'author':
-									return isAuthorEqual( value, post[ key ] );
-								case 'date':
-									return isDateEqual( value, post[ key ] );
-								case 'discussion':
-									return isDiscussionEqual( value, post[ key ] );
-								case 'featured_image':
-									return value === getFeaturedImageId( post );
-								case 'metadata':
-									// omit from unappliedPostEdits, metadata edits will be merged
-									return true;
-								case 'status':
-									return isStatusEqual( value, post[ key ] );
-								case 'terms':
-									return isTermsEqual( value, post[ key ] );
-							}
-							return isEqual( post[ key ], value );
-						} );
-
-						// remove edits that are already applied in the incoming metadata values and
-						// leave only the unapplied ones.
-						if ( postEdits.metadata ) {
-							const unappliedMetadataEdits = getUnappliedMetadataEdits(
-								postEdits.metadata,
-								post.metadata
-							);
-							if ( unappliedMetadataEdits.length > 0 ) {
-								unappliedPostEdits.metadata = unappliedMetadataEdits;
-							}
-						}
-
-						if ( ! isEmpty( unappliedPostEdits ) ) {
-							newEditsLog = [ unappliedPostEdits ];
-						}
+					if ( ! isEmpty( unappliedPostEdits ) ) {
+						newEditsLog = [ unappliedPostEdits ];
 					}
+				}
 
-					return set( memoState, [ post.site_ID, post.ID ], newEditsLog );
-				},
-				state
-			);
+				return set( memoState, [ post.site_ID, post.ID ], newEditsLog );
+			}, state );
 
 		case POST_EDIT: {
 			// process new edit for a post: merge it into the existing edits

--- a/client/state/posts/utils/apply-post-edits.js
+++ b/client/state/posts/utils/apply-post-edits.js
@@ -1,4 +1,4 @@
-import { find, map, mergeWith, reduce } from 'lodash';
+import { find, map, mergeWith } from 'lodash';
 
 /*
  * Applies a metadata edit operation (either update or delete) to an existing array of
@@ -29,7 +29,7 @@ function applyMetadataEdit( metadata, edit ) {
 }
 
 function applyMetadataEdits( metadata, edits ) {
-	return reduce( edits, applyMetadataEdit, metadata );
+	return ( edits ?? [] ).reduce( applyMetadataEdit, metadata );
 }
 
 /**

--- a/client/state/posts/utils/get-term-ids-from-edits.js
+++ b/client/state/posts/utils/get-term-ids-from-edits.js
@@ -1,5 +1,5 @@
 import { mapValues } from '@automattic/js-utils';
-import { isEmpty, map, reduce } from 'lodash';
+import { isEmpty, map } from 'lodash';
 
 /**
  * Takes existing term post edits and updates the `terms_by_id` attribute
@@ -13,9 +13,8 @@ export function getTermIdsFromEdits( post ) {
 
 	// Filter taxonomies that are set as arrays ( i.e. tags )
 	// This can be detected by an array of strings vs an array of objects
-	const taxonomies = reduce(
-		post.terms,
-		( prev, taxonomyTerms, taxonomyName ) => {
+	const taxonomies = Object.entries( post.terms ).reduce(
+		( prev, [ taxonomyName, taxonomyTerms ] ) => {
 			// Ensures we are working with an array
 			const termsArray = Object.values( taxonomyTerms );
 			if (

--- a/client/state/posts/utils/merge-post-edits.js
+++ b/client/state/posts/utils/merge-post-edits.js
@@ -1,4 +1,4 @@
-import { find, mergeWith, reduce } from 'lodash';
+import { find, mergeWith } from 'lodash';
 
 function mergeMetadataEdits( edits, nextEdits ) {
 	// remove existing edits that get updated in `nextEdits`
@@ -17,34 +17,30 @@ function mergeMetadataEdits( edits, nextEdits ) {
  * @returns {Object?}                    Merged edits object with changes from all sources
  */
 export const mergePostEdits = ( ...postEditsLog ) =>
-	reduce(
-		postEditsLog,
-		( mergedEdits, nextEdits ) => {
-			// filter out save markers
-			if ( typeof nextEdits === 'string' ) {
-				return mergedEdits;
-			}
+	postEditsLog.reduce( ( mergedEdits, nextEdits ) => {
+		// filter out save markers
+		if ( typeof nextEdits === 'string' ) {
+			return mergedEdits;
+		}
 
-			// return the input object if it's the first one to merge (optimization that avoids cloning)
-			if ( mergedEdits === null ) {
-				return nextEdits;
-			}
+		// return the input object if it's the first one to merge (optimization that avoids cloning)
+		if ( mergedEdits === null ) {
+			return nextEdits;
+		}
 
-			// proceed to do the merge
-			return mergeWith(
-				structuredClone( mergedEdits ),
-				nextEdits,
-				( objValue, srcValue, key, obj, src, stack ) => {
-					if ( key === 'metadata' && stack.size === 0 ) {
-						// merge metadata specially
-						return mergeMetadataEdits( objValue, srcValue );
-					}
-
-					if ( Array.isArray( srcValue ) ) {
-						return srcValue;
-					}
+		// proceed to do the merge
+		return mergeWith(
+			structuredClone( mergedEdits ),
+			nextEdits,
+			( objValue, srcValue, key, obj, src, stack ) => {
+				if ( key === 'metadata' && stack.size === 0 ) {
+					// merge metadata specially
+					return mergeMetadataEdits( objValue, srcValue );
 				}
-			);
-		},
-		null
-	);
+
+				if ( Array.isArray( srcValue ) ) {
+					return srcValue;
+				}
+			}
+		);
+	}, null );

--- a/client/state/posts/utils/normalize-post-for-state.js
+++ b/client/state/posts/utils/normalize-post-for-state.js
@@ -1,4 +1,4 @@
-import { map, reduce } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Recursively unset a value in an object by its path, represented by an array.
@@ -26,23 +26,18 @@ const recursiveUnset = ( object, path ) => {
  */
 export function normalizePostForState( post ) {
 	const normalizedPost = structuredClone( post );
-	return reduce(
-		[
-			[],
-			...reduce(
-				post.terms,
-				( memo, terms, taxonomy ) =>
-					memo.concat( map( terms, ( term, slug ) => [ 'terms', taxonomy, slug ] ) ),
-				[]
-			),
-			...map( post.categories, ( category, slug ) => [ 'categories', slug ] ),
-			...map( post.tags, ( tag, slug ) => [ 'tags', slug ] ),
-			...map( post.attachments, ( attachment, id ) => [ 'attachments', id ] ),
-		],
-		( memo, path ) => {
-			recursiveUnset( memo, path.concat( 'meta', 'links' ) );
-			return memo;
-		},
-		normalizedPost
-	);
+	return [
+		[],
+		...Object.entries( post.terms ?? {} ).reduce(
+			( memo, [ taxonomy, terms ] ) =>
+				memo.concat( map( terms, ( term, slug ) => [ 'terms', taxonomy, slug ] ) ),
+			[]
+		),
+		...map( post.categories, ( category, slug ) => [ 'categories', slug ] ),
+		...map( post.tags, ( tag, slug ) => [ 'tags', slug ] ),
+		...map( post.attachments, ( attachment, id ) => [ 'attachments', id ] ),
+	].reduce( ( memo, path ) => {
+		recursiveUnset( memo, path.concat( 'meta', 'links' ) );
+		return memo;
+	}, normalizedPost );
 }

--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -1,5 +1,4 @@
 import { omit } from '@automattic/js-utils';
-import { reduce } from 'lodash';
 import {
 	READER_SITE_BLOCK,
 	READER_SITE_BLOCKS_RECEIVE,
@@ -42,14 +41,10 @@ export const items = ( state = {}, action ) => {
 				return state;
 			}
 
-			const newBlocks = reduce(
-				action.payload.sites,
-				( obj, site ) => {
-					obj[ site.ID ] = true;
-					return obj;
-				},
-				{}
-			);
+			const newBlocks = action.payload.sites.reduce( ( obj, site ) => {
+				obj[ site.ID ] = true;
+				return obj;
+			}, {} );
 
 			return {
 				...state,

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,7 +1,7 @@
 import { isTitanMail, WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { snakeCase } from '@automattic/js-utils';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-import { isEmpty, reduce } from 'lodash';
+import { isEmpty } from 'lodash';
 import { assertValidDependencies } from 'calypso/lib/signup/asserts';
 import {
 	SIGNUP_PROGRESS_SAVE_STEP,
@@ -38,9 +38,8 @@ const EXCLUDED_DEPENDENCIES = [
 function recordSubmitStep( flow, stepName, providedDependencies, optionalProps ) {
 	// Transform the keys since tracks events only accept snaked prop names.
 	// And anonymize personally identifiable information.
-	const inputs = reduce(
-		providedDependencies,
-		( props, propValue, propName ) => {
+	const inputs = Object.entries( providedDependencies ?? {} ).reduce(
+		( props, [ propName, propValue ] ) => {
 			if ( EXCLUDED_DEPENDENCIES.includes( propName ) ) {
 				return props;
 			}

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -1,6 +1,6 @@
 import { omit } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { merge, reduce } from 'lodash';
+import { merge } from 'lodash';
 import {
 	MEDIA_DELETE,
 	SITE_LEAVE_RECEIVE,
@@ -79,53 +79,45 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 
 			const initialNextState = SITES_RECEIVE === action.type ? {} : state;
 
-			return reduce(
-				sites,
-				( memo, site ) => {
-					// Bypass if site object hasn't changed
-					if ( isEqual( memo[ site.ID ], site ) ) {
-						return memo;
-					}
-
-					// Avoid mutating state
-					if ( memo === state ) {
-						memo = { ...state };
-					}
-
-					memo[ site.ID ] = site;
+			return ( sites ?? [] ).reduce( ( memo, site ) => {
+				// Bypass if site object hasn't changed
+				if ( isEqual( memo[ site.ID ], site ) ) {
 					return memo;
-				},
-				initialNextState || {}
-			);
+				}
+
+				// Avoid mutating state
+				if ( memo === state ) {
+					memo = { ...state };
+				}
+
+				memo[ site.ID ] = site;
+				return memo;
+			}, initialNextState || {} );
 		}
 
 		case ODYSSEY_SITE_RECEIVE: {
 			// Treat the site info from WPCOM as default values for the site, and the info from Odyssey as the source of truth.
 			// This is because the site info from WPCOM is more complete, but the info from Odyssey is more up-to-date.
 			// For example, `options.is_commercial` is not present in the Odyssey site info, but is a remote option value stored in WPCOM.
-			return reduce(
-				[ action.site ],
-				( memo, site ) => {
-					// Bypass if site object hasn't changed
-					if ( isEqual( memo[ site.ID ], site ) ) {
-						return memo;
-					}
-
-					// Avoid mutating state
-					if ( memo === state ) {
-						memo = { ...state };
-					}
-
-					memo[ site.ID ] = {
-						...site,
-						...memo[ site.ID ],
-						options: { ...memo[ site.ID ]?.options, ...site?.options },
-						capabilities: { ...memo[ site.ID ]?.capabilities, ...site?.capabilities },
-					};
+			return [ action.site ].reduce( ( memo, site ) => {
+				// Bypass if site object hasn't changed
+				if ( isEqual( memo[ site.ID ], site ) ) {
 					return memo;
-				},
-				state
-			);
+				}
+
+				// Avoid mutating state
+				if ( memo === state ) {
+					memo = { ...state };
+				}
+
+				memo[ site.ID ] = {
+					...site,
+					...memo[ site.ID ],
+					options: { ...memo[ site.ID ]?.options, ...site?.options },
+					capabilities: { ...memo[ site.ID ]?.capabilities, ...site?.capabilities },
+				};
+				return memo;
+			}, state );
 		}
 
 		case SITE_LEAVE_RECEIVE:
@@ -161,8 +153,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 
 			let nextSite = site;
 
-			return reduce(
-				[ 'blog_public', 'wpcom_public_coming_soon', 'wpcom_coming_soon', 'site_icon' ],
+			return [ 'blog_public', 'wpcom_public_coming_soon', 'wpcom_coming_soon', 'site_icon' ].reduce(
 				( memo, key ) => {
 					// A site settings update may or may not include the icon or blog_public property.
 					// If not, we should simply return state unchanged.

--- a/client/state/utils/keyed-reducer.ts
+++ b/client/state/utils/keyed-reducer.ts
@@ -1,6 +1,6 @@
 import { mapValues, omit, omitBy } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { get, reduce } from 'lodash';
+import { get } from 'lodash';
 import { SerializationResult } from 'calypso/state/serialization-result';
 import { serialize, deserialize, SerializableReducer } from './serialize';
 import { withPersistence } from './with-persistence';
@@ -124,9 +124,8 @@ export const keyedReducer = < TState, TAction extends AnyAction = Action >(
 
 	return withPersistence( combinedReducer, {
 		serialize: ( state ) =>
-			reduce(
-				state,
-				( result, itemValue, itemKey ) => {
+			Object.entries( state ?? {} ).reduce(
+				( result, [ itemKey, itemValue ] ) => {
 					const serializedValue = serialize( reducer, itemValue );
 					if ( serializedValue !== undefined && ! isEqual( serializedValue, initialState ) ) {
 						if ( ! result ) {

--- a/client/state/utils/reducer-utils.ts
+++ b/client/state/utils/reducer-utils.ts
@@ -1,5 +1,5 @@
 import { mapValues } from '@automattic/js-utils';
-import { get, reduce } from 'lodash';
+import { get } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line no-restricted-imports
 import { APPLY_STORED_STATE } from 'calypso/state/action-types';
 import { SerializationResult } from 'calypso/state/serialization-result';
@@ -219,9 +219,8 @@ function serializeState< TState = any >(
 		return undefined;
 	}
 
-	return reduce(
-		reducers,
-		( result, reducer, reducerKey ) => {
+	return Object.entries( reducers ).reduce(
+		( result, [ reducerKey, reducer ] ) => {
 			const serialized = serialize( reducer, state[ reducerKey ] );
 			if ( serialized !== undefined ) {
 				if ( ! result ) {

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -92,6 +92,9 @@ const REJECT_MESSAGE =
 	'(expand object-match shorthands to a predicate, and guard nullable collections with `?? []`).';
 const CONCAT_MESSAGE =
 	'Please use native `array.concat( … )` (or `[].concat( ...arrays )`) instead of lodash `concat`.';
+const REDUCE_MESSAGE =
+	'Please use native `array.reduce()` (or `Object.entries( obj ).reduce()` to fold an object) ' +
+	'instead of lodash `reduce`. Guard nullable collections with `?? []` / `?? {}`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -118,6 +121,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'sortBy', 'orderBy' ], message: SORT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'reject' ], message: REJECT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'concat' ], message: CONCAT_MESSAGE },
+	{ name: 'lodash', importNames: [ 'reduce' ], message: REDUCE_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -146,6 +150,7 @@ const patterns = [
 	{ group: [ 'lodash/sortBy', 'lodash/orderBy' ], message: SORT_MESSAGE },
 	{ group: [ 'lodash/reject' ], message: REJECT_MESSAGE },
 	{ group: [ 'lodash/concat' ], message: CONCAT_MESSAGE },
+	{ group: [ 'lodash/reduce' ], message: REDUCE_MESSAGE },
 ];
 
 module.exports = { paths, patterns };


### PR DESCRIPTION
## Proposed Changes

* Replace all lodash `reduce` usage with native JavaScript and add a `no-restricted-imports` guard for it.
  * **Array** collections → `array.reduce( ( acc, value ) => …, init )`.
  * **Object** collections → `Object.entries( obj ).reduce( ( acc, [ key, value ] ) => …, init )` — lodash iterates an object's own enumerable values with the key as the third iteratee argument, so the native form folds over `[ key, value ]` entries.
* Nullable collections are guarded with `?? []` / `?? {}` (see below).

## Why are these changes being made?

* Part of the incremental effort to remove lodash in favor of native JavaScript.
* The one behavioral gap between lodash `reduce` and native `reduce` is null handling: lodash returns the accumulator for a `null`/`undefined` collection and never throws, whereas native `.reduce()` / `Object.entries()` throw. Every collection that can be null/undefined (Redux state slices, optional fields, function results) is guarded with `?? []` / `?? {}` to preserve the lodash behavior.

## Testing Instructions

* `yarn typecheck-client` and `yarn typecheck-packages` pass.
* `yarn eslint` passes on the changed files.
* Affected unit tests pass (`yarn test-client --findRelatedTests` on the changed files).
* No behavior change is expected — array reductions map directly, and object reductions preserve lodash's value/key iteration order and accumulator handling.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
