### PR TITLE
Desktop: Validate release artifacts on Buildkite

### DIFF
--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -9,6 +9,7 @@ export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export NODE_OPTIONS=--max-old-space-size=5120
+# Playwright and Electron use HOME for caches; keep it writable under the propagated UID.
 export HOME=/tmp/buildkite-home
 
 mkdir -p "$HOME"

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -8,9 +8,9 @@ export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export NODE_OPTIONS=--max-old-space-size=5120
 
 cd desktop
-corepack enable
 sudo apt update
 sudo apt-get install -y libsecret-1-dev
 yarn install --immutable --inline-builds

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -9,10 +9,10 @@ export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export NODE_OPTIONS=--max-old-space-size=5120
+export HOME=/tmp/buildkite-home
 
+mkdir -p "$HOME"
 cd desktop
-sudo apt update
-sudo apt-get install -y libsecret-1-dev
 yarn install --immutable --inline-builds
 yarn run build
 

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -11,8 +11,9 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 cd desktop
 corepack enable
+sudo apt update
+sudo apt-get install -y libsecret-1-dev
 yarn install --immutable --inline-builds
-yarn playwright install-deps chromium
 yarn run build
 
 # `-c.linux.target=dir` produces an unpacked `linux-unpacked/` tree. Assert

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 export CONFIG_ENV=release
 export USE_HARD_LINKS=false
-export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
@@ -12,21 +11,36 @@ export NODE_OPTIONS=--max-old-space-size=5120
 # Playwright and Electron use HOME for caches; keep it writable under the propagated UID.
 export HOME=/tmp/buildkite-home
 
+if [[ "${PR_DEBUG_RELEASE:-}" == "true" || "${BUILDKITE_TAG:-}" == desktop-v* || "${BUILDKITE_BRANCH:-}" == ainfra-2274-* ]]; then
+	export RELEASE_BUILD=true
+	unset ELECTRON_BUILDER_ARGS
+else
+	export RELEASE_BUILD=false
+	export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
+fi
+
 mkdir -p "$HOME"
 cd desktop
 yarn install --immutable --inline-builds
+echo "RELEASE_BUILD=$RELEASE_BUILD"
+echo "ELECTRON_BUILDER_ARGS=${ELECTRON_BUILDER_ARGS:-}"
 yarn run build
 
-# `-c.linux.target=dir` produces an unpacked `linux-unpacked/` tree. Assert
-# that it exists so CI fails loudly if the build output path changes or the
-# Linux target is misconfigured, then pack it into a single archive so the
-# artifact upload doesn't ferry thousands of individual files.
 if [[ ! -d release/linux-unpacked ]]; then
-  echo "Expected Linux build output directory 'release/linux-unpacked' was not produced." >&2
-  exit 1
+	echo "Expected Linux build output directory 'release/linux-unpacked' was not produced." >&2
+	exit 1
 fi
 
 yarn run test:e2e
 
-tar -zcf release/linux-unpacked.tar.gz -C release linux-unpacked
+if [[ "$RELEASE_BUILD" == "true" ]]; then
+	../.buildkite/commands/validate-desktop-artifacts.sh linux release
+else
+	# `-c.linux.target=dir` produces only an unpacked tree. Pack it into a
+	# single archive so the artifact upload doesn't ferry thousands of files.
+	tar -zcf release/linux-unpacked.tar.gz -C release linux-unpacked
+fi
+
 rm -rf release/linux-unpacked
+rm -rf release/.icon-set
+rm -f release/builder-debug.yml

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -12,6 +12,7 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 cd desktop
 corepack enable
 yarn install --immutable --inline-builds
+yarn playwright install-deps chromium
 yarn run build
 
 # `-c.linux.target=dir` produces an unpacked `linux-unpacked/` tree. Assert

--- a/.buildkite/commands/build-desktop-linux.sh
+++ b/.buildkite/commands/build-desktop-linux.sh
@@ -23,5 +23,7 @@ if [[ ! -d release/linux-unpacked ]]; then
   exit 1
 fi
 
+yarn run test:e2e
+
 tar -zcf release/linux-unpacked.tar.gz -C release linux-unpacked
 rm -rf release/linux-unpacked

--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -49,6 +49,7 @@ fi
 export APP_STORE_CONNECT_API_KEY_PATH="$ASC_KEY_PATH"
 
 yarn run ci:build-mac
+yarn run test:e2e
 
 # The afterSign hook already notarized and stapled the app; this notarizes and
 # staples the `.dmg` wrapper for offline Gatekeeper checks on first mount.

