### PR TITLE
Emails: validate the Add email forwarder form (DOTMSD-1342)

### DIFF
--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -303,8 +303,6 @@ function AddEmailForwarder() {
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'Forward to' ) }
-									// Reject anything that isn't a valid email so a malformed string
-									// can't be tokenized as a forwarding target.
 									__experimentalValidateInput={ ( token ) =>
 										emailValidator.validate( token.trim() )
 									}

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -120,6 +120,7 @@ function AddEmailForwarder() {
 				id: 'localPart',
 				label: __( 'Email address' ),
 				type: 'text',
+				isValid: { required: true },
 			},
 			{
 				elements: [
@@ -132,6 +133,7 @@ function AddEmailForwarder() {
 				id: 'domain',
 				label: __( 'Domain' ),
 				type: 'text',
+				isValid: { required: true },
 			},
 		],
 		[ eligibleDomains ]
@@ -301,6 +303,11 @@ function AddEmailForwarder() {
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'Forward to' ) }
+									// Reject anything that isn't a valid email so a malformed string
+									// can't be tokenized as a forwarding target.
+									__experimentalValidateInput={ ( token ) =>
+										emailValidator.validate( token.trim() )
+									}
 									onInputChange={ ( val ) => {
 										setUntokenizedInput( val );
 									} }
@@ -406,6 +413,14 @@ function AddEmailForwarder() {
 											/>
 										</VStack>
 									</Notice>
+								) }
+
+								{ ! allFieldsSet && (
+									<Text variant="muted">
+										{ __(
+											'Enter an email address, select a domain, and add at least one forwarding address to continue.'
+										) }
+									</Text>
 								) }
 
 								<ButtonStack justify="flex-start">

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -329,6 +329,10 @@ function AddEmailForwarder() {
 									} }
 								/>
 
+								{ untokenizedInput.trim() !== '' && ! isUntokenizedInputValidEmail && (
+									<Text intent="error">{ __( 'Please enter a valid email address.' ) }</Text>
+								) }
+
 								{ newForwardingAddresses.length > 0 && (
 									<Notice>
 										{ sprintf(

--- a/client/dashboard/emails/add-forwarder/test/index.test.tsx
+++ b/client/dashboard/emails/add-forwarder/test/index.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { EmailProvider } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import AddEmailForwarder from '../index';
+import type { EmailAccount } from '@automattic/api-core';
+
+const DOMAIN = 'example.com';
+
+function mockApi() {
+	// Eligible forwarding domain so the form renders.
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1/me/mailboxes' )
+		.query( true )
+		.reply( 200, [
+			{
+				account_type: EmailProvider.Forwarding,
+				can_user_add_email: true,
+				domains: [ { domain: DOMAIN } ],
+			},
+		] as EmailAccount[] );
+
+	// Existing forwarders for the eligible domain (queried on render).
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/domains/${ DOMAIN }/email` )
+		.query( true )
+		.reply( 200, { forwards: [], max_forwards: 100 } )
+		.persist();
+}
+
+describe( '<AddEmailForwarder>', () => {
+	// DOTMSD-1342
+	test( 'keeps Save disabled and shows a required-fields hint for an empty form', async () => {
+		mockApi();
+		render( <AddEmailForwarder /> );
+
+		// The form renders once the eligible domain loads.
+		expect( await screen.findByLabelText( 'Forward to' ) ).toBeVisible();
+
+		expect( screen.getByText( /add at least one forwarding address to continue/i ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	// DOTMSD-1342
+	test( 'rejects an invalid email in the Forward to field', async () => {
+		mockApi();
+		const user = userEvent.setup();
+		render( <AddEmailForwarder /> );
+
+		const forwardTo = await screen.findByLabelText( 'Forward to' );
+		await user.type( forwardTo, 'notanemail{Enter}' );
+
+		// A malformed value is not tokenized, so the verification notice never appears.
+		expect(
+			screen.queryByText( /set up an email forwarder to notanemail/i )
+		).not.toBeInTheDocument();
+		// The Save button stays disabled because there is no valid forwarding address.
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+} );

--- a/client/dashboard/emails/add-forwarder/test/index.test.tsx
+++ b/client/dashboard/emails/add-forwarder/test/index.test.tsx
@@ -58,7 +58,23 @@ describe( '<AddEmailForwarder>', () => {
 		expect(
 			screen.queryByText( /set up an email forwarder to notanemail/i )
 		).not.toBeInTheDocument();
+		// Instead, an inline error explains the input is invalid.
+		expect( screen.getByText( 'Please enter a valid email address.' ) ).toBeVisible();
 		// The Save button stays disabled because there is no valid forwarding address.
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	// DOTMSD-1342
+	test( 'accepts multiple valid forwarding addresses', async () => {
+		mockApi();
+		const user = userEvent.setup();
+		render( <AddEmailForwarder /> );
+
+		const forwardTo = await screen.findByLabelText( 'Forward to' );
+		await user.type( forwardTo, 'first@example.com{Enter}second@example.com{Enter}' );
+
+		expect( screen.getByText( 'first@example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'second@example.com' ) ).toBeVisible();
+		expect( screen.queryByText( 'Please enter a valid email address.' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes DOTMSD-1342

## Proposed Changes

Closes two client-side validation gaps on the **Add email forwarder** form (`/emails/add-forwarder`):

1. **Invalid "Forward to" address accepted as a chip.** Typing a malformed value like `notanemail` and pressing Enter added it as a token and showed the verification notice, treating it as a real forward target. Now the field uses `FormTokenField`'s `__experimentalValidateInput` to reject anything that isn't a valid email, so only valid addresses tokenize. When invalid text remains in the field (including a valid address typed after an invalid one in a comma-separated list), an inline error — "Please enter a valid email address." — explains why it wasn't added.

2. **Empty Save gave no feedback.** The email address and domain fields are now marked required, and a hint ("Enter an email address, select a domain, and add at least one forwarding address to continue.") is shown while the form is incomplete. Save stays disabled until the form is valid.

Multiple valid addresses tokenize normally; a leftover invalid entry keeps Save disabled so it can't slip through.

Adds integration tests covering the empty-form state, invalid-input rejection + inline error, and multiple valid addresses.

## Why are these changes being made?

The form let a malformed string become a forwarding target, and an incomplete submit silently did nothing (the Save button is disabled-until-valid, but the disabled state was easy to miss and nothing said what was required). Both were flagged in the MSD CfT regression pass.

## Testing Instructions

You can test on the **Calypso live link** generated for this PR (see the live-link comment/check on the PR), or run locally with `yarn start-dashboard` and open `/emails/add-forwarder`.

1. In **Forward to**, type `notanemail` and press Enter → it is not added as a chip, and an inline "Please enter a valid email address." error appears.
2. Type a valid address (e.g. `you@example.com`) and press Enter → it is accepted as a chip; add a second valid address → both chips appear.
3. Try a comma-separated mix (e.g. `a@example.com, bad, b@example.com`) → valid addresses tokenize, invalid text stays in the field with the inline error, and Save remains disabled until the field is clean.
4. With the form empty, note the hint under the fields and that **Save** is disabled. Fill the email address, select a domain, and add a valid forwarding address → the hint clears and **Save** enables.

Automated: `yarn test-client client/dashboard/emails/add-forwarder`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
