### PR TITLE
Plugins upload: upsell Personal plan instead of Business

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -28,10 +28,16 @@ function getHoldMessages( {
 	isMarketplace?: boolean;
 	hasEnTranslation: ( arg: string ) => boolean;
 } ) {
+	// Plugin upload is available on the Personal plan and up, so upsell the
+	// lowest eligible plan for that context instead of Business.
+	const upsellPersonalPlan =
+		context === 'plugins-upload' ||
+		( isMarketplace && isEnabled( 'marketplace-personal-premium' ) );
+
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
-				if ( isMarketplace && isEnabled( 'marketplace-personal-premium' ) ) {
+				if ( upsellPersonalPlan ) {
 					return translate( 'Upgrade to a %(personalPlanName)s plan', {
 						args: { personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
 					} );
@@ -54,7 +60,7 @@ function getHoldMessages( {
 						  );
 				}
 
-				if ( isMarketplace && isEnabled( 'marketplace-personal-premium' ) ) {
+				if ( upsellPersonalPlan ) {
 					return hasEnTranslation(
 						"You'll also get a free domain for one year, and access fast support."
 					)

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -5,6 +5,7 @@ import {
 	FEATURE_SFTP,
 	FEATURE_INSTALL_PLUGINS,
 	PLAN_BUSINESS,
+	PLAN_PERSONAL,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
@@ -117,7 +118,9 @@ export const EligibilityWarnings = ( {
 		}
 		if ( siteRequiresUpgrade( listHolds ) ) {
 			recordUpgradeClick( ctaName, feature );
-			const planSlug = PLAN_BUSINESS;
+			// Plugin upload is available on the Personal plan and up, so upsell the
+			// lowest eligible plan for that context instead of Business.
+			const planSlug = context === 'plugins-upload' ? PLAN_PERSONAL : PLAN_BUSINESS;
 			let redirectUrl = `/checkout/${ siteSlug }/${ planSlug }`;
 			if ( context === 'plugins-upload' ) {
 				redirectUrl = `${ redirectUrl }?redirect_to=${ encodeURIComponent(

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -186,6 +186,24 @@ describe( '<EligibilityWarnings>', () => {
 		);
 	} );
 
+	it( 'upsells the Personal plan when uploading a plugin', async () => {
+		const state = createState( {
+			holds: [ 'NO_BUSINESS_PLAN' ],
+			siteUrl: 'https://example.wordpress.com',
+		} );
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="/plugins/example.wordpress.com" onProceed={ noop } />,
+			state
+		);
+
+		await userEvent.click( getByText( 'Upgrade and continue' ) );
+
+		expect( page.redirect ).toHaveBeenCalledWith(
+			expect.stringContaining( '/checkout/example.wordpress.com/personal-bundle' )
+		);
+	} );
+
 	it( 'disables the "Continue" button if holds can\'t be handled automatically', async () => {
 		const state = createState( {
 			holds: [ 'NON_ADMIN_USER', 'SITE_PRIVATE' ],


### PR DESCRIPTION
Fixes DOTCOM-17722

## Proposed Changes

The Plugins → Upload screen (`/plugins/upload/:site`) shows an `EligibilityWarnings` upsell when a Simple site lacks plugin-upload access. That upsell hardcoded the **Business** plan, even though plugin upload is available on the **Personal** plan and up post Summer Special.

This scopes the upsell to the Personal plan for the `plugins-upload` context only:

- `index.tsx` — the "Upgrade and continue" checkout redirect now uses `PLAN_PERSONAL` instead of `PLAN_BUSINESS` when `context === 'plugins-upload'`.
- `hold-list.tsx` — the `NO_BUSINESS_PLAN` title ("Upgrade to a … plan") and description now use the Personal-plan wording for that context, via a shared `upsellPersonalPlan` flag that reuses the existing Personal branch (previously marketplace-only).
- Added a test asserting the plugins-upload context routes to `personal-bundle`.

Other contexts (themes upload, hosting, performance) continue to upsell Business, since those are genuinely Business/developer-tier features.

Before | After
--- | ---
<img width="1391" height="1111" alt="Screenshot 2026-06-26 at 11 45 30" src="https://github.com/user-attachments/assets/08d7d967-4092-4d33-97b4-5d8aef8dfb3e" /> | <img width="1392" height="1092" alt="Screenshot 2026-06-26 at 14 09 09" src="https://github.com/user-attachments/assets/629399a9-c249-4c18-b109-8781c5b1ffe6" />


## Why are these changes being made?

Before Summer Special, Business was a reasonable proxy for Atomic/plugin-upload access. That is no longer true — paid plans (Personal and up) are Atomic-eligible — so the old copy told users they needed Business when a cheaper plan already includes the feature. This was flagged in the Simple-to-Atomic upsell design review.

> Note: the server-side eligibility hold is still literally named `NO_BUSINESS_PLAN`. This PR corrects what Calypso tells and sells the user; the hold itself must clear once the site is on Personal for the flow to complete end-to-end.

## Testing Instructions

1. On a Simple site **without** plugin-upload access (Free/Personal-ineligible state), go to `/plugins/upload/:site`.
2. Observe the eligibility upsell: the title should read "Upgrade to a Personal plan" (not Business).
3. Click **Upgrade and continue** → you should be sent to checkout for the **Personal** plan (`/checkout/<site>/personal-bundle?redirect_to=...`).
4. Confirm the themes upload / hosting / performance upsells still reference Business.
5. `yarn test-client client/blocks/eligibility-warnings/test/index.tsx` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
