### PR TITLE
Plans: cache plan-pricing queries so the onboarding grid stops stalling (TESTOPS-197)

### DIFF
--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -47,7 +47,9 @@ function usePlans( {
 	const queryKeys = useQueryKeysFactory();
 	const locale = useLocale();
 	const params = new URLSearchParams();
-	coupon && params.append( 'coupon_code', coupon );
+	if ( coupon ) {
+		params.append( 'coupon_code', coupon );
+	}
 	params.append( 'locale', locale );
 
 	// Auto-detect Jetpack context and use appropriate request function
@@ -101,6 +103,11 @@ function usePlans( {
 				} )
 			);
 		},
+		// Plan pricing is effectively static within a session. Keeping it fresh for
+		// 5 minutes prevents the many grid hooks that read this query from each
+		// re-triggering a fetch on mount; without it those refetches can supersede
+		// one another and leave the plans grid stuck on its loading spinner.
+		staleTime: 5 * 60 * 1000,
 	} );
 }
 

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -30,7 +30,9 @@ interface Props {
 function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const params = new URLSearchParams();
-	coupon && params.append( 'coupon_code', coupon );
+	if ( coupon ) {
+		params.append( 'coupon_code', coupon );
+	}
 
 	return useQuery( {
 		queryKey: queryKeys.sitePlans( coupon, siteId ),
@@ -85,6 +87,10 @@ function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansInd
 			);
 		},
 		enabled: !! siteId,
+		// Matches use-plans: site plan pricing is static within a session, so cache
+		// it to stop the grid's many pricing hooks from each refetching on mount and
+		// starving the query of a settled result (which leaves the grid spinning).
+		staleTime: 5 * 60 * 1000,
 	} );
 }
 


### PR DESCRIPTION
Fixes [TESTOPS-197](https://linear.app/a8c/issue/TESTOPS-197)

## Proposed Changes

* Set `staleTime` (5 min) on the `usePlans` and `useSitePlans` data-store queries. Plan pricing is static within a session, so it no longer refetches on every observer mount.
* Convert two `coupon && params.append( … )` short-circuits in the touched files to `if` statements (satisfies `no-unused-expressions`).

## Why are these changes being made?

The onboarding/signup plans grid intermittently never rendered: the step stayed on its loading spinner and no plan buttons (`button.is-*-plan`) entered the DOM, so 22 E2E specs across onboarding/domain/launch timed out ([build #26322](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/18283824)).

Root cause: `usePlans`/`useSitePlans` ran with the default `staleTime: 0`. The grid instantiates these queries from a large fan-out of hooks; with `staleTime` 0 every observer that mounts re-triggers a fetch, the fetches supersede one another, and the query never commits a result. `useGridPlans` then returns `null` indefinitely and the grid never becomes ready. Probes on a local build showed the `/plans` request resolving successfully ~10 times yet the query staying `pending`, with the hook instantiated 600+ times in a single mount; a `staleTime` collapses that to one fetch that commits, and the grid renders.

## Testing Instructions

* Local: walk the onboarding plans step against staging or localhost; the grid renders its plan buttons on first load. `plans__signup-business.spec.ts` passes end to end.
* CI: the branch was built with `TEST_GROUP=@calypso-release` ([build #26390](https://teamcity.a8c.com/build/18287795)). All 10 affected spec files (74 desktop + mobile cases) pass, versus 22 failing on [build #26322](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/18283824). The single chain failure (`invite__revoke`) is an unrelated [TESTOPS-193](https://linear.app/a8c/issue/TESTOPS-193) flaky spec.
