### PR TITLE
Nav 2026: keep dropdown columns full-width on tablet

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1405,8 +1405,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		opacity $x-nav-2026-transition,
 		visibility $x-nav-2026-transition;
 
-	// At >= 1025px, align the content under the first nav item via the JS-set var.
-	@media ( min-width: 1025px ) {
+	// Align the content under the first nav item via the JS-set var. Gated at
+	// the wide breakpoint, not 1025px: on tablet the offset eats column width
+	// and wraps the columns.
+	@media ( min-width: $x-nav-breakpoint-wide ) {
 		padding-inline-start: calc( var( --dropdown-trigger-inline-start, 188px ) + 7px );
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

* On the 2026 global nav, the open dropdown panel's columns broke onto extra rows at tablet widths. The alignment offset that shifts the dropdown content under its trigger now turns on only at wider desktop widths, so tablet keeps the full-width column layout from the designs.

## Why are these changes being made?

* The trigger-alignment offset was active from 1025px, where it consumed enough horizontal space to wrap the dropdown columns on tablet. Reported in the Global Nav rollout thread.

## Testing Instructions

* Open a page with the 2026 nav, hover a nav item with a dropdown.
* At a tablet width (~1100px): columns stay on one row, full width.
* At a wide width (~1200px): columns align under the trigger as before.
