### PR TITLE
Keep masterbar item highlighted while its submenu is hovered

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -406,7 +406,8 @@ body.is-mobile-app-view {
 
 	// The hover colors are supposed to be the same as those in wp-admin.
 	&:hover,
-	&.is-open {
+	&.is-open,
+	&:has(+ .masterbar__item-subitems:hover) {
 		svg path,
 		.gridicon {
 			fill: var(--color-masterbar-highlight);


### PR DESCRIPTION
Fixes DOTMSD-1350

## Proposed Changes

* Keep a masterbar item's hover background (the theme color) while the cursor is over its open submenu, instead of dropping the highlight the moment the pointer leaves the item itself.

## Screenshots
| MSD | `/home/:siteSlug` | `/home/:siteSlug` |
|--------|--------|--------|
| <img width="155" height="163" alt="Screenshot 2026-06-26 at 3 11 28 PM" src="https://github.com/user-attachments/assets/3898d792-af99-499b-a057-472cfcb4fb26" /> | <img width="155" height="161" alt="Screenshot 2026-06-26 at 3 10 58 PM" src="https://github.com/user-attachments/assets/77d9915a-5cd6-4f01-8a40-cb88095fac06" /> | <img width="152" height="161" alt="Screenshot 2026-06-26 at 3 10 31 PM" src="https://github.com/user-attachments/assets/53821b11-4310-4627-8c66-ec11bea5ae67" /> |






## Why are these changes being made?

* Regression: hovering a masterbar item (e.g. the site "W" item) highlights it with the theme color, but moving onto its dropdown children removed that highlight even though the submenu stayed open. wp-admin keeps the parent highlighted the whole time.
* The submenu's *visibility* already accounted for this with `:has(+ .masterbar__item-subitems:hover)`, but the hover *background* rule only matched the item itself. This applies the same selector to the background rule so the two stay in sync.

## Testing Instructions

* Log in and open My Home (or any MSD surface with the masterbar).
* Hover the leftmost site item to open its dropdown.
* Move the cursor down into the dropdown items.
* The parent item should stay highlighted with the theme color the entire time (before this change it reverted to the default background).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?