### PR TITLE
MCP: add group analytics events (AIINT-475)

### DIFF
--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -43,7 +43,8 @@ export default function McpRead() {
 	const isDesktop = useViewportMatch( 'medium' );
 
 	const [ openGroups, setOpenGroups ] = useState( () => new Set< string >() );
-	const toggleGroupOpen = ( groupKey: string ) => {
+	const toggleGroupOpen = ( groupKey: string, groupName: string | null ) => {
+		const willBeOpen = ! openGroups.has( groupKey );
 		setOpenGroups( ( current ) => {
 			const next = new Set( current );
 			if ( next.has( groupKey ) ) {
@@ -52,6 +53,10 @@ export default function McpRead() {
 				next.add( groupKey );
 			}
 			return next;
+		} );
+		recordTracksEvent( 'calypso_dashboard_mcp_read_group_toggled', {
+			group: groupName ?? 'other',
+			is_open: willBeOpen,
 		} );
 	};
 
@@ -73,7 +78,7 @@ export default function McpRead() {
 		},
 	} );
 
-	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+	const handleToolChange = ( toolId: string, enabled: boolean, groupName: string | null ) => {
 		mutation.mutate(
 			{
 				mcp_abilities: {
@@ -85,6 +90,7 @@ export default function McpRead() {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
 						tool_id: toolId,
 						enabled,
+						group: groupName ?? 'other',
 					} );
 				},
 			}
@@ -214,7 +220,7 @@ export default function McpRead() {
 													icon={ isOpen ? chevronUp : chevronDown }
 													label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 													aria-expanded={ isOpen }
-													onClick={ () => toggleGroupOpen( groupKey ) }
+													onClick={ () => toggleGroupOpen( groupKey, descriptor?.name ?? null ) }
 												/>
 											</HStack>
 										) : (
@@ -234,7 +240,7 @@ export default function McpRead() {
 														icon={ isOpen ? chevronUp : chevronDown }
 														label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 														aria-expanded={ isOpen }
-														onClick={ () => toggleGroupOpen( groupKey ) }
+														onClick={ () => toggleGroupOpen( groupKey, descriptor?.name ?? null ) }
 													/>
 												</HStack>
 												<ToggleControl
@@ -274,7 +280,9 @@ export default function McpRead() {
 																	disabled={ mutation.isPending }
 																	label={ tool.title }
 																	help={ tool.description }
-																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+																	onChange={ ( checked ) =>
+																		handleToolChange( toolId, checked, descriptor?.name ?? null )
+																	}
 																/>
 															) ) }
 														</VStack>

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
-import { Fragment, useState } from 'react';
+import { Fragment, useRef, useState } from 'react';
 import { groupIntentKey, getOverridesToMatch } from '../../../../me/mcp/group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/groups';
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
@@ -42,18 +42,16 @@ export default function McpRead() {
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 	const isDesktop = useViewportMatch( 'medium' );
 
-	const [ openGroups, setOpenGroups ] = useState( () => new Set< string >() );
+	const openGroupsRef = useRef( new Set< string >() );
+	const [ openGroups, setOpenGroups ] = useState( () => openGroupsRef.current );
 	const toggleGroupOpen = ( groupKey: string, groupName: string | null ) => {
-		const willBeOpen = ! openGroups.has( groupKey );
-		setOpenGroups( ( current ) => {
-			const next = new Set( current );
-			if ( next.has( groupKey ) ) {
-				next.delete( groupKey );
-			} else {
-				next.add( groupKey );
-			}
-			return next;
-		} );
+		const willBeOpen = ! openGroupsRef.current.has( groupKey );
+		if ( willBeOpen ) {
+			openGroupsRef.current.add( groupKey );
+		} else {
+			openGroupsRef.current.delete( groupKey );
+		}
+		setOpenGroups( new Set( openGroupsRef.current ) );
 		recordTracksEvent( 'calypso_dashboard_mcp_read_group_toggled', {
 			group: groupName ?? 'other',
 			is_open: willBeOpen,

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -43,7 +43,8 @@ export default function McpWrite() {
 	const isDesktop = useViewportMatch( 'medium' );
 
 	const [ openGroups, setOpenGroups ] = useState( () => new Set< string >() );
-	const toggleGroupOpen = ( groupKey: string ) => {
+	const toggleGroupOpen = ( groupKey: string, groupName: string | null ) => {
+		const willBeOpen = ! openGroups.has( groupKey );
 		setOpenGroups( ( current ) => {
 			const next = new Set( current );
 			if ( next.has( groupKey ) ) {
@@ -52,6 +53,10 @@ export default function McpWrite() {
 				next.add( groupKey );
 			}
 			return next;
+		} );
+		recordTracksEvent( 'calypso_dashboard_mcp_write_group_toggled', {
+			group: groupName ?? 'other',
+			is_open: willBeOpen,
 		} );
 	};
 
@@ -73,7 +78,7 @@ export default function McpWrite() {
 		},
 	} );
 
-	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+	const handleToolChange = ( toolId: string, enabled: boolean, groupName: string | null ) => {
 		mutation.mutate(
 			{
 				mcp_abilities: {
@@ -85,6 +90,7 @@ export default function McpWrite() {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
 						tool_id: toolId,
 						enabled,
+						group: groupName ?? 'other',
 					} );
 				},
 			}
@@ -214,7 +220,7 @@ export default function McpWrite() {
 													icon={ isOpen ? chevronUp : chevronDown }
 													label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 													aria-expanded={ isOpen }
-													onClick={ () => toggleGroupOpen( groupKey ) }
+													onClick={ () => toggleGroupOpen( groupKey, descriptor?.name ?? null ) }
 												/>
 											</HStack>
 										) : (
@@ -234,7 +240,7 @@ export default function McpWrite() {
 														icon={ isOpen ? chevronUp : chevronDown }
 														label={ isOpen ? __( 'Hide operations' ) : __( 'Show operations' ) }
 														aria-expanded={ isOpen }
-														onClick={ () => toggleGroupOpen( groupKey ) }
+														onClick={ () => toggleGroupOpen( groupKey, descriptor?.name ?? null ) }
 													/>
 												</HStack>
 												<ToggleControl
@@ -274,7 +280,9 @@ export default function McpWrite() {
 																	disabled={ mutation.isPending }
 																	label={ tool.title }
 																	help={ tool.description }
-																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+																	onChange={ ( checked ) =>
+																		handleToolChange( toolId, checked, descriptor?.name ?? null )
+																	}
 																/>
 															) ) }
 														</VStack>

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
-import { Fragment, useState } from 'react';
+import { Fragment, useRef, useState } from 'react';
 import { groupIntentKey, getOverridesToMatch } from '../../../../me/mcp/group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/groups';
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
@@ -42,18 +42,16 @@ export default function McpWrite() {
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 	const isDesktop = useViewportMatch( 'medium' );
 
-	const [ openGroups, setOpenGroups ] = useState( () => new Set< string >() );
+	const openGroupsRef = useRef( new Set< string >() );
+	const [ openGroups, setOpenGroups ] = useState( () => openGroupsRef.current );
 	const toggleGroupOpen = ( groupKey: string, groupName: string | null ) => {
-		const willBeOpen = ! openGroups.has( groupKey );
-		setOpenGroups( ( current ) => {
-			const next = new Set( current );
-			if ( next.has( groupKey ) ) {
-				next.delete( groupKey );
-			} else {
-				next.add( groupKey );
-			}
-			return next;
-		} );
+		const willBeOpen = ! openGroupsRef.current.has( groupKey );
+		if ( willBeOpen ) {
+			openGroupsRef.current.add( groupKey );
+		} else {
+			openGroupsRef.current.delete( groupKey );
+		}
+		setOpenGroups( new Set( openGroupsRef.current ) );
 		recordTracksEvent( 'calypso_dashboard_mcp_write_group_toggled', {
 			group: groupName ?? 'other',
 			is_open: willBeOpen,

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
@@ -58,22 +58,20 @@ export default function McpToolsSubpage( {
 	useQuery( sitesQuery( 'all', { site_visibility: 'visible' } ) );
 
 	const [ reauthRequired, setReauthRequired ] = useState( false );
-	const [ openGroups, setOpenGroups ] = useState( () => new Set() );
+	const openGroupsRef = useRef( new Set() );
+	const [ openGroups, setOpenGroups ] = useState( () => openGroupsRef.current );
 
 	const eventPrefix =
 		toolCategory === 'write' ? 'calypso_dashboard_mcp_write' : 'calypso_dashboard_mcp_read';
 
 	const toggleGroupOpen = ( groupKey, groupName ) => {
-		const willBeOpen = ! openGroups.has( groupKey );
-		setOpenGroups( ( current ) => {
-			const next = new Set( current );
-			if ( next.has( groupKey ) ) {
-				next.delete( groupKey );
-			} else {
-				next.add( groupKey );
-			}
-			return next;
-		} );
+		const willBeOpen = ! openGroupsRef.current.has( groupKey );
+		if ( willBeOpen ) {
+			openGroupsRef.current.add( groupKey );
+		} else {
+			openGroupsRef.current.delete( groupKey );
+		}
+		setOpenGroups( new Set( openGroupsRef.current ) );
 		recordTracksEvent( `${ eventPrefix }_group_toggled`, {
 			group: groupName ?? 'other',
 			is_open: willBeOpen,

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -60,7 +60,11 @@ export default function McpToolsSubpage( {
 	const [ reauthRequired, setReauthRequired ] = useState( false );
 	const [ openGroups, setOpenGroups ] = useState( () => new Set() );
 
-	const toggleGroupOpen = ( groupKey ) => {
+	const eventPrefix =
+		toolCategory === 'write' ? 'calypso_dashboard_mcp_write' : 'calypso_dashboard_mcp_read';
+
+	const toggleGroupOpen = ( groupKey, groupName ) => {
+		const willBeOpen = ! openGroups.has( groupKey );
 		setOpenGroups( ( current ) => {
 			const next = new Set( current );
 			if ( next.has( groupKey ) ) {
@@ -69,6 +73,10 @@ export default function McpToolsSubpage( {
 				next.add( groupKey );
 			}
 			return next;
+		} );
+		recordTracksEvent( `${ eventPrefix }_group_toggled`, {
+			group: groupName ?? 'other',
+			is_open: willBeOpen,
 		} );
 	};
 
@@ -99,10 +107,7 @@ export default function McpToolsSubpage( {
 	const groupDescriptors = getGroupDescriptors( userSettings || {} );
 	const groups = groupToolsByGroup( tools, groupDescriptors );
 
-	const eventPrefix =
-		toolCategory === 'write' ? 'calypso_dashboard_mcp_write' : 'calypso_dashboard_mcp_read';
-
-	const handleToolChange = ( toolId, enabled ) => {
+	const handleToolChange = ( toolId, enabled, groupName ) => {
 		mutation.mutate(
 			{
 				mcp_abilities: {
@@ -113,7 +118,11 @@ export default function McpToolsSubpage( {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( `${ eventPrefix }_tool_toggled`, { tool_id: toolId, enabled } );
+					recordTracksEvent( `${ eventPrefix }_tool_toggled`, {
+						tool_id: toolId,
+						enabled,
+						group: groupName ?? 'other',
+					} );
 				},
 			}
 		);
@@ -259,9 +268,11 @@ export default function McpToolsSubpage( {
 												<Button
 													className="mcp-tools-subpage__group-chevron"
 													icon={ isOpen ? chevronUp : chevronDown }
-													label={ translate( 'Show operations' ) }
+													label={
+														isOpen ? translate( 'Hide operations' ) : translate( 'Show operations' )
+													}
 													aria-expanded={ isOpen }
-													onClick={ () => toggleGroupOpen( groupKey ) }
+													onClick={ () => toggleGroupOpen( groupKey, descriptor?.name ?? null ) }
 												/>
 											</div>
 											{ isOpen &&
@@ -286,7 +297,11 @@ export default function McpToolsSubpage( {
 																			label={ tool.title }
 																			help={ tool.description }
 																			onChange={ ( checked ) =>
-																				handleToolChange( toolId, checked )
+																				handleToolChange(
+																					toolId,
+																					checked,
+																					descriptor?.name ?? null
+																				)
 																			}
 																		/>
 																	) ) }


### PR DESCRIPTION
[AIINT-475](https://linear.app/a8c/issue/AIINT-475/analytics-tracks-events-for-new-group-level-mcp-toggles-readwrite)

## Proposed Changes

* Add `group` prop to existing `*_tool_toggled` events on both Calypso (`/me/mcp`) and Dashboard (`/me/preferences/mcp`) MCP settings surfaces.
* Add new `*_group_toggled` events fired when a group chevron is clicked to expand/collapse it, with `group` and `is_open` props. `is_open` is derived from a ref updated synchronously before the state setter, so rapid successive clicks always produce correct values.
* Fix the chevron button accessible label in Calypso (`tools-subpage.jsx`) to toggle between "Show operations" / "Hide operations" based on expanded state (was always "Show operations").

## Tracks Events

Both Calypso (`/me/mcp/read`, `/me/mcp/write`) and Dashboard (`/me/preferences/mcp/read`, `/me/preferences/mcp/write`) fire identically-named events via a shared prefix. The read and write surfaces are symmetric.

### New events (added in this PR)

| Event | Props | Fired when |
|---|---|---|
| `calypso_dashboard_mcp_read_group_toggled` | `group: string, is_open: boolean` | Read group chevron is clicked |
| `calypso_dashboard_mcp_write_group_toggled` | `group: string, is_open: boolean` | Write group chevron is clicked |

`group` is the backend `name` slug of the group descriptor, or `"other"` for ungrouped tools.

### Updated events (added `group` prop)

| Event | Props | Notes |
|---|---|---|
| `calypso_dashboard_mcp_read_tool_toggled` | `tool_id: string, enabled: boolean, group: string` | `group` added |
| `calypso_dashboard_mcp_write_tool_toggled` | `tool_id: string, enabled: boolean, group: string` | `group` added |

### Pre-existing events (unchanged, included for reference)

| Event | Props | Fired when |
|---|---|---|
| `calypso_dashboard_mcp_read_enable_all_toggled` | `enabled: boolean, scope: 'page' \| 'group', group?: string` | Page-level or group-level "Enable all" toggled |
| `calypso_dashboard_mcp_write_enable_all_toggled` | `enabled: boolean, scope: 'page' \| 'group', group?: string` | Page-level or group-level "Enable all" toggled |
| `calypso_dashboard_mcp_read_view` | — | Read page viewed (Dashboard only) |
| `calypso_dashboard_mcp_write_view` | — | Write page viewed (Dashboard only) |

## Why are these changes being made?

AIINT-475 requires analytics coverage for the new group-based MCP toggle layout introduced in AIINT-469/472. Without a `group` prop on `tool_toggled` and without a dedicated `group_toggled` event, there is no visibility into which group a user is interacting with.

## Testing Instructions

* Visit `/me/mcp/read` or `/me/mcp/write` and expand a group -- verify `calypso_dashboard_mcp_read_group_toggled` / `calypso_dashboard_mcp_write_group_toggled` fires with `{ group, is_open: true }`.
* Collapse the same group -- verify the event fires again with `is_open: false`.
* Toggle a tool within a group -- verify `tool_toggled` includes a `group` prop matching the group backend name slug (or `"other"` for the ungrouped bucket).
* Visit the Dashboard equivalents (`/me/preferences/mcp/read`, `/me/preferences/mcp/write`) and repeat.
* Confirm the chevron button label reads "Hide operations" when expanded and "Show operations" when collapsed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
