### PR TITLE
Domains: gate bundle experience behind a single on/off ExPlat experiment

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -135,6 +135,7 @@ const defaultProps = {
 		onContinue: jest.fn(),
 	},
 };
+const loggedInOptions = { initialState: { currentUser: { id: 1234 } } };
 
 describe( 'useWPCOMDomainSearchProps', () => {
 	beforeEach( () => {
@@ -1292,15 +1293,26 @@ describe( 'useWPCOMDomainSearchProps', () => {
 	} );
 
 	describe( 'showBundleSuggestions (fetch gate)', () => {
-		it( 'is enabled for a regular flow even when the domain-bundling flag is off, so both arms fetch', () => {
+		it( 'is enabled for a logged-in regular flow even when the domain-bundling flag is off, so both arms fetch', () => {
 			mockConfig.isEnabled.mockReturnValue( false );
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider(
+				() => useWPCOMDomainSearchProps( defaultProps ),
+				loggedInOptions
+			);
+
+			// Fetch is gated on logged-in flow eligibility only — never on the flag
+			// or experiment — so control and treatment both reach the decision point.
+			expect( result.current.config.showBundleSuggestions ).toBe( true );
+		} );
+
+		it( 'is disabled for logged-out users', () => {
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
 			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
 
-			// Fetch is gated on flow eligibility only — never on the flag or the
-			// experiment — so control and treatment both reach the decision point.
-			expect( result.current.config.showBundleSuggestions ).toBe( true );
+			expect( result.current.config.showBundleSuggestions ).toBe( false );
 		} );
 
 		it.each( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW, DOMAIN_FOR_GRAVATAR_FLOW ] )(
@@ -1308,8 +1320,9 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			( flowName ) => {
 				mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-				const { result } = renderHookWithProvider( () =>
-					useWPCOMDomainSearchProps( { ...defaultProps, flowName } )
+				const { result } = renderHookWithProvider(
+					() => useWPCOMDomainSearchProps( { ...defaultProps, flowName } ),
+					loggedInOptions
 				);
 
 				expect( result.current.config.showBundleSuggestions ).toBe( false );
@@ -1321,7 +1334,10 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		it( 'is enabled when the domain-bundling flag is on, without an experiment assignment', () => {
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+			const { result } = renderHookWithProvider(
+				() => useWPCOMDomainSearchProps( defaultProps ),
+				loggedInOptions
+			);
 
 			expect( result.current.config.showBundleCard ).toBe( true );
 		} );
@@ -1330,7 +1346,10 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			mockConfig.isEnabled.mockReturnValue( false );
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+			const { result } = renderHookWithProvider(
+				() => useWPCOMDomainSearchProps( defaultProps ),
+				loggedInOptions
+			);
 
 			expect( result.current.config.showBundleCard ).toBe( false );
 		} );
@@ -1340,7 +1359,10 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			mockLoadExperimentAssignment.mockResolvedValue( buildAssignment( 'treatment' ) );
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+			const { result } = renderHookWithProvider(
+				() => useWPCOMDomainSearchProps( defaultProps ),
+				loggedInOptions
+			);
 
 			expect( result.current.config.showBundleCard ).toBe( false );
 
@@ -1356,7 +1378,10 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			mockLoadExperimentAssignment.mockResolvedValue( buildAssignment( 'control' ) );
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+			const { result } = renderHookWithProvider(
+				() => useWPCOMDomainSearchProps( defaultProps ),
+				loggedInOptions
+			);
 
 			result.current.events.onBundleWouldShow?.( {} as never );
 
@@ -1371,8 +1396,9 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			( flowName ) => {
 				mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-				const { result } = renderHookWithProvider( () =>
-					useWPCOMDomainSearchProps( { ...defaultProps, flowName } )
+				const { result } = renderHookWithProvider(
+					() => useWPCOMDomainSearchProps( { ...defaultProps, flowName } ),
+					loggedInOptions
 				);
 
 				expect( result.current.config.showBundleCard ).toBe( false );
@@ -1385,7 +1411,10 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			mockConfig.isEnabled.mockReturnValue( false );
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
-			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+			const { result } = renderHookWithProvider(
+				() => useWPCOMDomainSearchProps( defaultProps ),
+				loggedInOptions
+			);
 
 			result.current.events.onBundleWouldShow?.( {} as never );
 
@@ -1394,6 +1423,17 @@ describe( 'useWPCOMDomainSearchProps', () => {
 					DOMAIN_BUNDLE_EXPERIMENT_NAME
 				);
 			} );
+		} );
+
+		it( 'does not load the bundle experiment assignment for logged-out users', () => {
+			mockConfig.isEnabled.mockReturnValue( false );
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			result.current.events.onBundleWouldShow?.( {} as never );
+
+			expect( mockLoadExperimentAssignment ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import config from '@automattic/calypso-config';
 import {
 	DOMAIN_FOR_GRAVATAR_FLOW,
 	HUNDRED_YEAR_DOMAIN_FLOW,
@@ -14,6 +15,9 @@ import {
 	UseShoppingCart,
 	useShoppingCart,
 } from '@automattic/shopping-cart';
+import { waitFor } from '@testing-library/react';
+import { DOMAIN_BUNDLE_EXPERIMENT_NAME } from 'calypso/lib/domains/bundle-experiment';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { renderHookWithProvider } from '../../../../test-helpers/testing-library';
 import {
 	recordDomainSearchStepSubmit,
@@ -21,16 +25,31 @@ import {
 	recordSearchFormSubmitButtonClick,
 } from '../analytics';
 import { getCartKey, useWPCOMDomainSearchProps } from '../use-wpcom-domain-search-props';
+import type { ExperimentAssignment } from '@automattic/explat-client';
 
 jest.mock( '@automattic/shopping-cart', () => ( {
 	...jest.requireActual( '@automattic/shopping-cart' ),
 	useShoppingCart: jest.fn(),
 } ) );
 
+const mockConfig = config as unknown as { isEnabled: jest.Mock };
 jest.mock( '@automattic/calypso-config', () => {
-	const config = () => 'development';
-	config.isEnabled = ( flag: string ) => flag === 'domain-bundling';
-	return config;
+	const mock = () => 'development';
+	mock.isEnabled = jest.fn();
+	return mock;
+} );
+
+jest.mock( 'calypso/lib/explat' );
+
+const mockLoadExperimentAssignment = loadExperimentAssignment as jest.MockedFunction<
+	typeof loadExperimentAssignment
+>;
+
+const buildAssignment = ( variationName: string | null ): ExperimentAssignment => ( {
+	experimentName: DOMAIN_BUNDLE_EXPERIMENT_NAME,
+	variationName,
+	retrievedTimestamp: Date.now(),
+	ttl: 60,
 } );
 
 jest.mock( '../analytics', () => ( {
@@ -120,6 +139,12 @@ const defaultProps = {
 describe( 'useWPCOMDomainSearchProps', () => {
 	beforeEach( () => {
 		mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+		mockConfig.isEnabled.mockImplementation( ( flag: string ) => flag === 'domain-bundling' );
+		mockLoadExperimentAssignment.mockResolvedValue( buildAssignment( 'control' ) );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
 	it( 'returns the expected structure for the items in the domain search cart', () => {
@@ -1266,12 +1291,15 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		} );
 	} );
 
-	describe( 'showBundleSuggestions', () => {
-		it( 'is enabled for a regular flow when the domain-bundling flag is on', () => {
+	describe( 'showBundleSuggestions (fetch gate)', () => {
+		it( 'is enabled for a regular flow even when the domain-bundling flag is off, so both arms fetch', () => {
+			mockConfig.isEnabled.mockReturnValue( false );
 			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
 
 			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
 
+			// Fetch is gated on flow eligibility only — never on the flag or the
+			// experiment — so control and treatment both reach the decision point.
 			expect( result.current.config.showBundleSuggestions ).toBe( true );
 		} );
 
@@ -1287,6 +1315,86 @@ describe( 'useWPCOMDomainSearchProps', () => {
 				expect( result.current.config.showBundleSuggestions ).toBe( false );
 			}
 		);
+	} );
+
+	describe( 'showBundleCard (render gate)', () => {
+		it( 'is enabled when the domain-bundling flag is on, without an experiment assignment', () => {
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			expect( result.current.config.showBundleCard ).toBe( true );
+		} );
+
+		it( 'is disabled when the flag is off and the user has not been assigned treatment', () => {
+			mockConfig.isEnabled.mockReturnValue( false );
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			expect( result.current.config.showBundleCard ).toBe( false );
+		} );
+
+		it( 'turns on once the would-show exposure resolves the treatment arm', async () => {
+			mockConfig.isEnabled.mockReturnValue( false );
+			mockLoadExperimentAssignment.mockResolvedValue( buildAssignment( 'treatment' ) );
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			expect( result.current.config.showBundleCard ).toBe( false );
+
+			result.current.events.onBundleWouldShow?.( {} as never );
+
+			await waitFor( () => {
+				expect( result.current.config.showBundleCard ).toBe( true );
+			} );
+		} );
+
+		it( 'stays off when the would-show exposure resolves the control arm', async () => {
+			mockConfig.isEnabled.mockReturnValue( false );
+			mockLoadExperimentAssignment.mockResolvedValue( buildAssignment( 'control' ) );
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			result.current.events.onBundleWouldShow?.( {} as never );
+
+			await waitFor( () => {
+				expect( mockLoadExperimentAssignment ).toHaveBeenCalled();
+			} );
+			expect( result.current.config.showBundleCard ).toBe( false );
+		} );
+
+		it.each( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW, DOMAIN_FOR_GRAVATAR_FLOW ] )(
+			'is disabled for the %s flow even when the flag is on',
+			( flowName ) => {
+				mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+				const { result } = renderHookWithProvider( () =>
+					useWPCOMDomainSearchProps( { ...defaultProps, flowName } )
+				);
+
+				expect( result.current.config.showBundleCard ).toBe( false );
+			}
+		);
+	} );
+
+	describe( 'onBundleWouldShow (experiment exposure)', () => {
+		it( 'loads the bundle experiment assignment, exposing both arms symmetrically', async () => {
+			mockConfig.isEnabled.mockReturnValue( false );
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			result.current.events.onBundleWouldShow?.( {} as never );
+
+			await waitFor( () => {
+				expect( mockLoadExperimentAssignment ).toHaveBeenCalledWith(
+					DOMAIN_BUNDLE_EXPERIMENT_NAME
+				);
+			} );
+		} );
 	} );
 
 	it( 'prepends products in the cart when adding a new domain', async () => {

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
@@ -96,12 +96,16 @@ export const useWPCOMDomainSearchProps = ( {
 	// bundle. It dedupes internally, so calling it again on a later search is
 	// harmless. Only treatment flips the render gate on.
 	const onBundleWouldShow = useCallback( () => {
+		if ( ! isLoggedIn ) {
+			return;
+		}
+
 		loadExperimentAssignment( DOMAIN_BUNDLE_EXPERIMENT_NAME ).then( ( assignment ) => {
 			if ( assignment.variationName === DOMAIN_BUNDLE_EXPERIMENT_TREATMENT ) {
 				setIsBundleTreatment( true );
 			}
 		} );
-	}, [] );
+	}, [ isLoggedIn ] );
 
 	const config = useMemo( () => {
 		// Bundles are fixed one-year registrations of multiple TLDs, so they
@@ -109,16 +113,17 @@ export const useWPCOMDomainSearchProps = ( {
 		// and those flows' beforeAddDomainToCart transforms (100-year term,
 		// Gravatar extras) are not applied to bundle members.
 		const flowSupportsBundles =
+			isLoggedIn &&
 			! isHundredYearPlanFlow( flowName ) &&
 			! isHundredYearDomainFlow( flowName ) &&
 			! isDomainForGravatarFlow( flowName );
 
 		return {
 			...externalConfig,
-			// Fetch for BOTH arms wherever the flow is eligible — never gated on the
-			// experiment — so control and treatment both reach the would-show
-			// decision point. The server bundle kill switch still returns nothing
-			// when bundles are off, so this fetches only when bundles can exist.
+			// Fetch for BOTH arms wherever the logged-in flow is eligible — never
+			// gated on the experiment — so control and treatment both reach the
+			// would-show decision point. The server bundle kill switch still returns
+			// nothing when bundles are off, so this fetches only when bundles can exist.
 			showBundleSuggestions: flowSupportsBundles,
 			// Render the card only for the dev/staging flag (force-on) or the
 			// experiment treatment arm. Control fetches the suggestion but renders
@@ -133,7 +138,14 @@ export const useWPCOMDomainSearchProps = ( {
 				freeForFirstYearDomains: freeDomainName ? [ freeDomainName ] : undefined,
 			},
 		};
-	}, [ externalConfig, isNextDomainFree, freeDomainName, flowName, isBundleTreatment ] );
+	}, [
+		externalConfig,
+		isNextDomainFree,
+		freeDomainName,
+		flowName,
+		isBundleTreatment,
+		isLoggedIn,
+	] );
 
 	const analyticsEvents = useWPCOMDomainSearchEvents( {
 		vendor: config.vendor,

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
@@ -6,8 +6,13 @@ import {
 	isHundredYearPlanFlow,
 } from '@automattic/onboarding';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
-import { useMemo, type ComponentProps, useCallback } from 'react';
+import { useMemo, type ComponentProps, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import {
+	DOMAIN_BUNDLE_EXPERIMENT_NAME,
+	DOMAIN_BUNDLE_EXPERIMENT_TREATMENT,
+} from 'calypso/lib/domains/bundle-experiment';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { mergeObjectFunctions } from '../../../lib/merge-object-functions';
 import { recordDomainSearchStepSubmit } from './analytics';
@@ -78,6 +83,26 @@ export const useWPCOMDomainSearchProps = ( {
 		beforeAddDomainToCart: externalBeforeAddDomainToCart,
 	} );
 
+	// Resolved once the user is assigned the bundle experiment's treatment arm at
+	// the search would-show decision point (see onBundleWouldShow). The dev/staging
+	// `domain-bundling` flag is OR'd in below, so this strictly tracks the
+	// experiment. Sticky once true: a user who is shown a bundle stays in the
+	// treatment experience for the rest of the session.
+	const [ isBundleTreatment, setIsBundleTreatment ] = useState( false );
+
+	// Fired by the package the moment a bundle card would render, for BOTH arms.
+	// This is the experiment exposure: loadExperimentAssignment assigns/exposes
+	// control and treatment identically, scoped to users who would have seen a
+	// bundle. It dedupes internally, so calling it again on a later search is
+	// harmless. Only treatment flips the render gate on.
+	const onBundleWouldShow = useCallback( () => {
+		loadExperimentAssignment( DOMAIN_BUNDLE_EXPERIMENT_NAME ).then( ( assignment ) => {
+			if ( assignment.variationName === DOMAIN_BUNDLE_EXPERIMENT_TREATMENT ) {
+				setIsBundleTreatment( true );
+			}
+		} );
+	}, [] );
+
 	const config = useMemo( () => {
 		// Bundles are fixed one-year registrations of multiple TLDs, so they
 		// don't fit flows that sell a single special-purpose registration —
@@ -90,7 +115,16 @@ export const useWPCOMDomainSearchProps = ( {
 
 		return {
 			...externalConfig,
-			showBundleSuggestions: isEnabled( 'domain-bundling' ) && flowSupportsBundles,
+			// Fetch for BOTH arms wherever the flow is eligible — never gated on the
+			// experiment — so control and treatment both reach the would-show
+			// decision point. The server bundle kill switch still returns nothing
+			// when bundles are off, so this fetches only when bundles can exist.
+			showBundleSuggestions: flowSupportsBundles,
+			// Render the card only for the dev/staging flag (force-on) or the
+			// experiment treatment arm. Control fetches the suggestion but renders
+			// nothing.
+			showBundleCard:
+				( isEnabled( 'domain-bundling' ) || isBundleTreatment ) && flowSupportsBundles,
 			priceRules: {
 				...externalConfig?.priceRules,
 				freeForFirstYear: isNextDomainFree,
@@ -99,7 +133,7 @@ export const useWPCOMDomainSearchProps = ( {
 				freeForFirstYearDomains: freeDomainName ? [ freeDomainName ] : undefined,
 			},
 		};
-	}, [ externalConfig, isNextDomainFree, freeDomainName, flowName ] );
+	}, [ externalConfig, isNextDomainFree, freeDomainName, flowName, isBundleTreatment ] );
 
 	const analyticsEvents = useWPCOMDomainSearchEvents( {
 		vendor: config.vendor,
@@ -111,9 +145,10 @@ export const useWPCOMDomainSearchProps = ( {
 	const events: ComponentProps< typeof DomainSearch >[ 'events' ] = useMemo( () => {
 		return {
 			...mergeObjectFunctions( analyticsEvents, otherExternalEvents ),
+			onBundleWouldShow,
 			onContinue,
 		};
-	}, [ analyticsEvents, otherExternalEvents, onContinue ] );
+	}, [ analyticsEvents, otherExternalEvents, onBundleWouldShow, onContinue ] );
 
 	return {
 		config,

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -1,10 +1,10 @@
-import config from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { MiniCart } from '@automattic/mini-cart';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
+import { isDomainBundleExperienceEnabled } from 'calypso/lib/domains/bundle-experiment';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MasterbarItem from '../item';
@@ -128,7 +128,7 @@ export function MasterbarCartButton( {
 						onRemoveCoupon={ onRemoveCoupon }
 						checkoutLabel={ checkoutLabel }
 						emptyCart={ emptyCart }
-						showBundleGrouping={ config.isEnabled( 'domain-bundling' ) }
+						showBundleGrouping={ isDomainBundleExperienceEnabled() }
 					/>
 				</CheckoutErrorBoundary>
 			</Popover>

--- a/client/lib/domains/bundle-experiment.ts
+++ b/client/lib/domains/bundle-experiment.ts
@@ -1,0 +1,39 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
+
+/**
+ * Single on/off ExPlat experiment that gates the production domain-bundle
+ * experience (search suggestion card + cart/checkout line-item grouping).
+ * Treatment turns the experience on; control keeps the current no-bundle
+ * behavior. The slug does not exist in ExPlat until it is created and approved,
+ * so `loadExperimentAssignment` returns the control fallback until then.
+ */
+export const DOMAIN_BUNDLE_EXPERIMENT_NAME = 'calypso_domains_search_bundle_suggestions_202606';
+
+/**
+ * Variation name for the bundle-on arm. Matches the default split produced by
+ * `explat-create-experiment` (control / treatment); centralized here so a rename
+ * is a one-line change.
+ */
+export const DOMAIN_BUNDLE_EXPERIMENT_TREATMENT = 'treatment';
+
+/**
+ * Whether the domain-bundle experience should be enabled for this request.
+ *
+ * True when the dev/staging `domain-bundling` flag is on, OR when the user has
+ * already been assigned the experiment treatment. This is a synchronous read of
+ * an assignment that was made earlier at the search would-show decision point —
+ * it deliberately uses `dangerouslyGetExperimentAssignment` so it does NOT
+ * create a new exposure. Use it for the cart/checkout grouping surfaces that
+ * must mirror the search arm without re-exposing the user.
+ */
+export function isDomainBundleExperienceEnabled(): boolean {
+	if ( isEnabled( 'domain-bundling' ) ) {
+		return true;
+	}
+
+	return (
+		dangerouslyGetExperimentAssignment( DOMAIN_BUNDLE_EXPERIMENT_NAME )?.variationName ===
+		DOMAIN_BUNDLE_EXPERIMENT_TREATMENT
+	);
+}

--- a/client/lib/domains/test/bundle-experiment.ts
+++ b/client/lib/domains/test/bundle-experiment.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import config from '@automattic/calypso-config';
+import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
+import {
+	DOMAIN_BUNDLE_EXPERIMENT_NAME,
+	isDomainBundleExperienceEnabled,
+} from '../bundle-experiment';
+import type { ExperimentAssignment } from '@automattic/explat-client';
+
+const mockConfig = config as unknown as { isEnabled: jest.Mock };
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = () => '';
+	mock.isEnabled = jest.fn();
+	return mock;
+} );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	dangerouslyGetExperimentAssignment: jest.fn(),
+} ) );
+
+const mockDangerouslyGetExperimentAssignment =
+	dangerouslyGetExperimentAssignment as jest.MockedFunction<
+		typeof dangerouslyGetExperimentAssignment
+	>;
+
+const buildAssignment = ( variationName: string | null ): ExperimentAssignment => ( {
+	experimentName: DOMAIN_BUNDLE_EXPERIMENT_NAME,
+	variationName,
+	retrievedTimestamp: Date.now(),
+	ttl: 60,
+} );
+
+describe( 'isDomainBundleExperienceEnabled', () => {
+	beforeEach( () => {
+		mockConfig.isEnabled.mockReset();
+		mockDangerouslyGetExperimentAssignment.mockReset();
+		mockDangerouslyGetExperimentAssignment.mockReturnValue( buildAssignment( null ) );
+	} );
+
+	it( 'returns true when the domain-bundling flag is on, without reading the experiment', () => {
+		mockConfig.isEnabled.mockImplementation( ( flag: string ) => flag === 'domain-bundling' );
+
+		expect( isDomainBundleExperienceEnabled() ).toBe( true );
+		expect( mockDangerouslyGetExperimentAssignment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns true when the flag is off but the user is assigned treatment', () => {
+		mockConfig.isEnabled.mockReturnValue( false );
+		mockDangerouslyGetExperimentAssignment.mockReturnValue( buildAssignment( 'treatment' ) );
+
+		expect( isDomainBundleExperienceEnabled() ).toBe( true );
+		expect( mockDangerouslyGetExperimentAssignment ).toHaveBeenCalledWith(
+			DOMAIN_BUNDLE_EXPERIMENT_NAME
+		);
+	} );
+
+	it( 'returns false when the flag is off and the assignment is control', () => {
+		mockConfig.isEnabled.mockReturnValue( false );
+		mockDangerouslyGetExperimentAssignment.mockReturnValue( buildAssignment( 'control' ) );
+
+		expect( isDomainBundleExperienceEnabled() ).toBe( false );
+	} );
+
+	it( 'returns false when the flag is off and no assignment has been made yet', () => {
+		mockConfig.isEnabled.mockReturnValue( false );
+		mockDangerouslyGetExperimentAssignment.mockReturnValue( buildAssignment( null ) );
+
+		expect( isDomainBundleExperienceEnabled() ).toBe( false );
+	} );
+} );

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isBiennially,
 	isDIFMProduct,
@@ -26,6 +25,7 @@ import {
 import styled from '@emotion/styled';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { isDomainBundleExperienceEnabled } from 'calypso/lib/domains/bundle-experiment';
 import useEquivalentMonthlyTotals, {
 	getSimulatedCostBeforeDiscounts,
 } from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
@@ -671,9 +671,10 @@ export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBun
 }
 
 export function ProductsAndCostOverridesList( { responseCart }: { responseCart: ResponseCart } ) {
-	// Bundle grouping is gated behind the `domain-bundling` feature flag. When off,
-	// every product renders on its own line exactly as before.
-	const groupedLineItems = config.isEnabled( 'domain-bundling' )
+	// Bundle grouping is gated behind the dev `domain-bundling` flag or the bundle
+	// ExPlat treatment arm. When off, every product renders on its own line exactly
+	// as before.
+	const groupedLineItems = isDomainBundleExperienceEnabled()
 		? groupBundleLineItems( responseCart.products )
 		: responseCart.products.map( ( product ) => ( { type: 'product' as const, product } ) );
 

--- a/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
+++ b/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import { thunk } from 'redux-thunk';
+import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
 import {
 	mockGetCartEndpointWith,
 	mockSetCartEndpointWith,
@@ -39,6 +40,13 @@ jest.mock( '@automattic/calypso-config', () => {
 	mock.isEnabled = jest.fn();
 	return mock;
 } );
+
+jest.mock( 'calypso/lib/explat' );
+
+const mockDangerouslyGetExperimentAssignment =
+	dangerouslyGetExperimentAssignment as jest.MockedFunction<
+		typeof dangerouslyGetExperimentAssignment
+	>;
 
 function buildDomainProduct( overrides: {
 	uuid: string;
@@ -203,6 +211,16 @@ function TestWrapper( {
 }
 
 describe( 'ProductsAndCostOverridesList', () => {
+	beforeEach( () => {
+		// Default: no experiment assignment, so grouping is driven by the flag alone.
+		mockDangerouslyGetExperimentAssignment.mockReturnValue( {
+			experimentName: 'calypso_domains_search_bundle_suggestions_202606',
+			variationName: null,
+			retrievedTimestamp: Date.now(),
+			ttl: 60,
+		} );
+	} );
+
 	afterEach( () => {
 		mockConfig.isEnabled.mockRestore();
 	} );
@@ -222,7 +240,26 @@ describe( 'ProductsAndCostOverridesList', () => {
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 	} );
 
-	it( 'renders each product on its own line when the flag is off', () => {
+	it( 'groups bundle-tagged products when the flag is off but the user is in the experiment treatment arm', () => {
+		mockConfig.isEnabled.mockImplementation( () => false );
+		mockDangerouslyGetExperimentAssignment.mockReturnValue( {
+			experimentName: 'calypso_domains_search_bundle_suggestions_202606',
+			variationName: 'treatment',
+			retrievedTimestamp: Date.now(),
+			ttl: 60,
+		} );
+		const responseCart = buildCartWithBundle();
+
+		render(
+			<TestWrapper initialCart={ responseCart }>
+				<ProductsAndCostOverridesList responseCart={ responseCart } />
+			</TestWrapper>
+		);
+
+		expect( screen.getByText( 'Domain Bundle' ) ).toBeVisible();
+	} );
+
+	it( 'renders each product on its own line when the flag is off and the user is not in treatment', () => {
 		mockConfig.isEnabled.mockImplementation( () => false );
 		const responseCart = buildCartWithBundle();
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -21,6 +21,7 @@ import styled from '@emotion/styled';
 import { getQueryArg } from '@wordpress/url';
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
+import { isDomainBundleExperienceEnabled } from 'calypso/lib/domains/bundle-experiment';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import {
@@ -126,9 +127,10 @@ export function WPOrderReviewLineItems( {
 	const [ initialProducts ] = useState( () => responseCart.products );
 	const [ forceShowAkQuantityDropdown, setForceShowAkQuantityDropdown ] = useState( false );
 
-	// Bundle grouping is gated behind the `domain-bundling` feature flag. When off,
-	// every product renders on its own line exactly as before.
-	const groupedLineItems: GroupedCartLineItem[] = config.isEnabled( 'domain-bundling' )
+	// Bundle grouping is gated behind the dev `domain-bundling` flag or the bundle
+	// ExPlat treatment arm. When off, every product renders on its own line exactly
+	// as before.
+	const groupedLineItems: GroupedCartLineItem[] = isDomainBundleExperienceEnabled()
 		? groupBundleLineItems( responseCart.products )
 		: responseCart.products.map( ( product ) => ( { type: 'product' as const, product } ) );
 

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -49,9 +49,11 @@ export const useSuggestionsList = () => {
 		enabled: config.skippable && ! isFqdnQuery,
 	} );
 
-	// Bundle suggestions are gated behind the frontend `domain-bundling` flag
-	// (surfaced as config.showBundleSuggestions). When off, the query never runs
-	// and bundleSuggestion stays undefined, leaving the rest of the flow unchanged.
+	// The fetch is gated on flow eligibility only (config.showBundleSuggestions),
+	// never on the experiment, so both arms fetch and reach the would-show decision
+	// point. When off, the query never runs and bundleSuggestion stays undefined,
+	// leaving the rest of the flow unchanged. Rendering the result is a separate
+	// gate (config.showBundleCard).
 	const { data: bundleSuggestion } = useQuery( {
 		...queries.bundleSuggestion( query ),
 		enabled: config.showBundleSuggestions,

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -39,6 +39,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onTrademarkClaimsNoticeAccepted: noop,
 		onTrademarkClaimsNoticeClosed: noop,
 		onPageView: noop,
+		onBundleWouldShow: noop,
 		onBundleShown: noop,
 		onBundleAddToCart: noop,
 	},
@@ -72,6 +73,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		allowedTlds: [],
 		numberOfDomainsResultsPerPage: 10,
 		showBundleSuggestions: false,
+		showBundleCard: false,
 		priceRules: {
 			hidePrice: false,
 			oneTimePrice: false,

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -156,22 +156,36 @@ export const ResultsPage = () => {
 
 	useRequestTracking();
 
-	// Fire `onBundleShown` once per distinct bundle that actually renders. Keyed on
-	// the group id so a new bundle (different query/experiment arm) re-fires, but
-	// re-renders of the same bundle do not.
+	// The would-show decision point: a non-null bundle suggestion is available for
+	// the current search. Keyed on the group id so a new bundle (different
+	// query/experiment arm) re-fires, but re-renders of the same bundle do not.
 	const shownBundleGroupId =
 		! isLoadingSuggestions && visibleBundleSuggestion && visibleBundleSuggestion.domains.length > 0
 			? visibleBundleSuggestion.bundle_group_id
 			: undefined;
 
+	// Fire `onBundleWouldShow` once per distinct bundle, for BOTH arms, the moment
+	// the card would render. This is the experiment exposure point — it must run
+	// regardless of whether the card actually shows, so control and treatment are
+	// assigned symmetrically.
 	useEffect( () => {
 		if ( shownBundleGroupId && visibleBundleSuggestion ) {
-			events.onBundleShown( visibleBundleSuggestion );
+			events.onBundleWouldShow( visibleBundleSuggestion );
 		}
-		// Intentionally keyed only on the group id: we want exactly one event per
-		// bundle that appears, not one per render or per `events`/object identity change.
+		// Intentionally keyed only on the group id: exactly one exposure per bundle
+		// that reaches the decision point, not one per render or per `events` identity.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ shownBundleGroupId ] );
+
+	// Fire `onBundleShown` once per distinct bundle that actually renders (treatment
+	// only). Keyed on the group id and `showBundleCard` so it fires after the
+	// assignment resolves and the card becomes visible, never for control.
+	useEffect( () => {
+		if ( shownBundleGroupId && visibleBundleSuggestion && config.showBundleCard ) {
+			events.onBundleShown( visibleBundleSuggestion );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ shownBundleGroupId, config.showBundleCard ] );
 
 	const showCompactBanner = !! slots?.BeforeResults;
 
@@ -213,7 +227,7 @@ export const ResultsPage = () => {
 				) : (
 					<FeaturedSearchResults suggestions={ featuredSuggestions } />
 				) }
-				{ ! isLoadingSuggestions && visibleBundleSuggestion && (
+				{ ! isLoadingSuggestions && config.showBundleCard && visibleBundleSuggestion && (
 					<BundleCard
 						suggestion={ visibleBundleSuggestion }
 						onAddToCart={ ( bundle ) => {

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -901,7 +901,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test"
 				>
 					<ResultsPage />
@@ -954,7 +954,7 @@ describe( 'ResultsPage', () => {
 			const { container } = render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-error"
 				>
 					<ResultsPage />
@@ -989,7 +989,7 @@ describe( 'ResultsPage', () => {
 			const { container } = render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-fallback"
 				>
 					<ResultsPage />
@@ -1032,7 +1032,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-permanent"
 				>
 					<ResultsPage />
@@ -1078,7 +1078,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-same-group"
 				>
 					<ResultsPage />
@@ -1139,7 +1139,7 @@ describe( 'ResultsPage', () => {
 			const { rerender } = render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-late-stale"
 				>
 					<ResultsPage />
@@ -1153,7 +1153,7 @@ describe( 'ResultsPage', () => {
 			rerender(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-late-fresh"
 				>
 					<ResultsPage />
@@ -1194,7 +1194,7 @@ describe( 'ResultsPage', () => {
 			const { container } = render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-retry"
 				>
 					<ResultsPage />
@@ -1241,7 +1241,7 @@ describe( 'ResultsPage', () => {
 			const { container, rerender } = render(
 				<TestDomainSearch
 					cart={ cart }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-stale"
 				>
 					<ResultsPage />
@@ -1259,7 +1259,7 @@ describe( 'ResultsPage', () => {
 			rerender(
 				<TestDomainSearch
 					cart={ cart }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-fresh"
 				>
 					<ResultsPage />
@@ -1295,7 +1295,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-pending"
 				>
 					<ResultsPage />
@@ -1340,7 +1340,7 @@ describe( 'ResultsPage', () => {
 			const { container } = render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="test-bundle-supersede"
 				>
 					<ResultsPage />
@@ -1380,7 +1380,7 @@ describe( 'ResultsPage', () => {
 			const { container } = render(
 				<TestDomainSearch
 					cart={ buildCart( { hasItem: ( domain ) => domain.startsWith( 'bundle-added.' ) } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					events={ { onContinue } }
 					query="bundle-added"
 				>
@@ -1413,7 +1413,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					cart={ buildCart( { hasItem: ( domain ) => domain === 'bundle-partial.com' } ) }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="bundle-partial"
 				>
 					<ResultsPage />
@@ -1501,7 +1501,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					events={ { onBundleShown } }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="bundle-shown"
 				>
 					<ResultsPage />
@@ -1540,6 +1540,120 @@ describe( 'ResultsPage', () => {
 			expect( onBundleShown ).not.toHaveBeenCalled();
 		} );
 
+		it( 'does not fire the onBundleShown event for the control arm (fetched but no card)', async () => {
+			const onBundleShown = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-control' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-control.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-control' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-control' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleShown } }
+					config={ { showBundleSuggestions: true, showBundleCard: false } }
+					query="bundle-control"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'bundle-control.com' ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+			expect( onBundleShown ).not.toHaveBeenCalled();
+		} );
+
+		it( 'fires onBundleWouldShow once for the control arm even though no card renders', async () => {
+			const onBundleWouldShow = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'would-show-control' },
+				suggestions: [ buildSuggestion( { domain_name: 'would-show-control.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'would-show-control' },
+				bundleSuggestion: buildBundleSuggestion( 'would-show-control' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleWouldShow } }
+					config={ { showBundleSuggestions: true, showBundleCard: false } }
+					query="would-show-control"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( onBundleWouldShow ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( onBundleWouldShow ).toHaveBeenCalledWith(
+				expect.objectContaining( { bundle_group_id: 'mock-would-show-control-group' } )
+			);
+			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'fires onBundleWouldShow once for the treatment arm alongside onBundleShown', async () => {
+			const onBundleWouldShow = jest.fn();
+			const onBundleShown = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'would-show-treatment' },
+				suggestions: [ buildSuggestion( { domain_name: 'would-show-treatment.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'would-show-treatment' },
+				bundleSuggestion: buildBundleSuggestion( 'would-show-treatment' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleWouldShow, onBundleShown } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
+					query="would-show-treatment"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+			await waitFor( () => {
+				expect( onBundleWouldShow ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( onBundleShown ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not fire onBundleWouldShow when no bundle suggestion is returned', async () => {
+			const onBundleWouldShow = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'would-show-empty' },
+				suggestions: [ buildSuggestion( { domain_name: 'would-show-empty.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'would-show-empty' },
+				bundleSuggestion: null,
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleWouldShow } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
+					query="would-show-empty"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'would-show-empty.com' ) ).toBeInTheDocument();
+			expect( onBundleWouldShow ).not.toHaveBeenCalled();
+		} );
+
 		it( 'fires the onBundleAddToCart event after the bundle add succeeds', async () => {
 			const user = userEvent.setup();
 			let resolveAddBundle: () => void = () => {};
@@ -1564,7 +1678,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					events={ { onBundleAddToCart } }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="bundle-accept"
 				>
 					<ResultsPage />
@@ -1606,7 +1720,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					events={ { onBundleAddToCart } }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="bundle-reject"
 				>
 					<ResultsPage />
@@ -1641,7 +1755,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle: undefined } ) }
 					events={ { onBundleAddToCart } }
-					config={ { showBundleSuggestions: true } }
+					config={ { showBundleSuggestions: true, showBundleCard: true } }
 					query="bundle-no-handler"
 				>
 					<ResultsPage />

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -106,6 +106,15 @@ export interface DomainSearchEvents {
 	onTrademarkClaimsNoticeAccepted: ( suggestion: ReturnType< typeof useSuggestion > ) => void;
 	onTrademarkClaimsNoticeClosed: ( suggestion: ReturnType< typeof useSuggestion > ) => void;
 	onPageView: () => void;
+	/**
+	 * Fired once per distinct bundle at the moment its card would render — i.e.
+	 * a non-null bundle suggestion is available for the current search. Fires for
+	 * BOTH experiment arms, before any render decision, so the app layer can use
+	 * it as the experiment exposure point and assign control and treatment
+	 * symmetrically (scoped to users who would have seen a bundle). Distinct from
+	 * `onBundleShown`, which only fires for the card that actually renders.
+	 */
+	onBundleWouldShow: ( bundle: BundleSuggestion ) => void;
 	onBundleShown: ( bundle: BundleSuggestion ) => void;
 	onBundleAddToCart: ( bundle: BundleSuggestion ) => void;
 }
@@ -121,11 +130,19 @@ export interface DomainSearchConfig {
 	includeOwnedDomainInSuggestions: boolean;
 	numberOfDomainsResultsPerPage: number;
 	/**
-	 * Show domain bundle suggestions in the search flow. Frontend dev/Storybook
-	 * gate, set from the `domain-bundling` feature flag at the app layer. Default
-	 * false, so bundles stay hidden unless a consumer opts in.
+	 * Fetch bundle suggestions for the current search. Gates only the bundle
+	 * suggestion query — never rendering. Set from flow eligibility at the app
+	 * layer and true for BOTH experiment arms, so control and treatment alike
+	 * reach the would-show decision point (`onBundleWouldShow`). Default false.
 	 */
 	showBundleSuggestions: boolean;
+	/**
+	 * Render the bundle suggestion card once a suggestion is available. Set at the
+	 * app layer from the dev `domain-bundling` flag OR the ExPlat treatment
+	 * assignment, so control fetches the suggestion but renders nothing. Default
+	 * false.
+	 */
+	showBundleCard: boolean;
 }
 
 export interface DomainSearchProps {


### PR DESCRIPTION
Related to #DOMAINS-2178

## What

Replace the dev-only `domain-bundling` feature flag for **production** exposure with a single on/off ExPlat experiment (`calypso_domains_search_bundle_suggestions_202606`), keeping the flag as the dev/staging gate. Treatment = bundle experience on; control = current no-bundle behavior.

## How — three distinct gates

- **Fetch** (`showBundleSuggestions`): flow-eligibility only, **both arms, all envs**. Deliberately *not* gated on the `domain-bundling` flag (it's off in prod) nor on the experiment — both arms must fetch so both reach the would-show decision point. The server kill switch (`WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED`) still returns nothing when bundles are off, so this only fetches when a bundle can actually exist.
- **Exposure**: when a non-null `bundle_suggestion` comes back (the would-show point), the app layer fires `loadExperimentAssignment(...)` once per bundle (keyed on `bundle_group_id`) — symmetric for both arms, scoped to "users who would have seen a bundle." Not `bundle_shown`, which is treatment-only and would expose asymmetrically.
- **Render / grouping** (`showBundleCard` / `isDomainBundleExperienceEnabled()`): `domain-bundling flag || treatment`. Dev/staging force-on via the flag; prod via the experiment.

Package portability preserved: `packages/domain-search`, `packages/mini-cart`, and `packages/wpcom-checkout` stay free of explat/config/analytics imports; the app layer (`client/`) owns all ExPlat calls. Cart/checkout grouping uses `dangerouslyGetExperimentAssignment` (synchronous read of the assignment already made at search — no re-exposure).

## Notes

- The experiment (DOMAINS-2182) doesn't exist in ExPlat yet, so `loadExperimentAssignment` returns the control fallback and this is inert until both the experiment and the server flag are on.
- Treatment variation name assumed `treatment` (the `explat-create-experiment` default split), centralized in `client/lib/domains/bundle-experiment.ts` — a one-line change if the experiment uses different variation names.

## Testing

<details>
<summary>Test commands + results</summary>

- `yarn jest --config=test/packages/jest.config.js packages/domain-search` → 31 suites, 368 passed
- `yarn test-client client/components/domains/wpcom-domain-search/test` → 60 passed
- `yarn test-client .../use-wpcom-domain-search-props.ts client/lib/domains/test/bundle-experiment.ts .../cost-overrides-list.test.tsx` → 57 passed
- `packages/domain-search`: `yarn tsc --noEmit` → 0 errors; `yarn typecheck-packages` → 0
- `yarn tsc --project client --noEmit` → 6 pre-existing errors only (missing d.ts in `client/dashboard`), none from these changes

New tests cover: both arms fetch; exposure fires exactly once at the decision point and not when the suggestion is null; control renders no card; treatment renders card + events; cart/checkout grouping respects flag-or-treatment.
</details>
