### PR TITLE
Reader: recolor the masterbar to the dashboard omnibar palette

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -953,6 +953,7 @@ class MasterbarLoggedIn extends Component {
 			loadHelpCenterIcon,
 			loadAgentsManager,
 			useUnifiedAgent,
+			dashboardOptIn,
 		} = this.props;
 
 		// Checkout flow uses it's own version of the masterbar
@@ -961,7 +962,7 @@ class MasterbarLoggedIn extends Component {
 		}
 
 		return (
-			<Masterbar>
+			<Masterbar className={ dashboardOptIn ? 'is-dashboard-opt-in' : undefined }>
 				<div className="masterbar__section masterbar__section--left">
 					{ this.renderSidebarMobileMenu() }
 					{ this.renderMySites() }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -28,8 +28,10 @@ body.is-mobile-app-view {
 	--masterbar-height: 0px;
 }
 
-// MSD cohort: recolor the masterbar to match the dashboard omnibar palette.
-.masterbar.is-dashboard-opt-in {
+// In the Reader, recolor the masterbar to the dashboard omnibar palette for
+// opted-in users. Scoped to the Reader so the old Calypso /sites dashboard stays
+// untouched for everyone during the MSD rollout.
+.is-group-reader .masterbar.is-dashboard-opt-in {
 	--color-masterbar-background: #1e1e1e;
 	--color-masterbar-border: #1e1e1e;
 	--color-masterbar-text: var(--studio-white);
@@ -39,11 +41,11 @@ body.is-mobile-app-view {
 	--color-masterbar-item-active-background: #0c0c0c;
 	--color-masterbar-submenu-group-background: #1e1e1e;
 	--color-masterbar-submenu-text: #bcbcbc;
-	--color-masterbar-submenu-hover-text: var(--studio-white);
+	--color-masterbar-submenu-hover-text: var(--color-masterbar-highlight);
 	// The global-sidebar context defines these submenu vars (to white), so the
 	// fallbacks above never apply — override them directly.
 	--color-global-masterbar-submenu-background: #0c0c0c;
-	--color-global-masterbar-submenu-hover-background: #2c2c2c;
+	--color-global-masterbar-submenu-hover-background: transparent;
 	--color-global-masterbar-site-info-background: #0c0c0c;
 	--color-global-masterbar-site-info-badge-background: rgba(255, 255, 255, 0.1);
 	--color-global-masterbar-site-info-badge-color: var(--studio-white);

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -28,6 +28,27 @@ body.is-mobile-app-view {
 	--masterbar-height: 0px;
 }
 
+// MSD cohort: recolor the masterbar to match the dashboard omnibar palette.
+.masterbar.is-dashboard-opt-in {
+	--color-masterbar-background: #1e1e1e;
+	--color-masterbar-border: #1e1e1e;
+	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-icon: var(--studio-white);
+	--color-masterbar-highlight: #7b90ff;
+	--color-masterbar-item-hover-background: #0c0c0c;
+	--color-masterbar-item-active-background: #0c0c0c;
+	--color-masterbar-submenu-group-background: #1e1e1e;
+	--color-masterbar-submenu-text: #bcbcbc;
+	--color-masterbar-submenu-hover-text: var(--studio-white);
+	// The global-sidebar context defines these submenu vars (to white), so the
+	// fallbacks above never apply — override them directly.
+	--color-global-masterbar-submenu-background: #0c0c0c;
+	--color-global-masterbar-submenu-hover-background: #2c2c2c;
+	--color-global-masterbar-site-info-background: #0c0c0c;
+	--color-global-masterbar-site-info-badge-background: rgba(255, 255, 255, 0.1);
+	--color-global-masterbar-site-info-badge-color: var(--studio-white);
+}
+
 // The WordPress.com Masterbar
 .masterbar {
 	background: var(--color-masterbar-background);


### PR DESCRIPTION
Part of DOTMSD-1349

Pairs with #112075 (which surfaces the W-icon dropdown in the Reader).

## Proposed Changes

* Recolor the Reader masterbar and its dropdowns to the dashboard omnibar palette for opted-in users. The override is scoped to the Reader (`.is-group-reader .masterbar.is-dashboard-opt-in`).

**Screenshots**
| Before | After |
|--------|--------|
| <img width="268" height="125" alt="Screenshot 2026-06-29 at 1 28 19 PM" src="https://github.com/user-attachments/assets/e8cc90ef-95cb-4bb7-9884-4f99f61e1662" /> | <img width="270" height="123" alt="Screenshot 2026-06-29 at 1 28 06 PM" src="https://github.com/user-attachments/assets/8bcd10ca-4354-4664-842b-e09dec19564b" /> | 


## Why are these changes being made?

* In the Reader the masterbar dropdowns were light (they come from the global-sidebar styles), so the top bar didn't match the dashboard for opted-in users.
* Scoping to the Reader keeps the old Calypso `/sites` dashboard — and non-opted-in users — unchanged during the MSD rollout, and prevents the override from leaking into the dashboard's interim-omnibar (which already supplies its own dark palette).

## Testing Instructions

* Opt into the hosting dashboard at `/me/account`, then open the Reader.
* Confirm the masterbar is dark and its dropdowns (e.g. the site menu) are dark with legible text, the plan badge reads as a light pill, grouped items stay visually separated, and dropdown-link hover shows highlight-colored text with no gray box.
* Confirm the old Calypso `/sites` dashboard and the MSD dashboard are unchanged.
* Opt out and confirm the Reader masterbar returns to its normal color.

## Considerations

* We're using variables to override the defaults and the opted in state to determine whether to do so. That isn't the greatest long-term strategy because the opt-in toggle won't be around forever. At the same time, this omnibar is not _supposed_ to be around forever.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?