### PR TITLE
Login: fix magic-link login for accounts with 2FA enabled

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -44,7 +44,7 @@ import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
 import EmailedLoginLinkExpired from './emailed-login-link-expired';
-class HandleEmailedLinkForm extends Component {
+export class HandleEmailedLinkForm extends Component {
 	static propTypes = {
 		// Passed props
 		clientId: PropTypes.string,
@@ -118,14 +118,20 @@ class HandleEmailedLinkForm extends Component {
 
 	// Lifted from `blocks/login`
 	// @TODO move to `state/login/actions` & use both places
-	handleValidToken = () => {
+	//
+	// Accepts `props` because `this.props` is not yet updated when called from
+	// `UNSAFE_componentWillUpdate`, which left `twoFactorEnabled` with a stale value.
+	// Users with 2FA enabled who tried to login with a magic link would be
+	// redirected to the logged-out home instead of the authenticator prompt because
+	// `twoFactorEnabled` was false.
+	handleValidToken = ( props = this.props ) => {
 		const {
 			redirectToSanitized,
 			twoFactorEnabled,
 			twoFactorNotificationSent,
 			oauth2Client,
 			wccomFrom,
-		} = this.props;
+		} = props;
 
 		if ( ! twoFactorEnabled ) {
 			this.props.rebootAfterLogin( { magic_login: 1 } );
@@ -160,7 +166,8 @@ class HandleEmailedLinkForm extends Component {
 			this.props.showMagicLoginLinkExpiredPage();
 			return;
 		}
-		this.handleValidToken();
+		// We pass `nextProps` here because `this.props` is not yet updated during this lifecycle
+		this.handleValidToken( nextProps );
 	}
 
 	render() {

--- a/client/login/magic-login/test/handle-emailed-link-form.test.jsx
+++ b/client/login/magic-login/test/handle-emailed-link-form.test.jsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import page from '@automattic/calypso-router';
+import { HandleEmailedLinkForm } from '../handle-emailed-link-form';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+
+// The two-factor-challenge fields the auth thunk dispatches via LOGIN_REQUEST_SUCCESS.
+const TWO_FACTOR_PROPS = {
+	twoFactorEnabled: true,
+	twoFactorNotificationSent: 'none',
+};
+
+function buildInstance( props = {} ) {
+	const instance = new HandleEmailedLinkForm( {
+		emailAddress: 'user@example.com',
+		token: 'a-token',
+		// Pre-auth state: the component mounts before the magic-link POST resolves, so
+		// `twoFactorEnabled` is still false on the committed props.
+		twoFactorEnabled: false,
+		twoFactorNotificationSent: null,
+		redirectToSanitized: null,
+		oauth2Client: {},
+		wccomFrom: undefined,
+		rebootAfterLogin: jest.fn(),
+		showMagicLoginLinkExpiredPage: jest.fn(),
+		...props,
+	} );
+	// We invoke lifecycle methods directly on an unmounted instance, so stub setState.
+	instance.setState = jest.fn();
+	instance.state = { hasSubmitted: true, isRedirecting: false };
+	return instance;
+}
+
+describe( 'HandleEmailedLinkForm 2FA handoff', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'routes an authenticator-2FA account to the authenticator prompt using nextProps', () => {
+		// Regression: `UNSAFE_componentWillUpdate` runs during the render phase, before
+		// `this.props` is committed. The 2FA challenge only exists on `nextProps`, so reading
+		// `this.props` would see the stale `twoFactorEnabled: false` and reboot to the
+		// logged-out home instead of showing the 2FA form.
+		const instance = buildInstance();
+
+		instance.UNSAFE_componentWillUpdate(
+			{
+				...instance.props,
+				...TWO_FACTOR_PROPS,
+				isAuthenticated: true,
+				isFetching: false,
+				authError: null,
+			},
+			{ hasSubmitted: true, isRedirecting: false }
+		);
+
+		expect( instance.props.rebootAfterLogin ).not.toHaveBeenCalled();
+		expect( page ).toHaveBeenCalledTimes( 1 );
+		expect( page ).toHaveBeenCalledWith( expect.stringContaining( '/log-in/authenticator' ) );
+		expect( instance.setState ).toHaveBeenCalledWith( { isRedirecting: true } );
+	} );
+
+	it( 'reboots after login when the account has no second factor', () => {
+		const instance = buildInstance();
+
+		instance.UNSAFE_componentWillUpdate(
+			{
+				...instance.props,
+				twoFactorEnabled: false,
+				twoFactorNotificationSent: null,
+				isAuthenticated: true,
+				isFetching: false,
+				authError: null,
+			},
+			{ hasSubmitted: true, isRedirecting: false }
+		);
+
+		expect( page ).not.toHaveBeenCalled();
+		expect( instance.props.rebootAfterLogin ).toHaveBeenCalledWith( { magic_login: 1 } );
+	} );
+
+	it( 'shows the expired page when authentication did not succeed', () => {
+		const instance = buildInstance();
+
+		instance.UNSAFE_componentWillUpdate(
+			{
+				...instance.props,
+				isAuthenticated: false,
+				isFetching: false,
+				authError: null,
+			},
+			{ hasSubmitted: true, isRedirecting: false }
+		);
+
+		expect( instance.props.showMagicLoginLinkExpiredPage ).toHaveBeenCalled();
+		expect( page ).not.toHaveBeenCalled();
+		expect( instance.props.rebootAfterLogin ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes DOTOBRD-488

## Proposed Changes

* Pass `nextProps` into `handleValidToken` in the magic-link handler so the 2FA routing decision reads the freshly-committed `twoFactorEnabled` instead of the stale `this.props`.
* Add a regression test for the magic-link → 2FA handoff.

## Why are these changes being made?

* Logging in with an "email me a login link" magic link never showed the 2FA code prompt for an account that has 2FA enabled. The user landed on the logged-out WordPress.com home, still signed out.
* `handleValidToken` is called from `UNSAFE_componentWillUpdate`, which runs before React commits the incoming props. It read `twoFactorEnabled` from `this.props` (still `false`), took the "no 2FA" path, and called `rebootAfterLogin()` — a reload with no session, since 2FA was never completed.

### Recordings

- Before

https://github.com/user-attachments/assets/97290218-42cb-4d0f-8aa5-7776d799f250

- After

https://github.com/user-attachments/assets/9c1f7a0b-2367-4cdf-b341-83ee8a9c120f

## Testing Instructions

Unit tests:
```
yarn test-client client/login/magic-login/test/handle-emailed-link-form.test.jsx
```

Manual test:
- Build Calypso locally or open the live Calypso link
- Create a new WPCOM account (you shouldn't need to set a password for it)
- Enable 2FA (don't set a password)
- Log out
- Try logging in with that account - you should receive a magic link in your email
- Use the magic link to log in
- You should see a page asking for your authentication app's code
- Without this PR, you would be redirected back to the WordPress.com homepage

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
