### PR TITLE
Domain contact form: show correct country for shared phone dial codes

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -95,9 +95,19 @@ export const getContactFormFields = (
 
 				const phoneValue = combinePhoneNumber( countryNumericCode, phoneNumber );
 
-				// Resolve the country from the numeric dialing code, disambiguating
-				// shared codes (e.g. +1) using the contact's own country (DOMENG-635).
-				const smsCountry = resolveSmsCountry( smsCountryCodes, countryNumericCode, countryCode );
+				// The stored phone value encodes only the numeric dialing code (for
+				// example +1), not which of the countries sharing that code the contact
+				// intends. Seed the displayed country from the contact's own country
+				// (DOMENG-635), but once the contact explicitly picks a country keep that
+				// choice — a shared code like +1 must not snap back to the address
+				// country on every re-render.
+				const [ selectedCountryCode, setSelectedCountryCode ] = useState< string | undefined >();
+				const resolvedCountryCode = resolveSmsCountry(
+					smsCountryCodes,
+					countryNumericCode,
+					countryCode
+				)?.code;
+				const displayedCountryCode = selectedCountryCode ?? resolvedCountryCode ?? '';
 
 				// Handle both sync and async validators
 				const [ validationMessage, setValidationMessage ] = useState< string | null >( null );
@@ -121,11 +131,17 @@ export const getContactFormFields = (
 							validationMessage ? { type: 'invalid', message: validationMessage } : undefined
 						}
 						data={ {
-							countryCode: smsCountry?.code || '',
+							countryCode: displayedCountryCode,
 							phoneNumber: phoneNumber,
 							countryNumericCode: countryNumericCode,
 						} }
 						onChange={ ( edits ) => {
+							// Changing the country dropdown (as opposed to typing the
+							// number) is a deliberate country choice; remember it so it
+							// survives re-render and later address-country changes.
+							if ( edits.countryCode && edits.countryCode !== displayedCountryCode ) {
+								setSelectedCountryCode( edits.countryCode );
+							}
 							// Format the phone value back to the expected format: +country_code.phone_number
 							const formattedPhone = combinePhoneNumber(
 								sanitizePhoneCountryCode( edits.countryNumericCode ?? '' ),

--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -138,7 +138,9 @@ export const getContactFormFields = (
 						onChange={ ( edits ) => {
 							// Changing the country dropdown (as opposed to typing the
 							// number) is a deliberate country choice; remember it so it
-							// survives re-render and later address-country changes.
+							// survives re-render instead of re-resolving from the address
+							// country. (Changing the address country rebuilds the field and
+							// re-seeds the default, which is the intended behavior.)
 							if ( edits.countryCode && edits.countryCode !== displayedCountryCode ) {
 								setSelectedCountryCode( edits.countryCode );
 							}

--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -18,6 +18,7 @@ import {
 	sanitizePhoneNumber,
 	splitPhoneNumber,
 	combinePhoneNumber,
+	resolveSmsCountry,
 } from './contact-validation-utils';
 import { RegionAddressFieldsets } from './region-address-fieldsets';
 import type { CountryListItem } from './custom-form-fieldsets/types';
@@ -93,9 +94,12 @@ export const getContactFormFields = (
 
 				const phoneValue = combinePhoneNumber( countryNumericCode, phoneNumber );
 
-				// Find country code from the numeric code using SMS country codes
-				const smsCountry = smsCountryCodes?.find(
-					( country ) => country.numeric_code === countryNumericCode
+				// Resolve the country from the numeric dialing code, disambiguating
+				// shared codes (e.g. +1) using the contact's own country (DOMENG-635).
+				const smsCountry = resolveSmsCountry(
+					smsCountryCodes,
+					countryNumericCode,
+					countryCode
 				);
 
 				// Handle both sync and async validators

--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -6,7 +6,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { type Field } from '@wordpress/dataviews';
+import { type Field, type DataFormControlProps } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
@@ -39,6 +39,83 @@ const getCountryElements = ( countryList: CountryListItem[] | undefined ) => {
 	}
 	return elements;
 };
+
+/**
+ * Phone field control.
+ *
+ * The stored phone value encodes only the numeric dialing code (for example +1),
+ * not which of the countries sharing that code the contact intends. On mount the
+ * displayed country is seeded from the contact's address country (DOMENG-635) so
+ * a shared code resolves to the right country on load. After that the phone
+ * country is fully independent: it is held in local state, so neither later
+ * address edits nor re-renders change it — only an explicit pick does.
+ *
+ * Keeping this as a stable, module-level component (rather than an inline Edit
+ * closure) is what lets that state survive: an address change rebuilds the
+ * fields array in getContactFormFields, and a fresh Edit function identity would
+ * remount the control and wipe the state.
+ */
+function PhoneNumberField( {
+	field,
+	data,
+	onChange,
+}: DataFormControlProps< DomainContactDetails > ) {
+	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
+	const phoneValueRaw = field.getValue( { item: data } );
+	const [ countryNumericCode, phoneNumber ] = splitPhoneNumber( phoneValueRaw );
+	const phoneValue = combinePhoneNumber( countryNumericCode, phoneNumber );
+
+	// Seed once from the address country; the initializer does not re-run on
+	// later renders, so an address edit never moves the phone country.
+	const [ selectedCountryCode, setSelectedCountryCode ] = useState(
+		() =>
+			resolveSmsCountry( smsCountryCodes, countryNumericCode, data.countryCode ?? '' )?.code ?? ''
+	);
+
+	// Handle both sync and async validators
+	const [ validationMessage, setValidationMessage ] = useState< string | null >( null );
+
+	useEffect( () => {
+		const result = field.isValid?.custom?.( data, field );
+
+		// Check if the result is a Promise (async validator)
+		if ( result instanceof Promise ) {
+			result.then( setValidationMessage );
+		} else {
+			// Sync validator - set the result directly
+			setValidationMessage( result ?? null );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- re-validate only when phoneValue changes
+	}, [ phoneValue ] );
+
+	return (
+		<PhoneNumberInput
+			customValidity={
+				validationMessage ? { type: 'invalid', message: validationMessage } : undefined
+			}
+			data={ {
+				countryCode: selectedCountryCode,
+				phoneNumber: phoneNumber,
+				countryNumericCode: countryNumericCode,
+			} }
+			onChange={ ( edits ) => {
+				// An explicit country pick updates the remembered country; typing the
+				// number echoes the current country back unchanged, so it is a no-op.
+				if ( edits.countryCode !== undefined && edits.countryCode !== selectedCountryCode ) {
+					setSelectedCountryCode( edits.countryCode );
+				}
+				// Format the phone value back to the expected format: +country_code.phone_number
+				const formattedPhone = combinePhoneNumber(
+					sanitizePhoneCountryCode( edits.countryNumericCode ?? '' ),
+					sanitizePhoneNumber( edits.phoneNumber ?? '' )
+				);
+				onChange( {
+					phone: formattedPhone,
+				} );
+			} }
+		/>
+	);
+}
 
 export const getContactFormFields = (
 	countryList: CountryListItem[] | undefined,
@@ -86,76 +163,7 @@ export const getContactFormFields = (
 			id: 'phone',
 			label: __( 'Phone' ),
 			type: 'text',
-			Edit: ( { field, data, onChange } ) => {
-				const { getValue } = field;
-				const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
-				const phoneValueRaw = getValue( { item: data } );
-
-				const [ countryNumericCode, phoneNumber ] = splitPhoneNumber( phoneValueRaw );
-
-				const phoneValue = combinePhoneNumber( countryNumericCode, phoneNumber );
-
-				// The stored phone value encodes only the numeric dialing code (for
-				// example +1), not which of the countries sharing that code the contact
-				// intends. Seed the displayed country from the contact's own country
-				// (DOMENG-635), but once the contact explicitly picks a country keep that
-				// choice — a shared code like +1 must not snap back to the address
-				// country on every re-render.
-				const [ selectedCountryCode, setSelectedCountryCode ] = useState< string | undefined >();
-				const resolvedCountryCode = resolveSmsCountry(
-					smsCountryCodes,
-					countryNumericCode,
-					countryCode
-				)?.code;
-				const displayedCountryCode = selectedCountryCode ?? resolvedCountryCode ?? '';
-
-				// Handle both sync and async validators
-				const [ validationMessage, setValidationMessage ] = useState< string | null >( null );
-
-				useEffect( () => {
-					const result = field.isValid?.custom?.( data, field );
-
-					// Check if the result is a Promise (async validator)
-					if ( result instanceof Promise ) {
-						result.then( setValidationMessage );
-					} else {
-						// Sync validator - set the result directly
-						setValidationMessage( result ?? null );
-					}
-					// eslint-disable-next-line react-hooks/exhaustive-deps -- re-validate only when phoneValue changes
-				}, [ phoneValue ] );
-
-				return (
-					<PhoneNumberInput
-						customValidity={
-							validationMessage ? { type: 'invalid', message: validationMessage } : undefined
-						}
-						data={ {
-							countryCode: displayedCountryCode,
-							phoneNumber: phoneNumber,
-							countryNumericCode: countryNumericCode,
-						} }
-						onChange={ ( edits ) => {
-							// Changing the country dropdown (as opposed to typing the
-							// number) is a deliberate country choice; remember it so it
-							// survives re-render instead of re-resolving from the address
-							// country. (Changing the address country rebuilds the field and
-							// re-seeds the default, which is the intended behavior.)
-							if ( edits.countryCode && edits.countryCode !== displayedCountryCode ) {
-								setSelectedCountryCode( edits.countryCode );
-							}
-							// Format the phone value back to the expected format: +country_code.phone_number
-							const formattedPhone = combinePhoneNumber(
-								sanitizePhoneCountryCode( edits.countryNumericCode ?? '' ),
-								sanitizePhoneNumber( edits.phoneNumber ?? '' )
-							);
-							onChange( {
-								phone: formattedPhone,
-							} );
-						} }
-					/>
-				);
-			},
+			Edit: PhoneNumberField,
 			isValid: {
 				required: true,
 				custom: createFieldAsyncValidator( 'phone', asyncValidator ),

--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -12,8 +12,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import InlineSupportLink from '../inline-support-link';
 import PhoneNumberInput from '../phone-number-input';
-import { createFieldAsyncValidator, type AsyncValidator } from './contact-validation-utils';
 import {
+	createFieldAsyncValidator,
+	type AsyncValidator,
 	sanitizePhoneCountryCode,
 	sanitizePhoneNumber,
 	splitPhoneNumber,
@@ -96,11 +97,7 @@ export const getContactFormFields = (
 
 				// Resolve the country from the numeric dialing code, disambiguating
 				// shared codes (e.g. +1) using the contact's own country (DOMENG-635).
-				const smsCountry = resolveSmsCountry(
-					smsCountryCodes,
-					countryNumericCode,
-					countryCode
-				);
+				const smsCountry = resolveSmsCountry( smsCountryCodes, countryNumericCode, countryCode );
 
 				// Handle both sync and async validators
 				const [ validationMessage, setValidationMessage ] = useState< string | null >( null );

--- a/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
+++ b/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
@@ -2,6 +2,7 @@ import type {
 	ContactValidationResponseMessages,
 	DomainContactDetails,
 	DomainContactValidationResponse,
+	SMSCountryCode,
 } from '@automattic/api-core';
 import type { NormalizedField } from '@wordpress/dataviews';
 
@@ -142,4 +143,26 @@ export function splitPhoneNumber( phoneNumber: string ): string[] {
 
 export function combinePhoneNumber( countryNumericCode: string, phoneNumber: string ): string {
 	return `${ countryNumericCode }.${ phoneNumber }`;
+}
+
+/**
+ * Resolves the SMS country entry for a phone number's numeric dialing code.
+ *
+ * A single dialing code can be shared by several countries (for example +1 is
+ * used by the US, Canada, and a number of Caribbean nations). Matching on the
+ * numeric code alone returns the first entry (the Bahamas for +1), which showed
+ * the wrong country for US and Canadian numbers (DOMENG-635). When the dialing
+ * code is shared, prefer the entry that matches the contact's own country code.
+ */
+export function resolveSmsCountry(
+	smsCountryCodes: SMSCountryCode[] | undefined,
+	numericCode: string,
+	preferredCountryCode: string
+): SMSCountryCode | undefined {
+	const countriesForCode =
+		smsCountryCodes?.filter( ( country ) => country.numeric_code === numericCode ) ?? [];
+	return (
+		countriesForCode.find( ( country ) => country.code === preferredCountryCode ) ??
+		countriesForCode[ 0 ]
+	);
 }

--- a/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
@@ -62,13 +62,20 @@ const alwaysValid: AsyncValidator = () => Promise.resolve( { success: true, mess
 
 /**
  * Renders the phone field's Edit control the way DataForm would, with the
- * contact's address country fixed and the phone value held in local state so a
- * change round-trips back through `data` exactly like the real form.
+ * contact's address country held in state (the real form memoizes the fields on
+ * it, so the phone Edit keeps a stable identity while the address is unchanged
+ * and remounts when it changes). The optional button changes the address
+ * country from within the provider-wrapped tree, since the test renderer's
+ * rerender does not re-wrap the element in the QueryClientProvider.
  */
-function PhoneField( { addressCountry }: { addressCountry: string } ) {
-	// The real form memoizes the fields on the address country (contact-form.tsx),
-	// so the phone Edit keeps a stable identity while the address is unchanged.
-	// Rebuilding it every render would remount the Edit and wipe its local state.
+function PhoneField( {
+	initialAddressCountry,
+	nextAddressCountry,
+}: {
+	initialAddressCountry: string;
+	nextAddressCountry?: string;
+} ) {
+	const [ addressCountry, setAddressCountry ] = useState( initialAddressCountry );
 	const phoneField = useMemo(
 		() =>
 			getContactFormFields( [], [], addressCountry, alwaysValid ).find(
@@ -85,12 +92,23 @@ function PhoneField( { addressCountry }: { addressCountry: string } ) {
 	const [ data, setData ] = useState( { phone: '+1.5551234' } as DomainContactDetails );
 
 	return (
-		<Edit
-			field={ { ...phoneField, getValue: ( { item } ) => item.phone ?? '' } }
-			data={ data }
-			onChange={ ( edits ) => setData( ( prev ) => ( { ...prev, ...edits } ) ) }
-		/>
+		<>
+			{ nextAddressCountry && (
+				<button onClick={ () => setAddressCountry( nextAddressCountry ) }>change address</button>
+			) }
+			<Edit
+				field={ { ...phoneField, getValue: ( { item } ) => item.phone ?? '' } }
+				data={ data }
+				onChange={ ( edits ) => setData( ( prev ) => ( { ...prev, ...edits } ) ) }
+			/>
+		</>
 	);
+}
+
+async function pickCountry( user: ReturnType< typeof userEvent.setup >, optionName: string ) {
+	const countryCode = screen.getByRole( 'combobox', { name: 'Country code' } );
+	await user.click( countryCode );
+	await user.click( await screen.findByRole( 'option', { name: optionName } ) );
 }
 
 describe( 'contact form phone field', () => {
@@ -109,16 +127,40 @@ describe( 'contact form phone field', () => {
 		const user = userEvent.setup();
 
 		// Address country is the US, so the +1 phone defaults to United States.
-		render( <PhoneField addressCountry="US" /> );
+		render( <PhoneField initialAddressCountry="US" /> );
 
 		const countryCode = await screen.findByRole( 'combobox', { name: 'Country code' } );
 		await waitFor( () => expect( countryCode ).toHaveValue( 'United States (+1)' ) );
 
-		// Pick Canada — another +1 country that is not the address country.
-		await user.click( countryCode );
-		await user.click( await screen.findByRole( 'option', { name: 'Canada (+1)' } ) );
-
-		// The pick must stick instead of snapping back to the US address country.
+		// Pick Canada — another +1 country that is not the address country — and
+		// confirm it sticks instead of snapping back to the US address country.
+		await pickCountry( user, 'Canada (+1)' );
 		await waitFor( () => expect( countryCode ).toHaveValue( 'Canada (+1)' ) );
+	} );
+
+	test( 'a manual pick after an address change re-seeds and then sticks again', async () => {
+		const user = userEvent.setup();
+
+		render( <PhoneField initialAddressCountry="US" nextAddressCountry="DE" /> );
+
+		// Re-query the combobox on each check: the address change remounts the
+		// field, so a reference captured earlier would point at a detached node.
+		const combo = () => screen.getByRole( 'combobox', { name: 'Country code' } );
+
+		await screen.findByRole( 'combobox', { name: 'Country code' } );
+		await waitFor( () => expect( combo() ).toHaveValue( 'United States (+1)' ) );
+
+		await pickCountry( user, 'Canada (+1)' );
+		await waitFor( () => expect( combo() ).toHaveValue( 'Canada (+1)' ) );
+
+		// Changing the address country remounts the field and re-seeds the
+		// default. The stored dialing code is still +1, so with no matching
+		// address entry it falls back to the first +1 country (the Bahamas).
+		await user.click( screen.getByRole( 'button', { name: 'change address' } ) );
+		await waitFor( () => expect( combo() ).toHaveValue( 'Bahamas (+1)' ) );
+
+		// A fresh manual pick after the reset is captured and sticks.
+		await pickCountry( user, 'Canada (+1)' );
+		await waitFor( () => expect( combo() ).toHaveValue( 'Canada (+1)' ) );
 	} );
 } );

--- a/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
@@ -1,8 +1,15 @@
 /**
  * @jest-environment jsdom
  */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { useMemo, useState } from 'react';
+import { render } from '../../../test-utils';
 import { getContactFormFields } from '../contact-form-fields';
+import type { AsyncValidator } from '../contact-validation-utils';
 import type { CountryListItem } from '../custom-form-fieldsets/types';
+import type { DomainContactDetails } from '@automattic/api-core';
 
 const asyncValidator = async () => ( { success: true as const } );
 
@@ -37,5 +44,81 @@ describe( 'getContactFormFields country field', () => {
 		const values = ( getCountryField().elements ?? [] ).map( ( e ) => e.value );
 		expect( values ).toEqual( [ ...new Set( values ) ] );
 		expect( values ).toEqual( [ 'US', 'FR', 'AF' ] );
+	} );
+} );
+
+// ComboboxControl scrolls the highlighted option into view; jsdom doesn't implement it.
+Element.prototype.scrollIntoView = jest.fn();
+
+// +1 is shared by the Bahamas, the US and Canada. The Bahamas is first so it is
+// the plain-first-match fallback; the address country disambiguates the default.
+const SMS_COUNTRY_CODES = [
+	{ code: 'BS', country_name: 'Bahamas', name: 'Bahamas (+1)', numeric_code: '+1' },
+	{ code: 'US', country_name: 'United States', name: 'United States (+1)', numeric_code: '+1' },
+	{ code: 'CA', country_name: 'Canada', name: 'Canada (+1)', numeric_code: '+1' },
+];
+
+const alwaysValid: AsyncValidator = () => Promise.resolve( { success: true, messages: {} } );
+
+/**
+ * Renders the phone field's Edit control the way DataForm would, with the
+ * contact's address country fixed and the phone value held in local state so a
+ * change round-trips back through `data` exactly like the real form.
+ */
+function PhoneField( { addressCountry }: { addressCountry: string } ) {
+	// The real form memoizes the fields on the address country (contact-form.tsx),
+	// so the phone Edit keeps a stable identity while the address is unchanged.
+	// Rebuilding it every render would remount the Edit and wipe its local state.
+	const phoneField = useMemo(
+		() =>
+			getContactFormFields( [], [], addressCountry, alwaysValid ).find(
+				( field ) => field.id === 'phone'
+			)!,
+		[ addressCountry ]
+	);
+	const Edit = phoneField.Edit as React.ComponentType< {
+		field: typeof phoneField & { getValue: ( args: { item: DomainContactDetails } ) => string };
+		data: DomainContactDetails;
+		onChange: ( edits: Partial< DomainContactDetails > ) => void;
+	} >;
+
+	const [ data, setData ] = useState( { phone: '+1.5551234' } as DomainContactDetails );
+
+	return (
+		<Edit
+			field={ { ...phoneField, getValue: ( { item } ) => item.phone ?? '' } }
+			data={ data }
+			onChange={ ( edits ) => setData( ( prev ) => ( { ...prev, ...edits } ) ) }
+		/>
+	);
+}
+
+describe( 'contact form phone field', () => {
+	beforeEach( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( '/rest/v1.1/meta/sms-country-codes/' )
+			.reply( 200, SMS_COUNTRY_CODES )
+			.persist();
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'keeps a manually picked country that shares its dialing code with the address country', async () => {
+		const user = userEvent.setup();
+
+		// Address country is the US, so the +1 phone defaults to United States.
+		render( <PhoneField addressCountry="US" /> );
+
+		const countryCode = await screen.findByRole( 'combobox', { name: 'Country code' } );
+		await waitFor( () => expect( countryCode ).toHaveValue( 'United States (+1)' ) );
+
+		// Pick Canada — another +1 country that is not the address country.
+		await user.click( countryCode );
+		await user.click( await screen.findByRole( 'option', { name: 'Canada (+1)' } ) );
+
+		// The pick must stick instead of snapping back to the US address country.
+		await waitFor( () => expect( countryCode ).toHaveValue( 'Canada (+1)' ) );
 	} );
 } );

--- a/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
@@ -51,7 +51,7 @@ describe( 'getContactFormFields country field', () => {
 Element.prototype.scrollIntoView = jest.fn();
 
 // +1 is shared by the Bahamas, the US and Canada. The Bahamas is first so it is
-// the plain-first-match fallback; the address country disambiguates the default.
+// the plain-first-match fallback; the address country disambiguates the seed.
 const SMS_COUNTRY_CODES = [
 	{ code: 'BS', country_name: 'Bahamas', name: 'Bahamas (+1)', numeric_code: '+1' },
 	{ code: 'US', country_name: 'United States', name: 'United States (+1)', numeric_code: '+1' },
@@ -61,27 +61,20 @@ const SMS_COUNTRY_CODES = [
 const alwaysValid: AsyncValidator = () => Promise.resolve( { success: true, messages: {} } );
 
 /**
- * Renders the phone field's Edit control the way DataForm would, with the
- * contact's address country held in state (the real form memoizes the fields on
- * it, so the phone Edit keeps a stable identity while the address is unchanged
- * and remounts when it changes). The optional button changes the address
- * country from within the provider-wrapped tree, since the test renderer's
- * rerender does not re-wrap the element in the QueryClientProvider.
+ * Renders the phone field's Edit control the way DataForm would. The address
+ * country lives on the form item (`data.countryCode`), and the optional button
+ * changes it from within the provider-wrapped tree (the test renderer's rerender
+ * would not re-wrap the element in the QueryClientProvider). The phone Edit is a
+ * stable component, so changing the address re-renders it without remounting —
+ * exactly what the real memoized form does.
  */
-function PhoneField( {
-	initialAddressCountry,
-	nextAddressCountry,
-}: {
-	initialAddressCountry: string;
-	nextAddressCountry?: string;
-} ) {
-	const [ addressCountry, setAddressCountry ] = useState( initialAddressCountry );
+function PhoneField( { addressButtons = [] }: { addressButtons?: string[] } ) {
+	// The address country passed here is unused by the phone field (it reads the
+	// item's countryCode); it only feeds the other, unrendered address fields.
 	const phoneField = useMemo(
 		() =>
-			getContactFormFields( [], [], addressCountry, alwaysValid ).find(
-				( field ) => field.id === 'phone'
-			)!,
-		[ addressCountry ]
+			getContactFormFields( [], [], '', alwaysValid ).find( ( field ) => field.id === 'phone' )!,
+		[]
 	);
 	const Edit = phoneField.Edit as React.ComponentType< {
 		field: typeof phoneField & { getValue: ( args: { item: DomainContactDetails } ) => string };
@@ -89,13 +82,20 @@ function PhoneField( {
 		onChange: ( edits: Partial< DomainContactDetails > ) => void;
 	} >;
 
-	const [ data, setData ] = useState( { phone: '+1.5551234' } as DomainContactDetails );
+	const [ data, setData ] = useState(
+		() => ( { phone: '+1.5551234', countryCode: 'US' } ) as DomainContactDetails
+	);
 
 	return (
 		<>
-			{ nextAddressCountry && (
-				<button onClick={ () => setAddressCountry( nextAddressCountry ) }>change address</button>
-			) }
+			{ addressButtons.map( ( code ) => (
+				<button
+					key={ code }
+					onClick={ () => setData( ( prev ) => ( { ...prev, countryCode: code } ) ) }
+				>
+					{ `address ${ code }` }
+				</button>
+			) ) }
 			<Edit
 				field={ { ...phoneField, getValue: ( { item } ) => item.phone ?? '' } }
 				data={ data }
@@ -106,8 +106,7 @@ function PhoneField( {
 }
 
 async function pickCountry( user: ReturnType< typeof userEvent.setup >, optionName: string ) {
-	const countryCode = screen.getByRole( 'combobox', { name: 'Country code' } );
-	await user.click( countryCode );
+	await user.click( screen.getByRole( 'combobox', { name: 'Country code' } ) );
 	await user.click( await screen.findByRole( 'option', { name: optionName } ) );
 }
 
@@ -123,44 +122,42 @@ describe( 'contact form phone field', () => {
 		nock.cleanAll();
 	} );
 
-	test( 'keeps a manually picked country that shares its dialing code with the address country', async () => {
+	test( 'seeds the country from the address on load and keeps a manual pick', async () => {
 		const user = userEvent.setup();
 
-		// Address country is the US, so the +1 phone defaults to United States.
-		render( <PhoneField initialAddressCountry="US" /> );
+		// The +1 number seeds to the US address country, not the first +1 entry.
+		render( <PhoneField /> );
 
 		const countryCode = await screen.findByRole( 'combobox', { name: 'Country code' } );
 		await waitFor( () => expect( countryCode ).toHaveValue( 'United States (+1)' ) );
 
-		// Pick Canada — another +1 country that is not the address country — and
-		// confirm it sticks instead of snapping back to the US address country.
+		// Pick Canada — another +1 country — and confirm it sticks.
 		await pickCountry( user, 'Canada (+1)' );
 		await waitFor( () => expect( countryCode ).toHaveValue( 'Canada (+1)' ) );
 	} );
 
-	test( 'a manual pick after an address change re-seeds and then sticks again', async () => {
+	test( 'does not change the phone country when the address country changes', async () => {
 		const user = userEvent.setup();
 
-		render( <PhoneField initialAddressCountry="US" nextAddressCountry="DE" /> );
+		render( <PhoneField addressButtons={ [ 'DE', 'US' ] } /> );
 
-		// Re-query the combobox on each check: the address change remounts the
-		// field, so a reference captured earlier would point at a detached node.
+		// Re-query the combobox each time in case a re-render replaces the node.
 		const combo = () => screen.getByRole( 'combobox', { name: 'Country code' } );
 
 		await screen.findByRole( 'combobox', { name: 'Country code' } );
 		await waitFor( () => expect( combo() ).toHaveValue( 'United States (+1)' ) );
 
+		// Changing the address country must not move the phone country, even
+		// before the contact has explicitly picked one.
+		await user.click( screen.getByRole( 'button', { name: 'address DE' } ) );
+		await waitFor( () => expect( combo() ).toHaveValue( 'United States (+1)' ) );
+
+		// An explicit pick wins...
 		await pickCountry( user, 'Canada (+1)' );
 		await waitFor( () => expect( combo() ).toHaveValue( 'Canada (+1)' ) );
 
-		// Changing the address country remounts the field and re-seeds the
-		// default. The stored dialing code is still +1, so with no matching
-		// address entry it falls back to the first +1 country (the Bahamas).
-		await user.click( screen.getByRole( 'button', { name: 'change address' } ) );
-		await waitFor( () => expect( combo() ).toHaveValue( 'Bahamas (+1)' ) );
-
-		// A fresh manual pick after the reset is captured and sticks.
-		await pickCountry( user, 'Canada (+1)' );
+		// ...and a later address change still does not move it.
+		await user.click( screen.getByRole( 'button', { name: 'address US' } ) );
 		await waitFor( () => expect( combo() ).toHaveValue( 'Canada (+1)' ) );
 	} );
 } );

--- a/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
@@ -1,5 +1,5 @@
-import { mapValidationMessagesToFieldErrors } from '../contact-validation-utils';
-import type { ContactValidationResponseMessages } from '@automattic/api-core';
+import { mapValidationMessagesToFieldErrors, resolveSmsCountry } from '../contact-validation-utils';
+import type { ContactValidationResponseMessages, SMSCountryCode } from '@automattic/api-core';
 
 describe( 'mapValidationMessagesToFieldErrors', () => {
 	it( 'returns an empty map when there are no messages', () => {
@@ -26,5 +26,37 @@ describe( 'mapValidationMessagesToFieldErrors', () => {
 		} as unknown as ContactValidationResponseMessages;
 
 		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {} );
+	} );
+} );
+
+const SMS_COUNTRY_CODES: SMSCountryCode[] = [
+	{ code: 'BS', country_name: 'Bahamas', name: 'Bahamas (+1)', numeric_code: '+1' },
+	{ code: 'CA', country_name: 'Canada', name: 'Canada (+1)', numeric_code: '+1' },
+	{ code: 'US', country_name: 'United States', name: 'United States (+1)', numeric_code: '+1' },
+	{ code: 'DE', country_name: 'Germany', name: 'Germany (+49)', numeric_code: '+49' },
+];
+
+describe( 'resolveSmsCountry', () => {
+	test( 'prefers the contact country when several countries share a dialing code', () => {
+		// Regression test for DOMENG-635: a +1 US number used to resolve to the
+		// first +1 entry (the Bahamas) instead of the contact's own country.
+		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+1', 'US' )?.code ).toBe( 'US' );
+		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+1', 'CA' )?.code ).toBe( 'CA' );
+	} );
+
+	test( 'falls back to the first match when the contact country does not share the code', () => {
+		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+1', 'GB' )?.code ).toBe( 'BS' );
+	} );
+
+	test( 'resolves an unambiguous dialing code regardless of the contact country', () => {
+		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+49', 'US' )?.code ).toBe( 'DE' );
+	} );
+
+	test( 'returns undefined when no country matches the dialing code', () => {
+		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+99', 'US' ) ).toBeUndefined();
+	} );
+
+	test( 'returns undefined when the country list is unavailable', () => {
+		expect( resolveSmsCountry( undefined, '+1', 'US' ) ).toBeUndefined();
 	} );
 } );

--- a/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
@@ -48,6 +48,12 @@ describe( 'resolveSmsCountry', () => {
 		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+1', 'GB' )?.code ).toBe( 'BS' );
 	} );
 
+	test( 'falls back to the first match when no contact country is set', () => {
+		// The call site defaults the contact country to '' when none is selected,
+		// so this is the real-world input before an address country is chosen.
+		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+1', '' )?.code ).toBe( 'BS' );
+	} );
+
 	test( 'resolves an unambiguous dialing code regardless of the contact country', () => {
 		expect( resolveSmsCountry( SMS_COUNTRY_CODES, '+49', 'US' )?.code ).toBe( 'DE' );
 	} );


### PR DESCRIPTION
Related to #DOMENG-635

## Problem

In the new hosting dashboard domain contact form, the phone **Country code** selector showed **Bahamas** for a US phone number (e.g. `+1.626...`), along with a "provide accurate contact info" warning, and the country could not be changed to the US. The stored contact details were correct in DARC the whole time.

## Root cause

The displayed country was derived purely from the numeric dial code:

```js
const smsCountry = smsCountryCodes?.find(
    ( country ) => country.numeric_code === countryNumericCode
);
```

Many countries share a dial code (`+1` covers the US, Canada, and several Caribbean nations). `Array.find` returns the first match, which is alphabetically **Bahamas** for `+1`, so any US/Canada number resolved to the wrong country. Selecting the US in the dropdown didn't stick because only the numeric code is persisted (`+1.<number>`), so the display re-derived back to Bahamas on the next render.

## Fix

Add a small `resolveSmsCountry( smsCountryCodes, numericCode, preferredCountryCode )` helper in `contact-validation-utils.ts`. When a dial code is shared by multiple countries it prefers the entry matching the contact's own country code (already available to the form), falling back to the first match otherwise. Unambiguous codes (e.g. `+49`) and empty input behave exactly as before.

The country choice among same-dial-code countries is cosmetic only - the stored value is `+<code>.<number>` regardless of US/CA/BS - so this corrects the displayed country without changing what gets saved.

## Scope note

This resolves the reported bug for the user (US address + US number now shows the US). It does **not** add full area-code-based inference (e.g. distinguishing a `+1 604` Canadian number from a US one by the digits after the dial code). Doing that here would require porting Calypso's ~270-entry NANPA area-code map into the dashboard, since the `client/dashboard` folder is not allowed to import from `calypso/components` (eslint boundary) and the SMS country-codes API carries no area-code data. Preferring the contact's own address country is the minimal, self-contained fix and is the right signal for this form.

## Testing

Added focused unit tests for `resolveSmsCountry` (shared-code preference, fallback, unambiguous code, no-match, undefined list) in `domain-contact-details-form/test/contact-validation-utils.test.ts`.

Co-Authored-By: Claude <noreply@anthropic.com>
