### PR TITLE
Fix components npm dependency metadata

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,8 +1,9 @@
-## Unreleased
+## 4.0.0
 
 ### Breaking Changes
 
 - `Icon`: Remove component. Use `Icon` from `@wordpress/ui` instead.
+- Use an npm-installable `@wordpress/compose` dependency range for package consumers.
 
 ## 3.0.5
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "3.0.5",
+	"version": "4.0.0",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed Changes

* Bump `@automattic/components` to `4.0.0`.
* Replace the published `@wordpress/compose` dependency metadata with the npm-installable `^8.1.0` range.
* Promote the existing `Unreleased` changelog entry into the `4.0.0` release entry.

## Why are these changes being made?

* Published package metadata should not expose Yarn's `patch:` protocol, because npm consumers cannot install it.
* `@automattic/components` uses `useResizeObserver`, `useMergeRefs`, `useIsomorphicLayoutEffect`, and `useEvent` from `@wordpress/compose`, so it does not depend on the local patch that only affects `useMediaQuery` and `useViewportMatch`.
* The package already had an unreleased breaking change documented, so this release entry is versioned as `4.0.0`.

## Testing Instructions

* `yarn install`
* `yarn workspace @automattic/components prepack`
* `cd packages/components && yarn pack --out /private/tmp/automattic-components-4.0.0.tgz`
* Inspected the packed `package.json` and confirmed `@wordpress/compose` is `^8.1.0`.
* Confirmed the tarball contains 1,062 `package/dist/**` files.

I also ran:

* `npm --cache /private/tmp/npm-cache-components-4.0.0 install /private/tmp/automattic-components-4.0.0.tgz --package-lock-only --ignore-scripts --legacy-peer-deps --loglevel=warn`

That full consumer install still fails on `EUNSUPPORTEDPROTOCOL` from transitive published packages that still expose the old `patch:` protocol. This PR fixes the direct `@automattic/components` metadata; the end-to-end install should be rerun after the related package metadata PRs land and are published.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
