### PR TITLE
Plugins: fix broken author link in detail panel after deleting a plugin from all sites (DOTMSD-1305)

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -1,13 +1,11 @@
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody } from '../../../components/card';
 import { Notice } from '../../../components/notice';
 import { SectionHeader } from '../../../components/section-header';
 import { Text } from '../../../components/text';
 import { TextBlur } from '../../../components/text-blur';
-import { isWebUrl } from '../../../utils/is-web-url';
 import { PluginTabs } from '../../plugin';
 import { usePlugin } from '../../plugin/use-plugin';
 import { getAllowedPluginActions } from '../../plugin/utils/get-allowed-plugin-actions';
@@ -59,24 +57,22 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 			return null;
 		}
 
-		const authorUrl =
-			'author_url' in plugin && isWebUrl( plugin.author_url ) ? plugin.author_url : null;
-
-		return authorUrl
+		// `author` and `authorUrl` are already normalized by `usePlugin`.
+		return plugin.authorUrl
 			? createInterpolateElement(
 					sprintf(
 						// translators: author is the plugin author.
 						__( 'By <link>%(author)s</link>' ),
-						{ author: decodeEntities( plugin.author ) }
+						{ author: plugin.author }
 					),
 					{
-						link: <ExternalLink href={ authorUrl } children={ null } />,
+						link: <ExternalLink href={ plugin.authorUrl } children={ null } />,
 					}
 			  )
 			: sprintf(
 					// translators: author is the plugin author.
 					__( 'By %(author)s' ),
-					{ author: decodeEntities( plugin.author ) }
+					{ author: plugin.author }
 			  );
 	};
 

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -57,7 +57,6 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 			return null;
 		}
 
