### PR TITLE
AGENTS: strip verbose code comments before pushing PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ If it fails, fix the type errors at the source — do not silence them with `// 
 
 ## Creating Pull Requests
 
+- Before pushing the changes, remove any verbose code comments that narrate what the change does or why it was made (e.g. `// Added this to fix X`, `// Changed from Y to Z`, restating the code in prose). Such explanation belongs in the PR description, not the source. Only keep comments that a future reader genuinely needs — non-obvious rationale, gotchas, links to context — and match the comment density and style of the surrounding code.
 - Create PRs as draft. Follow the template in .github/PULL_REQUEST_TEMPLATE.md.
 - Follow the branch naming conventions in docs/git-workflow.md.
 - In the PR description:


### PR DESCRIPTION
## Proposed Changes

* Add a guideline to the root `AGENTS.md` (under "Creating Pull Requests") instructing agents to remove verbose code comments that merely narrate what a change does or why it was made before pushing. Such explanation belongs in the PR description, not the source.

## Why are these changes being made?

* Agent-authored PRs often include noisy, redundant comments (e.g. `// Added this to fix X`, `// Changed from Y to Z`, or prose restating the code). These add review burden and clutter the codebase. Capturing the rationale in the PR description keeps the source clean while preserving the context, and the guideline still allows genuinely useful comments (non-obvious rationale, gotchas, links).

## Testing Instructions

* Documentation-only change. Review the wording in `AGENTS.md`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
