### PR TITLE
Account recovery: Reject malformed phone numbers in validation

### DIFF
--- a/client/dashboard/utils/phone-number.ts
+++ b/client/dashboard/utils/phone-number.ts
@@ -18,18 +18,18 @@ export function validatePhone( phoneNumber: string ) {
 		};
 	}
 
-	if ( phoneNumberWithoutPlus.length < 8 ) {
-		return {
-			error: 'phone_number_too_short',
-			message: __( 'This number is too short' ),
-		};
-	}
-
 	// The phone library silently strips extra plus signs, so reject them before validating.
 	if ( ! /^\+?\d+$/.test( phoneNumber ) ) {
 		return {
 			error: 'phone_number_contains_special_characters',
 			message: __( 'Phone numbers cannot contain special characters' ),
+		};
+	}
+
+	if ( phoneNumberWithoutPlus.length < 8 ) {
+		return {
+			error: 'phone_number_too_short',
+			message: __( 'This number is too short' ),
 		};
 	}
 

--- a/client/dashboard/utils/phone-number.ts
+++ b/client/dashboard/utils/phone-number.ts
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import phone from 'phone';
 
 export function validatePhone( phoneNumber: string ) {
-	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );
+	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/g, '' );
 
 	if ( phoneNumberWithoutPlus.length === 0 ) {
 		return {
@@ -11,7 +11,7 @@ export function validatePhone( phoneNumber: string ) {
 		};
 	}
 
-	if ( phoneNumber.search( /[a-z,A-Z]/ ) > -1 ) {
+	if ( /[a-zA-Z]/.test( phoneNumber ) ) {
 		return {
 			error: 'phone_number_contains_letters',
 			message: __( 'Phone numbers cannot contain letters' ),
@@ -25,7 +25,8 @@ export function validatePhone( phoneNumber: string ) {
 		};
 	}
 
-	if ( phoneNumber.search( /[^0-9,+]/ ) > -1 ) {
+	// The phone library silently strips extra plus signs, so reject them before validating.
+	if ( ! /^\+?\d+$/.test( phoneNumber ) ) {
 		return {
 			error: 'phone_number_contains_special_characters',
 			message: __( 'Phone numbers cannot contain special characters' ),

--- a/client/dashboard/utils/test/phone-number.ts
+++ b/client/dashboard/utils/test/phone-number.ts
@@ -96,27 +96,43 @@ describe( 'validatePhone', () => {
 	} );
 
 	describe( 'edge cases', () => {
+		it( 'should reject a valid number prefixed with multiple plus signs', () => {
+			const result = validatePhone( '++12025551234' );
+			expect( result ).toEqual( {
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
+			} );
+		} );
+
+		it( 'should reject a number with many leading plus signs', () => {
+			const result = validatePhone( '+++12025551234' );
+			expect( result ).toEqual( {
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
+			} );
+		} );
+
 		it( 'should handle phone number with multiple plus signs', () => {
 			const result = validatePhone( '++1234567890' );
 			expect( result ).toEqual( {
-				error: 'phone_number_invalid',
-				message: 'That phone number does not appear to be valid',
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
 			} );
 		} );
 
 		it( 'should handle phone number with plus sign in the middle', () => {
 			const result = validatePhone( '123+4567890' );
 			expect( result ).toEqual( {
-				error: 'phone_number_invalid',
-				message: 'That phone number does not appear to be valid',
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
 			} );
 		} );
 
-		it( 'should handle phone number with commas (bug in regex)', () => {
+		it( 'should reject phone number with commas', () => {
 			const result = validatePhone( '123,456,7890' );
 			expect( result ).toEqual( {
-				error: 'phone_number_contains_letters',
-				message: 'Phone numbers cannot contain letters',
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
 			} );
 		} );
 	} );

--- a/client/dashboard/utils/test/phone-number.ts
+++ b/client/dashboard/utils/test/phone-number.ts
@@ -135,6 +135,14 @@ describe( 'validatePhone', () => {
 				message: 'Phone numbers cannot contain special characters',
 			} );
 		} );
+
+		it( 'should report special characters over length for a short misplaced-plus number', () => {
+			const result = validatePhone( '+1+2345' );
+			expect( result ).toEqual( {
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
+			} );
+		} );
 	} );
 
 	describe( 'validation order', () => {


### PR DESCRIPTION
Fixes DOTMSD-1334

## Proposed Changes

* `validatePhone` now rejects misplaced and repeated `+` signs (e.g. `++12025551234`, `+1+2025551234`, `123+456`) in the recovery SMS number and two-step-auth SMS setup screens.
* The structural format is validated with a single rule — digits with an optional leading `+` (`/^\+?\d+$/`) — which also rejects other stray characters.
* Removes a stray comma from the letters check so commas now correctly report "special characters" instead of "cannot contain letters".

## Why are these changes being made?

The recovery SMS screen validates `countryNumericCode + phoneNumber` (e.g. `+1` + the user's input). The old check allowed `+` anywhere and any number of times, and the `phone` library **silently strips** extra `+` signs and reports the result as valid — so values like `++12025551234` and `+1+2025551234` passed validation. Since the country code already provides the leading `+`, any `+` a user types is invalid, and the new single-rule check rejects it before the lenient library validation runs.

The fix lives in the shared `validatePhone` util, so it covers both the account-recovery SMS screen and the two-step-auth SMS setup screen.

## Testing Instructions

1. Open the dashboard live link
2. Go to the account recovery screen and add a recovery SMS number.
3. In the phone number field, enter a value with extra/misplaced plus signs, e.g. `+2025551234` (the country code already supplies the `+`).
4. Submit and confirm validation now rejects it with "Phone numbers cannot contain special characters".
5. Enter a normal number without a `+` (e.g. `2025551234`) and confirm it still validates and saves.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)