-		// `author` and `authorUrl` are already normalized by `usePlugin`.
 		return plugin.authorUrl
 			? createInterpolateElement(
 					sprintf(

--- a/client/dashboard/plugins/manage/components/test/plugin-sites.test.tsx
+++ b/client/dashboard/plugins/manage/components/test/plugin-sites.test.tsx
@@ -126,16 +126,15 @@ describe( '<PluginSites> – author link XSS regression', () => {
 	} );
 
 	/**
-	 * When author_url is absent the component must not render any author
-	 * link at all – just the plain author name as text.
+	 * When neither author_url nor plugin_url is available the component must
+	 * not render any author link at all – just the plain author name as text.
 	 */
-	test( 'renders plain author text when author_url is missing', async () => {
-		// Remove the author_url property entirely so the 'author_url' in plugin
-		// check in the component evaluates to false.
+	test( 'renders plain author text when no author URL is available', async () => {
+		// Remove author_url and blank out plugin_url so there is nothing to link to.
 		const { author_url: _removed, ...pluginWithoutUrl } = makePluginsResponse().sites[ '1' ][ 0 ];
 		mockApiEndpoints( {
 			sites: {
-				'1': [ pluginWithoutUrl as PluginEntry ],
+				'1': [ { ...pluginWithoutUrl, plugin_url: '' } as PluginEntry ],
 			},
 		} );
 
@@ -143,6 +142,30 @@ describe( '<PluginSites> – author link XSS regression', () => {
 
 		await waitFor( () => expect( screen.getByText( /Malicious Author/i ) ).toBeVisible() );
 		expect( screen.queryByRole( 'link', { name: /Malicious Author/i } ) ).not.toBeInTheDocument();
+	} );
+
+	/**
+	 * Some installed plugins leave author_url empty but expose the plugin's own
+	 * site in plugin_url; the author link should fall back to that.
+	 */
+	test( 'falls back to plugin_url when author_url is missing', async () => {
+		const { author_url: _removed, ...pluginWithoutAuthorUrl } =
+			makePluginsResponse().sites[ '1' ][ 0 ];
+		mockApiEndpoints( {
+			sites: {
+				'1': [
+					{
+						...pluginWithoutAuthorUrl,
+						plugin_url: 'https://plugin-home.example.com',
+					} as PluginEntry,
+				],
+			},
+		} );
+
+		render( <PluginSites selectedPluginSlug="test-plugin" /> );
+
+		const authorLink = await screen.findByRole( 'link', { name: /Malicious Author/i } );
+		expect( ( authorLink as HTMLAnchorElement ).href ).toBe( 'https://plugin-home.example.com/' );
 	} );
 
 	/**
@@ -164,5 +187,94 @@ describe( '<PluginSites> – author link XSS regression', () => {
 		} );
 
 		expect( unsafeLinks ).toHaveLength( 0 );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Author normalization across data sources
+// ---------------------------------------------------------------------------
+
+describe( '<PluginSites> – author normalization across sources', () => {
+	afterEach( () => nock.cleanAll() );
+
+	/**
+	 * No installed plugins, so usePlugin resolves the plugin from the catalog
+	 * (marketplace or wp.org) instead of the WordPress.com installed data.
+	 */
+	function mockCatalogEndpoints( {
+		marketplace = { results: {} },
+		wpOrg = {},
+	}: {
+		marketplace?: { results: Record< string, unknown > };
+		wpOrg?: Record< string, unknown >;
+	} ) {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/sites/plugins' )
+			.query( true )
+			.reply( 200, { sites: {} } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( true )
+			.reply( 200, { sites: [] } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/marketplace/products' )
+			.query( true )
+			.reply( 200, marketplace );
+		nock( 'https://api.wordpress.org' )
+			.get( '/plugins/info/1.2/' )
+			.query( true )
+			.reply( 200, wpOrg );
+	}
+
+	/**
+	 * Catalog sources ship `author` as an HTML anchor and the URL in
+	 * `author_profile`. The panel must show the plain name with a link to the
+	 * profile, never raw markup.
+	 */
+	test( 'strips the HTML anchor from a catalog author and links to author_profile', async () => {
+		mockCatalogEndpoints( {
+			marketplace: {
+				results: {
+					'test-plugin': {
+						name: 'Test Plugin',
+						slug: 'test-plugin',
+						author: '<a href="https://acme.example.com/team/">Acme</a>',
+						author_profile: 'https://acme.example.com/team/',
+						icons: '',
+					},
+				},
+			},
+		} );
+
+		render( <PluginSites selectedPluginSlug="test-plugin" /> );
+
+		const authorLink = await screen.findByRole( 'link', { name: /Acme/ } );
+		expect( ( authorLink as HTMLAnchorElement ).href ).toBe( 'https://acme.example.com/team/' );
+	} );
+
+	/**
+	 * Marketplace also ships `author` as an HTML anchor, but `author_profile` is
+	 * frequently null — the panel must then show the plain name with no link
+	 * (and never the placeholder `href="#"`).
+	 */
+	test( 'strips the HTML anchor from a marketplace author and renders plain text when author_profile is null', async () => {
+		mockCatalogEndpoints( {
+			marketplace: {
+				results: {
+					'test-plugin': {
+						name: 'Test Plugin',
+						slug: 'test-plugin',
+						author: '<a href="#">Acme</a>',
+						author_profile: null,
+						icons: '',
+					},
+				},
+			},
+		} );
+
+		render( <PluginSites selectedPluginSlug="test-plugin" /> );
+
+		await waitFor( () => expect( screen.getByText( 'By Acme' ) ).toBeVisible() );
+		expect( screen.queryByRole( 'link', { name: /Acme/ } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -1,4 +1,11 @@
-import { MarketplaceSearch, PluginItem, Site, SitePlugin } from '@automattic/api-core';
+import {
+	MarketplacePlugin,
+	MarketplaceSearch,
+	PluginItem,
+	Site,
+	SitePlugin,
+	WpOrgPlugin,
+} from '@automattic/api-core';
 import {
 	pluginsQuery,
 	wpOrgPluginQuery,
@@ -19,6 +26,11 @@ const stripAuthorMarkup = ( author = '' ) =>
 	decodeEntities( author.replace( /<[^>]*>/g, '' ) ).trim();
 
 const toAuthorUrl = ( url?: string | null ) => ( url && isWebUrl( url ) ? url : null );
+
+export type NormalizedPlugin = ( PluginItem | MarketplacePlugin | WpOrgPlugin ) & {
+	author: string;
+	authorUrl: string | null;
+};
 
 export interface SiteWithPluginData extends Site {
 	actionLinks?: SitePlugin[ 'action_links' ];
@@ -99,7 +111,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	const siteIdsWithThisPlugin = Array.from( pluginBySiteId.keys() );
 
 	// Normalize the author per source so consumers get one shape
-	const plugin = useMemo( () => {
+	const plugin = useMemo< NormalizedPlugin | undefined >( () => {
 		const raw =
 			pluginBySiteId.values().next().value ??
 			( isMarketplacePlugin ? marketplacePlugins?.results[ pluginSlug ] : undefined ) ??

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -6,9 +6,19 @@ import {
 	marketplacePluginsQuery,
 } from '@automattic/api-queries';
 import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
+import { decodeEntities } from '@wordpress/html-entities';
 import { useMemo } from 'react';
 import { useAppContext } from '../../app/context';
 import { useLocale } from '../../app/locale';
+import { isWebUrl } from '../../utils/is-web-url';
+
+// wp.org/marketplace ship `author` as an HTML anchor (e.g.
+// `<a href="…">Automattic</a>`). Strip the markup with a regex — never
+// `innerHTML`, to avoid a DOM-XSS sink — and decode any entities.
+const stripAuthorMarkup = ( author = '' ) =>
+	decodeEntities( author.replace( /<[^>]*>/g, '' ) ).trim();
+
+const toAuthorUrl = ( url?: string | null ) => ( url && isWebUrl( url ) ? url : null );
 
 export interface SiteWithPluginData extends Site {
 	actionLinks?: SitePlugin[ 'action_links' ];
@@ -88,14 +98,28 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 
 	const siteIdsWithThisPlugin = Array.from( pluginBySiteId.keys() );
 
-	let pluginData;
-	if ( pluginBySiteId.size ) {
-		pluginData = pluginBySiteId.get( siteIdsWithThisPlugin[ 0 ] );
-	} else if ( isMarketplacePlugin ) {
-		pluginData = marketplacePlugins?.results[ pluginSlug ];
-	} else if ( wpOrgPlugin ) {
-		pluginData = wpOrgPlugin;
-	}
+	// Normalize the author per source so consumers get one shape
+	const plugin = useMemo( () => {
+		const raw =
+			pluginBySiteId.values().next().value ??
+			( isMarketplacePlugin ? marketplacePlugins?.results[ pluginSlug ] : undefined ) ??
+			wpOrgPlugin;
+
+		if ( ! raw ) {
+			return undefined;
+		}
+
+		return {
+			...raw,
+			author: stripAuthorMarkup( raw.author ),
+			authorUrl: toAuthorUrl(
+				( 'author_url' in raw && raw.author_url ) ||
+					( 'plugin_url' in raw && raw.plugin_url ) ||
+					( 'author_profile' in raw && raw.author_profile ) ||
+					undefined
+			),
+		};
+	}, [ pluginBySiteId, isMarketplacePlugin, marketplacePlugins, pluginSlug, wpOrgPlugin ] );
 
 	const [ sitesWithThisPlugin, sitesWithoutThisPlugin ]: [ SiteWithPluginData[], Site[] ] = sites
 		? sites
@@ -156,7 +180,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 		pluginBySiteId,
 		sitesWithThisPlugin,
 		sitesWithoutThisPlugin,
-		plugin: pluginData,
+		plugin,
 		icon,
 	};
 };


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTMSD-1305/after-deleting-a-plugin-from-all-sites-the-right-panel-looks-broken

## Proposed Changes

**`usePlugin` now normalizes the plugin author into one shape, so the detail panel never renders raw markup regardless of where the data came from.**

- The plugin shown in the right panel can come from three sources with different field shapes: installed plugins (WordPress.com API) expose a plain `author` name plus `author_url`/`plugin_url`; wp.org and marketplace expose `author` as an HTML anchor string and put the URL in `author_profile`.
- `usePlugin` now strips any markup from `author` (regex, not `innerHTML`, to avoid a DOM-XSS sink) and resolves a single `authorUrl` from `author_url` → `plugin_url` → `author_profile`, validated with `isWebUrl`.
- `PluginSites` is simplified to consume the normalized `author` + `authorUrl` and no longer branches on the source.

## Why are these changes being made?

In the Plugins manager, deleting a plugin from all your sites left the right-hand detail panel looking broken — the line under the plugin name showed literal HTML like `By <a href="#">Automattic</a>` instead of a clean “By Automattic” ([DOTMSD-1305](https://linear.app/a8c/issue/DOTMSD-1305)).

The panel pulls plugin info from whichever source has it. While a plugin is installed it uses the clean WordPress.com data, but once it’s gone from every site the panel falls back to the public wp.org/marketplace catalog — and those return the author already wrapped in an HTML link, which the panel printed as plain text. Normalizing at the data layer means the UI always gets a plain author name and a usable link, no matter the source.

## Testing Instructions

1. Run `yarn start-dashboard` and open the Plugins manager at `/plugins/manage`.
2. Pick a plugin that exists in the wp.org or marketplace catalog and is installed on at least one site (e.g. a forms or newsletter plugin).
3. Select it, then delete it from all sites.
4. Confirm the line under the plugin name reads a clean “By &lt;author&gt;” — no raw `<a …>` tags — and that the author link opens when a valid URL exists (and is simply plain text when it doesn’t).
5. Open a catalog-only plugin that is not installed anywhere and confirm the author renders the same clean way.
