### PR TITLE
Reader: Make settings tab public

### DIFF
--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -1,6 +1,4 @@
 import './style.scss';
-import { isAutomatticianQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect, useRef, useState, type JSX } from 'react';
@@ -29,7 +27,6 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 	);
 	const { isOwnProfile, showPosts, isPostsPublic, showSites, isSitesPublic } =
 		useProfileTabVisibility( user.user_login );
-	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ showMoreToggle, setShowMoreToggle ] = useState( false );
 	const bioRef = useRef< HTMLParagraphElement >( null );
@@ -88,7 +85,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 					},
 			  ]
 			: [] ),
-		...( isOwnProfile && isAutomattician
+		...( isOwnProfile
 			? [
 					{
 						label: translate( 'Settings' ),

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -4,7 +4,6 @@ import { Button, Dropdown, ToggleControl } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
-import useSetAchievementsVisibility from 'calypso/reader/components/achievements/use-set-achievements-visibility';
 import { recordAction } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -17,30 +16,20 @@ export default function AchievementsSettings() {
 	const translate = useTranslate();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 
-	const { data: savedVisibility } = useQuery( userPreferenceQuery( 'achievements-visibility' ) );
 	const { data: savedNotifications } = useQuery(
 		userPreferenceQuery( 'achievements-global-notifications' )
 	);
 
 	// Local state for immediate toggle feedback. Synced from query data on load.
-	const [ visibility, setLocalVisibility ] = useState( savedVisibility ?? 'private' );
 	const [ notifications, setLocalNotifications ] = useState( savedNotifications ?? 'enabled' );
-	useEffect( () => setLocalVisibility( savedVisibility ?? 'private' ), [ savedVisibility ] );
 	useEffect(
 		() => setLocalNotifications( savedNotifications ?? 'enabled' ),
 		[ savedNotifications ]
 	);
 
-	const { setVisibility } = useSetAchievementsVisibility();
 	const { mutate: setNotifications } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
 	);
-
-	const handleSetVisibility = ( checked: boolean ) => {
-		const newVisibility = checked ? 'public' : 'private';
-		setLocalVisibility( newVisibility );
-		setVisibility( newVisibility );
-	};
 
 	const handleSetNotifications = ( checked: boolean ) => {
 		const newNotifications = checked ? 'enabled' : 'disabled';
@@ -96,12 +85,6 @@ export default function AchievementsSettings() {
 			) }
 			renderContent={ () => (
 				<div className="achievements-settings__content">
-					<ToggleControl
-						checked={ visibility === 'public' }
-						onChange={ handleSetVisibility }
-						label={ translate( 'Public achievements' ) }
-						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
-					/>
 					<ToggleControl
 						checked={ notifications !== 'disabled' }
 						onChange={ handleSetNotifications }

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -3,6 +3,7 @@ import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
 import useAchievementsVisibility from 'calypso/reader/components/achievements/use-achievements-visibility';
+import UserProfilePrivateTabNotice from 'calypso/reader/user-profile/components/private-tab-notice';
 import AchievementsGrid from './achievements-grid';
 import AchievementsSettings from './achievements-settings';
 import { ActivityStreak } from './activity-streak';
@@ -34,6 +35,13 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 
 	return (
 		<div className="achievements">
+			{ isOwnProfile && (
+				<UserProfilePrivateTabNotice
+					title={ translate( 'Your achievements are private' ) }
+					tab="achievements"
+					userPreferencesKey="achievements-visibility"
+				/>
+			) }
 			<div className="achievements__header">
 				<ActivityStreak streak={ engagementStreak } isOwnProfile={ isOwnProfile } />
 				{ isOwnProfile && (

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -25,6 +25,12 @@ jest.mock( '../achievements-settings', () => ( {
 	default: () => <button data-testid="achievements-settings">Settings</button>,
 } ) );
 
+jest.mock( 'calypso/reader/user-profile/components/private-tab-notice', () => ( {
+	__esModule: true,
+	default: ( { title }: { title: string } ) => (
+		<div data-testid="private-tab-notice">{ title }</div>
+	),
+} ) );
 const mockActivityStreakProps = jest.fn();
 jest.mock( '../activity-streak', () => ( {
 	__esModule: true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/111757 we introduced a settings tab behind isAutomattician check, now we are making it public.
