### PR TITLE
Hide transformed context-only messages

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -93,6 +93,33 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [] );
 	} );
 
+	it( 'filters out messages transformed to context content', () => {
+		const message = createMessage( {
+			content: [ { type: 'context', text: 'This is only context for the model.' } ],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'filters out messages with context-only data flags', () => {
+		const message = createMessage( {
+			content: [
+				{ type: 'text', text: 'This is only context for the model.' },
+				{ type: 'data', data: { flags: { context_only: true } } },
+			],
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toEqual( [] );
+	} );
+
 	it( 'renders tool messages as components', () => {
 		const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
 			type: 'my-component',

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -310,6 +310,19 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
+	it( 'filters out unsuccessful apply-block-edits tool summaries', () => {
+		const message = createToolMessage( 'big_sky__apply_block_edits', {
+			success: false,
+			summary: 'Tried to update the header, but it did not stick.',
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toEqual( [] );
+	} );
+
 	it( 'suppresses transient thinking for converted apply-block-edits messages', () => {
 		const message = createToolMessage( 'big_sky__apply_block_edits', {
 			followUpTasks: true,

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -28,7 +28,18 @@ type MessageWithContextFlags = UIMessage & {
 };
 
 function isContextOnlyMessage( message: UIMessage ): boolean {
-	return ( message as MessageWithContextFlags ).context?.flags?.context_only === true;
+	return (
+		( message as MessageWithContextFlags ).context?.flags?.context_only === true ||
+		message.content?.some( ( content ) => {
+			if ( content.type === 'context' ) {
+				return true;
+			}
+
+			const flags =
+				content.type === 'data' ? ( content.data?.flags as { context_only?: boolean } ) : undefined;
+			return flags?.context_only === true;
+		} )
+	);
 }
 
 function getShowComponentSummary( message: UIMessage ): string | undefined {

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -66,6 +66,12 @@ function hasAgentRole( message: UIMessage ): boolean {
 	return role === 'agent' || role === 'assistant';
 }
 
+function isUnsuccessfulToolData( data: unknown ): boolean {
+	return (
+		typeof data === 'object' && data !== null && ( data as { success?: unknown } ).success === false
+	);
+}
+
 function isDuplicateAdjacentShowComponentSummary(
 	message: UIMessage,
 	messages: UIMessage[],
@@ -232,6 +238,10 @@ export default function convertToolMessagesToComponents( {
 
 		// Handle agent-facing Big Sky tool result summaries.
 		if ( isDisplayableToolMessageTool( textData.tool_id ) ) {
+			if ( isUnsuccessfulToolData( textData.data ) ) {
+				return [];
+			}
+
 			const summary = getDisplayMessageFromToolData( textData.data );
 			if ( ! summary ) {
 				return [];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

* Hide Agents Manager messages that are transformed from server history into context-only UI content.
* Extend the existing `context_only` filtering to also catch:
  * `content.type === 'context'`
  * data content with `flags.context_only === true`
* Hide displayable tool result summaries when the tool result payload includes `success: false`.
* Add test coverage for transformed context-only message shapes and unsuccessful tool result summaries.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Retry tool results should remain available for model context, but should not be shown as user-visible chat responses on page reload.
* On page reload, Agenttic transforms server messages before they reach Agents Manager. The original `message.context.flags.context_only` field may no longer be present, so context-only retry summaries could still appear in chat history.
* Newer retry tool results include `data.success: false`, which gives the UI a direct way to suppress failed/intermediate tool summaries while keeping the final bot response visible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run:
  * `yarn typecheck-packages --pretty false`
  * `yarn test-packages packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts --runInBand`
* In Agents Manager, use a conversation that includes persisted retry tool result messages with either:
  * `context.flags.context_only: true`, or
  * tool result `data.success: false`
* Reload the page.
* Confirm those retry/intermediate tool summaries are not shown in the visible chat history.
* Confirm the final bot response remains visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
