### PR TITLE
Masterbar: show the W-icon dropdown outside the My Sites view

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -287,40 +287,43 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
-		const subItems = isGlobalSidebarVisible
-			? null
-			: [
-					[
-						{
-							label: translate( 'Sites' ),
-							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
-							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
-						},
-						{
-							label: translate( 'Domains' ),
-							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
-							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
-						},
-					],
-					...( this.props.isSimpleSite
-						? []
-						: [
-								[
-									{
-										label: translate( 'About WordPress' ),
-										url: `${ siteAdminUrl }about.php`,
-										onClick: () =>
-											this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
-									},
-									{
-										label: translate( 'Get Involved' ),
-										url: `${ siteAdminUrl }contribute.php`,
-										onClick: () =>
-											this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
-									},
-								],
-						  ] ),
-			  ];
+		// The global sidebar normally replaces the W-icon dropdown, so it's hidden
+		// there — except in the Reader, which keeps it to match the dashboard.
+		const subItems =
+			isGlobalSidebarVisible && section !== 'reader'
+				? null
+				: [
+						[
+							{
+								label: translate( 'Sites' ),
+								url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
+								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
+							},
+							{
+								label: translate( 'Domains' ),
+								url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
+								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
+							},
+						],
+						...( this.props.isSimpleSite
+							? []
+							: [
+									[
+										{
+											label: translate( 'About WordPress' ),
+											url: `${ siteAdminUrl }about.php`,
+											onClick: () =>
+												this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
+										},
+										{
+											label: translate( 'Get Involved' ),
+											url: `${ siteAdminUrl }contribute.php`,
+											onClick: () =>
+												this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
+										},
+									],
+							  ] ),
+				  ];
 
 		return (
 			<Item

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -271,7 +271,6 @@ class MasterbarLoggedIn extends Component {
 			currentRoute,
 			siteAdminUrl,
 			dashboardOptIn,
-			sidebarType,
 		} = this.props;
 
 		let mySitesUrl = domainOnlySite
@@ -289,10 +288,7 @@ class MasterbarLoggedIn extends Component {
 
 		// Hidden across the My Sites view. Keys off the sidebar type, not its
 		// visibility, to also cover HD v1 site screens where the sidebar is hidden.
-		const isMySitesView =
-			( sidebarType === SidebarType.Global || sidebarType === SidebarType.GlobalCollapsed ) &&
-			( section === 'sites' || section === 'sites-dashboard' );
-		const subItems = isMySitesView
+		const subItems = this.isMySitesActive()
 			? null
 			: [
 					[

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -286,38 +286,42 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
-		const subItems = [
-			[
-				{
-					label: translate( 'Sites' ),
-					url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
-					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
-				},
-				{
-					label: translate( 'Domains' ),
-					url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
-					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
-				},
-			],
-			...( this.props.isSimpleSite
-				? []
+		// The sites dashboard is the My Sites view itself, so the dropdown is redundant there.
+		const subItems =
+			section === 'sites-dashboard'
+				? null
 				: [
 						[
 							{
-								label: translate( 'About WordPress' ),
-								url: `${ siteAdminUrl }about.php`,
-								onClick: () =>
-									this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
+								label: translate( 'Sites' ),
+								url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
+								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
 							},
 							{
-								label: translate( 'Get Involved' ),
-								url: `${ siteAdminUrl }contribute.php`,
-								onClick: () =>
-									this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
+								label: translate( 'Domains' ),
+								url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
+								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
 							},
 						],
-				  ] ),
-		];
+						...( this.props.isSimpleSite
+							? []
+							: [
+									[
+										{
+											label: translate( 'About WordPress' ),
+											url: `${ siteAdminUrl }about.php`,
+											onClick: () =>
+												this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
+										},
+										{
+											label: translate( 'Get Involved' ),
+											url: `${ siteAdminUrl }contribute.php`,
+											onClick: () =>
+												this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
+										},
+									],
+							  ] ),
+				  ];
 
 		return (
 			<Item

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -287,10 +287,8 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
-		// Hide the dropdown across the My Sites view — the sites dashboard and its
-		// site pages (including HD v1 screens, where the global sidebar can be hidden,
-		// so this keys off the sidebar type rather than its visibility). The W icon is
-		// already the active item there, so a second menu is redundant.
+		// Hidden across the My Sites view. Keys off the sidebar type, not its
+		// visibility, to also cover HD v1 site screens where the sidebar is hidden.
 		const isMySitesView =
 			( sidebarType === SidebarType.Global || sidebarType === SidebarType.GlobalCollapsed ) &&
 			( section === 'sites' || section === 'sites-dashboard' );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -271,6 +271,7 @@ class MasterbarLoggedIn extends Component {
 			currentRoute,
 			siteAdminUrl,
 			dashboardOptIn,
+			sidebarType,
 		} = this.props;
 
 		let mySitesUrl = domainOnlySite
@@ -286,9 +287,14 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
-		// Hide the dropdown wherever the My Sites view is already active (the sites
-		// dashboard and its site pages); a second menu there is redundant.
-		const subItems = this.isMySitesActive()
+		// Hide the dropdown across the My Sites view — the sites dashboard and its
+		// site pages (including HD v1 screens, where the global sidebar can be hidden,
+		// so this keys off the sidebar type rather than its visibility). The W icon is
+		// already the active item there, so a second menu is redundant.
+		const isMySitesView =
+			( sidebarType === SidebarType.Global || sidebarType === SidebarType.GlobalCollapsed ) &&
+			( section === 'sites' || section === 'sites-dashboard' );
+		const subItems = isMySitesView
 			? null
 			: [
 					[

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -286,42 +286,42 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
-		// The sites dashboard is the My Sites view itself, so the dropdown is redundant there.
-		const subItems =
-			section === 'sites-dashboard'
-				? null
-				: [
-						[
-							{
-								label: translate( 'Sites' ),
-								url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
-								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
-							},
-							{
-								label: translate( 'Domains' ),
-								url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
-								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
-							},
-						],
-						...( this.props.isSimpleSite
-							? []
-							: [
-									[
-										{
-											label: translate( 'About WordPress' ),
-											url: `${ siteAdminUrl }about.php`,
-											onClick: () =>
-												this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
-										},
-										{
-											label: translate( 'Get Involved' ),
-											url: `${ siteAdminUrl }contribute.php`,
-											onClick: () =>
-												this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
-										},
-									],
-							  ] ),
-				  ];
+		// Hide the dropdown wherever the My Sites view is already active (the sites
+		// dashboard and its site pages); a second menu there is redundant.
+		const subItems = this.isMySitesActive()
+			? null
+			: [
+					[
+						{
+							label: translate( 'Sites' ),
+							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
+							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
+						},
+						{
+							label: translate( 'Domains' ),
+							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
+							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
+						},
+					],
+					...( this.props.isSimpleSite
+						? []
+						: [
+								[
+									{
+										label: translate( 'About WordPress' ),
+										url: `${ siteAdminUrl }about.php`,
+										onClick: () =>
+											this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
+									},
+									{
+										label: translate( 'Get Involved' ),
+										url: `${ siteAdminUrl }contribute.php`,
+										onClick: () =>
+											this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
+									},
+								],
+						  ] ),
+			  ];
 
 		return (
 			<Item

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -269,7 +269,6 @@ class MasterbarLoggedIn extends Component {
 			translate,
 			section,
 			currentRoute,
-			isGlobalSidebarVisible,
 			siteAdminUrl,
 			dashboardOptIn,
 		} = this.props;
@@ -287,43 +286,38 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
-		// The global sidebar normally replaces the W-icon dropdown, so it's hidden
-		// there — except in the Reader, which keeps it to match the dashboard.
-		const subItems =
-			isGlobalSidebarVisible && section !== 'reader'
-				? null
+		const subItems = [
+			[
+				{
+					label: translate( 'Sites' ),
+					url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
+					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
+				},
+				{
+					label: translate( 'Domains' ),
+					url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
+					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
+				},
+			],
+			...( this.props.isSimpleSite
+				? []
 				: [
 						[
 							{
-								label: translate( 'Sites' ),
-								url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
-								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
+								label: translate( 'About WordPress' ),
+								url: `${ siteAdminUrl }about.php`,
+								onClick: () =>
+									this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
 							},
 							{
-								label: translate( 'Domains' ),
-								url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
-								onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
+								label: translate( 'Get Involved' ),
+								url: `${ siteAdminUrl }contribute.php`,
+								onClick: () =>
+									this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
 							},
 						],
-						...( this.props.isSimpleSite
-							? []
-							: [
-									[
-										{
-											label: translate( 'About WordPress' ),
-											url: `${ siteAdminUrl }about.php`,
-											onClick: () =>
-												this.props.recordTracksEvent( 'calypso_masterbar_about_wordpress_clicked' ),
-										},
-										{
-											label: translate( 'Get Involved' ),
-											url: `${ siteAdminUrl }contribute.php`,
-											onClick: () =>
-												this.props.recordTracksEvent( 'calypso_masterbar_get_involved_clicked' ),
-										},
-									],
-							  ] ),
-				  ];
+				  ] ),
+		];
 
 		return (
 			<Item

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -713,6 +713,14 @@ body.is-mobile-app-view {
 	}
 }
 
+// In the global sidebar the submenu group background is white (matching the panel),
+// which suits the user menu but leaves the W-icon dropdown's second group (About
+// WordPress / Get Involved) looking like a stray gap. Give just that group a light
+// grey so it reads as a distinct section.
+.is-global-sidebar-visible .masterbar__item-my-sites + .masterbar__item-subitems {
+	--color-masterbar-submenu-group-background: #{$gray-100};
+}
+
 .masterbar__item-launch-site {
 	gap: 6px;
 	cursor: pointer;

--- a/client/reader/color-scheme/dark-mode.scss
+++ b/client/reader/color-scheme/dark-mode.scss
@@ -45,6 +45,7 @@
 
 	&.theme-default .is-global-sidebar-visible {
 		// The shared sidebar sets these variables at this scope, so keep Reader dark overrides here too.
+		--color-masterbar-submenu-group-background: var( --dashboard__background-color );
 		--color-sidebar-menu-selected-background: var( --dashboard-item-selected__background-color );
 		--color-sidebar-menu-hover-background: var( --dashboard-item-selected-hover__background-color );
 		--color-sidebar-menu-hover-text: var( --color-text );
@@ -54,6 +55,12 @@
 		--color-sidebar-submenu-selected-hover-text: var( --color-sidebar-menu-selected-text );
 		--color-sidebar-gridicon-hover-fill: currentColor;
 		--color-sidebar-gridicon-selected-fill: var( --color-sidebar-menu-selected-text );
+
+		// The W-icon dropdown's second group hardcodes a light grey for the white
+		// menu; match the surrounding dark groups instead of that grey.
+		.masterbar__item-my-sites + .masterbar__item-subitems {
+			--color-masterbar-submenu-group-background: inherit;
+		}
 	}
 
 	.reader-onboarding-modal__footer {


### PR DESCRIPTION
Part of DOTMSD-1349

## Proposed Changes

* Show the masterbar's W-icon dropdown on the global-view surfaces where it was hidden (the Reader and `/me`), so its links are reachable there instead of only on site-specific views.
* Keep it hidden across the **My Sites view** (the v1 sites dashboard and its site pages), where the W icon is already the active item.
* Tint the dropdown's second group (About WordPress / Get Involved) light grey so it reads as a distinct section on the otherwise-white global-sidebar submenu.

## Why are these changes being made?

* The Reader (and `/me`) had no way to reach Sites/Domains from the W icon, because the dropdown was hidden whenever the global sidebar is visible.
* It stays hidden across the My Sites view: that view's current layout already reads as an open menu (the W icon is the active item there), so showing another menu from the W icon would be weird and redundant.

### Where the menu appears

Now shown (previously hidden):

* **Reader** — `/reader`, `/discover`, `/following`, `/tag/…`, `/activities/likes`, and other Reader routes
* **Me** — `/me` and its subpages (`/me/account`, `/me/security`, `/me/purchases`, …)

Unchanged (already showed it):

* **Per-site management views** — `/home/<site>`, `/posts/<site>`, `/pages/<site>`, `/plugins/<site>`, `/themes/<site>`, …

Hidden — the My Sites view (`isMySitesActive()`):

* `/sites`, `/p2s`
* Site dashboard pages — `/overview/<site>`, `/hosting-config/<site>`, `/hosting-features/<site>`, `/site-monitoring/<site>`, `/sites/performance/<site>`, `/site-logs/<site>`, `/staging-site/<site>`, `/github-deployments/<site>`, `/sites/settings/<site>`, `/plugins/manage/sites`
* `/domains/manage`

### History

* The WP-logo submenu was stripped down during the global-nav redesign (#92915 "Remove All Sites link and add tour tip to WP logo", #93110).
* #100627 (merged 2025-03-04, "Admin bar: add subitems to the top-left WP.com icon menu", from #98079) brought the items back — but deliberately only on site-specific views. Its description states: "These changes DO NOT apply to the global view; only on site-specific view." That introduced the `isGlobalSidebarVisible ? null` gate this PR replaces.
* The original reasoning was that the global sidebar already surfaces that navigation. That holds for the My Sites view, but not for surfaces like the Reader, whose sidebar is feed/subscription navigation — so the links were unreachable there.

## Testing Instructions

* Click the W icon in the masterbar on the Reader, `/me`, and a per-site page (e.g. `/home/<site>`): the dropdown should appear.
* Confirm it does NOT appear across the My Sites view — `/sites` and the site dashboard pages (e.g. `/site-monitoring/<site>`, `/overview/<site>`).
* Confirm the dropdown shows Sites and Domains, plus About WordPress / Get Involved on Atomic and Jetpack sites (Simple sites show only Sites / Domains), with the second group on a light-grey background.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?