### PR TITLE
Reader: whiten 2026 nav chevron over the dark hero regardless of flag

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -571,11 +571,18 @@ body.is-section-reader {
 		}
 	}
 
-	// Resting over the dark hero: white nav ink. Logo, CTA border and the chevron
-	// triangle all read currentcolor, so colouring .x-nav-item carries them — and
-	// staying on currentcolor lets the component's blue hover/open chevron win.
+	// Resting over the dark hero: white nav ink. Logo and CTA border read
+	// currentcolor from .x-nav-item, but the chevron has its own hardcoded blue
+	// `color` ($studio-blue-90). The component only whitens it under
+	// `.is-style-monochrome`, which is gated on the `site-profiler/metrics` flag
+	// (on in dev, off in production) — so on wordpress.com the chevron stayed
+	// blue and vanished into the hero. Whiten it here, flag-independently.
 	.lpc-header-nav-container .x-nav--2026-redesign .x-nav-item {
 		color: var( --studio-white );
+
+		.x-nav-link-chevron::before {
+			color: var( --studio-white );
+		}
 
 		// Hover flips the CTA to a white fill with dark ink.
 		--x-nav-2026-cta-hover-fill: var( --studio-white );
@@ -589,6 +596,10 @@ body.is-section-reader {
 	.lpc-header-nav-container:has( .x-dropdown--2026.is-dropdown-open ) {
 		.x-nav--2026-redesign .x-nav-item {
 			color: var( --studio-gray-100 );
+
+			.x-nav-link-chevron::before {
+				color: var( --studio-gray-100 );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #112000.

## Proposed Changes

* Make the 2026 nav dropdown chevrons white over the dark Reader hero in all environments.

## Why are these changes being made?

* The chevrons were invisible in production but fine locally — a dev/prod mismatch. Their white styling only applies under `.is-style-monochrome`, which is gated on the `site-profiler/metrics` flag (on in dev, off in prod). This sets the chevron colour directly so it no longer depends on the flag.

## Testing Instructions

* Logged out, load `/discover?flags=nav-redesign/2026,-site-profiler/metrics` on trunk — chevrons invisible. On this branch — white.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?