### PR TITLE
Declare date range picker sass dependency

### DIFF
--- a/packages/date-range-picker/CHANGELOG.md
+++ b/packages/date-range-picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5
+
+- Packaging: declare `sass` as a runtime dependency for the package build script.
+
 ## 1.0.4
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -46,7 +46,8 @@
 	},
 	"dependencies": {
 		"@automattic/ui": "workspace:^",
-		"date-fns": "^4.1.0"
+		"date-fns": "^4.1.0",
+		"sass": "1.77.8"
 	},
 	"peerDependencies": {
 		"@wordpress/components": ">=35.0.0",
@@ -96,7 +97,6 @@
 		"jest": "^29.7.0",
 		"mockdate": "^2.0.5",
 		"postcss": "^8.5.3",
-		"sass": "1.77.8",
 		"typescript": "^6.0.3",
 		"webpack": "^5.99.8"
 	}


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Bump `@automattic/date-range-picker` to `1.0.5`.
* Move `sass` from `devDependencies` to `dependencies`.
* Add a changelog entry for the packaging fix.

## Why are these changes being made?

The package build script at `packages/date-range-picker/bin/build-styles.js` imports `sass` directly when `prepack` builds the package CSS. Since that script is part of the package's build/pack behavior, `sass` should be declared as a package dependency instead of only as a dev dependency.

## Testing Instructions

* `yarn workspace @automattic/date-range-picker prepack`
* `yarn workspace @automattic/date-range-picker pack --out /private/tmp/automattic-date-range-picker-1.0.5.tgz`
* Verified the packed `package/package.json` includes `"sass": "1.77.8"` under `dependencies`.
* `yarn test-packages packages/date-range-picker`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
