### PR TITLE
Reader: restore legacy nav white ink over the dark hero

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -540,28 +540,48 @@ body.is-section-reader {
 	// bar must match its 64px white surface, not this 78px), so keep it off.
 	.masterbar-menu .masterbar:not( :has( .x-nav--2026-redesign ) ) {
 		height: 78px;
-
+		.x-nav-link__logo svg path {
+			fill: var( --studio-white );
+		}
 		.x-nav {
 			padding-top: 10px;
 			padding-left: 16px;
 			padding-right: 16px;
-		}
-		.cta-btn-nav {
-			margin-top: 9px;
-		}
-		.x-nav-link-chevron {
-			opacity: 1;
-		}
-		.x-nav-link__primary {
-			border: 2px solid var( --studio-white );
-			background: transparent !important;
+			.x-nav-item {
+				color: var( --studio-white );
+				&:hover {
+					color: var( --studio-white );
+				}
+				.cta-btn-nav {
+					margin-top: 9px;
+				}
+				.x-nav-link-chevron {
+					opacity: 1;
+					&::after,
+					&::before {
+						color: var( --studio-white );
+					}
+				}
+			}
+
+			.x-nav-link__primary {
+				border: 2px solid var( --studio-white );
+				background: transparent !important;
+			}
 		}
 	}
 
-	// Resting over the dark hero: white nav ink. Logo fill, chevron border and
-	// CTA border all read currentcolor, so colouring .x-nav-item carries them.
+	// Resting over the dark hero: white nav ink. Logo fill and CTA border read
+	// currentcolor, so colouring .x-nav-item carries them. The chevron glyph has
+	// its own hardcoded blue `color`, so override it explicitly (it's the glyph's
+	// `color`, not the triangle's `border-color`, so the blue hover/open state —
+	// which sets `border-color` — still wins).
 	.lpc-header-nav-container .x-nav--2026-redesign .x-nav-item {
 		color: var( --studio-white );
+
+		.x-nav-link-chevron::before {
+			color: var( --studio-white );
+		}
 
 		// Hover flips the CTA to a white fill with dark ink.
 		--x-nav-2026-cta-hover-fill: var( --studio-white );
@@ -575,6 +595,10 @@ body.is-section-reader {
 	.lpc-header-nav-container:has( .x-dropdown--2026.is-dropdown-open ) {
 		.x-nav--2026-redesign .x-nav-item {
 			color: var( --studio-gray-100 );
+
+			.x-nav-link-chevron::before {
+				color: var( --studio-gray-100 );
+			}
 		}
 	}
 }

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -571,17 +571,11 @@ body.is-section-reader {
 		}
 	}
 
-	// Resting over the dark hero: white nav ink. Logo fill and CTA border read
-	// currentcolor, so colouring .x-nav-item carries them. The chevron glyph has
-	// its own hardcoded blue `color`, so override it explicitly (it's the glyph's
-	// `color`, not the triangle's `border-color`, so the blue hover/open state —
-	// which sets `border-color` — still wins).
+	// Resting over the dark hero: white nav ink. Logo, CTA border and the chevron
+	// triangle all read currentcolor, so colouring .x-nav-item carries them — and
+	// staying on currentcolor lets the component's blue hover/open chevron win.
 	.lpc-header-nav-container .x-nav--2026-redesign .x-nav-item {
 		color: var( --studio-white );
-
-		.x-nav-link-chevron::before {
-			color: var( --studio-white );
-		}
 
 		// Hover flips the CTA to a white fill with dark ink.
 		--x-nav-2026-cta-hover-fill: var( --studio-white );
@@ -595,10 +589,6 @@ body.is-section-reader {
 	.lpc-header-nav-container:has( .x-dropdown--2026.is-dropdown-open ) {
 		.x-nav--2026-redesign .x-nav-item {
 			color: var( --studio-gray-100 );
-
-			.x-nav-link-chevron::before {
-				color: var( --studio-gray-100 );
-			}
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #112000.

## Proposed Changes

* Restore the legacy logged-out nav's white ink (logo, menu items, and chevrons) over the dark Reader hero, which the previous refactor dropped.

## Why are these changes being made?

* #112000 reworked the Reader hero nav colours and accidentally left the legacy nav's chevrons, menu links, and logo in their default dark colour, which is unreadable over the dark hero. This restores correct contrast. (The 2026 nav was already correct — its chevron rides `currentcolor`, so the white nav-item colour already carries it.)

## Testing Instructions

* Open the logged-out Reader landing page (`/read`) over the dark hero with the 2026 global nav **off** (legacy nav).
* Confirm the menu labels, the WordPress logo, and the dropdown chevrons are all white and legible against the dark hero.
* Turn the 2026 nav **on** and confirm it is unchanged — chevrons white at rest, blue on hover/open, ink flips dark when scrolled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?