### PR TITLE
Reader: fall back to post_thumbnail when featured image URL is unsafe

### DIFF
--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -3,9 +3,19 @@ import { makeImageURLSafe } from './utils';
 export default function safeImagePropertiesForWidth( maxWidth ) {
 	return function safeImageProperties( post ) {
 		makeImageURLSafe( post.author, 'avatar_URL', maxWidth );
+
+		const hadFeaturedImage = !! post.featured_image;
 		makeImageURLSafe( post, 'featured_image', maxWidth, post.URL );
 		if ( post.post_thumbnail ) {
 			makeImageURLSafe( post.post_thumbnail, 'URL', maxWidth, post.URL );
+		}
+
+		// safeImageUrl() returns null for external image URLs that carry a
+		// non-resize query string (e.g. `?wsr` from WebP-delivery plugins). When
+		// that strips a featured image we'd otherwise show, fall back to the
+		// Reader API's separate post_thumbnail, which the mobile apps already use.
+		if ( hadFeaturedImage && ! post.featured_image && post.post_thumbnail?.URL ) {
+			post.featured_image = post.post_thumbnail.URL;
 		}
 		if ( post.featured_media && post.featured_media.type === 'image' ) {
 			makeImageURLSafe( post.featured_media, 'uri', maxWidth, post.URL );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -191,6 +191,38 @@ describe( 'index', () => {
 			const normalized = safeImageProperties( 200 )( post );
 			expect( normalized.featured_media.uri ).toBe( 'http://example.com/media.jpg' );
 		} );
+
+		test( 'falls back to post_thumbnail when featured_image cannot be made safe', () => {
+			const post = {
+				// The `?ad` param makes the mocked safeImageUrl return null, mirroring
+				// how the real safeImageUrl rejects external URLs with non-resize query
+				// strings (e.g. `?wsr` appended by WebP-delivery plugins).
+				featured_image: 'http://foo.bar/image.webp?ad=1',
+				post_thumbnail: {
+					URL: 'http://example.com/thumb.jpg',
+					height: 1000,
+					width: 1000,
+					mime_type: '',
+				},
+			};
+			const normalized = safeImageProperties( 200 )( post );
+			expect( normalized.featured_image ).toBe(
+				'http://example.com/thumb.jpg-SAFE?quality=80&strip=info&w=200'
+			);
+		} );
+
+		test( 'does not fabricate a featured_image from post_thumbnail when none was set', () => {
+			const post = {
+				post_thumbnail: {
+					URL: 'http://example.com/thumb.jpg',
+					height: 1000,
+					width: 1000,
+					mime_type: '',
+				},
+			};
+			const normalized = safeImageProperties( 200 )( post );
+			expect( normalized.featured_image ).toBeUndefined();
+		} );
 	} );
 
 	describe( 'pickPrimaryTag', () => {


### PR DESCRIPTION
Closes READ-576

## Proposed Changes

* When the Reader's image-safety layer (`safeImageUrl()`) can't make a post's featured image URL safe, fall back to the API's separate `post_thumbnail.URL` during post normalization (`rule-safe-image-properties.js`).
* Added regression tests covering the fallback and a guard that no featured image is fabricated when a post never had one.

## Why are these changes being made?

`safeImageUrl()` intentionally returns `null` for external image URLs that carry a non-resize query string (Photon can't handle arbitrary query params on external URLs). Some sites serve featured images with a trailing flag param like `?wsr` (added by WebP-delivery plugins), so the featured image got nulled during normalization.

The result: the featured image disappeared from **both** the web Reader feed card and the full-post view — even though the wpcom Reader API delivers a perfectly usable `post_thumbnail` (a clean `.jpg`, no query string) that the mobile apps already render. So an image visible in the mobile app Reader was missing entirely on the web.

Both web surfaces read from `post.featured_image` downstream (full post uses it directly; the card derives `canonical_media` from it via `pickCanonicalMedia`), so restoring it from `post_thumbnail.URL` fixes both at once. The fallback is scoped to only fire when a featured image existed but couldn't be made safe, so posts with no featured image are unaffected.

## Testing Instructions

1. Apply this branch and run the Reader.
2. Visit a feed/post whose featured image URL carries a non-resize query string, e.g.:
   * Feed: `/reader/feeds/150788139`
   * Post: `/reader/feeds/150788139/posts/6097628492`
3. Confirm the featured image now renders both in the feed card and in the full-post view.
4. Sanity-check an unrelated post with a normal featured image to confirm no regression.
5. `yarn test-client client/lib/post-normalizer/test/index.js` — all green.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?