### PR TITLE
Notifications: log errors to logstash via api-core

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
+		"@wordpress/ui": "^0.15.0",
 		"autoprefixer": "^10.4.21",
 		"calypso": "workspace:^",
 		"clsx": "^2.1.1",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -26,6 +26,7 @@
 		"translate": "rm -rf dist/strings && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './' --dir './dist/strings' --jobs 4 --output './dist/notifications.pot' && build-app-languages --stringsFilePath='./dist/notifications.pot' --outputPath='./dist/languages'"
 	},
 	"dependencies": {
+		"@automattic/api-core": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",

--- a/apps/notifications/src/app/error-boundary.tsx
+++ b/apps/notifications/src/app/error-boundary.tsx
@@ -1,0 +1,57 @@
+import { logToLogstash } from '@automattic/api-core';
+import { __ } from '@wordpress/i18n';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+/**
+ * Send an error to logstash. Fire-and-forget: logging must never throw and
+ * take down the surface it is trying to report on.
+ */
+export function logError( error: unknown, extra?: Record< string, unknown > ) {
+	const err = error instanceof Error ? error : new Error( String( error ) );
+
+	try {
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: err.message || 'Unknown error',
+			tags: [ 'notifications' ],
+			extra: {
+				stack: err.stack,
+				...extra,
+			},
+		} ).catch( () => {} );
+	} catch {
+		// Never let logging crash the app.
+	}
+}
+
+interface Props {
+	children: ReactNode;
+}
+
+interface State {
+	hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component< Props, State > {
+	state: State = { hasError: false };
+
+	static getDerivedStateFromError(): State {
+		return { hasError: true };
+	}
+
+	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
+		logError( error, { componentStack: errorInfo.componentStack } );
+	}
+
+	render() {
+		if ( this.state.hasError ) {
+			return (
+				<div className="wpnc-app__error">
+					{ __( 'Something went wrong. Please close and reopen notifications.' ) }
+				</div>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/apps/notifications/src/app/error-boundary.tsx
+++ b/apps/notifications/src/app/error-boundary.tsx
@@ -1,28 +1,6 @@
-import { logToLogstash } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
-
-/**
- * Send an error to logstash. Fire-and-forget: logging must never throw and
- * take down the surface it is trying to report on.
- */
-export function logError( error: unknown, extra?: Record< string, unknown > ) {
-	const err = error instanceof Error ? error : new Error( String( error ) );
-
-	try {
-		logToLogstash( {
-			feature: 'calypso_client',
-			message: err.message || 'Unknown error',
-			tags: [ 'notifications' ],
-			extra: {
-				stack: err.stack,
-				...extra,
-			},
-		} ).catch( () => {} );
-	} catch {
-		// Never let logging crash the app.
-	}
-}
+import { logError } from '../panel/helpers/log-error';
 
 interface Props {
 	children: ReactNode;

--- a/apps/notifications/src/app/error-boundary.tsx
+++ b/apps/notifications/src/app/error-boundary.tsx
@@ -23,9 +23,14 @@ export default class ErrorBoundary extends Component< Props, State > {
 
 	render() {
 		if ( this.state.hasError ) {
+			// A slightly opaque overlay over the panel (rather than replacing it)
+			// so the surrounding chrome stays put and the user keeps their context
+			// instead of the panel collapsing to a bare message.
 			return (
-				<div className="wpnc-app__error">
-					{ __( 'Something went wrong. Please close and reopen notifications.' ) }
+				<div className="wpnc-app__error" role="alert">
+					<p className="wpnc-app__error-message">
+						{ __( 'Something went wrong. Please close and reopen notifications.' ) }
+					</p>
 				</div>
 			);
 		}

--- a/apps/notifications/src/app/error-boundary.tsx
+++ b/apps/notifications/src/app/error-boundary.tsx
@@ -24,9 +24,6 @@ export default class ErrorBoundary extends Component< Props, State > {
 
 	render() {
 		if ( this.state.hasError ) {
-			// A slightly opaque overlay over the panel (rather than replacing it)
-			// so the surrounding chrome stays put and the user keeps their context
-			// instead of the panel collapsing to a bare message.
 			return (
 				<div className="wpnc-app__error">
 					<Notice.Root intent="error" className="wpnc-app__error-notice">

--- a/apps/notifications/src/app/error-boundary.tsx
+++ b/apps/notifications/src/app/error-boundary.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { logError } from '../panel/helpers/log-error';
 
@@ -27,10 +28,13 @@ export default class ErrorBoundary extends Component< Props, State > {
 			// so the surrounding chrome stays put and the user keeps their context
 			// instead of the panel collapsing to a bare message.
 			return (
-				<div className="wpnc-app__error" role="alert">
-					<p className="wpnc-app__error-message">
-						{ __( 'Something went wrong. Please close and reopen notifications.' ) }
-					</p>
+				<div className="wpnc-app__error">
+					<Notice.Root intent="error" className="wpnc-app__error-notice">
+						<Notice.Title>{ __( 'Something went wrong' ) }</Notice.Title>
+						<Notice.Description>
+							{ __( 'Please close and reopen notifications.' ) }
+						</Notice.Description>
+					</Notice.Root>
 				</div>
 			);
 		}

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type TransitionEvent } from 'react';
 import { Provider } from 'react-redux';
 import repliesCache from '../panel/comment-replies-cache';
 import { modifierKeyIsActive } from '../panel/helpers/input';
+import { logError } from '../panel/helpers/log-error';
 import RestClient from '../panel/rest-client';
 import { init as initAPI } from '../panel/rest-client/wpcom';
 import { init as initStore } from '../panel/state';
@@ -13,7 +14,7 @@ import { addListeners, removeListeners } from '../panel/state/create-listener-mi
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
 import getKeyboardShortcutsEnabled from '../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { AppProvider } from './context';
-import ErrorBoundary, { logError } from './error-boundary';
+import ErrorBoundary from './error-boundary';
 import Note from './note';
 import { useNoteNavigation } from './note/hooks';
 import NotePanel from './note-panel';

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -13,6 +13,7 @@ import { addListeners, removeListeners } from '../panel/state/create-listener-mi
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
 import getKeyboardShortcutsEnabled from '../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { AppProvider } from './context';
+import ErrorBoundary, { logError } from './error-boundary';
 import Note from './note';
 import { useNoteNavigation } from './note/hooks';
 import NotePanel from './note-panel';
@@ -180,6 +181,22 @@ const NotificationApp = ( {
 	}, [] );
 
 	useEffect( () => {
+		const handleError = ( event: ErrorEvent ) => {
+			logError( event.error ?? event.message );
+		};
+		const handleRejection = ( event: PromiseRejectionEvent ) => {
+			logError( event.reason );
+		};
+
+		window.addEventListener( 'error', handleError );
+		window.addEventListener( 'unhandledrejection', handleRejection );
+		return () => {
+			window.removeEventListener( 'error', handleError );
+			window.removeEventListener( 'unhandledrejection', handleRejection );
+		};
+	}, [] );
+
+	useEffect( () => {
 		const stopEvent = ( event: KeyboardEvent ) => {
 			event.stopPropagation();
 			event.preventDefault();
@@ -215,11 +232,13 @@ const NotificationApp = ( {
 	}
 
 	return (
-		<Provider store={ store }>
-			<AppProvider client={ client } locale={ locale }>
-				<NotificationContent isDismissible={ isDismissible } />
-			</AppProvider>
-		</Provider>
+		<ErrorBoundary>
+			<Provider store={ store }>
+				<AppProvider client={ client } locale={ locale }>
+					<NotificationContent isDismissible={ isDismissible } />
+				</AppProvider>
+			</Provider>
+		</ErrorBoundary>
 	);
 };
 

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -98,12 +98,14 @@ const NotificationContent = ( { isDismissible }: { isDismissible: boolean } ) =>
 				// @ts-expect-error React 18 types don't include `inert`.
 				inert={ displayedNoteId === undefined ? '' : undefined }
 			>
-				<Note
-					isDismissible={ isDismissible }
-					noteId={ displayedNoteId }
-					setSelectedNoteId={ setSelectedNoteId }
-					noteNavigation={ noteNavigation }
-				/>
+				<ErrorBoundary>
+					<Note
+						isDismissible={ isDismissible }
+						noteId={ displayedNoteId }
+						setSelectedNoteId={ setSelectedNoteId }
+						noteNavigation={ noteNavigation }
+					/>
+				</ErrorBoundary>
 			</div>
 			<div className="wpnc-app__list-pane">
 				<NotePanel

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'react-redux';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
 import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { getFilters } from '../../panel/templates/filters';
+import ErrorBoundary from '../error-boundary';
 import NoteList from '../note-list';
 import CloseButton from '../templates/close-button';
 import NotePanelActions from './actions';
@@ -142,16 +143,21 @@ const NotePanel = ( {
 					</Tabs>
 				</VStack>
 			</CardHeader>
-			{ /* Key by `filterName` so switching tabs remounts the list. The tab
-			   filter is applied outside the DataViews `view`, so DataViews'
-			   infinite-scroll row accumulation would otherwise carry stale
-			   notes from the previously selected tab. */ }
-			<NoteList
-				key={ filterName }
-				filterName={ filterName }
-				selectedNoteId={ selectedNoteId }
-				setSelectedNoteId={ setSelectedNoteId }
-			/>
+			{ /* Scope the boundary to the list content so a render error there
+			   leaves the header controls (tabs, settings) intact and only
+			   overlays the message, instead of collapsing the whole panel. */ }
+			<ErrorBoundary>
+				{ /* Key by `filterName` so switching tabs remounts the list. The tab
+				   filter is applied outside the DataViews `view`, so DataViews'
+				   infinite-scroll row accumulation would otherwise carry stale
+				   notes from the previously selected tab. */ }
+				<NoteList
+					key={ filterName }
+					filterName={ filterName }
+					selectedNoteId={ selectedNoteId }
+					setSelectedNoteId={ setSelectedNoteId }
+				/>
+			</ErrorBoundary>
 		</>
 	);
 };

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -92,6 +92,7 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 	// Above both panes (list/detail use z-index 1–2).
 	z-index: 3;
 	display: flex;
+	flex-direction: column;
 	align-items: center;
 	justify-content: center;
 	padding: 24px;
@@ -100,9 +101,11 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 }
 
 .wpnc-app__error-notice {
-	max-width: 320px;
+	// Give the Notice a definite width so its internal layout lays out
+	// normally; centering alone would shrink it to a narrow strip.
+	width: 100%;
 	// Notice ships with asymmetric margins meant for stacked banners; reset them
-	// so it sits centered in the scrim.
+	// so it sits flush in the scrim.
 	margin: 0;
 }
 

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -99,13 +99,11 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 	background: color-mix(in srgb, var(--color-surface, #fff) 85%, transparent);
 }
 
-.wpnc-app__error-message {
-	max-width: 240px;
+.wpnc-app__error-notice {
+	max-width: 320px;
+	// Notice ships with asymmetric margins meant for stacked banners; reset them
+	// so it sits centered in the scrim.
 	margin: 0;
-	text-align: center;
-	font-size: 13px;
-	line-height: 1.5;
-	color: var(--color-text, #1e1e1e);
 }
 
 // Both panes use absolute positioning so they can overlap during the slide.

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -82,6 +82,32 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 	height: 100%;
 }
 
+// Error fallback: a slightly opaque scrim filling the nearest pane (or the
+// whole app when nothing narrower caught the error), so the panel keeps its
+// size and chrome and the user stays in context instead of it collapsing to a
+// bare message.
+.wpnc-app__error {
+	position: absolute;
+	inset: 0;
+	// Above both panes (list/detail use z-index 1–2).
+	z-index: 3;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	box-sizing: border-box;
+	background: color-mix(in srgb, var(--color-surface, #fff) 85%, transparent);
+}
+
+.wpnc-app__error-message {
+	max-width: 240px;
+	margin: 0;
+	text-align: center;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--color-text, #1e1e1e);
+}
+
 // Both panes use absolute positioning so they can overlap during the slide.
 .wpnc-app__list-pane,
 .wpnc-app__detail-pane {

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -82,14 +82,9 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 	height: 100%;
 }
 
-// Error fallback: a slightly opaque scrim filling the nearest pane (or the
-// whole app when nothing narrower caught the error), so the panel keeps its
-// size and chrome and the user stays in context instead of it collapsing to a
-// bare message.
 .wpnc-app__error {
 	position: absolute;
 	inset: 0;
-	// Above both panes (list/detail use z-index 1–2).
 	z-index: 3;
 	display: flex;
 	flex-direction: column;
@@ -101,11 +96,7 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 }
 
 .wpnc-app__error-notice {
-	// Give the Notice a definite width so its internal layout lays out
-	// normally; centering alone would shrink it to a narrow strip.
 	width: 100%;
-	// Notice ships with asymmetric margins meant for stacked banners; reset them
-	// so it sits flush in the scrim.
 	margin: 0;
 }
 

--- a/apps/notifications/src/panel/helpers/log-error.ts
+++ b/apps/notifications/src/panel/helpers/log-error.ts
@@ -1,0 +1,33 @@
+import { logToLogstash } from '@automattic/api-core';
+
+/**
+ * Send an error to logstash. Fire-and-forget: logging must never throw and
+ * take down the surface it is trying to report on.
+ * @param error The error (or error-like value) to report.
+ * @param extra Optional structured context to attach to the log entry.
+ */
+export function logError( error: unknown, extra?: Record< string, unknown > ) {
+	// wpcom request callbacks hand back plain error objects (with `message`,
+	// `error` code and `status`), not always real Error instances — normalize
+	// both so the message and stack survive into the log entry.
+	const isObject = !! error && typeof error === 'object';
+	const message =
+		error instanceof Error
+			? error.message
+			: ( isObject && String( ( error as { message?: unknown } ).message ?? '' ) ) || '';
+	const stack = error instanceof Error ? error.stack : undefined;
+
+	try {
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: message || 'Unknown error',
+			tags: [ 'notifications' ],
+			extra: {
+				stack,
+				...extra,
+			},
+		} ).catch( () => {} );
+	} catch {
+		// Never let logging crash the app.
+	}
+}

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,5 +1,6 @@
 import debugFactory from 'debug';
 import repliesCache from '../comment-replies-cache';
+import { logError } from '../helpers/log-error';
 import { store } from '../state';
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
@@ -166,6 +167,7 @@ function getNote( note_id ) {
 
 	fetchNote( note_id, parameters, ( error, data ) => {
 		if ( error ) {
+			logError( error, { request: 'getNote', note_id, status: error.status, code: error.error } );
 			return;
 		}
 		store.dispatch( actions.notes.addNotes( data.notes ) );
@@ -216,6 +218,13 @@ function getNotes( before ) {
 		this.gettingNotes = false;
 
 		if ( error ) {
+			logError( error, {
+				request: 'getNotes',
+				before: before ?? null,
+				retries: this.retries,
+				status: error.status,
+				code: error.error,
+			} );
 			// Load-more: clear the spinner, leave state untouched; scrolling retries.
 			if ( before ) {
 				store.dispatch( actions.ui.loadedNotes() );
@@ -333,6 +342,12 @@ function getNotesList() {
 		debug( 'getNotesList callback:', error, data );
 		this.gettingNotes = false;
 		if ( error ) {
+			logError( error, {
+				request: 'getNotesList',
+				retries: this.retries,
+				status: error.status,
+				code: error.error,
+			} );
 			this.retries = this.retries + 1;
 			const backoff_ms = Math.min(
 				settings.refresh_ms * ( this.retries + 1 ),
@@ -463,6 +478,12 @@ function getFilteredNotes( before ) {
 		this.gettingFilteredNotes = false;
 
 		if ( error ) {
+			logError( error, {
+				request: 'getFilteredNotes',
+				before: before ?? null,
+				status: error.status,
+				code: error.error,
+			} );
 			// Leave the polling path's state untouched; it will recover on its
 			// own schedule. A retry happens when the user re-enters the tab.
 			store.dispatch( actions.ui.loadedNotes( { filter } ) );

--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -191,6 +191,14 @@ const NotesWrapper = ( { wpcom } ) => {
 		sendMessage( { action: 'widescreen', widescreen: true } );
 	}, [] );
 
+	// Don't render the app while the panel is closed: unmounting and remounting
+	// on reopen mounts a fresh tree, which clears any error caught by the app's
+	// boundary. NotesWrapper stays mounted so it keeps handling host messages and
+	// can render the app again on the next open.
+	if ( ! isShowing ) {
+		return null;
+	}
+
 	return (
 		<NotificationApp
 			customEnhancer={ customEnhancer }

--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -191,10 +191,6 @@ const NotesWrapper = ( { wpcom } ) => {
 		sendMessage( { action: 'widescreen', widescreen: true } );
 	}, [] );
 
-	// Don't render the app while the panel is closed: unmounting and remounting
-	// on reopen mounts a fresh tree, which clears any error caught by the app's
-	// boundary. NotesWrapper stays mounted so it keeps handling host messages and
-	// can render the app again on the next open.
 	if ( ! isShowing ) {
 		return null;
 	}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -37,6 +37,7 @@ export * from './hosting-github';
 export * from './hosting-update-schedules';
 export * from './jetpack-agency-sites';
 export * from './jetpack-user-license';
+export * from './logstash';
 export * from './marketplace-products';
 export * from './marketplace-search';
 export * from './marketing-survey';

--- a/packages/api-core/src/logstash/index.ts
+++ b/packages/api-core/src/logstash/index.ts
@@ -1,0 +1,27 @@
+import { wpcom } from '../wpcom-fetcher';
+
+/**
+ * Parameters sent to the logstash endpoint.
+ * @see PCYsg-5T4-p2
+ */
+export interface LogToLogstashParams {
+	/**
+	 * Feature name.
+	 *
+	 * Should be explicitly allowed. @see D31385-code
+	 */
+	feature: 'calypso_ssr' | 'calypso_client';
+	message: string;
+	extra?: any;
+	site_id?: number;
+	tags?: string[];
+	[ key: string ]: any;
+}
+
+/**
+ * Log to logstash. This function is inefficient because
+ * the data goes over the REST API, so use sparingly.
+ */
+export async function logToLogstash( params: LogToLogstashParams ): Promise< void > {
+	await wpcom.req.post( '/logstash', { params: JSON.stringify( params ) } );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,7 @@ __metadata:
     "@wordpress/element": "npm:^8.0.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
+    "@wordpress/ui": "npm:^0.15.0"
     autoprefixer: "npm:^10.4.21"
     calypso: "workspace:^"
     clsx: "npm:^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/notifications@workspace:apps/notifications"
   dependencies:
+    "@automattic/api-core": "workspace:^"
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"


### PR DESCRIPTION
Fixes DOTMSD-1327

## Proposed Changes

* Port `logToLogstash` into `@automattic/api-core` (`src/logstash`), using api-core's own wpcom fetcher.
* Add error logging to the notifications app via a shared, React-free `logError` helper (reports to logstash, feature `calypso_client`, tagged `notifications`, fire-and-forget so logging can never crash the panel):
  * An `ErrorBoundary` for React render errors.
  * Global `error` and `unhandledrejection` listeners for uncaught exceptions and rejected promises.
  * Logging in `RestClient`'s API error paths (`getNote`, `getNotes`, `getNotesList`, `getFilteredNotes`) with request context (request name, `before` cursor, retries, status, error code).
* Add a visible error state: the boundary renders a `@wordpress/ui` `Notice` (intent `error`) as a slightly opaque overlay that fills the pane instead of replacing the panel, so the surrounding chrome stays put and the user keeps their context.
  * Boundaries are scoped per pane (note list and note detail), so a render error leaves the header controls intact and only overlays the affected pane; a top-level boundary remains as a last-resort safety net.
* Recover from the error state on reopen for the standalone iframe: it keeps the app mounted across open/close, so it now skips rendering the app while the panel is closed — reopening mounts a fresh tree and clears any caught error.

<img width="914" height="1658" alt="image" src="https://github.com/user-attachments/assets/23df9312-87d0-4cf9-964f-d939b127acfe" />


## Why are these changes being made?

The notifications panel had no error reporting. Notification load failures flow through `RestClient`'s callback-based error handling and were silently swallowed, leaving them undiagnosable; render crashes and rejected promises were equally invisible. This wires the panel into the existing logstash pipeline, reused from api-core so other clients can adopt it too, and gives the user a clear, in-context error state that recovers on reopen.

## Considerations

* WebSocket subscribe errors (`pinghubCallback`) are intentionally not logged — they self-recover by falling back to polling and would be noise rather than signal.
* `feature` is logged as `calypso_client`, which is already allowlisted by the logstash endpoint; no backend change needed.
* `logError` lives in `panel/helpers` (not the `app/` layer) so the legacy `RestClient` core can report without depending on the newer app layer.
* New app dependencies: `@automattic/api-core` (for `logToLogstash`) and `@wordpress/ui` (for the `Notice` error state).
* Two new translatable strings are added for the error state ("Something went wrong", "Please close and reopen notifications.").
* **Error-state recovery & the closed badge.** Recovery works by unmounting the app while the panel is closed (standalone) or on the Dropdown hosts that already mount-on-open (redesigned masterbar, Dashboard, Reader header). Unmounting stops `RestClient` polling (`client.setVisibility({ isVisible: false })`), so the unread badge freezes at its last value while closed and resumes updating on reopen. This is **already the behavior of the new app on every Dropdown consumer** — those surfaces unmount the app on close and have no live background count poll — so the standalone change aligns it with the rest of the new app rather than introducing new behavior. Only the legacy always-mounted implementations polled the badge live while closed.

## Testing Instructions

* Open the notifications panel and confirm it renders and behaves normally.
* Block/return an error from the notes endpoint (e.g. throttle or force a 5xx) and confirm a logstash request fires (Network tab → POST `/rest/v1.1/logstash`, `feature: calypso_client`, tag `notifications`, `extra.request` naming the failed call).
* Temporarily throw inside a notifications component (e.g. the note list) and confirm: the error `Notice` overlay shows while the panel header/tabs stay visible, a matching logstash request fires, and **closing and reopening the panel clears the error**.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
