### PR TITLE
Fix viewport-react npm dependency metadata

### DIFF
--- a/packages/viewport-react/CHANGELOG.md
+++ b/packages/viewport-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
+
 ## 1.0.2
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/viewport-react",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "React helpers for tracking viewport changes.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Related DOTCOM-17711

## Proposed Changes

* Bump `@automattic/viewport-react` to `1.0.3`.
* Replace its published `@wordpress/compose` dependency metadata from Yarn `patch:` protocol to the npm-installable `^8.1.0` range.
* Update the package changelog.

## Why are these changes being made?

The Yarn patch was a local hotfix for @wordpress/compose.
@wordpress/compose’s built `useMediaQuery` / `useViewportMatch` code defaulted a parameter to window, so in SSR or other non-browser contexts it could throw when window was undefined. The patch changed that default to guard window first. `npm` consumers cannot install that. For `@automattic/viewport-react`, the patch is not needed anyway because it only uses createHigherOrderComponent, not the patched hooks, so switching it to a normal npm range is the easiest safe fix.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/viewport-react prepack`
* `cd packages/viewport-react && yarn pack --out /private/tmp/automattic-viewport-react-1.0.3.tgz`
* Confirmed the packed `package.json` contains `"@wordpress/compose": "^8.1.0"`.
* Created a temporary npm consumer and ran `npm install --package-lock-only --ignore-scripts --legacy-peer-deps` against the packed tarball successfully.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