--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -8,7 +8,13 @@ export SKIP_TSC=true
 export PLAYWRIGHT_SKIP_DOWNLOAD=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
-# `desktop/.ruby-version` pins 3.3.0 but the a8c BK mac VM image only
+if [[ "${PR_DEBUG_RELEASE:-}" == "true" || "${BUILDKITE_TAG:-}" == desktop-v* || "${BUILDKITE_BRANCH:-}" == ainfra-2274-* ]]; then
+	export RELEASE_BUILD=true
+else
+	export RELEASE_BUILD=false
+fi
+
+# `desktop/.ruby-version` pins 3.3.0 but the a8c Buildkite mac VM image only
 # ships 3.2.2 (default) and 3.3.4. Override here so `bundle` resolves.
 # TODO: remove this and bump `desktop/.ruby-version` to 3.3.4 once
 # CircleCI's `wp-desktop-mac` job is decommissioned (its build runs
@@ -48,12 +54,18 @@ else
 fi
 export APP_STORE_CONNECT_API_KEY_PATH="$ASC_KEY_PATH"
 
+echo "RELEASE_BUILD=$RELEASE_BUILD"
+
 yarn run ci:build-mac
 yarn run test:e2e
 
 # The afterSign hook already notarized and stapled the app; this notarizes and
 # staples the `.dmg` wrapper for offline Gatekeeper checks on first mount.
 bundle exec fastlane notarize_app
+
+if [[ "$RELEASE_BUILD" == "true" ]]; then
+	../.buildkite/commands/validate-desktop-artifacts.sh mac release
+fi
 
 # Drop the unpacked app trees electron-builder leaves behind so the artifact
 # upload ferries only the distributables (zip, dmg, blockmaps, update yml),

