### PR TITLE
Agents Manager: AI & Help entry points in the block editor

### DIFF
--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -31,6 +31,12 @@ function HelpCenterContent() {
 
 	const canvasMode = useCanvasMode();
 
+	// Gutenberg's "admin bar in editor" (omnibar) experiment puts a top admin bar in the editor.
+	// When it's active, the legacy Help button moves out of the toolbar and into that admin bar.
+	const isAdminBarInEditor =
+		!! window.__experimentalAdminBarInEditor ||
+		document.body.classList.contains( 'has-admin-bar-in-editor' );
+
 	const trackIconInteraction = useCallback( () => {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown ?? false,
@@ -105,14 +111,22 @@ function HelpCenterContent() {
 	const sidebarActionsContainer = document.querySelector( '.edit-site-site-hub__actions' );
 
 	const hasInitialized = useRef( false );
-	// On mobile the SlotFill button is hidden by Gutenberg's own CSS, so wire up the
-	// admin bar icon that our PHP adds for the gutenberg variant instead.
+	// When the toolbar SlotFill button isn't shown — on mobile (hidden by Gutenberg's CSS) or
+	// under the omnibar (where we hide it) — wire up the admin bar icon our PHP adds instead.
 	const adminBarButton = document.getElementById( 'wp-admin-bar-help-center' );
 	useEffect( () => {
-		if ( isDesktop || ! adminBarButton ) {
+		if ( ( isDesktop && ! isAdminBarInEditor ) || ! adminBarButton ) {
 			return;
 		}
 		adminBarButton.onclick = handleToggleHelpCenter;
+
+		// At >= 600px our PHP hides this admin bar item to avoid duplicating the toolbar button;
+		// under the omnibar that button is gone, so reveal it. Revealing from JS — which the
+		// unified experience dequeues with this bundle — keeps it hidden when unified, like the
+		// toolbar button.
+		if ( isAdminBarInEditor ) {
+			adminBarButton.style.setProperty( 'display', 'block', 'important' );
+		}
 
 		// make sure it's closed from the beginning
 		if ( ! hasInitialized.current ) {
@@ -132,9 +146,10 @@ function HelpCenterContent() {
 
 		return () => {
 			adminBarButton.onclick = null;
+			adminBarButton.style.removeProperty( 'display' );
 			document.documentElement.style.removeProperty( '--masterbar-height' );
 		};
-	}, [ isDesktop, adminBarButton, handleToggleHelpCenter, setShowHelpCenter ] );
+	}, [ isDesktop, isAdminBarInEditor, adminBarButton, handleToggleHelpCenter, setShowHelpCenter ] );
 
 	// On mobile, close the Help Center as soon as the user taps a button in
 	// the editor header or the admin bar. The panel has a very high z-index
@@ -241,7 +256,9 @@ function HelpCenterContent() {
 				canvasMode === 'view' &&
 				sidebarActionsContainer &&
 				ReactDOM.createPortal( content, sidebarActionsContainer ) }
-			{ isDesktop && showHelpIcon && <Fill name="PinnedItems/core">{ content }</Fill> }
+			{ isDesktop && showHelpIcon && ! isAdminBarInEditor && (
+				<Fill name="PinnedItems/core">{ content }</Fill>
+			) }
 			<HelpCenter
 				locale={ helpCenterData.locale }
 				sectionName={ helpCenterData.sectionName || 'gutenberg-editor' }

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -82,6 +82,14 @@ jest.mock( '../../utils/persist-last-activity', () => ( {
 	persistLastActivity: jest.fn(),
 } ) );
 jest.mock( '../agent-dock/style.scss', () => ( {} ) );
+jest.mock( '../editor-ai-chat-button', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( '../editor-help-center-button', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
 jest.mock( '../orchestrator-chat', () => ( {
 	__esModule: true,
 	default: ( {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -22,6 +22,8 @@ import { persistLastActivity } from '../../utils/persist-last-activity';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
+import EditorAiChatButton from '../editor-ai-chat-button';
+import EditorHelpCenterButton from '../editor-help-center-button';
 import OrchestratorChat from '../orchestrator-chat';
 import SupportGuide from '../support-guide';
 import SupportGuides from '../support-guides';
@@ -152,24 +154,24 @@ export default function AgentDock( {
 		}
 	};
 
+	// Open/un-minimize the chat panel, leaving the route unchanged.
+	const openChat = () => {
+		if ( isMinimized ) {
+			setIsMinimized( false );
+		}
+
+		// Skip a redundant save when the chat is already open.
+		if ( ! isPersistedOpen ) {
+			if ( isDocked ) {
+				openSidebar();
+			} else {
+				setOpenState( true );
+			}
+		}
+	};
+
 	// WP admin bar integration. Returns whether the AI chat entry button is present.
-	const hasAiChatEntry = useAdminBarIntegration( {
-		closeChat: handleClose,
-		// Open/un-minimize the chat panel, leaving the route unchanged.
-		maybeOpenChat: () => {
-			if ( isMinimized ) {
-				setIsMinimized( false );
-			}
-			// Skip a redundant save when the chat is already open.
-			if ( ! isPersistedOpen ) {
-				if ( isDocked ) {
-					openSidebar();
-				} else {
-					setOpenState( true );
-				}
-			}
-		},
-	} );
+	const hasAiChatEntry = useAdminBarIntegration( { closeChat: handleClose, openChat } );
 
 	// Route visibility. All are hidden in reader chat (public blog frontends);
 	// some add a further requirement, noted below. Ordered to match the routes.
@@ -370,19 +372,31 @@ export default function AgentDock( {
 		/>
 	);
 
+	// When chat rendering is disabled there's nothing to open, so render nothing — the editor
+	// entry-point buttons would otherwise be dead.
+	if ( ! shouldRenderChat ) {
+		return null;
+	}
+
 	return (
-		shouldRenderChat &&
-		isChatVisible &&
-		createAgentPortal(
-			// NOTE: Use route state to pass data that needs to be accessed throughout the app.
-			<Routes>
-				<Route path="/chat" element={ OrchestratorChatRoute } />
-				{ showZendeskChat && <Route path="/zendesk" element={ ZendeskChatRoute } /> }
-				{ showSupportGuides && <Route path="/support-guides" element={ SupportGuidesRoute } /> }
-				{ showSupportGuide && <Route path="/post" element={ SupportGuideRoute } /> }
-				{ showChatHistory && <Route path="/history" element={ HistoryRoute } /> }
-				<Route path="*" element={ <Navigate to="/chat" state={ { isNewChat: true } } replace /> } />
-			</Routes>
-		)
+		<>
+			<EditorHelpCenterButton onClose={ handleClose } onOpenChat={ openChat } />
+			<EditorAiChatButton onClose={ handleClose } onOpenChat={ openChat } />
+			{ isChatVisible &&
+				createAgentPortal(
+					// NOTE: Use route state to pass data that needs to be accessed throughout the app.
+					<Routes>
+						<Route path="/chat" element={ OrchestratorChatRoute } />
+						{ showZendeskChat && <Route path="/zendesk" element={ ZendeskChatRoute } /> }
+						{ showSupportGuides && <Route path="/support-guides" element={ SupportGuidesRoute } /> }
+						{ showSupportGuide && <Route path="/post" element={ SupportGuideRoute } /> }
+						{ showChatHistory && <Route path="/history" element={ HistoryRoute } /> }
+						<Route
+							path="*"
+							element={ <Navigate to="/chat" state={ { isNewChat: true } } replace /> }
+						/>
+					</Routes>
+				) }
+		</>
 	);
 }

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -380,6 +380,11 @@ body.site-editor-php.agents-manager-sidebar-container {
 	&.agents-manager-sidebar-container--sidebar-open {
 		@include sidebar-open-base( '.edit-site-layout__canvas' );
 		@include editor-save-panel-open();
+		// Under the omnibar, square off the canvas top (the admin bar above owns the top rounding).
+		&.has-admin-bar-in-editor .edit-site-layout__canvas {
+			border-top-left-radius: 0;
+			border-top-right-radius: 0;
+		}
 
 		// Override canvas styles when the site editor navigation menu is open
 		.edit-site-layout:not( .is-full-canvas ) .edit-site-layout__canvas {
@@ -389,7 +394,7 @@ body.site-editor-php.agents-manager-sidebar-container {
 	}
 }
 
-/* Page editor */
+/* Post editor (posts and pages) */
 body.post-php.agents-manager-sidebar-container,
 body.post-new-php.agents-manager-sidebar-container {
 	@include sidebar-base( '.edit-post-layout' );
@@ -401,6 +406,11 @@ body.post-new-php.agents-manager-sidebar-container {
 	&.agents-manager-sidebar-container--sidebar-open {
 		@include sidebar-open-base( '.edit-post-layout' );
 		@include editor-save-panel-open();
+		// Under the omnibar, square off the canvas top (the admin bar above owns the top rounding).
+		&.has-admin-bar-in-editor .edit-post-layout {
+			border-top-left-radius: 0;
+			border-top-right-radius: 0;
+		}
 
 		// Split-screen clips the editor shell for rounded corners. Gutenberg's
 		// desktop header grid can otherwise push the settings group past that

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -27,8 +27,8 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 	const { setIsMinimized } = useDispatch( AGENTS_MANAGER_STORE );
 	const [ hasAiChatEntry ] = useState( hasAiChatEntryButton );
 
-	// Minimize only applies to the floating chat reachable from the AI chat button
-	// (WP admin bar or Calypso masterbar).
+	// Minimize only applies to the floating chat reachable from an AI chat entry button
+	// (wp-admin bar, Calypso masterbar, or editor toolbar).
 	const showMinimize = hasAiChatEntry && ! isDocked;
 
 	return (

--- a/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
+++ b/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
@@ -1,0 +1,68 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, Fill } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useAgentsManagerContext } from '../../contexts';
+import { AGENTS_MANAGER_STORE } from '../../stores';
+import { isEditorAiEntryEnabled } from '../../utils/editor-entry-points';
+import { AI } from '../icons';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+import './style.scss';
+
+interface Props {
+	/** Closes/hides the chat — owned by `AgentDock`. */
+	onClose: () => void;
+	/** Opens/un-minimizes the chat — owned by `AgentDock`'s layout manager. */
+	onOpenChat: () => void;
+}
+
+/**
+ * Ask AI button for the block editor header, shown to the right of the Help Center "?" button.
+ * The `PinnedItems/core` fill is inert outside the editor.
+ */
+export default function EditorAiChatButton( { onClose, onOpenChat }: Props ) {
+	const { resumeActiveChat, sectionName } = useAgentsManagerContext();
+	const { isOpen, isMinimized } = useSelect(
+		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getAgentsManagerState(),
+		[]
+	);
+
+	if ( ! isEditorAiEntryEnabled() ) {
+		return null;
+	}
+
+	const isChatVisible = isOpen && ! isMinimized;
+
+	// Mirrors the admin-bar button: close if showing, else resume the active conversation and open.
+	const handleToggle = () => {
+		recordTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
+			section: sectionName || 'gutenberg',
+			action: isChatVisible ? 'close' : 'open',
+		} );
+
+		if ( isChatVisible ) {
+			onClose();
+			return;
+		}
+
+		resumeActiveChat();
+		onOpenChat();
+	};
+
+	return (
+		<Fill name="PinnedItems/core">
+			<Button
+				className={ clsx( 'entry-point-button', 'agents-manager-ai-chat', {
+					'is-active': isChatVisible,
+				} ) }
+				onClick={ handleToggle }
+				icon={ <AI /> }
+				label={ __( 'Ask AI', '__i18n_text_domain__' ) }
+				aria-pressed={ isChatVisible }
+				aria-expanded={ isChatVisible }
+				size="compact"
+			/>
+		</Fill>
+	);
+}

--- a/packages/agents-manager/src/components/editor-ai-chat-button/style.scss
+++ b/packages/agents-manager/src/components/editor-ai-chat-button/style.scss
@@ -1,0 +1,15 @@
+// Order our entry points first in the editor's pinned items — Help Center "?" then Ask AI —
+// ahead of other plugins (default `order: 0`), without affecting them. `.help-center` is the
+// legacy Help button and `.agents-manager-help-center` our unified one (only one shows at a
+// time). `:has()` limits this to when our entry points are present.
+.interface-pinned-items:has( .agents-manager-ai-chat ),
+.interface-pinned-items:has( .agents-manager-help-center ) {
+	> .help-center,
+	> .agents-manager-help-center {
+		order: -2;
+	}
+
+	> .agents-manager-ai-chat {
+		order: -1;
+	}
+}

--- a/packages/agents-manager/src/components/editor-help-center-button/index.tsx
+++ b/packages/agents-manager/src/components/editor-help-center-button/index.tsx
@@ -1,0 +1,118 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { DropdownMenu, Fill } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { backup, comment, help, page, rss, video } from '@wordpress/icons';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAgentsManagerContext } from '../../contexts';
+import { AGENTS_MANAGER_STORE } from '../../stores';
+import { isEditorHelpMenuEnabled } from '../../utils/editor-entry-points';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+
+interface Props {
+	/** Closes/hides the chat — owned by `AgentDock`. */
+	onClose: () => void;
+	/** Opens/un-minimizes the chat — owned by `AgentDock`'s layout manager. */
+	onOpenChat: () => void;
+}
+
+/**
+ * Help Center "?" dropdown for the block editor header, shown to the left of the Ask AI button.
+ * Replaces the legacy Help Center button in the unified experience (which dequeues it). Items
+ * and behavior mirror the `/wp-admin` admin-bar Help menu. The `PinnedItems/core` fill is inert
+ * outside the editor.
+ */
+export default function EditorHelpCenterButton( { onClose, onOpenChat }: Props ) {
+	const navigate = useNavigate();
+	const { pathname } = useLocation();
+	const { resumeActiveChat, sectionName } = useAgentsManagerContext();
+	const { isOpen, isMinimized } = useSelect(
+		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getAgentsManagerState(),
+		[]
+	);
+
+	if ( ! isEditorHelpMenuEnabled() ) {
+		return null;
+	}
+
+	const isChatVisible = isOpen && ! isMinimized;
+
+	// Chat items mirror the admin-bar Help menu: re-clicking the item for the route already
+	// showing closes the chat; otherwise navigate there and open it.
+	const selectChatRoute = ( destination: string, route: string, onSelect: () => void ) => {
+		const isClosing = isChatVisible && pathname === route;
+
+		recordTracksEvent( 'calypso_editor_agents_manager_help_menu_clicked', {
+			section: sectionName || 'gutenberg',
+			destination,
+			action: isClosing ? 'close' : 'open',
+		} );
+
+		if ( isClosing ) {
+			onClose();
+			return;
+		}
+
+		onSelect();
+		onOpenChat();
+	};
+
+	const openExternalLink = ( url: string ) => window.open( url, '_blank', 'noopener,noreferrer' );
+
+	// Grouped like the admin-bar Help menu: a chat group, then a resources group, split by a
+	// divider. Chat support, Chat history, and Support guides open the chat; Courses and Product
+	// updates open external pages (untracked, matching the admin bar's plain links).
+	const controls = [
+		[
+			{
+				title: __( 'Chat support', '__i18n_text_domain__' ),
+				icon: comment,
+				onClick: () => selectChatRoute( 'agents-manager-chat', '/chat', resumeActiveChat ),
+			},
+			{
+				title: __( 'Chat history', '__i18n_text_domain__' ),
+				icon: backup,
+				onClick: () =>
+					selectChatRoute( 'agents-manager-history', '/history', () => navigate( '/history' ) ),
+			},
+		],
+		[
+			{
+				title: __( 'Support guides', '__i18n_text_domain__' ),
+				icon: page,
+				onClick: () =>
+					selectChatRoute( 'agents-manager-support-guides', '/support-guides', () =>
+						navigate( '/support-guides' )
+					),
+			},
+			{
+				title: __( 'Courses', '__i18n_text_domain__' ),
+				icon: video,
+				onClick: () => openExternalLink( localizeUrl( 'https://wordpress.com/support/courses/' ) ),
+			},
+			{
+				title: __( 'Product updates', '__i18n_text_domain__' ),
+				icon: rss,
+				onClick: () =>
+					openExternalLink(
+						localizeUrl( 'https://wordpress.com/blog/category/product-features/' )
+					),
+			},
+		],
+	];
+
+	return (
+		<Fill name="PinnedItems/core">
+			<DropdownMenu
+				className="entry-point-button agents-manager-help-center"
+				icon={ help }
+				label={ __( 'Help Center', '__i18n_text_domain__' ) }
+				controls={ controls }
+				popoverProps={ { position: 'bottom left' } }
+				// Match the Ask AI button (and editor-header convention) so the icon/button size lines up.
+				toggleProps={ { size: 'compact' } }
+			/>
+		</Fill>
+	);
+}

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { isEditorAiEntryEnabled } from '../../utils/editor-entry-points';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 import './style.scss';
 
@@ -19,11 +20,12 @@ const ADMIN_BAR_AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
 const MASTERBAR_AI_CHAT_BUTTON_SELECTOR = '.masterbar__item-agents-manager-ai-chat';
 
 /**
- * Whether the AI chat button (wp-admin bar or Calypso masterbar) is present.
- * If so, the chat hides on close and reopens from it instead of a floating bubble.
+ * Whether an AI chat entry button (wp-admin bar, Calypso masterbar, or editor toolbar) is
+ * present. If so, the chat hides on close and reopens from it instead of a floating bubble.
  */
 export function hasAiChatEntryButton(): boolean {
 	return (
+		isEditorAiEntryEnabled() ||
 		!! document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID ) ||
 		!! document.querySelector( MASTERBAR_AI_CHAT_BUTTON_SELECTOR )
 	);
@@ -38,7 +40,7 @@ const DESTINATION_HISTORY = 'agents-manager-history';
 const DESTINATION_GUIDES = 'agents-manager-support-guides';
 
 interface UseAdminBarIntegrationOptions {
-	maybeOpenChat: () => void;
+	openChat: () => void;
 	closeChat: () => void;
 }
 
@@ -53,7 +55,7 @@ interface UseAdminBarIntegrationOptions {
  * Returns whether the AI chat entry button is present on the page.
  */
 export default function useAdminBarIntegration( {
-	maybeOpenChat,
+	openChat,
 	closeChat,
 }: UseAdminBarIntegrationOptions ): boolean {
 	const navigate = useNavigate();
@@ -65,8 +67,8 @@ export default function useAdminBarIntegration( {
 	);
 
 	// Refs keep the latest callbacks without re-attaching DOM listeners each render.
-	const maybeOpenChatRef = useRef( maybeOpenChat );
-	maybeOpenChatRef.current = maybeOpenChat;
+	const openChatRef = useRef( openChat );
+	openChatRef.current = openChat;
 	const closeChatRef = useRef( closeChat );
 	closeChatRef.current = closeChat;
 	const resumeActiveChatRef = useRef( resumeActiveChat );
@@ -148,7 +150,7 @@ export default function useAdminBarIntegration( {
 				return;
 			}
 			resumeActiveChatRef.current();
-			maybeOpenChatRef.current();
+			openChatRef.current();
 		};
 
 		aiChatButton.addEventListener( 'click', handleClick );
@@ -196,7 +198,7 @@ export default function useAdminBarIntegration( {
 					return;
 				}
 				onSelect();
-				maybeOpenChatRef.current();
+				openChatRef.current();
 			};
 
 			element?.addEventListener( 'click', handleClick );

--- a/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	isAdminBarInEditor,
+	isEditorAiEntryEnabled,
+	isEditorHelpMenuEnabled,
+} from '../editor-entry-points';
+import { getAgentsManagerInlineData } from '../get-agents-manager-inline-data';
+import { isEditorPage } from '../is-editor-page';
+
+jest.mock( '../get-agents-manager-inline-data', () => ( {
+	getAgentsManagerInlineData: jest.fn(),
+} ) );
+jest.mock( '../is-editor-page', () => ( {
+	isEditorPage: jest.fn(),
+} ) );
+
+const mockInlineData = getAgentsManagerInlineData as jest.Mock;
+const mockIsEditorPage = isEditorPage as jest.Mock;
+const ADMIN_BAR_IN_EDITOR_CLASS = 'has-admin-bar-in-editor';
+// Saved so each suite can restore it — `setDesktop` overwrites `window.matchMedia`.
+const originalMatchMedia = window.matchMedia;
+
+type TestWindow = Window & { __experimentalAdminBarInEditor?: boolean };
+
+function setOmnibarActive( active: boolean ) {
+	( window as TestWindow ).__experimentalAdminBarInEditor = active;
+}
+
+describe( 'isAdminBarInEditor', () => {
+	afterEach( () => {
+		delete ( window as TestWindow ).__experimentalAdminBarInEditor;
+		document.body.classList.remove( ADMIN_BAR_IN_EDITOR_CLASS );
+	} );
+
+	it( 'returns false when neither omnibar signal is present', () => {
+		expect( isAdminBarInEditor() ).toBe( false );
+	} );
+
+	it( 'returns true when window.__experimentalAdminBarInEditor is set', () => {
+		setOmnibarActive( true );
+		expect( isAdminBarInEditor() ).toBe( true );
+	} );
+
+	it( 'returns true when the body carries the has-admin-bar-in-editor class', () => {
+		document.body.classList.add( ADMIN_BAR_IN_EDITOR_CLASS );
+		expect( isAdminBarInEditor() ).toBe( true );
+	} );
+
+	it( 'returns false when the window flag is falsy and the class is absent', () => {
+		setOmnibarActive( false );
+		expect( isAdminBarInEditor() ).toBe( false );
+	} );
+} );
+
+describe( 'isEditorAiEntryEnabled', () => {
+	function setDesktop( matches: boolean ) {
+		window.matchMedia = jest
+			.fn()
+			.mockReturnValue( { matches } ) as unknown as typeof window.matchMedia;
+	}
+
+	afterEach( () => {
+		mockInlineData.mockReset();
+		mockIsEditorPage.mockReset();
+		delete ( window as TestWindow ).__experimentalAdminBarInEditor;
+		window.matchMedia = originalMatchMedia;
+	} );
+
+	it( 'returns true on an editor page, in a dev context, on desktop, with the omnibar off', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { isDevMode: true } );
+		setDesktop( true );
+		expect( isEditorAiEntryEnabled() ).toBe( true );
+	} );
+
+	it( 'returns false outside an editor page', () => {
+		mockIsEditorPage.mockReturnValue( false );
+		mockInlineData.mockReturnValue( { isDevMode: true } );
+		setDesktop( true );
+		expect( isEditorAiEntryEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false outside dev mode', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { isDevMode: false } );
+		setDesktop( true );
+		expect( isEditorAiEntryEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false on mobile', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { isDevMode: true } );
+		setDesktop( false );
+		expect( isEditorAiEntryEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false when the omnibar experiment is active', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { isDevMode: true } );
+		setDesktop( true );
+		setOmnibarActive( true );
+		expect( isEditorAiEntryEnabled() ).toBe( false );
+	} );
+} );
+
+describe( 'isEditorHelpMenuEnabled', () => {
+	function setDesktop( matches: boolean ) {
+		window.matchMedia = jest
+			.fn()
+			.mockReturnValue( { matches } ) as unknown as typeof window.matchMedia;
+	}
+
+	afterEach( () => {
+		mockInlineData.mockReset();
+		mockIsEditorPage.mockReset();
+		delete ( window as TestWindow ).__experimentalAdminBarInEditor;
+		window.matchMedia = originalMatchMedia;
+	} );
+
+	it( 'returns true on an editor page, on desktop, in the unified experience', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { useUnifiedExperience: true } );
+		setDesktop( true );
+		expect( isEditorHelpMenuEnabled() ).toBe( true );
+	} );
+
+	it( 'returns false outside the unified experience', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { useUnifiedExperience: false } );
+		setDesktop( true );
+		expect( isEditorHelpMenuEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false outside an editor page', () => {
+		mockIsEditorPage.mockReturnValue( false );
+		mockInlineData.mockReturnValue( { useUnifiedExperience: true } );
+		setDesktop( true );
+		expect( isEditorHelpMenuEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false on mobile', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { useUnifiedExperience: true } );
+		setDesktop( false );
+		expect( isEditorHelpMenuEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false when the omnibar experiment is active', () => {
+		mockIsEditorPage.mockReturnValue( true );
+		mockInlineData.mockReturnValue( { useUnifiedExperience: true } );
+		setDesktop( true );
+		setOmnibarActive( true );
+		expect( isEditorHelpMenuEnabled() ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/is-editor-page.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/is-editor-page.test.ts
@@ -1,81 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
 import { isEditorPage } from '../is-editor-page';
 
 describe( 'isEditorPage', () => {
-	const originalWindow = globalThis.window;
-
-	const mockLocation = ( path: string ) => {
-		const url = new URL( `https://wordpress.com${ path }` );
-
-		globalThis.window = {
-			location: { href: url.href, search: url.search },
-		} as Window & typeof globalThis;
+	const setBodyClasses = ( classes: string ) => {
+		document.body.className = classes;
 	};
 
-	beforeEach( () => {
-		// @ts-expect-error - Mocking window
-		delete globalThis.window;
-	} );
-
 	afterEach( () => {
-		globalThis.window = originalWindow;
+		document.body.className = '';
 	} );
 
-	it( 'returns `false` when `window` is undefined (SSR)', () => {
-		expect( isEditorPage() ).toBe( false );
-	} );
-
-	it( 'returns `true` for site editor URL', () => {
-		mockLocation( '/wp-admin/site-editor.php?canvas=edit' );
-		expect( isEditorPage() ).toBe( true );
-	} );
-
-	it( 'returns `true` for site editor URL without query params', () => {
-		mockLocation( '/wp-admin/site-editor.php' );
+	it( 'returns `true` for the site editor', () => {
+		setBodyClasses( 'wp-admin site-editor-php' );
 		expect( isEditorPage() ).toBe( true );
 	} );
 
 	it( 'returns `true` for editing a post', () => {
-		mockLocation( '/wp-admin/post.php?post=4&action=edit' );
+		setBodyClasses( 'wp-admin post-php post-type-post' );
 		expect( isEditorPage() ).toBe( true );
 	} );
 
 	it( 'returns `true` for creating a new post', () => {
-		mockLocation( '/wp-admin/post-new.php' );
-		expect( isEditorPage() ).toBe( true );
-	} );
-
-	it( 'returns `true` for creating a new post with explicit post_type', () => {
-		mockLocation( '/wp-admin/post-new.php?post_type=post' );
-		expect( isEditorPage() ).toBe( true );
-	} );
-
-	it( 'returns `true` for creating a new page', () => {
-		mockLocation( '/wp-admin/post-new.php?post_type=page' );
+		setBodyClasses( 'wp-admin post-new-php post-type-post' );
 		expect( isEditorPage() ).toBe( true );
 	} );
 
 	it( 'returns `true` for editing a page', () => {
-		mockLocation( '/wp-admin/post.php?post=10&action=edit&post_type=page' );
+		setBodyClasses( 'wp-admin post-php post-type-page' );
 		expect( isEditorPage() ).toBe( true );
 	} );
 
-	it( 'returns `false` for custom post type', () => {
-		mockLocation( '/wp-admin/post-new.php?post_type=product' );
+	it( 'returns `true` for creating a new page', () => {
+		setBodyClasses( 'wp-admin post-new-php post-type-page' );
+		expect( isEditorPage() ).toBe( true );
+	} );
+
+	it( 'returns `false` when editing a custom post type', () => {
+		setBodyClasses( 'wp-admin post-php post-type-product' );
 		expect( isEditorPage() ).toBe( false );
 	} );
 
-	it( 'returns `false` for editing a custom post type', () => {
-		mockLocation( '/wp-admin/post.php?post=5&action=edit&post_type=product' );
+	it( 'returns `false` when creating a custom post type', () => {
+		setBodyClasses( 'wp-admin post-new-php post-type-product' );
 		expect( isEditorPage() ).toBe( false );
 	} );
 
-	it( 'returns `false` for non-editor admin pages', () => {
-		mockLocation( '/wp-admin/index.php' );
+	it( 'returns `false` for the post list screen (editor screen class absent)', () => {
+		setBodyClasses( 'wp-admin edit-php post-type-post' );
 		expect( isEditorPage() ).toBe( false );
 	} );
 
-	it( 'returns `false` for frontend pages', () => {
-		mockLocation( '/my-blog-post' );
+	it( 'returns `false` for other admin pages', () => {
+		setBodyClasses( 'wp-admin index-php' );
 		expect( isEditorPage() ).toBe( false );
 	} );
 } );

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -1,0 +1,47 @@
+import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
+import { isEditorPage } from './is-editor-page';
+
+/**
+ * Desktop breakpoint for the editor toolbar entry points, kept in sync with the Help Center
+ * button (`apps/help-center/help-center-gutenberg.jsx`), which hides below it on mobile.
+ */
+const EDITOR_ENTRY_MEDIA_QUERY = '(min-width: 480px)';
+
+/**
+ * Whether Gutenberg's "admin bar in editor" (omnibar) experiment is active — it renders a top
+ * admin bar in the fullscreen editor. Both signals below are set server-side by Gutenberg core.
+ */
+export function isAdminBarInEditor(): boolean {
+	const hasExperimentFlag = !! ( window as Window & { __experimentalAdminBarInEditor?: boolean } )
+		.__experimentalAdminBarInEditor;
+	const hasBodyClass = document.body.classList.contains( 'has-admin-bar-in-editor' );
+
+	return hasExperimentFlag || hasBodyClass;
+}
+
+/**
+ * Whether an editor toolbar entry point can show at all: on a block editor page, on desktop, and
+ * with the omnibar off (when it's on, the entries live in the editor admin bar instead). All
+ * checks are synchronous, so it's safe to read during render — e.g. from `hasAiChatEntryButton()`.
+ */
+function isEditorEntryVisible(): boolean {
+	return (
+		isEditorPage() &&
+		window.matchMedia( EDITOR_ENTRY_MEDIA_QUERY ).matches &&
+		! isAdminBarInEditor()
+	);
+}
+
+/**
+ * Whether the editor toolbar Ask AI button should show — only in a dev/internal context.
+ */
+export function isEditorAiEntryEnabled(): boolean {
+	return isEditorEntryVisible() && !! getAgentsManagerInlineData()?.isDevMode;
+}
+
+/**
+ * Whether the editor toolbar Help Center "?" menu should show — only in the unified AI experience.
+ */
+export function isEditorHelpMenuEnabled(): boolean {
+	return isEditorEntryVisible() && !! getAgentsManagerInlineData()?.useUnifiedExperience;
+}

--- a/packages/agents-manager/src/utils/is-editor-page.ts
+++ b/packages/agents-manager/src/utils/is-editor-page.ts
@@ -1,23 +1,28 @@
 /**
- * Checks if the current page is a site editor or post editor.
+ * Whether the current page is the post/page block editor or the site editor.
+ *
+ * Reads WordPress's server-set admin body classes — present in the initial HTML for both "new"
+ * and "edit" screens — rather than the URL, since the edit URL (`post.php?post=N`) omits the
+ * post type and would misclassify custom post types. Custom post types are intentionally
+ * excluded (the post type comes from `post-type-{type}`, set in `wp-admin/admin-header.php`).
  */
 export function isEditorPage(): boolean {
-	if ( typeof window === 'undefined' ) {
+	if ( typeof document === 'undefined' || ! document.body ) {
 		return false;
 	}
 
-	const { href, search } = window.location;
+	const { classList } = document.body;
 
-	// Site editor
-	if ( href.includes( '/wp-admin/site-editor.php' ) ) {
+	// Site editor.
+	if ( classList.contains( 'site-editor-php' ) ) {
 		return true;
 	}
 
-	// Post/page editor
-	if ( href.includes( '/wp-admin/post.php' ) || href.includes( '/wp-admin/post-new.php' ) ) {
-		const postType = new URLSearchParams( search ).get( 'post_type' );
-		return ! postType || [ 'post', 'page' ].includes( postType );
-	}
+	// Post or page editor (`post.php` / `post-new.php`), excluding custom post types.
+	const isPostEditorScreen =
+		classList.contains( 'post-php' ) || classList.contains( 'post-new-php' );
+	const isPostOrPage =
+		classList.contains( 'post-type-post' ) || classList.contains( 'post-type-page' );
 
-	return false;
+	return isPostEditorScreen && isPostOrPage;
 }


### PR DESCRIPTION
Part of AI-1016. And this PR also covers [111889](https://github.com/Automattic/wp-calypso/pull/111889).

## Proposed Changes

Adds AI and Help entry points to the WordPress.com block editor, mirroring the `/wp-admin` admin-bar experience:

- **Ask AI** button in the editor toolbar (`PinnedItems/core`), gated to dev mode. Toggles the agents-manager chat — resumes the active conversation on open, closes it when already visible.
- **Help Center “?”** dropdown menu in the editor toolbar, gated to the unified AI experience. Groups the chat actions (Chat support, Chat history) and resources (Support guides, Courses, Product updates), matching the `/wp-admin` Help menu.
- When Gutenberg’s admin-bar-in-editor (omnibar) experiment is active, the toolbar entry points step aside and the legacy Help Center toolbar button hides — the omnibar (driven by the companion Jetpack change) provides the entry points instead.
- The floating chat now minimizes to a bar (instead of a floating bubble) whenever an AI chat entry button is present, now including the new editor toolbar button.

Tracking events mirror the `/wp-admin` shapes: `calypso_editor_agents_manager_ai_chat_clicked` and `calypso_editor_agents_manager_help_menu_clicked`.

Companion backend change (editor omnibar admin-bar nodes): Automattic/jetpack#49967

## Why are these changes being made?

The unified AI experience is reachable from the `/wp-admin` admin bar and the Calypso masterbar, but not from inside the block editor, where users spend most of their authoring time. These entry points bring the same Ask AI and Help affordances into the editor, consistent with the `/wp-admin` behavior and event tracking.

## Testing Instructions

- Test with: https://github.com/Automattic/jetpack/pull/49967
- Sandbox **both HC and AM packages**
- Go to the site editor
- You will see the HC and AI buttons in the toolbar:
  -  The legacy HC button and the new HC menu will be shown depending on the unified AI experience option
  - All the buttons / menu should work the same as the ones on `/wp-admin`

<img width="524" height="174" alt="截圖 2026-06-26 凌晨12 52 13" src="https://github.com/user-attachments/assets/134ee12a-d0e7-4553-937b-5c87f9c3d944" />

- In mobile view (`< 480px`), reload the editor, and the entry buttons will be hidden in the toolbar (GB default behavior). So you will see the FAB button and not the "Minimized" header option:
  - Note: The legacy HC panel originally did not show on mobile

https://github.com/user-attachments/assets/ab01f4d7-6aea-448c-b2e1-294abfdd32e5

- Enable the editor > omni-bar by:
  - Go to `/wp-admin/admin.php?page=gutenberg-experiments`, and turn the "Toolbar in editor" on
  - Or, dropping this in a sandbox mu-plugin (e.g. `wp-content/mu-plugins/omnibar.php`)
    - Enable: add the file.
    - Disable: delete the file. 

```php
<?php
// Enable Gutenberg's "admin bar in editor" (omnibar). Delete this file to disable.
add_filter( 'option_gutenberg-experiments', function ( $v ) {
	$v = (array) $v;
	$v['gutenberg-admin-bar-in-editor'] = 1;
	return $v;
} );
```

- You will see the HC and AI buttons in the omnibar, and the toolbar ones will be hidden:
  -  The legacy HC button and the new HC menu will be shown depending on the unified AI experience option
  - All the buttons / menu should work the same as the ones on `/wp-admin`

<img width="524" height="174" alt="截圖 2026-06-26 凌晨12 51 20" src="https://github.com/user-attachments/assets/5469f525-f1a6-4846-9dd6-28c076b15081" />

- The HC and AI buttons still work the same on `/wp-admin`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

