### PR TITLE
Lodash: replace xor() with a native symmetric difference

### DIFF
--- a/client/sites/marketing/sharing/options.jsx
+++ b/client/sites/marketing/sharing/options.jsx
@@ -1,7 +1,7 @@
 import { FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { filter, get, some, xor } from 'lodash';
+import { filter, get, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -57,7 +57,14 @@ class SharingButtonsOptions extends Component {
 
 	handleMultiCheckboxChange = ( name, event ) => {
 		const { path } = this.props;
-		const delta = xor( this.props.settings.sharing_show, event.value );
+		const previous = Array.isArray( this.props.settings.sharing_show )
+			? this.props.settings.sharing_show
+			: [];
+		const next = Array.isArray( event.value ) ? event.value : [];
+		// Symmetric difference: the services toggled on or off by this change.
+		const delta = [ ...previous, ...next ].filter(
+			( service ) => previous.includes( service ) !== next.includes( service )
+		);
 		this.props.onChange( name, event.value );
 		if ( delta.length ) {
 			const checked = -1 !== event.value.indexOf( delta[ 0 ] ) ? 1 : 0;

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -103,6 +103,10 @@ const FINDLAST_MESSAGE =
 const HAS_MESSAGE =
 	'Please use native `Object.hasOwn( obj, key )` instead of lodash `has` for single-key checks ' +
 	'(expand dotted-path checks manually with optional chaining).';
+const XOR_MESSAGE =
+	'Please compute the symmetric difference natively, e.g. ' +
+	'`Array.from( new Set( [ ...a, ...b ] ) ).filter( ( item ) => a.includes( item ) !== b.includes( item ) )`, ' +
+	'instead of lodash `xor` (the Set dedupes to match lodash; you can drop it when the inputs are known unique).';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -133,6 +137,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'find' ], message: FIND_MESSAGE },
 	{ name: 'lodash', importNames: [ 'findLast' ], message: FINDLAST_MESSAGE },
 	{ name: 'lodash', importNames: [ 'has' ], message: HAS_MESSAGE },
+	{ name: 'lodash', importNames: [ 'xor' ], message: XOR_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -165,6 +170,7 @@ const patterns = [
 	{ group: [ 'lodash/find' ], message: FIND_MESSAGE },
 	{ group: [ 'lodash/findLast' ], message: FINDLAST_MESSAGE },
 	{ group: [ 'lodash/has' ], message: HAS_MESSAGE },
+	{ group: [ 'lodash/xor' ], message: XOR_MESSAGE },
 ];
 
 module.exports = { paths, patterns };


### PR DESCRIPTION
## Proposed Changes

* Replace the single remaining lodash `xor()` call with a native symmetric difference.
* Add an eslint `no-restricted-imports` guard for `xor` (named and deep imports) so it can't return.

## Why are these changes being made?

* Part of the incremental removal of lodash in favor of native JavaScript. `xor` had a single usage and a faithful native equivalent, making it a low-risk, self-contained change. The native form was verified to match `lodash/xor` across the toggle/empty/unloaded-collection cases the call site exercises.

## Testing Instructions

* In Sharing Settings, toggle individual "Show sharing buttons on" checkboxes on and off.
* Confirm each toggle still records a single analytics event for the changed service, and that behavior is unchanged when settings are still loading (no buttons selected yet).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
