### PR TITLE
Agents Manager: show page editor suggestions

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -311,6 +311,52 @@ describe( 'OrchestratorChat', () => {
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
 	} );
 
+	it( 'combines provider empty-view suggestions with dynamic suggestions', () => {
+		const emptySuggestions: Suggestion[] = [
+			{ id: 'customize-colors', label: 'Customize colors', prompt: 'Customize colors' },
+			{ id: 'change-page-layout', label: 'Change page layout', prompt: 'Change page layout' },
+		];
+		const dynamicSuggestions: Suggestion[] = [
+			{ id: 'dynamic-action', label: 'Dynamic action', prompt: 'Run the dynamic action' },
+		];
+		const useSuggestions = jest.fn( () => ( { suggestions: dynamicSuggestions } ) );
+
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: dynamicSuggestions,
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ emptySuggestions }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Customize colors' ) ).toBeTruthy();
+		expect( screen.getByText( 'Change page layout' ) ).toBeTruthy();
+		expect( screen.getByText( 'Dynamic action' ) ).toBeTruthy();
+	} );
+
 	it( 'falls back to the static empty-view suggestions when the provider has none', () => {
 		const staticDefaults: Suggestion[] = [
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -357,6 +357,57 @@ describe( 'OrchestratorChat', () => {
 		expect( screen.getByText( 'Dynamic action' ) ).toBeTruthy();
 	} );
 
+	it( 'replaces provider empty-view suggestions with contextual dynamic suggestions', () => {
+		const emptySuggestions: Suggestion[] = [
+			{ id: 'simple-review', label: 'Simple Review', prompt: 'Review this page' },
+			{ id: 'proofread', label: 'Proofread', prompt: 'Proofread this page' },
+		];
+		const blockSuggestions: Suggestion[] = [
+			{ id: 'change-tone', label: 'Change tone', prompt: 'Change the tone' },
+			{ id: 'check-grammar', label: 'Check grammar', prompt: 'Check the grammar' },
+		];
+		const useSuggestions = jest.fn( () => ( {
+			suggestions: blockSuggestions,
+			replaceEmptyViewSuggestions: true,
+		} ) );
+
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: blockSuggestions,
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ emptySuggestions }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.queryByText( 'Simple Review' ) ).toBeNull();
+		expect( screen.queryByText( 'Proofread' ) ).toBeNull();
+		expect( screen.getByText( 'Change tone' ) ).toBeTruthy();
+		expect( screen.getByText( 'Check grammar' ) ).toBeTruthy();
+	} );
+
 	it( 'falls back to the static empty-view suggestions when the provider has none', () => {
 		const staticDefaults: Suggestion[] = [
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -378,6 +378,7 @@ export default function OrchestratorChat( {
 		suggestionsVisible: areSuggestionsVisible,
 	} );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
+	const replaceEmptyViewSuggestions = dynamicSuggestions?.replaceEmptyViewSuggestions === true;
 	const dynamicSuggestionsKey = JSON.stringify(
 		dynamicSuggestionsList.map( ( s ) => [ s.id, s.label, s.prompt ] )
 	);
@@ -815,7 +816,10 @@ export default function OrchestratorChat( {
 		// Persistent empty-view chips must survive that clear.
 		displayedEmptyViewSuggestions = mergeEmptyViewSuggestions(
 			emptyViewSuggestions,
-			suggestions.length > 0 ? suggestions : dynamicSuggestionsList
+			replaceEmptyViewSuggestions || suggestions.length === 0
+				? dynamicSuggestionsList
+				: suggestions,
+			replaceEmptyViewSuggestions
 		);
 	} else if ( suggestions.length > 0 ) {
 		displayedEmptyViewSuggestions = suggestions;

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -239,7 +239,8 @@ export default function OrchestratorChat( {
 	const [ isRegenerating, setIsRegenerating ] = useState( false );
 	const [ hasUserSentMessage, setHasUserSentMessage ] = useState( false );
 	const currentPostId = useSelect( ( select ) => {
-		return ( select( 'core/editor' ) as { getCurrentPostId?: () => number } )?.getCurrentPostId?.();
+		const editor = select( 'core/editor' ) as { getCurrentPostId?: () => number | string };
+		return editor?.getCurrentPostId?.();
 	}, [] );
 
 	const {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -15,7 +15,6 @@ import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conv
 import useCheckpointAction from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
-import { DEFAULT_EMPTY_VIEW_SUGGESTION_IDS } from '../../hooks/use-empty-view-suggestions';
 import useFeedbackAction from '../../hooks/use-feedback-action';
 import useRegenerateAction from '../../hooks/use-regenerate-action';
 import useSaveNewChatRoute from '../../hooks/use-save-new-chat-route';
@@ -33,6 +32,7 @@ import {
 	type ExternalContextCardAction,
 } from '../../utils/external-context';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
+import { mergeEmptyViewSuggestions } from '../../utils/merge-empty-view-suggestions';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
@@ -68,43 +68,6 @@ function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
  */
 function formatSuggestionIds( suggestions: Suggestion[] ): string {
 	return '|' + suggestions.map( ( s ) => s.id ).join( '|' ) + '|';
-}
-
-const DEFAULT_EMPTY_VIEW_SUGGESTION_ID_SET = new Set< string >(
-	Object.values( DEFAULT_EMPTY_VIEW_SUGGESTION_IDS )
-);
-
-function isDefaultEmptyViewSuggestions( suggestions: Suggestion[] ): boolean {
-	return (
-		suggestions.length > 0 &&
-		suggestions.every( ( suggestion ) => DEFAULT_EMPTY_VIEW_SUGGESTION_ID_SET.has( suggestion.id ) )
-	);
-}
-
-function mergeEmptyViewSuggestions(
-	emptyViewSuggestions: Suggestion[],
-	dynamicSuggestions: Suggestion[]
-): Suggestion[] {
-	if ( dynamicSuggestions.length === 0 ) {
-		return emptyViewSuggestions;
-	}
-
-	const combined: Suggestion[] = [];
-	const seenIds = new Set< string >();
-	// Contextual suggestions should replace generic defaults, but custom provider
-	// empty-view chips should be shown alongside them.
-	const baseSuggestions = isDefaultEmptyViewSuggestions( emptyViewSuggestions )
-		? []
-		: emptyViewSuggestions;
-
-	for ( const suggestion of [ ...baseSuggestions, ...dynamicSuggestions ] ) {
-		if ( ! seenIds.has( suggestion.id ) ) {
-			seenIds.add( suggestion.id );
-			combined.push( suggestion );
-		}
-	}
-
-	return combined;
 }
 
 function getToolMessageData( message: Pick< UIMessage, 'content' > ):
@@ -845,11 +808,11 @@ export default function OrchestratorChat( {
 		displayedMessages.length === 0 &&
 		inputValue.length === 0
 	) {
-		// Read straight from the live `useSuggestions` output rather than the
-		// registered store. Clicking a suggestion calls `clearSuggestions()`,
-		// which empties the store, and the re-registration effect is keyed on
-		// the (unchanged) hook output so it won't restore it. Persistent
-		// empty-view chips must survive that clear.
+		// Prefer the registered store, but fall back to the live `useSuggestions`
+		// output when the store is empty. Clicking a suggestion calls
+		// `clearSuggestions()`, which empties the store, and the re-registration
+		// effect is keyed on the (unchanged) hook output so it won't restore it.
+		// Persistent empty-view chips must survive that clear.
 		displayedEmptyViewSuggestions = mergeEmptyViewSuggestions(
 			emptyViewSuggestions,
 			suggestions.length > 0 ? suggestions : dynamicSuggestionsList

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -15,6 +15,7 @@ import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conv
 import useCheckpointAction from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
+import { DEFAULT_EMPTY_VIEW_SUGGESTION_IDS } from '../../hooks/use-empty-view-suggestions';
 import useFeedbackAction from '../../hooks/use-feedback-action';
 import useRegenerateAction from '../../hooks/use-regenerate-action';
 import useSaveNewChatRoute from '../../hooks/use-save-new-chat-route';
@@ -67,6 +68,43 @@ function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
  */
 function formatSuggestionIds( suggestions: Suggestion[] ): string {
 	return '|' + suggestions.map( ( s ) => s.id ).join( '|' ) + '|';
+}
+
+const DEFAULT_EMPTY_VIEW_SUGGESTION_ID_SET = new Set< string >(
+	Object.values( DEFAULT_EMPTY_VIEW_SUGGESTION_IDS )
+);
+
+function isDefaultEmptyViewSuggestions( suggestions: Suggestion[] ): boolean {
+	return (
+		suggestions.length > 0 &&
+		suggestions.every( ( suggestion ) => DEFAULT_EMPTY_VIEW_SUGGESTION_ID_SET.has( suggestion.id ) )
+	);
+}
+
+function mergeEmptyViewSuggestions(
+	emptyViewSuggestions: Suggestion[],
+	dynamicSuggestions: Suggestion[]
+): Suggestion[] {
+	if ( dynamicSuggestions.length === 0 ) {
+		return emptyViewSuggestions;
+	}
+
+	const combined: Suggestion[] = [];
+	const seenIds = new Set< string >();
+	// Contextual suggestions should replace generic defaults, but custom provider
+	// empty-view chips should be shown alongside them.
+	const baseSuggestions = isDefaultEmptyViewSuggestions( emptyViewSuggestions )
+		? []
+		: emptyViewSuggestions;
+
+	for ( const suggestion of [ ...baseSuggestions, ...dynamicSuggestions ] ) {
+		if ( ! seenIds.has( suggestion.id ) ) {
+			seenIds.add( suggestion.id );
+			combined.push( suggestion );
+		}
+	}
+
+	return combined;
 }
 
 function getToolMessageData( message: Pick< UIMessage, 'content' > ):
@@ -794,15 +832,13 @@ export default function OrchestratorChat( {
 		( isProcessing || ( isThinking && ! isBuildingSite ) ) && ! shouldSuppressTransientThinking;
 
 	// Determine which suggestions to show following Big Sky's logic:
-	// - When there are dynamic suggestions (from block selection, etc.), show those
-	// - Otherwise, show empty view suggestions only when there are no messages AND no input text
+	// - Empty chat: show provider empty-view chips plus dynamic chips.
+	// - Active chat/input: show dynamic suggestions only.
 	let displayedEmptyViewSuggestions: Suggestion[] = [];
 	if ( ! areSuggestionsVisible ) {
 		// Minimized/collapsed: the chat renders no suggestions, so leave the list
 		// empty to avoid firing chat_suggestions_rendered for hidden chips.
 		displayedEmptyViewSuggestions = [];
-	} else if ( suggestions.length > 0 ) {
-		displayedEmptyViewSuggestions = suggestions;
 	} else if (
 		! isLoadingConversation &&
 		displayedMessages.length === 0 &&
@@ -812,10 +848,13 @@ export default function OrchestratorChat( {
 		// registered store. Clicking a suggestion calls `clearSuggestions()`,
 		// which empties the store, and the re-registration effect is keyed on
 		// the (unchanged) hook output so it won't restore it. Persistent
-		// empty-view chips must survive that clear; fall back to the static
-		// defaults only when the hook genuinely has none.
-		displayedEmptyViewSuggestions =
-			dynamicSuggestionsList.length > 0 ? dynamicSuggestionsList : emptyViewSuggestions;
+		// empty-view chips must survive that clear.
+		displayedEmptyViewSuggestions = mergeEmptyViewSuggestions(
+			emptyViewSuggestions,
+			suggestions.length > 0 ? suggestions : dynamicSuggestionsList
+		);
+	} else if ( suggestions.length > 0 ) {
+		displayedEmptyViewSuggestions = suggestions;
 	}
 
 	// Track when a set of suggestions is rendered — the dynamic block-context

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -52,6 +52,20 @@ const jetpackSuggestion = {
 	prompt: 'Proofread this saved content.',
 };
 
+const UNSUPPORTED_POST_LEVEL_SUGGESTION_TYPES: Array<
+	[ label: string, postType: string | undefined ]
+> = [
+	[ 'templates', 'wp_template' ],
+	[ 'template parts', 'wp_template_part' ],
+	[ 'patterns', 'wp_block' ],
+	[ 'navigation', 'wp_navigation' ],
+	[ 'global styles', 'wp_global_styles' ],
+	[ 'Site Editor dashboard/list views', undefined ],
+	[ 'Jetpack Forms', 'jetpack_form' ],
+	[ 'Jetpack Search overlays', 'jp_search_overlay' ],
+	[ 'other custom post types', 'custom_post_type' ],
+];
+
 function mockCoreStoreReady( isReady: boolean ) {
 	mockUseSelect.mockImplementation( ( mapSelect ) =>
 		mapSelect( ( storeName: string ) => {
@@ -284,9 +298,9 @@ describe( 'useEmptyViewSuggestions', () => {
 		}
 	);
 
-	it.each( [ 'wp_template', 'wp_template_part', 'wp_navigation', 'wp_block' ] )(
+	it.each( UNSUPPORTED_POST_LEVEL_SUGGESTION_TYPES )(
 		'refreshes provider suggestions when navigating from a page to %s and back',
-		async ( postType ) => {
+		async ( _label, postType ) => {
 			window.history.pushState( {}, '', '/wp-admin/site-editor.php' );
 			mockContext = {
 				sectionName: 'site-editor',

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -259,19 +259,22 @@ describe( 'useEmptyViewSuggestions', () => {
 		);
 	} );
 
-	it( 'keeps site-editor-only provider suggestions for Site Editor template post types', async () => {
-		mockCurrentPostType = 'wp_template';
-		mockContext = {
-			sectionName: 'site-editor',
-			currentRoute: '/wp-admin/site-editor.php?postType=wp_template',
-		};
-		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
-		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+	it.each( [ 'wp_template', 'wp_template_part' ] )(
+		'keeps site-editor-only provider suggestions for the %s post type',
+		async ( postType ) => {
+			mockCurrentPostType = postType;
+			mockContext = {
+				sectionName: 'site-editor',
+				currentRoute: `/wp-admin/site-editor.php?postType=${ postType }`,
+			};
+			const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+			const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
 
-		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+			const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
 
-		await waitFor( () =>
-			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
-		);
-	} );
+			await waitFor( () =>
+				expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+			);
+		}
+	);
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -7,6 +7,7 @@ let mockContext = {
 	sectionName: 'gutenberg',
 	currentRoute: undefined as string | undefined,
 };
+let mockCurrentPostType: string | undefined;
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: (
@@ -47,9 +48,17 @@ const siteEditorSuggestion = {
 
 function mockCoreStoreReady( isReady: boolean ) {
 	mockUseSelect.mockImplementation( ( mapSelect ) =>
-		mapSelect( () => ( {
-			getCurrentTheme: () => ( isReady ? { stylesheet: 'pub/theme' } : null ),
-		} ) )
+		mapSelect( ( storeName: string ) => {
+			if ( storeName === 'core/editor' ) {
+				return {
+					getCurrentPostType: () => mockCurrentPostType,
+				};
+			}
+
+			return {
+				getCurrentTheme: () => ( isReady ? { stylesheet: 'pub/theme' } : null ),
+			};
+		} )
 	);
 }
 
@@ -68,6 +77,7 @@ describe( 'useEmptyViewSuggestions', () => {
 			sectionName: 'gutenberg',
 			currentRoute: undefined,
 		};
+		mockCurrentPostType = undefined;
 		mockCoreStoreReady( true );
 	} );
 
@@ -135,6 +145,7 @@ describe( 'useEmptyViewSuggestions', () => {
 	} );
 
 	it( 'filters site-editor-only provider suggestions in the post editor even if section is misreported', async () => {
+		mockCurrentPostType = 'post';
 		mockContext = {
 			sectionName: 'site-editor',
 			currentRoute: '/wp-admin/post.php?post=1&action=edit',
@@ -167,6 +178,56 @@ describe( 'useEmptyViewSuggestions', () => {
 		await waitFor( () => expect( result.current ).toEqual( [] ) );
 	} );
 
+	it( 'keeps site-editor-only provider suggestions in the page editor', async () => {
+		mockCurrentPostType = 'page';
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: '/wp-admin/post.php?post=1&action=edit',
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+
+	it( 'filters site-editor-only provider suggestions for non-page post types', async () => {
+		mockCurrentPostType = 'product';
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: '/wp-admin/post.php?post=1&action=edit',
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ bigSkySuggestion ] ) );
+	} );
+
+	it( 'updates site-editor-only provider suggestions when the page editor post type resolves', async () => {
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: '/wp-admin/post.php?post=1&action=edit',
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result, rerender } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ bigSkySuggestion ] ) );
+
+		mockCurrentPostType = 'page';
+		rerender();
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+
 	it( 'keeps site-editor-only provider suggestions in Site Editor', async () => {
 		mockContext = {
 			sectionName: 'site-editor',
@@ -187,6 +248,22 @@ describe( 'useEmptyViewSuggestions', () => {
 		mockContext = {
 			sectionName: 'gutenberg',
 			currentRoute: undefined,
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+
+	it( 'keeps site-editor-only provider suggestions for Site Editor template post types', async () => {
+		mockCurrentPostType = 'wp_template';
+		mockContext = {
+			sectionName: 'site-editor',
+			currentRoute: '/wp-admin/site-editor.php?postType=wp_template',
 		};
 		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
 		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -46,6 +46,12 @@ const siteEditorSuggestion = {
 	prompt: 'Show me color palettes for my site that are:',
 };
 
+const jetpackSuggestion = {
+	id: 'proofread-content',
+	label: 'Proofread',
+	prompt: 'Proofread this saved content.',
+};
+
 function mockCoreStoreReady( isReady: boolean ) {
 	mockUseSelect.mockImplementation( ( mapSelect ) =>
 		mapSelect( ( storeName: string ) => {
@@ -274,6 +280,40 @@ describe( 'useEmptyViewSuggestions', () => {
 
 			await waitFor( () =>
 				expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+			);
+		}
+	);
+
+	it.each( [ 'wp_template', 'wp_template_part', 'wp_navigation', 'wp_block' ] )(
+		'refreshes provider suggestions when navigating from a page to %s and back',
+		async ( postType ) => {
+			window.history.pushState( {}, '', '/wp-admin/site-editor.php' );
+			mockContext = {
+				sectionName: 'site-editor',
+				currentRoute: '/wp-admin/site-editor.php',
+			};
+			mockCurrentPostType = 'page';
+			const getEmptyViewSuggestions = jest.fn( () => [
+				siteEditorSuggestion,
+				...( mockCurrentPostType === 'page' ? [ jetpackSuggestion ] : [] ),
+			] );
+			const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+			const { result, rerender } = renderHook( () =>
+				useEmptyViewSuggestions( { loadedProviders } )
+			);
+
+			await waitFor( () =>
+				expect( result.current ).toEqual( [ siteEditorSuggestion, jetpackSuggestion ] )
+			);
+
+			mockCurrentPostType = postType;
+			rerender();
+			await waitFor( () => expect( result.current ).toEqual( [ siteEditorSuggestion ] ) );
+
+			mockCurrentPostType = 'page';
+			rerender();
+			await waitFor( () =>
+				expect( result.current ).toEqual( [ siteEditorSuggestion, jetpackSuggestion ] )
 			);
 		}
 	);

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -237,6 +237,8 @@ export function useEmptyViewSuggestions( {
 		};
 	}, [ isReaderChat ] );
 
+	// Providers can key suggestions by entity type even when the coarse Site
+	// Editor surface flag stays true during client-side navigation.
 	useEffect( () => {
 		// Re-read override before the core-store readiness gate. Reader-chat
 		// suggestions come from the host page and do not depend on theme data.
@@ -303,6 +305,7 @@ export function useEmptyViewSuggestions( {
 		emptyViewSuggestions,
 		overrideVersion,
 		shouldShowSiteEditorSuggestions,
+		currentPostType,
 	] );
 
 	return emptyViewSuggestions;

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -20,6 +20,14 @@ const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
 	'what-else-can-i-do',
 ] );
 
+const SITE_EDITOR_POST_TYPES = new Set( [ 'wp_template', 'wp_template_part' ] );
+
+export const DEFAULT_EMPTY_VIEW_SUGGESTION_IDS = {
+	gettingStarted: 'getting-started',
+	createPost: 'create-post',
+	customizeSite: 'customize-site',
+} as const;
+
 /**
  * Hook to manage empty view suggestions, handling Big Sky's theme-dependent suggestions
  *
@@ -97,7 +105,7 @@ function getWindowPathname(): string {
 	return typeof window !== 'undefined' ? window.location.pathname : '';
 }
 
-function isPostEditorSurface( currentRoute?: string ): boolean {
+function isPostEditorRoute( currentRoute?: string ): boolean {
 	const pathname = getWindowPathname();
 	return (
 		!! currentRoute?.includes( 'post.php' ) ||
@@ -107,16 +115,29 @@ function isPostEditorSurface( currentRoute?: string ): boolean {
 	);
 }
 
-function isSiteEditorSurface( sectionName: string, currentRoute?: string ): boolean {
-	if ( isPostEditorSurface( currentRoute ) ) {
+function isSiteEditorRoute( currentRoute?: string ): boolean {
+	const pathname = getWindowPathname();
+	return !! currentRoute?.includes( 'site-editor.php' ) || pathname.includes( 'site-editor.php' );
+}
+
+function shouldShowSiteEditorSuggestionsForSurface(
+	sectionName: string,
+	currentRoute?: string,
+	currentPostType?: string
+): boolean {
+	if ( isSiteEditorRoute( currentRoute ) || SITE_EDITOR_POST_TYPES.has( currentPostType ?? '' ) ) {
+		return true;
+	}
+
+	if ( currentPostType ) {
+		return currentPostType === 'page';
+	}
+
+	if ( isPostEditorRoute( currentRoute ) ) {
 		return false;
 	}
 
-	return (
-		sectionName === 'site-editor' ||
-		!! currentRoute?.includes( 'site-editor.php' ) ||
-		getWindowPathname().includes( 'site-editor.php' )
-	);
+	return sectionName === 'site-editor';
 }
 
 function filterEmptyViewSuggestions(
@@ -136,23 +157,37 @@ export function useEmptyViewSuggestions( {
 }: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
 	const isReaderChat = isReaderChatHost();
 	const { sectionName, currentRoute } = useAgentsManagerContext();
-	const shouldShowSiteEditorSuggestions = isSiteEditorSurface( sectionName, currentRoute );
+	const currentPostType = useSelect( ( select ) => {
+		try {
+			const editorStore = select( 'core/editor' ) as {
+				getCurrentPostType?: () => string | undefined;
+			};
+			return editorStore?.getCurrentPostType?.();
+		} catch {
+			return undefined;
+		}
+	}, [] );
+	const shouldShowSiteEditorSuggestions = shouldShowSiteEditorSuggestionsForSurface(
+		sectionName,
+		currentRoute,
+		currentPostType
+	);
 
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(
 		() => [
 			{
-				id: 'getting-started',
+				id: DEFAULT_EMPTY_VIEW_SUGGESTION_IDS.gettingStarted,
 				label: __( 'Getting started with WordPress', __i18n_text_domain__ ),
 				prompt: __( 'How do I get started with WordPress?', __i18n_text_domain__ ),
 			},
 			{
-				id: 'create-post',
+				id: DEFAULT_EMPTY_VIEW_SUGGESTION_IDS.createPost,
 				label: __( 'Create a blog post', __i18n_text_domain__ ),
 				prompt: __( 'How do I create a blog post?', __i18n_text_domain__ ),
 			},
 			{
-				id: 'customize-site',
+				id: DEFAULT_EMPTY_VIEW_SUGGESTION_IDS.customizeSite,
 				label: __( 'Customize my site', __i18n_text_domain__ ),
 				prompt: __( 'How can I customize my site?', __i18n_text_domain__ ),
 			},
@@ -183,7 +218,7 @@ export function useEmptyViewSuggestions( {
 		[ hasBigSkySuggestions ]
 	);
 
-	// Compute empty view suggestions once when store is ready
+	// Compute empty view suggestions when store/context is ready.
 	const [ emptyViewSuggestions, setEmptyViewSuggestions ] = useState< Suggestion[] | null >( null );
 
 	// Signal that bumps whenever the host dispatches
@@ -221,9 +256,13 @@ export function useEmptyViewSuggestions( {
 			return;
 		}
 
-		if ( emptyViewSuggestions !== null ) {
-			return;
-		}
+		const setSuggestionsIfChanged = ( nextSuggestions: Suggestion[] ) => {
+			const nextKey = getSuggestionsKey( nextSuggestions );
+			const stateKey = getSuggestionsKey( emptyViewSuggestions );
+			if ( nextKey !== stateKey ) {
+				setEmptyViewSuggestions( nextSuggestions );
+			}
+		};
 
 		// Opt-out: a loaded provider can suppress the built-in defaults for
 		// its surfaces (e.g. WooCommerce AI doesn't want WordPress-flavored
@@ -233,7 +272,7 @@ export function useEmptyViewSuggestions( {
 
 		if ( ! hasBigSkySuggestions ) {
 			// No Big Sky suggestions provider, use defaults immediately
-			setEmptyViewSuggestions( fallbackSuggestions );
+			setSuggestionsIfChanged( fallbackSuggestions );
 		} else {
 			// Big Sky provides suggestions and store is ready - get filtered suggestions
 			const providerSuggestions = loadedProviders.getEmptyViewSuggestions?.() ?? [];
@@ -242,18 +281,18 @@ export function useEmptyViewSuggestions( {
 				shouldShowSiteEditorSuggestions
 			);
 			if ( suggestions.length > 0 ) {
-				setEmptyViewSuggestions( suggestions );
+				setSuggestionsIfChanged( suggestions );
 			} else if ( providerSuggestions.length > 0 ) {
 				// The provider returned suggestions, but all of them are hidden
 				// on this surface (for example Site Editor suggestions in the
 				// post editor). Keep the empty view empty instead of falling
 				// back to generic suggestions.
-				setEmptyViewSuggestions( [] );
+				setSuggestionsIfChanged( [] );
 			} else {
 				// Provider exists but returned empty/undefined (e.g. lazy proxy
 				// race where the IIFE hasn't set window globals yet). Fall back
 				// to defaults so the AM still renders.
-				setEmptyViewSuggestions( fallbackSuggestions );
+				setSuggestionsIfChanged( fallbackSuggestions );
 			}
 		}
 	}, [

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -495,7 +495,7 @@ describe( 'convertToolMessagesToComponents', () => {
 	const stalenessCases: Array< {
 		name: string;
 		data: Record< string, unknown >;
-		currentPostId?: number;
+		currentPostId?: number | string;
 		laterMessages?: UIMessage[];
 		disabled: boolean;
 	} > = [
@@ -514,6 +514,12 @@ describe( 'convertToolMessagesToComponents', () => {
 			name: 'stays enabled when `postId` matches `currentPostId`',
 			data: { type: 'my-component', isCurrent: true, postId: 10 },
 			currentPostId: 10,
+			disabled: false,
+		},
+		{
+			name: 'stays enabled when string `postId` matches `currentPostId`',
+			data: { type: 'my-component', isCurrent: true, postId: 'theme//front-page' },
+			currentPostId: 'theme//front-page',
 			disabled: false,
 		},
 		{

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -505,4 +505,20 @@ describe( 'mergeUseSuggestionsHooks', () => {
 		expect( firstHook ).toHaveBeenCalledWith( undefined, options );
 		expect( secondHook ).toHaveBeenCalledWith( undefined, options );
 	} );
+
+	it( 'uses only contextual suggestions when any provider replaces the empty view', () => {
+		const firstHook = jest.fn( () => ( {
+			suggestions: [ { id: 'first', label: 'First', prompt: 'First prompt.' } ],
+		} ) ) as UseSuggestionsHook;
+		const secondHook = jest.fn( () => ( {
+			suggestions: [ { id: 'second', label: 'Second', prompt: 'Second prompt.' } ],
+			replaceEmptyViewSuggestions: true,
+		} ) ) as UseSuggestionsHook;
+		const merged = mergeUseSuggestionsHooks( [ firstHook, secondHook ] );
+
+		expect( merged?.() ).toEqual( {
+			suggestions: [ { id: 'second', label: 'Second', prompt: 'Second prompt.' } ],
+			replaceEmptyViewSuggestions: true,
+		} );
+	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/merge-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/merge-empty-view-suggestions.test.ts
@@ -1,0 +1,57 @@
+import { DEFAULT_EMPTY_VIEW_SUGGESTION_IDS } from '../../hooks/use-empty-view-suggestions';
+import { mergeEmptyViewSuggestions } from '../merge-empty-view-suggestions';
+
+const customChip = {
+	id: 'customize-colors',
+	label: 'Customize colors',
+	prompt: 'Show me color palettes for my site.',
+};
+
+const dynamicSuggestion = {
+	id: 'improve-writing',
+	label: 'Improve writing',
+	prompt: 'Improve the writing in this post.',
+};
+
+const defaultChip = {
+	id: DEFAULT_EMPTY_VIEW_SUGGESTION_IDS.gettingStarted,
+	label: 'Getting started',
+	prompt: 'Help me get started.',
+};
+
+describe( 'mergeEmptyViewSuggestions', () => {
+	it( 'returns empty-view suggestions unchanged when there are no dynamic suggestions', () => {
+		expect( mergeEmptyViewSuggestions( [ customChip ], [] ) ).toEqual( [ customChip ] );
+	} );
+
+	it( 'replaces default empty-view chips with dynamic suggestions', () => {
+		expect( mergeEmptyViewSuggestions( [ defaultChip ], [ dynamicSuggestion ] ) ).toEqual( [
+			dynamicSuggestion,
+		] );
+	} );
+
+	it( 'shows custom provider chips alongside dynamic suggestions', () => {
+		expect( mergeEmptyViewSuggestions( [ customChip ], [ dynamicSuggestion ] ) ).toEqual( [
+			customChip,
+			dynamicSuggestion,
+		] );
+	} );
+
+	it( 'dedupes suggestions with the same id across provider chips and dynamic suggestions', () => {
+		const dynamicDuplicate = {
+			id: customChip.id,
+			label: 'Dynamic duplicate',
+			prompt: 'A dynamic suggestion sharing an id with a provider chip.',
+		};
+
+		expect(
+			mergeEmptyViewSuggestions( [ customChip ], [ dynamicDuplicate, dynamicSuggestion ] )
+		).toEqual( [ customChip, dynamicSuggestion ] );
+	} );
+
+	it( 'dedupes repeated ids within the dynamic suggestions', () => {
+		expect(
+			mergeEmptyViewSuggestions( [], [ dynamicSuggestion, { ...dynamicSuggestion } ] )
+		).toEqual( [ dynamicSuggestion ] );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/merge-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/merge-empty-view-suggestions.test.ts
@@ -37,6 +37,16 @@ describe( 'mergeEmptyViewSuggestions', () => {
 		] );
 	} );
 
+	it( 'replaces custom provider chips with contextual dynamic suggestions', () => {
+		expect( mergeEmptyViewSuggestions( [ customChip ], [ dynamicSuggestion ], true ) ).toEqual( [
+			dynamicSuggestion,
+		] );
+	} );
+
+	it( 'keeps contextual empty states empty instead of restoring provider chips', () => {
+		expect( mergeEmptyViewSuggestions( [ customChip ], [], true ) ).toEqual( [] );
+	} );
+
 	it( 'dedupes suggestions with the same id across provider chips and dynamic suggestions', () => {
 		const dynamicDuplicate = {
 			id: customChip.id,

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -15,7 +15,7 @@ export interface AgentsManagerUIMessage extends UIMessage {
 interface Options {
 	messages: UIMessage[];
 	getChatComponent?: GetChatComponent;
-	currentPostId?: number;
+	currentPostId?: number | string;
 }
 
 interface MessageWithContextFlags extends UIMessage {
@@ -212,7 +212,8 @@ export default function convertToolMessagesToComponents( {
 			// In the site editor, React-Query caching keeps past conversations alive when the
 			// user navigates to a different page. Compare the picker's `postId` with the
 			// current editor page to disable pickers that no longer belong to this page.
-			const isPageChanged = !! postId && !! currentPostId && postId !== currentPostId;
+			const isPageChanged =
+				!! postId && !! currentPostId && String( postId ) !== String( currentPostId );
 			const isStale = hasUserReplied || ! isCurrent || isPageChanged;
 
 			const componentMessage: AgentsManagerUIMessage = {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -71,6 +71,8 @@ export type UseSuggestionsHook = (
 	options?: { suggestionsVisible?: boolean }
 ) => {
 	suggestions: Suggestion[];
+	/** Whether contextual suggestions replace, rather than extend, the empty-view suggestions. */
+	replaceEmptyViewSuggestions?: boolean;
 } | void;
 
 export type SiteBuildUtils = {
@@ -205,8 +207,16 @@ export function mergeUseSuggestionsHooks(
 	return ( maxSuggestions?: number, options?: { suggestionsVisible?: boolean } ) => {
 		const combined: Suggestion[] = [];
 		const seenIds = new Set< string >();
-		for ( const hook of hooks ) {
-			const suggestions = hook( maxSuggestions, options )?.suggestions ?? [];
+		const results = hooks.map( ( hook ) => hook( maxSuggestions, options ) );
+		const replaceEmptyViewSuggestions = results.some(
+			( result ) => result?.replaceEmptyViewSuggestions === true
+		);
+
+		for ( const result of results ) {
+			if ( ! result || ( replaceEmptyViewSuggestions && ! result.replaceEmptyViewSuggestions ) ) {
+				continue;
+			}
+			const suggestions = result.suggestions ?? [];
 			for ( const s of suggestions ) {
 				if ( ! seenIds.has( s.id ) ) {
 					seenIds.add( s.id );
@@ -214,7 +224,10 @@ export function mergeUseSuggestionsHooks(
 				}
 			}
 		}
-		return { suggestions: combined };
+		return {
+			suggestions: combined,
+			...( replaceEmptyViewSuggestions && { replaceEmptyViewSuggestions: true } ),
+		};
 	};
 }
 

--- a/packages/agents-manager/src/utils/merge-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/utils/merge-empty-view-suggestions.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_EMPTY_VIEW_SUGGESTION_IDS } from '../hooks/use-empty-view-suggestions';
+import type { Suggestion } from '../types';
+
+const DEFAULT_EMPTY_VIEW_SUGGESTION_ID_SET = new Set< string >(
+	Object.values( DEFAULT_EMPTY_VIEW_SUGGESTION_IDS )
+);
+
+function isDefaultEmptyViewSuggestions( suggestions: Suggestion[] ): boolean {
+	return (
+		suggestions.length > 0 &&
+		suggestions.every( ( suggestion ) => DEFAULT_EMPTY_VIEW_SUGGESTION_ID_SET.has( suggestion.id ) )
+	);
+}
+
+export function mergeEmptyViewSuggestions(
+	emptyViewSuggestions: Suggestion[],
+	dynamicSuggestions: Suggestion[]
+): Suggestion[] {
+	if ( dynamicSuggestions.length === 0 ) {
+		return emptyViewSuggestions;
+	}
+
+	const combined: Suggestion[] = [];
+	const seenIds = new Set< string >();
+	// Contextual suggestions should replace generic defaults, but custom provider
+	// empty-view chips should be shown alongside them.
+	const baseSuggestions = isDefaultEmptyViewSuggestions( emptyViewSuggestions )
+		? []
+		: emptyViewSuggestions;
+
+	for ( const suggestion of [ ...baseSuggestions, ...dynamicSuggestions ] ) {
+		if ( ! seenIds.has( suggestion.id ) ) {
+			seenIds.add( suggestion.id );
+			combined.push( suggestion );
+		}
+	}
+
+	return combined;
+}

--- a/packages/agents-manager/src/utils/merge-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/utils/merge-empty-view-suggestions.ts
@@ -14,19 +14,21 @@ function isDefaultEmptyViewSuggestions( suggestions: Suggestion[] ): boolean {
 
 export function mergeEmptyViewSuggestions(
 	emptyViewSuggestions: Suggestion[],
-	dynamicSuggestions: Suggestion[]
+	dynamicSuggestions: Suggestion[],
+	replaceEmptyViewSuggestions = false
 ): Suggestion[] {
-	if ( dynamicSuggestions.length === 0 ) {
+	if ( dynamicSuggestions.length === 0 && ! replaceEmptyViewSuggestions ) {
 		return emptyViewSuggestions;
 	}
 
 	const combined: Suggestion[] = [];
 	const seenIds = new Set< string >();
-	// Contextual suggestions should replace generic defaults, but custom provider
-	// empty-view chips should be shown alongside them.
-	const baseSuggestions = isDefaultEmptyViewSuggestions( emptyViewSuggestions )
-		? []
-		: emptyViewSuggestions;
+	// Contextual suggestions always replace the empty view when requested.
+	// Otherwise they replace generic defaults and extend custom provider chips.
+	const baseSuggestions =
+		replaceEmptyViewSuggestions || isDefaultEmptyViewSuggestions( emptyViewSuggestions )
+			? []
+			: emptyViewSuggestions;
 
 	for ( const suggestion of [ ...baseSuggestions, ...dynamicSuggestions ] ) {
 		if ( ! seenIds.has( suggestion.id ) ) {

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
@@ -29,7 +29,12 @@ import {
 	toggleBlockReferenceFocus,
 	undoBlockEdit,
 } from '../utils/block-actions';
-import { countOccurrences, flattenBlocks } from '../utils/blocks';
+import {
+	countOccurrences,
+	flattenBlocks,
+	getEditorContentBlocks,
+	type BlockEditorStore,
+} from '../utils/blocks';
 import BlockRef, { type BlockSnapshot } from './block-ref';
 
 export interface FeedbackListItem {
@@ -232,9 +237,7 @@ export default function FeedbackList( {
 	const editSnapshots = useRef< Record< string, EditSnapshot > >( {} );
 
 	const blocks = useSelect(
-		( select ) =>
-			( select( 'core/block-editor' ) as { getBlocks?: () => BlockSnapshot[] } )?.getBlocks?.() ??
-			[],
+		( select ) => getEditorContentBlocks( select( 'core/block-editor' ) as BlockEditorStore ),
 		[]
 	);
 	const currentPostId = useSelect(

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
@@ -34,6 +34,7 @@ import {
 	flattenBlocks,
 	getEditorContentBlocks,
 	type BlockEditorStore,
+	type EditorStore,
 } from '../utils/blocks';
 import BlockRef, { type BlockSnapshot } from './block-ref';
 
@@ -237,7 +238,11 @@ export default function FeedbackList( {
 	const editSnapshots = useRef< Record< string, EditSnapshot > >( {} );
 
 	const blocks = useSelect(
-		( select ) => getEditorContentBlocks( select( 'core/block-editor' ) as BlockEditorStore ),
+		( select ) =>
+			getEditorContentBlocks(
+				select( 'core/block-editor' ) as BlockEditorStore,
+				select( 'core/editor' ) as EditorStore
+			),
 		[]
 	);
 	const currentPostId = useSelect(

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
@@ -58,6 +58,8 @@ interface SummaryNote {
 /** Root class name; prefixes every class this component renders. */
 const CLASS_PREFIX = 'jetpack-ai-feedback-list';
 
+export type EditorPostId = number | string;
+
 /**
  * Per-flow copy and options. The data props (summary/items/sections/postId)
  * come from the show-component payload; everything here is flow configuration.
@@ -66,7 +68,7 @@ export interface FeedbackListProps {
 	summary: string;
 	items?: FeedbackListItem[];
 	sections?: FeedbackListSection[];
-	postId?: number;
+	postId?: EditorPostId;
 	/** Title used when the flow provides flat items rather than sections. */
 	sectionFallbackTitle: string;
 	/** Label shown above a suggested rewrite, e.g. "Suggested rewrite". */
@@ -92,7 +94,7 @@ interface EditSnapshot {
 	editableAttribute?: string;
 }
 
-type WpCurrentPostStore = { getCurrentPostId?: () => number | null };
+type WpCurrentPostStore = { getCurrentPostId?: () => EditorPostId | null };
 type WpDataWindow = {
 	wp?: {
 		data?: {
@@ -101,12 +103,22 @@ type WpDataWindow = {
 	};
 };
 
-function getCurrentEditorPostIdFromStore(): number | undefined {
+function normalizeEditorPostId( postId: unknown ): EditorPostId | undefined {
+	if ( typeof postId === 'number' && postId > 0 ) {
+		return postId;
+	}
+	if ( typeof postId === 'string' && postId.trim() ) {
+		return postId;
+	}
+	return undefined;
+}
+
+function getCurrentEditorPostIdFromStore(): EditorPostId | undefined {
 	try {
 		const postId = ( window as unknown as WpDataWindow ).wp?.data
 			?.select?.( 'core/editor' )
 			?.getCurrentPostId?.();
-		return typeof postId === 'number' && postId > 0 ? postId : undefined;
+		return normalizeEditorPostId( postId );
 	} catch {
 		return undefined;
 	}
@@ -227,7 +239,9 @@ export default function FeedbackList( {
 	);
 	const currentPostId = useSelect(
 		( select ) =>
-			( select( 'core/editor' ) as WpCurrentPostStore )?.getCurrentPostId?.() ?? undefined,
+			normalizeEditorPostId(
+				( select( 'core/editor' ) as WpCurrentPostStore )?.getCurrentPostId?.()
+			),
 		[]
 	);
 	const flatBlocks = useMemo( () => flattenBlocks( blocks ), [ blocks ] );
@@ -235,10 +249,10 @@ export default function FeedbackList( {
 		() => normaliseSections( sectionFallbackTitle, items, sections ),
 		[ sectionFallbackTitle, items, sections ]
 	);
-	const isPostStale = ! postId || ! currentPostId || postId !== currentPostId;
+	const isPostStale = ! postId || ! currentPostId || String( postId ) !== String( currentPostId );
 	const isLatestPostContextStale = useCallback( () => {
 		const latestCurrentPostId = getCurrentEditorPostIdFromStore() ?? currentPostId;
-		return ! postId || ! latestCurrentPostId || postId !== latestCurrentPostId;
+		return ! postId || ! latestCurrentPostId || String( postId ) !== String( latestCurrentPostId );
 	}, [ currentPostId, postId ] );
 	const setItemStatus = useCallback( ( key: string, status: ItemStatus ) => {
 		setItemStatuses( ( prev ) => ( { ...prev, [ key ]: status } ) );

--- a/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
@@ -14,13 +14,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import FeedbackList, { type FeedbackListItem, type FeedbackListSection } from './feedback-list';
+import FeedbackList, {
+	type EditorPostId,
+	type FeedbackListItem,
+	type FeedbackListSection,
+} from './feedback-list';
 
 export interface PostFeedbackProps {
 	summary: string;
 	items?: FeedbackListItem[];
 	sections?: FeedbackListSection[];
-	postId?: number;
+	postId?: EditorPostId;
 }
 
 /**

--- a/packages/jetpack-ai-sidebar/src/components/proofread.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/proofread.tsx
@@ -12,13 +12,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import FeedbackList, { type FeedbackListItem, type FeedbackListSection } from './feedback-list';
+import FeedbackList, {
+	type EditorPostId,
+	type FeedbackListItem,
+	type FeedbackListSection,
+} from './feedback-list';
 
 export interface ProofreadProps {
 	summary: string;
 	items?: FeedbackListItem[];
 	sections?: FeedbackListSection[];
-	postId?: number;
+	postId?: EditorPostId;
 }
 
 /**

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
@@ -86,7 +86,11 @@ jest.mock( '@wordpress/data', () => ( {
 				return { getBlocks: () => mockBlocks };
 			}
 			if ( store === 'core/editor' ) {
-				return { getCurrentPostId: () => mockCurrentPostId };
+				return {
+					getCurrentPostId: () => mockCurrentPostId,
+					getCurrentPostType: () => 'post',
+					getRenderingMode: () => 'post-only',
+				};
 			}
 			return {};
 		} ),

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -83,6 +83,8 @@ interface GuidelineViolation {
 	issue: string;
 }
 
+type EditorPostId = number | string;
+
 interface ReviewMediationProps {
 	summary: string;
 	conflicts: Conflict[];
@@ -91,7 +93,7 @@ interface ReviewMediationProps {
 	guideline_violations: GuidelineViolation[];
 	review_context?: ReviewContext;
 	/** Source post the review was generated for. Used to detect navigation to a different post. */
-	postId?: number;
+	postId?: EditorPostId;
 	/**
 	 * Server-built map keyed by reviewer display name. Optional — older
 	 * mediations or the empty-state payload may omit it; consumers degrade
@@ -109,7 +111,7 @@ interface ReviewMediationProps {
 }
 
 type EditStatus = 'pending' | 'applying' | 'accepted' | 'dismissed' | 'failed';
-type WpCurrentPostStore = { getCurrentPostId?: () => number | null };
+type WpCurrentPostStore = { getCurrentPostId?: () => EditorPostId | null };
 type WpGlobal = Window & {
 	wp?: {
 		data?: {
@@ -118,12 +120,22 @@ type WpGlobal = Window & {
 	};
 };
 
-function getCurrentEditorPostIdFromStore(): number | undefined {
+function normalizeEditorPostId( postId: unknown ): EditorPostId | undefined {
+	if ( typeof postId === 'number' && postId > 0 ) {
+		return postId;
+	}
+	if ( typeof postId === 'string' && postId.trim() ) {
+		return postId;
+	}
+	return undefined;
+}
+
+function getCurrentEditorPostIdFromStore(): EditorPostId | undefined {
 	if ( typeof window === 'undefined' ) {
 		return undefined;
 	}
 	const wp = ( window as WpGlobal ).wp;
-	return wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.() ?? undefined;
+	return normalizeEditorPostId( wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.() );
 }
 
 /**
@@ -313,20 +325,17 @@ export default function ReviewMediation( {
 	reviewers_metadata,
 	cached_at,
 }: ReviewMediationProps ) {
-	// Review actions are only safe when the result can be tied to the current editor post.
-	const currentPostId = useSelect(
-		( select ) =>
-			(
-				select( 'core/editor' ) as { getCurrentPostId?: () => number | null }
-			 )?.getCurrentPostId?.() ?? undefined,
-		[]
-	);
-	const isPostStale = ! postId || ! currentPostId || postId !== currentPostId;
+	// Review actions are only safe when the result can be tied to the current editor entity.
+	const currentPostId = useSelect( ( select ) => {
+		const editor = select( 'core/editor' ) as WpCurrentPostStore;
+		return normalizeEditorPostId( editor?.getCurrentPostId?.() );
+	}, [] );
+	const isPostStale = ! postId || ! currentPostId || String( postId ) !== String( currentPostId );
 	const isLatestPostContextStale = useCallback( () => {
 		// Async edit guards must read the editor store at call time so navigation
 		// between the click and delayed block write is observed immediately.
 		const latestCurrentPostId = getCurrentEditorPostIdFromStore() ?? currentPostId;
-		return ! postId || ! latestCurrentPostId || postId !== latestCurrentPostId;
+		return ! postId || ! latestCurrentPostId || String( postId ) !== String( latestCurrentPostId );
 	}, [ currentPostId, postId ] );
 
 	const [ editStatuses, setEditStatuses ] = useState< Record< number, EditStatus > >( {} );

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -27,6 +27,7 @@ import {
 	flattenBlocks,
 	getEditorContentBlocks,
 	type BlockEditorStore,
+	type EditorStore,
 } from '../utils/blocks';
 import {
 	trackAiEditorialReviewItemAction,
@@ -409,7 +410,8 @@ export default function ReviewMediation( {
 	// Matches wpcom's recursive Review_Mediator_Ability::extract_blocks() order.
 	const blocks = useSelect( ( select ) => {
 		const contentBlocks = getEditorContentBlocks(
-			select( 'core/block-editor' ) as BlockEditorStore
+			select( 'core/block-editor' ) as BlockEditorStore,
+			select( 'core/editor' ) as EditorStore
 		);
 		return flattenBlocks( contentBlocks );
 	}, [] );

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -22,7 +22,12 @@ import {
 	toggleBlockReferenceFocus,
 	undoBlockEdit,
 } from '../utils/block-actions';
-import { countOccurrences, flattenBlocks } from '../utils/blocks';
+import {
+	countOccurrences,
+	flattenBlocks,
+	getEditorContentBlocks,
+	type BlockEditorStore,
+} from '../utils/blocks';
 import {
 	trackAiEditorialReviewItemAction,
 	trackAiEditorialReviewResultRendered,
@@ -403,10 +408,10 @@ export default function ReviewMediation( {
 	// Flat pre-order list of blocks; ability's `block_index` maps to this array.
 	// Matches wpcom's recursive Review_Mediator_Ability::extract_blocks() order.
 	const blocks = useSelect( ( select ) => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const rootBlocks = ( ( select as any )( 'core/block-editor' ).getBlocks?.() ??
-			[] ) as BlockSnapshot[];
-		return flattenBlocks( rootBlocks );
+		const contentBlocks = getEditorContentBlocks(
+			select( 'core/block-editor' ) as BlockEditorStore
+		);
+		return flattenBlocks( contentBlocks );
 	}, [] );
 
 	const getBlock = useCallback(

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -278,14 +278,16 @@ function SuggestionsProbe( {
 	maxSuggestions,
 	suggestionsVisible = true,
 }: {
-	onSuggestions: ( suggestions: any[] ) => void;
+	onSuggestions: ( suggestions: any[], replaceEmptyViewSuggestions?: boolean ) => void;
 	maxSuggestions?: number;
 	suggestionsVisible?: boolean;
 } ) {
-	const { suggestions } = useSuggestions( maxSuggestions, { suggestionsVisible } );
+	const { suggestions, replaceEmptyViewSuggestions } = useSuggestions( maxSuggestions, {
+		suggestionsVisible,
+	} );
 	React.useEffect( () => {
-		onSuggestions( suggestions );
-	}, [ onSuggestions, suggestions ] );
+		onSuggestions( suggestions, replaceEmptyViewSuggestions );
+	}, [ onSuggestions, replaceEmptyViewSuggestions, suggestions ] );
 	return null;
 }
 
@@ -1350,6 +1352,11 @@ describe( 'getEmptyViewSuggestions', () => {
 
 describe( 'useSuggestions', () => {
 	beforeEach( () => {
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: false,
+		} as any );
 		mockSelectedBlock = null;
 		mockBlocksByClientId = {};
 		mockCurrentPostType = 'post';
@@ -1436,6 +1443,35 @@ describe( 'useSuggestions', () => {
 				},
 			],
 		] );
+	} );
+
+	it( 'replaces editor-level empty-view suggestions when a block is selected', () => {
+		installAiEditorialReviewData( { proofreadContent: true } );
+		mockSelectedBlock = { clientId: 'b-context', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestCall = onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ];
+		expect( latestCall?.[ 0 ].map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
+		expect( latestCall?.[ 1 ] ).toBe( true );
+	} );
+
+	it( 'does not fall back to editor-level suggestions for unsupported selected blocks', () => {
+		installAiEditorialReviewData( { proofreadContent: true } );
+		mockSelectedBlock = { clientId: 'b-unsupported', name: 'core/list' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestCall = onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ];
+		expect( latestCall?.[ 0 ] ).toEqual( [] );
+		expect( latestCall?.[ 1 ] ).toBe( true );
 	} );
 
 	it( 'limits block-specific suggestions to maxSuggestions', () => {
@@ -1940,6 +1976,40 @@ describe( 'useSuggestions', () => {
 			'Check grammar',
 			'Simplify text',
 		] );
+	} );
+
+	it( 'keeps block suggestions hidden after a Proofread request finishes', () => {
+		installAiEditorialReviewData( { proofreadContent: true } );
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'b-proofread', name: 'core/paragraph' };
+		const proofreadPrompt = getEmptyViewSuggestions().find(
+			( suggestion ) => suggestion.id === 'proofread-content'
+		)?.prompt;
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: proofreadPrompt },
+				} )
+			);
+			useAbilitiesSetup( {
+				addMessage: () => undefined,
+				clearSuggestions: () => undefined,
+				isProcessing: true,
+			} as any );
+			useAbilitiesSetup( {
+				addMessage: () => undefined,
+				clearSuggestions: () => undefined,
+				isProcessing: false,
+			} as any );
+		} );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions ).toEqual( [] );
 	} );
 
 	it( 'does not start the selected block shimmer when a suggestion is only selected', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -141,8 +141,14 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 // Stub @wordpress/data on window so useCheckpoint / handleShowComponent
-// can read/write the post title and current post id via the core/editor store.
-function installWpDataMock( initialTitle: string, postId = 123, initialExcerpt = '' ) {
+// can read/write the post title and current editor entity id via the core/editor store.
+type EditorPostId = number | string;
+
+function installWpDataMock(
+	initialTitle: string,
+	postId: EditorPostId | null = 123,
+	initialExcerpt = ''
+) {
 	const state = { title: initialTitle, excerpt: initialExcerpt };
 	( window as any ).wp = {
 		data: {
@@ -185,7 +191,7 @@ function installWpDataMock( initialTitle: string, postId = 123, initialExcerpt =
 
 function installPostTypeMock(
 	postType?: string,
-	postId: number | null = 123,
+	postId: EditorPostId | null = 123,
 	supportsExcerpt: boolean = postType === 'post',
 	postTypeRecordResolved = true
 ) {
@@ -219,7 +225,7 @@ function installPostTypeMock(
 	};
 }
 
-function installContextProviderMock( postType = 'post', postId: number | null = 123 ) {
+function installContextProviderMock( postType = 'post', postId: EditorPostId | null = 123 ) {
 	const blocks = [
 		{
 			name: 'core/paragraph',
@@ -1030,14 +1036,53 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( labels ).toContain( 'Simple Review' );
 	} );
 
-	it( 'hides Editorial Review on page editors', () => {
+	it( 'shows Editorial Review on page editors', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'page' );
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'Simple Review' );
+	} );
+
+	it( 'shows all enabled editor-level suggestions on page editors', () => {
+		installAiEditorialReviewData( {
+			optimizeTitleSuggestion: true,
+			excerptSuggestion: true,
+			proofreadContent: true,
+		} );
+		installPostTypeMock( 'page', 123, true );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).toEqual( [
+			'Optimize Title',
+			'Generate Excerpt',
+			'Simple Review',
+			'Proofread',
+			'Editorial Review',
+		] );
+	} );
+
+	it( 'shows all enabled editor-level suggestions on site editor templates', () => {
+		installAiEditorialReviewData( {
+			optimizeTitleSuggestion: true,
+			excerptSuggestion: true,
+			proofreadContent: true,
+		} );
+		installPostTypeMock( 'wp_template', 'theme//front-page', true );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).toEqual( [
+			'Optimize Title',
+			'Generate Excerpt',
+			'Simple Review',
+			'Proofread',
+			'Editorial Review',
+		] );
 	} );
 
 	it( 'hides Editorial Review until the post type is known', () => {
@@ -1050,7 +1095,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( labels ).not.toContain( 'Editorial Review' );
 	} );
 
-	it( 'hides Simple Review until the post has a saved post ID', () => {
+	it( 'hides Simple Review until the editor entity has a saved ID', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post', null );
 
@@ -1084,7 +1129,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		);
 	} );
 
-	it( 'hides Proofread until the post has a saved post ID', () => {
+	it( 'hides Proofread until the editor entity has a saved ID', () => {
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installPostTypeMock( 'post', null );
 
@@ -1198,10 +1243,19 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( ids ).toContain( 'generate-excerpt' );
 	} );
 
-	it( 'hides Generate Excerpt for templates and patterns even though they support excerpts', () => {
+	it( 'shows Generate Excerpt for site editor templates that support excerpts', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		installPostTypeMock( 'wp_template', 123, true );
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-excerpt' );
+	} );
+
+	it( 'hides Generate Excerpt for patterns even though they support excerpts', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		// Core registers excerpt support for wp_block (patterns), but the excerpt
-		// field acts as a description there — the legacy panel excludes these types.
+		// field acts as a description there — the chip still excludes patterns.
 		installPostTypeMock( 'wp_block', 123, true );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
@@ -1434,7 +1488,7 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
-	it( 'shows post-level suggestions after the selected-block chip is cleared', () => {
+	it( 'shows editor-level suggestions after the selected-block chip is cleared', () => {
 		installAiEditorialReviewData();
 		const block = { clientId: 'b-clear', name: 'core/paragraph' };
 		mockSelectedBlock = block;
@@ -1839,8 +1893,8 @@ describe( 'useSuggestions', () => {
 
 	it( 'does not open split-screen when Editorial Review is unavailable', () => {
 		installAiEditorialReviewData();
-		mockCurrentPostType = 'page';
-		installPostTypeMock( 'page' );
+		mockCurrentPostType = 'product';
+		installPostTypeMock( 'product' );
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 
@@ -2339,7 +2393,7 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.props.postId ).toBe( 123 );
 		} );
 
-		it( 'stamps post-feedback components with the current post ID', async () => {
+		it( 'stamps post-feedback components with the current editor entity ID', async () => {
 			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
 				type: 'post-feedback',
 				props: {
@@ -2356,6 +2410,24 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.hideZoomAction ).toBe( true );
 			expect( parsed.data.postId ).toBe( 123 );
 			expect( parsed.data.props.postId ).toBe( 123 );
+		} );
+
+		it( 'stamps post-feedback components with the current site editor entity ID', async () => {
+			installWpDataMock( 'Original Title', 'theme//front-page' );
+
+			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
+				type: 'post-feedback',
+				props: {
+					summary: 'Summary.',
+					items: [],
+				},
+				toolCallId: 'call_post_feedback_template',
+			} ) ) as any;
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( parsed.data.type ).toBe( 'post-feedback' );
+			expect( parsed.data.postId ).toBe( 'theme//front-page' );
+			expect( parsed.data.props.postId ).toBe( 'theme//front-page' );
 		} );
 
 		it( 'preserves the reviewed post ID on post-feedback components', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -144,6 +144,20 @@ jest.mock( '@wordpress/data', () => ( {
 // can read/write the post title and current editor entity id via the core/editor store.
 type EditorPostId = number | string;
 
+const UNSUPPORTED_POST_LEVEL_SUGGESTION_ENTITIES: Array<
+	[ label: string, postType: string | undefined, postId: EditorPostId | null ]
+> = [
+	[ 'templates', 'wp_template', 'theme//front-page' ],
+	[ 'template parts', 'wp_template_part', 'theme//header' ],
+	[ 'patterns', 'wp_block', 456 ],
+	[ 'navigation', 'wp_navigation', 123 ],
+	[ 'global styles', 'wp_global_styles', 789 ],
+	[ 'Site Editor dashboard/list views', undefined, null ],
+	[ 'Jetpack Forms', 'jetpack_form', 101 ],
+	[ 'Jetpack Search overlays', 'jp_search_overlay', 102 ],
+	[ 'other custom post types', 'custom_post_type', 103 ],
+];
+
 function installWpDataMock(
 	initialTitle: string,
 	postId: EditorPostId | null = 123,
@@ -1068,24 +1082,22 @@ describe( 'getEmptyViewSuggestions', () => {
 		] );
 	} );
 
-	it.each( [
-		[ 'wp_template', 'theme//front-page' ],
-		[ 'wp_template_part', 'theme//header' ],
-		[ 'wp_navigation', 123 ],
-		[ 'wp_block', 456 ],
-	] )( 'hides all Jetpack AI suggestions for %s entities', ( postType, postId ) => {
-		installAiEditorialReviewData( {
-			optimizeTitleSuggestion: true,
-			excerptSuggestion: true,
-			proofreadContent: true,
-			seoSuggestions: true,
-		} );
-		installPostTypeMock( postType, postId, true );
+	it.each( UNSUPPORTED_POST_LEVEL_SUGGESTION_ENTITIES )(
+		'hides all post-level Jetpack AI suggestions for %s',
+		( _label, postType, postId ) => {
+			installAiEditorialReviewData( {
+				optimizeTitleSuggestion: true,
+				excerptSuggestion: true,
+				proofreadContent: true,
+				seoSuggestions: true,
+			} );
+			installPostTypeMock( postType, postId, true );
 
-		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+			const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
-		expect( labels ).toEqual( [] );
-	} );
+			expect( labels ).toEqual( [] );
+		}
+	);
 
 	it( 'hides Editorial Review until the post type is known', () => {
 		installAiEditorialReviewData();
@@ -1474,9 +1486,9 @@ describe( 'useSuggestions', () => {
 		expect( latestCall?.[ 1 ] ).toBe( true );
 	} );
 
-	it.each( [ 'wp_template', 'wp_template_part', 'wp_navigation', 'wp_block' ] )(
-		'hides editor-level Jetpack AI suggestions for %s entities',
-		( postType ) => {
+	it.each( UNSUPPORTED_POST_LEVEL_SUGGESTION_ENTITIES )(
+		'hides dynamic post-level Jetpack AI suggestions for %s',
+		( _label, postType ) => {
 			installAiEditorialReviewData( {
 				optimizeTitleSuggestion: true,
 				proofreadContent: true,

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1068,23 +1068,23 @@ describe( 'getEmptyViewSuggestions', () => {
 		] );
 	} );
 
-	it( 'shows all enabled editor-level suggestions on site editor templates', () => {
+	it.each( [
+		[ 'wp_template', 'theme//front-page' ],
+		[ 'wp_template_part', 'theme//header' ],
+		[ 'wp_navigation', 123 ],
+		[ 'wp_block', 456 ],
+	] )( 'hides all Jetpack AI suggestions for %s entities', ( postType, postId ) => {
 		installAiEditorialReviewData( {
 			optimizeTitleSuggestion: true,
 			excerptSuggestion: true,
 			proofreadContent: true,
+			seoSuggestions: true,
 		} );
-		installPostTypeMock( 'wp_template', 'theme//front-page', true );
+		installPostTypeMock( postType, postId, true );
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
-		expect( labels ).toEqual( [
-			'Optimize Title',
-			'Generate Excerpt',
-			'Simple Review',
-			'Proofread',
-			'Editorial Review',
-		] );
+		expect( labels ).toEqual( [] );
 	} );
 
 	it( 'hides Editorial Review until the post type is known', () => {
@@ -1245,13 +1245,13 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( ids ).toContain( 'generate-excerpt' );
 	} );
 
-	it( 'shows Generate Excerpt for site editor templates that support excerpts', () => {
+	it( 'hides Generate Excerpt for site editor templates that support excerpts', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		installPostTypeMock( 'wp_template', 123, true );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
-		expect( ids ).toContain( 'generate-excerpt' );
+		expect( ids ).not.toContain( 'generate-excerpt' );
 	} );
 
 	it( 'hides Generate Excerpt for patterns even though they support excerpts', () => {
@@ -1471,6 +1471,43 @@ describe( 'useSuggestions', () => {
 
 		const latestCall = onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ];
 		expect( latestCall?.[ 0 ] ).toEqual( [] );
+		expect( latestCall?.[ 1 ] ).toBe( true );
+	} );
+
+	it.each( [ 'wp_template', 'wp_template_part', 'wp_navigation', 'wp_block' ] )(
+		'hides editor-level Jetpack AI suggestions for %s entities',
+		( postType ) => {
+			installAiEditorialReviewData( {
+				optimizeTitleSuggestion: true,
+				proofreadContent: true,
+				seoSuggestions: true,
+			} );
+			mockCurrentPostType = postType;
+			const onSuggestions = jest.fn();
+
+			render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+			const latestCall = onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ];
+			expect( latestCall?.[ 0 ] ).toEqual( [] );
+			expect( latestCall?.[ 1 ] ).toBe( false );
+		}
+	);
+
+	it( 'keeps selected-block suggestions on template entities', () => {
+		installAiEditorialReviewData();
+		mockCurrentPostType = 'wp_template';
+		mockSelectedBlock = { clientId: 'template-paragraph', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestCall = onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ];
+		expect( latestCall?.[ 0 ].map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
 		expect( latestCall?.[ 1 ] ).toBe( true );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -42,7 +42,6 @@ import {
 	getSelectedOrRememberedBlock,
 	rememberSelectedBlock,
 	clearRememberedSelectedBlock,
-	notifyBlockActionComplete,
 	BLOCK_ACTION_COMPLETE_EVENT,
 	SELECTED_BLOCK_CLEAR_EVENT,
 } from './utils/block-actions';
@@ -593,7 +592,6 @@ export function useAbilitiesSetup( actions: {
 		startBlockShimmer();
 	} else if ( ! isProcessing && wasAgentProcessing ) {
 		stopBlockShimmer();
-		notifyBlockActionComplete();
 	}
 	wasAgentProcessing = isProcessing;
 }
@@ -1212,7 +1210,8 @@ export const capabilities = {
  * Block-aware dynamic suggestions for the AM sidebar.
  *
  * Returns contextual suggestions based on the selected block type.
- * Hides permanently once the conversation becomes active.
+ * Hides after a suggestion is clicked, then restores block suggestions only
+ * after a block action completes.
  * @returns {Object} Object containing a suggestions array.
  */
 export function useSuggestions(
@@ -1226,6 +1225,7 @@ export function useSuggestions(
 		prompt?: string;
 		options?: SuggestionOption[];
 	} >;
+	replaceEmptyViewSuggestions: boolean;
 } {
 	const [ hidden, setHidden ] = useState( false );
 
@@ -1237,11 +1237,11 @@ export function useSuggestions(
 			clearSuggestionsFn?.();
 			suppressCurrentPageContentForNextContext = false;
 
-			// Review-style responses are dense, so auto-expand those suggestion
-			// flows to 50vw when they are started from chips.
 			if ( typeof value === 'string' ) {
 				trackBlockTransformationSuggestionClickForValue( value );
 			}
+
+			// Auto-expand the review-style chip flows below to 50vw.
 			if ( typeof value === 'string' && value === POST_FEEDBACK_SUGGESTION.prompt ) {
 				suppressCurrentPageContentForNextContext = true;
 				try {
@@ -1423,5 +1423,10 @@ export function useSuggestions(
 		visibleBlockTransformationSuggestionsKey,
 	] );
 
-	return { suggestions: visibleSuggestions };
+	return {
+		suggestions: visibleSuggestions,
+		// Any selected block owns the suggestion surface, even when that block has
+		// no contextual actions, so whole-post suggestions never leak into block context.
+		replaceEmptyViewSuggestions: !! selectedBlock,
+	};
 }

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -259,17 +259,9 @@ function currentPostTypeSupportsExcerpt(
 }
 
 /**
- * Post types where the excerpt field acts as a description. Core registers
- * excerpt support for wp_block (patterns), but the chip excludes patterns.
+ * Editor entities that support whole-content Jetpack AI suggestions.
  */
-const EDITOR_LEVEL_SUGGESTION_POST_TYPES = new Set( [
-	'post',
-	'page',
-	'wp_template',
-	'wp_template_part',
-] );
-
-const EXCERPT_EXCLUDED_POST_TYPES = [ 'wp_block' ];
+const EDITOR_LEVEL_SUGGESTION_POST_TYPES = new Set( [ 'post', 'page' ] );
 
 function isEditorLevelSuggestionPostType(
 	currentPostType: string | undefined = getCurrentEditorPostType()
@@ -286,7 +278,7 @@ function isExcerptSuggestionAvailable(
 	if ( ! isExcerptSuggestionEnabled() ) {
 		return false;
 	}
-	if ( ! currentPostType || EXCERPT_EXCLUDED_POST_TYPES.includes( currentPostType ) ) {
+	if ( ! currentPostType ) {
 		return false;
 	}
 	return supportsExcerpt ?? currentPostTypeSupportsExcerpt( currentPostType );
@@ -340,6 +332,10 @@ function getPostLevelSuggestions(
 	currentPostId?: EditorPostId | null,
 	supportsExcerpt?: boolean
 ) {
+	if ( ! isEditorLevelSuggestionPostType( currentPostType ) ) {
+		return [];
+	}
+
 	return [
 		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
 		...( isExcerptSuggestionAvailable( currentPostType, supportsExcerpt )
@@ -909,7 +905,7 @@ export function getEmptyViewSuggestions(): Array< {
 	prompt?: string;
 	options?: SuggestionOption[];
 } > {
-	return getPostLevelSuggestions();
+	return getPostLevelSuggestions( getCurrentEditorPostType() );
 }
 
 // ---------- useSuggestions ----------

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -103,7 +103,7 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 };
 
 /**
- * Post-level suggestion to generate the post excerpt. Routes through the
+ * Editor-level suggestion to generate the current content excerpt. Routes through the
  * orchestrator to the jetpack-ai/generate-excerpt ability, which returns the
  * excerpt picker. The prompt is deliberately parameter-free: words/tone
  * defaults live server-side, and the picker intro invites adjustments.
@@ -116,15 +116,15 @@ const GENERATE_EXCERPT_SUGGESTION = {
 };
 
 /**
- * Post-level SEO Enhancer suggestion. Targets the post's SEO surfaces (the HTML
+ * Editor-level SEO Enhancer suggestion. Targets the content's SEO surfaces (the HTML
  * <title>, meta description, and image alt text), distinct from
  * OPTIMIZE_TITLE_SUGGESTION which rewrites the visible post title. Rendered as a
  * dropdown (via the `options` field): picking Title, Description or Image Alt
  * Text submits that option's `value`, which routes through the orchestrator to
  * the jetpack-ai/generate-seo-title, jetpack-ai/generate-seo-description or jetpack-ai/generate-seo-image-alt-text
- * ability and returns the matching picker. Alt text is post-level here (every
- * image in the post); the block-level `generate-alt-text` suggestion still
- * targets a single selected image.
+ * ability and returns the matching picker. Alt text is content-level here
+ * (every image in the editor content); the block-level `generate-alt-text`
+ * suggestion still targets a single selected image.
  *
  * `prompt` is intentionally empty: the dropdown combines `prompt` with the
  * selected option's `value`, so an empty prompt makes the submitted text equal
@@ -162,7 +162,7 @@ const SEO_ENHANCER_SUGGESTION = {
 };
 
 /**
- * Post-level suggestion to run AI Editorial Review on a draft.
+ * Editor-level suggestion to run AI Editorial Review on saved content.
  *
  * The id remains stable because saved chats/tests may still refer to the
  * original review-mediation identifier.
@@ -205,14 +205,27 @@ const LIMITED_BLOCK_SUGGESTION_PRIORITY = [
 	'generate-alt-text',
 ];
 
+type EditorPostId = number | string;
+
 function getCurrentEditorPostType(): string | undefined {
 	const postType = ( window as any ).wp?.data?.select?.( 'core/editor' )?.getCurrentPostType?.();
 	return typeof postType === 'string' ? postType : undefined;
 }
 
-function getCurrentEditorPostId(): number | undefined {
-	const postId = ( window as any ).wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.();
-	return typeof postId === 'number' && postId > 0 ? postId : undefined;
+function normalizeEditorPostId( postId: unknown ): EditorPostId | undefined {
+	if ( typeof postId === 'number' && postId > 0 ) {
+		return postId;
+	}
+	if ( typeof postId === 'string' && postId.trim() ) {
+		return postId;
+	}
+	return undefined;
+}
+
+function getCurrentEditorPostId(): EditorPostId | undefined {
+	return normalizeEditorPostId(
+		( window as any ).wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.()
+	);
 }
 
 /**
@@ -247,11 +260,23 @@ function currentPostTypeSupportsExcerpt(
 }
 
 /**
- * Post types where the excerpt field acts as a description (templates,
- * template parts, patterns). Core registers excerpt support for wp_block, but
- * the legacy AI Excerpt panel excludes these types and so does the chip.
+ * Post types where the excerpt field acts as a description. Core registers
+ * excerpt support for wp_block (patterns), but the chip excludes patterns.
  */
-const EXCERPT_EXCLUDED_POST_TYPES = [ 'wp_template', 'wp_template_part', 'wp_block' ];
+const EDITOR_LEVEL_SUGGESTION_POST_TYPES = new Set( [
+	'post',
+	'page',
+	'wp_template',
+	'wp_template_part',
+] );
+
+const EXCERPT_EXCLUDED_POST_TYPES = [ 'wp_block' ];
+
+function isEditorLevelSuggestionPostType(
+	currentPostType: string | undefined = getCurrentEditorPostType()
+): boolean {
+	return EDITOR_LEVEL_SUGGESTION_POST_TYPES.has( currentPostType ?? '' );
+}
 
 function isExcerptSuggestionAvailable(
 	currentPostType: string | undefined = getCurrentEditorPostType(),
@@ -273,21 +298,27 @@ function isAiEditorialReviewAvailable(
 	// want the current editor state read live.
 	currentPostType: string | undefined = getCurrentEditorPostType()
 ): boolean {
-	return isAiEditorialReviewEnabled() && currentPostType === 'post';
+	return isAiEditorialReviewEnabled() && isEditorLevelSuggestionPostType( currentPostType );
 }
 
 function isGenerateFeedbackAvailable(
 	currentPostType: string | undefined = getCurrentEditorPostType(),
-	currentPostId: number | null | undefined = getCurrentEditorPostId()
+	currentPostId: EditorPostId | null | undefined = getCurrentEditorPostId()
 ): boolean {
-	return isGenerateFeedbackEnabled() && currentPostType === 'post' && !! currentPostId;
+	return (
+		isGenerateFeedbackEnabled() &&
+		isEditorLevelSuggestionPostType( currentPostType ) &&
+		!! currentPostId
+	);
 }
 
 function isProofreadAvailable(
 	currentPostType: string | undefined = getCurrentEditorPostType(),
-	currentPostId: number | null | undefined = getCurrentEditorPostId()
+	currentPostId: EditorPostId | null | undefined = getCurrentEditorPostId()
 ): boolean {
-	return isProofreadEnabled() && currentPostType === 'post' && !! currentPostId;
+	return (
+		isProofreadEnabled() && isEditorLevelSuggestionPostType( currentPostType ) && !! currentPostId
+	);
 }
 
 function trackAiEditorialReviewSuggestionRenderedOnce(): void {
@@ -307,7 +338,7 @@ function getAiEditorialReviewSuggestions( currentPostType?: string ) {
 
 function getPostLevelSuggestions(
 	currentPostType?: string,
-	currentPostId?: number | null,
+	currentPostId?: EditorPostId | null,
 	supportsExcerpt?: boolean
 ) {
 	return [
@@ -451,9 +482,7 @@ function handleShowComponent( input: any ): any {
 	};
 	if ( type === 'review-mediation' || type === 'post-feedback' || type === 'proofread' ) {
 		const reviewedPostId =
-			typeof componentProps.postId === 'number' && componentProps.postId > 0
-				? componentProps.postId
-				: getCurrentEditorPostId();
+			normalizeEditorPostId( componentProps.postId ) ?? getCurrentEditorPostId();
 		if ( reviewedPostId ) {
 			componentProps.postId = reviewedPostId;
 			data.postId = reviewedPostId;
@@ -1273,7 +1302,7 @@ export function useSuggestions(
 	const editorContext = useSelect( ( select ) => {
 		const blockEditor = select( 'core/block-editor' ) as { getSelectedBlock?: () => any };
 		const editor = select( 'core/editor' ) as {
-			getCurrentPostId?: () => number | null | undefined;
+			getCurrentPostId?: () => EditorPostId | null | undefined;
 			getCurrentPostType?: () => string | undefined;
 		};
 		const core = select( 'core' ) as {
@@ -1282,7 +1311,7 @@ export function useSuggestions(
 		const postType = editor?.getCurrentPostType?.();
 		return {
 			selectedBlock: blockEditor?.getSelectedBlock?.() ?? null,
-			postId: editor?.getCurrentPostId?.(),
+			postId: normalizeEditorPostId( editor?.getCurrentPostId?.() ),
 			postType,
 			supportsExcerpt:
 				postType && isExcerptSuggestionEnabled()
@@ -1319,7 +1348,7 @@ export function useSuggestions(
 			applicable.map( ( { id, label, prompt, options } ) => ( { id, label, prompt, options } ) ),
 		[ applicable ]
 	);
-	// Post-level reviews (Optimize Title, Generate Feedback, AI Editorial Review)
+	// Editor-level reviews (Optimize Title, Generate Feedback, AI Editorial Review)
 	// show only with no block selected; a selected block shows block transforms.
 	const visibleSuggestions = useMemo( () => {
 		if ( hidden ) {

--- a/packages/jetpack-ai-sidebar/src/utils/blocks.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/blocks.test.ts
@@ -1,0 +1,77 @@
+import { getEditorContentBlocks } from './blocks';
+import type { BlockSnapshot } from '../components/block-ref';
+
+const rootBlocks: BlockSnapshot[] = [
+	{
+		clientId: 'header',
+		name: 'core/template-part',
+		innerBlocks: [],
+	},
+	{
+		clientId: 'post-content',
+		name: 'core/post-content',
+		innerBlocks: [],
+	},
+	{
+		clientId: 'footer',
+		name: 'core/template-part',
+		innerBlocks: [],
+	},
+];
+
+const contentBlocks: BlockSnapshot[] = [
+	{
+		clientId: 'paragraph',
+		name: 'core/paragraph',
+		attributes: {
+			content: 'Body copy',
+		},
+	},
+];
+
+describe( 'getEditorContentBlocks', () => {
+	it( 'returns controlled post content blocks when a post-content block exists', () => {
+		const getBlocks = jest.fn( ( rootClientId?: string ) =>
+			rootClientId === 'post-content' ? contentBlocks : rootBlocks
+		);
+
+		expect(
+			getEditorContentBlocks( {
+				getBlocks,
+				getBlocksByName: jest.fn( () => [ 'post-content' ] ),
+			} )
+		).toBe( contentBlocks );
+		expect( getBlocks ).toHaveBeenCalledWith( 'post-content' );
+	} );
+
+	it( 'falls back to root blocks when no post-content block exists', () => {
+		const getBlocks = jest.fn( () => rootBlocks );
+
+		expect(
+			getEditorContentBlocks( {
+				getBlocks,
+				getBlocksByName: jest.fn( () => [] ),
+			} )
+		).toBe( rootBlocks );
+		expect( getBlocks ).toHaveBeenCalledWith();
+	} );
+
+	it( 'uses the experimental global block lookup when the stable lookup is unavailable', () => {
+		const getBlocks = jest.fn( ( rootClientId?: string ) =>
+			rootClientId === 'post-content' ? contentBlocks : rootBlocks
+		);
+
+		expect(
+			getEditorContentBlocks( {
+				getBlocks,
+				__experimentalGetGlobalBlocksByName: jest.fn( () => [ 'post-content' ] ),
+			} )
+		).toBe( contentBlocks );
+		expect( getBlocks ).toHaveBeenCalledWith( 'post-content' );
+	} );
+
+	it( 'returns an empty list when the block editor store is unavailable', () => {
+		expect( getEditorContentBlocks() ).toEqual( [] );
+		expect( getEditorContentBlocks( {} ) ).toEqual( [] );
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/blocks.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/blocks.test.ts
@@ -1,4 +1,4 @@
-import { getEditorContentBlocks } from './blocks';
+import { getEditorContentBlocks, type EditorStore } from './blocks';
 import type { BlockSnapshot } from '../components/block-ref';
 
 const rootBlocks: BlockSnapshot[] = [
@@ -29,6 +29,16 @@ const contentBlocks: BlockSnapshot[] = [
 	},
 ];
 
+const postEditor: EditorStore = {
+	getCurrentPostType: () => 'post',
+	getRenderingMode: () => 'post-only',
+};
+
+const pageSiteEditor: EditorStore = {
+	getCurrentPostType: () => 'page',
+	getRenderingMode: () => 'template-locked',
+};
+
 describe( 'getEditorContentBlocks', () => {
 	it( 'returns controlled post content blocks when a post-content block exists', () => {
 		const getBlocks = jest.fn( ( rootClientId?: string ) =>
@@ -36,24 +46,45 @@ describe( 'getEditorContentBlocks', () => {
 		);
 
 		expect(
-			getEditorContentBlocks( {
-				getBlocks,
-				getBlocksByName: jest.fn( () => [ 'post-content' ] ),
-			} )
+			getEditorContentBlocks(
+				{
+					getBlocks,
+					getBlocksByName: jest.fn( () => [ 'post-content' ] ),
+				},
+				pageSiteEditor
+			)
 		).toBe( contentBlocks );
 		expect( getBlocks ).toHaveBeenCalledWith( 'post-content' );
 	} );
 
-	it( 'falls back to root blocks when no post-content block exists', () => {
+	it( 'returns root blocks for a post-only post editor', () => {
 		const getBlocks = jest.fn( () => rootBlocks );
 
 		expect(
-			getEditorContentBlocks( {
-				getBlocks,
-				getBlocksByName: jest.fn( () => [] ),
-			} )
+			getEditorContentBlocks(
+				{
+					getBlocks,
+					getBlocksByName: jest.fn( () => [] ),
+				},
+				postEditor
+			)
 		).toBe( rootBlocks );
 		expect( getBlocks ).toHaveBeenCalledWith();
+	} );
+
+	it( 'returns no blocks when post content is missing in template-locked page editing', () => {
+		const getBlocks = jest.fn( () => rootBlocks );
+
+		expect(
+			getEditorContentBlocks(
+				{
+					getBlocks,
+					getBlocksByName: jest.fn( () => [] ),
+				},
+				pageSiteEditor
+			)
+		).toEqual( [] );
+		expect( getBlocks ).not.toHaveBeenCalled();
 	} );
 
 	it( 'uses the experimental global block lookup when the stable lookup is unavailable', () => {
@@ -62,16 +93,37 @@ describe( 'getEditorContentBlocks', () => {
 		);
 
 		expect(
-			getEditorContentBlocks( {
-				getBlocks,
-				__experimentalGetGlobalBlocksByName: jest.fn( () => [ 'post-content' ] ),
-			} )
+			getEditorContentBlocks(
+				{
+					getBlocks,
+					__experimentalGetGlobalBlocksByName: jest.fn( () => [ 'post-content' ] ),
+				},
+				pageSiteEditor
+			)
 		).toBe( contentBlocks );
 		expect( getBlocks ).toHaveBeenCalledWith( 'post-content' );
 	} );
 
 	it( 'returns an empty list when the block editor store is unavailable', () => {
-		expect( getEditorContentBlocks() ).toEqual( [] );
-		expect( getEditorContentBlocks( {} ) ).toEqual( [] );
+		expect( getEditorContentBlocks( undefined, postEditor ) ).toEqual( [] );
+		expect( getEditorContentBlocks( {}, postEditor ) ).toEqual( [] );
 	} );
+
+	it.each( [ 'wp_template', 'wp_template_part', 'wp_navigation', 'wp_global_styles' ] )(
+		'returns no post content blocks for %s entities',
+		( postType ) => {
+			const getBlocks = jest.fn( () => rootBlocks );
+
+			expect(
+				getEditorContentBlocks(
+					{ getBlocks, getBlocksByName: jest.fn( () => [ 'post-content' ] ) },
+					{
+						getCurrentPostType: () => postType,
+						getRenderingMode: () => 'template-locked',
+					}
+				)
+			).toEqual( [] );
+			expect( getBlocks ).not.toHaveBeenCalled();
+		}
+	);
 } );

--- a/packages/jetpack-ai-sidebar/src/utils/blocks.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/blocks.ts
@@ -4,6 +4,27 @@
 
 import type { BlockSnapshot } from '../components/block-ref';
 
+export type BlockEditorStore = {
+	getBlocks?: ( rootClientId?: string ) => BlockSnapshot[];
+	getBlocksByName?: ( blockName: string ) => string[];
+	__experimentalGetGlobalBlocksByName?: ( blockName: string ) => string[];
+};
+
+export function getEditorContentBlocks( blockEditor?: BlockEditorStore ): BlockSnapshot[] {
+	if ( ! blockEditor?.getBlocks ) {
+		return [];
+	}
+
+	const [ postContentClientId ] =
+		blockEditor.getBlocksByName?.( 'core/post-content' ) ??
+		blockEditor.__experimentalGetGlobalBlocksByName?.( 'core/post-content' ) ??
+		[];
+
+	return postContentClientId
+		? blockEditor.getBlocks( postContentClientId )
+		: blockEditor.getBlocks();
+}
+
 /** Flatten a block tree into a pre-order list, skipping nameless blocks. */
 export function flattenBlocks( blocks: BlockSnapshot[] ): BlockSnapshot[] {
 	const out: BlockSnapshot[] = [];

--- a/packages/jetpack-ai-sidebar/src/utils/blocks.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/blocks.ts
@@ -10,8 +10,21 @@ export type BlockEditorStore = {
 	__experimentalGetGlobalBlocksByName?: ( blockName: string ) => string[];
 };
 
-export function getEditorContentBlocks( blockEditor?: BlockEditorStore ): BlockSnapshot[] {
-	if ( ! blockEditor?.getBlocks ) {
+export type EditorStore = {
+	getCurrentPostType?: () => string | undefined;
+	getRenderingMode?: () => string | undefined;
+};
+
+const CONTENT_POST_TYPES = new Set( [ 'post', 'page' ] );
+
+export function getEditorContentBlocks(
+	blockEditor?: BlockEditorStore,
+	editor?: EditorStore
+): BlockSnapshot[] {
+	if (
+		! blockEditor?.getBlocks ||
+		! CONTENT_POST_TYPES.has( editor?.getCurrentPostType?.() ?? '' )
+	) {
 		return [];
 	}
 
@@ -20,9 +33,11 @@ export function getEditorContentBlocks( blockEditor?: BlockEditorStore ): BlockS
 		blockEditor.__experimentalGetGlobalBlocksByName?.( 'core/post-content' ) ??
 		[];
 
-	return postContentClientId
-		? blockEditor.getBlocks( postContentClientId )
-		: blockEditor.getBlocks();
+	if ( postContentClientId ) {
+		return blockEditor.getBlocks( postContentClientId );
+	}
+
+	return editor?.getRenderingMode?.() === 'template-locked' ? [] : blockEditor.getBlocks();
 }
 
 /** Flatten a block tree into a pre-order list, skipping nameless blocks. */


### PR DESCRIPTION
Part of FORNO-326

## Proposed Changes

* Show page/site provider empty-view suggestions in the page editor and Site Editor, while filtering Site Editor-only provider chips from post and non-page CPT editors.
* Limit post-level Jetpack AI suggestions to `post` and `page`. Hide them for templates, template parts, patterns, navigation, global styles, Site Editor dashboard/list views without a current post type, and all other custom post types, including `jetpack_form` and `jp_search_overlay`.
* Replace empty-view and post-level suggestions whenever a block is selected. Only show the applicable block transformations: Translate content, Change tone, Check grammar, Simplify text, and Generate alt text.
* Keep selected-block transformations available in templates, while preventing post-level suggestions from leaking into block context or reappearing after a Proofread request.
* Merge custom provider empty-view chips with dynamic suggestions when there is no selected-block context.
* Add focused coverage for the post/page allowlist, excluded editor entities, selected blocks, template block transformations, suggestion lifecycle, and merged provider/dynamic suggestions.

## Why are these changes being made?

The combined suggestion path could surface post-level suggestions while a block was selected and could bring block suggestions back into an active Proofread conversation. That regressed the behavior established in https://github.com/Automattic/wp-calypso/pull/112015.

This restores the intended boundaries: whole-content Jetpack AI actions are limited to posts and pages, selected blocks own the suggestion surface, and block-level transformations remain available in template editing contexts.

## Testing Instructions

See WPCOM PR 227219.

Automated validation:

* `yarn test-packages packages/agents-manager packages/jetpack-ai-sidebar --runInBand`
  * Passed 50 test suites and 674 tests.
* `yarn workspace @automattic/agents-manager-app run teamcity:build-app`
  * Build and translation generation completed successfully.
* `yarn eslint packages/agents-manager/src packages/jetpack-ai-sidebar/src`
  * Passed with 0 errors and 16 existing warnings.

Manual checks:

1. Open a saved post and page with no block selected. Confirm the enabled post-level Jetpack AI suggestions appear.
2. Select a paragraph or heading. Confirm only the applicable Translate content, Change tone, Check grammar, and Simplify text actions appear, with no post-level suggestions.
3. Select a supported image block. Confirm Generate alt text appears, with no post-level suggestions.
4. Select an unsupported block. Confirm post-level suggestions do not return as a fallback.
5. Run Proofread and wait for its response. Confirm suggestion chips do not reappear alongside the active Proofread conversation.
6. Open a template, template part, pattern, navigation entity, global styles, and a Site Editor dashboard/list view. Confirm no post-level Jetpack AI suggestions appear.
7. Open `jetpack_form`, `jp_search_overlay`, or another custom post type. Confirm no post-level Jetpack AI suggestions appear.
8. Select a supported block inside a template. Confirm the applicable block-level transformations remain available.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
