### PR TITLE
Dashboard: handle taken-domain error in MSD domain upsell

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -61,10 +61,10 @@ const DomainUpsellCardContent = ( {
 		if ( suggestedDomain ) {
 			setIsSubmitting( true );
 
-			const { shoppingCartManagerClient } = await import(
-				/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
-			);
 			try {
+				const { shoppingCartManagerClient } = await import(
+					/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
+				);
 				await shoppingCartManagerClient.forCartKey( site.ID ).actions.replaceProductsInCart( [
 					{
 						product_slug: suggestedDomain?.product_slug ?? '',

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -73,8 +73,7 @@ const DomainUpsellCardContent = ( {
 				] );
 			} catch ( error ) {
 				createErrorNotice(
-					( error as Error ).message ||
-						__( 'Failed to claim domain. Please try again.' ),
+					( error as Error ).message || __( 'Failed to claim domain. Please try again.' ),
 					{ type: 'snackbar' }
 				);
 				setIsSubmitting( false );

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -1,8 +1,10 @@
 import { domainSuggestionsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalText as Text } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 // eslint-disable-next-line no-restricted-imports
@@ -52,6 +54,7 @@ const DomainUpsellCardContent = ( {
 } ) => {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const backUrl = redirectToDashboardLink( { supportBackport: true } );
 	const handleUpsell = async () => {
@@ -61,12 +64,22 @@ const DomainUpsellCardContent = ( {
 			const { shoppingCartManagerClient } = await import(
 				/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
 			);
-			await shoppingCartManagerClient.forCartKey( site.ID ).actions.replaceProductsInCart( [
-				{
-					product_slug: suggestedDomain?.product_slug ?? '',
-					meta: suggestedDomain?.domain_name,
-				},
-			] );
+			try {
+				await shoppingCartManagerClient.forCartKey( site.ID ).actions.replaceProductsInCart( [
+					{
+						product_slug: suggestedDomain?.product_slug ?? '',
+						meta: suggestedDomain?.domain_name,
+					},
+				] );
+			} catch ( error ) {
+				createErrorNotice(
+					( error as Error ).message ||
+						__( 'Sorry, we had a problem adding that domain. Please try again.' ),
+					{ type: 'snackbar' }
+				);
+				setIsSubmitting( false );
+				return;
+			}
 		}
 
 		if ( requiresPlanUpgrade( site ) ) {

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -74,7 +74,7 @@ const DomainUpsellCardContent = ( {
 			} catch ( error ) {
 				createErrorNotice(
 					( error as Error ).message ||
-						__( 'Sorry, we had a problem adding that domain. Please try again.' ),
+						__( 'Failed to claim domain. Please try again.' ),
 					{ type: 'snackbar' }
 				);
 				setIsSubmitting( false );

--- a/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
@@ -14,6 +14,7 @@ const mockFetchSitePlans = jest.fn();
 const mockFetchDomainSuggestions = jest.fn();
 const mockReplaceProductsInCart = jest.fn();
 const mockCreateErrorNotice = jest.fn();
+let mockShoppingCartImportError: Error | null = null;
 
 jest.mock( '@automattic/api-core', () => ( {
 	...jest.requireActual( '@automattic/api-core' ),
@@ -21,15 +22,21 @@ jest.mock( '@automattic/api-core', () => ( {
 	fetchDomainSuggestions: ( ...args: unknown[] ) => mockFetchDomainSuggestions( ...args ),
 } ) );
 
-jest.mock( '../../../app/shopping-cart', () => ( {
-	shoppingCartManagerClient: {
-		forCartKey: () => ( {
-			actions: {
-				replaceProductsInCart: ( ...args: unknown[] ) => mockReplaceProductsInCart( ...args ),
-			},
-		} ),
-	},
-} ) );
+jest.mock( '../../../app/shopping-cart', () => {
+	if ( mockShoppingCartImportError ) {
+		throw mockShoppingCartImportError;
+	}
+
+	return {
+		shoppingCartManagerClient: {
+			forCartKey: () => ( {
+				actions: {
+					replaceProductsInCart: ( ...args: unknown[] ) => mockReplaceProductsInCart( ...args ),
+				},
+			} ),
+		},
+	};
+} );
 
 // eslint-disable-next-line no-restricted-imports
 jest.mock( 'calypso/lib/domains', () => ( {
@@ -61,6 +68,7 @@ const mockSite: Site = {
 
 beforeEach( () => {
 	jest.clearAllMocks();
+	mockShoppingCartImportError = null;
 	mockFetchSitePlans.mockResolvedValue( {
 		plans: [ { current_plan: true, has_domain_credit: true } ],
 	} );
@@ -70,6 +78,24 @@ beforeEach( () => {
 } );
 
 describe( 'DomainUpsellCard', () => {
+	test( 'shows an error notice when the shopping cart chunk fails to load', async () => {
+		const user = userEvent.setup();
+		mockShoppingCartImportError = new Error( 'Loading chunk failed' );
+
+		render( <DomainUpsellCard site={ mockSite } /> );
+
+		const button = await screen.findByRole( 'button', { name: 'Claim this domain' } );
+		await user.click( button );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith( 'Loading chunk failed', {
+				type: 'snackbar',
+			} );
+		} );
+
+		expect( button ).not.toHaveClass( 'is-busy' );
+	} );
+
 	test( 'shows an error notice when adding an unavailable domain to the cart fails', async () => {
 		const user = userEvent.setup();
 		const errorMessage = 'Sorry, the domain you are trying to add is no longer available.';

--- a/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import DomainUpsellCard from '../index';
+import type { Site } from '@automattic/api-core';
+
+const mockSiteId = 123;
+
+const mockFetchSitePlans = jest.fn();
+const mockFetchDomainSuggestions = jest.fn();
+const mockReplaceProductsInCart = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	fetchSitePlans: ( ...args: unknown[] ) => mockFetchSitePlans( ...args ),
+	fetchDomainSuggestions: ( ...args: unknown[] ) => mockFetchDomainSuggestions( ...args ),
+} ) );
+
+jest.mock( '../../../app/shopping-cart', () => ( {
+	shoppingCartManagerClient: {
+		forCartKey: () => ( {
+			actions: {
+				replaceProductsInCart: ( ...args: unknown[] ) => mockReplaceProductsInCart( ...args ),
+			},
+		} ),
+	},
+} ) );
+
+// eslint-disable-next-line no-restricted-imports
+jest.mock( 'calypso/lib/domains', () => ( {
+	getDomainAndPlanUpsellUrl: () => '/upsell-url',
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		createErrorNotice: mockCreateErrorNotice,
+	} ),
+	useSelect: jest.fn( () => ( {} ) ),
+	combineReducers: jest.fn( ( reducers ) => reducers ),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+	createSelector: jest.fn(),
+	keyedReducer: () => () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	...jest.requireActual( '@wordpress/i18n' ),
+	__: ( text: string ) => text,
+} ) );
+
+const mockSite: Site = {
+	ID: mockSiteId,
+	slug: 'example.wordpress.com',
+	plan: {},
+} as Site;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockFetchSitePlans.mockResolvedValue( {
+		plans: [ { current_plan: true, has_domain_credit: true } ],
+	} );
+	mockFetchDomainSuggestions.mockResolvedValue( [
+		{ domain_name: 'example.com', product_slug: 'domain_reg' },
+	] );
+} );
+
+describe( 'DomainUpsellCard', () => {
+	test( 'shows an error notice when adding an unavailable domain to the cart fails', async () => {
+		const user = userEvent.setup();
+		const errorMessage = 'Sorry, the domain you are trying to add is no longer available.';
+		mockReplaceProductsInCart.mockRejectedValue( new Error( errorMessage ) );
+
+		render( <DomainUpsellCard site={ mockSite } /> );
+
+		const button = await screen.findByRole( 'button', { name: 'Claim this domain' } );
+		await user.click( button );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith( errorMessage, { type: 'snackbar' } );
+		} );
+
+		// The button should no longer be busy after the failure.
+		expect( button ).not.toHaveClass( 'is-busy' );
+	} );
+} );


### PR DESCRIPTION
Related to #DOMENG-439

### Problem

In the new dashboard (MSD) site overview, the "Claim your free domain" upsell card lets a user claim the suggested free domain. Clicking the button calls `replaceProductsInCart`. When the suggested domain is already taken, the shopping-cart manager rejects with a `CartActionResponseError`.

That rejection was unhandled, so:
- it surfaced as an `Uncaught (in promise) CartActionResponseError` console error, and
- the claim button stayed stuck in its busy state.

### Fix

Wrap the cart action in `try/catch`. On failure:
- show the cart error message as a snackbar notice via `createErrorNotice` (matching the convention in `domain-overview/actions.tsx`),
- reset the busy state, and
- return early so we don't navigate to checkout with a failed cart.

### Testing

Added a focused test that mocks the cart action to reject and asserts that an error snackbar is shown and the button is no longer busy. The test fails without either half of the fix.

<details>
<summary>Manual repro</summary>

1. On a paid plan with domain credit, open the site overview dashboard.
2. Click "Claim this domain" for a domain that is already taken (the suggestion endpoint / cart returns "no longer available").
3. Before: uncaught console error, button stuck busy. After: an error snackbar appears and the button returns to normal.

</details>

Co-Authored-By: Claude <noreply@anthropic.com>