### PR TITLE
Dashboard: track site URL click in Site Switcher

### DIFF
--- a/client/dashboard/sites/site-sidebar/site-switcher-item.tsx
+++ b/client/dashboard/sites/site-sidebar/site-switcher-item.tsx
@@ -7,6 +7,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { chevronUpDown } from '@wordpress/icons';
 import { Suspense, lazy, useMemo } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import { SidebarMenuSwitcherItem } from '../../components/sidebar';
 import SiteIcon from '../../components/site-icon';
@@ -18,6 +19,7 @@ import type { Site } from '@automattic/api-core';
 
 export default function SiteSwitcherItem( { site }: { site: Site } ) {
 	const { components } = useAppContext();
+	const { recordTracksEvent } = useAnalytics();
 	const SiteSwitcher = useMemo(
 		() =>
 			lazy( components.siteSwitcher ) as React.LazyExoticComponent< React.FC< SiteSwitcherProps > >,
@@ -60,6 +62,9 @@ export default function SiteSwitcherItem( { site }: { site: Site } ) {
 					<ExternalLink
 						href={ site.URL }
 						style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dashboard_site_switcher_site_url_click' );
+						} }
 					>
 						{ getSiteDisplayUrl( site ) }
 					</ExternalLink>


### PR DESCRIPTION
Fixes DOTMSD-1353

## Proposed Changes

* Fire a `calypso_dashboard_site_switcher_site_url_click` Tracks event when the site URL below the site title in the Site Switcher is clicked.

## Why are these changes being made?

* No Tracks event fired for clicks on the site URL in the Site Switcher. This event is needed for the first iteration of multi-site dashboard reporting so those outbound site visits can be included in the data pipeline and dashboard coverage.

## Testing Instructions

* Open the Dashboard Site Switcher.
* Click the site URL shown below a site title.
* Confirm a `calypso_dashboard_site_switcher_site_url_click` event fires (e.g. via the Tracks/analytics debug output).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
