### PR TITLE
Domain cancellation: remove redundant "Something not listed here" reason

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx
@@ -536,15 +536,9 @@ export const DOMAIN_REGISTRATION_CANCELLATION_REASONS: CancellationReason[] = [
 			return __( 'Please tell us more' );
 		},
 	},
-	{
-		value: 'other',
-		get label() {
-			return __( 'Something not listed here' );
-		},
-		get textPlaceholder() {
-			return __( 'Please tell us more' );
-		},
-	},
+	// The generic "Another reason…" catch-all (LAST_REASON) is appended to every
+	// reason list by getCancellationReasons(), so this list intentionally omits its
+	// own "Something not listed here" option to avoid showing two redundant catch-alls.
 ];
 
 export const GSUITE_CANCELLATION_REASONS: CancellationReason[] = [


### PR DESCRIPTION
Related to #DOMENG-735

## Problem

In the new dashboard domain cancellation flow, the cancellation reason list shows two effectively identical catch-all options:

- **Something not listed here** — the `other` entry in `DOMAIN_REGISTRATION_CANCELLATION_REASONS`
- **Another reason…** — the generic `LAST_REASON` that `getCancellationReasons()` appends to every reason list

Having both is redundant and confusing (reported during MSD domain testing).

## Fix

Remove the domain-specific `other` ("Something not listed here") entry so the domain flow uses the same single "Another reason…" catch-all (value `anotherReasonOne`) as every other cancellation flow.

The selected reason value is only reported as survey `response` data (it is not used for any control flow), and the survey payload already tags the product type, so dropping the domain-specific `other` value loses no signal.

## Scope

Pure UX/copy consolidation. Single file, 3 insertions / 9 deletions.

For testing, you'll need to run this locally and start at http://my.localhost:3000/domains in order to see the correct offboarding flow.

<details>
<summary>How to verify</summary>

1. Open the new dashboard purchase settings for a domain registration and start the cancel/remove flow.
2. On the "Why would you like to cancel?" step, confirm the reason list now ends with a single "Another reason…" option and no longer also shows "Something not listed here".
3. The legacy DomainCancellationSurvey (SelectControl dropdown) is unaffected — it already had only one catch-all.
</details>

Co-Authored-By: Claude <noreply@anthropic.com>