### PR TITLE
Subscribers: stop the table flash on detail deep links

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -272,7 +272,11 @@ export default function SubscriberDataViews( {
 	);
 
 	// Fetch subscriber details.
-	const { data: subscriberDetails, isLoading: isLoadingDetails } = useSubscriberDetailsQuery(
+	const {
+		data: subscriberDetails,
+		isLoading: isLoadingDetails,
+		isFetching: isFetchingDetails,
+	} = useSubscriberDetailsQuery(
 		siteId ?? null,
 		// Only pass subscriberId if it's a valid number
 		subscriberId && ! isNaN( parseInt( subscriberId, 10 ) )
@@ -305,9 +309,27 @@ export default function SubscriberDataViews( {
 		if ( subscriberDetails && subscriberId === getSubscriptionIdString( subscriberDetails ) ) {
 			setSelectedSubscriber( subscriberDetails );
 		}
-		// Don't clear selectedSubscriber - let it keep showing the previous subscriber while loading
-		// The SubscriberDetailsSkeleton will show because subscriberDetails won't match subscriberId
+		// Keep the previous selectedSubscriber until the new details load so the
+		// highlighted row in the list doesn't blink off mid-navigation. The detail
+		// pane shows SubscriberDetailsSkeleton meanwhile, since subscriberDetails
+		// won't match subscriberId yet.
 	}, [ subscriberId, subscriberDetails ] );
+
+	// Drive the list + detail layout off the URL and query state rather than the
+	// loaded `selectedSubscriber` (which lags a render). Stay in detail view while
+	// the details request is in flight or has loaded a matching record, so a cold
+	// deep link (e.g. from the Stats Subscribers module) opens straight into the
+	// list + detail view instead of flashing the full-width table first. Use
+	// `isFetching`, not `isLoading`: the query keeps previous data across detail
+	// navigations (placeholderData: keepPreviousData), so on an A->B switch
+	// `isLoading` is false while the stale `subscriberDetails` still points at A.
+	// Fall back to the table only once the request settles without a matching
+	// record (stale or deleted id, or an error), so the user isn't stranded on a
+	// skeleton with no list, since the list is hidden below $break-wide.
+	const isDetailView =
+		!! subscriberId &&
+		( isFetchingDetails ||
+			( !! subscriberDetails && getSubscriptionIdString( subscriberDetails ) === subscriberId ) );
 
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId ?? null );
 	const grandTotal = subscribersTotals?.total_subscribers ?? 0;
@@ -508,8 +530,8 @@ export default function SubscriberDataViews( {
 	);
 
 	const actions = useMemo< Action< Subscriber >[] >( () => {
-		// If we're in list view (when a subscriber is selected), return empty actions array.
-		if ( selectedSubscriber ) {
+		// In detail view the list collapses to a narrow selector, so hide row actions.
+		if ( isDetailView ) {
 			return [];
 		}
 
@@ -586,7 +608,7 @@ export default function SubscriberDataViews( {
 
 		return baseActions;
 	}, [
-		selectedSubscriber,
+		isDetailView,
 		handleSubscriberSelection,
 		handleUnsubscribe,
 		onCompSubscription,
@@ -659,8 +681,8 @@ export default function SubscriberDataViews( {
 				showMedia: false,
 				fields: [],
 			} ) );
-		} else if ( selectedSubscriber ) {
-			// If we're on subscribers page, we want to show the list view (name & media).
+		} else if ( isDetailView ) {
+			// In detail view, show the list as a compact name + avatar selector.
 			setCurrentView( ( prevView ) => ( {
 				...prevView,
 				type: 'list',
@@ -677,7 +699,7 @@ export default function SubscriberDataViews( {
 				layout: defaultView.layout,
 			} ) );
 		}
-	}, [ isMobile, selectedSubscriber ] );
+	}, [ isMobile, isDetailView ] );
 
 	useEffect( () => {
 		// Handle search term from the view.
@@ -708,14 +730,12 @@ export default function SubscriberDataViews( {
 	}, [ subscribers, total, pages ] );
 
 	return (
-		<div
-			className={ `subscriber-data-views ${ selectedSubscriber ? 'has-selected-subscriber' : '' }` }
-		>
+		<div className={ `subscriber-data-views ${ isDetailView ? 'has-selected-subscriber' : '' }` }>
 			<section className="subscriber-data-views__list">
 				<Page
 					title={ <JetpackTitle title={ translate( 'Subscribers' ) } /> }
 					subTitle={
-						! selectedSubscriber &&
+						! isDetailView &&
 						translate(
 							'Add subscribers to your site and filter your audience list. {{link}}Learn more{{/link}}.',
 							{
@@ -746,8 +766,7 @@ export default function SubscriberDataViews( {
 								size="compact"
 								icon={ <Icon icon={ plus } size={ 18 } /> }
 								{ ...{
-									[ isMobile || !! selectedSubscriber ? 'label' : 'text' ]:
-										translate( 'Add subscribers' ),
+									[ isMobile || isDetailView ? 'label' : 'text' ]: translate( 'Add subscribers' ),
 								} }
 							/>
 							<SubscribersHeaderPopover
@@ -809,7 +828,7 @@ export default function SubscriberDataViews( {
 								isLoading={ isLoading }
 								paginationInfo={ paginationInfo }
 								getItemId={ ( item: Subscriber ) => getSubscriptionIdString( item ) }
-								defaultLayouts={ selectedSubscriber ? { list: {} } : { table: {} } }
+								defaultLayouts={ isDetailView ? { list: {} } : { table: {} } }
 								actions={ actions }
 								search
 								searchLabel={ translate( 'Search subscribers…' ) }


### PR DESCRIPTION
When testing NL-266 I noticed that the individual subscriber page would flash a different page at me while loading. This PR attempts to remove that.

## Proposed Changes

Drive the Subscribers list + detail layout off the `subscriberId` URL param and the details query state, not the loaded `selectedSubscriber` (which lags a render). On a cold deep link to `/subscribers/{slug}/{id}`, the page used to render the full-width table for the whole details request, then snap to the detail view. Now it opens straight into list + detail with a skeleton.

Detail mode holds while the request is in flight (`isFetching`, so the `keepPreviousData` refetch on detail-to-detail navigation stays put) or has loaded a matching record. A stale or deleted id, or a details error, settles without a match and falls back to the table, so the user is never stranded on a skeleton with no list, since the list is hidden below the wide breakpoint.

## Why are these changes being made?

The Stats Subscribers module now links each subscriber name to its details page (NL-266), so `/subscribers/{slug}/{id}` is a common deep-link entry point for the first time. On that path the old gating flashed the full table before the detail loaded.

## Testing Instructions

Calypso Live: https://calypso.live/?branch=fix/subscribers-detail-deep-link-flash

1. Open Subscribers stats in wp-admin (`admin.php?page=stats#!/stats/subscribers/{slug}`) and click a subscriber name. The details page should open directly in list + detail with a loading skeleton, with no full-width table flash.
2. Detail to detail: from the details page, click another subscriber in the list. The detail pane should stay; no table flash.
3. Stale id: visit `/subscribers/{slug}/{bogus-id}`. After the request settles it should fall back to the subscribers table, not a stuck skeleton.

Note: this is a transient-render fix, so a still before/after screenshot can't capture it. A screen recording on Calypso Live shows the difference.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? (N/A: render-timing fix in one component, no pure logic or contract to pin)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors? (typecheck-client clean for the changed file; eslint and prettier clean)
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? (N/A: no new computation; `isDetailView` is a boolean derived in render)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (N/A: no new strings)
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? (N/A: no new strings)
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? (N/A: no tracking or data changes)
