### PR TITLE
Fix wrong 'switched to monthly billing' notice after plan downgrade

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -431,11 +431,15 @@ const PlansFeaturesMain = ( {
 					}
 
 					// Fallback: deep-link to the new plan's settings page (or the plans
-					// page) with a notice.
+					// page) with a notice. Use `plan_changed` (not `downgraded`) so the
+					// accurate "Your plan has been updated to X" notice shows: this is a
+					// generic plan downgrade that may stay on annual billing, whereas
+					// `downgraded=true` is reserved for the monthly-switch flow and reads
+					// "You've switched to monthly billing."
 					window.location.href =
 						newPurchase && siteSlug
-							? `${ managePurchase( siteSlug, newPurchase.ID ) }?downgraded=true`
-							: `/plans/${ siteSlug }?downgraded=true`;
+							? `${ managePurchase( siteSlug, newPurchase.ID ) }?plan_changed=true`
+							: `/plans/${ siteSlug }?plan_changed=true`;
 				},
 				onError: ( error: Error ) => {
 					setIsDowngrading( false );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2199/

## Proposed changes

After completing a plan downgrade from the Plans page, the customer was redirected to the Purchases page with a success banner reading “You’ve switched to monthly billing” — even for an annual-to-annual downgrade where billing never changed to monthly. This fixes the redirect to show an accurate, term-agnostic notice instead.

* Change the `confirmDowngrade` fallback redirect in `plans-features-main` to append `?plan_changed=true` instead of `?downgraded=true`.
* `?plan_changed=true` renders the existing, accurate “Your plan has been updated to X” notice (already supported by both the classic and Dashboard purchase notice components).
* Leave the genuine monthly-switch flows (`onSwitchToMonthly`) untouched — they correctly keep `?downgraded=true` and the “You’ve switched to monthly billing” message.

## Why are these changes being made?

The `?downgraded=true` query param is reserved for the cancel-flow “switch to monthly billing” action: both notice components (`client/me/purchases/manage-purchase/notices.tsx` and `client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx`) hardcode it to the message “You’ve switched to monthly billing.”

The generic Plans-page downgrade flow, which can downgrade to any lower plan (including another annual plan), was reusing that same param. As a result, any downgrade triggered the monthly-billing message regardless of the actual billing term — confusing customers who never selected monthly and stayed on annual billing.

The accurate notice already exists and is keyed on `?plan_changed=true`, which renders “Your plan has been updated to X” using the new plan’s name. Switching the generic downgrade to that param fixes the message without introducing any new strings, and keeps the monthly-specific message exactly where it’s true.

## Testing instructions

Manual testing:
* On a site with an annual paid plan that has a lower annual plan available (e.g. Business → Personal), open `/plans/{site}`.
* Downgrade to the lower annual plan and complete the flow.
* Confirm the Purchases page shows “Your plan has been updated to {plan name}.” and NOT “You’ve switched to monthly billing.”
* Separately, via Manage Purchase → Cancel → “Switch to monthly payments”, confirm that flow still shows “You’ve switched to monthly billing.”
