### PR TITLE
Fix grid npm dependency metadata

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.2
+
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
+
 ## 0.2.1
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/grid",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Grid component for Automattic projects.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related DOTCOM-17711

## Proposed Changes

* Bump `@automattic/grid` to `0.2.2`.
* Replace the published `@wordpress/compose` dependency metadata with the npm-installable `^8.1.0` range.
* Add a changelog entry for the package consumer installability fix.

## Why are these changes being made?

* Published `@automattic/grid` metadata currently exposes Yarn's `patch:` protocol for `@wordpress/compose`, which npm consumers cannot install.
* `@automattic/grid` uses `useResizeObserver`, `useDebounce`, `useEvent`, and `useThrottle` from `@wordpress/compose`, so it does not depend on the local patch that only affects `useMediaQuery` and `useViewportMatch`.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/grid prepack`
* `cd packages/grid && yarn pack --out /private/tmp/automattic-grid-0.2.2.tgz`
* `npm --cache /private/tmp/npm-cache-grid-0.2.2 install /private/tmp/automattic-grid-0.2.2.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
