### PR TITLE
MCP read/write: hide border between group header and expanded tools

### DIFF
--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -133,27 +133,30 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 
 	// First sub-group when a group row is expanded: negative margins bleed to the
 	// card edge, inner padding aligns the tool list with the group header content.
+	// No bottom padding — the CardBody's own padding provides the card-edge spacing,
+	// and the sub-divider's top margin provides the gap before any following divider.
 	.mcp-tools-subpage__group-body {
 		margin-inline-start: -16px;
 		margin-inline-end: -16px;
-		padding: 20px 16px 16px;
+		padding: 20px 16px 0;
 
 		@include break-mobile {
 			margin-inline-start: -24px;
 			margin-inline-end: -24px;
-			padding: 24px 24px 20px;
+			padding: 24px 24px 0;
 		}
 	}
 
-	// Subsequent sub-groups: same horizontal padding, no top border (sub-divider provides it)
+	// Subsequent sub-groups: no bottom padding — CardBody edge handles it.
 	.mcp-tools-subpage__sub-group-body {
-		padding: 0 0 16px;
+		padding: 0;
 	}
 
-	// Divider between sub-groups within an expanded group card
+	// Divider between sub-groups within an expanded group card.
+	// Top margin provides the gap after the preceding tool list.
 	.mcp-tools-subpage__sub-divider {
 		border-top: 1px solid var(--color-border-subtle);
-		margin: 0 0 16px;
+		margin: 16px 0 16px;
 	}
 }
 

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -136,12 +136,12 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 	.mcp-tools-subpage__group-body {
 		margin-inline-start: -16px;
 		margin-inline-end: -16px;
-		padding: 16px 16px 16px;
+		padding: 20px 16px 16px;
 
 		@include break-mobile {
 			margin-inline-start: -24px;
 			margin-inline-end: -24px;
-			padding: 20px 24px 20px;
+			padding: 24px 24px 20px;
 		}
 	}
 
@@ -153,7 +153,7 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 	// Divider between sub-groups within an expanded group card
 	.mcp-tools-subpage__sub-divider {
 		border-top: 1px solid var(--color-border-subtle);
-		margin: 16px 0 20px;
+		margin: 0 0 16px;
 	}
 }
 

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -131,10 +131,9 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 		}
 	}
 
-	// First sub-group when a group row is expanded: full-bleed border separates
-	// from the group header, then inner padding for the tool list.
+	// First sub-group when a group row is expanded: negative margins bleed to the
+	// card edge, inner padding aligns the tool list with the group header content.
 	.mcp-tools-subpage__group-body {
-		border-top: 1px solid var(--color-border-subtle);
 		margin-inline-start: -16px;
 		margin-inline-end: -16px;
 		padding: 16px 16px 16px;


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Remove the `border-top` from `.mcp-tools-subpage__group-body` so the group header flows seamlessly into the expanded tool list with no visible separator line between them.
* Increase top padding on the expanded group body (16→20px mobile, 20→24px desktop) to add breathing room between the group header and the first tool row.
* Remove the redundant bottom padding from group-body and sub-group-body — the CardBody's own padding handles the card-edge spacing, eliminating the double-padding that was making the card bottom look too tall.
* Restore the sub-divider top margin (0→16px) so the gap above each intra-group divider remains consistent.

## Why are these changes being made?

When a group is expanded on `/me/mcp/read` or `/me/mcp/write`:
- A 1px border between the group header and the first tool was visible — removing it gives the header and body a unified appearance.
- The first tool row was too close to the group header — padding increase adds visual separation.
- The bottom of the card had excessive whitespace — the group-body and sub-group-body were adding bottom padding on top of the CardBody's own built-in padding, resulting in double spacing.

## Testing Instructions

* Visit `/me/mcp/read` or `/me/mcp/write`.
* Expand any group by clicking the chevron.
* Confirm no border appears between the group header and the first tool row.
* Confirm there is appropriate spacing between the group header and the first tool (more breathing room than before).
* Confirm the bottom of the expanded card has consistent padding matching other cards on the page.
* Confirm sub-group dividers (inset lines between sub-categories) still have even spacing above and below.
* Confirm collapsed groups appear unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?