### PR TITLE
Reader: restore inline achievements visibility toggle for all owners

### DIFF
--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -4,6 +4,7 @@ import { Button, Dropdown, ToggleControl } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import useSetAchievementsVisibility from 'calypso/reader/components/achievements/use-set-achievements-visibility';
 import { recordAction } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -16,20 +17,30 @@ export default function AchievementsSettings() {
 	const translate = useTranslate();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 
+	const { data: savedVisibility } = useQuery( userPreferenceQuery( 'achievements-visibility' ) );
 	const { data: savedNotifications } = useQuery(
 		userPreferenceQuery( 'achievements-global-notifications' )
 	);
 
 	// Local state for immediate toggle feedback. Synced from query data on load.
+	const [ visibility, setLocalVisibility ] = useState( savedVisibility ?? 'private' );
 	const [ notifications, setLocalNotifications ] = useState( savedNotifications ?? 'enabled' );
+	useEffect( () => setLocalVisibility( savedVisibility ?? 'private' ), [ savedVisibility ] );
 	useEffect(
 		() => setLocalNotifications( savedNotifications ?? 'enabled' ),
 		[ savedNotifications ]
 	);
 
+	const { setVisibility } = useSetAchievementsVisibility();
 	const { mutate: setNotifications } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
 	);
+
+	const handleSetVisibility = ( checked: boolean ) => {
+		const newVisibility = checked ? 'public' : 'private';
+		setLocalVisibility( newVisibility );
+		setVisibility( newVisibility );
+	};
 
 	const handleSetNotifications = ( checked: boolean ) => {
 		const newNotifications = checked ? 'enabled' : 'disabled';
@@ -85,6 +96,12 @@ export default function AchievementsSettings() {
 			) }
 			renderContent={ () => (
 				<div className="achievements-settings__content">
+					<ToggleControl
+						checked={ visibility === 'public' }
+						onChange={ handleSetVisibility }
+						label={ translate( 'Public achievements' ) }
+						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
+					/>
 					<ToggleControl
 						checked={ notifications !== 'disabled' }
 						onChange={ handleSetNotifications }

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -3,7 +3,6 @@ import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
 import useAchievementsVisibility from 'calypso/reader/components/achievements/use-achievements-visibility';
-import UserProfilePrivateTabNotice from 'calypso/reader/user-profile/components/private-tab-notice';
 import AchievementsGrid from './achievements-grid';
 import AchievementsSettings from './achievements-settings';
 import { ActivityStreak } from './activity-streak';
@@ -35,13 +34,6 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 
 	return (
 		<div className="achievements">
-			{ isOwnProfile && (
-				<UserProfilePrivateTabNotice
-					title={ translate( 'Your achievements are private' ) }
-					tab="achievements"
-					userPreferencesKey="achievements-visibility"
-				/>
-			) }
 			<div className="achievements__header">
 				<ActivityStreak streak={ engagementStreak } isOwnProfile={ isOwnProfile } />
 				{ isOwnProfile && (

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -25,12 +25,6 @@ jest.mock( '../achievements-settings', () => ( {
 	default: () => <button data-testid="achievements-settings">Settings</button>,
 } ) );
 
-jest.mock( 'calypso/reader/user-profile/components/private-tab-notice', () => ( {
-	__esModule: true,
-	default: ( { title }: { title: string } ) => (
-		<div data-testid="private-tab-notice">{ title }</div>
-	),
-} ) );
 const mockActivityStreakProps = jest.fn();
 jest.mock( '../activity-streak', () => ( {
 	__esModule: true,


### PR DESCRIPTION
## Proposed Changes

* Restore the **Public achievements** visibility toggle in the inline achievements gear menu (`views/achievements/achievements-settings/index.tsx`), so all profile owners — not just Automatticians — can make their achievements public/private.
* Remove the `UserProfilePrivateTabNotice` ("Only you can see them. Make them public from the Settings tab.") from the achievements tab. The Settings tab it pointed to is gated to Automatticians, so for everyone else the notice was a dead end.
* No changes to the Settings tab itself, and no changes to the Posts/Sites notices (their visibility genuinely lives only in the Settings tab).
* No new translatable strings — reuses copy that previously shipped.

<img width="844" height="497" alt="Screenshot 2026-06-25 at 4 28 11 PM" src="https://github.com/user-attachments/assets/409f2fbc-0e7d-40bb-8295-7eebfd692749" />


## Why are these changes being made?

The Reader user-profile **Settings** tab is intentionally gated to Automatticians (`isOwnProfile && isAutomattician`). A later refactor moved the achievements visibility toggle off the public achievements page and into that gated tab, but left the "Make them public from the Settings tab" notice visible to **all** owners. The result: non-Automattician owners with private achievements saw a banner instructing them to use a Settings tab that doesn't render for them.

This restores a working, self-service way for every owner to manage achievements visibility inline while the Settings tab remains in flux behind the Automattician gate.

See p1782416589637809-slack-C03NLNTPZ2T

## Testing Instructions

1. As a non-Automattician account, visit your own Reader profile achievements tab (`/reader/users/<your-login>`).
2. Confirm there is **no** "Make them public from the Settings tab" notice.
3. Open the achievements **gear** menu and confirm the **Public achievements** toggle is present and reflects your current visibility.
4. Toggle it on/off and confirm achievements visibility updates (success notice appears; reload reflects the new state).
5. Confirm the achievements notifications toggle still works as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)