### PR TITLE
Reader: show pending posts immediately from poll cache

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -886,7 +886,7 @@ const withStreamPosts = ( WrappedComponent ) =>
 		const {
 			pendingCount,
 			hasPendingPosts,
-			reset: resetPending,
+			consume: consumePendingPosts,
 		} = useStreamPendingPosts( {
 			streamKey: props.streamKey,
 			feedId: props.selectedFeedId,
@@ -907,15 +907,13 @@ const withStreamPosts = ( WrappedComponent ) =>
 			}
 		}, [ hasPendingPosts, invalidate ] );
 
-		// Click handler for `<UpdateNotice>`: refetch all loaded pages now and
-		// drop the polled head from cache so the pill clears immediately
-		// (instead of flickering until the next poll tick recomputes against
-		// the freshly refetched items).
-		const { refetch } = streamPostsQuery;
+		// Click handler for `<UpdateNotice>`: prepend the already-polled head to
+		// the rendered infinite stream and clear the poll cache. This keeps the
+		// legacy "show updates" behavior without waiting on a second fetch.
 		const consumePending = React.useCallback( () => {
-			refetch();
-			resetPending();
-		}, [ refetch, resetPending ] );
+			consumePendingPosts();
+		}, [ consumePendingPosts ] );
+		const { refetch } = streamPostsQuery;
 
 		// Selection lives in the React Query cache (not Redux). The hook is
 		// keyed by `[streamKey, localeSlug]`, so switching streams (including

--- a/client/reader/stream/test/use-stream-pending-posts.test.tsx
+++ b/client/reader/stream/test/use-stream-pending-posts.test.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from 'react';
 
 const BASE = 'https://public-api.wordpress.com';
 const LIKES_PATH = '/rest/v1.2/read/liked';
