### PR TITLE
Fix duplicate site button appearence

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -85,6 +85,21 @@ export function canTransferSite( site: Site, user: User ) {
 	return ! site.is_wpcom_staging_site && isSiteOwner && ! isSelfHostedJetpackConnected( site );
 }
 
+// Mirrors the eligibility checks the Copy Site stepper flow enforces in
+// `useSiteCopy` (client/landing/stepper/hooks/use-site-copy.tsx). Keep these in
+// sync: if the menu shows "Duplicate" but any of these are false, the flow
+// silently redirects back to the sites list with no error (DOTDEV-421).
+export function canDuplicateSite( site: Site, user: User ) {
+	const isSiteOwner = site.site_owner === user.ID;
+
+	return (
+		hasPlanFeature( site, DotcomFeatures.COPY_SITE ) &&
+		isSiteOwner &&
+		!! site.plan &&
+		site.is_wpcom_atomic
+	);
+}
+
 export function canLeaveSite( site: Site ) {
 	return (
 		! site.is_wpcom_staging_site &&

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -1,14 +1,13 @@
-import { DotcomFeatures } from '@automattic/api-core';
 import { sitePlanSoftwareRestoreMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { useAuth } from '../../app/auth';
 import { ActionList } from '../../components/action-list';
 import { SectionHeader } from '../../components/section-header';
 import { wpcomLink } from '../../utils/link';
-import { hasPlanFeature } from '../../utils/site-features';
-import { canViewSiteActions } from '../features';
+import { canViewSiteActions, canDuplicateSite } from '../features';
 import type { Site } from '@automattic/api-core';
 
 const RestorePlanSoftware = ( { site }: { site: Site } ) => {
@@ -67,15 +66,15 @@ const DuplicateSite = ( { site }: { site: Site } ) => {
 };
 
 export default function SiteActions( { site }: { site: Site } ) {
+	const { user } = useAuth();
+
 	if ( ! canViewSiteActions( site ) ) {
 		return null;
 	}
 
 	const actions = [
 		site.is_wpcom_atomic && <RestorePlanSoftware key="restore-plan-software" site={ site } />,
-		hasPlanFeature( site, DotcomFeatures.COPY_SITE ) && (
-			<DuplicateSite key="duplicate-site" site={ site } />
-		),
+		canDuplicateSite( site, user ) && <DuplicateSite key="duplicate-site" site={ site } />,
 	].filter( Boolean );
 
 	if ( ! actions.length ) {


### PR DESCRIPTION
Fixes DOTDEV-421

## Proposed Changes
<img width="660" height="80" alt="Screenshot 2026-06-25 at 17 50 46" src="https://github.com/user-attachments/assets/763c4351-9909-4e6c-a5db-16f7c75a4f5a" /><br />
When the user clicks the "Duplicate" site button in Site Settings, we initiate the duplicate flow. During this flow we are checking the eligibility to duplicate site [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx#L214).
But, during rendering the "Duplicate" button we check only [hasPlanFeature](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/sites/settings/site-actions.tsx#L76) and ignore isAtomic and other checks.
So with this PR we are adding the same conditions to both rendering the button and initiating the duplicate flow.


## Why are these changes being made?
In DOTDEV-421 user reported such issue but in their case it was a feeling that it was caused by subdomain. I haven't managed to reproduce it this way. But I did manage to reproduce it with a simple default WordPress site. The issue is obvious - the conditions should be aligned.

## Testing Instructions
1. Create a new site with Business plan (to have oportunity to switch to Atomic later)
2. Open site Settings and assert that you don't see Duplicate section (it was visible before and caused that user's error)
3. Switch your site to Atomic (for example, open the Staging Site tab and click activate feature)
4. Open site Settings again and assert that you see Duplicatre section now
5. Click on it - assert that it works (before you woudl be redirected to /sites page)

