### PR TITLE
Fix ui npm package metadata

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.0.0
 
 ### Breaking Changes
 
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - `Stepper`, `VerticalStepper`, `HorizontalStepper`: Add Stepper component suite with vertical and horizontal orientations, step indicators, linear flow support, and accessible ARIA semantics ([#111036](https://github.com/Automattic/wp-calypso/pull/111036)).
+- Remove the unused `@wordpress/compose` dependency from the published package metadata.
 
 ## 1.0.3
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/ui",
-	"version": "1.0.3",
+	"version": "2.0.0",
 	"description": "Automattic Design System UI components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -42,7 +42,6 @@
 	"dependencies": {
 		"@base-ui/react": "^1.5.0",
 		"@wordpress/base-styles": "9.1.0",
-		"@wordpress/compose": "^8.2.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,7 +2355,6 @@ __metadata:
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
     "@wordpress/base-styles": "npm:9.1.0"
-    "@wordpress/compose": "npm:^8.2.0"
     "@wordpress/element": "npm:^8.0.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"


### PR DESCRIPTION
## Proposed Changes

* Bump `@automattic/ui` to `2.0.0`.
* Remove the unused `@wordpress/compose` dependency from the published package metadata.
* Promote the existing `Unreleased` changelog entries into the `2.0.0` release entry.

## Why are these changes being made?

* Published package metadata should not expose Yarn's `patch:` protocol, because npm consumers cannot install it.
* `@automattic/ui` does not import `@wordpress/compose`, so the dependency can be removed instead of converted to a normal npm range.
* The package already had an unreleased breaking change documented, so this release entry is versioned as `2.0.0`.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/ui prepack`
* `cd packages/ui && env PATH=/Users/omaralshaker/.nvm/versions/node/v24.16.0/bin:$PATH yarn pack --out /private/tmp/automattic-ui-2.0.0.tgz`
* `npm --cache /private/tmp/npm-cache-ui-2.0.0 install /private/tmp/automattic-ui-2.0.0.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

Note: the explicit `PATH` in the pack command keeps Yarn on the same arm64 Node used by the repo-root workspace command. The package-local shell otherwise picked `/usr/local/bin/node` x64 and tripped Rollup's optional native dependency lookup.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
