### PR TITLE
Include the source post link when sharing a generated video clip

### DIFF
--- a/packages/image-studio/src/hooks/use-generic-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.test.ts
@@ -12,6 +12,7 @@ let mockState: {
 	currentAttachmentId: number | null;
 	entryPoint: string;
 	isAiProcessing: boolean;
+	postPermalink: string | null;
 };
 
 jest.mock( '@wordpress/data', () => ( {
@@ -27,6 +28,11 @@ jest.mock( '@wordpress/data', () => ( {
 				return {
 					getEntryPoint: () => mockState.entryPoint,
 					getImageStudioAiProcessing: () => mockState.isAiProcessing,
+				};
+			}
+			if ( storeName === 'core/editor' ) {
+				return {
+					getPermalink: () => mockState.postPermalink,
 				};
 			}
 			return {};
@@ -121,6 +127,7 @@ describe( 'useGenericShare', () => {
 			currentAttachmentId: 555,
 			entryPoint: 'post_editor_feature_clip',
 			isAiProcessing: false,
+			postPermalink: null,
 		};
 		mockAddNotice.mockResolvedValue( undefined );
 		// The share button must never open a tab or download anything itself —
@@ -181,6 +188,36 @@ describe( 'useGenericShare', () => {
 				surface: 'modal',
 				method: 'web-share',
 			} );
+		} );
+
+		it( 'includes the post permalink as share text when available', async () => {
+			mockState.postPermalink = 'https://example.com/my-post/';
+			const mockShare = jest.fn().mockResolvedValue( undefined );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'video' ], { type: 'video/mp4' } ) );
+
+			const { result } = renderHook( () => useGenericShare( 'modal' ) );
+			await act( async () => {
+				await result.current.handleShare();
+			} );
+
+			expect( mockShare ).toHaveBeenCalledWith(
+				expect.objectContaining( { text: 'https://example.com/my-post/' } )
+			);
+		} );
+
+		it( 'omits share text when no permalink is available', async () => {
+			mockState.postPermalink = null;
+			const mockShare = jest.fn().mockResolvedValue( undefined );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
+
+			const { result } = renderHook( () => useGenericShare( 'modal' ) );
+			await act( async () => {
+				await result.current.handleShare();
+			} );
+
+			expect( mockShare.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'text' );
 		} );
 
 		it( 'silently exits when the user dismisses the share sheet', async () => {

--- a/packages/image-studio/src/hooks/use-generic-share/index.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.ts
@@ -47,16 +47,21 @@ export function useGenericShare(
 ): UseGenericShareReturn {
 	const hasOverride = clip !== undefined;
 
-	const { storeUrl, storeAttachmentId, entryPoint, isAiProcessing } = useSelect( ( select ) => {
-		const videoStore = select( videoStudioStore );
-		const studio = select( imageStudioStore );
-		return {
-			storeUrl: videoStore.getCurrentVideoUrl?.() ?? null,
-			storeAttachmentId: videoStore.getCurrentAttachmentId?.() ?? null,
-			entryPoint: studio.getEntryPoint?.() ?? null,
-			isAiProcessing: studio.getImageStudioAiProcessing?.() ?? false,
-		};
-	}, [] );
+	const { storeUrl, storeAttachmentId, entryPoint, isAiProcessing, postPermalink } = useSelect(
+		( select ) => {
+			const videoStore = select( videoStudioStore );
+			const studio = select( imageStudioStore );
+			const editor = select( 'core/editor' ) as { getPermalink?: () => string | null } | undefined;
+			return {
+				storeUrl: videoStore.getCurrentVideoUrl?.() ?? null,
+				storeAttachmentId: videoStore.getCurrentAttachmentId?.() ?? null,
+				entryPoint: studio.getEntryPoint?.() ?? null,
+				isAiProcessing: studio.getImageStudioAiProcessing?.() ?? false,
+				postPermalink: editor?.getPermalink?.() ?? null,
+			};
+		},
+		[]
+	);
 
 	const currentVideoUrl = hasOverride ? clip.url : storeUrl;
 	const currentAttachmentId = hasOverride ? clip.attachmentId : storeAttachmentId;
@@ -149,6 +154,7 @@ export function useGenericShare(
 				await nav.share?.( {
 					files: [ file ],
 					title: __( 'Generated video clip', __i18n_text_domain__ ),
+					...( postPermalink ? { text: postPermalink } : {} ),
 				} );
 				trackImageStudioGenericShareCompleted( { surface, method: 'web-share' } );
 			} catch ( err ) {
@@ -171,7 +177,7 @@ export function useGenericShare(
 			isSharingRef.current = false;
 			setIsSharing( false );
 		}
-	}, [ showNotice, currentAttachmentId, currentVideoUrl, surface ] );
+	}, [ showNotice, currentAttachmentId, currentVideoUrl, surface, postPermalink ] );
 
 	return {
 		isVisible,


### PR DESCRIPTION
When sharing a generated video clip through the browser/OS share sheet, the share now includes the source post's permalink alongside the video, so viewers have a way back to the post. Previously only the video file was shared, with no link.

**Scope:** this covers the generic Web Share path. The Instagram/Reels share already includes the post link in its caption (added server-side by Jetpack Social), so it is untouched.

## How to test

This rides on the Web Share API with a file attachment, so the native share sheet only appears on platforms that can share files: mobile (Android Chrome / iOS Safari) and macOS Safari. Desktop Chrome and Firefox won't trigger it.

Prerequisites: a **saved or published** post (so it has a permalink), with this branch's image-studio bundle served to your sandbox.

**On a device (full end-to-end):**
1. Open the post editor on a phone or in macOS Safari over https, and generate a video clip.
2. Tap the share button on the clip.
3. Pick a target that shows a caption alongside media — Messages, X, or Mail.
4. Confirm the post link is included next to the video. On macOS the share sheet header reads "1 Link and 1 Document" (the link + the video). "Save the file" targets like Notes ignore the text, which is expected.

**On desktop (quick payload check, no device):**
1. Generate a clip, then in the devtools console — before clicking share — run:
   ```js
   navigator.canShare = () => true;
   navigator.share = ( data ) => { console.log( 'share payload →', data ); return Promise.resolve(); };
   ```
2. Click the clip's share button and confirm the logged payload includes `text: '<post permalink>'` alongside `files` and `title`.

**Negative check:** on an unsaved draft (no permalink), the share omits the link and still works without errors.

Already verified: typecheck + lint clean, and confirmed on-device via iMessage (the share sheet surfaces the post link next to the video).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
