### PR TITLE
A4A: gate MCP page behind private-beta allowlist

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -19,7 +19,7 @@ const useLearnMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 	const agency = useSelector( getActiveAgency );
 	const isAgentStudioEnabled = isEnabled( 'a4a-agent-studio' );
-	const isAiMcpEnabled = isEnabled( 'a4a-ai-mcp' ) && !! agency?.mcp?.allowed;
+	const isAiMcpEnabled = !! agency?.mcp?.allowed;
 	const isBenchmarksEnabled = isEnabled( 'a4a-benchmarks' );
 
 	const menuItems = useMemo( () => {

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -3,6 +3,8 @@ import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { brush, chartBar, pages, tool } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_AGENT_STUDIO_LINK,
 	A4A_AI_MCP_LINK,
@@ -15,8 +17,9 @@ import { createItem } from '../lib/utils';
 
 const useLearnMenuItems = ( path: string ) => {
 	const translate = useTranslate();
+	const agency = useSelector( getActiveAgency );
 	const isAgentStudioEnabled = isEnabled( 'a4a-agent-studio' );
-	const isAiMcpEnabled = isEnabled( 'a4a-ai-mcp' );
+	const isAiMcpEnabled = isEnabled( 'a4a-ai-mcp' ) && !! agency?.mcp?.allowed;
 	const isBenchmarksEnabled = isEnabled( 'a4a-benchmarks' );
 
 	const menuItems = useMemo( () => {

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -95,3 +95,13 @@ export const requireTierAccessContext: Callback = ( context, next ) => {
 	}
 	next();
 };
+
+export const requireMcpBetaAccessContext: Callback = ( context, next ) => {
+	const agency = getActiveAgency( context.store.getState() );
+
+	if ( ! agency?.mcp?.allowed ) {
+		page.redirect( A4A_OVERVIEW_LINK );
+		return;
+	}
+	next();
+};

--- a/client/a8c-for-agencies/sections/learn/index.ts
+++ b/client/a8c-for-agencies/sections/learn/index.ts
@@ -10,7 +10,10 @@ import {
 	A4A_LEARN_LINK,
 	A4A_RESOURCES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import {
+	requireAccessContext,
+	requireMcpBetaAccessContext,
+} from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	agentStudioBriefContext,
@@ -65,10 +68,18 @@ export default function () {
 	}
 
 	if ( isEnabled( 'a4a-ai-mcp' ) ) {
-		page( A4A_AI_MCP_LINK, requireAccessContext, aiMcpOverviewContext, makeLayout, clientRender );
+		page(
+			A4A_AI_MCP_LINK,
+			requireAccessContext,
+			requireMcpBetaAccessContext,
+			aiMcpOverviewContext,
+			makeLayout,
+			clientRender
+		);
 		page(
 			A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
 			requireAccessContext,
+			requireMcpBetaAccessContext,
 			aiMcpAvailableToolsContext,
 			makeLayout,
 			clientRender
@@ -76,6 +87,7 @@ export default function () {
 		page(
 			A4A_AI_MCP_CONNECT_LINK,
 			requireAccessContext,
+			requireMcpBetaAccessContext,
 			aiMcpConnectContext,
 			makeLayout,
 			clientRender

--- a/client/a8c-for-agencies/sections/learn/index.ts
+++ b/client/a8c-for-agencies/sections/learn/index.ts
@@ -67,32 +67,30 @@ export default function () {
 		page( A4A_BENCHMARKS_LINK, requireAccessContext, benchmarksContext, makeLayout, clientRender );
 	}
 
-	if ( isEnabled( 'a4a-ai-mcp' ) ) {
-		page(
-			A4A_AI_MCP_LINK,
-			requireAccessContext,
-			requireMcpBetaAccessContext,
-			aiMcpOverviewContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
-			requireAccessContext,
-			requireMcpBetaAccessContext,
-			aiMcpAvailableToolsContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			A4A_AI_MCP_CONNECT_LINK,
-			requireAccessContext,
-			requireMcpBetaAccessContext,
-			aiMcpConnectContext,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		A4A_AI_MCP_LINK,
+		requireAccessContext,
+		requireMcpBetaAccessContext,
+		aiMcpOverviewContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
+		requireAccessContext,
+		requireMcpBetaAccessContext,
+		aiMcpAvailableToolsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_AI_MCP_CONNECT_LINK,
+		requireAccessContext,
+		requireMcpBetaAccessContext,
+		aiMcpConnectContext,
+		makeLayout,
+		clientRender
+	);
 
 	page( A4A_RESOURCES_LINK, () =>
 		page.redirect( isEnabled( 'a4a-agent-studio' ) ? A4A_AGENT_STUDIO_LINK : A4A_LEARN_LINK )

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -13,7 +13,7 @@ export default function AgencySidebar() {
 		return null;
 	}
 
-	const canAccessMcp = !! ( supports.agency?.mcp && activeAgency?.mcp?.allowed );
+	const canAccessMcp = !! ( supports.agency && supports.agency.mcp && activeAgency?.mcp?.allowed );
 
 	return (
 		<>

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -1,4 +1,4 @@
-import { agencyQuery } from '@automattic/api-queries';
+import { agencyQuery, activeAgencyQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { home, globe, pages, tag } from '@wordpress/icons';
@@ -8,9 +8,12 @@ import { useAppContext } from '../context';
 export default function AgencySidebar() {
 	const { supports } = useAppContext();
 	const { data: agency } = useSuspenseQuery( agencyQuery() );
+	const { data: activeAgency } = useSuspenseQuery( activeAgencyQuery() );
 	if ( agency.isClientUser ) {
 		return null;
 	}
+
+	const canAccessMcp = !! ( supports.agency?.mcp && activeAgency?.mcp?.allowed );
 
 	return (
 		<>
@@ -33,12 +36,12 @@ export default function AgencySidebar() {
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
-			{ supports.agency && ( supports.agency.learn || supports.agency.mcp ) && (
+			{ supports.agency && ( supports.agency.learn || canAccessMcp ) && (
 				<SidebarExpandableMenuItem label={ __( 'Resources' ) } icon={ pages } to="/resources">
 					{ supports.agency.learn && (
 						<SidebarMenuItem to="/resources/learn">{ __( 'Learn' ) }</SidebarMenuItem>
 					) }
-					{ supports.agency.mcp && (
+					{ canAccessMcp && (
 						<SidebarMenuItem to="/resources/ai-mcp">{ __( 'MCP' ) }</SidebarMenuItem>
 					) }
 				</SidebarExpandableMenuItem>

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -19,7 +19,10 @@ const agencyRoute = createRoute( {
 			return; // Don't redirect on hover/intent preloads.
 		}
 
-		const agency = await queryClient.ensureQueryData( agencyQuery() );
+		const [ agency ] = await Promise.all( [
+			queryClient.ensureQueryData( agencyQuery() ),
+			queryClient.ensureQueryData( activeAgencyQuery() ),
+		] );
 		if ( agency.isClientUser ) {
 			throw redirectAsNotAllowed( { to: '/client/subscriptions' } );
 		}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -117,6 +117,16 @@ const mcpRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'MCP' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'resources/ai-mcp',
+	beforeLoad: async ( { cause } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const agency = await queryClient.ensureQueryData( activeAgencyQuery() );
+		if ( ! agency?.mcp?.allowed ) {
+			throw redirectAsNotAllowed( { to: '/overview' } );
+		}
+	},
 } );
 
 const mcpOverviewRoute = createRoute( {

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -119,6 +119,9 @@ export interface Agency {
 		allowed: boolean;
 		directories: DirectoryApplicationType[];
 	};
+	mcp?: {
+		allowed: boolean;
+	};
 	lead_matching?: {
 		allowed?: boolean;
 		draft?: LeadMatchingDetails | null;

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -29,7 +29,6 @@
 	"oauth_client_id": 95928,
 	"features": {
 		"a4a-agent-studio": true,
-		"a4a-ai-mcp": true,
 		"a4a-benchmarks": true,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -26,7 +26,6 @@
 	],
 	"features": {
 		"a4a-agent-studio": false,
-		"a4a-ai-mcp": true,
 		"a4a-benchmarks": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -28,7 +28,6 @@
 	"oauth_client_id": 95932,
 	"features": {
 		"a4a-agent-studio": false,
-		"a4a-ai-mcp": false,
 		"a4a-benchmarks": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -28,7 +28,6 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a4a-agent-studio": false,
-		"a4a-ai-mcp": true,
 		"a4a-benchmarks": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -23,6 +23,9 @@ export interface Agency {
 	name: string;
 	url: string;
 	tier?: AgencyTier;
+	mcp?: {
+		allowed: boolean;
+	};
 	influenced_revenue?: number;
 	created_at: string;
 	billing_system?: 'billingdragon' | 'legacy';


### PR DESCRIPTION
Part of [A4A-2866](https://linear.app/a8c/issue/A4A-2866/enable-private-beta-mcp-for-selected-agencies).

Part of the MCP private-beta work:

Backend: 225372-ghe-Automattic/wpcom
MC: 163177-ghe-Automattic/missioncontrol

## Proposed Changes

* Add an optional `mcp: { allowed }` field to the Agency type, surfaced from the agency profile.
* Hide the **AI and MCP** sidebar item unless the agency is allowlisted (`mcp.allowed`).
* Add a `requireMcpBetaAccessContext` route guard that redirects the MCP routes to the overview for non-allowlisted agencies, so the pages are inaccessible by direct URL.

## Why are these changes being made?

Private Beta launch: the AI & MCP pages should only be reachable by a limited set of agencies during the beta. The allowlist itself is determined server-side and exposed to the dashboard as `mcp.allowed`.

## Testing Instructions

* Requires the `a4a-ai-mcp` feature flag enabled.
* As an agency **without** `mcp.allowed`: the *AI and MCP* sidebar item is hidden, and visiting `/resources-and-tools/ai-mcp` (and `/tools`, `/connect`) redirects to `/overview`.
* As an agency **with** `mcp.allowed`: the sidebar item appears and the pages load normally.
* Repeat the same step for dashboard

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?