### PR TITLE
Jetpack AI Sidebar: Extract shared block helpers for Review Tools

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
@@ -24,6 +24,7 @@ import {
 	toggleBlockReferenceFocus,
 	undoBlockEdit,
 } from '../utils/block-actions';
+import { countOccurrences, flattenBlocks } from '../utils/blocks';
 import BlockRef, { type BlockSnapshot } from './block-ref';
 
 interface PostFeedbackItem {
@@ -76,39 +77,6 @@ function getCurrentEditorPostIdFromStore(): number | undefined {
 		return typeof postId === 'number' && postId > 0 ? postId : undefined;
 	} catch {
 		return undefined;
-	}
-}
-
-function flattenBlocks( blocks: BlockSnapshot[] ): BlockSnapshot[] {
-	const out: BlockSnapshot[] = [];
-	const walk = ( items: BlockSnapshot[] ) => {
-		items.forEach( ( block ) => {
-			if ( ! block.name ) {
-				return;
-			}
-			out.push( block );
-			if ( Array.isArray( block.innerBlocks ) && block.innerBlocks.length > 0 ) {
-				walk( block.innerBlocks );
-			}
-		} );
-	};
-	walk( blocks );
-	return out;
-}
-
-function countOccurrences( source: string, needle: string ): number {
-	if ( needle === '' ) {
-		return 0;
-	}
-	let count = 0;
-	let pos = 0;
-	while ( true ) {
-		const found = source.indexOf( needle, pos );
-		if ( found === -1 ) {
-			return count;
-		}
-		count++;
-		pos = found + 1;
 	}
 }
 
@@ -192,7 +160,7 @@ function getUnavailableMessage( item: PostFeedbackItem, reason: string ): string
 }
 
 /**
- * Render the post feedback prototype component.
+ * Render the post feedback component.
  * @param {PostFeedbackProps} props Component props.
  * @returns React element.
  */

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -22,6 +22,7 @@ import {
 	toggleBlockReferenceFocus,
 	undoBlockEdit,
 } from '../utils/block-actions';
+import { countOccurrences, flattenBlocks } from '../utils/blocks';
 import {
 	trackAiEditorialReviewItemAction,
 	trackAiEditorialReviewResultRendered,
@@ -218,39 +219,6 @@ function getAiButtonLabel( status: EditStatus ): string {
 			return __( 'Retry AI resolution', 'jetpack' );
 		default:
 			return __( 'Accept AI resolution', 'jetpack' );
-	}
-}
-
-function flattenBlocks( blocks: BlockSnapshot[] ): BlockSnapshot[] {
-	const out: BlockSnapshot[] = [];
-	const walk = ( items: BlockSnapshot[] ) => {
-		items.forEach( ( block ) => {
-			if ( ! block.name ) {
-				return;
-			}
-			out.push( block );
-			if ( Array.isArray( block.innerBlocks ) && block.innerBlocks.length > 0 ) {
-				walk( block.innerBlocks );
-			}
-		} );
-	};
-	walk( blocks );
-	return out;
-}
-
-function countOccurrences( source: string, needle: string ): number {
-	if ( needle === '' ) {
-		return 0;
-	}
-	let count = 0;
-	let pos = 0;
-	while ( true ) {
-		const found = source.indexOf( needle, pos );
-		if ( found === -1 ) {
-			return count;
-		}
-		count++;
-		pos = found + 1;
 	}
 }
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -8,6 +8,7 @@
 
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { dispatch, select } from '@wordpress/data';
+import { countOccurrences } from './blocks';
 
 /**
  * Checkpoint API shared between the React `useCheckpoint` hook (which AM
@@ -408,22 +409,6 @@ export function startBlockShimmer(): void {
 }
 
 // ---------- Ability callbacks ----------
-
-function countOccurrences( source: string, needle: string ): number {
-	if ( needle === '' ) {
-		return 0;
-	}
-	let count = 0;
-	let startIndex = 0;
-	while ( true ) {
-		const index = source.indexOf( needle, startIndex );
-		if ( index === -1 ) {
-			return count;
-		}
-		count++;
-		startIndex = index + 1;
-	}
-}
 
 function normaliseAttributeName( attributeName?: string | null ): string | undefined {
 	return typeof attributeName === 'string' && attributeName.trim() !== ''

--- a/packages/jetpack-ai-sidebar/src/utils/blocks.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/blocks.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared block-tree and string helpers used by the Jetpack AI Sidebar components.
+ */
+
+import type { BlockSnapshot } from '../components/block-ref';
+
+/** Flatten a block tree into a pre-order list, skipping nameless blocks. */
+export function flattenBlocks( blocks: BlockSnapshot[] ): BlockSnapshot[] {
+	const out: BlockSnapshot[] = [];
+	const walk = ( items: BlockSnapshot[] ) => {
+		items.forEach( ( block ) => {
+			if ( ! block.name ) {
+				return;
+			}
+			out.push( block );
+			if ( Array.isArray( block.innerBlocks ) && block.innerBlocks.length > 0 ) {
+				walk( block.innerBlocks );
+			}
+		} );
+	};
+	walk( blocks );
+	return out;
+}
+
+/** Count occurrences of `needle` in `source` (overlapping matches counted). */
+export function countOccurrences( source: string, needle: string ): number {
+	if ( needle === '' ) {
+		return 0;
+	}
+	let count = 0;
+	let pos = 0;
+	while ( true ) {
+		const found = source.indexOf( needle, pos );
+		if ( found === -1 ) {
+			return count;
+		}
+		count++;
+		pos = found + 1;
+	}
+}


### PR DESCRIPTION
## Proposed Changes

- Extract the duplicated `flattenBlocks` and `countOccurrences` helpers into a shared `packages/jetpack-ai-sidebar/src/utils/blocks.ts`.
- Replace the three identical local copies (`components/review-mediation.tsx`, `components/post-feedback.tsx`, `utils/block-actions.ts`) with imports from it.

## Why are these changes being made?

These two pure helpers were copy-pasted across the AI Editorial Review and Generate Feedback components, plus a third copy in `block-actions.ts`. Consolidating them removes the duplication so a fix can't silently drift between copies. No behaviour change — the functions are moved verbatim.

## Testing Instructions

- `yarn test-packages packages/jetpack-ai-sidebar` — 154 tests pass.
- Pure refactor, so no behaviour change. Optionally, in the post editor with the Jetpack AI Sidebar, confirm AI Editorial Review and Generate Feedback still render and their block references/edits work as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

## Testing instructions
1. Sandbox `widgets.wp.com`
2. Checkout this branch locally
3. Install the plugin to sandbox using `yarn dev --sync` from Calypso local repo `apps/agents-manager`
4. Goto a draft post and open sidebar
5. Behind A8C gate, use Generate Feedback feature or AER
6. The features should work as expected
