### PR TITLE
React 19 prep: extract type-safe changes that land under React 18

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -56,7 +56,9 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		const urlValue = new URLSearchParams( search ).get( 'from' ) || '';
 		if ( skipInitialChecking ) {
 			setUrlValue( urlValue );
-			validateUrl( urlValue );
+			if ( urlValue ) {
+				validateUrl( urlValue );
+			}
 			return;
 		}
 

--- a/client/components/chart-uplot/index.tsx
+++ b/client/components/chart-uplot/index.tsx
@@ -22,7 +22,7 @@ interface UplotChartProps {
 	fillColorFrom?: string;
 	fillColorTo?: string;
 	options?: Partial< uPlot.Options >;
-	legendContainer?: React.RefObject< HTMLDivElement >;
+	legendContainer?: React.RefObject< HTMLDivElement | null >;
 	solidFill?: boolean;
 	period?: string;
 	yAxisFilter?: uPlot.Axis.Filter | undefined;

--- a/client/components/empty-content/index.tsx
+++ b/client/components/empty-content/index.tsx
@@ -17,7 +17,7 @@ interface EmptyContentProps {
 	actionCallback?: () => void;
 	actionTarget?: string;
 	actionDisabled?: boolean;
-	actionRef?: RefObject< HTMLElement > | LegacyRef< HTMLButtonElement >;
+	actionRef?: RefObject< HTMLElement | null > | LegacyRef< HTMLButtonElement >;
 	secondaryAction?: React.ReactNode;
 	secondaryActionURL?: string;
 	secondaryActionCallback?: () => void;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/index.tsx
@@ -16,7 +16,10 @@ export const SurveyActionsContext = React.createContext< SurveyActionsContextTyp
 
 const Trigger = ( { asChild, children, onClick, as }: TriggerProps ) => {
 	if ( asChild ) {
-		return cloneElement( children, { onClick } );
+		return cloneElement(
+			children as React.ReactElement< { onClick?: React.MouseEventHandler< HTMLElement > } >,
+			{ onClick }
+		);
 	}
 	const Tag = as ?? 'button';
 	return <Tag onClick={ onClick }>{ children }</Tag>;

--- a/client/layout/hosting-dashboard/item-view/types.ts
+++ b/client/layout/hosting-dashboard/item-view/types.ts
@@ -53,7 +53,7 @@ export interface ItemViewHeaderExtraProps {
 	externalIconSize?: number;
 	siteIconFallback?: SiteFaviconFallback;
 	headerButtons?: React.ComponentType< {
-		focusRef: React.RefObject< HTMLButtonElement >;
+		focusRef: React.RefObject< HTMLButtonElement | null >;
 		itemData: ItemData;
 		closeSitePreviewPane: () => void;
 	} >;

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -5,7 +5,7 @@ import React, { Component, Fragment, forwardRef } from 'react';
 import { navigate } from 'calypso/lib/navigate';
 import type {
 	ComponentPropsWithoutRef,
-	ElementRef,
+	ComponentRef,
 	ElementType,
 	ForwardedRef,
 	LegacyRef,
@@ -308,7 +308,7 @@ class MasterbarItem extends Component< MasterbarItemWithInnerRef > {
 
 interface MasterbarItemComponent {
 	< C extends ElementType >(
-		props: MasterbarItemProps< C > & { ref?: ForwardedRef< ElementRef< C > > }
+		props: MasterbarItemProps< C > & { ref?: ForwardedRef< ComponentRef< C > > }
 	): ReactElement | null;
 	(
 		props: MasterbarItemProps< undefined > & {

--- a/client/lib/react-node-to-string/index.ts
+++ b/client/lib/react-node-to-string/index.ts
@@ -14,7 +14,7 @@ export default function reactNodeToString( node: ReactNode ): string {
 	const arr: string[] = [];
 
 	const walkElt = ( elt: ReactElement ) => {
-		const items = elt.props.children;
+		const items = ( elt.props as { children?: ReactNode } ).children;
 
 		if ( 'string' === typeof items && items.trim() ) {
 			arr.push( items.trim() );

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -53,7 +53,7 @@ export function showDomainManagementPage( route: string ) {
 }
 
 type BtnProps = {
-	focusRef: React.RefObject< HTMLButtonElement >;
+	focusRef: React.RefObject< HTMLButtonElement | null >;
 	itemData: ItemData;
 };
 
@@ -194,9 +194,11 @@ const DomainOverviewPane = ( {
 			<ItemView
 				itemData={ itemData }
 				closeItemView={ () => {
-					inSiteContext
-						? page.show( '/sites' )
-						: page.show( addQueryArgs( queryParams, paths.domainManagementRoot() ) );
+					if ( inSiteContext ) {
+						page.show( '/sites' );
+					} else {
+						page.show( addQueryArgs( queryParams, paths.domainManagementRoot() ) );
+					}
 				} }
 				features={ features }
 				enforceTabsView

--- a/client/my-sites/earn/components/free-plan-modal/test/index.tsx
+++ b/client/my-sites/earn/components/free-plan-modal/test/index.tsx
@@ -16,7 +16,6 @@ jest.mock( 'calypso/state/site-settings/actions', () => ( {
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { unmountComponentAtNode } from 'react-dom';
 import Modal from 'react-modal';
 import { requestSiteSettings, saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
@@ -43,7 +42,6 @@ describe( 'FreePlanModal', () => {
 	} );
 
 	afterEach( () => {
-		unmountComponentAtNode( modalRoot );
 		document.body.removeChild( modalRoot );
 		[ ...document.getElementsByClassName( 'ReactModalPortal' ) ].forEach( ( el ) =>
 			document.body.removeChild( el )

--- a/client/my-sites/plugins/marketplace-ai-experience/prompt-form.tsx
+++ b/client/my-sites/plugins/marketplace-ai-experience/prompt-form.tsx
@@ -6,7 +6,7 @@ import '@automattic/agenttic-ui/index.css';
 import { AgentUIProvider, ChatInput, Suggestions, type Suggestion } from '@automattic/agenttic-ui';
 import { useMemo, useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import type { JSX } from 'react';
+import type { JSX, RefObject } from 'react';
 
 import './prompt-form.scss';
 
@@ -101,7 +101,7 @@ export default function PromptForm( { onSubmit, mode = 'initial' }: PromptFormPr
 					onChange={ setValue }
 					onSubmit={ () => submit( value ) }
 					onKeyDown={ handleKeyDown }
-					textareaRef={ textareaRef }
+					textareaRef={ textareaRef as RefObject< HTMLTextAreaElement > }
 					isProcessing={ false }
 					// Cycle the suggestion prompts through the placeholder so
 					// the input keeps suggesting examples without the user

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -52,7 +52,10 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 	};
 
 	const triggerNode = trigger ? (
-		React.cloneElement( trigger, { onClick: handleClick } )
+		React.cloneElement(
+			trigger as React.ReactElement< { onClick?: React.MouseEventHandler< HTMLElement > } >,
+			{ onClick: handleClick }
+		)
 	) : (
 		<Button
 			icon={ link }

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -23,7 +23,7 @@ import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types'
 import './preview-pane-header-buttons.scss';
 
 type Props = {
-	focusRef: React.RefObject< HTMLButtonElement >;
+	focusRef: React.RefObject< HTMLButtonElement | null >;
 	itemData: ItemData;
 };
 

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -108,13 +108,13 @@ export default function useAgentLayoutManager( {
 	onUndock = () => {},
 	isSplitScreen = false,
 }: Options = {} ): ReturnValue {
-	const portalRef = useRef< HTMLDivElement >();
+	const portalRef = useRef< HTMLDivElement | undefined >( undefined );
 	const [ isPortalReady, setIsPortalReady ] = useState( false );
 	const [ isDocked, setIsDocked ] = useState< boolean | null >( null );
 	const { canDock, calculateAdminMenuHeight } = useCanDock( { desktopMediaQuery } );
 	const shouldRenderSidebar = canDock && isDocked;
-	const openSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
-	const closeSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
+	const openSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
+	const closeSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
 
 	// Store default state refs to avoid stale closures and prevent unnecessary re-renders
 	const defaultDockedRef = useRef( defaultDocked );


### PR DESCRIPTION
Part of DOTCOM-17400

## Proposed Changes

Splits the **React-18-safe** portion out of the React 19 upgrade spike (#111325) so it can land ahead of the `react`/`react-dom`/`@wordpress/element` bump, shrinking that PR to the changes that genuinely require React 19.

Every change here type-checks and lints cleanly against the **current React 18** toolchain (verified locally, see below). 13 files:

- **Ref/prop type widening to `RefObject< T | null >`** only where the consuming ref slot accepts it under React 18 (chart-uplot, empty-content, hosting-dashboard item-view types, domain-overview-pane, preview-pane-header-buttons).
- **`cloneElement` / `elt.props` casts** for stricter prop typing (survey trigger, stats UTM builder, react-node-to-string).
- **`ElementRef` → `ComponentRef`** in masterbar item (alias already present in `@types/react` 18.3.x).
- **Explicit `useRef` initial values** in agents-manager (`useRef< T | undefined >( undefined )` — identical resulting type under React 18).
- **Drop `unmountComponentAtNode`** from the free-plan-modal test (React Testing Library auto-unmounts; the API is removed in React 19).
- **Empty-URL guard** in capture-input's initial validation.

### What was intentionally left in #111325

Changes that look mechanical but **only type-check under React 19** (or are otherwise coupled to the bump) were kept in the spike:

- **site-profiler** ref changes and **wpcom-template-parts nav-2026** (`desktop-dropdown`, `mobile-menu`, `hooks`): they pass a `RefObject< T | null >` into a `forwardRef< T >` / native-element ref slot. Under React 18, `RefObject` is covariant in `T`, so `RefObject< T | null >` is *not* assignable to `Ref< T >`; React 19 fixed this by defining `Ref< T >` to accept `RefObject< T | null >`.
- JSDoc `@param` annotations on shared `.jsx` components were dropped from this slice (they don't add enough value on their own to justify landing separately).
- React-19-only items: the `@wordpress/element` patch, dependency/lockfile bumps, `inert` (`subscribe-modal`), `forwardRef` → ref-as-prop (reader thread-node), the React-19 snapshot update, and tsconfig/jest config changes.

## Why are these changes being made?

To make the eventual React 19 PR (#111325) as small and reviewable as possible by landing the parts that carry no React-19 dependency first.

## Testing Instructions

No runtime behavior change is expected (type cleanups, one validation guard, one test cleanup).

Verified locally against React 18 (using the main checkout's installed deps):

- `yarn typecheck-client` — **0 new errors** vs trunk (identical error set before/after).
- `yarn lint:js` on the changed files — **0 errors**.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
