### PR TITLE
Checkout: add clarifying text to footer refund window

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
+++ b/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
@@ -1,11 +1,9 @@
-import { isPlan } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { CheckIcon } from './check-icon';
-import { getRefundWindowSummary } from './refund-policies';
+import { getRefundWindowCopy } from './refund-policies';
 import type { ResponseCart } from '@automattic/shopping-cart';
-import type { TranslateResult } from 'i18n-calypso';
 
 const StyledIcon = styled( Icon )`
 	fill: #1e1e1e;
@@ -48,32 +46,9 @@ export function CheckoutSummaryRefundWindows( {
 } ) {
 	const translate = useTranslate();
 
-	const summary = getRefundWindowSummary( cart );
-	if ( ! summary ) {
+	const text = getRefundWindowCopy( cart, translate );
+	if ( ! text ) {
 		return null;
-	}
-	const { days, usePlanProductName } = summary;
-
-	let text: TranslateResult;
-	if ( usePlanProductName ) {
-		const planProduct = cart.products.find( isPlan );
-		text = translate(
-			'%(days)d-day money back guarantee for %(product)s',
-			'%(days)d-day money back guarantee for %(product)s',
-			{
-				count: days,
-				args: {
-					days,
-					product: planProduct?.product_name ?? '',
-				},
-			}
-		);
-	} else {
-		text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-			count: days,
-			args: { days },
-			comment: 'The number of days until the shortest refund window in the cart expires.',
-		} );
 	}
 
 	return (

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -1,3 +1,4 @@
+import { isPlan } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/components';
 import { reusableBlock, shield } from '@wordpress/icons';
@@ -66,19 +67,28 @@ const TrustCardBody = styled.div`
 
 export default function CheckoutTrustCards( { cart }: { cart: ResponseCart } ) {
 	const translate = useTranslate();
-	const refundDays = getRefundWindowSummary( cart )?.days ?? null;
+	const refundSummary = getRefundWindowSummary( cart );
+	const refundPlanProduct = refundSummary?.usePlanProductName
+		? cart.products.find( isPlan )
+		: undefined;
 
 	return (
 		<TrustCardsRow className="checkout-trust-cards">
-			{ refundDays !== null && (
+			{ refundSummary !== null && (
 				<TrustCard>
 					<TrustCardHeader>
 						<Icon icon={ reusableBlock } size={ 20 } />
 						{ translate( '%(days)d-day money back', {
-							args: { days: refundDays },
+							args: { days: refundSummary.days },
 						} ) }
 					</TrustCardHeader>
-					<TrustCardBody>{ translate( 'Full refund, no questions asked.' ) }</TrustCardBody>
+					<TrustCardBody>
+						{ refundPlanProduct
+							? translate( 'Full refund for %(product)s, no questions asked.', {
+									args: { product: refundPlanProduct.product_name },
+							  } )
+							: translate( 'Full refund, no questions asked.' ) }
+					</TrustCardBody>
 				</TrustCard>
 			) }
 

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -65,6 +65,12 @@ const TrustCardBody = styled.div`
 	font-size: 13px;
 `;
 
+const TrustCardNote = styled.div`
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	font-size: 12px;
+	font-style: italic;
+`;
+
 export default function CheckoutTrustCards( { cart }: { cart: ResponseCart } ) {
 	const translate = useTranslate();
 	const refundSummary = getRefundWindowSummary( cart );
@@ -89,6 +95,11 @@ export default function CheckoutTrustCards( { cart }: { cart: ResponseCart } ) {
 							  } )
 							: translate( 'Full refund, no questions asked.' ) }
 					</TrustCardBody>
+					{ refundSummary.hasMultipleWindows && (
+						<TrustCardNote>
+							{ translate( 'Other products in your cart may have different refund windows.' ) }
+						</TrustCardNote>
+					) }
 				</TrustCard>
 			) }
 

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -14,7 +14,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { DOMAIN_CANCEL, REFUNDS } from '@automattic/urls';
 import { isWpComProductRenewal as isRenewal, isValueTruthy } from '@automattic/wpcom-checkout';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { has100YearPlan, has100YearDomain } from 'calypso/lib/cart-values/cart-items';
 import CheckoutTermsItem from './checkout-terms-item';
@@ -249,8 +249,8 @@ export type RefundWindowSummary = {
  * only domains, or has no refund windows). When multiple windows exist, picks
  * the longest plan window for renewal-only / monthly-bundle carts and the
  * shortest window otherwise. The product-name flag captures the cases the
- * sidebar copy uses to render "X-day money back guarantee for %(product)s";
- * surfaces that don't show the product name (e.g. trust cards) can ignore it.
+ * money-back copy renders as "X-day money back guarantee for %(product)s";
+ * see getRefundWindowCopy, which is the shared consumer of this flag.
  */
 export function getRefundWindowSummary( cart: ResponseCart ): RefundWindowSummary | null {
 	const refundPolicies = getRefundPolicies( cart );
@@ -286,6 +286,46 @@ export function getRefundWindowSummary( cart: ResponseCart ): RefundWindowSummar
 	}
 
 	return { days: Math.min( ...refundWindows ), usePlanProductName: false };
+}
+
+/**
+ * Builds the headline money-back-guarantee copy for a cart. When the refund
+ * window is tied to a specific plan, the copy names that plan (e.g. "14-day
+ * money back guarantee for WordPress.com Personal") so the day count is never
+ * shown without the product it applies to; otherwise it states the bare
+ * window. Returns null when no refund window applies. Shared by the sidebar
+ * summary and the checkout trust footer so both surface the same copy.
+ */
+export function getRefundWindowCopy(
+	cart: ResponseCart,
+	translate: ReturnType< typeof useTranslate >
+): TranslateResult | null {
+	const summary = getRefundWindowSummary( cart );
+	if ( ! summary ) {
+		return null;
+	}
+	const { days, usePlanProductName } = summary;
+
+	const planProduct = usePlanProductName ? cart.products.find( isPlan ) : undefined;
+	if ( planProduct ) {
+		return translate(
+			'%(days)d-day money back guarantee for %(product)s',
+			'%(days)d-day money back guarantee for %(product)s',
+			{
+				count: days,
+				args: {
+					days,
+					product: planProduct.product_name,
+				},
+			}
+		);
+	}
+
+	return translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
+		count: days,
+		args: { days },
+		comment: 'The number of days until the shortest refund window in the cart expires.',
+	} );
 }
 
 function RefundPolicyItem( {

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -239,6 +239,7 @@ export function getRefundWindows( refundPolicies: RefundPolicy[] ): RefundWindow
 export type RefundWindowSummary = {
 	days: number;
 	usePlanProductName: boolean;
+	hasMultipleWindows: boolean;
 };
 
 /**
@@ -266,7 +267,7 @@ export function getRefundWindowSummary( cart: ResponseCart ): RefundWindowSummar
 				refundPolicy === RefundPolicy.PlanBiennialBundle ||
 				refundPolicy === RefundPolicy.PlanYearlyBundle
 		);
-		return { days: refundWindows[ 0 ], usePlanProductName };
+		return { days: refundWindows[ 0 ], usePlanProductName, hasMultipleWindows: false };
 	}
 
 	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
@@ -282,10 +283,18 @@ export function getRefundWindowSummary( cart: ResponseCart ): RefundWindowSummar
 			refundPolicy === RefundPolicy.PlanBiennialRenewal
 	);
 	if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
-		return { days: Math.max( ...refundWindows ), usePlanProductName: true };
+		return {
+			days: Math.max( ...refundWindows ),
+			usePlanProductName: true,
+			hasMultipleWindows: true,
+		};
 	}
 
-	return { days: Math.min( ...refundWindows ), usePlanProductName: false };
+	return {
+		days: Math.min( ...refundWindows ),
+		usePlanProductName: false,
+		hasMultipleWindows: true,
+	};
 }
 
 /**

--- a/client/my-sites/checkout/src/components/test/refund-policies.ts
+++ b/client/my-sites/checkout/src/components/test/refund-policies.ts
@@ -449,6 +449,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 4,
 			usePlanProductName: false,
+			hasMultipleWindows: false,
 		} );
 	} );
 
@@ -470,6 +471,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 14,
 			usePlanProductName: true,
+			hasMultipleWindows: false,
 		} );
 	} );
 
@@ -479,6 +481,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 14,
 			usePlanProductName: true,
+			hasMultipleWindows: false,
 		} );
 	} );
 
@@ -494,6 +497,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 14,
 			usePlanProductName: false,
+			hasMultipleWindows: false,
 		} );
 	} );
 
@@ -509,6 +513,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 7,
 			usePlanProductName: false,
+			hasMultipleWindows: false,
 		} );
 	} );
 
@@ -532,6 +537,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 7,
 			usePlanProductName: true,
+			hasMultipleWindows: true,
 		} );
 	} );
 
@@ -555,6 +561,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 14,
 			usePlanProductName: true,
+			hasMultipleWindows: true,
 		} );
 	} );
 
@@ -571,6 +578,7 @@ describe( 'getRefundWindowSummary', () => {
 		expect( getRefundWindowSummary( cart ) ).toEqual( {
 			days: 4,
 			usePlanProductName: false,
+			hasMultipleWindows: true,
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2196/

## Proposed changes

The RSM checkout redesign added a flat "%(days)d-day money back" trust card to the checkout footer that surfaced a single refund window for every cart, with no indication of which product it applied to or that other products might differ. This makes the footer copy match the nuance the sidebar already shows, by reusing the same refund-window logic and naming the relevant plan.

* Extract a shared `getRefundWindowCopy` helper in `refund-policies.tsx` that builds product-aware money-back copy ("14-day money back guarantee for WordPress.com Personal" when the window is tied to a plan, otherwise the bare window).
* Point the sidebar (`CheckoutSummaryRefundWindows`) at the shared helper so both surfaces stay in sync.
* Update the footer trust card to keep a short day-count header while moving the plan name into the card body.
* Add a `hasMultipleWindows` flag to the refund-window summary and render an italic note — "Other products in your cart may have different refund windows." — only when the cart genuinely spans more than one refund window.
* Update `getRefundWindowSummary` unit tests for the new field.

When | Before             |  After
:------:|:-------------------------:|:-------------------------:
Just plan | <img width="602" height="228" alt="Screenshot 2026-06-26 at 4 58 16 PM" src="https://github.com/user-attachments/assets/4feaa4e4-befc-41df-9b38-a937735ee301" /> | <img width="602" height="228" alt="Screenshot 2026-06-26 at 4 58 16 PM" src="https://github.com/user-attachments/assets/4feaa4e4-befc-41df-9b38-a937735ee301" />
Plan and bundled domain | <img width="618" height="223" alt="Screenshot 2026-06-26 at 4 27 10 PM" src="https://github.com/user-attachments/assets/1b36b97f-0027-4060-a988-7cc52da2d425" /> | <img width="629" height="258" alt="Screenshot 2026-06-26 at 4 27 14 PM" src="https://github.com/user-attachments/assets/8cc3775f-3bb9-4e2d-97ec-42e4cc634a10" />
Plan and two domains (one free, one separate) | <img width="607" height="222" alt="Screenshot 2026-06-26 at 4 57 33 PM" src="https://github.com/user-attachments/assets/8c3510b2-add1-4e4b-a0f5-63d1280e088d" /> | <img width="629" height="264" alt="Screenshot 2026-06-26 at 4 57 18 PM" src="https://github.com/user-attachments/assets/8933f53e-2213-4c6b-9a52-2e8e7e166df4" />

## Why are these changes being made?

The redesigned checkout footer was developed outside Payments and introduced a money-back trust card that always read like a flat "14-day money back" guarantee. Different products we sell have different refund periods, so a single generic window is misleading: it neither says which product the window applies to nor acknowledges that other items in the cart may have shorter or different windows. The sidebar already handles this correctly by naming the product (e.g. "14-day money back guarantee for WordPress.com Personal").

Rather than duplicate the sidebar's copy logic in the footer, the refund-window copy is extracted into one shared helper so the sidebar, the money-back-guarantee footer, and the new trust card all derive their text from the same source. The trust card keeps its compact header (the longer product-named string wrapped to three lines), so the day count stays a one-line headline while the product name lives in the body.

The "other products may have different refund windows" note is deliberately gated on the cart actually containing more than one distinct refund window. A plan bundled with a free domain shares a single window in the refund model (and is shown that way in the sidebar and detailed refund terms), so the note is suppressed there to stay consistent and avoid implying a difference that does not exist. It appears for carts that genuinely differ, e.g. a plan plus a separately-paid domain (14 vs 4 days).

## Testing instructions

TC:
```
yarn test-client client/my-sites/checkout/src/components/test/refund-policies.ts
```

Manual testing:
* Start checkout on a sandbox (`yarn start`) and open a cart in the redesigned checkout footer.
* Cart with a plan + its free bundled domain: footer trust card shows "14-day money back" with "Full refund for <plan name>, no questions asked." and no extra note.
* Cart with a plan + a separately-paid domain registration: trust card shows the shortest window and the note "Other products in your cart may have different refund windows."
* Confirm the sidebar refund copy is unchanged.