+const RECOMMENDATIONS_SITES_PATH = '/rest/v1.2/read/recommendations/sites';
 
 afterEach( () => {
 	nock.cleanAll();
@@ -49,9 +50,17 @@ interface ApiPost {
 	ID: number;
 	site_ID: number;
 	URL?: string;
+	date?: string;
 	date_liked?: string;
 	content?: string;
 	railcar?: Record< string, unknown >;
+}
+
+interface ApiSite {
+	name: string;
+	feed_ID: number;
+	URL: string;
+	posts: ApiPost[];
 }
 
 function apiPost( id: number, overrides: Partial< ApiPost > = {} ): ApiPost {
@@ -67,6 +76,16 @@ function apiPost( id: number, overrides: Partial< ApiPost > = {} ): ApiPost {
 
 function postKey( id: number, siteId = 100 ): StreamItem {
 	return { blogId: siteId, postId: id };
+}
+
+function apiSite( siteId: number, postId: number, overrides: Partial< ApiSite > = {} ): ApiSite {
+	return {
+		name: `Recommended site ${ siteId }`,
+		feed_ID: siteId,
+		URL: `https://site-${ siteId }.example.com`,
+		posts: [ apiPost( postId, { site_ID: siteId, date: '2026-04-01T00:00:00Z' } ) ],
+		...overrides,
+	};
 }
 
 describe( 'useStreamPendingPosts', () => {
@@ -326,6 +345,60 @@ describe( 'useStreamPendingPosts', () => {
 			pages: Array< { posts?: ApiPost[] } >;
 		} >( streamQueryKey );
 		expect( streamData?.pages[ 0 ].posts?.map( ( post ) => post.ID ) ).toEqual( [ 1, 2, 3 ] );
+		await waitFor( () => expect( result.current.pendingCount ).toBe( 0 ) );
+	} );
+
+	it( 'consume() merges sites-shaped pending pages into the first rendered page', async () => {
+		nock( BASE )
+			.get( RECOMMENDATIONS_SITES_PATH )
+			.query( true )
+			.reply( 200, {
+				sites: [ apiSite( 100, 1 ), apiSite( 200, 2 ), apiSite( 300, 3 ) ],
+			} );
+
+		const queryClient = makeQueryClient();
+		const streamQueryKey = getStreamInfiniteQueryKey( {
+			streamKey: 'custom_recs_sites_with_images',
+			feedId: null,
+			localeSlug: null,
+			startDate: null,
+		} );
+		queryClient.setQueryData( streamQueryKey, {
+			pageParams: [ null ],
+			pages: [
+				{
+					sites: [ apiSite( 200, 2 ), apiSite( 300, 3 ) ],
+				},
+			],
+		} );
+
+		const { Wrapper } = makeWrapper( queryClient );
+		const items = [ postKey( 2, 200 ), postKey( 3, 300 ) ];
+		const { result } = renderHook(
+			() =>
+				useStreamPendingPosts( {
+					streamKey: 'custom_recs_sites_with_images',
+					items,
+					shouldPoll: true,
+				} ),
+			{ wrapper: Wrapper }
+		);
+
+		await waitFor( () => expect( result.current.pendingCount ).toBe( 1 ) );
+
+		act( () => {
+			result.current.consume();
+		} );
+
+		const streamData = queryClient.getQueryData< {
+			pageParams: unknown[];
+			pages: Array< { sites?: ApiSite[] } >;
+		} >( streamQueryKey );
+		expect( streamData?.pageParams ).toEqual( [ null ] );
+		expect( streamData?.pages ).toHaveLength( 1 );
+		expect( streamData?.pages[ 0 ].sites?.map( ( site ) => site.posts[ 0 ].ID ) ).toEqual( [
+			1, 2, 3,
+		] );
 		await waitFor( () => expect( result.current.pendingCount ).toBe( 0 ) );
 	} );
 

--- a/client/reader/stream/test/use-stream-pending-posts.test.tsx
+++ b/client/reader/stream/test/use-stream-pending-posts.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { getStreamInfiniteQueryKey } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
@@ -224,7 +225,111 @@ describe( 'useStreamPendingPosts', () => {
 		expect( result.current.pendingCount ).toBe( 0 );
 	} );
 
-	it( 'reset() drops the polled head from cache', async () => {
+	it( 'consume() prepends the polled pending posts to the rendered stream cache', async () => {
+		nock( BASE )
+			.get( LIKES_PATH )
+			.query( true )
+			.reply( 200, {
+				posts: [ apiPost( 1 ), apiPost( 2 ), apiPost( 3 ) ],
+				date_range: { after: null, before: null },
+			} );
+
+		const queryClient = makeQueryClient();
+		const streamQueryKey = getStreamInfiniteQueryKey( {
+			streamKey: 'likes',
+			feedId: null,
+			localeSlug: null,
+			startDate: null,
+		} );
+		queryClient.setQueryData( streamQueryKey, {
+			pageParams: [ null ],
+			pages: [
+				{
+					posts: [ apiPost( 2 ), apiPost( 3 ) ],
+					date_range: { after: null, before: null },
+				},
+			],
+		} );
+
+		const { Wrapper } = makeWrapper( queryClient );
+		const items = [ postKey( 2 ), postKey( 3 ) ];
+		const { result } = renderHook(
+			() => useStreamPendingPosts( { streamKey: 'likes', items, shouldPoll: true } ),
+			{ wrapper: Wrapper }
+		);
+
+		await waitFor( () => expect( result.current.pendingCount ).toBe( 1 ) );
+
+		act( () => {
+			result.current.consume();
+		} );
+
+		const streamData = queryClient.getQueryData< {
+			pages: Array< { posts?: ApiPost[] } >;
+		} >( streamQueryKey );
+		expect( streamData?.pages[ 0 ].posts?.map( ( post ) => post.ID ) ).toEqual( [ 1, 2, 3 ] );
+		await waitFor( () =>
+			expect( queryClient.getQueryState( streamQueryKey )?.isInvalidated ).toBe( true )
+		);
+		await waitFor( () => expect( result.current.pendingCount ).toBe( 0 ) );
+	} );
+
+	it( 'consume() does not duplicate posts already present in the current stream cache', async () => {
+		nock( BASE )
+			.get( LIKES_PATH )
+			.query( true )
+			.reply( 200, {
+				posts: [ apiPost( 1 ), apiPost( 2 ), apiPost( 3 ) ],
+				date_range: { after: null, before: null },
+			} );
+
+		const queryClient = makeQueryClient();
+		const streamQueryKey = getStreamInfiniteQueryKey( {
+			streamKey: 'likes',
+			feedId: null,
+			localeSlug: null,
+			startDate: null,
+		} );
+		queryClient.setQueryData( streamQueryKey, {
+			pageParams: [ null ],
+			pages: [
+				{
+					posts: [ apiPost( 2 ), apiPost( 3 ) ],
+					date_range: { after: null, before: null },
+				},
+			],
+		} );
+
+		const { Wrapper } = makeWrapper( queryClient );
+		const items = [ postKey( 2 ), postKey( 3 ) ];
+		const { result } = renderHook(
+			() => useStreamPendingPosts( { streamKey: 'likes', items, shouldPoll: true } ),
+			{ wrapper: Wrapper }
+		);
+
+		await waitFor( () => expect( result.current.pendingCount ).toBe( 1 ) );
+
+		act( () => {
+			queryClient.setQueryData( streamQueryKey, {
+				pageParams: [ null ],
+				pages: [
+					{
+						posts: [ apiPost( 1 ), apiPost( 2 ), apiPost( 3 ) ],
+						date_range: { after: null, before: null },
+					},
+				],
+			} );
+			result.current.consume();
+		} );
+
+		const streamData = queryClient.getQueryData< {
+			pages: Array< { posts?: ApiPost[] } >;
+		} >( streamQueryKey );
+		expect( streamData?.pages[ 0 ].posts?.map( ( post ) => post.ID ) ).toEqual( [ 1, 2, 3 ] );
+		await waitFor( () => expect( result.current.pendingCount ).toBe( 0 ) );
+	} );
+
+	it( 'reset() drops the polled head from cache without immediately refetching', async () => {
 		nock( BASE )
 			.get( LIKES_PATH )
 			.query( true )
@@ -243,8 +348,7 @@ describe( 'useStreamPendingPosts', () => {
 
 		await waitFor( () => expect( result.current.pendingCount ).toBe( 1 ) );
 
-		// `resetQueries` re-fetches active observers; mock the second call.
-		nock( BASE )
+		const unexpectedRefetch = nock( BASE )
 			.get( LIKES_PATH )
 			.query( true )
 			.reply( 200, {
@@ -256,9 +360,10 @@ describe( 'useStreamPendingPosts', () => {
 			result.current.reset();
 		} );
 
-		// pendingCount snaps to 0 immediately after reset (data is undefined),
-		// and stays 0 once the follow-up fetch lands matching the visible items.
+		// pendingCount snaps to 0 immediately after reset (data is cleared),
+		// without the active poll observer starting a new network request.
 		await waitFor( () => expect( result.current.pendingCount ).toBe( 0 ) );
+		expect( unexpectedRefetch.isDone() ).toBe( false );
 	} );
 
 	it( 'rotates queryKey on streamKey change so polled head does not bleed across streams', async () => {

--- a/client/reader/stream/use-stream-pending-posts.ts
+++ b/client/reader/stream/use-stream-pending-posts.ts
@@ -94,6 +94,14 @@ const countPendingItems = (
 const streamItemsFromPages = ( pages: ReadStreamResponse[], streamType: string ): StreamItem[] =>
 	pages.flatMap( ( page ) => normalizeStreamPage( page, streamType ).streamItems );
 
+const siteHasPost = ( site: unknown ): boolean => {
+	if ( ! site || typeof site !== 'object' ) {
+		return false;
+	}
+	const posts = ( site as { posts?: unknown } ).posts;
+	return Array.isArray( posts ) && posts.length > 0;
+};
+
 const takePendingFromPage = (
 	page: ReadStreamResponse,
 	pendingCount: number
@@ -122,7 +130,18 @@ const takePendingFromPage = (
 	}
 
 	if ( Array.isArray( page.sites ) ) {
-		return { ...page, sites: page.sites.slice( 0, pendingCount ) };
+		let remaining = pendingCount;
+		const sites: unknown[] = [];
+		for ( const site of page.sites ) {
+			if ( remaining <= 0 ) {
+				break;
+			}
+			sites.push( site );
+			if ( siteHasPost( site ) ) {
+				remaining -= 1;
+			}
+		}
+		return { ...page, sites };
 	}
 
 	return page;
@@ -156,6 +175,16 @@ const prependPendingPage = (
 			...current,
 			pages: [
 				{ ...firstPage, cards: [ ...pendingOnlyPage.cards, ...firstPage.cards ] },
+				...remainingPages,
+			],
+		};
+	}
+
+	if ( Array.isArray( pendingOnlyPage.sites ) && Array.isArray( firstPage.sites ) ) {
+		return {
+			...current,
+			pages: [
+				{ ...firstPage, sites: [ ...pendingOnlyPage.sites, ...firstPage.sites ] },
 				...remainingPages,
 			],
 		};

--- a/client/reader/stream/use-stream-pending-posts.ts
+++ b/client/reader/stream/use-stream-pending-posts.ts
@@ -1,5 +1,10 @@
-import { fetchReadStream, getStreamType } from '@automattic/api-queries';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+	fetchReadStream,
+	getStreamInfiniteQueryKey,
+	getStreamType,
+	type PageHandle,
+} from '@automattic/api-queries';
+import { useQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { EVERY_MINUTE } from 'calypso/lib/interval';
 import { syncConversationFollowStatus, syncPostCache } from 'calypso/reader/data/post/cache';
@@ -34,9 +39,16 @@ export interface UseStreamPendingPostsResult {
 	/** Sugar for `pendingCount > 0`. */
 	hasPendingPosts: boolean;
 	/**
+	 * Insert the current polled head into the rendered stream and clear it from
+	 * the poll cache. Mirrors the legacy Reader `showUpdates` action, which
+	 * prepended `pendingItems` instead of waiting on a second stream request.
+	 */
+	consume: () => void;
+	/**
 	 * Drop the polled head from cache. Use after the consumer has acted on the
-	 * pending posts (e.g., refetched the infinite query) so the pill clears
-	 * immediately, instead of waiting for the next `refetchInterval` tick.
+	 * pending posts (e.g., consumed them into the infinite query) so the pill
+	 * clears immediately, instead of waiting for the next `refetchInterval`
+	 * tick.
 	 */
 	reset: () => void;
 }
@@ -62,18 +74,111 @@ const railcarId = ( railcar: unknown ): string | null => {
 	return typeof id === 'string' ? id : JSON.stringify( railcar );
 };
 
+type StreamInfiniteData = InfiniteData< ReadStreamResponse, PageHandle >;
+
+const countPendingItems = (
+	pollPage: ReadStreamResponse | null | undefined,
+	items: StreamItem[],
+	streamType: string
+): number => {
+	const streamItems = pollPage ? normalizeStreamPage( pollPage, streamType ).streamItems : [];
+	const seen = new Set( items.map( postKeyId ) );
+	// Stop at the first polled-head item the user has already seen. Items past
+	// that boundary are older posts the user hasn't scrolled to (the poll
+	// fetches `PER_POLL` items > `INITIAL_FETCH`), not new content. Mirrors the
+	// legacy reducer's `lastUpdated` date pre-filter.
+	const firstSeen = streamItems.findIndex( ( k ) => seen.has( postKeyId( k ) ) );
+	return firstSeen === -1 ? streamItems.length : firstSeen;
+};
+
+const streamItemsFromPages = ( pages: ReadStreamResponse[], streamType: string ): StreamItem[] =>
+	pages.flatMap( ( page ) => normalizeStreamPage( page, streamType ).streamItems );
+
+const takePendingFromPage = (
+	page: ReadStreamResponse,
+	pendingCount: number
+): ReadStreamResponse => {
+	if ( pendingCount <= 0 ) {
+		return page;
+	}
+
+	if ( Array.isArray( page.posts ) ) {
+		return { ...page, posts: page.posts.slice( 0, pendingCount ) };
+	}
+
+	if ( Array.isArray( page.cards ) ) {
+		let remaining = pendingCount;
+		const cards: NonNullable< ReadStreamResponse[ 'cards' ] > = [];
+		for ( const card of page.cards ) {
+			if ( remaining <= 0 ) {
+				break;
+			}
+			cards.push( card );
+			if ( card.type === 'post' ) {
+				remaining -= 1;
+			}
+		}
+		return { ...page, cards };
+	}
+
+	if ( Array.isArray( page.sites ) ) {
+		return { ...page, sites: page.sites.slice( 0, pendingCount ) };
+	}
+
+	return page;
+};
+
+const prependPendingPage = (
+	current: StreamInfiniteData | undefined,
+	pendingPage: ReadStreamResponse,
+	pendingCount: number,
+	initialPageParam: PageHandle
+): StreamInfiniteData => {
+	const pendingOnlyPage = takePendingFromPage( pendingPage, pendingCount );
+
+	if ( ! current?.pages.length ) {
+		return { pageParams: [ initialPageParam ], pages: [ pendingOnlyPage ] };
+	}
+
+	const [ firstPage, ...remainingPages ] = current.pages;
+	if ( Array.isArray( pendingOnlyPage.posts ) && Array.isArray( firstPage.posts ) ) {
+		return {
+			...current,
+			pages: [
+				{ ...firstPage, posts: [ ...pendingOnlyPage.posts, ...firstPage.posts ] },
+				...remainingPages,
+			],
+		};
+	}
+
+	if ( Array.isArray( pendingOnlyPage.cards ) && Array.isArray( firstPage.cards ) ) {
+		return {
+			...current,
+			pages: [
+				{ ...firstPage, cards: [ ...pendingOnlyPage.cards, ...firstPage.cards ] },
+				...remainingPages,
+			],
+		};
+	}
+
+	return {
+		pageParams: [ initialPageParam, ...current.pageParams ],
+		pages: [ pendingOnlyPage, ...current.pages ],
+	};
+};
+
 /**
  * Drives the "X new posts" pill. A separate `useQuery` polls the head of the
  * stream every minute (`refetchInterval`); the diff between the polled head
  * and the currently visible items is exposed as `pendingCount`. The polled
  * payload carries full post bodies (see `getQueryStringForPoll`), and is
  * written into the canonical Reader post cache on every tick so
- * `<PostLifecycle>` resolves rich cards immediately when the consumer triggers
- * a refetch of the infinite query.
+ * `<PostLifecycle>` resolves rich cards immediately when the consumer prepends
+ * the polled head into the infinite query.
  *
- * The hook is purely informational. Reacting to a non-zero `hasPendingPosts`
- * (passive invalidate, imperative refetch on click) is the consumer's job —
- * see `withStreamPosts` in `client/reader/stream/index.jsx`.
+ * Reacting to a non-zero `hasPendingPosts` (passive invalidate, consume on
+ * click) is the consumer's job — see `withStreamPosts` in
+ * `client/reader/stream/index.jsx`.
  */
 export function useStreamPendingPosts( {
 	streamKey,
@@ -97,7 +202,7 @@ export function useStreamPendingPosts( {
 	// pending count is meaningless until we have a baseline of "what is shown".
 	const enabled = shouldPoll && items.length > 0;
 
-	const pollHead = useQuery< ReadStreamResponse >( {
+	const pollHead = useQuery< ReadStreamResponse | null >( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: pollQueryKey,
 		queryFn: () => {
@@ -156,22 +261,56 @@ export function useStreamPendingPosts( {
 		}
 	}, [ pollHead.data, streamKey, streamType, queryClient, dispatch ] );
 
-	const pendingCount = useMemo( () => {
-		const streamItems = pollHead.data
-			? normalizeStreamPage( pollHead.data, streamType ).streamItems
-			: [];
-		const seen = new Set( items.map( postKeyId ) );
-		// Stop at the first polled-head item the user has already seen. Items
-		// past that boundary are older posts the user hasn't scrolled to (the
-		// poll fetches `PER_POLL` items > `INITIAL_FETCH`), not new content.
-		// Mirrors the legacy reducer's `lastUpdated` date pre-filter.
-		const firstSeen = streamItems.findIndex( ( k ) => seen.has( postKeyId( k ) ) );
-		return firstSeen === -1 ? streamItems.length : firstSeen;
-	}, [ pollHead.data, items, streamType ] );
+	const pendingCount = useMemo(
+		() => countPendingItems( pollHead.data, items, streamType ),
+		[ pollHead.data, items, streamType ]
+	);
 
 	const reset = useCallback( () => {
-		queryClient.resetQueries( { queryKey: pollQueryKey, exact: true } );
+		void queryClient.cancelQueries( { queryKey: pollQueryKey, exact: true }, { silent: true } );
+		queryClient.setQueryData< ReadStreamResponse | null >( pollQueryKey, null );
 	}, [ queryClient, pollQueryKey ] );
 
-	return { pendingCount, hasPendingPosts: pendingCount > 0, reset };
+	const consume = useCallback( () => {
+		if ( pollHead.data ) {
+			const streamQueryKey = getStreamInfiniteQueryKey( {
+				streamKey,
+				feedId,
+				localeSlug,
+				startDate,
+			} );
+			queryClient.setQueryData< StreamInfiniteData >( streamQueryKey, ( current ) => {
+				const currentItems = current?.pages.length
+					? streamItemsFromPages( current.pages, streamType )
+					: items;
+				const currentPendingCount = countPendingItems( pollHead.data, currentItems, streamType );
+				return currentPendingCount > 0
+					? prependPendingPage(
+							current,
+							pollHead.data as ReadStreamResponse,
+							currentPendingCount,
+							startDate ? { before: startDate } : null
+					  )
+					: current;
+			} );
+			void queryClient.invalidateQueries( {
+				queryKey: streamQueryKey,
+				exact: true,
+				refetchType: 'none',
+			} );
+		}
+		reset();
+	}, [
+		feedId,
+		items,
+		localeSlug,
+		pollHead.data,
+		queryClient,
+		reset,
+		startDate,
+		streamKey,
+		streamType,
+	] );
+
+	return { pendingCount, hasPendingPosts: pendingCount > 0, consume, reset };
 }

--- a/client/reader/stream/use-stream-pending-posts.ts
+++ b/client/reader/stream/use-stream-pending-posts.ts
@@ -91,8 +91,31 @@ const countPendingItems = (
 	return firstSeen === -1 ? streamItems.length : firstSeen;
 };
 
-const streamItemsFromPages = ( pages: ReadStreamResponse[], streamType: string ): StreamItem[] =>
-	pages.flatMap( ( page ) => normalizeStreamPage( page, streamType ).streamItems );
+const countPendingItemsFromPages = (
+	pollPage: ReadStreamResponse | null | undefined,
+	pages: ReadStreamResponse[],
+	streamType: string
+): number => {
+	const streamItems = pollPage ? normalizeStreamPage( pollPage, streamType ).streamItems : [];
+	if ( streamItems.length === 0 ) {
+		return 0;
+	}
+
+	let firstSeen = -1;
+	for ( const page of pages ) {
+		const seen = new Set( normalizeStreamPage( page, streamType ).streamItems.map( postKeyId ) );
+		const pageFirstSeen = streamItems.findIndex( ( k ) => seen.has( postKeyId( k ) ) );
+		if ( pageFirstSeen === -1 ) {
+			continue;
+		}
+		firstSeen = firstSeen === -1 ? pageFirstSeen : Math.min( firstSeen, pageFirstSeen );
+		if ( firstSeen === 0 ) {
+			break;
+		}
+	}
+
+	return firstSeen === -1 ? streamItems.length : firstSeen;
+};
 
 const siteHasPost = ( site: unknown ): boolean => {
 	if ( ! site || typeof site !== 'object' ) {
@@ -309,10 +332,9 @@ export function useStreamPendingPosts( {
 				startDate,
 			} );
 			queryClient.setQueryData< StreamInfiniteData >( streamQueryKey, ( current ) => {
-				const currentItems = current?.pages.length
-					? streamItemsFromPages( current.pages, streamType )
-					: items;
-				const currentPendingCount = countPendingItems( pollHead.data, currentItems, streamType );
+				const currentPendingCount = current?.pages.length
+					? countPendingItemsFromPages( pollHead.data, current.pages, streamType )
+					: countPendingItems( pollHead.data, items, streamType );
 				return currentPendingCount > 0
 					? prependPendingPage(
 							current,


### PR DESCRIPTION
I've been noticing the Reader having a very delayed response to show new posts, and will regenerate the "x new posts" pill notification again before the posts show. Here's my attempt to fix it:

## Proposed Changes

* Update the Reader pending-posts flow so clicking the “X new posts” notice consumes the already-polled stream head into the visible infinite stream cache.
* Avoid the extra stream refetch/reset sequence on click, which could clear and then re-show the notice before the new posts rendered.
* Keep the infinite stream query invalidated with `refetchType: 'none'` after the cache write, so the UI updates immediately while future remounts still revalidate.
* Recompute pending items from the current stream cache at click time to avoid duplicate prepends if the cache has already refreshed.
* Optimize the click-time cache check so it scans cached pages only until it finds the first overlap with the polled head.
* Add coverage for post-shaped and site-shaped stream payloads.

## Why are these changes being made?

In Reader, the new-post notice could appear correctly but clicking it did not reliably show the new posts right away. The click path triggered another fetch and reset the poll query, which created a visible race where the notice could disappear and then reappear before the stream updated.

This restores the legacy behavior: the poll response already contains the pending head items, so the click action can prepend those items into the active stream cache immediately.

This is a follow-up to the Reader stream React Query migration. The poll response already contains the new posts, so clicking the notice now consumes that cached response into the visible stream instead of triggering a second fetch.

## Testing Instructions

### Automated

```bash
yarn test-client client/reader/stream/test/use-stream-pending-posts.test.tsx
yarn test-client client/reader/stream/test/index.test.tsx
yarn eslint client/reader/stream/use-stream-pending-posts.ts client/reader/stream/index.jsx client/reader/stream/test/use-stream-pending-posts.test.tsx
yarn typecheck-client
```

### Manual

1. Start Calypso locally.
2. Open `/reader`.
3. Wait for the “X new posts” notice to appear.
4. Click the notice.
5. Confirm the pending posts appear in the stream immediately.
6. Confirm the notice clears and does not reappear before the newly inserted posts render.
7. Confirm there are no TypeScript, React, or other console errors.


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
