### PR TITLE
Reader: migrate ReaderInfiniteStream to @tanstack/react-virtual

### DIFF
--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -1,152 +1,272 @@
 import { pickBy } from '@automattic/js-utils';
-import {
-	CellMeasurer,
-	CellMeasurerCache,
-	InfiniteLoader,
-	List,
-	WindowScroller,
-} from '@automattic/react-virtualized';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { debounce } from '@wordpress/compose';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { recordTracksRailcarRender } from 'calypso/reader/stats';
 import './style.scss';
 
 const noop = () => {};
 
-class ReaderInfiniteStream extends Component {
-	static propTypes = {
-		items: PropTypes.array.isRequired,
-		width: PropTypes.number.isRequired,
-		rowRenderer: PropTypes.func.isRequired,
-		fetchNextPage: PropTypes.func,
-		hasNextPage: PropTypes.func,
-		windowScrollerRef: PropTypes.func,
-		extraRenderItemProps: PropTypes.object,
-		minHeight: PropTypes.number,
-	};
+// Rows rendered above and below the visible range, mirroring the prefetch feel
+// of react-virtualized's default overscan.
+const OVERSCAN_ROW_COUNT = 5;
 
-	static defaultProps = {
-		windowScrollerRef: noop,
-		minHeight: 70,
-		hasNextPage: () => false,
-	};
+// Number of trailing placeholder rows kept while another page can still load,
+// matching the previous `items.length + 10` behaviour so trailing loaders
+// render before the next page resolves.
+const PLACEHOLDER_ROW_COUNT = 10;
 
-	heightCache = new CellMeasurerCache( {
-		fixedWidth: true,
-		minHeight: this.props.minHeight,
-	} );
+/**
+ * One measured row. Holds its own DOM node so it can remeasure just itself when
+ * the consumer's component calls `onShouldMeasure` (e.g. after an image loads),
+ * preserving the react-virtualized `onShouldMeasure` contract without forcing a
+ * full-list remeasure. The wrapper keeps the absolute transform `style` and the
+ * `reader-infinite-stream__row-wrapper` class that the stylesheet relies on.
+ */
+function MeasuredRow( { index, style, measureElement, ComponentToMeasure, componentProps } ) {
+	const nodeRef = useRef( null );
 
-	recordedRender = new Set(); // used to ensure we only fire render event once per item
-
-	recordTraintrackForRowRender = ( { index, railcar, eventName } ) => {
-		recordTracksRailcarRender( eventName, railcar, { ui_position: index } );
-	};
-
-	rowRenderer = ( rowRendererProps ) => {
-		const railcar = get( this.props.items[ rowRendererProps.index ], 'railcar', undefined );
-		if ( railcar && ! this.recordedRender.has( rowRendererProps.index ) ) {
-			this.recordedRender.add( rowRendererProps.index );
-			this.recordTraintrackForRowRender(
-				pickBy( {
-					index: rowRendererProps.index,
-					railcar,
-				} )
-			);
-		}
-
-		return this.props.rowRenderer( {
-			items: this.props.items,
-			extraRenderItemProps: this.props.extraRenderItemProps,
-			rowRendererProps,
-			measuredRowRenderer: this.measuredRowRenderer,
-		} );
-	};
-
-	measuredRowRenderer = ( ComponentToMeasure, props, { key, index, style, parent } ) => (
-		<CellMeasurer
-			cache={ this.heightCache }
-			columnIndex={ 0 }
-			key={ key }
-			rowIndex={ index }
-			parent={ parent }
-		>
-			{ ( { measure } ) => (
-				<div key={ key } style={ style } className="reader-infinite-stream__row-wrapper">
-					<ComponentToMeasure { ...props } onShouldMeasure={ measure } />
-				</div>
-			) }
-		</CellMeasurer>
+	const setNode = useCallback(
+		( node ) => {
+			nodeRef.current = node;
+			// `virtualizer.measureElement` is itself a ref callback; forward to it
+			// so the per-row ResizeObserver attaches and initial size is captured.
+			measureElement( node );
+		},
+		[ measureElement ]
 	);
 
-	handleListMounted = ( registerChild ) => ( list ) => {
-		this.listRef = list;
-		registerChild( list ); // InfiniteLoader also wants a ref
-	};
+	const handleShouldMeasure = useCallback( () => {
+		if ( nodeRef.current ) {
+			measureElement( nodeRef.current );
+		}
+	}, [ measureElement ] );
 
-	handleResize = debounce( () => this.clearListCaches(), 50 );
-
-	clearListCaches = () => {
-		this.heightCache.clearAll();
-		this.listRef && this.listRef.forceUpdateGrid();
-	};
-
-	isRowLoaded = ( { index } ) => {
-		return !! this.props.items[ index ];
-	};
-
-	// technically this function should return a promise that only resolves when the data is fetched.
-	// initially I had created a promise that would setInterval and see if the startIndex
-	// exists in sites, and if so the resolve. It was super hacky, and its muchs simpler to just fake that it instantly
-	// returns
-	loadMoreRows = ( { startIndex } ) => {
-		this.props.fetchNextPage( startIndex );
-		return Promise.resolve();
-	};
-
-	componentDidMount() {
-		window.addEventListener( 'resize', this.handleResize );
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.handleResize );
-	}
-
-	render() {
-		const { hasNextPage, width } = this.props;
-		const rowCount = hasNextPage( this.props.items.length )
-			? this.props.items.length + 10
-			: this.props.items.length;
-
-		return (
-			<InfiniteLoader
-				isRowLoaded={ this.isRowLoaded }
-				loadMoreRows={ this.loadMoreRows }
-				rowCount={ rowCount }
-			>
-				{ ( { onRowsRendered, registerChild } ) => (
-					<WindowScroller ref={ this.props.windowScrollerRef }>
-						{ ( { height, scrollTop } ) => (
-							<List
-								autoHeight
-								height={ height }
-								rowCount={ rowCount }
-								rowHeight={ this.heightCache.rowHeight }
-								rowRenderer={ this.rowRenderer }
-								onRowsRendered={ onRowsRendered }
-								ref={ this.handleListMounted( registerChild ) }
-								scrollTop={ scrollTop }
-								width={ width }
-								items={ this.props.items } // passthrough-prop unused by the component except to signal a rerender
-								aria-readonly={ false }
-							/>
-						) }
-					</WindowScroller>
-				) }
-			</InfiniteLoader>
-		);
-	}
+	return (
+		<div
+			data-index={ index }
+			ref={ setNode }
+			style={ style }
+			className="reader-infinite-stream__row-wrapper"
+		>
+			<ComponentToMeasure { ...componentProps } onShouldMeasure={ handleShouldMeasure } />
+		</div>
+	);
 }
+
+MeasuredRow.propTypes = {
+	index: PropTypes.number.isRequired,
+	style: PropTypes.object.isRequired,
+	measureElement: PropTypes.func.isRequired,
+	ComponentToMeasure: PropTypes.elementType.isRequired,
+	componentProps: PropTypes.object,
+};
+
+/**
+ * A window-scrolled, dynamically-measured infinite stream built on TanStack
+ * Virtual. The list lays out at its full content height within the page flow
+ * and the window itself is the scroll container. Row heights are seeded from
+ * `minHeight` and then measured from the DOM (via a ResizeObserver-backed
+ * `measureElement`), so variable, content-driven heights reflow automatically.
+ *
+ * Public API (consumed by other Reader components — preserve this contract):
+ * @param {Object} props
+ * @param {Array} props.items The items backing the stream.
+ * @param {number} props.width Pixel width passed through to row renderers.
+ * @param {Function} props.rowRenderer Required. Called per row with
+ *   `{ items, extraRenderItemProps, rowRendererProps, measuredRowRenderer }`.
+ *   `rowRendererProps` carries `{ key, index, style }`.
+ * @param {Function} [props.fetchNextPage] `( offset ) => void`, called when the
+ *   end of the rendered range is reached and `hasNextPage` is true.
+ * @param {Function} [props.hasNextPage] `( length ) => boolean`.
+ * @param {Object} [props.windowScrollerRef] Forwarded ref exposing an
+ *   imperative handle (`scrollToOffset`, `scrollToIndex`, `updatePosition`).
+ * @param {Object} [props.extraRenderItemProps] Extra props forwarded to rows.
+ * @param {number} [props.minHeight] Estimated/minimum row height before measure.
+ */
+function ReaderInfiniteStream( {
+	items,
+	width,
+	rowRenderer,
+	fetchNextPage = noop,
+	hasNextPage = () => false,
+	windowScrollerRef,
+	extraRenderItemProps,
+	minHeight = 70,
+} ) {
+	// State (not a ref) so the scroll margin recomputes once the list attaches.
+	const [ listElement, setListElement ] = useState( null );
+	const [ scrollMargin, setScrollMargin ] = useState( 0 );
+
+	// Offset (px) from the document top to the top of the list, so window scroll
+	// maps to the right items even when a header sits above the stream.
+	useEffect( () => {
+		if ( ! listElement ) {
+			return;
+		}
+		const measure = () => {
+			const next = listElement.getBoundingClientRect().top + window.scrollY;
+			setScrollMargin( ( current ) => ( current === next ? current : next ) );
+		};
+		measure();
+		const observer = new ResizeObserver( measure );
+		observer.observe( listElement );
+		observer.observe( document.body );
+		return () => observer.disconnect();
+	}, [ listElement ] );
+
+	const itemsLength = items.length;
+	const moreToLoad = hasNextPage( itemsLength );
+	const rowCount = moreToLoad ? itemsLength + PLACEHOLDER_ROW_COUNT : itemsLength;
+
+	const estimateSize = useCallback( () => minHeight, [ minHeight ] );
+
+	const virtualizer = useWindowVirtualizer( {
+		count: rowCount,
+		estimateSize,
+		overscan: OVERSCAN_ROW_COUNT,
+		scrollMargin,
+	} );
+
+	// Used to ensure we only fire the railcar render event once per item index.
+	const recordedRender = useRef( new Set() );
+
+	// Guards `fetchNextPage` against being spammed on every measurement render
+	// near the end. We remember the length we already requested a page for and
+	// only request again once `items` actually grew past it (a new page landed).
+	const requestedForLength = useRef( -1 );
+
+	const virtualItems = virtualizer.getVirtualItems();
+	const lastIndex = virtualItems[ virtualItems.length - 1 ]?.index;
+
+	// Paging: when the rendered range reaches the end and more pages remain,
+	// request the next page exactly once per page boundary.
+	useEffect( () => {
+		if (
+			moreToLoad &&
+			lastIndex !== undefined &&
+			lastIndex >= rowCount - 1 &&
+			requestedForLength.current !== itemsLength
+		) {
+			requestedForLength.current = itemsLength;
+			fetchNextPage( itemsLength );
+		}
+	}, [ moreToLoad, lastIndex, rowCount, itemsLength, fetchNextPage ] );
+
+	// Width-driven height reflow is detected automatically by the per-row
+	// ResizeObserver in `measureElement`. We keep a debounced safety-net remeasure
+	// on window resize so any layout the observer cannot see (e.g. a media query
+	// flip that does not change a measured element's box) still settles.
+	useEffect( () => {
+		const handleResize = debounce( () => virtualizer.measure(), 50 );
+		window.addEventListener( 'resize', handleResize );
+		return () => {
+			handleResize.cancel?.();
+			window.removeEventListener( 'resize', handleResize );
+		};
+	}, [ virtualizer ] );
+
+	// Expose an imperative handle in place of the old WindowScroller instance.
+	// No current consumer reads this ref, but it is part of the public API, so we
+	// keep equivalent affordances backed by the virtualizer / window scroll.
+	useImperativeHandle(
+		windowScrollerRef,
+		() => ( {
+			scrollToOffset: ( offset, options ) => virtualizer.scrollToOffset( offset, options ),
+			scrollToIndex: ( index, options ) => virtualizer.scrollToIndex( index, options ),
+			// react-virtualized's WindowScroller exposed `updatePosition` to force a
+			// re-sync after layout changes; mirror it with a remeasure.
+			updatePosition: () => virtualizer.measure(),
+		} ),
+		[ virtualizer ]
+	);
+
+	const measureElement = virtualizer.measureElement;
+
+	const measuredRowRenderer = useCallback(
+		( ComponentToMeasure, props, { key, index, style } ) => (
+			<MeasuredRow
+				key={ key }
+				index={ index }
+				style={ style }
+				measureElement={ measureElement }
+				ComponentToMeasure={ ComponentToMeasure }
+				componentProps={ props }
+			/>
+		),
+		[ measureElement ]
+	);
+
+	const renderRow = useCallback(
+		( rowRendererProps ) => {
+			const railcar = get( items[ rowRendererProps.index ], 'railcar', undefined );
+			if ( railcar && ! recordedRender.current.has( rowRendererProps.index ) ) {
+				recordedRender.current.add( rowRendererProps.index );
+				const {
+					index,
+					railcar: railcarValue,
+					eventName,
+				} = pickBy( {
+					index: rowRendererProps.index,
+					railcar,
+				} );
+				recordTracksRailcarRender( eventName, railcarValue, { ui_position: index } );
+			}
+
+			return rowRenderer( {
+				items,
+				extraRenderItemProps,
+				rowRendererProps,
+				measuredRowRenderer,
+			} );
+		},
+		[ items, extraRenderItemProps, rowRenderer, measuredRowRenderer ]
+	);
+
+	const totalSize = virtualizer.getTotalSize();
+
+	const innerStyle = useMemo(
+		() => ( {
+			position: 'relative',
+			inlineSize: width,
+			blockSize: totalSize,
+		} ),
+		[ width, totalSize ]
+	);
+
+	return (
+		<div ref={ setListElement }>
+			<div style={ innerStyle }>
+				{ virtualItems.map( ( virtualRow ) =>
+					renderRow( {
+						key: virtualRow.key,
+						index: virtualRow.index,
+						style: {
+							position: 'absolute',
+							insetBlockStart: 0,
+							insetInlineStart: 0,
+							inlineSize: '100%',
+							transform: `translateY(${ virtualRow.start - scrollMargin }px)`,
+						},
+					} )
+				) }
+			</div>
+		</div>
+	);
+}
+
+ReaderInfiniteStream.propTypes = {
+	items: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	rowRenderer: PropTypes.func.isRequired,
+	fetchNextPage: PropTypes.func,
+	hasNextPage: PropTypes.func,
+	// A ref (object or callback) receiving the imperative handle.
+	windowScrollerRef: PropTypes.oneOfType( [ PropTypes.func, PropTypes.object ] ),
+	extraRenderItemProps: PropTypes.object,
+	minHeight: PropTypes.number,
+};
 
 export default ReaderInfiniteStream;


### PR DESCRIPTION
Task-related: DOTCOM-17718

## Proposed Changes

* Migrate `client/reader/components/reader-infinite-stream` off the unmaintained `@automattic/react-virtualized` fork (`CellMeasurer` / `CellMeasurerCache` / `InfiniteLoader` / `List` / `WindowScroller`) onto `@tanstack/react-virtual` (`useWindowVirtualizer`).
* Convert the class to a function component (hooks); keep the default export `ReaderInfiniteStream` and its public prop surface.
* Window scroll + `measureElement` (per-row `ResizeObserver`) for variable, DOM-measured row heights, with a document-relative `scrollMargin` recomputed via `ResizeObserver` — mirroring the in-repo blueprint `client/reader/hooks/use-infinite-list/use-scroll-margin.ts`.
* Preserve the public contract consumed by Reader row renderers:
  * `rowRenderer` / `measuredRowRenderer` signatures unchanged.
  * `measuredRowRenderer( Component, props, { key, index, style } )` keeps the absolute-transform `style` and the `reader-infinite-stream__row-wrapper` class. It drops the CellMeasurer-only `parent` field, which no consumer reads.
  * `onShouldMeasure` still works — each row (`MeasuredRow`) holds its own DOM node and remeasures just that element, so post-image-load remeasures keep functioning without a full-list pass.
* Paging: replace `InfiniteLoader` / `loadMoreRows` with a load-more effect that calls `fetchNextPage( items.length )` when the last rendered index reaches the end and `hasNextPage( items.length )` is true. Guarded against repeated calls by tracking the length a page was already requested for (the `isLoadingMore` concern from `use-load-more.ts`), so it does not spam `fetchNextPage` on every measurement render. Keeps the `+10` trailing placeholder rows so trailing loaders render.
* Railcar / traintrack analytics fire exactly once per item index (the `recordedRender` Set is kept, as a ref).
* Resize handling: width-driven height reflow is auto-detected by `measureElement`'s `ResizeObserver`; a debounced `virtualizer.measure()` on window resize is kept as a safety net for layout the per-row observer cannot see.
* `windowScrollerRef`: there is no `WindowScroller` instance anymore. I inspected every consumer — **none reads this ref** — but it is part of the public API, so rather than silently dropping it the component exposes an equivalent imperative handle via `useImperativeHandle` (`scrollToOffset`, `scrollToIndex`, `updatePosition` → `virtualizer.measure()`).
* `@automattic/react-virtualized` is **intentionally NOT removed** from `client/package.json` — other files still import it.

## Why are these changes being made?

* Part of the effort to retire the unmaintained `@automattic/react-virtualized` fork. This is the hardest of the set: a window-scrolled infinite stream with DOM-measured variable row heights, infinite paging, railcar analytics, and a public API consumed by other Reader components.

## Testing Instructions

* Sole consumer: `client/reader/search-stream/site-results.jsx` (Reader search → Sites results). It required **no code changes**.
* Open Reader search and run a query that returns many sites. Verify:
  * The site results list renders, scrolls smoothly under window scroll, and rows have correct, non-overlapping heights.
  * Scrolling to the bottom loads more results (infinite paging) without runaway repeated network requests.
  * Logged-out users still hit the login-prompt cap (`hasMore` returns false past `MAX_POSTS_FOR_LOGGED_OUT_USERS`).
  * Railcar/traintrack render events fire once per row.
  * Resizing the window keeps row heights/positions correct.
* `yarn typecheck-client` passes locally. ESLint clean on the changed file.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)