--- a/.buildkite/commands/validate-desktop-artifacts.sh
+++ b/.buildkite/commands/validate-desktop-artifacts.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+platform="${1:-}"
+release_dir="${2:-desktop/release}"
+missing=()
+
+if [[ -z "$platform" ]]; then
+	echo "Usage: $0 <mac|linux> [release-dir]" >&2
+	exit 2
+fi
+
+require_artifact() {
+	local label="$1"
+	local pattern="$2"
+
+	if ! compgen -G "$pattern" > /dev/null; then
+		missing+=( "$label ($pattern)" )
+	fi
+}
+
+case "$platform" in
+	mac)
+		require_artifact "macOS x64 app zip" "$release_dir/wordpress.com-macOS-app-*-x64.zip"
+		require_artifact "macOS arm64 app zip" "$release_dir/wordpress.com-macOS-app-*-arm64.zip"
+		require_artifact "macOS x64 app blockmap" "$release_dir/wordpress.com-macOS-app-*-x64.zip.blockmap"
+		require_artifact "macOS arm64 app blockmap" "$release_dir/wordpress.com-macOS-app-*-arm64.zip.blockmap"
+		require_artifact "macOS x64 dmg" "$release_dir/wordpress.com-macOS-dmg-*-x64.dmg"
+		require_artifact "macOS arm64 dmg" "$release_dir/wordpress.com-macOS-dmg-*-arm64.dmg"
+		require_artifact "macOS x64 dmg blockmap" "$release_dir/wordpress.com-macOS-dmg-*-x64.dmg.blockmap"
+		require_artifact "macOS arm64 dmg blockmap" "$release_dir/wordpress.com-macOS-dmg-*-arm64.dmg.blockmap"
+		require_artifact "macOS updater manifest" "$release_dir/latest-mac.yml"
+		;;
+	linux)
+		require_artifact "Linux deb package" "$release_dir/wordpress.com-linux-deb-*.deb"
+		require_artifact "Linux tarball" "$release_dir/wordpress.com-linux-x64-*.tar.gz"
+		;;
+	*)
+		echo "Unknown desktop platform '$platform'. Expected 'mac' or 'linux'." >&2
+		exit 2
+		;;
+esac
+
+if (( ${#missing[@]} > 0 )); then
+	echo "Missing expected $platform release artifacts:" >&2
+	printf '  - %s\n' "${missing[@]}" >&2
+	echo >&2
+	echo "Files in $release_dir:" >&2
+	find "$release_dir" -maxdepth 1 -type f -print 2>/dev/null | sort >&2
+	exit 1
+fi
+
+echo "Validated $platform release artifacts in $release_dir"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,7 +31,7 @@ steps:
   # while the CircleCI -> Buildkite port is still in development.
   # Gate it on `ainfra-*` branches until the port is stabilized.
   - label: ":desktop_computer: Build desktop (mac)"
-    branches: ainfra-*
+    branches: ainfra-* desktop-v*
     notify:
       - github_commit_status:
           context: Desktop / Build (mac)
@@ -50,7 +50,7 @@ steps:
       - desktop/test/e2e/results/**/*
 
   - label: ":desktop_computer: Build desktop (linux, unsigned)"
-    branches: ainfra-*
+    branches: ainfra-* desktop-v*
     notify:
       - github_commit_status:
           context: Desktop / Build (linux, unsigned)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,8 +56,11 @@ steps:
           context: Desktop / Build (linux, unsigned)
     agents:
       queue: default
+    env:
+      NODE_OPTIONS: --max-old-space-size=5120
     plugins:
-      - automattic/nvm#0.6.0
+      - docker#v5.13.0:
+          image: cimg/node:24.15.0-browsers
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,6 +47,7 @@ steps:
       - desktop/release/*.dmg
       - desktop/release/*.blockmap
       - desktop/release/*.yml
+      - desktop/test/e2e/results/**/*
 
   - label: ":desktop_computer: Build desktop (linux, unsigned)"
     branches: ainfra-*
@@ -60,6 +61,7 @@ steps:
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*
+      - desktop/test/e2e/results/**/*
 
   - label: ":windows: Build desktop (windows store, unsigned)"
     branches: ainfra-*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,6 +61,9 @@ steps:
           image: cimg/node:24.15.0-browsers
           propagate-uid-gid: true
           userns: host
+          environment:
+            - E2EGUTENBERGUSER
+            - E2EPASSWORD
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,6 +59,7 @@ steps:
     plugins:
       - docker#v5.13.0:
           image: cimg/node:24.15.0-browsers
+          propagate-uid-gid: true
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,8 +56,6 @@ steps:
           context: Desktop / Build (linux, unsigned)
     agents:
       queue: default
-    env:
-      NODE_OPTIONS: --max-old-space-size=5120
     plugins:
       - docker#v5.13.0:
           image: cimg/node:24.15.0-browsers

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,7 @@ steps:
       - docker#v5.13.0:
           image: cimg/node:24.15.0-browsers
           propagate-uid-gid: true
+          userns: host
     command: .buildkite/commands/build-desktop-linux.sh
     artifact_paths:
       - desktop/release/*

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -37,6 +37,7 @@ const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
 const LAUNCH_ARGS = [ '--disable-http-cache', '--start-maximized' ];
 
+// Linux CI lacks Electron's SUID sandbox setup.
 if ( process.platform === 'linux' ) {
 	LAUNCH_ARGS.push( '--no-sandbox' );
 }

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -35,6 +35,11 @@ const HAR_PATH = path.join( __dirname, '../results/network.har' );
 const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
 
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
+const LAUNCH_ARGS = [ '--disable-http-cache', '--start-maximized' ];
+
+if ( process.platform === 'linux' ) {
+	LAUNCH_ARGS.push( '--no-sandbox' );
+}
 
 const skipIfOAuthLogin = config.oauthLoginEnabled ? it.skip : it;
 const runIfOAuthLogin = config.oauthLoginEnabled ? it : it.skip;
@@ -52,7 +57,7 @@ describe( 'User Can log in', () => {
 
 		electronApp = await electron.launch( {
 			executablePath: APP_PATH,
-			args: [ '--disable-http-cache', '--start-maximized' ],
+			args: LAUNCH_ARGS,
 			timeout: 0,
 			recordHar: {
 				path: HAR_PATH,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AINFRA-2274

## Proposed Changes

* Add a release-shaped macOS/Linux desktop Buildkite dry run for desktop tags, explicit debug runs, and AINFRA-2274 migration branches.
* Fail the build when expected release artifacts are missing before artifact upload.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This closes the next release automation parity gap before moving the GitHub release publishing step off CircleCI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `bash -n .buildkite/commands/build-desktop-mac.sh .buildkite/commands/build-desktop-linux.sh .buildkite/commands/validate-desktop-artifacts.sh`
* `shellcheck .buildkite/commands/build-desktop-mac.sh .buildkite/commands/build-desktop-linux.sh .buildkite/commands/validate-desktop-artifacts.sh`
* `ruby -e 'require "yaml"; YAML.load_file(".buildkite/pipeline.yml")'`
* `env BUILDKITE_AGENT_ACCESS_TOKEN=dummy buildkite-agent pipeline upload --dry-run .buildkite/pipeline.yml`
* Smoke-tested the artifact validator against complete macOS/Linux temp directories and an intentionally incomplete Linux directory.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

*Posted by Codex (GPT-5) on behalf of @mokagio with approval.*
