### PR TITLE
Desktop: Add Buildkite publish dry-run

### DIFF
--- a/.buildkite/commands/publish-desktop-dry-run.sh
+++ b/.buildkite/commands/publish-desktop-dry-run.sh
@@ -7,18 +7,38 @@ changelog_path="desktop/CHANGELOG.md"
 
 download_step_artifacts() {
 	local step="$1"
+	shift
+	local query
 
-	echo "--- :buildkite: Downloading artifacts from $step"
-	buildkite-agent artifact download "desktop/release/*" . --step "$step"
+	for query in "$@"; do
+		echo "--- :buildkite: Downloading artifacts from $step"
+		if buildkite-agent artifact download "$query" . --step "$step"; then
+			normalize_windows_artifact_paths
+			return
+		fi
+	done
+
+	echo "Failed to download artifacts from $step." >&2
+	exit 1
+}
+
+normalize_windows_artifact_paths() {
+	local artifact
+	local filename
+
+	while IFS= read -r -d '' artifact; do
+		filename="${artifact##*\\}"
+		mv "$artifact" "$release_dir/$filename"
+	done < <(find . -maxdepth 1 -type f -name 'desktop\\release\\*' -print0)
 }
 
 rm -rf "$release_dir" "$changelog_path"
 mkdir -p "$release_dir"
 
-download_step_artifacts desktop-build-mac
-download_step_artifacts desktop-build-linux
-download_step_artifacts desktop-build-windows-store
-download_step_artifacts desktop-build-windows-nsis
+download_step_artifacts desktop-build-mac 'desktop/release/*'
+download_step_artifacts desktop-build-linux 'desktop/release/*'
+download_step_artifacts desktop-build-windows-store 'desktop\release\*'
+download_step_artifacts desktop-build-windows-nsis 'desktop\release\*'
 
 echo "--- :mag: Validating combined desktop release payload"
 .buildkite/commands/validate-desktop-artifacts.sh all "$release_dir"

--- a/.buildkite/commands/publish-desktop-dry-run.sh
+++ b/.buildkite/commands/publish-desktop-dry-run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+release_dir="desktop/release"
+changelog_path="desktop/CHANGELOG.md"
+
+download_step_artifacts() {
+	local step="$1"
+
+	echo "--- :buildkite: Downloading artifacts from $step"
+	buildkite-agent artifact download "desktop/release/*" . --step "$step"
+}
+
+rm -rf "$release_dir" "$changelog_path"
+mkdir -p "$release_dir"
+
+download_step_artifacts desktop-build-mac
+download_step_artifacts desktop-build-linux
+download_step_artifacts desktop-build-windows-store
+download_step_artifacts desktop-build-windows-nsis
+
+echo "--- :mag: Validating combined desktop release payload"
+.buildkite/commands/validate-desktop-artifacts.sh all "$release_dir"
+find "$release_dir" -maxdepth 1 -type f -print | sort
+
+if [[ "${SKIP_DESKTOP_TAG_FETCH:-}" != "true" ]]; then
+	echo "--- :git: Fetching desktop release tags"
+	git fetch --force origin 'refs/tags/desktop-v*:refs/tags/desktop-v*'
+fi
+
+echo "--- :memo: Generating desktop changelog"
+VERSION="${BUILDKITE_TAG:-}" desktop/bin/make-changelog.sh > "$changelog_path"
+
+if [[ ! -s "$changelog_path" ]]; then
+	echo "Expected $changelog_path to be generated." >&2
+	exit 1
+fi
+
+sed -n '1,40p' "$changelog_path"

--- a/.buildkite/commands/validate-desktop-artifacts.sh
+++ b/.buildkite/commands/validate-desktop-artifacts.sh
@@ -20,24 +20,47 @@ require_artifact() {
 	fi
 }
 
+validate_mac_artifacts() {
+	require_artifact "macOS x64 app zip" "$release_dir/wordpress.com-macOS-app-*-x64.zip"
+	require_artifact "macOS arm64 app zip" "$release_dir/wordpress.com-macOS-app-*-arm64.zip"
+	require_artifact "macOS x64 app blockmap" "$release_dir/wordpress.com-macOS-app-*-x64.zip.blockmap"
+	require_artifact "macOS arm64 app blockmap" "$release_dir/wordpress.com-macOS-app-*-arm64.zip.blockmap"
+	require_artifact "macOS x64 dmg" "$release_dir/wordpress.com-macOS-dmg-*-x64.dmg"
+	require_artifact "macOS arm64 dmg" "$release_dir/wordpress.com-macOS-dmg-*-arm64.dmg"
+	require_artifact "macOS x64 dmg blockmap" "$release_dir/wordpress.com-macOS-dmg-*-x64.dmg.blockmap"
+	require_artifact "macOS arm64 dmg blockmap" "$release_dir/wordpress.com-macOS-dmg-*-arm64.dmg.blockmap"
+	require_artifact "macOS updater manifest" "$release_dir/latest-mac.yml"
+}
+
+validate_linux_artifacts() {
+	require_artifact "Linux deb package" "$release_dir/wordpress.com-linux-deb-*.deb"
+	require_artifact "Linux tarball" "$release_dir/wordpress.com-linux-x64-*.tar.gz"
+}
+
+validate_windows_artifacts() {
+	require_artifact "Windows Store appx" "$release_dir/*.appx"
+	require_artifact "Windows NSIS installer" "$release_dir/*.exe"
+	require_artifact "Windows NSIS blockmap" "$release_dir/*.exe.blockmap"
+	require_artifact "Windows updater manifest" "$release_dir/latest.yml"
+}
+
 case "$platform" in
 	mac)
