### PR TITLE
Subscriptions: migrate VirtualizedList to @tanstack/react-virtual

### DIFF
--- a/client/landing/subscriptions/components/virtualized-list/virtualized-list.tsx
+++ b/client/landing/subscriptions/components/virtualized-list/virtualized-list.tsx
@@ -1,17 +1,11 @@
-import {
-	CellMeasurer,
-	CellMeasurerCache,
-	List,
-	WindowScroller,
-} from '@automattic/react-virtualized';
-import React, { useEffect, useCallback, useRef, type JSX } from 'react';
-import withDimensions from 'calypso/lib/with-dimensions';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useEffect, useState, type JSX } from 'react';
 
 type VirtualizedListFunctionProps< T > = {
 	item: T;
 	key: string;
 	style: React.CSSProperties;
-	registerChild: React.Ref< HTMLDivElement >;
+	registerChild: ( node: Element | null ) => void;
 };
 
 type VirtualizedListProps< T > = {
@@ -21,23 +15,18 @@ type VirtualizedListProps< T > = {
 	width?: number;
 };
 
-const cellMeasureCache = new CellMeasurerCache( {
-	fixedWidth: true,
-	// Since all our rows are of equal height, we can use this performance optimization
-	keyMapper: () => 1,
-} );
+// All rows render at equal height, so a single estimate seeds the layout before
+// each row is measured from the DOM.
+const ESTIMATED_ROW_HEIGHT = 100;
 
-type RowRenderProps = {
-	index: number;
-	key: string;
-	style: React.CSSProperties;
-	parent: unknown;
-};
+// Rows rendered above and below the visible range, mirroring react-virtualized's
+// default overscan behaviour.
+const OVERSCAN_ROW_COUNT = 10;
 
-const getScrollContainer = ( node: HTMLElement | null ): HTMLElement | Window => {
-	// Default to window if the node is null or it's the root element.
+const getScrollContainer = ( node: HTMLElement | null ): HTMLElement | null => {
+	// Fall back to the window (null) if the node is missing or it's the root element.
 	if ( ! node || node.ownerDocument === node.parentNode ) {
-		return window;
+		return null;
 	}
 
 	// Return when overflow is defined to either auto or scroll.
@@ -52,86 +41,94 @@ const getScrollContainer = ( node: HTMLElement | null ): HTMLElement | Window =>
 		return getScrollContainer( parentNode );
 	}
 
-	// Default to window if no scroll container is found.
-	return window;
+	// Fall back to the window (null) if no scroll container is found.
+	return null;
 };
 
-const VirtualizedList = < T, >( { width, items, children }: VirtualizedListProps< T > ) => {
-	const contentRef = useRef< HTMLDivElement | null >( null );
-	const scrollContainerRef = useRef< HTMLElement | Window >( window );
+const VirtualizedList = < T, >( { items, children }: VirtualizedListProps< T > ) => {
+	// State (not a ref) so the scroll container and margin recompute once the
+	// list attaches to the DOM.
+	const [ listElement, setListElement ] = useState< HTMLDivElement | null >( null );
+	const [ scrollElement, setScrollElement ] = useState< HTMLElement | null >( null );
+	const [ scrollMargin, setScrollMargin ] = useState( 0 );
 
+	// Resolve the nearest scrollable ancestor; falls back to the window
+	// (`scrollElement === null`) when none is found.
 	useEffect( () => {
-		if ( contentRef.current ) {
-			scrollContainerRef.current = getScrollContainer( contentRef.current );
-		}
-	}, [] );
+		setScrollElement( getScrollContainer( listElement ) );
+	}, [ listElement ] );
 
-	// WindowScroller hands us a `registerChild` ref through its render prop. We merge it with
-	// our own `contentRef` via a stable callback ref: this keeps WindowScroller tracking its
-	// DOM node through `registerChild` (so its internal, React 19-removed `findDOMNode`
-	// fallback is never hit) while giving us the node to resolve the scroll container.
-	const registerChildRef = useRef< React.Ref< HTMLDivElement > >( null );
-	const setContentNode = useCallback( ( node: HTMLDivElement | null ) => {
-		contentRef.current = node;
-		const registerChild = registerChildRef.current;
-		if ( typeof registerChild === 'function' ) {
-			registerChild( node );
-		} else if ( registerChild ) {
-			( registerChild as React.MutableRefObject< HTMLDivElement | null > ).current = node;
+	// Offset (px) from the top of the scroll container to the top of the list, so
+	// the scroll position maps to the right items when content sits above the list.
+	useEffect( () => {
+		if ( ! listElement ) {
+			return;
 		}
-	}, [] );
+		const measure = () => {
+			const listTop = listElement.getBoundingClientRect().top;
+			const next = scrollElement
+				? listTop - scrollElement.getBoundingClientRect().top + scrollElement.scrollTop
+				: listTop + window.scrollY;
+			setScrollMargin( ( current ) => ( current === next ? current : next ) );
+		};
+		measure();
+		const observer = new ResizeObserver( measure );
+		observer.observe( listElement );
+		observer.observe( scrollElement ?? document.body );
+		return () => observer.disconnect();
+	}, [ listElement, scrollElement ] );
 
-	const rowRenderer = useCallback(
-		( { index, key, style, parent }: RowRenderProps ) => {
-			const item = items?.[ index ];
-			return item ? (
-				<CellMeasurer
-					cache={ cellMeasureCache }
-					columnIndex={ 0 }
-					key={ key }
-					rowIndex={ index }
-					parent={ parent }
-				>
-					{ ( { registerChild }: { registerChild: React.Ref< HTMLDivElement > } ) =>
-						children( { item, key, style, registerChild } )
-					}
-				</CellMeasurer>
-			) : null;
-		},
-		[ items, children ]
-	);
+	const virtualizer = useVirtualizer< Element, Element >( {
+		count: items?.length ?? 0,
+		// `getScrollElement` returns the resolved scrollable ancestor, or the
+		// document scrolling element when the list scrolls with the window.
+		getScrollElement: () => scrollElement ?? document.scrollingElement ?? document.documentElement,
+		estimateSize: () => ESTIMATED_ROW_HEIGHT,
+		overscan: OVERSCAN_ROW_COUNT,
+		scrollMargin,
+	} );
+
+	const virtualItems = virtualizer.getVirtualItems();
 
 	return (
-		<WindowScroller scrollElement={ scrollContainerRef.current }>
-			{ ( {
-				height,
-				scrollTop,
-				registerChild,
-			}: {
-				height: number;
-				scrollTop: number;
-				registerChild: React.Ref< HTMLDivElement >;
-			} ) => {
-				registerChildRef.current = registerChild;
-				return (
-					<div ref={ setContentNode }>
-						<List
-							autoHeight
-							rowCount={ items?.length }
-							deferredMeasurementCache={ cellMeasureCache }
-							rowHeight={ cellMeasureCache.rowHeight }
-							height={ height }
-							scrollTop={ scrollTop }
-							width={ width }
-							items={ items }
-							rowRenderer={ rowRenderer }
-						/>
-					</div>
-				);
-			} }
-		</WindowScroller>
+		<div ref={ setListElement }>
+			<div
+				style={ {
+					position: 'relative',
+					inlineSize: '100%',
+					blockSize: virtualizer.getTotalSize(),
+				} }
+			>
+				{ virtualItems.map( ( virtualRow ) => {
+					const item = items?.[ virtualRow.index ];
+					if ( ! item ) {
+						return null;
+					}
+					// `measureElement` reads `data-index` off the row node to know which
+					// row it is measuring, so set it on the consumer's row element before
+					// handing the node to the virtualizer.
+					const registerChild = ( node: Element | null ) => {
+						if ( node ) {
+							node.setAttribute( 'data-index', String( virtualRow.index ) );
+						}
+						virtualizer.measureElement( node );
+					};
+					return children( {
+						item,
+						key: virtualRow.key.toString(),
+						registerChild,
+						style: {
+							position: 'absolute',
+							insetBlockStart: 0,
+							insetInlineStart: 0,
+							inlineSize: '100%',
+							transform: `translateY(${ virtualRow.start - scrollMargin }px)`,
+						},
+					} );
+				} ) }
+			</div>
+		</div>
 	);
 };
 
-// cast as typeof VirtualizedList to avoid TS error
-export default withDimensions( VirtualizedList ) as typeof VirtualizedList;
+export default VirtualizedList;


### PR DESCRIPTION
Task-related: DOTCOM-17718


## Proposed Changes

* Migrate the subscriptions `VirtualizedList` component (`client/landing/subscriptions/components/virtualized-list/virtualized-list.tsx`) off the unmaintained `@automattic/react-virtualized` fork (`CellMeasurer` / `CellMeasurerCache` / `List` / `WindowScroller`) onto `@tanstack/react-virtual` (`useVirtualizer`).
* Remove the component's bespoke React-19 `findDOMNode` workaround — the `registerChildRef` / `setContentNode` callback-ref merging that existed solely to keep `WindowScroller` from hitting its (React-19-removed) `findDOMNode` fallback. TanStack Virtual is ref-based, so that plumbing is gone.
* Preserve the public render-prop contract exactly — `children({ item, key, style, registerChild })` — so both consumers (`site-subscriptions-list`, `comment-list`) compile and behave the same with no edits:
  * `registerChild` → a per-row ref callback that sets `data-index` on the row node (required by `measureElement`) and forwards the node to `virtualizer.measureElement`.
  * `style` → the absolute-position row style, using CSS logical properties (`inset-block-start` / `inset-inline-start` / `inline-size`) and a `translateY` that accounts for `scrollMargin`.
  * `key` → the virtual row key.
* Keep the original `getScrollContainer` capability (walk up to the nearest `overflow: auto|scroll` ancestor, else the window) via `useVirtualizer` + `getScrollElement` and a measured `scrollMargin`.
* Drop the `withDimensions` HOC / `width`-driven `fixedWidth` measurement (TanStack measures rows from the DOM). `width` is retained as an accepted optional prop for contract stability.
* The generic `<T,>` parameter is preserved so callers keep their item typing.

This is part of the `@automattic/react-virtualized` → `@tanstack/react-virtual` migration tied to the React 19 effort (the fork relies on the removed `findDOMNode`). `@automattic/react-virtualized` is intentionally **not** removed from `client/package.json` — other files still depend on it.

## Why are these changes being made?

`@automattic/react-virtualized` is an unmaintained fork that relies on `findDOMNode`, which is removed in React 19. Each consumer of the fork either needs a bespoke `findDOMNode`-avoidance shim (as this file carried) or has to be migrated off it. Moving to `@tanstack/react-virtual` removes the shim and aligns with the React 19 migration and other in-flight virtual-list migrations.

## Scroll-container decision

Kept the original resolve-a-scroll-container behavior (`useVirtualizer` + `getScrollElement` returning the nearest scrollable ancestor, with a measured `scrollMargin`) rather than `useWindowVirtualizer`. These subscription components render both in the standalone subscriptions SPA (window scroll) and inside Calypso via `SubscriptionManagerPage`, where a scrollable ancestor can exist; preserving `getScrollContainer` is the faithful, lower-risk choice. When no scrollable ancestor is found it falls back to the document scrolling element, equivalent to window scrolling.

## Testing Instructions

* Make sure http://calypso.localhost:3000/reader/subscriptions and http://calypso.localhost:3000/reader/subscriptions/comments works as expected
* Verify rows render, virtualize on scroll, and that row heights/spacing are correct (no overlap or gaps), in both the standalone subscriptions surface and inside Calypso.


<img width="1213" height="766" alt="image" src="https://github.com/user-attachments/assets/bcd41efc-59d1-467c-9763-4d103fa46f36" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)