### PR TITLE
Help Center/Agents Manager: dedupe Smooch to one instance across bundles

### DIFF
--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -54,6 +54,7 @@ function getIndividualConfig( options = {} ) {
 				...( webpackConfig.resolve?.alias || {} ),
 				// Share one Smooch instance with the Help Center bundle when both load
 				// together (e.g. the Site Editor). See smooch-shim.js.
+				// TODO: Remove once Agents Manager takes over the Help Center.
 				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
 			},
 		},
@@ -154,6 +155,7 @@ function getReaderConfig( options = {} ) {
 			alias: {
 				...( webpackConfig.resolve?.alias || {} ),
 				// Share one Smooch instance across bundles (see smooch-shim.js).
+				// TODO: Remove once Agents Manager takes over the Help Center.
 				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
 				'../agent-history': path.join( __dirname, 'reader-chat-route-stub.js' ),
 				'../support-guide': path.join( __dirname, 'reader-chat-route-stub.js' ),

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -48,6 +48,15 @@ function getIndividualConfig( options = {} ) {
 				},
 			],
 		},
+		resolve: {
+			...webpackConfig.resolve,
+			alias: {
+				...( webpackConfig.resolve?.alias || {} ),
+				// Share one Smooch instance with the Help Center bundle when both load
+				// together (e.g. the Site Editor). See smooch-shim.js.
+				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
+			},
+		},
 		optimization: {
 			...webpackConfig.optimization,
 			// disable module concatenation so that instances of `__()` are not renamed
@@ -144,6 +153,8 @@ function getReaderConfig( options = {} ) {
 			...webpackConfig.resolve,
 			alias: {
 				...( webpackConfig.resolve?.alias || {} ),
+				// Share one Smooch instance across bundles (see smooch-shim.js).
+				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
 				'../agent-history': path.join( __dirname, 'reader-chat-route-stub.js' ),
 				'../support-guide': path.join( __dirname, 'reader-chat-route-stub.js' ),
 				'../support-guides': path.join( __dirname, 'reader-chat-route-stub.js' ),

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -25,6 +25,15 @@ function getIndividualConfig( options = {} ) {
 			chunkFilename: `[id].[contenthash:8].min.js`,
 			library: 'helpCenter',
 		},
+		resolve: {
+			...webpackConfig.resolve,
+			alias: {
+				...( webpackConfig.resolve?.alias || {} ),
+				// Share one Smooch instance with the Agents Manager bundle when both load
+				// together (e.g. the Site Editor). See smooch-shim.js.
+				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
+			},
+		},
 		optimization: {
 			...webpackConfig.optimization,
 			// disable module concatenation so that instances of `__()` are not renamed

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -31,6 +31,7 @@ function getIndividualConfig( options = {} ) {
 				...( webpackConfig.resolve?.alias || {} ),
 				// Share one Smooch instance with the Agents Manager bundle when both load
 				// together (e.g. the Site Editor). See smooch-shim.js.
+				// TODO: Remove once Agents Manager takes over the Help Center.
 				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
 			},
 		},

--- a/build-tools/webpack/smooch-shim.js
+++ b/build-tools/webpack/smooch-shim.js
@@ -1,0 +1,31 @@
+/**
+ * Shares a single Smooch instance across bundles.
+ *
+ * Smooch expects to be the only copy on the page — it owns a global callback and a fixed
+ * iframe id. So when Help Center and Agents Manager load as separate bundles together
+ * (e.g. the Site Editor), two copies collide and throw "Cannot read properties of
+ * undefined (reading 'contentWindow')".
+ *
+ * This is aliased as `smooch` in both apps' webpack configs. The first bundle to import
+ * it loads the real library and caches it on `window`; later bundles reuse that same
+ * instance instead of loading their own. Consumers keep using `import Smooch from 'smooch'`.
+ */
+const SHARED_KEY = '__sharedSmoochInstance__';
+
+let instance;
+if ( typeof window !== 'undefined' && window[ SHARED_KEY ] ) {
+	instance = window[ SHARED_KEY ];
+} else {
+	// Full path bypasses the `smooch$` alias to load the real library. Only runs when no
+	// shared instance exists yet, so a second bundle never loads its own copy. smooch is a
+	// dependency of the app bundles that use this shim (help-center, agents-manager).
+	// eslint-disable-next-line import/no-extraneous-dependencies
+	const real = require( 'smooch/lib/index.js' );
+	instance = real && real.default ? real.default : real;
+	if ( typeof window !== 'undefined' ) {
+		window[ SHARED_KEY ] = instance;
+	}
+}
+
+Object.defineProperty( exports, '__esModule', { value: true } );
+exports.default = instance;

--- a/build-tools/webpack/smooch-shim.js
+++ b/build-tools/webpack/smooch-shim.js
@@ -10,6 +10,9 @@
  * it loads the real library and caches it on `window`; later bundles reuse that same
  * instance instead of loading their own. Consumers keep using `import Smooch from 'smooch'`.
  */
+
+// TODO: Remove this shim and the `smooch$` webpack aliases once Agents Manager takes over
+// the Help Center — they'll no longer load together, so only one Smooch copy will exist.
 const SHARED_KEY = '__sharedSmoochInstance__';
 
 let instance;


### PR DESCRIPTION
Part of AI-1027

## Proposed Changes

Help Center and Agents Manager each bundle their own copy of the `smooch` (Zendesk messaging) library. When both load on the same page (e.g. the Site Editor), the two copies collide and crash.

This adds a small shim (`build-tools/webpack/smooch-shim.js`), aliased as `smooch` in both apps' webpack configs, so the library loads once and is shared:

* The first bundle to import `smooch` loads it and caches it on `window`; later bundles reuse that instance.
* **Safe fallback:** if nothing is cached yet, the shim loads the library itself — so `import Smooch from 'smooch'` always returns a working instance, never `undefined`. An absent `window.__sharedSmoochInstance__` just means the next import will load it; nothing crashes.
* **No application code changes** — consumers keep using `import Smooch from 'smooch'`.

## Why are these changes being made?

`smooch` assumes it is the only copy on the page — it owns a global callback (`window.__onWebMessengerFrameReady__`) and a fixed iframe id (`web-messenger-container`). With two copies loaded together they fight over those globals and throw `Cannot read properties of undefined (reading 'contentWindow')`.

The two apps must be able to coexist (e.g. Big Sky's block-editor mode keeps Help Center available alongside Agents Manager), so dropping one isn't an option. Sharing a single `smooch` instance fixes it at the source with no app-code changes, so Reader chat, the Help Center AI chat, and the unified experience all keep working. In a single-bundle context (e.g. Calypso) Help Center and Agents Manager share one build, so there is already a single `smooch` instance and this change has no effect there.

## Testing Instructions

This verifies the `Cannot read properties of undefined (reading 'contentWindow')` error is gone when Help Center and Agents Manager load together.

1. Sandbox `widgets.wp.com` and sync both bundles:
   - `cd apps/help-center && yarn dev --sync`
   - `cd apps/agents-manager && yarn dev --sync`
2. Disable the unified AI experience, so the Help Center shows its own chat.
3. In the Site Editor, make sure both Help Center and Agents Manager are loaded.
4. Confirm there is **no** `Cannot read properties of undefined (reading 'contentWindow')` error in the browser console.

_Optional — no regression, in `/wp-admin`:_
- Enable the unified AI experience and confirm the Agents Manager human chat still works.
- Disable it and confirm the Help Center human chat still works. _(Note: it isn't clear how to reach the Help Center human chat in a dev / proxied environment, but it should work.)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)




