### PR TITLE
Reader: fix 2026 global nav chrome over the dark hero

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -536,37 +536,45 @@ body.is-section-reader {
 		}
 	}
 
-	// logged out master bar
-	.masterbar-menu .masterbar {
+	// Legacy logged-out nav layout — the 2026 nav sets its own (e.g. its 64px
+	// bar must match its 64px white surface, not this 78px), so keep it off.
+	.masterbar-menu .masterbar:not( :has( .x-nav--2026-redesign ) ) {
 		height: 78px;
-		.x-nav-link__logo svg path {
-			fill: var( --studio-white );
-		}
+
 		.x-nav {
 			padding-top: 10px;
 			padding-left: 16px;
 			padding-right: 16px;
-			.x-nav-item {
-				color: var( --studio-white );
-				&:hover {
-					color: var( --studio-white );
-				}
-				.cta-btn-nav {
-					margin-top: 9px;
-				}
-				.x-nav-link-chevron {
-					opacity: 1;
-					&::after,
-					&::before {
-						color: var( --studio-white );
-					}
-				}
-			}
+		}
+		.cta-btn-nav {
+			margin-top: 9px;
+		}
+		.x-nav-link-chevron {
+			opacity: 1;
+		}
+		.x-nav-link__primary {
+			border: 2px solid var( --studio-white );
+			background: transparent !important;
+		}
+	}
 
-			.x-nav-link__primary {
-				border: 2px solid var( --studio-white );
-				background: transparent !important;
-			}
+	// Resting over the dark hero: white nav ink. Logo fill, chevron border and
+	// CTA border all read currentcolor, so colouring .x-nav-item carries them.
+	.lpc-header-nav-container .x-nav--2026-redesign .x-nav-item {
+		color: var( --studio-white );
+
+		// Hover flips the CTA to a white fill with dark ink.
+		--x-nav-2026-cta-hover-fill: var( --studio-white );
+		--x-nav-2026-cta-hover-ink: var( --studio-gray-100 );
+	}
+
+	// White surface up (scrolled, a trigger hovered, or a dropdown open): the
+	// nav paints its own white band, so the ink flips back to dark.
+	.lpc-header-nav-container.is-scrolled,
+	.lpc-header-nav-container:has( .x-nav-item__wide:hover .x-nav-link-chevron ),
+	.lpc-header-nav-container:has( .x-dropdown--2026.is-dropdown-open ) {
+		.x-nav--2026-redesign .x-nav-item {
+			color: var( --studio-gray-100 );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

On Reader logged-out pages (Discover, tag streams, etc.), the 2026 Global Nav looked wrong over the dark hero:

* Opening a nav dropdown made the WordPress.com logo and "Get started" button disappear.
* The "Get started" button looked off — heavier outline than elsewhere, and its hover colours were inverted.
* The nav bar sat slightly misaligned and, once scrolled, was taller than its own background strip.

<img width="480" alt="Screenshot 2026-06-25 at 14 20 23" src="https://github.com/user-attachments/assets/b7c0504e-d5b3-4c90-b9e3-bf654b1861cf" />

<img width="480" alt="Screenshot 2026-06-25 at 15 19 18" src="https://github.com/user-attachments/assets/a0293125-fd87-47f9-b11b-abfd1c50f7e0" />

## Why are these changes being made?

The 2026 nav was picking up styles meant for the old logged-out nav, so its appearance broke over the Reader hero.

## Testing Instructions

1. Run Calypso locally and open `/discover?flags=nav-redesign/2026` logged out.
2. Open a nav dropdown — the logo and "Get started" button should stay visible.
3. Hover "Get started" — dark text on a white fill.
4. Scroll the page — the white nav bar should match its background with no overhang.
5. Compare against `/patterns?flags=nav-redesign/2026` — they should match.
6. With the flag off, confirm the old logged-out nav is unchanged.

<img width="480" alt="Screenshot 2026-06-25 at 15 17 20" src="https://github.com/user-attachments/assets/e4d9bd4d-dd52-4fd4-8deb-a52ffe5826cd" />
<img width="480" alt="Screenshot 2026-06-25 at 15 17 14" src="https://github.com/user-attachments/assets/0233ca0f-1721-4f9b-bd4d-49de172eb668" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
