### PR TITLE
Checkout: add stripe-wallet payment method (Stripe Link via ExpressCheckoutElement)

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1031,7 +1031,7 @@ export default function CheckoutMainContent( {
 						validatingButtonText={ validatingButtonText }
 						validatingButtonAriaLabel={ validatingButtonText }
 						onPageLoadError={ onPageLoadError }
-						waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
+						waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay', 'stripe-wallet' ] }
 						{ ...( isMobileCheckoutStickySummary && {
 							/* Figma 3971:13237 — the active heading reads "Payment method"
 							   under the experiment (vs. composite-checkout's default

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -58,6 +58,7 @@ import payPalProcessor from '../lib/paypal-express-processor';
 import { payPalJsProcessor } from '../lib/paypal-js-processor';
 import { pixAutomaticoProcessor } from '../lib/pix-automatico-processor';
 import { pixProcessor } from '../lib/pix-processor';
+import stripeWalletProcessor from '../lib/stripe-wallet-processor';
 import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
 import upiProcessor from '../lib/upi-processor';
 import weChatProcessor from '../lib/we-chat-processor';
@@ -591,6 +592,8 @@ export default function CheckoutMain( {
 				),
 			'stripe-blik': ( transactionData: unknown ) =>
 				blikProcessor( transactionData, dataForProcessor, translate ),
+			'stripe-wallet': ( transactionData: unknown ) =>
+				stripeWalletProcessor( transactionData, dataForProcessor ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			'existing-card-ebanx': ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -30,6 +30,7 @@ import {
 	createPixPaymentMethod,
 	createPixAutomaticoPaymentMethod,
 } from '../../payment-methods/pix';
+import { createStripeWalletMethod } from '../../payment-methods/stripe-wallet';
 import { createWeChatMethod } from '../../payment-methods/wechat';
 import useCreateExistingCards from './use-create-existing-cards';
 import useCreateExistingPayPalPPCP from './use-create-existing-paypal-ppcp';
@@ -368,6 +369,33 @@ function useCreateStripeUpi( {
 	);
 }
 
+function useCreateStripeWallet( {
+	isStripeLoading,
+	stripeLoadingError,
+	stripeConfiguration,
+	stripe,
+	responseCart,
+}: {
+	isStripeLoading: boolean;
+	stripeLoadingError: StripeLoadingError;
+	stripeConfiguration: StripeConfiguration | null;
+	stripe: Stripe | null;
+	responseCart: ReturnType< typeof useShoppingCart >[ 'responseCart' ];
+} ): PaymentMethod | null {
+	const isReady =
+		! isStripeLoading &&
+		! stripeLoadingError &&
+		stripe &&
+		stripeConfiguration &&
+		isEnabled( 'checkout/stripe-wallet' );
+
+	return useMemo( () => {
+		return isReady && stripe && stripeConfiguration
+			? createStripeWalletMethod( { stripe, stripeConfiguration, responseCart } )
+			: null;
+	}, [ isReady, stripe, stripeConfiguration, responseCart ] );
+}
+
 /**
  * Create all possible payment methods.
  *
@@ -505,6 +533,14 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 	} );
 
+	const stripeWalletMethod = useCreateStripeWallet( {
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+		responseCart,
+	} );
+
 	// The order of this array is the order that Payment Methods will be
 	// displayed in Checkout, although not all payment methods here will be
 	// listed; the list of allowed payment methods is returned by the shopping
@@ -513,6 +549,7 @@ export default function useCreatePaymentMethods( {
 	let paymentMethods = [
 		...existingCardMethods,
 		...existingPayPalPPCPMethods,
+		stripeWalletMethod,
 		applePayMethod,
 		googlePayMethod,
 		stripeMethod,
@@ -538,6 +575,7 @@ export default function useCreatePaymentMethods( {
 		paymentMethods = [
 			...existingCardMethods,
 			...existingPayPalPPCPMethods,
+			stripeWalletMethod,
 			applePayMethod,
 			googlePayMethod,
 			paypalExpressMethod,

--- a/client/my-sites/checkout/src/lib/stripe-wallet-processor.ts
+++ b/client/my-sites/checkout/src/lib/stripe-wallet-processor.ts
@@ -1,6 +1,7 @@
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
-import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { logStashEvent, recordTransactionBeginAnalytics } from './analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import { addUrlToPendingPageRedirect } from './pending-page';
@@ -48,7 +49,7 @@ export default async function stripeWalletProcessor(
 
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'stripe-wallet' } ) );
 
-	const { elements } = submitData;
+	const { elements, expressPaymentType } = submitData;
 
 	// Build the pending-page URL used as return_url for stripe.confirmPayment and
 	// as the success landing URL after an inline confirm.
@@ -103,7 +104,19 @@ export default async function stripeWalletProcessor(
 		orderId = ( response as { order_id?: number | '' } ).order_id ?? '';
 	} catch ( error ) {
 		debug( 'transaction submission failed', error );
-		return makeErrorResponse( ( error as Error ).message );
+		const errorMessage = ( error as Error ).message;
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_stripe_wallet_transaction_failed', {
+				express_payment_type: expressPaymentType,
+				error: errorMessage,
+			} )
+		);
+		logStashEvent( 'calypso_checkout_stripe_wallet_transaction_failed', {
+			express_payment_type: expressPaymentType,
+			tags: [ `express_payment_type:${ expressPaymentType }` ],
+			error: errorMessage,
+		} );
+		return makeErrorResponse( errorMessage );
 	}
 
 	// Confirm the PaymentIntent client-side. redirect:'if_required' means Stripe.js
@@ -119,7 +132,19 @@ export default async function stripeWalletProcessor(
 
 	if ( confirmError ) {
 		debug( 'stripe.confirmPayment failed', confirmError );
-		return makeErrorResponse( confirmError.message ?? 'Payment confirmation failed' );
+		const errorMessage = confirmError.message ?? 'Payment confirmation failed';
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_stripe_wallet_transaction_failed', {
+				express_payment_type: expressPaymentType,
+				error: errorMessage,
+			} )
+		);
+		logStashEvent( 'calypso_checkout_stripe_wallet_transaction_failed', {
+			express_payment_type: expressPaymentType,
+			tags: [ `express_payment_type:${ expressPaymentType }` ],
+			error: errorMessage,
+		} );
+		return makeErrorResponse( errorMessage );
 	}
 
 	// Inline confirm succeeded — return success so composite-checkout routes to the

--- a/client/my-sites/checkout/src/lib/stripe-wallet-processor.ts
+++ b/client/my-sites/checkout/src/lib/stripe-wallet-processor.ts
@@ -1,0 +1,141 @@
+import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import getDomainDetails from './get-domain-details';
+import getPostalCode from './get-postal-code';
+import { addUrlToPendingPageRedirect } from './pending-page';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import {
+	createTransactionEndpointRequestPayload,
+	createTransactionEndpointCartFromResponseCart,
+} from './translate-cart';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type { StripeElements } from '@stripe/stripe-js';
+
+const debug = debugFactory( 'calypso:composite-checkout:stripe-wallet-processor' );
+
+type StripeWalletTransactionRequest = {
+	elements: StripeElements;
+	expressPaymentType: string;
+};
+
+export default async function stripeWalletProcessor(
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const {
+		stripe,
+		stripeConfiguration,
+		responseCart,
+		contactDetails,
+		siteSlug,
+		siteId,
+		fromSiteSlug,
+		getThankYouUrl,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+	} = transactionOptions;
+
+	if ( ! stripe ) {
+		throw new Error( 'Stripe is required for stripe-wallet payment' );
+	}
+
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'stripe-wallet' } ) );
+
+	const { elements } = submitData;
+
+	// Build the pending-page URL used as return_url for stripe.confirmPayment and
+	// as the success landing URL after an inline confirm.
+	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+		siteSlug,
+		fromSiteSlug,
+		urlType: 'absolute',
+	} );
+
+	const formattedTransactionData = createTransactionEndpointRequestPayload( {
+		country: contactDetails?.countryCode?.value ?? '',
+		postalCode: getPostalCode( contactDetails ),
+		subdivisionCode: contactDetails?.state?.value,
+		domainDetails: getDomainDetails( contactDetails, {
+			includeDomainDetails,
+			includeGSuiteDetails,
+		} ),
+		cart: createTransactionEndpointCartFromResponseCart( {
+			siteId,
+			contactDetails:
+				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
+			responseCart,
+		} ),
+		paymentMethodType: 'WPCOM_Billing_Stripe_Wallet',
+		paymentPartnerProcessorId: stripeConfiguration?.processor_id,
+		successUrl,
+		name: contactDetails?.firstName?.value ?? '',
+		email: contactDetails?.email?.value,
+	} );
+
+	debug( 'sending stripe-wallet transaction', formattedTransactionData );
+
+	let clientSecret: string;
+	let orderId: number | '' = '';
+
+	try {
+		const response = await submitWpcomTransaction( formattedTransactionData, transactionOptions );
+		const message = ( response as { message?: unknown } ).message;
+
+		if (
+			! message ||
+			typeof message !== 'object' ||
+			! ( 'payment_intent_client_secret' in message )
+		) {
+			throw new Error( 'Server did not return a payment intent client secret' );
+		}
+
+		clientSecret = String(
+			( message as { payment_intent_client_secret: string } ).payment_intent_client_secret
+		);
+		orderId = ( response as { order_id?: number | '' } ).order_id ?? '';
+	} catch ( error ) {
+		debug( 'transaction submission failed', error );
+		return makeErrorResponse( ( error as Error ).message );
+	}
+
+	// Confirm the PaymentIntent client-side. redirect:'if_required' means Stripe.js
+	// only navigates away when the payment method genuinely requires a browser redirect
+	// (e.g. 3DS); otherwise the promise resolves inline and we route to the pending page.
+	debug( 'confirming payment client-side', { orderId } );
+	const { error: confirmError } = await stripe.confirmPayment( {
+		elements,
+		clientSecret,
+		confirmParams: { return_url: successUrl },
+		redirect: 'if_required',
+	} );
+
+	if ( confirmError ) {
+		debug( 'stripe.confirmPayment failed', confirmError );
+		return makeErrorResponse( confirmError.message ?? 'Payment confirmation failed' );
+	}
+
+	// Inline confirm succeeded — return success so composite-checkout routes to the
+	// pending page, which will poll for the webhook-driven provisioning.
+	return makeSuccessResponse( { order_id: orderId } );
+}
+
+function isValidTransactionData(
+	submitData: unknown
+): submitData is StripeWalletTransactionRequest {
+	const data = submitData as StripeWalletTransactionRequest;
+	if ( ! data?.elements ) {
+		throw new Error( 'Transaction requires Stripe Elements and none was provided' );
+	}
+	if ( ! data?.expressPaymentType ) {
+		throw new Error( 'Transaction requires expressPaymentType and none was provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
@@ -124,7 +124,6 @@ function StripeWalletSubmitButton( {
 			mode: 'payment' as const,
 			amount,
 			currency: currency.toLowerCase(),
-			setup_future_usage: 'off_session' as const,
 		} ),
 		[ amount, currency ]
 	);

--- a/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
@@ -1,14 +1,18 @@
-import { useProcessPayment } from '@automattic/composite-checkout';
+import {
+	useProcessPayment,
+	useRegisterPaymentMethodLoading,
+	useTogglePaymentMethod,
+} from '@automattic/composite-checkout';
 import { Elements, ExpressCheckoutElement, useElements, useStripe } from '@stripe/react-stripe-js';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type {
 	Stripe,
+	StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent,
 	StripeExpressCheckoutElementConfirmEvent,
-	StripeExpressCheckoutElementReadyEvent,
 } from '@stripe/stripe-js';
 
 type StripeWalletMethodProps = {
@@ -35,6 +39,18 @@ function StripeWalletContent( {
 	const stripe = useStripe();
 	const elements = useElements();
 	const processPayment = useProcessPayment( 'stripe-wallet' );
+	const togglePaymentMethod = useTogglePaymentMethod();
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	useRegisterPaymentMethodLoading( 'stripe-wallet', isLoading );
+
+	const onAvailablePaymentMethodsChange = useCallback(
+		( { paymentMethods }: StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent ) => {
+			setIsLoading( false );
+			togglePaymentMethod( 'stripe-wallet', Boolean( paymentMethods ) );
+		},
+		[ togglePaymentMethod ]
+	);
 
 	const onConfirm = useCallback(
 		async ( event: StripeExpressCheckoutElementConfirmEvent ) => {
@@ -60,19 +76,10 @@ function StripeWalletContent( {
 		[ processPayment, stripe, stripeConfiguration, elements ]
 	);
 
-	const onReady = useCallback(
-		( { availablePaymentMethods }: StripeExpressCheckoutElementReadyEvent ) => {
-			// No-op: the payment method row is always shown if it's in the cart's
-			// allowed_payment_methods. ECE itself hides buttons when they aren't available.
-			void availablePaymentMethods;
-		},
-		[]
-	);
-
 	return (
 		<ExpressCheckoutElement
 			onConfirm={ onConfirm }
-			onReady={ onReady }
+			onAvailablePaymentMethodsChange={ onAvailablePaymentMethodsChange }
 			options={ {
 				paymentMethods: {
 					link: 'auto',
@@ -120,6 +127,7 @@ export function createStripeWalletMethod( {
 		paymentProcessorId: 'stripe-wallet',
 		label: <StripeWalletLabel />,
 		hasRequiredFields: false,
+		isInitiallyDisabled: true,
 		activeContent: (
 			<StripeWalletFields
 				stripe={ stripe }

--- a/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
@@ -1,5 +1,5 @@
 import {
-	useProcessPayment,
+	PaymentProcessorResponseType,
 	useRegisterPaymentMethodLoading,
 	useTogglePaymentMethod,
 } from '@automattic/composite-checkout';
@@ -7,7 +7,11 @@ import { Elements, ExpressCheckoutElement, useElements, useStripe } from '@strip
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
-import type { PaymentMethod, PaymentMethodSubmitButtonProps } from '@automattic/composite-checkout';
+import type {
+	PaymentMethod,
+	PaymentMethodSubmitButtonProps,
+	ProcessPayment,
+} from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type {
 	Stripe,
@@ -28,12 +32,13 @@ function StripeWalletLabel() {
 
 function StripeWalletContent( {
 	stripeConfiguration,
+	onClick,
 }: {
 	stripeConfiguration: StripeConfiguration | null;
+	onClick?: ProcessPayment;
 } ) {
 	const stripe = useStripe();
 	const elements = useElements();
-	const processPayment = useProcessPayment( 'stripe-wallet' );
 	const togglePaymentMethod = useTogglePaymentMethod();
 	const [ isLoading, setIsLoading ] = useState( true );
 
@@ -52,6 +57,11 @@ function StripeWalletContent( {
 			if ( ! elements ) {
 				return;
 			}
+			if ( ! onClick ) {
+				throw new Error(
+					'Missing onClick prop; StripeWalletContent must be used as a payment button in CheckoutSubmitButton'
+				);
+			}
 
 			const { expressPaymentType } = event;
 
@@ -61,14 +71,22 @@ function StripeWalletContent( {
 				return;
 			}
 
-			await processPayment( {
+			// Runs the same isActive/validateForm checks every other payment method
+			// goes through (e.g. marketplace consent, 100-year-plan terms) before
+			// processPayment is called. If that rejects, the wallet's own sheet is
+			// still open, so we must signal failure back through the ECE event
+			// rather than just returning an error response like other methods do.
+			const response = await onClick( {
 				stripe,
 				stripeConfiguration,
 				elements,
 				expressPaymentType,
 			} );
+			if ( response.type === PaymentProcessorResponseType.ERROR ) {
+				event.paymentFailed( { reason: 'fail', message: response.payload } );
+			}
 		},
-		[ processPayment, stripe, stripeConfiguration, elements ]
+		[ onClick, stripe, stripeConfiguration, elements ]
 	);
 
 	return (
@@ -90,12 +108,14 @@ function StripeWalletContent( {
 
 // Rendered as the payment method's submitButton (like apple-pay/google-pay) so the
 // wallet buttons appear in the sidebar next to the total, not inline in the payment
-// method list. The framework's injected `disabled`/`onClick` are unused: ECE's own
-// onConfirm event calls processPayment directly once the shopper taps a wallet button.
+// method list. `onClick` is injected by CheckoutSubmitButton and called from ECE's
+// onConfirm event once the shopper taps a wallet button; `disabled` is unused since
+// ECE has no concept of a disabled state to reflect it with.
 function StripeWalletSubmitButton( {
 	stripe,
 	stripeConfiguration,
 	responseCart,
+	onClick,
 }: StripeWalletMethodProps & PaymentMethodSubmitButtonProps ) {
 	const { total_cost_integer: amount, currency } = responseCart;
 
@@ -111,7 +131,7 @@ function StripeWalletSubmitButton( {
 
 	return (
 		<Elements stripe={ stripe } options={ elementsOptions }>
-			<StripeWalletContent stripeConfiguration={ stripeConfiguration } />
+			<StripeWalletContent stripeConfiguration={ stripeConfiguration } onClick={ onClick } />
 		</Elements>
 	);
 }

--- a/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
@@ -97,7 +97,7 @@ function StripeWalletContent( {
 				paymentMethods: {
 					link: 'auto',
 					applePay: 'never',
-					googlePay: 'never',
+					googlePay: 'auto',
 					amazonPay: 'never',
 					paypal: 'never',
 				},

--- a/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
@@ -1,0 +1,134 @@
+import { useProcessPayment } from '@automattic/composite-checkout';
+import { Elements, ExpressCheckoutElement, useElements, useStripe } from '@stripe/react-stripe-js';
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useMemo } from 'react';
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { ResponseCart } from '@automattic/shopping-cart';
+import type {
+	Stripe,
+	StripeExpressCheckoutElementConfirmEvent,
+	StripeExpressCheckoutElementReadyEvent,
+} from '@stripe/stripe-js';
+
+type StripeWalletMethodProps = {
+	stripe: Stripe | null;
+	stripeConfiguration: StripeConfiguration | null;
+	responseCart: ResponseCart;
+};
+
+function StripeWalletLabel() {
+	const { __ } = useI18n();
+	return <span>{ __( 'Express checkout' ) }</span>;
+}
+
+function StripeWalletSubmitButton() {
+	// ECE renders its own payment buttons; this submit button is unused.
+	return null;
+}
+
+function StripeWalletContent( {
+	stripeConfiguration,
+}: {
+	stripeConfiguration: StripeConfiguration | null;
+} ) {
+	const stripe = useStripe();
+	const elements = useElements();
+	const processPayment = useProcessPayment( 'stripe-wallet' );
+
+	const onConfirm = useCallback(
+		async ( event: StripeExpressCheckoutElementConfirmEvent ) => {
+			if ( ! elements ) {
+				return;
+			}
+
+			const { expressPaymentType } = event;
+
+			const { error: submitError } = await elements.submit();
+			if ( submitError ) {
+				event.paymentFailed( { reason: 'invalid_payment_data' } );
+				return;
+			}
+
+			await processPayment( {
+				stripe,
+				stripeConfiguration,
+				elements,
+				expressPaymentType,
+			} );
+		},
+		[ processPayment, stripe, stripeConfiguration, elements ]
+	);
+
+	const onReady = useCallback(
+		( { availablePaymentMethods }: StripeExpressCheckoutElementReadyEvent ) => {
+			// No-op: the payment method row is always shown if it's in the cart's
+			// allowed_payment_methods. ECE itself hides buttons when they aren't available.
+			void availablePaymentMethods;
+		},
+		[]
+	);
+
+	return (
+		<ExpressCheckoutElement
+			onConfirm={ onConfirm }
+			onReady={ onReady }
+			options={ {
+				paymentMethods: {
+					link: 'auto',
+					applePay: 'never',
+					googlePay: 'never',
+					amazonPay: 'never',
+					paypal: 'never',
+				},
+			} }
+		/>
+	);
+}
+
+function StripeWalletFields( {
+	stripe,
+	stripeConfiguration,
+	responseCart,
+}: StripeWalletMethodProps ) {
+	const { total_cost_integer: amount, currency } = responseCart;
+
+	const elementsOptions = useMemo(
+		() => ( {
+			mode: 'payment' as const,
+			amount,
+			currency: currency.toLowerCase(),
+			setup_future_usage: 'off_session' as const,
+		} ),
+		[ amount, currency ]
+	);
+
+	return (
+		<Elements stripe={ stripe } options={ elementsOptions }>
+			<StripeWalletContent stripeConfiguration={ stripeConfiguration } />
+		</Elements>
+	);
+}
+
+export function createStripeWalletMethod( {
+	stripe,
+	stripeConfiguration,
+	responseCart,
+}: StripeWalletMethodProps ): PaymentMethod {
+	return {
+		id: 'stripe-wallet',
+		paymentProcessorId: 'stripe-wallet',
+		label: <StripeWalletLabel />,
+		hasRequiredFields: false,
+		activeContent: (
+			<StripeWalletFields
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+				responseCart={ responseCart }
+			/>
+		),
+		submitButton: <StripeWalletSubmitButton />,
+		inactiveContent: <StripeWalletLabel />,
+		getAriaLabel: ( __: ( text: string ) => string ) => __( 'Express checkout' ),
+	};
+}

--- a/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/stripe-wallet/index.tsx
@@ -7,7 +7,7 @@ import { Elements, ExpressCheckoutElement, useElements, useStripe } from '@strip
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
-import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { PaymentMethod, PaymentMethodSubmitButtonProps } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type {
 	Stripe,
@@ -24,11 +24,6 @@ type StripeWalletMethodProps = {
 function StripeWalletLabel() {
 	const { __ } = useI18n();
 	return <span>{ __( 'Express checkout' ) }</span>;
-}
-
-function StripeWalletSubmitButton() {
-	// ECE renders its own payment buttons; this submit button is unused.
-	return null;
 }
 
 function StripeWalletContent( {
@@ -93,11 +88,15 @@ function StripeWalletContent( {
 	);
 }
 
-function StripeWalletFields( {
+// Rendered as the payment method's submitButton (like apple-pay/google-pay) so the
+// wallet buttons appear in the sidebar next to the total, not inline in the payment
+// method list. The framework's injected `disabled`/`onClick` are unused: ECE's own
+// onConfirm event calls processPayment directly once the shopper taps a wallet button.
+function StripeWalletSubmitButton( {
 	stripe,
 	stripeConfiguration,
 	responseCart,
-}: StripeWalletMethodProps ) {
+}: StripeWalletMethodProps & PaymentMethodSubmitButtonProps ) {
 	const { total_cost_integer: amount, currency } = responseCart;
 
 	const elementsOptions = useMemo(
@@ -128,14 +127,13 @@ export function createStripeWalletMethod( {
 		label: <StripeWalletLabel />,
 		hasRequiredFields: false,
 		isInitiallyDisabled: true,
-		activeContent: (
-			<StripeWalletFields
+		submitButton: (
+			<StripeWalletSubmitButton
 				stripe={ stripe }
 				stripeConfiguration={ stripeConfiguration }
 				responseCart={ responseCart }
 			/>
 		),
-		submitButton: <StripeWalletSubmitButton />,
 		inactiveContent: <StripeWalletLabel />,
 		getAriaLabel: ( __: ( text: string ) => string ) => __( 'Express checkout' ),
 	};

--- a/client/my-sites/checkout/src/test/stripe-wallet-processor.ts
+++ b/client/my-sites/checkout/src/test/stripe-wallet-processor.ts
@@ -1,0 +1,150 @@
+// @ts-nocheck - TODO: Fix TypeScript issues
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import stripeWalletProcessor from '../lib/stripe-wallet-processor';
+import {
+	mockTransactionsEndpoint,
+	mockLogStashEndpoint,
+	processorOptions,
+	countryCode,
+	postalCode,
+} from './util';
+
+describe( 'stripeWalletProcessor', () => {
+	const product = getEmptyResponseCartProduct();
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		...processorOptions,
+		responseCart: cart,
+		contactDetails: {
+			countryCode,
+			postalCode,
+		},
+	};
+
+	const submitData = {
+		elements: {},
+		expressPaymentType: 'apple_pay',
+	};
+
+	beforeEach( () => {
+		mockLogStashEndpoint();
+	} );
+
+	it( 'throws an error if there are no elements', async () => {
+		await expect(
+			stripeWalletProcessor( { expressPaymentType: 'apple_pay' }, options )
+		).rejects.toThrow( /Transaction requires Stripe Elements/ );
+	} );
+
+	it( 'throws an error if there is no expressPaymentType', async () => {
+		await expect( stripeWalletProcessor( { elements: {} }, options ) ).rejects.toThrow(
+			/Transaction requires expressPaymentType/
+		);
+	} );
+
+	it( 'throws an error if there is no stripe object', async () => {
+		await expect( stripeWalletProcessor( submitData, options ) ).rejects.toThrow(
+			/Stripe is required for stripe-wallet payment/
+		);
+	} );
+
+	it( 'confirms the payment client-side and returns a success response', async () => {
+		mockTransactionsEndpoint( () => [
+			200,
+			{ order_id: 12345, message: { payment_intent_client_secret: 'test-client-secret' } },
+		] );
+		const confirmPayment = jest.fn().mockResolvedValue( {} );
+		const stripe = { confirmPayment };
+
+		await expect(
+			stripeWalletProcessor( submitData, { ...options, stripe } )
+		).resolves.toStrictEqual( { payload: { order_id: 12345 }, type: 'SUCCESS' } );
+
+		expect( confirmPayment ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				elements: submitData.elements,
+				clientSecret: 'test-client-secret',
+				redirect: 'if_required',
+			} )
+		);
+	} );
+
+	it( 'returns an explicit error response and records telemetry if the transaction submission fails', async () => {
+		mockTransactionsEndpoint( () => [ 400, { error: 'test_error', message: 'test error' } ] );
+		const confirmPayment = jest.fn();
+		const reduxDispatch = jest.fn();
+
+		await expect(
+			stripeWalletProcessor( submitData, { ...options, stripe: { confirmPayment }, reduxDispatch } )
+		).resolves.toStrictEqual( { payload: 'test error', type: 'ERROR' } );
+
+		expect( confirmPayment ).not.toHaveBeenCalled();
+		expect( reduxDispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				meta: expect.objectContaining( {
+					analytics: [
+						expect.objectContaining( {
+							payload: expect.objectContaining( {
+								name: 'calypso_checkout_stripe_wallet_transaction_failed',
+								properties: expect.objectContaining( {
+									express_payment_type: 'apple_pay',
+									error: 'test error',
+								} ),
+							} ),
+						} ),
+					],
+				} ),
+			} )
+		);
+	} );
+
+	it( 'returns an error response if the server does not return a client secret', async () => {
+		mockTransactionsEndpoint( () => [ 200, { order_id: 12345, message: {} } ] );
+		const confirmPayment = jest.fn();
+
+		await expect(
+			stripeWalletProcessor( submitData, { ...options, stripe: { confirmPayment } } )
+		).resolves.toStrictEqual( {
+			payload: 'Server did not return a payment intent client secret',
+			type: 'ERROR',
+		} );
+		expect( confirmPayment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns an error response and records telemetry if stripe.confirmPayment fails', async () => {
+		mockTransactionsEndpoint( () => [
+			200,
+			{ order_id: 12345, message: { payment_intent_client_secret: 'test-client-secret' } },
+		] );
+		const confirmPayment = jest.fn().mockResolvedValue( {
+			error: { message: 'Your card was declined.' },
+		} );
+		const reduxDispatch = jest.fn();
+
+		await expect(
+			stripeWalletProcessor( submitData, {
+				...options,
+				stripe: { confirmPayment },
+				reduxDispatch,
+			} )
+		).resolves.toStrictEqual( { payload: 'Your card was declined.', type: 'ERROR' } );
+
+		expect( reduxDispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				meta: expect.objectContaining( {
+					analytics: [
+						expect.objectContaining( {
+							payload: expect.objectContaining( {
+								name: 'calypso_checkout_stripe_wallet_transaction_failed',
+								properties: expect.objectContaining( {
+									express_payment_type: 'apple_pay',
+									error: 'Your card was declined.',
+								} ),
+							} ),
+						} ),
+					],
+				} ),
+			} )
+		);
+	} );
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -64,6 +64,7 @@
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
 		"checkout/stripe-upi": true,
+		"checkout/stripe-wallet": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
 		"comments/filters-in-posts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -34,6 +34,7 @@
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
 		"checkout/stripe-upi": true,
+		"checkout/stripe-wallet": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
 		"cookie-banner": true,

--- a/packages/wpcom-checkout/src/translate-payment-method-names.ts
+++ b/packages/wpcom-checkout/src/translate-payment-method-names.ts
@@ -49,6 +49,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'stripe-upi';
 		case 'WPCOM_Billing_Stripe_Blik':
 			return 'stripe-blik';
+		case 'WPCOM_Billing_Stripe_Wallet':
+			return 'stripe-wallet';
 		default:
 			throw new Error( `Unknown payment method '${ paymentMethod }'` );
 	}
@@ -105,6 +107,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_Stripe_Upi';
 		case 'stripe-blik':
 			return 'WPCOM_Billing_Stripe_Blik';
+		case 'stripe-wallet':
+			return 'WPCOM_Billing_Stripe_Wallet';
 	}
 	return null;
 }
@@ -129,6 +133,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Web_Payment':
 		case 'WPCOM_Billing_Stripe_Upi':
 		case 'WPCOM_Billing_Stripe_Blik':
+		case 'WPCOM_Billing_Stripe_Wallet':
 			return slug;
 	}
 	return null;
@@ -165,6 +170,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'free-purchase':
 		case 'stripe-upi':
 		case 'stripe-blik':
+		case 'stripe-wallet':
 			return slug;
 		case 'apple-pay':
 		case 'google-pay':

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -351,7 +351,8 @@ export type CheckoutPaymentMethodSlug =
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay' // a synonym for 'web-pay'
 	| 'stripe-upi'
-	| 'stripe-blik';
+	| 'stripe-blik'
+	| 'stripe-wallet';
 
 /**
  * Payment method slugs as returned by the WPCOM backend.
@@ -376,7 +377,8 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix'
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix_Automatico'
 	| 'WPCOM_Billing_Stripe_Upi'
-	| 'WPCOM_Billing_Stripe_Blik';
+	| 'WPCOM_Billing_Stripe_Blik'
+	| 'WPCOM_Billing_Stripe_Wallet';
 
 export type ContactDetailsType = 'gsuite' | 'tax' | 'domain' | 'none';
 


### PR DESCRIPTION
Part of SHILL-2099

## Proposed Changes

* Add a new `stripe-wallet` payment method backed by Stripe's `ExpressCheckoutElement` (ECE), scoped to **Link only** in this phase
* Add `WPCOM_Billing_Stripe_Wallet` ↔ `stripe-wallet` to both directions of the payment method name translation map and to the `CheckoutPaymentMethodSlug` / `WPCOMPaymentMethod` type unions
* Add `stripe-wallet-processor.ts` implementing a deferred client-confirm flow: POST to `/me/transactions` with `WPCOM_Billing_Stripe_Wallet` → extract `payment_intent_client_secret` → call `stripe.confirmPayment({ elements, clientSecret, redirect: 'if_required' })` → return success with `order_id` for pending-page polling
* Nest a scoped `<Elements>` provider (deferred-intent mode: `mode/amount/currency/setup_future_usage`) inside the payment method's `activeContent` so ECE can render without touching the shared `StripeHookProvider`
* Gate the method behind `checkout/stripe-wallet` feature flag (enabled in `development` and `wpcalypso`, off in production)

## Why are these changes being made?

Stripe Link is an express wallet checkout that lets returning Stripe-networked users pay with a single click. The `ExpressCheckoutElement` is Stripe's modern unified surface for Link, Apple Pay, and Google Pay; this PR adds the frontend plumbing for the Link-only phase. The backend `WPCOM_Billing_Stripe_Wallet` processor is a companion piece tracked separately.

The deferred client-confirm pattern (server parks an unconfirmed PaymentIntent, client calls `stripe.confirmPayment`) was chosen to align with an open precedent from the Memberships team and to enable webhook-driven provisioning without a custom return-URL endpoint.

## Testing Instructions

* Requires the backend `WPCOM_Billing_Stripe_Wallet` processor to be in place before end-to-end testing is possible — that work is not yet merged
* With the flag enabled locally (`checkout/stripe-wallet: true`) and a backend returning a mock `payment_intent_client_secret`, the ECE mounts under the payment method row and the Link button renders in Chrome (suppressed in Firefox with strict ETP — expected, not a bug)
* Account alignment note: local dev with a US billing address routes to the US Stripe account where Link/ECE is configured; EU addresses route to the IE account which may not have Link active

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?