### PR TITLE
Show post-level AI review suggestions only when no block is selected

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -797,14 +797,12 @@ describe( 'useSuggestions', () => {
 			'Change tone',
 			'Check grammar',
 			'Simplify text',
-			'Generate Feedback',
-			'AI Editorial Review',
 		] );
 		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
 		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [] );
 	} );
 
-	it( 'appends AI Editorial Review to block-specific suggestions', () => {
+	it( 'shows only block-specific suggestions when a block is selected', () => {
 		installAiEditorialReviewData();
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
 		const onSuggestions = jest.fn();
@@ -818,13 +816,8 @@ describe( 'useSuggestions', () => {
 			'Change tone',
 			'Check grammar',
 			'Simplify text',
-			'Generate Feedback',
-			'AI Editorial Review',
 		] );
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_editorial_review_suggestion_rendered',
-			{}
-		);
+		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
 		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
 			[
 				'jetpack_ai_block_transformation_suggestion_rendered',
@@ -865,7 +858,7 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
-	it( 'keeps AI Editorial Review visible when block suggestions are limited', () => {
+	it( 'limits block-specific suggestions to maxSuggestions', () => {
 		installAiEditorialReviewData();
 		mockSelectedBlock = { clientId: 'b-limited', name: 'core/heading' };
 		const onSuggestions = jest.fn();
@@ -881,14 +874,32 @@ describe( 'useSuggestions', () => {
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
 			'Translate content',
-			'Generate Feedback',
-			'AI Editorial Review',
+			'Change tone',
+			'Check grammar',
 		] );
 		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
 			[
 				'jetpack_ai_block_transformation_suggestion_rendered',
 				{
 					suggestion_id: 'translate',
+					suggestion_type: 'text',
+					block_type: 'core/heading',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'change-tone',
+					suggestion_type: 'text',
+					block_type: 'core/heading',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'check-grammar',
 					suggestion_type: 'text',
 					block_type: 'core/heading',
 					surface: 'jetpack_ai_sidebar',
@@ -937,8 +948,6 @@ describe( 'useSuggestions', () => {
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
 			'Generate alt text',
-			'Generate Feedback',
-			'AI Editorial Review',
 		] );
 		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
 			[
@@ -953,7 +962,7 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
-	it( 'keeps AI Editorial Review when the feature disables block transformations', () => {
+	it( 'hides review suggestions when a block is selected and block transformations are disabled', () => {
 		installAiEditorialReviewData( { blockTransformations: false } );
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
 		const onSuggestions = jest.fn();
@@ -962,20 +971,17 @@ describe( 'useSuggestions', () => {
 
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
-			'Generate Feedback',
-			'AI Editorial Review',
-		] );
+		expect( latestSuggestions ).toEqual( [] );
 	} );
 
-	it( 'keeps AI Editorial Review when the block transformations feature is missing', () => {
+	it( 'shows review suggestions at post level regardless of the block transformations feature', () => {
 		( globalThis as any ).agentsManagerData = {
 			jetpackAiSidebar: {
 				enabled: true,
 				features: { aiEditorialReview: true },
 			},
 		};
-		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		mockSelectedBlock = null;
 		const onSuggestions = jest.fn();
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
@@ -1192,8 +1198,6 @@ describe( 'useSuggestions', () => {
 			'Change tone',
 			'Check grammar',
 			'Simplify text',
-			'Generate Feedback',
-			'AI Editorial Review',
 		] );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -951,10 +951,6 @@ export function useSuggestions(
 	}, [ editorContext.selectedBlock?.clientId ] );
 
 	const selectedBlock = editorContext.selectedBlock;
-	const aiEditorialReviewSuggestions = useMemo(
-		() => getAiEditorialReviewSuggestions( editorContext.postType ),
-		[ editorContext.postType ]
-	);
 	const postLevelSuggestions = useMemo(
 		() => getPostLevelSuggestions( editorContext.postType, editorContext.postId ),
 		[ editorContext.postId, editorContext.postType ]
@@ -971,43 +967,18 @@ export function useSuggestions(
 		() => applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
 		[ applicable ]
 	);
+	// Post-level reviews (Optimize Title, Generate Feedback, AI Editorial Review)
+	// show only with no block selected; a selected block shows block transforms.
 	const visibleSuggestions = useMemo( () => {
 		if ( hidden ) {
 			return [];
 		}
-
-		if ( ! selectedBlock ) {
-			return applySuggestionLimit( postLevelSuggestions, maxSuggestions );
-		}
-
-		if ( ! blockTransformationsEnabled ) {
-			return applySuggestionLimit(
-				[
-					...( isGenerateFeedbackAvailable( editorContext.postType, editorContext.postId )
-						? [ POST_FEEDBACK_SUGGESTION ]
-						: [] ),
-					...aiEditorialReviewSuggestions,
-				],
-				maxSuggestions
-			);
-		}
-
 		return applySuggestionLimit(
-			[
-				...blockTransformationSuggestions,
-				...( isGenerateFeedbackAvailable( editorContext.postType, editorContext.postId )
-					? [ POST_FEEDBACK_SUGGESTION ]
-					: [] ),
-				...aiEditorialReviewSuggestions,
-			],
+			selectedBlock ? blockTransformationSuggestions : postLevelSuggestions,
 			maxSuggestions
 		);
 	}, [
-		aiEditorialReviewSuggestions,
 		blockTransformationSuggestions,
-		blockTransformationsEnabled,
-		editorContext.postId,
-		editorContext.postType,
 		hidden,
 		maxSuggestions,
 		postLevelSuggestions,


### PR DESCRIPTION
## Proposed Changes

- Limit post-level review suggestions like AER when block is selected.
- When a block is selected, show only block-transformation suggestions (translate, change tone, check grammar, simplify, generate alt text).
- Decouple the post-level suggestions from the `blockTransformations` feature flag.
- Simplify `visibleSuggestions` and remove the now-dead `aiEditorialReviewSuggestions` memo.
- Update the `jetpack-ai-sidebar` unit tests for the new behavior.

## Why are these changes being made?

Refine the sidebar's AI suggestions so that post-level review actions are limited out when a block is selected. Optimise Title, Generate Feedback, and AI Editorial Review act on the whole post rather than an individual block, so they should surface only when nothing is selected; block-specific transforms surface when a block is selected.

## Testing Instructions

1. Check out this branch.
2. Sandbox `widgets.wp.com` and sync local calypso: `cd apps/agents-manager && yarn dev --sync`.
3. Open a draft post and open the sidebar.
4. With a block selected: post-level review suggestions (AI Editorial Review, Generate Feedback) and other post-level suggestions (Optimize Title) should **not** be shown — only block-level suggestions should appear.
5. With no block selected: block-transformation suggestions (Simplify, Check grammar, Translate) should **not** be shown — post-level suggestions should be displayed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
