### PR TITLE
Recovery SMS: sanitize phone number input

### DIFF
--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -17,6 +17,7 @@ import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import ConfirmModal from '../../components/confirm-modal';
+import { sanitizePhoneNumber } from '../../components/domain-contact-details-form/contact-validation-utils';
 import Notice from '../../components/notice';
 import PhoneNumberInput from '../../components/phone-number-input';
 import { SectionHeader } from '../../components/section-header';
@@ -166,7 +167,13 @@ export default function RecoverySMS() {
 						<PhoneNumberInput
 							data={ data.smsNumber }
 							onChange={ ( edits ) => {
-								onChange( { ...data, smsNumber: edits } );
+								onChange( {
+									...data,
+									smsNumber: {
+										...edits,
+										phoneNumber: sanitizePhoneNumber( edits.phoneNumber ?? '' ),
+									},
+								} );
 							} }
 							isDisabled={ isValidateSMSPending }
 						/>


### PR DESCRIPTION
Related to #DOMENG-288

## Proposed Changes

- Apply the existing `sanitizePhoneNumber` helper (from the domain contact details form) to the phone number field on the MSD account recovery SMS screen, stripping any non-digit characters on input.

## Why are these changes being made?

We changed how the phone number is processed before sending it for validation in #107694. The same logic makes sense on the account recovery screen. Without it, the recovery SMS phone field accepts badly formatted input — most notably multiple `+` characters (DOTMSD-1334).

The country code is selected from a dropdown, so only the free-text phone number field needs sanitizing.

## Testing Instructions

1. Go to the account recovery screen in the Multi-site Dashboard (Me -> Security -> Account recovery).
2. In the Recovery SMS number field, try typing `+` characters or other non-digits into the phone number input.
3. Confirm the non-digit characters are stripped and only digits remain.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?

Co-Authored-By: Claude <noreply@anthropic.com>