### PR TITLE
Fix i18n-utils npm dependency metadata

### DIFF
--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Next
+## 1.3.0
 
-Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully supported) `new Intl.Locale( locale ).getWeekInfo()`
+- Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully supported) `new Intl.Locale( locale ).getWeekInfo()`.
 
-Get rid of implicit lodash dependency
+- Get rid of implicit lodash dependency.
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
 
 ## 1.2.4
 

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-utils",
-	"version": "1.2.4",
+	"version": "1.3.0",
 	"description": "WordPress.com i18n utils.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",


### PR DESCRIPTION
Related DOTCOM-17711

## Proposed Changes

* Bump `@automattic/i18n-utils` to `1.3.0`.
* Replace the published `@wordpress/compose` dependency metadata with the npm-installable `^8.1.0` range.
* Promote the existing `Next` changelog entries into the `1.3.0` release entry.

## Why are these changes being made?

* Published `@automattic/i18n-utils` metadata currently exposes Yarn's `patch:` protocol for `@wordpress/compose`, which npm consumers cannot install.
* `@automattic/i18n-utils` only uses `createHigherOrderComponent` from `@wordpress/compose`, so it does not depend on the local patch that only affects `useMediaQuery` and `useViewportMatch`.
* The package already had unreleased minor changes documented under `Next`, so this release entry is versioned as `1.3.0`.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/i18n-utils prepack`
* `cd packages/i18n-utils && yarn pack --out /private/tmp/automattic-i18n-utils-1.3.0.tgz`
* `npm --cache /private/tmp/npm-cache-i18n-utils-1.3.0 install /private/tmp/automattic-i18n-utils-1.3.0.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
