### PR TITLE
Gutenberg e2e: temporary Like-widget probe for the Atomic edge likes__post failure

### DIFF
--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -19,6 +19,74 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
+// Temporary instrumentation for the flaky "Like post" step. Remove with the
+// probe in the test body once the Like-widget render failure is understood.
+type LikeProbeData = {
+	console: { type: string; text: string }[];
+	pageErrors: string[];
+	responses: { url: string; status: number }[];
+	requestFailures: { url: string; failure: string | null }[];
+};
+
+/**
+ * Dumps the state of the Like widget when `likePost()` fails, so a CI build log
+ * shows whether the iframe is missing, empty, or errored, and what the
+ * widgets.wp.com requests returned. Output is a single `[LIKE_PROBE]` line.
+ */
+async function logLikeWidgetProbe( page: Page, probe: LikeProbeData ): Promise< void > {
+	let dom: unknown;
+	try {
+		dom = await page.evaluate( () => {
+			const trunc = ( html: string | null | undefined ) => ( html ? html.slice( 0, 1200 ) : null );
+			const iframe = document.querySelector(
+				'iframe[title="Like or Reblog"]'
+			) as HTMLIFrameElement | null;
+			const container =
+				document.querySelector( '.jetpack-likes-widget-wrapper' ) ||
+				document.querySelector( '[id^="like-post-wrapper"]' ) ||
+				document.querySelector( '.sharedaddy' );
+			return {
+				hasLikeContainer: !! container,
+				likeContainerHTML: trunc( ( container as HTMLElement | null )?.outerHTML ),
+				iframe: iframe
+					? {
+							src: iframe.getAttribute( 'src' ),
+							width: iframe.clientWidth,
+							height: iframe.clientHeight,
+					  }
+					: null,
+			};
+		} );
+	} catch ( e ) {
+		dom = { evaluateError: String( e ).slice( 0, 200 ) };
+	}
+
+	const frames: { url: string; name: string; bodyText: string }[] = [];
+	for ( const f of page.frames() ) {
+		let bodyText = '';
+		try {
+			bodyText = ( await f.locator( 'body' ).innerText( { timeout: 1000 } ) ).slice( 0, 200 );
+		} catch {
+			// Frame may be empty, cross-origin-blocked, or detached; skip its text.
+		}
+		frames.push( { url: f.url(), name: f.name(), bodyText } );
+	}
+
+	// eslint-disable-next-line no-console
+	console.log(
+		'[LIKE_PROBE] ' +
+			JSON.stringify( {
+				url: page.url(),
+				dom,
+				frames,
+				console: probe.console.slice( -20 ),
+				pageErrors: probe.pageErrors.slice( -20 ),
+				responses: probe.responses.slice( -40 ),
+				requestFailures: probe.requestFailures.slice( -40 ),
+			} )
+	);
+}
+
 describe( 'Likes: Post', function () {
 	const features = envToFeatureKey( envVariables );
 	// @todo Does it make sense to create a `simpleSitePersonalPlanUserEdge` with GB edge?
@@ -72,12 +140,50 @@ describe( 'Likes: Post', function () {
 
 		it( 'Like post', async function () {
 			const siteID = postingUser.credentials.testSites?.primary.id as number;
+
+			// Temporary diagnostics: the Like button (loaded in an iframe from
+			// widgets.wp.com) intermittently fails to render on Atomic, leaving the
+			// "Like this:" section empty and the test timing out. Collect
+			// network/console/DOM/frame state on failure so a CI run shows why.
+			// Remove once the cause is identified.
+			const probe: LikeProbeData = {
+				console: [],
+				pageErrors: [],
+				responses: [],
+				requestFailures: [],
+			};
+			const widgetUrl = /widgets\.wp\.com|\/likes|like\.php/i;
+			page.on( 'console', ( msg ) => {
+				if ( msg.type() === 'error' || msg.type() === 'warning' ) {
+					probe.console.push( { type: msg.type(), text: msg.text().slice( 0, 300 ) } );
+				}
+			} );
+			page.on( 'pageerror', ( err ) => probe.pageErrors.push( String( err ).slice( 0, 300 ) ) );
+			page.on( 'response', ( res ) => {
+				if ( widgetUrl.test( res.url() ) ) {
+					probe.responses.push( { url: res.url(), status: res.status() } );
+				}
+			} );
+			page.on( 'requestfailed', ( req ) => {
+				if ( widgetUrl.test( req.url() ) ) {
+					probe.requestFailures.push( {
+						url: req.url(),
+						failure: req.failure()?.errorText ?? null,
+					} );
+				}
+			} );
+
 			await ElementHelper.reloadAndRetry( page, async () => {
 				// Reset like state via REST API before each attempt.
 				await restAPIClient.postLikeAction( 'unlike', siteID, newPost.ID );
 				await page.reload();
 				publishedPostPage = new PublishedPostPage( page );
-				await publishedPostPage.likePost();
+				try {
+					await publishedPostPage.likePost();
+				} catch ( error ) {
+					await logLikeWidgetProbe( page, probe );
+					throw error;
+				}
 			} );
 		} );
 

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -273,18 +273,21 @@ describe( 'Likes: Post', function () {
 					.map( ( frame ) => attachNetworkProbe( frame ) )
 			);
 
-			await ElementHelper.reloadAndRetry( page, async () => {
-				// Reset like state via REST API before each attempt.
-				await restAPIClient.postLikeAction( 'unlike', siteID, newPost.ID );
-				await page.reload();
-				publishedPostPage = new PublishedPostPage( page );
-				try {
+			// Log the probe only when the whole step fails (all retries exhausted),
+			// not on individual attempts that reloadAndRetry recovers from, so
+			// green runs stay clean.
+			try {
+				await ElementHelper.reloadAndRetry( page, async () => {
+					// Reset like state via REST API before each attempt.
+					await restAPIClient.postLikeAction( 'unlike', siteID, newPost.ID );
+					await page.reload();
+					publishedPostPage = new PublishedPostPage( page );
 					await publishedPostPage.likePost();
-				} catch ( error ) {
-					await logLikeWidgetProbe( page, probe );
-					throw error;
-				}
-			} );
+				} );
+			} catch ( error ) {
+				await logLikeWidgetProbe( page, probe );
+				throw error;
+			}
 		} );
 
 		it( 'Unlike post', async function () {

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -15,7 +15,7 @@ import {
 	RestAPIClient,
 	PostResponse,
 } from '@automattic/calypso-e2e';
-import { Page, Browser } from 'playwright';
+import { Page, Browser, Frame } from 'playwright';
 
 declare const browser: Browser;
 
@@ -24,8 +24,20 @@ declare const browser: Browser;
 type LikeProbeData = {
 	console: { type: string; text: string }[];
 	pageErrors: string[];
-	responses: { url: string; status: number }[];
-	requestFailures: { url: string; failure: string | null }[];
+	responses: { url: string; status: number; frame: string }[];
+	requestFailures: {
+		url: string;
+		failure: string | null;
+		frame: string;
+		method: string;
+		resourceType: string;
+		origin: string | undefined;
+		hasCookie: boolean;
+	}[];
+	// Low-level network failures from CDP, including the cross-origin rest-proxy
+	// iframe (an OOPIF), which page-level events report only as net::ERR_FAILED.
+	// Carries blockedReason / corsErrorStatus that name the real transport block.
+	cdp: Record< string, unknown >[];
 };
 
 /**
@@ -83,6 +95,7 @@ async function logLikeWidgetProbe( page: Page, probe: LikeProbeData ): Promise< 
 				pageErrors: probe.pageErrors.slice( -20 ),
 				responses: probe.responses.slice( -40 ),
 				requestFailures: probe.requestFailures.slice( -40 ),
+				cdp: probe.cdp.slice( -40 ),
 			} )
 	);
 }
@@ -151,8 +164,16 @@ describe( 'Likes: Post', function () {
 				pageErrors: [],
 				responses: [],
 				requestFailures: [],
+				cdp: [],
 			};
-			const widgetUrl = /widgets\.wp\.com|\/likes|like\.php/i;
+			const widgetUrl = /widgets\.wp\.com|\/likes|like\.php|\/rest\/v1\/batch/i;
+			const frameUrl = ( r: { frame: () => Frame } ) => {
+				try {
+					return r.frame().url();
+				} catch {
+					return '(detached)';
+				}
+			};
 			page.on( 'console', ( msg ) => {
 				if ( msg.type() === 'error' || msg.type() === 'warning' ) {
 					probe.console.push( { type: msg.type(), text: msg.text().slice( 0, 300 ) } );
@@ -161,17 +182,96 @@ describe( 'Likes: Post', function () {
 			page.on( 'pageerror', ( err ) => probe.pageErrors.push( String( err ).slice( 0, 300 ) ) );
 			page.on( 'response', ( res ) => {
 				if ( widgetUrl.test( res.url() ) ) {
-					probe.responses.push( { url: res.url(), status: res.status() } );
+					probe.responses.push( {
+						url: res.url(),
+						status: res.status(),
+						frame: frameUrl( res.request() ),
+					} );
 				}
 			} );
 			page.on( 'requestfailed', ( req ) => {
 				if ( widgetUrl.test( req.url() ) ) {
+					const headers = req.headers();
 					probe.requestFailures.push( {
 						url: req.url(),
 						failure: req.failure()?.errorText ?? null,
+						frame: frameUrl( req ),
+						method: req.method(),
+						resourceType: req.resourceType(),
+						origin: headers.origin,
+						hasCookie: Boolean( headers.cookie ),
 					} );
 				}
 			} );
+
+			// Attach a CDP Network probe per frame to recover the transport-level
+			// block reason behind net::ERR_FAILED. Needed because the authenticated
+			// batch travels through the cross-origin public-api.wordpress.com proxy
+			// iframe, an OOPIF whose network events page-level listeners do not see.
+			// Fully guarded: any CDP failure is swallowed and never affects the test.
+			// ponytail: first-request-per-frame may race the attach; reloadAndRetry
+			// reloads several times, so a later attempt catches it.
+			const cdpReqUrl = new Map< string, string >();
+			const attachNetworkProbe = async ( target: Page | Frame ) => {
+				try {
+					const cdp = await page.context().newCDPSession( target );
+					await cdp.send( 'Network.enable' );
+					cdp.on(
+						'Network.requestWillBeSent',
+						( e: { requestId: string; request: { url: string } } ) => {
+							if ( widgetUrl.test( e.request.url ) ) {
+								cdpReqUrl.set( e.requestId, e.request.url );
+							}
+						}
+					);
+					cdp.on(
+						'Network.loadingFailed',
+						( e: {
+							requestId: string;
+							type?: string;
+							errorText?: string;
+							blockedReason?: string;
+							corsErrorStatus?: { corsError?: string };
+						} ) => {
+							const url = cdpReqUrl.get( e.requestId );
+							if ( ! url ) {
+								return;
+							}
+							probe.cdp.push( {
+								event: 'loadingFailed',
+								url,
+								type: e.type,
+								errorText: e.errorText,
+								blockedReason: e.blockedReason,
+								corsError: e.corsErrorStatus?.corsError,
+							} );
+						}
+					);
+					cdp.on(
+						'Network.responseReceivedExtraInfo',
+						( e: { requestId: string; blockedCookies?: unknown[] } ) => {
+							const url = cdpReqUrl.get( e.requestId );
+							if ( url && e.blockedCookies?.length ) {
+								probe.cdp.push( {
+									event: 'blockedCookies',
+									url,
+									blockedCookies: e.blockedCookies,
+								} );
+							}
+						}
+					);
+				} catch {
+					// Non-Chromium, or frame detached/cross-process at attach time; skip.
+				}
+			};
+			await attachNetworkProbe( page );
+			page.on( 'frameattached', ( frame ) => void attachNetworkProbe( frame ) );
+			await Promise.all(
+				page
+					.frames()
+					.filter( ( frame ) => frame !== page.mainFrame() )
+					.map( ( frame ) => attachNetworkProbe( frame ) )
+			);
 
 			await ElementHelper.reloadAndRetry( page, async () => {
 				// Reset like state via REST API before each attempt.


### PR DESCRIPTION
Part of [TESTOPS-200](https://linear.app/a8c/issue/TESTOPS-200).

## Proposed Changes

* `test/e2e/specs/published-content/likes__post.ts`: temporary probe on the `Like post` step. When the step fails (all `reloadAndRetry` attempts exhausted, not a single attempt that later recovers), it logs one `[LIKE_PROBE]` line with the Like-widget DOM, the `iframe[title="Like or Reblog"]` src/size, each frame's URL and body snippet, console and page errors, and the status of `widgets.wp.com` / likes / `/rest/v1/batch` requests, then re-throws (retry behaviour unchanged). Every request records its originating frame, method, `Origin` header and whether a `Cookie` went with it. A per-frame CDP `Network` probe covers the cross-origin `public-api.wordpress.com` rest-proxy iframe (an OOPIF page-level listeners can't see) and records `loadingFailed` `blockedReason` / `corsErrorStatus` and blocked cookies. Nothing is logged on a passing run.

## Why are these changes being made?

`Likes: Post > While authenticated > Like post` breaks only on `calypso_WPComTests_gutenberg_atomic_edge_{desktop,mobile}`; simple edge and both production configs stay green. It had been patched as flaky before without a root cause.

The failure isn't constant, it's a window. The `likes__post` result on the desktop edge config: green through #2340 (Jun 23), red #2341 to #2351 (Jun 24 to 30), green again from #2352 (Jul 1); mobile flips on the same days. Whatever changed did so around Jun 24 and cleared around Jul 1, and it's specific to the one edge site.

What the probe and the failing-run trace show: the authenticated `/rest/v1/batch` call (the post's `likes` + `reblogs/mine`) fails with `net::ERR_FAILED` inside the cross-origin rest-proxy iframe, the session cookie blocked there as `SameSiteUnspecifiedTreatedAsLax`; the widget then hits `Cannot read properties of null (reading 'appendChild')` and the `Like or Reblog` iframe stays empty, so the `Like` link never renders and the step times out. The post itself is fine: `/sites/<id>/posts/<n>/likes` returns 200 and the widget assets all load.

## Testing Instructions

* Run `calypso_WPComTests_gutenberg_atomic_edge_desktop` (and mobile) against this branch.
* On a `Like post` failure the build log carries one `[LIKE_PROBE]` JSON line with the widget and network state, including the CDP block reason for the failed `/rest/v1/batch`. A passing run logs nothing.
* The bug is currently dormant (recovered around Jul 1), so a green run is expected right now and doesn't clear the underlying issue; the probe is here to catch the next recurrence.

Builds:
- Failing edge run, trace shows the batch `net::ERR_FAILED`: [failing edge run](https://teamcity.a8c.com/build/18327682)
- Probe output with the cookie block reason: [probe run 1](https://teamcity.a8c.com/build/18314050), [probe run 2](https://teamcity.a8c.com/build/18289047)
- This branch, both green (bug dormant): [desktop](https://teamcity.a8c.com/build/18348526), [mobile](https://teamcity.a8c.com/build/18348527)
- Passing reference: [nightly](https://teamcity.a8c.com/build/18311778), [production](https://teamcity.a8c.com/build/18311780)
