### PR TITLE
Lodash: replace filter() with native Array.prototype.filter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -596,6 +596,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/every': 'error',
 		'you-dont-need-lodash-underscore/extend-own': 'error',
 		'you-dont-need-lodash-underscore/fill': 'error',
+		'you-dont-need-lodash-underscore/filter': 'error',
 		'you-dont-need-lodash-underscore/find': 'error',
 		'you-dont-need-lodash-underscore/find-index': 'error',
 		'you-dont-need-lodash-underscore/first': 'error',

--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -248,13 +248,15 @@ function processLibPhoneNumberMetadata( libPhoneNumberData ) {
 		}
 	}
 
-	const noPattern = _.filter(
-		data,
+	const noPattern = Object.values( data ).filter(
 		_.conforms( { patterns: ( patterns ) => patterns.length === 0 } )
 	);
 	_.forIn( noPattern, function ( country ) {
 		country.patternRegion = (
-			_.maxBy( Object.values( _.filter( data, { dialCode: country.dialCode } ) ), 'priority' ) || {}
+			_.maxBy(
+				Object.values( data ).filter( ( c ) => c.dialCode === country.dialCode ),
+				'priority'
+			) || {}
 		).isoCode;
 		console.log(
 			'Info: ' +

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,6 +1,6 @@
 import { uniqBy } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { map, filter } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { isAncestor } from 'calypso/blocks/comments/utils';
@@ -32,9 +32,9 @@ class ConversationCaterpillarComponent extends Component {
 
 		const childComments = isRoot
 			? comments
-			: filter( comments, ( child ) => isAncestor( parentComment, child, commentsTree ) );
+			: comments.filter( ( child ) => isAncestor( parentComment, child, commentsTree ) );
 
-		const commentsToExpand = filter( childComments, ( comment ) => ! commentsToShow[ comment.ID ] );
+		const commentsToExpand = childComments.filter( ( comment ) => ! commentsToShow[ comment.ID ] );
 
 		return commentsToExpand;
 	};

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,5 +1,5 @@
 import { keyBy, partition, pickBy } from '@automattic/js-utils';
-import { map, filter } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
@@ -167,7 +167,7 @@ export class ConversationCommentList extends Component {
 			return [];
 		}
 
-		const withParents = filter( commentIds, ( id ) => this.commentHasParent( commentsTree, id ) );
+		const withParents = commentIds.filter( ( id ) => this.commentHasParent( commentsTree, id ) );
 		const parentIds = map( withParents, ( id ) => this.getParentId( commentsTree, id ) );
 
 		const [ accessible, inaccessible ] = partition( parentIds, ( id ) =>
@@ -265,7 +265,9 @@ export class ConversationCommentList extends Component {
 		// if you have finished loading comments, then lets use the comments we have as the final comment count
 		// if we are still loading comments, then assume what the server initially told us is right
 		const commentCount = isDoneLoadingComments
-			? filter( commentsTree, ( comment ) => comment?.data?.type === 'comment' ).length // filter out pingbacks/trackbacks
+			? Object.values( commentsTree ?? {} ).filter(
+					( comment ) => comment?.data?.type === 'comment'
+			  ).length // filter out pingbacks/trackbacks
 			: post.discussion.comment_count;
 
 		const showCaterpillar =

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -5,7 +5,7 @@ import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { filter, map, merge, isEmpty } from 'lodash';
+import { map, merge, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -253,13 +253,13 @@ class SignupForm extends Component {
 	};
 
 	validate = ( fields, onComplete ) => {
-		const fieldsForValidation = filter( [
+		const fieldsForValidation = [
 			'email',
 			this.props.isPasswordless === false && 'password', // Remove password from validation if passwordless
 			this.displayUsernameInput() && 'username',
 			this.props.displayNameInput && 'firstName',
 			this.props.displayNameInput && 'lastName',
-		] );
+		].filter( Boolean );
 
 		const data = mapKeys( pick( fields, fieldsForValidation ), ( value, key ) => snakeCase( key ) );
 		wpcom.req.post(

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -1,7 +1,7 @@
 import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { merge, map, filter, get } from 'lodash';
+import { merge, map, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import DayPicker from 'react-day-picker';
@@ -216,7 +216,7 @@ class DatePicker extends PureComponent {
 
 		if ( this.props.events && this.props.events.length ) {
 			modifiers.events = map(
-				filter( this.props.events, ( event ) => event.date ),
+				this.props.events.filter( ( event ) => event.date ),
 				( event ) => this.getDateInstance( event.date )
 			);
 		}

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -1,5 +1,5 @@
 import { uniqBy } from '@automattic/js-utils';
-import { map, filter } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Gravatar from 'calypso/components/gravatar';
@@ -23,9 +23,9 @@ class GravatarCaterpillar extends Component {
 		const gravatarSmallScreenThreshold = maxGravatarsToDisplay / 2;
 
 		// Only display authors with a gravatar, and only display each author once
-		const displayedUsers = filter( uniqBy( users, 'avatar_URL' ), 'avatar_URL' ).slice(
-			-1 * maxGravatarsToDisplay
-		);
+		const displayedUsers = uniqBy( users, 'avatar_URL' )
+			.filter( ( user ) => user.avatar_URL )
+			.slice( -1 * maxGravatarsToDisplay );
 		const displayedUsersCount = displayedUsers.length;
 
 		return (

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -24,7 +24,7 @@ class GravatarCaterpillar extends Component {
 
 		// Only display authors with a gravatar, and only display each author once
 		const displayedUsers = uniqBy( users, 'avatar_URL' )
-			.filter( ( user ) => user.avatar_URL )
+			.filter( ( user ) => user?.avatar_URL )
 			.slice( -1 * maxGravatarsToDisplay );
 		const displayedUsersCount = displayedUsers.length;
 

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -1,11 +1,11 @@
 import { flow, sortBy } from '@automattic/js-utils';
-import { filter, map } from 'lodash';
+import { map } from 'lodash';
 import { PureComponent } from 'react';
 import PaymentLogo, { POSSIBLE_TYPES } from '../index';
 
 const genVendors = flow(
 	// 'placeholder' is a special case that needs to be demonstrated separately
-	( arr ) => filter( arr, ( type ) => type !== 'placeholder' ),
+	( arr ) => arr.filter( ( type ) => type !== 'placeholder' ),
 
 	( arr ) => map( arr, ( type ) => ( { type, isCompact: false } ) ),
 	( arr ) => arr.concat( [ { type: 'paypal', isCompact: true } ] ),

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -5,7 +5,7 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testOnBlur", "expect.*"] }] */
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { filter, map } from 'lodash';
+import { map } from 'lodash';
 import fixtures from './lib/fixtures';
 import TokenFieldWrapper, { suggestions } from './lib/token-field-wrapper';
 
@@ -78,8 +78,7 @@ describe( 'TokenField', () => {
 		div.innerHTML = node.querySelector( 'span' ).outerHTML;
 
 		return map(
-			filter(
-				div.firstChild.childNodes,
+			Array.from( div.firstChild.childNodes ).filter(
 				( childNode ) => childNode.nodeType !== window.Node.COMMENT_NODE
 			),
 			( childNode ) => childNode.textContent

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -1,7 +1,7 @@
 import { camelCase, mapValues, pickBy } from '@automattic/js-utils';
 import { debounce } from '@wordpress/compose';
 import update from 'immutability-helper';
-import { filter, isEmpty, map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {
@@ -299,9 +299,9 @@ function isFieldValidating( formState, fieldName ) {
 }
 
 function getInvalidFields( formState ) {
-	return filter( formState, function ( field, fieldName ) {
-		return isFieldInvalid( formState, fieldName );
-	} );
+	return Object.values(
+		pickBy( formState, ( field, fieldName ) => isFieldInvalid( formState, fieldName ) )
+	);
 }
 function getErrorMessages( formState ) {
 	const invalidFields = getInvalidFields( formState );

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { orderBy } from '@automattic/js-utils';
 import { TranslateResult, translate } from 'i18n-calypso';
-import { filter } from 'lodash';
 import { type ImporterOption } from 'calypso/blocks/import/list';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { appStates } from 'calypso/state/imports/constants';
@@ -421,7 +420,7 @@ export function getImporterByKey(
 	key: string,
 	args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' }
 ) {
-	return filter( getImporters( args ), ( importer ) => importer.key === key )[ 0 ];
+	return getImporters( args ).find( ( importer ) => importer.key === key );
 }
 
 export function isSupportedImporterEngine( engine: string ): boolean {

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -1,5 +1,4 @@
 import { maxBy } from '@automattic/js-utils';
-import { filter } from 'lodash';
 import { getSections } from 'calypso/sections-helper';
 
 export default function pathToSection( path ) {
@@ -13,7 +12,7 @@ export default function pathToSection( path ) {
 	);
 
 	// sort out special case we don't want to match: matching on '/' but path isn't exactly '/'
-	const matchingPaths = filter( bestMatch.paths, ( sectionPath ) =>
+	const matchingPaths = bestMatch.paths.filter( ( sectionPath ) =>
 		( path ?? '' ).startsWith( sectionPath )
 	);
 	if ( matchingPaths.length === 1 && matchingPaths[ 0 ] === '/' && path !== '/' ) {

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -1,5 +1,4 @@
 import { addQueryArgs } from '@wordpress/url';
-import { filter } from 'lodash';
 import validUrl from 'valid-url';
 import { allowedTags, customTags } from './allowed-tags';
 
@@ -137,13 +136,14 @@ export const sanitizeSectionContent = ( content ) => {
 		// as we go on the first pass.
 		//
 		// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes
-		filter(
-			node.attributes,
-			( { name, value } ) =>
-				! isAllowedAttr( isYoutube ? customTags.YOUTUBE : tagName, name ) ||
-				// only valid http(s) URLs are allowed
-				( ( 'href' === name || 'src' === name ) && ! validUrl.isWebUri( value ) )
-		).forEach( ( { name } ) => node.removeAttribute( name ) );
+		Array.from( node.attributes ?? [] )
+			.filter(
+				( { name, value } ) =>
+					! isAllowedAttr( isYoutube ? customTags.YOUTUBE : tagName, name ) ||
+					// only valid http(s) URLs are allowed
+					( ( 'href' === name || 'src' === name ) && ! validUrl.isWebUri( value ) )
+			)
+			.forEach( ( { name } ) => node.removeAttribute( name ) );
 
 		// of course, all links need to be normalized since
 		// they now exist inside of the Calypso context

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -12,7 +12,7 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 } from '@automattic/calypso-products';
 import { pick, sortBy } from '@automattic/js-utils';
-import { filter, map } from 'lodash';
+import { map } from 'lodash';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -283,7 +283,7 @@ export function normalizePluginsList( pluginsList ) {
  * @returns {Array} Array of filtered logs that match the criteria
  */
 export function filterNotices( logs, siteId, pluginId ) {
-	return filter( logs, filterNoticesBy.bind( this, siteId, pluginId ) );
+	return ( logs ?? [] ).filter( filterNoticesBy.bind( this, siteId, pluginId ) );
 }
 
 /**

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,6 +1,6 @@
 /* eslint-disable jsdoc/no-undefined-types */
 
-import { map, filter } from 'lodash';
+import { map } from 'lodash';
 import getEmbedMetadata from 'calypso/lib/get-video-id';
 import { READER_CONTENT_WIDTH } from 'calypso/reader/data/post/sizes';
 import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
@@ -159,8 +159,8 @@ export default function detectMedia( post, dom ) {
 	} );
 
 	post.content_media = contentMedia.filter( Boolean );
-	post.content_embeds = filter( post.content_media, ( m ) => m.mediaType === 'video' );
-	post.content_images = filter( post.content_media, ( m ) => m.mediaType === 'image' );
+	post.content_embeds = post.content_media.filter( ( m ) => m.mediaType === 'video' );
+	post.content_images = post.content_media.filter( ( m ) => m.mediaType === 'image' );
 
 	// TODO: figure out a more sane way of combining featured_image + content media
 	// so that changes to logic don't need to exist in multiple places

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -1,5 +1,4 @@
 import { getUrlParts, getUrlFromParts, safeImageUrl } from '@automattic/calypso-url';
-import { filter } from 'lodash';
 import { resolveRelativePath } from 'calypso/lib/url';
 import { maxWidthPhotonishURL } from './utils';
 
@@ -14,7 +13,7 @@ const removeUnwantedAttributes = ( node ) => {
 		return;
 	}
 
-	const inlineEventHandlerAttributes = filter( node.attributes, ( attr ) =>
+	const inlineEventHandlerAttributes = Array.from( node.attributes ).filter( ( attr ) =>
 		attr.name.startsWith( 'on' )
 	);
 	inlineEventHandlerAttributes.forEach( ( a ) => node.removeAttribute( a.name ) );

--- a/client/lib/post-normalizer/rule-keep-valid-images.js
+++ b/client/lib/post-normalizer/rule-keep-valid-images.js
@@ -1,5 +1,4 @@
 import { safeImageUrl } from '@automattic/calypso-url';
-import { filter } from 'lodash';
 
 function isValidImage( width, height ) {
 	return function ( image ) {
@@ -11,10 +10,10 @@ export default function keepValidImages( minWidth, minHeight ) {
 	return function keepValidImagesForWidthAndHeight( post ) {
 		const imageFilter = isValidImage( minWidth, minHeight );
 		if ( post.images ) {
-			post.images = filter( post.images, imageFilter );
+			post.images = post.images.filter( imageFilter );
 		}
 		if ( post.content_images ) {
-			post.content_images = filter( post.content_images, imageFilter );
+			post.content_images = post.content_images.filter( imageFilter );
 		}
 		return post;
 	};

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { pick } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { translate } from 'i18n-calypso';
-import { filter, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -350,11 +350,11 @@ export default class SignupFlowController {
 
 	_process() {
 		const currentSteps = this._getFlowSteps();
-		const signupProgress = filter( getSignupProgress( this._reduxStore.getState() ), ( step ) =>
-			currentSteps.includes( step.stepName )
-		);
-		const pendingSteps = filter( signupProgress, { status: 'pending' } );
-		const completedSteps = filter( signupProgress, { status: 'completed' } );
+		const signupProgress = Object.values(
+			getSignupProgress( this._reduxStore.getState() ) ?? {}
+		).filter( ( step ) => currentSteps.includes( step.stepName ) );
+		const pendingSteps = signupProgress.filter( ( step ) => step.status === 'pending' );
+		const completedSteps = signupProgress.filter( ( step ) => step.status === 'completed' );
 		const dependencies = getSignupDependencyStore( this._reduxStore.getState() );
 
 		if ( dependencies.bearer_token && ! wpcom.isTokenLoaded() ) {
@@ -383,10 +383,9 @@ export default class SignupFlowController {
 		const dependenciesFound = this._findDependencies( step.stepName, 'dependencies' );
 		const dependenciesSatisfied = dependencies.length === Object.keys( dependenciesFound ).length;
 		const currentSteps = this._getFlowSteps();
-		const signupProgress = filter(
-			getSignupProgress( this._reduxStore.getState() ),
-			( { stepName } ) => currentSteps.includes( stepName )
-		);
+		const signupProgress = Object.values(
+			getSignupProgress( this._reduxStore.getState() ) ?? {}
+		).filter( ( { stepName } ) => currentSteps.includes( stepName ) );
 		const allStepsSubmitted =
 			signupProgress.filter( ( step ) => step.status !== 'in-progress' ).length ===
 			currentSteps.length;

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { filter } from 'lodash';
 import { stringify } from 'qs';
 import { addQueryArgs } from 'calypso/lib/url';
 import { isUnderEmailManagementAll, isUnderCheckoutRoute } from 'calypso/my-sites/email/paths';
@@ -52,7 +51,7 @@ function domainManagementTransferBase(
 	return domainManagementEditBase(
 		siteName,
 		domainName,
-		filter( [ 'transfer', transferType ] ).join( '/' ),
+		[ 'transfer', transferType ].filter( Boolean ).join( '/' ),
 		relativeTo
 	);
 }
@@ -130,7 +129,7 @@ export function domainManagementList( siteName, relativeTo = null, isDomainOnlyS
 	) {
 		return domainManagementRoot();
 	}
-	return domainManagementRoot() + '/' + siteName ?? '';
+	return domainManagementRoot() + '/' + siteName;
 }
 
 /**

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -1,5 +1,4 @@
 import { withRtl } from 'i18n-calypso';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, Component } from 'react';
 import { connect } from 'react-redux';
@@ -95,7 +94,7 @@ export class MediaLibraryList extends Component {
 		// seeking to select a single item
 		let selectedItems;
 		if ( this.props.single ) {
-			selectedItems = filter( this.props.selectedItems, { ID: item.ID } );
+			selectedItems = ( this.props.selectedItems ?? [] ).filter( ( i ) => i.ID === item.ID );
 		} else {
 			selectedItems = [ ...this.props.selectedItems ];
 		}

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -5,7 +5,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { groupBy, pickBy } from '@automattic/js-utils';
 import debugModule from 'debug';
 import { localize, fixMe } from 'i18n-calypso';
-import { filter } from 'lodash';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -162,7 +161,7 @@ class InvitePeople extends Component {
 			return filteredTokens.includes( key );
 		} );
 
-		const filteredSuccess = filter( success, ( successfulValidation ) => {
+		const filteredSuccess = success.filter( ( successfulValidation ) => {
 			return filteredTokens.includes( successfulValidation );
 		} );
 

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -9,7 +9,6 @@ import {
 	JETPACK_SUPPORT,
 } from '@automattic/urls';
 import { localize, fixMe } from 'i18n-calypso';
-import { filter } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -88,7 +87,7 @@ class PlansSetup extends Component {
 
 	allPluginsHaveWporgData = () => {
 		const plugins = this.addWporgDataToPlugins( this.props.plugins );
-		return plugins.length === filter( plugins, { wporg: true } ).length;
+		return plugins.every( ( plugin ) => plugin.wporg === true );
 	};
 
 	componentDidMount() {
@@ -466,7 +465,7 @@ class PlansSetup extends Component {
 			return null;
 		}
 
-		const pluginsWithErrors = filter( this.props.plugins, ( item ) => {
+		const pluginsWithErrors = ( this.props.plugins ?? [] ).filter( ( item ) => {
 			const errorCode = item?.error?.code ?? null;
 			return errorCode && errorCode !== 'already_registered';
 		} );

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,7 +1,6 @@
 import { ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 import { createRef, Component } from 'react';
 import titleCase from 'to-title-case';
 import SectionNav from 'calypso/components/section-nav';
@@ -168,7 +167,7 @@ class PluginSections extends Component {
 
 	getAvailableSections = () => {
 		const sections = this.props.plugin.sections;
-		return filter( this.getFilteredSections(), function ( section ) {
+		return this.getFilteredSections().filter( function ( section ) {
 			return sections?.[ section.key ];
 		} );
 	};

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,6 +1,6 @@
 import { pick, sortBy } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { filter, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
@@ -146,7 +146,7 @@ export function getFilteredSteps( flowName, progress, isUserLoggedIn ) {
 
 	return sortBy(
 		// filter steps...
-		filter( progress, ( step ) => flow.steps.includes( step.stepName ) ),
+		Object.values( progress ?? {} ).filter( ( step ) => flow.steps.includes( step.stepName ) ),
 		// then order according to the flow definition...
 		( { stepName } ) => flow.steps.indexOf( stepName )
 	);
@@ -163,13 +163,11 @@ export function getCompletedSteps( flowName, progress, options = {}, isUserLogge
 	// This is to ensure that when resuming progress, we only do so if
 	// the last known flow matches the one that the user is returning to.
 	if ( options.shouldMatchFlowName ) {
-		return filter(
-			getFilteredSteps( flowName, progress, isUserLoggedIn ),
+		return getFilteredSteps( flowName, progress, isUserLoggedIn ).filter(
 			( step ) => 'in-progress' !== step.status && step.lastKnownFlow === flowName
 		);
 	}
-	return filter(
-		getFilteredSteps( flowName, progress, isUserLoggedIn ),
+	return getFilteredSteps( flowName, progress, isUserLoggedIn ).filter(
 		( step ) => 'in-progress' !== step.status
 	);
 }

--- a/client/sites/marketing/connections/account-dialog.jsx
+++ b/client/sites/marketing/connections/account-dialog.jsx
@@ -2,7 +2,6 @@ import { Dialog } from '@automattic/components';
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -81,7 +80,9 @@ class AccountDialog extends Component {
 	}
 
 	getAccountsByConnectedStatus( isConnected ) {
-		return filter( this.props.accounts, { isConnected } );
+		return ( this.props.accounts ?? [] ).filter(
+			( account ) => account.isConnected === isConnected
+		);
 	}
 
 	getAccountToConnect() {

--- a/client/sites/marketing/sharing/options.jsx
+++ b/client/sites/marketing/sharing/options.jsx
@@ -1,7 +1,6 @@
 import { FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -21,6 +20,8 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+
+const isPublicPostType = ( postType ) => postType.public;
 
 class SharingButtonsOptions extends Component {
 	static propTypes = {
@@ -299,7 +300,9 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const path = getCurrentRouteParameterized( state, siteId );
 
-		const postTypes = filter( Object.values( getPostTypes( state, siteId ) || {} ), 'public' );
+		const postTypes = Object.values( getPostTypes( state, siteId ) || {} ).filter(
+			isPublicPostType
+		);
 
 		return {
 			initialized: !! postTypes || !! getSiteSettings( state, siteId ),

--- a/client/sites/marketing/sharing/options.jsx
+++ b/client/sites/marketing/sharing/options.jsx
@@ -21,7 +21,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-const isPublicPostType = ( postType ) => postType.public;
+const isPublicPostType = ( postType ) => postType?.public;
 
 class SharingButtonsOptions extends Component {
 	static propTypes = {

--- a/client/sites/marketing/sharing/preview-buttons.jsx
+++ b/client/sites/marketing/sharing/preview-buttons.jsx
@@ -2,7 +2,6 @@
 import clsx from 'clsx';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import ResizableIframe from 'calypso/components/resizable-iframe';
@@ -168,7 +167,9 @@ class SharingButtonsPreviewButtons extends Component {
 		// to include the non-enabled icons in a preview. Non-enabled icons are
 		// only needed in the button selection tray, where official buttons are
 		// rendered in the text-only style.
-		const buttons = filter( this.props.buttons, { visibility: this.props.visibility } );
+		const buttons = ( this.props.buttons ?? [] ).filter(
+			( button ) => button.visibility === this.props.visibility
+		);
 		const previewUrl = previewWidget.generatePreviewUrlFromButtons( buttons, this.props.showMore );
 
 		return (
@@ -227,7 +228,9 @@ class SharingButtonsPreviewButtons extends Component {
 
 		// The more preview is only ever used to show hidden buttons, so we
 		// filter on the current set of buttons
-		const hiddenButtons = filter( this.props.buttons, { visibility: 'hidden' } );
+		const hiddenButtons = ( this.props.buttons ?? [] ).filter(
+			( button ) => button.visibility === 'hidden'
+		);
 
 		return (
 			<div className={ classes } style={ this.state.morePreviewOffset }>

--- a/client/sites/marketing/sharing/preview.jsx
+++ b/client/sites/marketing/sharing/preview.jsx
@@ -2,7 +2,6 @@
 import { Gridicon } from '@automattic/components';
 import { Icon, starEmpty } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -169,7 +168,9 @@ class SharingButtonsPreview extends Component {
 	};
 
 	getPreviewButtonsElement = () => {
-		const enabledButtons = filter( this.props.buttons, { enabled: true } );
+		const enabledButtons = ( this.props.buttons ?? [] ).filter(
+			( button ) => button.enabled === true
+		);
 
 		if ( enabledButtons.length ) {
 			return (

--- a/client/sites/marketing/sharing/tray.jsx
+++ b/client/sites/marketing/sharing/tray.jsx
@@ -3,7 +3,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import SortableList from 'calypso/components/forms/sortable-list';
@@ -101,7 +100,9 @@ class SharingButtonsTray extends Component {
 	};
 
 	getButtonsOfCurrentVisibility = () => {
-		return filter( this.props.buttons, { visibility: this.props.visibility } );
+		return ( this.props.buttons ?? [] ).filter(
+			( button ) => button.visibility === this.props.visibility
+		);
 	};
 
 	onButtonsReordered = ( order ) => {

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,7 +1,7 @@
 import { omit, orderBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { filter, map, get } from 'lodash';
+import { map, get } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,
@@ -209,8 +209,7 @@ export function pendingItems( state = {}, action ) {
 			const receivedCommentIds = map( action.comments, 'ID' );
 			return {
 				...state,
-				[ stateKey ]: filter(
-					state[ stateKey ],
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).filter(
 					( _comment ) => ! receivedCommentIds.includes( _comment.ID )
 				),
 			};

--- a/client/state/comments/selectors/get-comment-by-id.js
+++ b/client/state/comments/selectors/get-comment-by-id.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import { deconstructStateKey, getErrorKey } from 'calypso/state/comments/utils';
 
 import 'calypso/state/comments/init';
@@ -9,8 +8,8 @@ export function getCommentById( { state, commentId, siteId } ) {
 		return state.comments.errors[ errorKey ];
 	}
 
-	const commentsForSite = filter( state.comments.items, ( comment, key ) => {
-		return deconstructStateKey( key ).siteId === siteId;
-	} ).flat();
+	const commentsForSite = Object.entries( state.comments.items ?? {} ).flatMap(
+		( [ key, comments ] ) => ( deconstructStateKey( key ).siteId === siteId ? comments : [] )
+	);
 	return commentsForSite.find( ( comment ) => commentId === comment.ID );
 }

--- a/client/state/comments/selectors/get-post-comments-tree.js
+++ b/client/state/comments/selectors/get-post-comments-tree.js
@@ -1,6 +1,6 @@
 import { groupBy, keyBy, mapValues, partition } from '@automattic/js-utils';
 import treeSelect from '@automattic/tree-select';
-import { filter, map } from 'lodash';
+import { map } from 'lodash';
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';
@@ -17,7 +17,7 @@ import 'calypso/state/comments/init';
 export const getPostCommentsTree = treeSelect(
 	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
 	( [ allItems ], siteId, postId, status = 'approved', authorId ) => {
-		const items = filter( allItems, ( item ) => {
+		const items = ( allItems ?? [] ).filter( ( item ) => {
 			//only return pending comments that match the comment author
 			const commentAuthorId = item?.author?.ID;
 			if (

--- a/client/state/comments/selectors/get-site-comments.js
+++ b/client/state/comments/selectors/get-site-comments.js
@@ -1,16 +1,14 @@
 import { orderBy } from '@automattic/js-utils';
 import { createSelector } from '@automattic/state-utils';
-import { filter } from 'lodash';
 
 import 'calypso/state/comments/init';
 
 function filterCommentsByStatus( comments, status ) {
 	return 'all' === status
-		? filter(
-				comments,
+		? comments.filter(
 				( comment ) => 'approved' === comment.status || 'unapproved' === comment.status
 		  )
-		: filter( comments, ( comment ) => status === comment.status );
+		: comments.filter( ( comment ) => status === comment.status );
 }
 
 /**

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -1,6 +1,6 @@
 import { pick } from '@automattic/js-utils';
 import update from 'immutability-helper';
-import { filter, matches } from 'lodash';
+import { matches } from 'lodash';
 import {
 	DOMAINS_DNS_ADD,
 	DOMAINS_DNS_ADD_COMPLETED,
@@ -34,10 +34,10 @@ function isNsRecord( domain ) {
 }
 
 function removeDuplicateWpcomRecords( domain, records ) {
-	const rootARecords = filter( records, isRootARecord( domain ) );
+	const rootARecords = records.filter( isRootARecord( domain ) );
 	const wpcomARecord = rootARecords.find( isWpcomRecord );
 	const customARecord = rootARecords.find( ( record ) => ! isWpcomRecord( record ) );
-	const customRootAaaaRecords = filter( records, isRootAaaaRecord( domain ) );
+	const customRootAaaaRecords = records.filter( isRootAaaaRecord( domain ) );
 
 	if ( wpcomARecord && ( customARecord || customRootAaaaRecords ) ) {
 		return records.filter( ( record ) => record !== wpcomARecord );

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -1,5 +1,4 @@
 import { mapValues } from '@automattic/js-utils';
-import { filter } from 'lodash';
 
 function validateAllFields( fieldValues, domainName, domain ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -155,7 +154,7 @@ function getFieldWithDot( field ) {
 }
 
 function isDeletingLastMXRecord( recordToDelete, records ) {
-	const currentMXRecords = filter( records, { type: 'MX' } );
+	const currentMXRecords = ( records ?? [] ).filter( ( record ) => record.type === 'MX' );
 
 	return recordToDelete.type === 'MX' && currentMXRecords.length === 1;
 }

--- a/client/state/memberships/subscribers/reducer.js
+++ b/client/state/memberships/subscribers/reducer.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import { combineReducers } from 'calypso/state/utils';
 import {
 	MEMBERSHIPS_SUBSCRIBERS_RECEIVE,
@@ -24,8 +23,7 @@ const list = ( state = {}, action ) => {
 			};
 			break;
 		case MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS: {
-			const ownerships = filter(
-				state?.[ action.siteId ]?.ownerships ?? {},
+			const ownerships = Object.values( state?.[ action.siteId ]?.ownerships ?? {} ).filter(
 				( { id } ) => id !== action.subscriptionId
 			);
 			state = {

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,6 +1,5 @@
 import { pick, sortBy } from '@automattic/js-utils';
 import { createSelector } from '@automattic/state-utils';
-import { filter } from 'lodash';
 import {
 	getSite,
 	getSiteTitle,
@@ -113,7 +112,7 @@ function getPluginsSelector( state, siteIds, pluginFilter ) {
 	}, {} );
 
 	if ( pluginFilter && _filters[ pluginFilter ] ) {
-		pluginList = filter( pluginList, _filters[ pluginFilter ] );
+		pluginList = Object.values( pluginList ).filter( _filters[ pluginFilter ] );
 	}
 
 	return sortBy( pluginList, ( item ) => item.slug.toLowerCase() );
@@ -133,11 +132,11 @@ export const getPlugins = createSelector(
 
 export const getPluginsWithUpdateStatuses = createSelector(
 	( state, allPlugins ) => {
-		const active = filter( allPlugins, _filters.active );
-		const inactive = filter( allPlugins, _filters.inactive );
-		const withUpdate = filter( allPlugins, _filters.updates );
-		const withAutoUpdate = filter( allPlugins, _filters.autoupdates );
-		const withAutoUpdateDisabled = filter( allPlugins, _filters.autoupdates_disabled );
+		const active = allPlugins.filter( _filters.active );
+		const inactive = allPlugins.filter( _filters.inactive );
+		const withUpdate = allPlugins.filter( _filters.updates );
+		const withAutoUpdate = allPlugins.filter( _filters.autoupdates );
+		const withAutoUpdateDisabled = allPlugins.filter( _filters.autoupdates_disabled );
 
 		return allPlugins.reduce( ( memo, plugin ) => {
 			const status = [];
@@ -182,11 +181,13 @@ export const getPluginsWithUpdateStatuses = createSelector(
 );
 
 export function getPluginsWithUpdates( state, siteIds ) {
-	return filter( getPlugins( state, siteIds ), _filters.updates ).map( ( plugin ) => ( {
-		...plugin,
-		version: plugin?.update?.new_version,
-		type: 'plugin',
-	} ) );
+	return getPlugins( state, siteIds )
+		.filter( _filters.updates )
+		.map( ( plugin ) => ( {
+			...plugin,
+			version: plugin?.update?.new_version,
+			type: 'plugin',
+		} ) );
 }
 
 export const getPluginOnSites = createSelector( ( state, siteIds, pluginSlug ) =>
@@ -211,7 +212,7 @@ export function getSitesWithPlugin( state, siteIds, pluginSlug ) {
 	}
 
 	// Filter the requested sites list by the list of sites for this plugin
-	const pluginSites = filter( siteIds, ( siteId ) => {
+	const pluginSites = ( siteIds ?? [] ).filter( ( siteId ) => {
 		return plugin.sites.hasOwnProperty( siteId );
 	} );
 
@@ -225,7 +226,7 @@ export function getSiteObjectsWithPlugin( state, siteIds, pluginSlug ) {
 
 export function getSitesWithoutPlugin( state, siteIds, pluginSlug ) {
 	const installedOnSiteIds = getSitesWithPlugin( state, siteIds, pluginSlug ) || [];
-	return filter( siteIds, function ( siteId ) {
+	return ( siteIds ?? [] ).filter( function ( siteId ) {
 		if ( ! getSite( state, siteId )?.visible || ! isJetpackSite( state, siteId ) ) {
 			return false;
 		}

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -1,5 +1,3 @@
-import { filter } from 'lodash';
-
 import 'calypso/state/plugins/init';
 
 export const isRequesting = function ( state, siteId ) {
@@ -37,7 +35,7 @@ export const getPluginsForSite = function ( state, siteId, forPlugin = false ) {
 		forPlugin = 'vaultpress';
 	}
 
-	return filter( pluginList, ( plugin ) => {
+	return pluginList.filter( ( plugin ) => {
 		// eslint-disable-next-line no-extra-boolean-cast
 		if ( !! forPlugin ) {
 			return forPlugin === plugin.slug;

--- a/client/state/posts/selectors/get-site-posts-by-term.js
+++ b/client/state/posts/selectors/get-site-posts-by-term.js
@@ -1,10 +1,9 @@
-import { filter } from 'lodash';
 import { getSitePosts } from 'calypso/state/posts/selectors/get-site-posts';
 
 import 'calypso/state/posts/init';
 
 export function getSitePostsByTerm( state, siteId, taxonomy, termId ) {
-	return filter( getSitePosts( state, siteId ), ( post ) => {
+	return ( getSitePosts( state, siteId ) ?? [] ).filter( ( post ) => {
 		return (
 			post.terms &&
 			post.terms[ taxonomy ] &&

--- a/client/state/posts/utils/metadata-edits.js
+++ b/client/state/posts/utils/metadata-edits.js
@@ -1,5 +1,3 @@
-import { filter } from 'lodash';
-
 function isUnappliedMetadataEdit( edit, savedMetadata ) {
 	const savedRecord = ( Array.isArray( savedMetadata ) ? savedMetadata : [] ).find(
 		( record ) => record.key === edit.key
@@ -24,5 +22,5 @@ function isUnappliedMetadataEdit( edit, savedMetadata ) {
  * - when deleting, the property is still present in `savedMetadata`
  */
 export function getUnappliedMetadataEdits( edits, savedMetadata ) {
-	return filter( edits, ( edit ) => isUnappliedMetadataEdit( edit, savedMetadata ) );
+	return ( edits ?? [] ).filter( ( edit ) => isUnappliedMetadataEdit( edit, savedMetadata ) );
 }

--- a/client/state/reader/site-blocks/selectors/is-fetching-site-blocks.js
+++ b/client/state/reader/site-blocks/selectors/is-fetching-site-blocks.js
@@ -1,5 +1,3 @@
-import { filter } from 'lodash';
-
 import 'calypso/state/reader/init';
 
 /**
@@ -7,12 +5,6 @@ import 'calypso/state/reader/init';
  * @returns {boolean} true if we are fetching site blocks
  */
 export default function isFetchingSiteBlocks( state ) {
-	const inflightPages = state?.reader?.siteBlocks?.inflightPages;
-	if ( ! inflightPages || inflightPages.length < 1 ) {
-		return false;
-	}
-
-	const fetchingPages = filter( inflightPages, ( inflightPage ) => inflightPage === true );
-
-	return fetchingPages.length > 0;
+	const inflightPages = state?.reader?.siteBlocks?.inflightPages ?? {};
+	return Object.values( inflightPages ).some( ( inflightPage ) => inflightPage === true );
 }

--- a/client/state/selectors/get-google-my-business-connected-location.js
+++ b/client/state/selectors/get-google-my-business-connected-location.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import getGoogleMyBusinessLocations from 'calypso/state/selectors/get-google-my-business-locations';
 
 /**
@@ -9,7 +8,7 @@ import getGoogleMyBusinessLocations from 'calypso/state/selectors/get-google-my-
  * @returns {Object[]}        A connected GMB location
  */
 export default function getGoogleMyBusinessConnectedLocation( state, siteId ) {
-	return filter( getGoogleMyBusinessLocations( state, siteId ), {
-		isConnected: true,
-	} ).at( -1 );
+	return getGoogleMyBusinessLocations( state, siteId ).findLast(
+		( location ) => location.isConnected === true
+	);
 }

--- a/client/state/selectors/get-google-my-business-locations.js
+++ b/client/state/selectors/get-google-my-business-locations.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import { getAvailableExternalAccounts } from 'calypso/state/sharing/selectors';
 import { getSiteKeyringsForService } from 'calypso/state/site-keyrings/selectors';
 
@@ -13,9 +12,9 @@ export default function getGoogleMyBusinessLocations( state, siteId ) {
 		return [];
 	}
 
-	const externalUsers = filter( getAvailableExternalAccounts( state, 'google_my_business' ), {
-		keyringConnectionId: googleMyBusinessSiteKeyring.keyring_id,
-	} );
+	const externalUsers = getAvailableExternalAccounts( state, 'google_my_business' ).filter(
+		( account ) => account.keyringConnectionId === googleMyBusinessSiteKeyring.keyring_id
+	);
 
 	externalUsers.forEach( ( externalUser ) => {
 		externalUser.isConnected = externalUser.ID === googleMyBusinessSiteKeyring.external_user_id;

--- a/client/state/selectors/get-removable-connections.js
+++ b/client/state/selectors/get-removable-connections.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getKeyringConnectionsByName } from 'calypso/state/sharing/keyring/selectors';
 import { getRemovableConnections as getRemovablePublicizeConnections } from 'calypso/state/sharing/publicize/selectors';
@@ -16,8 +15,7 @@ import { getRemovableConnections as getRemovablePublicizeConnections } from 'cal
  */
 export default function getRemovableConnections( state, service ) {
 	const userId = getCurrentUserId( state );
-	const keyringConnections = filter(
-		getKeyringConnectionsByName( state, service ),
+	const keyringConnections = getKeyringConnectionsByName( state, service ).filter(
 		( { type, user_ID } ) => 'publicize' !== type && user_ID === userId
 	);
 

--- a/client/state/selectors/get-site-user-connections-for-google-my-business.js
+++ b/client/state/selectors/get-site-user-connections-for-google-my-business.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import { getKeyringConnectionsByName } from 'calypso/state/sharing/keyring/selectors';
 import { getSiteKeyringsForService } from 'calypso/state/site-keyrings/selectors';
 
@@ -49,5 +48,5 @@ export default function getSiteUserConnectionsForGoogleMyBusiness( state, siteId
 		}
 	} );
 
-	return filter( locations, { isConnected: true } );
+	return locations.filter( ( location ) => location.isConnected === true );
 }

--- a/client/state/selectors/has-navigated.js
+++ b/client/state/selectors/has-navigated.js
@@ -1,7 +1,8 @@
-import { filter } from 'lodash';
 import { ROUTE_SET } from 'calypso/state/action-types';
 import { getActionLog } from 'calypso/state/ui/action-log/selectors';
 
 export default function hasNavigated( state ) {
-	return filter( getActionLog( state ), { type: ROUTE_SET } ).length > 1;
+	return (
+		( getActionLog( state ) ?? [] ).filter( ( action ) => action.type === ROUTE_SET ).length > 1
+	);
 }

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { filter } from 'lodash';
 
 import 'calypso/state/sharing/init';
 
@@ -29,7 +28,8 @@ export function getKeyringConnectionById( state, keyringConnectionId ) {
  * @returns {Array}         Keyring connections, if known.
  */
 export const getKeyringConnectionsByName = createSelector(
-	( state, service ) => filter( getKeyringConnections( state ), { service } ),
+	( state, service ) =>
+		getKeyringConnections( state ).filter( ( connection ) => connection.service === service ),
 	( state ) => [ state.sharing.keyring.items ]
 );
 
@@ -40,9 +40,9 @@ export const getKeyringConnectionsByName = createSelector(
  * @returns {Array}         Keyring connections, if known.
  */
 export function getBrokenKeyringConnectionsByName( state, service ) {
-	return filter( getKeyringConnectionsByName( state, service ), {
-		status: 'broken',
-	} );
+	return getKeyringConnectionsByName( state, service ).filter(
+		( connection ) => connection.status === 'broken'
+	);
 }
 
 /**
@@ -53,8 +53,7 @@ export function getBrokenKeyringConnectionsByName( state, service ) {
  * @returns {Array}         Keyring connections, if any.
  */
 export function getRefreshableKeyringConnections( state, service ) {
-	return filter(
-		getKeyringConnectionsByName( state, service ),
+	return getKeyringConnectionsByName( state, service ).filter(
 		( conn ) => 'broken' === conn.status || 'refresh-failed' === conn.status
 	);
 }
@@ -66,8 +65,7 @@ export function getRefreshableKeyringConnections( state, service ) {
  * @returns {Array}         Site connections, if known.
  */
 export function getUserConnections( state, userId ) {
-	return filter(
-		state.sharing.keyring.items,
+	return Object.values( state.sharing.keyring.items ?? {} ).filter(
 		( connection ) => connection.shared || connection.keyring_connection_user_ID === userId
 	);
 }

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { filter } from 'lodash';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -13,7 +12,9 @@ import 'calypso/state/sharing/init';
  * @returns {Array}         Site connections
  */
 export function getConnectionsBySiteId( state, siteId ) {
-	return filter( state.sharing.publicize.connections, { site_ID: siteId } );
+	return Object.values( state.sharing.publicize.connections ?? {} ).filter(
+		( connection ) => connection.site_ID === siteId
+	);
 }
 
 /**
@@ -26,8 +27,7 @@ export function getConnectionsBySiteId( state, siteId ) {
  */
 export const getSiteUserConnections = createSelector(
 	( state, siteId, userId ) =>
-		filter(
-			state.sharing.publicize.connections,
+		Object.values( state.sharing.publicize.connections ?? {} ).filter(
 			( connection ) =>
 				connection.site_ID === siteId &&
 				( connection.shared || connection.keyring_connection_user_ID === userId )
@@ -45,7 +45,9 @@ export const getSiteUserConnections = createSelector(
  * @returns {Array}          User connections
  */
 export function getSiteUserConnectionsForService( state, siteId, userId, service ) {
-	return filter( getSiteUserConnections( state, siteId, userId ), { service } );
+	return getSiteUserConnections( state, siteId, userId ).filter(
+		( connection ) => connection.service === service
+	);
 }
 
 /**
@@ -57,9 +59,9 @@ export function getSiteUserConnectionsForService( state, siteId, userId, service
  * @returns {Array}          Broken user connections.
  */
 export function getBrokenSiteUserConnectionsForService( state, siteId, userId, service ) {
-	return filter( getSiteUserConnectionsForService( state, siteId, userId, service ), {
-		status: 'broken',
-	} );
+	return getSiteUserConnectionsForService( state, siteId, userId, service ).filter(
+		( connection ) => connection.status === 'broken'
+	);
 }
 
 /**
@@ -88,7 +90,7 @@ export function getRemovableConnections( state, service ) {
 		return siteUserConnectionsForService;
 	}
 
-	return filter( siteUserConnectionsForService, { user_ID: userId } );
+	return siteUserConnectionsForService.filter( ( connection ) => connection.user_ID === userId );
 }
 
 /**

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { FEATURE_GOOGLE_MY_BUSINESS } from '@automattic/calypso-products';
-import { filter } from 'lodash';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -24,7 +23,9 @@ export function getKeyringServices( state ) {
  * @returns {Array}        Keyring services, if known.
  */
 export function getKeyringServicesByType( state, type ) {
-	return filter( getKeyringServices( state ), { type } );
+	return Object.values( getKeyringServices( state ) ?? {} ).filter(
+		( service ) => service.type === type
+	);
 }
 
 /**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,6 +1,6 @@
 import { camelCase, capitalize, sortBy } from '@automattic/js-utils';
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { get, filter, map } from 'lodash';
+import { get, map } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
@@ -548,7 +548,7 @@ export const normalizers = {
 		const dataPath = query.summarize ? [ 'summary', 'views' ] : [ 'days', startOf, 'views' ];
 
 		// filter out country views that have no legitimate country data associated with them
-		const countryData = filter( get( data, dataPath, [] ), ( viewData ) => {
+		const countryData = get( data, dataPath, [] ).filter( ( viewData ) => {
 			// Ignore the unknown location of sources from the legacy stats geoviews table.
 			if ( [ 'A1', 'A2', 'ZZ' ].includes( viewData.country_code ) ) {
 				return false;

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -66,7 +66,7 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 				// We also have to update post terms
 				const postsToUpdate = getSitePostsByTerm( state, siteId, taxonomy, termId );
 				postsToUpdate.forEach( ( post ) => {
-					const newTerms = ( post.terms[ taxonomy ] ?? [] ).filter(
+					const newTerms = Object.values( post.terms[ taxonomy ] ?? {} ).filter(
 						( postTerm ) => postTerm.ID !== termId
 					);
 					newTerms.push( updatedTerm );
@@ -149,7 +149,7 @@ const removeTermFromState = ( { dispatch, getState, siteId, taxonomy, termId } )
 	// Drop the term from posts
 	const postsToUpdate = getSitePostsByTerm( state, siteId, taxonomy, termId );
 	postsToUpdate.forEach( ( post ) => {
-		const newTerms = ( post.terms[ taxonomy ] ?? [] ).filter(
+		const newTerms = Object.values( post.terms[ taxonomy ] ?? {} ).filter(
 			( postTerm ) => postTerm.ID !== termId
 		);
 		dispatch(

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import {
 	TERM_REMOVE,
@@ -58,16 +57,18 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 				// When updating a term, we receive a newId and a new Slug
 				// We have to remove the old term and add the new one
 				// We also have to update the parent ID of its children
-				const children = filter( getTerms( state, siteId, taxonomy ), {
-					parent: termId,
-				} ).map( ( child ) => ( { ...child, parent: updatedTerm.ID } ) );
+				const children = ( getTerms( state, siteId, taxonomy ) ?? [] )
+					.filter( ( child ) => child.parent === termId )
+					.map( ( child ) => ( { ...child, parent: updatedTerm.ID } ) );
 				dispatch( removeTerm( siteId, taxonomy, termId ) );
 				dispatch( receiveTerms( siteId, taxonomy, children.concat( [ updatedTerm ] ) ) );
 
 				// We also have to update post terms
 				const postsToUpdate = getSitePostsByTerm( state, siteId, taxonomy, termId );
 				postsToUpdate.forEach( ( post ) => {
-					const newTerms = filter( post.terms[ taxonomy ], ( postTerm ) => postTerm.ID !== termId );
+					const newTerms = ( post.terms[ taxonomy ] ?? [] ).filter(
+						( postTerm ) => postTerm.ID !== termId
+					);
 					newTerms.push( updatedTerm );
 					dispatch(
 						editPost( siteId, post.ID, {
@@ -134,11 +135,13 @@ const removeTermFromState = ( { dispatch, getState, siteId, taxonomy, termId } )
 	const deletedTermPostCount = deletedTerm?.post_count ?? 0;
 
 	// Update the parentId of its children
-	const termsToUpdate = filter( getTerms( state, siteId, taxonomy ), ( term ) => {
-		return term.parent === termId;
-	} ).map( ( term ) => {
-		return { ...term, parent: deletedTerm.parent };
-	} );
+	const termsToUpdate = ( getTerms( state, siteId, taxonomy ) ?? [] )
+		.filter( ( term ) => {
+			return term.parent === termId;
+		} )
+		.map( ( term ) => {
+			return { ...term, parent: deletedTerm.parent };
+		} );
 	if ( termsToUpdate.length ) {
 		dispatch( receiveTerms( siteId, taxonomy, termsToUpdate ) );
 	}
@@ -146,7 +149,9 @@ const removeTermFromState = ( { dispatch, getState, siteId, taxonomy, termId } )
 	// Drop the term from posts
 	const postsToUpdate = getSitePostsByTerm( state, siteId, taxonomy, termId );
 	postsToUpdate.forEach( ( post ) => {
-		const newTerms = filter( post.terms[ taxonomy ], ( postTerm ) => postTerm.ID !== termId );
+		const newTerms = ( post.terms[ taxonomy ] ?? [] ).filter(
+			( postTerm ) => postTerm.ID !== termId
+		);
 		dispatch(
 			editPost( siteId, post.ID, {
 				terms: {

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -515,6 +515,54 @@ describe( 'actions', () => {
 			} );
 		} );
 
+		test( 'should drop the term from post terms stored as an object map keyed by term ID', async () => {
+			const postObjects = {
+				[ siteId ]: {
+					'0fcb4eb16f493c19b627438fdc18d57c': {
+						ID: 120,
+						site_ID: siteId,
+						global_ID: 'f0cb4eb16f493c19b627438fdc18d57c',
+						title: 'Steak &amp; Eggs',
+						// Post terms can be stored as an object map, not only an array.
+						terms: {
+							[ taxonomyName ]: { 10: { ID: 10, name: 'ribs', slug: 'ribs' } },
+						},
+					},
+				},
+			};
+			const state = {
+				posts: {
+					queries: {
+						[ siteId ]: new PostQueryManager( { items: postObjects[ siteId ] } ),
+					},
+				},
+				terms: {
+					queries: {
+						[ siteId ]: {
+							[ taxonomyName ]: new TermQueryManager( {
+								items: { 10: { ID: 10, name: 'ribs', slug: 'ribs', parent: 0 } },
+								queries: {},
+							} ),
+						},
+					},
+				},
+			};
+
+			const spy = jest.fn();
+			await deleteTerm( siteId, taxonomyName, 10, 'ribs' )( spy, () => state );
+
+			expect( spy ).toHaveBeenCalledWith( {
+				type: POST_EDIT,
+				siteId: siteId,
+				postId: 120,
+				post: {
+					terms: {
+						[ taxonomyName ]: [],
+					},
+				},
+			} );
+		} );
+
 		test( 'should dispatch a TERMS_RECEIVE for default category on Success', async () => {
 			const state = {
 				posts: {

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -337,6 +337,57 @@ describe( 'actions', () => {
 			} );
 		} );
 
+		test( 'should update post terms stored as an object map keyed by term ID', async () => {
+			const postObjects = {
+				[ siteId ]: {
+					'0fcb4eb16f493c19b627438fdc18d57c': {
+						ID: 120,
+						site_ID: siteId,
+						global_ID: 'f0cb4eb16f493c19b627438fdc18d57c',
+						title: 'Steak &amp; Eggs',
+						// Post terms can be stored as an object map, not only an array.
+						terms: {
+							[ categoryTaxonomyName ]: {
+								10: { ID: 10, name: 'old category name', slug: 'old' },
+							},
+						},
+					},
+				},
+			};
+			const state = {
+				posts: {
+					queries: {
+						[ siteId ]: new PostQueryManager( { items: postObjects[ siteId ] } ),
+					},
+				},
+				siteSettings: { items: { [ siteId ]: { default_category: 10 } } },
+				terms: {
+					queries: {
+						[ siteId ]: {
+							[ categoryTaxonomyName ]: new TermQueryManager( { items: {}, queries: {} } ),
+						},
+					},
+				},
+			};
+
+			const spy = jest.fn();
+			await updateTerm( siteId, categoryTaxonomyName, 10, 'rib', { name: 'ribs' } )(
+				spy,
+				() => state
+			);
+
+			expect( spy ).toHaveBeenCalledWith( {
+				type: POST_EDIT,
+				siteId: siteId,
+				postId: 120,
+				post: {
+					terms: {
+						[ categoryTaxonomyName ]: [ { ID: 123, name: 'ribs', description: '' } ],
+					},
+				},
+			} );
+		} );
+
 		test( 'should not dispatch SITE_SETTINGS_UPDATE on Success if the taxonomy is not equal to "category"', async () => {
 			const state = {
 				posts: { queries: {} },

--- a/client/state/themes/actions/receive-themes.js
+++ b/client/state/themes/actions/receive-themes.js
@@ -1,4 +1,3 @@
-import { filter } from 'lodash';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { THEMES_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
 import { isDelisted, isThemeMatchingQuery } from 'calypso/state/themes/utils';
@@ -24,7 +23,7 @@ export function receiveThemes( themes, siteId, query, foundCount ) {
 			 * We need to do client-side filtering for Jetpack sites
 			 * because Jetpack theme API does not support search queries
 			 */
-			filteredThemes = filter( themes, ( theme ) => isThemeMatchingQuery( query, theme ) );
+			filteredThemes = themes.filter( ( theme ) => isThemeMatchingQuery( query, theme ) );
 
 			// Jetpack API returns all themes in one response (no paging)
 			found = filteredThemes.length;
@@ -35,7 +34,7 @@ export function receiveThemes( themes, siteId, query, foundCount ) {
 			 * We need to do client-side filtering for wporg results
 			 * because we fetch them directly from the wporg API.
 			 */
-			filteredThemes = filter( themes, ( theme ) => ! isDelisted( theme ) );
+			filteredThemes = themes.filter( ( theme ) => ! isDelisted( theme ) );
 			found = filteredThemes.length;
 		}
 

--- a/client/state/themes/selectors/find-theme-filter-term.js
+++ b/client/state/themes/selectors/find-theme-filter-term.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { filter } from 'lodash';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
 import { getThemeFilters } from 'calypso/state/themes/selectors/get-theme-filters';
 
@@ -20,7 +19,7 @@ export const findThemeFilterTerm = createSelector(
 
 		const filters = getThemeFilters( state );
 
-		const results = filter( filters, ( terms ) => !! terms?.[ left ] );
+		const results = Object.values( filters ?? {} ).filter( ( terms ) => !! terms?.[ left ] );
 
 		if ( results.length !== 1 ) {
 			// No or ambiguous results

--- a/client/state/themes/selectors/is-ambiguous-theme-filter-term.js
+++ b/client/state/themes/selectors/is-ambiguous-theme-filter-term.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { filter } from 'lodash';
 import { getThemeFilters } from 'calypso/state/themes/selectors/get-theme-filters';
 
 import 'calypso/state/themes/init';
@@ -15,7 +14,7 @@ export const isAmbiguousThemeFilterTerm = createSelector(
 	( state, term ) => {
 		const filters = getThemeFilters( state );
 
-		const results = filter( filters, ( terms ) => !! terms?.[ term ] );
+		const results = Object.values( filters ?? {} ).filter( ( terms ) => !! terms?.[ term ] );
 
 		return results.length > 1;
 	},

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -127,6 +127,10 @@ const FOREACH_MESSAGE =
 	'`Object.values( obj ).forEach( … )` / `Object.entries( obj ).forEach( ( [ key, value ] ) => … )` for objects, ' +
 	'`Array.from( … ).forEach( … )` for DOM collections, guard nullable collections with `?? []`, and convert ' +
 	'early-exit callbacks (those returning `false`) to a `for…of` loop with `break`.';
+const FILTER_MESSAGE =
+	'Please use native `array.filter( ( item ) => … )` (or `Object.values( obj ).filter( … )` for objects) ' +
+	'instead of lodash `filter`. Expand iteratee shorthands to a predicate, use `Array.from( … )` for DOM ' +
+	'collections (a NodeList has no native `.filter`), and guard nullable collections with `?? []`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -160,6 +164,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'xor' ], message: XOR_MESSAGE },
 	{ name: 'lodash', importNames: [ 'some' ], message: SOME_MESSAGE },
 	{ name: 'lodash', importNames: [ 'forEach' ], message: FOREACH_MESSAGE },
+	{ name: 'lodash', importNames: [ 'filter' ], message: FILTER_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -195,6 +200,7 @@ const patterns = [
 	{ group: [ 'lodash/xor' ], message: XOR_MESSAGE },
 	{ group: [ 'lodash/some' ], message: SOME_MESSAGE },
 	{ group: [ 'lodash/forEach' ], message: FOREACH_MESSAGE },
+	{ group: [ 'lodash/filter' ], message: FILTER_MESSAGE },
 ];
 
 module.exports = { paths, patterns };

--- a/packages/components/src/embed-container/index.jsx
+++ b/packages/components/src/embed-container/index.jsx
@@ -1,7 +1,6 @@
 import { loadScript, loadjQueryDependentScript } from '@automattic/load-script';
 import clsx from 'clsx';
 import debugFactory from 'debug';
-import { filter } from 'lodash';
 import { createRef, PureComponent } from 'react';
 import { createRoot } from 'react-dom/client';
 import DotPager from '../dot-pager';
@@ -40,7 +39,7 @@ const SLIDESHOW_URLS = {
 function processEmbeds( domNode ) {
 	Object.entries( embedsToLookFor ).forEach( ( [ embedSelector, fn ] ) => {
 		const nodes = domNode.querySelectorAll( embedSelector );
-		filter( nodes, nodeNeedsProcessing ).forEach( fn );
+		Array.from( nodes ).filter( nodeNeedsProcessing ).forEach( fn );
 	} );
 }
 

--- a/packages/components/src/select-dropdown/index.jsx
+++ b/packages/components/src/select-dropdown/index.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component, forwardRef } from 'react';
 import Count from '../count';
@@ -365,7 +364,7 @@ class SelectDropdown extends Component {
 		let focusedIndex;
 
 		if ( this.props.options.length ) {
-			items = filter( this.props.options, ( item ) => {
+			items = this.props.options.filter( ( item ) => {
 				if ( ! item || item.isLabel ) {
 					return false;
 				}
@@ -382,7 +381,9 @@ class SelectDropdown extends Component {
 					? this.focused
 					: items.findIndex( ( item ) => item.value === this.state.selected );
 		} else {
-			items = filter( this.props.children, ( item ) => item.type === DropdownItem );
+			items = Children.toArray( this.props.children ).filter(
+				( item ) => item.type === DropdownItem
+			);
 
 			focusedIndex =
 				typeof this.focused === 'number'

--- a/packages/state-utils/src/create-selector/test/index.js
+++ b/packages/state-utils/src/create-selector/test/index.js
@@ -1,5 +1,4 @@
 import warn from '@wordpress/warning';
-import { filter } from 'lodash';
 import createSelector from '../';
 
 jest.mock( '@wordpress/warning', () => jest.fn() );
@@ -7,7 +6,9 @@ jest.mock( '@wordpress/warning', () => jest.fn() );
 describe( 'index', () => {
 	let getSitePosts;
 
-	const selector = jest.fn( ( state, siteId ) => filter( state.posts, { site_ID: siteId } ) );
+	const selector = jest.fn( ( state, siteId ) =>
+		Object.values( state.posts ?? {} ).filter( ( post ) => post.site_ID === siteId )
+	);
 
 	beforeAll( () => {
 		getSitePosts = createSelector( selector, ( state ) => state.posts );


### PR DESCRIPTION
## Proposed Changes

Continues the incremental lodash removal. Replaces every remaining lodash `filter()` call with native `Array.prototype.filter`:

- `array.filter( ( item ) => … )` for arrays (guarding nullable collections with `?? []`)
- `Object.values( obj ).filter( … )` for object-keyed redux state
- `Array.from( … ).filter( … )` for DOM collections (a NodeList / HTMLCollection / NamedNodeMap has no native `.filter`)
- iteratee shorthands (`{ key: value }`, `'prop'`) expanded into predicate functions

Since this removes the last usages, it also adds the `no-restricted-imports` guard for `filter` and enables the `eslint-plugin-you-dont-need-lodash-underscore/filter` rule (which catches the namespace/`require` shapes `no-restricted-imports` cannot). The remaining `_.filter` namespace calls in `bin/` are converted too.

## Testing Instructions

- `yarn typecheck-client`
- `yarn test-client client/state client/lib client/sites` (and the other touched `test/` dirs) — the existing suites cover the object-vs-array and null-tolerance behavior, including the sanitizer and the sharing/plugins/themes selectors.
- `yarn jest -c=test/packages/jest.config.js packages/components packages/state-utils`

## Pre-merge Checklist

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used `defaultProps` for props that are not required?
- [ ] Have you translated all user-facing strings?
- [ ] Have you tested using a real WordPress.com account on both Simple and Atomic sites?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