-		require_artifact "macOS x64 app zip" "$release_dir/wordpress.com-macOS-app-*-x64.zip"
-		require_artifact "macOS arm64 app zip" "$release_dir/wordpress.com-macOS-app-*-arm64.zip"
-		require_artifact "macOS x64 app blockmap" "$release_dir/wordpress.com-macOS-app-*-x64.zip.blockmap"
-		require_artifact "macOS arm64 app blockmap" "$release_dir/wordpress.com-macOS-app-*-arm64.zip.blockmap"
-		require_artifact "macOS x64 dmg" "$release_dir/wordpress.com-macOS-dmg-*-x64.dmg"
-		require_artifact "macOS arm64 dmg" "$release_dir/wordpress.com-macOS-dmg-*-arm64.dmg"
-		require_artifact "macOS x64 dmg blockmap" "$release_dir/wordpress.com-macOS-dmg-*-x64.dmg.blockmap"
-		require_artifact "macOS arm64 dmg blockmap" "$release_dir/wordpress.com-macOS-dmg-*-arm64.dmg.blockmap"
-		require_artifact "macOS updater manifest" "$release_dir/latest-mac.yml"
+		validate_mac_artifacts
 		;;
 	linux)
-		require_artifact "Linux deb package" "$release_dir/wordpress.com-linux-deb-*.deb"
-		require_artifact "Linux tarball" "$release_dir/wordpress.com-linux-x64-*.tar.gz"
+		validate_linux_artifacts
+		;;
+	windows)
+		validate_windows_artifacts
+		;;
+	all)
+		validate_mac_artifacts
+		validate_linux_artifacts
+		validate_windows_artifacts
 		;;
 	*)
-		echo "Unknown desktop platform '$platform'. Expected 'mac' or 'linux'." >&2
+		echo "Unknown desktop platform '$platform'. Expected 'mac', 'linux', 'windows', or 'all'." >&2
 		exit 2
 		;;
 esac

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,6 +64,9 @@ steps:
           propagate-uid-gid: true
           userns: host
           environment:
+            - BUILDKITE_BRANCH
+            - BUILDKITE_TAG
+            - PR_DEBUG_RELEASE
             - E2EGUTENBERGUSER
             - E2EPASSWORD
     command: .buildkite/commands/build-desktop-linux.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,7 @@ steps:
   # while the CircleCI -> Buildkite port is still in development.
   # Gate it on `ainfra-*` branches until the port is stabilized.
   - label: ":desktop_computer: Build desktop (mac)"
+    key: desktop-build-mac
     branches: ainfra-* desktop-v*
     notify:
       - github_commit_status:
@@ -50,6 +51,7 @@ steps:
       - desktop/test/e2e/results/**/*
 
   - label: ":desktop_computer: Build desktop (linux, unsigned)"
+    key: desktop-build-linux
     branches: ainfra-* desktop-v*
     notify:
       - github_commit_status:
@@ -70,7 +72,8 @@ steps:
       - desktop/test/e2e/results/**/*
 
   - label: ":windows: Build desktop (windows store, unsigned)"
-    branches: ainfra-*
+    key: desktop-build-windows-store
+    branches: ainfra-* desktop-v*
     notify:
       - github_commit_status:
           context: Desktop / Build (windows store, unsigned)
@@ -84,7 +87,8 @@ steps:
   # updater stays enabled). Signs via Azure Artifact Signing by default, with the
   # org Sectigo PFX as a fallback behind FORCE_PFX_SIGNING (AINFRA-2237).
   - label: ":windows: Build desktop (windows nsis, signed)"
-    branches: ainfra-*
+    key: desktop-build-windows-nsis
+    branches: ainfra-* desktop-v*
     notify:
       - github_commit_status:
           context: Desktop / Build (windows nsis, signed)
@@ -97,3 +101,20 @@ steps:
       - desktop/release/*.exe
       - desktop/release/*.exe.blockmap
       - desktop/release/latest.yml
+
+  - label: ":desktop_computer: Desktop publish dry-run"
+    branches: ainfra-2274-* desktop-v*
+    depends_on:
+      - desktop-build-mac
+      - desktop-build-linux
+      - desktop-build-windows-store
+      - desktop-build-windows-nsis
+    notify:
+      - github_commit_status:
+          context: Desktop / Publish dry-run
+    agents:
+      queue: default
+    command: .buildkite/commands/publish-desktop-dry-run.sh
+    artifact_paths:
+      - desktop/release/*
+      - desktop/CHANGELOG.md


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of AINFRA-2274

## Proposed Changes

* Add a Buildkite desktop publish dry-run step after the platform build jobs.
* Aggregate desktop release artifacts from the keyed platform steps and validate the combined payload.
* Generate `desktop/CHANGELOG.md` without creating or updating a GitHub release.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This proves the publish-shaped aggregation path before moving the real `wp-desktop` release write off CircleCI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `bash -n .buildkite/commands/publish-desktop-dry-run.sh .buildkite/commands/validate-desktop-artifacts.sh`
* `shellcheck .buildkite/commands/publish-desktop-dry-run.sh .buildkite/commands/validate-desktop-artifacts.sh`
* `ruby -e 'require "yaml"; YAML.load_file(".buildkite/pipeline.yml")'`
* `env BUILDKITE_AGENT_ACCESS_TOKEN=dummy buildkite-agent pipeline upload --dry-run .buildkite/pipeline.yml`
* Smoke-tested `publish-desktop-dry-run.sh` with a fake `buildkite-agent` that produced the expected platform artifacts.
* Smoke-tested the Windows validator success and missing-artifact failure paths.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

*Posted by Codex (GPT-5) on behalf of @mokagio with approval.*
