### PR TITLE
Account Recovery: gate the Dashboard interstitial behind an A/B experiment

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -28,12 +28,6 @@ const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
 const EXPERIMENT_TREATMENT_VARIATION = 'email_recovery_modal';
 
 /**
- * How secure the user's account already is. Single source of truth for the tiers;
- * SNOOZE_DAYS and the copy map are both keyed by it.
- */
-type SecurityLevel = 'none' | 'partial' | 'strong';
-
-/**
  * Snooze windows (in days) by security level
  */
 const SNOOZE_DAYS: Record< SecurityLevel, number > = {
@@ -130,7 +124,7 @@ export default function AccountRecoveryInterstitial() {
 	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
 	// missing a recovery method, 2FA, or backup codes. The modal is also not shown to users who are
 	// not in the experiment treatment group.
-	if ( isDismissed || ! isEligible || variant === 'strong' || ! isInExperimentTreatment ) {
+	if ( isDismissed || ! isEligible || securityLevel === 'strong' || ! isInExperimentTreatment ) {
 		return null;
 	}
 

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -21,11 +21,11 @@ import './style.scss';
 const DAY_IN_SECONDS = 86400;
 
 /**
- * ExPlat A/B experiment gating the interstitial. Users in the `treatment` variation see the
- * modal; everyone else (control / unassigned) does not. Update this to the registered
- * experiment name when it changes.
+ * ExPlat A/B experiment gating the interstitial. Users in the `email_recovery_modal` variation see the
+ * modal; everyone else (control / unassigned) does not.
  */
-const EXPERIMENT_NAME = 'account_recovery_nudge_interstitial_experiment';
+const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
+const EXPERIMENT_TREATMENT_VARIATION = 'email_recovery_modal';
 
 /**
  * How secure the user's account already is. Single source of truth for the tiers;
@@ -124,7 +124,8 @@ export default function AccountRecoveryInterstitial() {
 		isEligible,
 	} );
 	const isInExperimentTreatment =
-		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'treatment';
+		! isLoadingExperimentAssignment &&
+		experimentAssignment?.variationName === EXPERIMENT_TREATMENT_VARIATION;
 
 	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
 	// missing a recovery method, 2FA, or backup codes. The modal is also not shown to users who are

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -9,6 +9,7 @@ import { useRouter } from '@tanstack/react-router';
 import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useId, useState } from 'react';
+import { useExperiment } from 'calypso/lib/explat';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Text } from '../../components/text';
 import { useAnalytics } from '../analytics';
@@ -18,6 +19,19 @@ import type { InterstitialCta, SecurityLevel } from './copy';
 import './style.scss';
 
 const DAY_IN_SECONDS = 86400;
+
+/**
+ * ExPlat A/B experiment gating the interstitial. Users in the `treatment` variation see the
+ * modal; everyone else (control / unassigned) does not. Update this to the registered
+ * experiment name when it changes.
+ */
+const EXPERIMENT_NAME = 'account_recovery_nudge_interstitial_experiment';
+
+/**
+ * How secure the user's account already is. Single source of truth for the tiers;
+ * SNOOZE_DAYS and the copy map are both keyed by it.
+ */
+type SecurityLevel = 'none' | 'partial' | 'strong';
 
 /**
  * Snooze windows (in days) by security level
@@ -103,9 +117,19 @@ export default function AccountRecoveryInterstitial() {
 	const isEligible =
 		isAccountRecoveryLoaded && isUserSettingsLoaded && isSnoozeLoaded && ! isSnoozed;
 
-	// Fully-secured users (securityLevel === 'strong') are left alone — we only nudge people who are
-	// still missing a recovery method, 2FA, or backup codes.
-	if ( isDismissed || ! isEligible || securityLevel === 'strong' ) {
+	// Gate the interstitial behind an A/B experiment. Mark the user eligible only once they would
+	// otherwise qualify, so the exposure event fires for the right population and the control vs.
+	// treatment split isn't diluted by users who would never see the modal.
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible,
+	} );
+	const isInExperimentTreatment =
+		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'treatment';
+
+	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
+	// missing a recovery method, 2FA, or backup codes. The modal is also not shown to users who are
+	// not in the experiment treatment group.
+	if ( isDismissed || ! isEligible || variant === 'strong' || ! isInExperimentTreatment ) {
 		return null;
 	}
 

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -21,11 +21,11 @@ import './style.scss';
 const DAY_IN_SECONDS = 86400;
 
 /**
- * ExPlat A/B experiment gating the interstitial. Users in the `email_recovery_modal` variation see the
- * modal; everyone else (control / unassigned) does not.
+ * ExPlat A/B experiment gating the interstitial. Users in the `no_recovery_modal` variation will _not_ see the
+ * modal; everyone else (control / unassigned) does.
  */
 const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
-const EXPERIMENT_TREATMENT_VARIATION = 'email_recovery_modal';
+const EXPERIMENT_TREATMENT_VARIATION = 'no_recovery_modal';
 
 /**
  * Snooze windows (in days) by security level
@@ -117,14 +117,14 @@ export default function AccountRecoveryInterstitial() {
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
 		isEligible,
 	} );
-	const isInExperimentTreatment =
+	const isInExperimentControl =
 		! isLoadingExperimentAssignment &&
-		experimentAssignment?.variationName === EXPERIMENT_TREATMENT_VARIATION;
+		experimentAssignment?.variationName !== EXPERIMENT_TREATMENT_VARIATION;
 
 	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
 	// missing a recovery method, 2FA, or backup codes. The modal is also not shown to users who are
-	// not in the experiment treatment group.
-	if ( isDismissed || ! isEligible || securityLevel === 'strong' || ! isInExperimentTreatment ) {
+	// not in the experiment control group.
+	if ( isDismissed || ! isEligible || securityLevel === 'strong' || ! isInExperimentControl ) {
 		return null;
 	}
 

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -52,7 +52,33 @@ function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} )
 		.reply( 200, { calypso_preferences } );
 }
 
+const EXPERIMENT_NAME = 'account_recovery_nudge_interstitial_experiment';
+
+// The interstitial only renders for users assigned to the experiment's `treatment` variation.
+// Seed a live assignment into the storage ExPlat reads from, so the real `useExperiment` hook
+// resolves to the given variation through its normal code path — no network call, no mocking.
+// `loadExperimentAssignment` returns a stored, still-alive assignment before hitting the server.
+function assignExperiment( variationName: string | null = 'treatment' ) {
+	window.localStorage.setItem(
+		`explat-experiment--${ EXPERIMENT_NAME }`,
+		JSON.stringify( {
+			experimentName: EXPERIMENT_NAME,
+			variationName,
+			retrievedTimestamp: Date.now(),
+			ttl: 3600,
+		} )
+	);
+}
+
 describe( '<AccountRecoveryInterstitial>', () => {
+	beforeEach( () => {
+		assignExperiment();
+	} );
+
+	afterEach( () => {
+		window.localStorage.clear();
+	} );
+
 	test( 'shows the modal and records an impression for a user with no recovery method', async () => {
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
@@ -220,6 +246,24 @@ describe( '<AccountRecoveryInterstitial>', () => {
 				has_backup_codes: false,
 				snooze_period: 14,
 			}
+		);
+	} );
+
+	test( 'does not show for a user in the experiment control group, even when eligible', async () => {
+		// Otherwise-eligible user (no recovery method, not snoozed) assigned to control.
+		assignExperiment( null );
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences();
+
+		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			'calypso_account_recovery_nudge_interstitial_impression',
+			expect.anything()
 		);
 	} );
 } );

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -52,13 +52,15 @@ function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} )
 		.reply( 200, { calypso_preferences } );
 }
 
-const EXPERIMENT_NAME = 'account_recovery_nudge_interstitial_experiment';
+const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
+const TREATMENT_VARIATION = 'no_recovery_modal';
 
-// The interstitial only renders for users assigned to the experiment's `treatment` variation.
-// Seed a live assignment into the storage ExPlat reads from, so the real `useExperiment` hook
-// resolves to the given variation through its normal code path — no network call, no mocking.
-// `loadExperimentAssignment` returns a stored, still-alive assignment before hitting the server.
-function assignExperiment( variationName: string | null = 'treatment' ) {
+// The interstitial is hidden only for users in the `no_recovery_modal` treatment; control and
+// unassigned users still see it. Seed a live assignment into the storage ExPlat reads from, so the
+// real `useExperiment` hook resolves to the given variation through its normal code path — no
+// network call, no mocking. `loadExperimentAssignment` returns a stored, still-alive assignment
+// before hitting the server.
+function assignExperiment( variationName: string | null = null ) {
 	window.localStorage.setItem(
 		`explat-experiment--${ EXPERIMENT_NAME }`,
 		JSON.stringify( {
@@ -249,9 +251,10 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		);
 	} );
 
-	test( 'does not show for a user in the experiment control group, even when eligible', async () => {
-		// Otherwise-eligible user (no recovery method, not snoozed) assigned to control.
-		assignExperiment( null );
+	test( 'does not show for a user in the experiment treatment group, even when eligible', async () => {
+		// Otherwise-eligible user (no recovery method, not snoozed) assigned to the treatment that
+		// suppresses the modal.
+		assignExperiment( TREATMENT_VARIATION );
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
 		mockPreferences();


### PR DESCRIPTION
Part of DOTOBRD-372

## Proposed Changes

Follow-up to #111546. Gates the account-recovery interstitial behind an ExPlat A/B experiment so we can measure its effect before rolling it out broadly.

- Wires the interstitial to the `calypso_onboarding_account_recovery_modal_202606` ExPlat experiment via `useExperiment`.
- The user is marked eligible for the experiment only once they would otherwise qualify to see the modal (data loaded, not snoozed), so the exposure event fires for the right population and the control vs. treatment split isn't diluted by users who would never see it.
- Control and unassigned users see the modal; only users in the `no_recovery_modal` treatment variation do not.
- Adds a test covering the treatment group (eligible user assigned to `no_recovery_modal`: no modal, no impression event).

## Why are these changes being made?

Layering an A/B experiment on top of the feature flag lets us quantify the interstitial's impact on recovery-setup completion (and downstream support volume) against a control group, rather than rolling it out blind.

## Testing Instructions

Run the tests:

    yarn test-client client/dashboard/app/account-recovery-interstitial

For manual testing, enable the `dashboard/account-recovery-interstitial` flag and seed an ExPlat assignment for `calypso_onboarding_account_recovery_modal_202606`; the modal appears for control and unassigned users, and is suppressed only for the `no_recovery_modal` variation.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
