### PR TITLE
Remove unused @automattic/react-virtualized dependency

### DIFF
--- a/client/landing/subscriptions/types.d.ts
+++ b/client/landing/subscriptions/types.d.ts
@@ -1,1 +1,0 @@
-declare module '@automattic/react-virtualized';

--- a/client/package.json
+++ b/client/package.json
@@ -64,7 +64,6 @@
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/plans-grid-next": "workspace:^",
 		"@automattic/posthog": "workspace:^",
-		"@automattic/react-virtualized": "^9.22.4",
 		"@automattic/request-external-access": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -24,15 +24,6 @@ jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
 	useSiteSubscriptions: () => ( { subscriptions: [], isLoading: false, isError: false } ),
 } ) );
 
-jest.mock( '@automattic/react-virtualized', () => ( {
-	AutoSizer: ( {
-		children,
-	}: {
-		children: ( size: { width: number; height: number } ) => React.ReactNode;
-	} ) => children( { width: 480, height: 360 } ),
-	List: () => null,
-} ) );
-
 const SPACES: ReadSpace[] = [
 	{
 		id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -69,7 +69,6 @@ const nodeModulesToTranspile = [
 	// In some cases we do want prefix style matching (lodash. for lodash.assign)
 	'@automattic/calypso-polyfills/',
 	'@automattic/lasagna/',
-	'@automattic/react-virtualized/',
 	'@github/webauthn-json/',
 	'acorn-jsx/',
 	'chalk/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,20 +2113,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/react-virtualized@npm:^9.22.4":
-  version: 9.22.4
-  resolution: "@automattic/react-virtualized@npm:9.22.4"
-  dependencies:
-    clsx: "npm:^1.0.4"
-    loose-envify: "npm:^1.4.0"
-    react-lifecycles-compat: "npm:^3.0.4"
-  peerDependencies:
-    react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
-    react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
-  checksum: 06079435a6ac66876d181edaabedaeda10638a40ed6f0a7b863af4635265894bece28050079a575abd6f7ae465ba5508bf733f4cbc539ef422d513513d4d32ea
-  languageName: node
-  linkType: hard
-
 "@automattic/request-external-access@workspace:^, @automattic/request-external-access@workspace:packages/request-external-access":
   version: 0.0.0-use.local
   resolution: "@automattic/request-external-access@workspace:packages/request-external-access"
@@ -14369,7 +14355,6 @@ __metadata:
     "@automattic/onboarding": "workspace:^"
     "@automattic/plans-grid-next": "workspace:^"
     "@automattic/posthog": "workspace:^"
-    "@automattic/react-virtualized": "npm:^9.22.4"
     "@automattic/request-external-access": "workspace:^"
     "@automattic/search": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
@@ -15119,7 +15104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.0.4, clsx@npm:^1.1.1":
+"clsx@npm:^1.1.1":
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 34dead8bee24f5e96f6e7937d711978380647e936a22e76380290e35486afd8634966ce300fc4b74a32f3762c7d4c0303f442c3e259f4ce02374eb0c82834f27
@@ -27504,7 +27489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-lifecycles-compat@npm:^3.0.0, react-lifecycles-compat@npm:^3.0.4":
+"react-lifecycles-compat@npm:^3.0.0":
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
   checksum: 1d0df3c85af79df720524780f00c064d53a9dd1899d785eddb7264b378026979acbddb58a4b7e06e7d0d12aa1494fd5754562ee55d32907b15601068dae82c27


### PR DESCRIPTION
Part of DOTCOM-17718 (final step — remove the dependency)
Related to #112025, #112027, #112028, #112029, #112031

## Proposed Changes

Removes the now-unused `@automattic/react-virtualized` dependency. This is the last step of the migration off the fork.

* Drop `@automattic/react-virtualized` from `client/package.json` and `yarn.lock`. `yarn install` also pruned its only-consumer version ranges `clsx@^1.0.4` and `react-lifecycles-compat@^3.0.4` (the packages remain for other consumers; only the react-virtualized-specific ranges are gone).
* Remove `client/landing/subscriptions/types.d.ts` — an ambient `declare module '@automattic/react-virtualized'` shim that no longer has any importer.
* Remove the dead `jest.mock( '@automattic/react-virtualized', … )` in `client/reader/sidebar/spaces/test/index.test.tsx` — the Sources tab it was stubbing moved to `@tanstack/react-virtual` in #112028, so the mock targeted a module that's no longer in the import graph.
* Remove the stale `'@automattic/react-virtualized/'` entry from the `calypso-build` webpack transpile list.

## Why are these changes being made?

Every consumer of the unmaintained `@automattic/react-virtualized` fork (last published 2023, whose runtime relies on `findDOMNode`, removed in React 19) has been migrated to `@tanstack/react-virtual` or deleted:

| Consumer | Resolution |
| --- | --- |
| `components/virtual-list` + `taxonomy-manager` | migrated (#112025) |
| `term-tree-selector` | deleted as dead code (#112031); migration PR #112027 closed |
| subscriptions `VirtualizedList` | migrated (#112028) |
| `reader-infinite-stream` | migrated (#112029) |

With no importers left, the dependency (and the `findDOMNode` Yarn patch that the React 19 spike branch carried locally) is obsolete. Removing it drops the fork from the bundle and unblocks React 19. Note: the `findDOMNode` patch only ever lived on the spike branch, never on trunk, so there's no patch file to delete here.

## Testing Instructions

* `git grep "@automattic/react-virtualized"` returns only incidental code comments and a `CHANGELOG.md` line — no imports, no `package.json`/`yarn.lock` entries.
* `yarn install` is a no-op (lockfile already in sync).
* `yarn test-client client/reader/sidebar/spaces` passes (14 tests) with the mock removed.
* Smoke-test the four migrated virtualized surfaces to confirm nothing regressed now that the fork is fully gone:
  * Posts → (Reader) infinite feed scroll & pagination
  * Reader → Subscriptions list
  * Reader search → Sites results

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
