### PR TITLE
Subscribers sidebar: highlight Newsletter on /subscribers pages

### DIFF
--- a/client/my-sites/sidebar/test/index.js
+++ b/client/my-sites/sidebar/test/index.js
@@ -70,6 +70,46 @@ describe( 'MySitesSidebar', () => {
 		} );
 	} );
 
+	describe( '#itemLinkMatches() subscribers pages highlight Newsletter', () => {
+		const subscriberDetailPath = '/subscribers/example.wordpress.com/123';
+
+		test( 'selects the Newsletter wp-admin link on Simple sites', () => {
+			expect(
+				itemLinkMatches(
+					'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-newsletter',
+					subscriberDetailPath
+				)
+			).toBe( true );
+		} );
+
+		test( 'selects the relative Newsletter route on Atomic sites', () => {
+			expect( itemLinkMatches( '/newsletter/example.wordpress.com', subscriberDetailPath ) ).toBe(
+				true
+			);
+		} );
+
+		test( 'selects a /settings/newsletter Newsletter menu URL', () => {
+			expect(
+				itemLinkMatches( '/settings/newsletter/example.wordpress.com', subscriberDetailPath )
+			).toBe( true );
+		} );
+
+		test( 'does not select the Subscribers wp-admin link on Simple sites', () => {
+			expect(
+				itemLinkMatches(
+					'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-subscribers',
+					subscriberDetailPath
+				)
+			).toBe( false );
+		} );
+
+		test( 'does not select the relative Subscribers route, so the highlight moves to Newsletter', () => {
+			expect( itemLinkMatches( '/subscribers/example.wordpress.com', subscriberDetailPath ) ).toBe(
+				false
+			);
+		} );
+	} );
+
 	describe( '#isItemSelected()', () => {
 		const site = { ID: 1234 };
 

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -117,6 +117,18 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		return fragmentIsEqual( path, currentPath, 2 );
 	}
 
+	// For `/subscribers/*` paths, show the Newsletter menu as selected. Subscribers
+	// is folding into Newsletter, so its pages live under that menu. On Simple sites
+	// the Subscribers and Newsletter items are wp-admin links (e.g.
+	// `admin.php?page=jetpack-newsletter`) whose first path fragment is empty, so the
+	// default fragment match below never selects them. Match any Newsletter menu URL
+	// (wp-admin link, `/newsletter`, or `/settings/newsletter`) so it highlights on
+	// Simple, Atomic, and Jetpack Cloud; the Subscribers item has no `newsletter` in
+	// its URL, so the highlight moves off it.
+	if ( pathIncludes( currentPath, 'subscribers', 1 ) ) {
+		return path.includes( 'newsletter' );
+	}
+
 	return fragmentIsEqual( path, currentPath, 1 );
 };
 


### PR DESCRIPTION
## Proposed Changes

The My Sites sidebar selects a menu item by matching the first segment of its URL against the current route. On the `/subscribers/*` pages that left the menu inconsistent: Atomic highlighted Subscribers, Simple highlighted nothing. On Simple the Subscribers and Newsletter items are wp-admin links (`admin.php?page=jetpack-newsletter`) whose first segment is empty, so nothing matched.

This adds a `/subscribers/*` case to `itemLinkMatches` that selects the Newsletter item on both platforms, matching any Newsletter menu URL (the wp-admin link, `/newsletter`, or `/settings/newsletter`). The Subscribers item has no `newsletter` in its URL, so the highlight moves off it.

## Why are these changes being made?

Subscribers is folding into Newsletter, so the sidebar should point at Newsletter. The Stats Subscribers module now links names to `/subscribers/{slug}/{id}`, so that page is a common landing spot, and the sidebar should mark where you are, the same way on Simple, Atomic, and Jetpack Cloud.

## Testing Instructions

Calypso Live: https://calypso.live/?branch=add/subscribers-highlight-newsletter

1. On a Simple site, open `/subscribers/{slug}` and `/subscribers/{slug}/{id}`. The **Newsletter** item in the left sidebar should highlight (it was blank before).
2. On an Atomic site, do the same. **Newsletter** should highlight (it highlighted Subscribers before).
3. Confirm no other section regresses (Posts, Settings, People, Plugins).

Unit tests cover the matcher: `yarn test-client client/my-sites/sidebar/test/index.js`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? (Added `itemLinkMatches` cases for the Simple wp-admin link, relative `/newsletter`, `/settings/newsletter`, and the Subscribers items.)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors? (eslint and prettier clean; sidebar test suite passes)
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)? (N/A: selection logic only, no styling change)
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? (N/A: a string check in existing match logic)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (N/A: no new strings)
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? (N/A: no new strings)
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? (N/A: no tracking or data changes)
