### PR TITLE
Social logins: Fix Google Connect button stuck in loading state

### DIFF
--- a/client/dashboard/me/security-social-logins/google-login.tsx
+++ b/client/dashboard/me/security-social-logins/google-login.tsx
@@ -129,12 +129,13 @@ export default function GoogleLogin( {
 			state: nonce,
 			callback: async ( response: { error: string; code: string; state: string } ) => {
 				if ( response.error ) {
-					setShowLoading( false );
 					return;
 				}
+				setShowLoading( true );
 				handleAuthorizationCode( { auth_code: response.code, state: response.state } );
 			},
 		} );
+		setShowLoading( false );
 		client?.requestCode();
 	};
 


### PR DESCRIPTION
Fixes DOTMSD-1332

## Proposed Changes

* On the Social logins security screen (`/me/security/social-logins`), the Google **Connect** button no longer gets stuck in a loading state when the user opens the Google sign-in popup and closes it without completing the flow.
* Loading is now shown only during the work the app actually controls — the nonce fetch / GIS script load before the popup opens, and the token exchange after a code is returned — instead of being carried through the popup phase.

## Why are these changes being made?

The button set its loading state on click and only cleared it from the Google Identity Services (GIS) `callback`. When the user closes the popup without completing sign-in, GIS fires no callback, so the loading state was never reset and the button stayed busy and un-clickable until a page refresh.

GIS exposes no reliable "popup closed" signal for `initCodeClient` (`error_callback` fires inconsistently, sometimes while the popup is still open), so rather than trying to observe the popup we simply don't keep a loading state during the one phase we can't observe. While the popup is open it is the user's focus and provides its own feedback; cancelling now leaves the button in its normal, ready state.

## Testing Instructions

1. Open the dashboard live link
2. Go to `/me/security/social-logins`.
3. Click **Connect** on Google.
4. When the Google popup appears, close it without completing sign-in.
5. Confirm the **Connect** button returns to its normal, clickable state (no stuck loading spinner) without needing a refresh.
6. Click **Connect** again and complete the flow; confirm the button shows loading during the token exchange and the account connects successfully.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
