### PR TITLE
Plans: enable delayed downgrades in staging

### DIFF
--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -38,7 +38,7 @@
 		"me/legacy-contact": false,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
-		"plans/delayed-downgrade": false,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"performance/apm": true,
-		"plans/delayed-downgrade": false,
+		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-2197/enable-delayed-downgrades-on-staging-for-testing

## Proposed Changes

This PR enables the delayed downgrade feature in our staging environment for testing. You can read more about it in https://github.com/Automattic/wp-calypso/pull/111637

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The existing downgrade flow only handles two cases: instant cancel-and-refund (within the refund window) and routing to checkout (expired plan). For active subscribers outside the refund window, there was no downgrade path at all. The backend now has an end-of-term downgrade API that schedules the transition for the next renewal so the user keeps their current plan until it lapses — this PR builds the UI side of that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in as a user on an active paid plan outside the refund window (e.g. Business plan, purchased more than 14 days ago)
* Navigate to the purchase settings page (calypso or dashboard) for your active plan.
* Make sure that you have a rechargeable payment method assigned.
* Click "Change plans" which will navigate to the plans page.
* Click the Downgrade button for a lower-tier paid plan.
* Confirm the modal shows "Schedule downgrade" as the title and end-of-term copy in the body.
* Confirm the modal lists features that will be lost, and the confirm button reads "Schedule downgrade to [plan]".
* Confirm clicking the button shows a confirmation and a notice that the downgrade is pending.
* On the purchase settings page confirm that clicking "Cancel downgrade" calls dismisses the notice.
