### PR TITLE
Dashboard MCP: adopt group-based layout for Read/Write pages

### DIFF
--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -212,7 +212,7 @@ export default function McpRead() {
 												/>
 												<Button
 													icon={ isOpen ? chevronUp : chevronDown }
-													label={ __( 'Show operations' ) }
+													label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 													aria-expanded={ isOpen }
 													onClick={ () => toggleGroupOpen( groupKey ) }
 												/>
@@ -232,7 +232,7 @@ export default function McpRead() {
 													</VStack>
 													<Button
 														icon={ isOpen ? chevronUp : chevronDown }
-														label={ __( 'Show operations' ) }
+														label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 														aria-expanded={ isOpen }
 														onClick={ () => toggleGroupOpen( groupKey ) }
 													/>

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -16,7 +16,7 @@ import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/g
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { Card, CardBody, CardDivider } from '../../../components/card';
+import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -253,7 +253,17 @@ export default function McpRead() {
 										( groupToolsBySubCategory( groupTools ) as SubGroup[] ).map(
 											( { subCategory, tools: subTools }, subIndex ) => (
 												<Fragment key={ subCategory ?? '__ungrouped__' }>
-													{ subIndex > 0 && <CardDivider /> }
+													{ subIndex > 0 && (
+														<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
+															<hr
+																style={ {
+																	border: 'none',
+																	borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
+																	margin: 0,
+																} }
+															/>
+														</CardBody>
+													) }
 													<CardBody>
 														<VStack spacing={ 4 }>
 															{ subTools.map( ( [ toolId, tool ] ) => (

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -4,49 +4,64 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
+	Button,
 	ToggleControl,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
-import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import { chevronDown, chevronUp } from '@wordpress/icons';
+import { Fragment, useState } from 'react';
+import { groupIntentKey, getOverridesToMatch } from '../../../../me/mcp/group-intents';
+import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/groups';
+import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { Card, CardBody, CardDivider } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
-import {
-	CATEGORY_ORDER,
-	SUB_CATEGORY_ORDER,
-	getDisplayCategory,
-	getSubCategory,
-	isWriteTool,
-	sortTools,
-} from '../categories';
+import { isWriteTool } from '../categories';
+import type { McpAbility, McpGroupDescriptor } from '@automattic/api-core';
 
-interface McpAbility {
-	title: string;
-	description: string;
-	enabled: boolean;
-	category?: string;
-	category_label?: string;
-	type?: string;
-	readonly?: boolean;
-	visible?: boolean;
-	annotations?: Record< string, unknown >;
+const TOOL_CATEGORY = 'read' as const;
+
+interface ToolGroup {
+	group: McpGroupDescriptor | null;
+	label: string;
+	tools: Array< [ string, McpAbility ] >;
+}
+
+interface SubGroup {
+	subCategory: string | null;
+	tools: Array< [ string, McpAbility ] >;
 }
 
 export default function McpRead() {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+	const isDesktop = useViewportMatch( 'medium' );
 
-	// Show all tools on the Read page — the type field may not be set by all tools,
-	// and the Figma Read page shows all read-type tools (Sites & Content, Posts, etc.)
-	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
-		( [ , tool ] ) => tool.visible !== false
-	);
-	const readTools = allTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
+	const [ openGroups, setOpenGroups ] = useState( () => new Set< string >() );
+	const toggleGroupOpen = ( groupKey: string ) => {
+		setOpenGroups( ( current ) => {
+			const next = new Set( current );
+			if ( next.has( groupKey ) ) {
+				next.delete( groupKey );
+			} else {
+				next.add( groupKey );
+			}
+			return next;
+		} );
+	};
+
+	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > )
+		.filter( ( [ , tool ] ) => tool.visible !== false )
+		.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
+
+	const groupDescriptors = getGroupDescriptors( userSettings || {} ) as McpGroupDescriptor[];
+	const groups = groupToolsByGroup( allTools, groupDescriptors ) as ToolGroup[];
+	const pageAllEnabled = allTools.length > 0 && allTools.every( ( [ , tool ] ) => tool.enabled );
 
 	const mutation = useMutation( {
 		...userSettingsMutation(),
@@ -62,9 +77,7 @@ export default function McpRead() {
 		mutation.mutate(
 			{
 				mcp_abilities: {
-					account: {
-						[ toolId ]: enabled,
-					},
+					account: { [ toolId ]: enabled },
 				},
 			} as any,
 			{
@@ -78,92 +91,67 @@ export default function McpRead() {
 		);
 	};
 
-	const handleEnableAll = (
-		categoryTools: Array< [ string, McpAbility ] >,
-		enabled: boolean,
-		category: string
-	) => {
-		const accountAbilities: Record< string, boolean > = {};
-		categoryTools.forEach( ( [ toolId ] ) => {
-			accountAbilities[ toolId ] = enabled;
-		} );
+	const handlePageToggle = ( enabled: boolean ) => {
+		const overrides = getOverridesToMatch( allTools, enabled ) as
+			| Record< string, boolean >
+			| undefined;
+		const groupIntents: Record< string, boolean > = { [ TOOL_CATEGORY ]: enabled };
+		if ( ! enabled ) {
+			groupDescriptors.forEach( ( group ) => {
+				groupIntents[ groupIntentKey( TOOL_CATEGORY, group.name ) ] = false;
+			} );
+		}
 		mutation.mutate(
 			{
 				mcp_abilities: {
-					account: accountAbilities,
+					...( overrides && { account: overrides } ),
+					group_intents: groupIntents,
 				},
 			} as any,
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_enable_all_toggled', {
 						enabled,
-						category,
+						scope: 'page',
 					} );
 				},
 			}
 		);
 	};
 
-	// Group tools by display category
-	const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
-	readTools.forEach( ( [ toolId, tool ] ) => {
-		const category = getDisplayCategory( toolId, tool );
-		if ( ! grouped[ category ] ) {
-			grouped[ category ] = [];
-		}
-		grouped[ category ].push( [ toolId, tool ] );
-	} );
-
-	const renderToolToggles = ( tools: Array< [ string, McpAbility ] > ) =>
-		tools.map( ( [ toolId, tool ] ) => (
-			<ToggleControl
-				key={ toolId }
-				__nextHasNoMarginBottom
-				checked={ tool.enabled }
-				disabled={ mutation.isPending }
-				label={ tool.title }
-				help={ tool.description }
-				onChange={ ( checked ) => handleToolChange( toolId, checked ) }
-			/>
-		) );
-
-	const renderSubGroupedTools = (
-		categoryTools: Array< [ string, McpAbility ] >,
-		categoryName: string
+	const handleGroupEnableAll = (
+		groupName: string | null,
+		groupTools: Array< [ string, McpAbility ] >,
+		enabled: boolean
 	) => {
-		const subGrouped: Record< string, Array< [ string, McpAbility ] > > = {};
-		categoryTools.forEach( ( [ toolId, tool ] ) => {
-			const sub = getSubCategory( toolId, tool ) ?? '';
-			if ( ! subGrouped[ sub ] ) {
-				subGrouped[ sub ] = [];
+		const overrides = getOverridesToMatch( groupTools, enabled ) as
+			| Record< string, boolean >
+			| undefined;
+		const groupIntents = groupName
+			? { [ groupIntentKey( TOOL_CATEGORY, groupName ) ]: enabled }
+			: undefined;
+
+		if ( ! overrides && ! groupIntents ) {
+			return;
+		}
+
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					...( overrides && { account: overrides } ),
+					...( groupIntents && { group_intents: groupIntents } ),
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_read_enable_all_toggled', {
+						enabled,
+						scope: 'group',
+						group: groupName ?? 'other',
+					} );
+				},
 			}
-			subGrouped[ sub ].push( [ toolId, tool ] );
-		} );
-
-		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
-		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
-		// Tools with no sub-category are appended at the end so they are never silently dropped.
-		const ungrouped = subGrouped[ '' ] ?? [];
-		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
-
-		return allGroups.map( ( subName, index ) => (
-			<Fragment key={ subName || '__ungrouped__' }>
-				{ index > 0 && (
-					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
-						<hr
-							style={ {
-								border: 'none',
-								borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
-								margin: 0,
-							} }
-						/>
-					</CardBody>
-				) }
-				<CardBody>
-					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
-				</CardBody>
-			</Fragment>
-		) );
+		);
 	};
 
 	return (
@@ -179,44 +167,122 @@ export default function McpRead() {
 		>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_read_view" />
 			<VStack spacing={ 4 }>
-				{ CATEGORY_ORDER.map( ( categoryName ) => {
-					const categoryTools = grouped[ categoryName ];
-					if ( ! categoryTools || categoryTools.length === 0 ) {
-						return null;
-					}
+				<Card>
+					<CardBody>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ pageAllEnabled }
+							disabled={ mutation.isPending || allTools.length === 0 }
+							label={ <Text weight="600">{ __( 'Enable all' ) }</Text> }
+							onChange={ handlePageToggle }
+						/>
+					</CardBody>
+				</Card>
 
-					const allEnabled = categoryTools.every( ( [ , tool ] ) => tool.enabled );
-					const subOrder = SUB_CATEGORY_ORDER[ categoryName ];
+				{ groups.length > 0 ? (
+					<VStack spacing={ 3 }>
+						{ groups.map( ( { group: descriptor, label, tools: groupTools }: ToolGroup ) => {
+							const groupKey = descriptor?.name ?? '__other__';
+							const allGroupEnabled = groupTools.every( ( [ , t ] ) => t.enabled );
+							const isOpen = openGroups.has( groupKey );
 
-					return (
-						<Card key={ categoryName }>
-							<CardBody>
-								<HStack justify="space-between" alignment="center">
-									<Text as="h3" weight={ 600 } size={ 14 }>
-										{ categoryName }
-									</Text>
-									<ToggleControl
-										__nextHasNoMarginBottom
-										checked={ allEnabled }
-										disabled={ mutation.isPending }
-										label={ __( 'Enable all' ) }
-										onChange={ ( checked ) =>
-											handleEnableAll( categoryTools, checked, categoryName )
-										}
-									/>
-								</HStack>
-							</CardBody>
-							<CardDivider />
-							{ subOrder ? (
-								renderSubGroupedTools( categoryTools, categoryName )
-							) : (
-								<CardBody>
-									<VStack spacing={ 4 }>{ renderToolToggles( categoryTools ) }</VStack>
-								</CardBody>
-							) }
-						</Card>
-					);
-				} ) }
+							return (
+								<Card key={ groupKey }>
+									<CardBody>
+										{ isDesktop ? (
+											<HStack justify="space-between" alignment="center" spacing={ 4 }>
+												<VStack spacing={ 1 } style={ { flex: 1, minWidth: 0 } }>
+													<Text truncate weight={ 600 } size={ 14 }>
+														{ label }
+													</Text>
+													{ descriptor?.description && (
+														<Text truncate variant="muted" size={ 12 }>
+															{ descriptor.description }
+														</Text>
+													) }
+												</VStack>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													checked={ allGroupEnabled }
+													disabled={ mutation.isPending }
+													label={ __( 'Enable all' ) }
+													onChange={ ( checked ) =>
+														handleGroupEnableAll( descriptor?.name ?? null, groupTools, checked )
+													}
+												/>
+												<Button
+													icon={ isOpen ? chevronUp : chevronDown }
+													label={ __( 'Show operations' ) }
+													aria-expanded={ isOpen }
+													onClick={ () => toggleGroupOpen( groupKey ) }
+												/>
+											</HStack>
+										) : (
+											<VStack spacing={ 2 }>
+												<HStack justify="space-between" alignment="center">
+													<VStack spacing={ 1 } style={ { flex: 1, minWidth: 0 } }>
+														<Text truncate weight={ 600 } size={ 14 }>
+															{ label }
+														</Text>
+														{ descriptor?.description && (
+															<Text truncate variant="muted" size={ 12 }>
+																{ descriptor.description }
+															</Text>
+														) }
+													</VStack>
+													<Button
+														icon={ isOpen ? chevronUp : chevronDown }
+														label={ __( 'Show operations' ) }
+														aria-expanded={ isOpen }
+														onClick={ () => toggleGroupOpen( groupKey ) }
+													/>
+												</HStack>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													checked={ allGroupEnabled }
+													disabled={ mutation.isPending }
+													label={ __( 'Enable all' ) }
+													onChange={ ( checked ) =>
+														handleGroupEnableAll( descriptor?.name ?? null, groupTools, checked )
+													}
+												/>
+											</VStack>
+										) }
+									</CardBody>
+									{ isOpen &&
+										( groupToolsBySubCategory( groupTools ) as SubGroup[] ).map(
+											( { subCategory, tools: subTools }, subIndex ) => (
+												<Fragment key={ subCategory ?? '__ungrouped__' }>
+													{ subIndex > 0 && <CardDivider /> }
+													<CardBody>
+														<VStack spacing={ 4 }>
+															{ subTools.map( ( [ toolId, tool ] ) => (
+																<ToggleControl
+																	key={ toolId }
+																	__nextHasNoMarginBottom
+																	checked={ tool.enabled }
+																	disabled={ mutation.isPending }
+																	label={ tool.title }
+																	help={ tool.description }
+																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+																/>
+															) ) }
+														</VStack>
+													</CardBody>
+												</Fragment>
+											)
+										) }
+								</Card>
+							);
+						} ) }
+					</VStack>
+				) : (
+					<Card>
+						<CardBody>
+							<Text variant="muted">{ __( 'No read tools are available for your account.' ) }</Text>
+						</CardBody>
+					</Card>
+				) }
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -4,47 +4,64 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
+	Button,
 	ToggleControl,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
-import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import { chevronDown, chevronUp } from '@wordpress/icons';
+import { Fragment, useState } from 'react';
+import { groupIntentKey, getOverridesToMatch } from '../../../../me/mcp/group-intents';
+import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/groups';
+import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { Card, CardBody, CardDivider } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
-import {
-	CATEGORY_ORDER,
-	SUB_CATEGORY_ORDER,
-	getDisplayCategory,
-	getSubCategory,
-	isWriteTool,
-	sortTools,
-} from '../categories';
+import { isWriteTool } from '../categories';
+import type { McpAbility, McpGroupDescriptor } from '@automattic/api-core';
 
-interface McpAbility {
-	title: string;
-	description: string;
-	enabled: boolean;
-	category?: string;
-	category_label?: string;
-	type?: string;
-	readonly?: boolean;
-	visible?: boolean;
-	annotations?: Record< string, unknown >;
+const TOOL_CATEGORY = 'write' as const;
+
+interface ToolGroup {
+	group: McpGroupDescriptor | null;
+	label: string;
+	tools: Array< [ string, McpAbility ] >;
+}
+
+interface SubGroup {
+	subCategory: string | null;
+	tools: Array< [ string, McpAbility ] >;
 }
 
 export default function McpWrite() {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+	const isDesktop = useViewportMatch( 'medium' );
 
-	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
-		( [ , tool ] ) => tool.visible !== false
-	);
-	const writeTools = allTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
+	const [ openGroups, setOpenGroups ] = useState( () => new Set< string >() );
+	const toggleGroupOpen = ( groupKey: string ) => {
+		setOpenGroups( ( current ) => {
+			const next = new Set( current );
+			if ( next.has( groupKey ) ) {
+				next.delete( groupKey );
+			} else {
+				next.add( groupKey );
+			}
+			return next;
+		} );
+	};
+
+	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > )
+		.filter( ( [ , tool ] ) => tool.visible !== false )
+		.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
+
+	const groupDescriptors = getGroupDescriptors( userSettings || {} ) as McpGroupDescriptor[];
+	const groups = groupToolsByGroup( allTools, groupDescriptors ) as ToolGroup[];
+	const pageAllEnabled = allTools.length > 0 && allTools.every( ( [ , tool ] ) => tool.enabled );
 
 	const mutation = useMutation( {
 		...userSettingsMutation(),
@@ -60,9 +77,7 @@ export default function McpWrite() {
 		mutation.mutate(
 			{
 				mcp_abilities: {
-					account: {
-						[ toolId ]: enabled,
-					},
+					account: { [ toolId ]: enabled },
 				},
 			} as any,
 			{
@@ -76,94 +91,67 @@ export default function McpWrite() {
 		);
 	};
 
-	const handleEnableAll = (
-		categoryTools: Array< [ string, McpAbility ] >,
-		enabled: boolean,
-		category: string
-	) => {
-		const accountAbilities: Record< string, boolean > = {};
-		categoryTools.forEach( ( [ toolId ] ) => {
-			accountAbilities[ toolId ] = enabled;
-		} );
+	const handlePageToggle = ( enabled: boolean ) => {
+		const overrides = getOverridesToMatch( allTools, enabled ) as
+			| Record< string, boolean >
+			| undefined;
+		const groupIntents: Record< string, boolean > = { [ TOOL_CATEGORY ]: enabled };
+		if ( ! enabled ) {
+			groupDescriptors.forEach( ( group ) => {
+				groupIntents[ groupIntentKey( TOOL_CATEGORY, group.name ) ] = false;
+			} );
+		}
 		mutation.mutate(
 			{
 				mcp_abilities: {
-					account: accountAbilities,
+					...( overrides && { account: overrides } ),
+					group_intents: groupIntents,
 				},
 			} as any,
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_enable_all_toggled', {
 						enabled,
-						category,
+						scope: 'page',
 					} );
 				},
 			}
 		);
 	};
 
-	// Group tools by display category
-	const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
-	writeTools.forEach( ( [ toolId, tool ] ) => {
-		const category = getDisplayCategory( toolId, tool );
-		if ( ! grouped[ category ] ) {
-			grouped[ category ] = [];
-		}
-		grouped[ category ].push( [ toolId, tool ] );
-	} );
-
-	const hasWriteTools = writeTools.length > 0;
-
-	const renderToolToggles = ( tools: Array< [ string, McpAbility ] > ) =>
-		tools.map( ( [ toolId, tool ] ) => (
-			<ToggleControl
-				key={ toolId }
-				__nextHasNoMarginBottom
-				checked={ tool.enabled }
-				disabled={ mutation.isPending }
-				label={ tool.title }
-				help={ tool.description }
-				onChange={ ( checked ) => handleToolChange( toolId, checked ) }
-			/>
-		) );
-
-	const renderSubGroupedTools = (
-		categoryTools: Array< [ string, McpAbility ] >,
-		categoryName: string
+	const handleGroupEnableAll = (
+		groupName: string | null,
+		groupTools: Array< [ string, McpAbility ] >,
+		enabled: boolean
 	) => {
-		const subGrouped: Record< string, Array< [ string, McpAbility ] > > = {};
-		categoryTools.forEach( ( [ toolId, tool ] ) => {
-			const sub = getSubCategory( toolId, tool ) ?? '';
-			if ( ! subGrouped[ sub ] ) {
-				subGrouped[ sub ] = [];
+		const overrides = getOverridesToMatch( groupTools, enabled ) as
+			| Record< string, boolean >
+			| undefined;
+		const groupIntents = groupName
+			? { [ groupIntentKey( TOOL_CATEGORY, groupName ) ]: enabled }
+			: undefined;
+
+		if ( ! overrides && ! groupIntents ) {
+			return;
+		}
+
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					...( overrides && { account: overrides } ),
+					...( groupIntents && { group_intents: groupIntents } ),
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_write_enable_all_toggled', {
+						enabled,
+						scope: 'group',
+						group: groupName ?? 'other',
+					} );
+				},
 			}
-			subGrouped[ sub ].push( [ toolId, tool ] );
-		} );
-
-		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
-		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
-		// Tools with no sub-category are appended at the end so they are never silently dropped.
-		const ungrouped = subGrouped[ '' ] ?? [];
-		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
-
-		return allGroups.map( ( subName, index ) => (
-			<Fragment key={ subName || '__ungrouped__' }>
-				{ index > 0 && (
-					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
-						<hr
-							style={ {
-								border: 'none',
-								borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
-								margin: 0,
-							} }
-						/>
-					</CardBody>
-				) }
-				<CardBody>
-					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
-				</CardBody>
-			</Fragment>
-		) );
+		);
 	};
 
 	return (
@@ -179,7 +167,116 @@ export default function McpWrite() {
 		>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_write_view" />
 			<VStack spacing={ 4 }>
-				{ ! hasWriteTools && (
+				<Card>
+					<CardBody>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ pageAllEnabled }
+							disabled={ mutation.isPending || allTools.length === 0 }
+							label={ <Text weight="600">{ __( 'Enable all' ) }</Text> }
+							onChange={ handlePageToggle }
+						/>
+					</CardBody>
+				</Card>
+
+				{ groups.length > 0 ? (
+					<VStack spacing={ 3 }>
+						{ groups.map( ( { group: descriptor, label, tools: groupTools }: ToolGroup ) => {
+							const groupKey = descriptor?.name ?? '__other__';
+							const allGroupEnabled = groupTools.every( ( [ , t ] ) => t.enabled );
+							const isOpen = openGroups.has( groupKey );
+
+							return (
+								<Card key={ groupKey }>
+									<CardBody>
+										{ isDesktop ? (
+											<HStack justify="space-between" alignment="center" spacing={ 4 }>
+												<VStack spacing={ 1 } style={ { flex: 1, minWidth: 0 } }>
+													<Text truncate weight={ 600 } size={ 14 }>
+														{ label }
+													</Text>
+													{ descriptor?.description && (
+														<Text truncate variant="muted" size={ 12 }>
+															{ descriptor.description }
+														</Text>
+													) }
+												</VStack>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													checked={ allGroupEnabled }
+													disabled={ mutation.isPending }
+													label={ __( 'Enable all' ) }
+													onChange={ ( checked ) =>
+														handleGroupEnableAll( descriptor?.name ?? null, groupTools, checked )
+													}
+												/>
+												<Button
+													icon={ isOpen ? chevronUp : chevronDown }
+													label={ __( 'Show operations' ) }
+													aria-expanded={ isOpen }
+													onClick={ () => toggleGroupOpen( groupKey ) }
+												/>
+											</HStack>
+										) : (
+											<VStack spacing={ 2 }>
+												<HStack justify="space-between" alignment="center">
+													<VStack spacing={ 1 } style={ { flex: 1, minWidth: 0 } }>
+														<Text truncate weight={ 600 } size={ 14 }>
+															{ label }
+														</Text>
+														{ descriptor?.description && (
+															<Text truncate variant="muted" size={ 12 }>
+																{ descriptor.description }
+															</Text>
+														) }
+													</VStack>
+													<Button
+														icon={ isOpen ? chevronUp : chevronDown }
+														label={ __( 'Show operations' ) }
+														aria-expanded={ isOpen }
+														onClick={ () => toggleGroupOpen( groupKey ) }
+													/>
+												</HStack>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													checked={ allGroupEnabled }
+													disabled={ mutation.isPending }
+													label={ __( 'Enable all' ) }
+													onChange={ ( checked ) =>
+														handleGroupEnableAll( descriptor?.name ?? null, groupTools, checked )
+													}
+												/>
+											</VStack>
+										) }
+									</CardBody>
+									{ isOpen &&
+										( groupToolsBySubCategory( groupTools ) as SubGroup[] ).map(
+											( { subCategory, tools: subTools }, subIndex ) => (
+												<Fragment key={ subCategory ?? '__ungrouped__' }>
+													{ subIndex > 0 && <CardDivider /> }
+													<CardBody>
+														<VStack spacing={ 4 }>
+															{ subTools.map( ( [ toolId, tool ] ) => (
+																<ToggleControl
+																	key={ toolId }
+																	__nextHasNoMarginBottom
+																	checked={ tool.enabled }
+																	disabled={ mutation.isPending }
+																	label={ tool.title }
+																	help={ tool.description }
+																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+																/>
+															) ) }
+														</VStack>
+													</CardBody>
+												</Fragment>
+											)
+										) }
+								</Card>
+							);
+						} ) }
+					</VStack>
+				) : (
 					<Card>
 						<CardBody>
 							<Text variant="muted">
@@ -188,44 +285,6 @@ export default function McpWrite() {
 						</CardBody>
 					</Card>
 				) }
-				{ CATEGORY_ORDER.map( ( categoryName ) => {
-					const categoryTools = grouped[ categoryName ];
-					if ( ! categoryTools || categoryTools.length === 0 ) {
-						return null;
-					}
-
-					const allEnabled = categoryTools.every( ( [ , tool ] ) => tool.enabled );
-					const subOrder = SUB_CATEGORY_ORDER[ categoryName ];
-
-					return (
-						<Card key={ categoryName }>
-							<CardBody>
-								<HStack justify="space-between" alignment="center">
-									<Text as="h3" weight={ 600 } size={ 14 }>
-										{ categoryName }
-									</Text>
-									<ToggleControl
-										__nextHasNoMarginBottom
-										checked={ allEnabled }
-										disabled={ mutation.isPending }
-										label={ __( 'Enable all' ) }
-										onChange={ ( checked ) =>
-											handleEnableAll( categoryTools, checked, categoryName )
-										}
-									/>
-								</HStack>
-							</CardBody>
-							<CardDivider />
-							{ subOrder ? (
-								renderSubGroupedTools( categoryTools, categoryName )
-							) : (
-								<CardBody>
-									<VStack spacing={ 4 }>{ renderToolToggles( categoryTools ) }</VStack>
-								</CardBody>
-							) }
-						</Card>
-					);
-				} ) }
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -212,7 +212,7 @@ export default function McpWrite() {
 												/>
 												<Button
 													icon={ isOpen ? chevronUp : chevronDown }
-													label={ __( 'Show operations' ) }
+													label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 													aria-expanded={ isOpen }
 													onClick={ () => toggleGroupOpen( groupKey ) }
 												/>
@@ -232,7 +232,7 @@ export default function McpWrite() {
 													</VStack>
 													<Button
 														icon={ isOpen ? chevronUp : chevronDown }
-														label={ __( 'Show operations' ) }
+														label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 														aria-expanded={ isOpen }
 														onClick={ () => toggleGroupOpen( groupKey ) }
 													/>

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -16,7 +16,7 @@ import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/g
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { Card, CardBody, CardDivider } from '../../../components/card';
+import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -253,7 +253,17 @@ export default function McpWrite() {
 										( groupToolsBySubCategory( groupTools ) as SubGroup[] ).map(
 											( { subCategory, tools: subTools }, subIndex ) => (
 												<Fragment key={ subCategory ?? '__ungrouped__' }>
-													{ subIndex > 0 && <CardDivider /> }
+													{ subIndex > 0 && (
+														<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
+															<hr
+																style={ {
+																	border: 'none',
+																	borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
+																	margin: 0,
+																} }
+															/>
+														</CardBody>
+													) }
 													<CardBody>
 														<VStack spacing={ 4 }>
 															{ subTools.map( ( [ toolId, tool ] ) => (

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -72,23 +72,11 @@ export function getSiteAccountToolsEnabled( userSettings, siteId ) {
 	return true;
 }
 
-/**
- * Get the ordered group descriptors from user settings (AIINT-469/472).
- * Each ability carries a `group` slug matching one of these descriptor `name` values.
- * @param {Object} userSettings - The user settings object
- * @returns {Array<{name: string, label: string, description: string, order: number}>}
- */
 export function getGroupDescriptors( userSettings ) {
 	const groups = userSettings?.mcp_abilities?.groups ?? [];
 	return [ ...groups ].sort( ( a, b ) => a.order - b.order );
 }
 
-/**
- * Get the account-level group "enable all" intents (AIINT-471).
- * Keys are `read`, `write`, or a compound `"{read|write}:{groupName}"` slug.
- * @param {Object} userSettings - The user settings object
- * @returns {Record<string, boolean>}
- */
 export function getGroupIntents( userSettings ) {
 	return userSettings?.mcp_abilities?.group_intents ?? {};
 }

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -73,6 +73,27 @@ export function getSiteAccountToolsEnabled( userSettings, siteId ) {
 }
 
 /**
+ * Get the ordered group descriptors from user settings (AIINT-469/472).
+ * Each ability carries a `group` slug matching one of these descriptor `name` values.
+ * @param {Object} userSettings - The user settings object
+ * @returns {Array<{name: string, label: string, description: string, order: number}>}
+ */
+export function getGroupDescriptors( userSettings ) {
+	const groups = userSettings?.mcp_abilities?.groups ?? [];
+	return [ ...groups ].sort( ( a, b ) => a.order - b.order );
+}
+
+/**
+ * Get the account-level group "enable all" intents (AIINT-471).
+ * Keys are `read`, `write`, or a compound `"{read|write}:{groupName}"` slug.
+ * @param {Object} userSettings - The user settings object
+ * @returns {Record<string, boolean>}
+ */
+export function getGroupIntents( userSettings ) {
+	return userSettings?.mcp_abilities?.group_intents ?? {};
+}
+
+/**
  * Get the set of tool IDs that are relevant in a site context.
  * Uses mcp_abilities.site as the authoritative list of site-applicable tools.
  * @param {Object} userSettings - The user settings object

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -148,30 +148,6 @@ export function getDisabledSiteIds( userSettings ) {
 }
 
 /**
- * Get the ordered display-group descriptors for the settings UI's middle
- * grouping layer (AIINT-469), sorted by their `order` field. A group defaults
- * to a STRAP facade, but some facades are merged into another group (e.g.
- * Create Site into Site).
- * @param {Object} userSettings - The user settings object
- * @returns {Array<{name: string, label: string, description: string, order: number}>}
- */
-export function getGroupDescriptors( userSettings ) {
-	const groups = userSettings?.mcp_abilities?.groups ?? [];
-	return [ ...groups ].sort( ( a, b ) => a.order - b.order );
-}
-
-/**
- * Get the account-level group "enable all" intents (AIINT-471).
- * Keys are `read`, `write`, or a bare group slug (e.g. `site`) — matching a
- * getGroupDescriptors() entry's `name`.
- * @param {Object} userSettings - The user settings object
- * @returns {Record<string, boolean>}
- */
-export function getGroupIntents( userSettings ) {
-	return userSettings?.mcp_abilities?.group_intents ?? {};
-}
-
-/**
  * Check if the site-level MCP server is enabled for a specific site.
  * Uses site_level_enabled from the site's entry if present, otherwise
  * falls back to mcp_abilities.site_level_enabled_default.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-473/calypso-restructure-mywordpresscom-dashboard-site-level-mcp-settings

## Proposed Changes

Port the restructured `/me/mcp` Read/Write layout to the Dashboard `/me/preferences/mcp` pages (`client/dashboard/me/mcp/read/` and `client/dashboard/me/mcp/write/`):

- **Group-based structure**: replaces frontend display-category grouping with backend-driven group descriptors (`mcp_abilities.groups`), each rendered as a separate Card
- **Collapse/expand**: groups are collapsed by default; a chevron button expands to reveal individual tool toggles
- **Page-level Enable all**: a top card with a toggle to enable/disable all tools in the Read or Write category, using `group_intents`
- **Group-level Enable all**: each group card header has its own toggle, using `group_intents` with compound `"{read|write}:{group}"` keys
- **Sub-group separators**: expanded groups use CardDivider + CardBody to visually separate tools by sub-category
- **Responsive header**: `useViewportMatch('medium')` renders chevron inline with title on mobile (toggle below), all three inline on desktop
- **group_intents save pattern**: both page-level and group-level toggles write `group_intents` instead of materializing per-op overrides, matching the Calypso implementation

Also adds the shared utility files needed by both Calypso and Dashboard:

- `client/me/mcp/groups.js` — `groupToolsByGroup`, `groupToolsBySubCategory`
- `client/me/mcp/group-intents.js` — `groupIntentKey`, `getOverridesToMatch`
- `client/me/mcp/utils.js` — adds `getGroupDescriptors`, `getGroupIntents`
- `packages/api-core/src/me-settings/types.ts` — adds `group`, `readonly`, `McpGroupDescriptor`, `groups`, `group_intents` to the MCP types

Note: this PR depends on the backend fields (`mcp_abilities.groups`, `group` on each ability, `group_intents`) shipped in AIINT-469/471. It shares utility files with PR #111954 (the Calypso port); one of these should merge first and the other rebased.

## Why are these changes being made?

AIINT-472 calls for the Dashboard MCP settings pages to match the new group-based layout already built for `/me/mcp`. This makes the two surfaces consistent and adopts the cleaner backend-driven grouping model.

## Testing Instructions

1. Sign in and navigate to `/me/preferences/mcp` (Dashboard)
2. Click **Read** — confirm group cards appear collapsed by default
3. Expand a group — tools appear sub-grouped by category with CardDivider separators
4. Toggle Enable all at the page level — network request should include `group_intents: { read: true/false }`
5. Toggle a group Enable all — network request should include `group_intents: { "read:{groupName}": true/false }`
6. Repeat for **Write** page
7. On mobile, confirm toggle wraps below the title/chevron row

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
