### PR TITLE
Fix search npm package metadata

### DIFF
--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
+
 ## 1.1.1
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/search",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Automattic Search.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -53,6 +53,7 @@
 		"react-dom": "^18.3.1 || ^19.0.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
@@ -62,6 +63,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"@wordpress/data": "^10.48.0",
 		"@wordpress/is-shallow-equal": "^5.48.0",
+		"postcss": "^8.5.3",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"storybook": "^9.1.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,6 +2142,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/search@workspace:packages/search"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -2161,6 +2162,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     fuse.js: "npm:^6.6.2"
     lodash: "npm:^4.17.21"
+    postcss: "npm:^8.5.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"


### PR DESCRIPTION
Related DOTCOM-17711

## Proposed Changes

* Bump `@automattic/search` to `1.1.2`.
* Replace the published `@wordpress/compose` dependency metadata with the npm-installable `^8.1.0` range.
* Add the missing `@automattic/calypso-build` and `postcss` dev dependencies required by the package's `prepack` build.
* Add a changelog entry for the package consumer installability fix.

## Why are these changes being made?

* Published package metadata should not expose Yarn's `patch:` protocol, because npm consumers cannot install it.
* `@automattic/search` uses `debounce` and `useInstanceId` from `@wordpress/compose`, so it does not depend on the local patch that only affects `useMediaQuery` and `useViewportMatch`.
* The package build script runs `copy-assets`, which is provided by `@automattic/calypso-build`; declaring it keeps the package packable in isolation.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/search prepack`
* `cd packages/search && yarn pack --out /private/tmp/automattic-search-1.1.2.tgz`
* `npm --cache /private/tmp/npm-cache-search-1.1.2 install /private/tmp/automattic-search-1.1.2.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
