### PR TITLE
Dashboard: Fix untranslated strings

### DIFF
--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -111,7 +111,9 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 	const renderMessage = () => {
 		if ( ! canUserSetPrimaryDomainOnThisSite ) {
 			const message = createInterpolateElement(
-				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink/>',
+				__(
+					'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink/>'
+				),
 				{
 					upgradeLink: (
 						<UpsellCTAButton
@@ -131,7 +133,9 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 
 		if ( domainsList.length === 0 ) {
 			return createInterpolateElement(
-				'Before changing your primary site address you must register or connect a new custom domain. <learnMoreLink />',
+				__(
+					'Before changing your primary site address you must register or connect a new custom domain. <learnMoreLink />'
+				),
 				{
 					learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
 				}
@@ -139,7 +143,9 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		}
 
 		return createInterpolateElement(
-			'The current primary site address for this site is: <currentPrimaryDomain />. This is the site address your visitors will see while browsing your site. <learnMoreLink />',
+			__(
+				'The current primary site address for this site is: <currentPrimaryDomain />. This is the site address your visitors will see while browsing your site. <learnMoreLink />'
+			),
 			{
 				currentPrimaryDomain: <strong>{ currentPrimaryDomain }</strong>,
 				learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -159,14 +159,16 @@ export default function CoreMetricsChart( {
 	const formatThresholdValue = ( valuation: Valuation ) => {
 		const unit = getDisplayUnit( metric );
 		if ( valuation === 'good' ) {
-			return sprintf( '(0–%(to)s%(unit)s)', {
+			// translators: %(to)s is the upper bound of the metric value, %(unit)s is its unit (e.g. "ms" or "s"). Renders a range like "(0–2.5s)".
+			return sprintf( __( '(0–%(to)s%(unit)s)' ), {
 				to: String( getFormattedValue( metric, good ) ),
 				unit,
 			} );
 		}
 
 		if ( valuation === 'needsImprovement' ) {
-			return sprintf( '(%(from)s–%(to)s%(unit)s)', {
+			// translators: %(from)s and %(to)s are the lower and upper bounds of the metric value, %(unit)s is its unit (e.g. "ms" or "s"). Renders a range like "(2.5–4s)".
+			return sprintf( __( '(%(from)s–%(to)s%(unit)s)' ), {
 				from: String( getFormattedValue( metric, good ) ),
 				to: String( getFormattedValue( metric, needsImprovement ) ),
 				unit,
@@ -174,7 +176,8 @@ export default function CoreMetricsChart( {
 		}
 
 		if ( valuation === 'bad' ) {
-			return sprintf( '(Over %(from)s%(unit)s)', {
+			// translators: %(from)s is the lower threshold of the metric value, %(unit)s is its unit (e.g. "ms" or "s"). Renders like "(Over 4s)".
+			return sprintf( __( '(Over %(from)s%(unit)s)' ), {
 				from: String( getFormattedValue( metric, needsImprovement ) ),
 				unit,
 			} );


### PR DESCRIPTION
## Proposed Changes

* Wrap six user-facing dashboard strings in `__()` so they're actually translatable. They were being passed to `createInterpolateElement()` / `sprintf()` as raw string literals.
  * `client/dashboard/sites/domains/primary-domain-selector.tsx` — 3 `createInterpolateElement` messages (primary-domain selector copy).
  * `client/dashboard/sites/performance/core-metrics-chart.tsx` — 3 `sprintf` threshold-range labels, each given the `// translators:` comment the `@wordpress/i18n-translator-comments` lint rule requires.
* No behavior or markup changes: interpolation maps and `sprintf` args are untouched, and the curly apostrophe / en-dashes are preserved verbatim.

## Why are these changes being made?
<!-- -->
* These strings shipped untranslatable — non-English users saw English copy. Found by scanning the dashboard for `createInterpolateElement`/`sprintf` calls whose first argument was a raw literal instead of a `__()` call.

## Intentionally not changed

The scan also surfaced one raw `createInterpolateElement` string that is **deliberately** left untranslated and is excluded from this PR:

* `client/dashboard/me/security-legacy-contact/index.tsx:37` — `'Your legacy contact is <contactEmail />.'`. It's guarded by an explicit `// TODO: translate this string once the legacy contact UI is finalized.` comment (and a matching TODO on the nearby "View printable details" label). Wrapping it now would prematurely send in-flux copy for translation, so it stays as-is until that UI is finalized.

## Testing Instructions

* `yarn typecheck-client` and `yarn eslint` on the two files pass (no errors introduced; only pre-existing unrelated package-build errors remain).
* Open the Primary domain selector (Sites → Domains) and the site Performance → Core Web Vitals chart; confirm all affected copy renders identically in English.
* The wrapped strings are now extracted for translation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<img width="3236" height="926" alt="CleanShot 2026-06-30 at 17 02 11@2x" src="https://github.com/user-attachments/assets/347f7b4a-cbdb-4ceb-979b-972be4c5f5db" />

<img width="3232" height="966" alt="CleanShot 2026-06-30 at 17 02 59@2x" src="https://github.com/user-attachments/assets/62cb9787-cc42-4c7e-b466-60e7bc86d2f8" />

<img width="3246" height="964" alt="CleanShot 2026-06-30 at 17 03 30@2x" src="https://github.com/user-attachments/assets/7845978e-4409-4dae-a91f-41d062c93e25" />

<img width="2700" height="1298" alt="CleanShot 2026-06-30 at 17 05 20@2x" src="https://github.com/user-attachments/assets/5fcbfe48-5fbc-4990-9499-4563500836a3" />
