### PR TITLE
Remove A4A payment notice feature flag

### DIFF
--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/constants.ts
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/constants.ts
@@ -1,8 +1,0 @@
-import { isEnabled } from '@automattic/calypso-config';
-import type { PaymentNoticeSeverity } from 'calypso/state/a8c-for-agencies/types';
-
-export const PAYMENT_RISK_NOTICE_BANNER_FLAG = 'a4a-payment-risk-notice-banner';
-
-export type PaymentRiskNoticeSeverity = PaymentNoticeSeverity;
-
-export const isPaymentRiskNoticeBannerEnabled = () => isEnabled( PAYMENT_RISK_NOTICE_BANNER_FLAG );

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import type { PaymentRiskNoticeSeverity } from './constants';
+import type { PaymentNoticeSeverity } from 'calypso/state/a8c-for-agencies/types';
 
 import './style.scss';
 
 type PaymentRiskNoticeMenuIndicatorProps = {
-	severity: PaymentRiskNoticeSeverity;
+	severity: PaymentNoticeSeverity;
 };
 
 export default function PaymentRiskNoticeMenuIndicator( {

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
@@ -106,16 +106,18 @@ describe( 'PaymentRiskNoticeBanner', () => {
 			primary_action_label: 'Update your payment method',
 			primary_action_url: 'https://wordpress.com/me/billing/purchases',
 		};
-		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'a4a-payment-risk-notice-banner' );
+		mockedIsEnabled.mockReturnValue( false );
 	} );
 
-	it( 'does not render when the feature flag is disabled', () => {
-		mockedIsEnabled.mockReturnValue( false );
+	it( 'renders when the payment notice is present without requiring a feature flag', () => {
+		render( <PaymentRiskNoticeBanner source="overview" /> );
 
-		const { container } = render( <PaymentRiskNoticeBanner source="overview" /> );
-
-		expect( container ).toBeEmptyDOMElement();
-		expect( mockDispatch ).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole( 'heading', {
+				name: 'Action required: We are unable to renew your subscription(s)',
+			} )
+		).toBeVisible();
+		expect( mockedIsEnabled ).toHaveBeenCalledWith( 'a4a-bd-checkout' );
 	} );
 
 	it( 'does not render when the payment notice is missing', () => {

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice.ts
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice.ts
@@ -1,14 +1,9 @@
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { isPaymentRiskNoticeBannerEnabled } from './constants';
 import type { PaymentNotice } from 'calypso/state/a8c-for-agencies/types';
 
 export default function usePaymentRiskNotice(): PaymentNotice | null {
 	const agency = useSelector( getActiveAgency );
-
-	if ( ! isPaymentRiskNoticeBannerEnabled() ) {
-		return null;
-	}
 
 	return agency?.payment_notice ?? null;
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -34,7 +34,6 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
-		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": true,
 		"a4a-pressable-referrals": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -31,7 +31,6 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
-		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -33,7 +33,6 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
-		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -33,7 +33,6 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
-		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,


### PR DESCRIPTION
Part of #

## Proposed Changes

* Remove the temporary `a4a-payment-risk-notice-banner` config flag.
* Show the A4A payment-risk banner whenever the agency API returns `payment_notice`.
* Show the Purchases sidebar indicator whenever the agency API returns `payment_notice`.

## Why are these changes being made?

* The backend payment notice payload and Calypso CTA rendering have merged, so the temporary kill switch can be removed.

## Testing Instructions

* Check the code changes.
* Run `yarn prettier --write client/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator.tsx client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx client/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice.ts config/a8c-for-agencies-development.json config/a8c-for-agencies-horizon.json config/a8c-for-agencies-production.json config/a8c-for-agencies-stage.json`.
* Run `yarn eslint --quiet client/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator.tsx client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx client/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice.ts`.
* Run `yarn test-client client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx --runInBand`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.
* Open A4A with an agency whose API response includes `payment_notice`.
* Verify the banner shows on Overview and Purchases pages without enabling a feature flag.
* Verify the Purchases sidebar indicator appears without enabling a feature flag.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

_— ClemenAgent (Powered by Codex)_
