### PR TITLE
Plans paid tiers - add HStack to space badges.

### DIFF
--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -315,7 +315,7 @@ function ProductsList() {
 						) }
 						<sub className="memberships__products-product-price">{ translate( 'Free' ) }</sub>
 						<div className="memberships__products-product-badge">
-							<HStack spacing={ 2 }>
+							<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
 								<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
 								{ isFreeTierHidden && (
 									<Badge type="warning">{ translate( 'Hidden from subscribers' ) }</Badge>

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -5,6 +5,7 @@ import {
 } from '@automattic/calypso-products';
 import { Badge, Button, Card, CompactCard, Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import DOMPurify from 'dompurify';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -314,10 +315,12 @@ function ProductsList() {
 						) }
 						<sub className="memberships__products-product-price">{ translate( 'Free' ) }</sub>
 						<div className="memberships__products-product-badge">
-							<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
-							{ isFreeTierHidden && (
-								<Badge type="warning">{ translate( 'Hidden from subscribers' ) }</Badge>
-							) }
+							<HStack spacing={ 2 }>
+								<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
+								{ isFreeTierHidden && (
+									<Badge type="warning">{ translate( 'Hidden from subscribers' ) }</Badge>
+								) }
+							</HStack>
 						</div>
 					</div>
 					<EllipsisMenu position="bottom left">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # item 1 noted from pe7F0s-3OB-p2#comment-4415

## Proposed Changes

* Adds a HStack component to add space between badges in the plans

BEFORE
<img width="352" height="56" alt="Screenshot 2026-06-26 at 2 01 05 PM" src="https://github.com/user-attachments/assets/0665b8df-7266-40db-ae29-89eb2c6418fc" />

AFTER
<img width="360" height="58" alt="Screenshot 2026-06-26 at 2 04 08 PM" src="https://github.com/user-attachments/assets/4fd29cfd-dfb9-4fa5-9115-966a4addae19" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit the plans page in calypso and jetpack cloud
* verify no regressions to no badge and 1 badge cases
* verify the 2 badge case (newsletter tier + free tier hidden) now has space between badges.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?