### PR TITLE
e2e: open Link preview via the new "View previews" button

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -122,8 +122,24 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Link preview', function () {
 			it( 'Open link preview', async function () {
-				await editorPage.expandSection( 'Link preview' );
-				await editorPage.clickSidebarButton( 'Open link preview' );
+				// Newer Jetpack replaced the standalone "Link preview" panel with a
+				// "View previews" button in the "Optimize SEO" panel (same previews
+				// modal). Older Jetpack still renders the panel. Support both until the
+				// environments converge.
+				const editorParent = await editorPage.getEditorParent();
+				const viewPreviewsButton = editorParent.getByRole( 'button', { name: 'View previews' } );
+				const linkPreviewPanelButton = editorParent.locator(
+					'.components-panel__body-title button:has-text("Link preview")'
+				);
+				// Wait for whichever entry point this Jetpack version renders.
+				await viewPreviewsButton.or( linkPreviewPanelButton ).first().waitFor();
+
+				if ( await viewPreviewsButton.count() ) {
+					await viewPreviewsButton.first().click();
+				} else {
+					await editorPage.expandSection( 'Link preview' );
+					await editorPage.clickSidebarButton( 'Open link preview' );
+				}
 			} );
 
 			it( 'Show link preview for Tumblr', async function () {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -127,19 +127,29 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 				// modal). Older Jetpack still renders the panel. Support both until the
 				// environments converge.
 				const editorParent = await editorPage.getEditorParent();
-				const viewPreviewsButton = editorParent.getByRole( 'button', { name: 'View previews' } );
+				const viewPreviewsButton = editorParent.getByRole( 'button', {
+					name: 'View previews',
+					exact: true,
+				} );
 				const linkPreviewPanelButton = editorParent.locator(
 					'.components-panel__body-title button:has-text("Link preview")'
 				);
 				// Wait for whichever entry point this Jetpack version renders.
 				await viewPreviewsButton.or( linkPreviewPanelButton ).first().waitFor();
 
-				if ( await viewPreviewsButton.count() ) {
+				// count() resolves immediately on DOM presence, which is what tells the
+				// two Jetpack variants apart; click() then auto-waits for the button to
+				// become actionable (e.g. while the panel animates open).
+				if ( ( await viewPreviewsButton.count() ) > 0 ) {
 					await viewPreviewsButton.first().click();
 				} else {
 					await editorPage.expandSection( 'Link preview' );
 					await editorPage.clickSidebarButton( 'Open link preview' );
 				}
+
+				// Confirm the previews modal (identified by its per-platform tabs) opened,
+				// so a broken entry point fails here instead of in the next (serial) test.
+				await editorParent.getByRole( 'dialog' ).getByRole( 'tab', { name: 'Tumblr' } ).waitFor();
 			} );
 
 			it( 'Show link preview for Tumblr', async function () {


### PR DESCRIPTION
## Proposed Changes

* Open the Link preview / Social Previews modal via the new "View previews" button in the "Optimize SEO" panel, with a fallback to the old standalone "Link preview" panel for environments still on the previous Jetpack UI.

## Why are these changes being made?

Reported via TeamCity Slack alert p1782361095728099-slack-C020H2DD6MD.

The Gutenberg Atomic nightly `Link preview: Open link preview` test has failed on every run since 2026-06-24. Newer Jetpack, now deployed to Atomic, removed the standalone "Link preview" editor panel; the previews modal is now opened by a "View previews" button inside the "Optimize SEO" panel. The same test still passes on Simple sites, which run the older UI, so the change keeps both paths working until they converge.

The previews modal itself (Tumblr tab, dismiss) is unchanged, confirmed by a TeamCity probe run against a real Atomic site.

### Builds

- First failing nightly (#1858): https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_nightly_desktop/18260757
- Latest failing nightly (#1861): https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_nightly_desktop/18279940
- Probe run that captured the new UI: https://teamcity.a8c.com/build/18284276
- Same config passing on this branch: https://teamcity.a8c.com/build/18288115

## Testing Instructions

* Gutenberg Atomic desktop E2E build against this branch should pass `Editor: Basic Post Flow: Jetpack features: Link preview` (Open / Show Tumblr / Dismiss).
* Simple Gutenberg E2E build should remain green (fallback path).

