### PR TITLE
Data Stores: drop @automattic/js-utils dependency

### DIFF
--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -50,7 +50,6 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/design-types": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/js-utils": "workspace:^",
 		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/oauth-token": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -1,5 +1,18 @@
-import { snakeToCamelCase } from '@automattic/js-utils';
 import type { PurchasePriceTier, Purchase, RawPurchase } from '../types';
+
+/**
+ * Convert a snake_case_word to a camelCaseWord.
+ */
+function snakeToCamelCase( snakeCaseString: string | undefined ): string {
+	if ( ! snakeCaseString ) {
+		return '';
+	}
+	return snakeCaseString
+		.toLowerCase()
+		.replace( /([-_][a-z0-9])/g, ( group ) =>
+			group.toUpperCase().replace( '-', '' ).replace( '_', '' )
+		);
+}
 
 export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 	const object: Purchase = {

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -15,7 +15,6 @@
 		{ "path": "../api-queries" },
 		{ "path": "../design-types" },
 		{ "path": "../i18n-utils" },
-		{ "path": "../shopping-cart" },
-		{ "path": "../js-utils" }
+		{ "path": "../shopping-cart" }
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,7 +1019,6 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/design-types": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
-    "@automattic/js-utils": "workspace:^"
     "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/oauth-token": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Inline the single `snakeToCamelCase` helper used by the purchases assembler and drop the `@automattic/js-utils` dependency from `@automattic/data-stores` (dependency, TS project reference, and import).

## Why are these changes being made?

`@automattic/data-stores` used `@automattic/js-utils` for exactly one thing: `snakeToCamelCase` in the purchases response assembler, called at a single site. Because consumers like `@automattic/launchpad` depend on the whole of `@automattic/data-stores`, this pulls `@automattic/js-utils` into their install closure (e.g. jetpack-mu-wpcom) even though nothing else uses it. Inlining the small, dependency-free helper removes `@automattic/js-utils` from the data-stores dependency tree for every consumer, with no behavior change — the helper is copied verbatim.

## Testing Instructions

* `yarn typecheck-packages` (or build `@automattic/data-stores`) — compiles with no errors.
* Confirm purchases continue to expose `expiryStatus` correctly: multi-word backend values (e.g. `auto-renewing`, `manual-renew`, `one-time-purchase`) are still camelCased to `autoRenewing` / `manualRenew` / `oneTimePurchase`, and single-word values (`expired`, `included`) pass through unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
