### PR TITLE
Reader: use sentence case for sidebar menu labels

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -260,7 +260,7 @@ export class ReaderSidebar extends Component {
 							className={ ReaderSidebarHelper.itemLinkClass( '/reader/conversations/a8c', path, {
 								'sidebar-streams__conversations': true,
 							} ) }
-							label="A8C Conversations"
+							label="A8C conversations"
 							onNavigate={ this.handleSidebarMenuClick( TrackingKeys.a8cConversations ) }
 							link="/reader/conversations/a8c"
 							customIcon={ <ReaderA8cConversationsIcon size={ 24 } viewBox="-2 -2 24 24" /> }
@@ -270,7 +270,7 @@ export class ReaderSidebar extends Component {
 					<SidebarSeparator />
 
 					<SidebarItem
-						label={ translate( 'New Subscription' ) }
+						label={ translate( 'New subscription' ) }
 						onNavigate={ () => recordReaderTracksEvent( 'calypso_reader_sidebar_add_new_clicked' ) }
 						customIcon={ <Icon className="sidebar__menu-icon" icon={ plus } viewBox="2 0 24 24" /> }
 						link="/reader/new"
@@ -280,14 +280,14 @@ export class ReaderSidebar extends Component {
 						className={ ReaderSidebarHelper.itemLinkClass( '/reader/subscriptions', path, {
 							'sidebar-streams__manage-subscriptions': true,
 						} ) }
-						label={ translate( 'Manage Subscriptions' ) }
+						label={ translate( 'Manage subscriptions' ) }
 						onNavigate={ this.handleSidebarMenuClick( TrackingKeys.manageSubscriptions ) }
 						customIcon={ <ReaderManageSubscriptionsIcon size={ 24 } viewBox="0 0 24 24" /> }
 						link="/reader/subscriptions"
 					/>
 
 					<SidebarItem
-						label={ translate( 'Reader Profile' ) }
+						label={ translate( 'Reader profile' ) }
 						onNavigate={ () => recordReaderTracksEvent( 'calypso_reader_sidebar_profile_clicked' ) }
 						customIcon={
 							<Icon

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -235,7 +235,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 		<li>
 			<ExpandableSidebarMenu
 				expanded={ isOpen }
-				title={ translate( 'Social Feeds' ) }
+				title={ translate( 'Social feeds' ) }
 				customIcon={ <Icon className="sidebar__menu-icon" icon={ people } /> }
 				onClick={ handleMainClick }
 				expandableIconClick={ () => setIsOpen( ! isOpen ) }
@@ -261,7 +261,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 							href={ BASE_PATH }
 							onClick={ recordViewMoreClick }
 						>
-							<span>{ translate( 'View More' ) }</span>
+							<span>{ translate( 'View more' ) }</span>
 						</MenuItemLink>
 					</MenuItem>
 				) }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -164,7 +164,7 @@ const ReaderSidebarRecent = ( {
 			{ shouldShowViewMoreButton && (
 				<MenuItem selected={ showAllSites }>
 					<MenuItemLink className="view-more-link" onClick={ toggleShowAllSites }>
-						<span>{ showAllSites ? translate( 'View Less' ) : translate( 'View More' ) }</span>
+						<span>{ showAllSites ? translate( 'View less' ) : translate( 'View more' ) }</span>
 					</MenuItemLink>
 				</MenuItem>
 			) }


### PR DESCRIPTION
Closes READ-577

## Proposed Changes

Align the classic Calypso **Reader** sidebar with the sentence-case convention used in the Multi-site Dashboard (MSD). Converts the title-case, multi-word menu labels to sentence case:

- `A8C Conversations` → `A8C conversations`
- `New Subscription` → `New subscription`
- `Manage Subscriptions` → `Manage subscriptions`
- `Reader Profile` → `Reader profile`
- `Social Feeds` → `Social feeds`
- `View More` / `View Less` → `View more` / `View less`

Single-word labels (Search, Discover, Likes, Saved, Conversations, Recent, Lists, Tags, Spaces) were already correct and are untouched. The `A8C` acronym keeps its casing.

## Why are these changes being made?

We've standardized on sentence case in MSD, which feels nicer than the title case inherited from Core. When switching from MSD to parts of Calypso that haven't been ported, the title-case menus look inconsistent — and the Reader is the most visible remaining classic surface. This brings the Reader sidebar in line.

## Testing Instructions

* Open the Reader (`/reader`) and look at the left sidebar.
* Confirm the menu labels read in sentence case: "New subscription", "Manage subscriptions", "Reader profile", "Social feeds", and the "View more" / "View less" toggles.
* Automatticians: confirm the "A8C conversations" item also reads in sentence case.
* No behavioral change — only label capitalization.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
