### PR TITLE
Fix i18n-calypso packed artifacts

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,9 +1,11 @@
-## Trunk
+## 8.0.0
 
 - Breaking: Emitter object replaced with subscriber
   - Before: `i18n.on( 'change', callback ); i18n.off( 'change', callback );`
   - After: `const unsubscribe = i18n.subscribe( callback ); unsubscribe();`
 - Breaking: Removed `geolocateCurrencySymbol` function. Country code assignment is handled in the `format-currency` package `setGeoLocation` function.
+- Fix the package lifecycle so packed artifacts include built `dist` files.
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
 
 ## 7.4.1
 

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "7.4.1",
+	"version": "8.0.0",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -28,6 +28,7 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepare": "yarn run clean && yarn run build",
+		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
 		"test": "yarn jest"
 	},


### PR DESCRIPTION
## Proposed Changes

* Bump `i18n-calypso` to `8.0.0`.
* Add a `prepack` lifecycle script so `yarn pack` builds `dist` before creating the package artifact.
* Replace the published `@wordpress/compose` dependency metadata with the npm-installable `^8.1.0` range.
* Promote the existing `Trunk` changelog entries into the `8.0.0` release entry.

## Why are these changes being made?

* A clean `yarn pack` for `i18n-calypso` produced a tarball without `dist/**`, even though `main` and `module` point to `dist/cjs/index.js` and `dist/esm/index.js`.
* Yarn calls `prepack` before packing, but this package only had `prepare`, so the build output could be absent from the artifact.
* Published package metadata should not expose Yarn's `patch:` protocol, because npm consumers cannot install it.
* The package already had unreleased breaking changes documented, so this release entry is versioned as `8.0.0`.

## Testing Instructions

Before this change, after cleaning `dist`, the packed tarball did not contain any `package/dist/**` files.

After this change:

* `yarn install`
* `yarn workspace i18n-calypso run clean`
* Confirmed `packages/i18n-calypso/dist` was missing after clean.
* `cd packages/i18n-calypso && yarn pack --out /private/tmp/i18n-calypso-8.0.0-clean-pack-check.tgz`
* `tar -tf /private/tmp/i18n-calypso-8.0.0-clean-pack-check.tgz | rg '^package/dist/(cjs|esm|types)/'`
* Confirmed the tarball contains 44 `package/dist/**` files.
* `npm --cache /private/tmp/npm-cache-i18n-calypso-8.0.0 install /private/tmp/i18n-calypso-8.0.0-clean-pack-check.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
