### PR TITLE
Fix site-admin npm dependency metadata

### DIFF
--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
+
 ## 0.1.4
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/site-admin",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "A reusable UI package providing essential resources for building a modern administrative interface within the WordPress admin. It offers structured components, a routing system, and layout utilities.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Related DOTCOM-17711

## Proposed Changes

* Bump `@automattic/site-admin` to `0.1.5`.
* Replace the published `@wordpress/compose` dependency metadata with the npm-installable `^8.1.0` range.
* Add a changelog entry for the package consumer installability fix.

## Why are these changes being made?

* Published `@automattic/site-admin` metadata currently exposes Yarn's `patch:` protocol for `@wordpress/compose`, which npm consumers cannot install.
* `@automattic/site-admin` imports `useEvent` from `@wordpress/compose`, so it does not depend on the local patch that only affects `useMediaQuery` and `useViewportMatch`.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/site-admin prepack`
* `cd packages/site-admin && yarn pack --out /private/tmp/automattic-site-admin-0.1.5.tgz`
* `npm --cache /private/tmp/npm-cache-site-admin-0.1.5 install /private/tmp/automattic-site-admin-0.1.5.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
