### PR TITLE
Student plan: Plans page and my-plan cards and touchpoints

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -25,6 +25,7 @@ import {
 	TYPE_WOO_HOSTED_PRO,
 	TYPE_100_YEAR,
 	TYPE_STARTER,
+	TYPE_STUDENT,
 	FEATURE_LEGACY_STORAGE_200GB,
 } from '@automattic/calypso-products';
 import PropTypes from 'prop-types';
@@ -168,6 +169,19 @@ export class ProductPurchaseFeaturesList extends Component {
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
 				<SellOnlinePaypal isJetpack={ false } />
+			</Fragment>
+		);
+	}
+
+	getStudentFeatures() {
+		const { selectedSite } = this.props;
+
+		return (
+			<Fragment>
+				<UploadPlugins selectedSite={ selectedSite } />
+				{ isEnabled( 'themes/premium' ) && <FindNewTheme selectedSite={ selectedSite } /> }
+				<AdvertisingRemoved isEligiblePlan selectedSite={ selectedSite } />
+				<MobileApps onClick={ this.handleMobileAppsClick } />
 			</Fragment>
 		);
 	}
@@ -418,6 +432,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_PRO ]: () => this.getProFeatuers(),
 				[ TYPE_100_YEAR ]: () => this.getBusinessFeatures(),
 				[ TYPE_STARTER ]: () => this.getWPCOMLegacyStarterFeatures(),
+				[ TYPE_STUDENT ]: () => this.getStudentFeatures(),
 			},
 			[ GROUP_JETPACK ]: {
 				[ TYPE_BUSINESS ]: () => this.getJetpackBusinessFeatures(),

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -278,6 +278,10 @@ class PlansComponent extends Component {
 				currentPlan={ currentPlan }
 				selectedSite={ selectedSite }
 				intervalType={ intervalType }
+				isOwner={ selectedSite.plan?.user_is_owner }
+				coupon={ this.props.coupon }
+				redirectTo={ this.props.redirectTo }
+				pluginSlug={ this.props.pluginSlug }
 			/>
 		);
 	}
@@ -350,7 +354,7 @@ class PlansComponent extends Component {
 			PLAN_WOOEXPRESS_SMALL,
 			PLAN_WOOEXPRESS_SMALL_MONTHLY,
 		].includes( currentPlanSlug );
-		const isStudent = isStudentPlan( currentPlanSlug );
+		const isStudent = isStudentPlan( currentPlan.productSlug );
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -282,6 +282,7 @@ class PlansComponent extends Component {
 				coupon={ this.props.coupon }
 				redirectTo={ this.props.redirectTo }
 				pluginSlug={ this.props.pluginSlug }
+				discountEndDate={ this.props.discountEndDate }
 			/>
 		);
 	}
@@ -354,7 +355,7 @@ class PlansComponent extends Component {
 			PLAN_WOOEXPRESS_SMALL,
 			PLAN_WOOEXPRESS_SMALL_MONTHLY,
 		].includes( currentPlanSlug );
-		const isStudent = isStudentPlan( currentPlanSlug );
+		const isStudent = isStudentPlan( currentPlan.productSlug );
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -354,7 +354,7 @@ class PlansComponent extends Component {
 			PLAN_WOOEXPRESS_SMALL,
 			PLAN_WOOEXPRESS_SMALL_MONTHLY,
 		].includes( currentPlanSlug );
-		const isStudent = isStudentPlan( currentPlan.productSlug );
+		const isStudent = isStudentPlan( currentPlanSlug );
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -267,13 +267,19 @@ class PlansComponent extends Component {
 	}
 
 	renderStudentPlansPage() {
-		const { currentPlan, selectedSite } = this.props;
+		const { currentPlan, selectedSite, intervalType } = this.props;
 
 		if ( ! selectedSite ) {
 			return this.renderPlaceholder();
 		}
 
-		return <StudentPlansPage currentPlan={ currentPlan } selectedSite={ selectedSite } />;
+		return (
+			<StudentPlansPage
+				currentPlan={ currentPlan }
+				selectedSite={ selectedSite }
+				intervalType={ intervalType }
+			/>
+		);
 	}
 
 	renderMainContent( {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,6 +5,7 @@ import {
 	getPlan,
 	is100Year,
 	isFreePlanProduct,
+	isStudentPlan,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
@@ -60,6 +61,7 @@ import DomainUpsellDialog from './components/domain-upsell-dialog';
 import PlansHeader from './components/plans-header';
 import ECommerceTrialPlansPage from './ecommerce-trial';
 import ModernizedLayout from './modernized-layout';
+import StudentPlansPage from './student-plans-page';
 import BusinessTrialPlansPage from './trials/business-trial-plans-page';
 import WooExpressPlansPage from './woo-express-plans-page';
 
@@ -264,10 +266,21 @@ class PlansComponent extends Component {
 		);
 	}
 
+	renderStudentPlansPage() {
+		const { currentPlan, selectedSite } = this.props;
+
+		if ( ! selectedSite ) {
+			return this.renderPlaceholder();
+		}
+
+		return <StudentPlansPage currentPlan={ currentPlan } selectedSite={ selectedSite } />;
+	}
+
 	renderMainContent( {
 		isEcommerceTrial,
 		isBusinessTrial,
 		isWooExpressPlan,
+		isStudent,
 		isA4APlan,
 		is100YearPlan,
 	} ) {
@@ -279,6 +292,9 @@ class PlansComponent extends Component {
 		}
 		if ( isBusinessTrial ) {
 			return this.renderBusinessTrialPage();
+		}
+		if ( isStudent ) {
+			return this.renderStudentPlansPage();
 		}
 		if ( isA4APlan || is100YearPlan ) {
 			return null;
@@ -328,6 +344,7 @@ class PlansComponent extends Component {
 			PLAN_WOOEXPRESS_SMALL,
 			PLAN_WOOEXPRESS_SMALL_MONTHLY,
 		].includes( currentPlanSlug );
+		const isStudent = isStudentPlan( currentPlanSlug );
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);
@@ -387,6 +404,7 @@ class PlansComponent extends Component {
 									isEcommerceTrial,
 									isBusinessTrial,
 									isWooExpressPlan,
+									isStudent,
 									isA4APlan,
 									is100YearPlan,
 								} ) }

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_STUDENT } from '@automattic/calypso-products';
+import { applyTestFiltersToPlansList, PLAN_STUDENT } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card } from '@automattic/components';
 import { type SiteDetails, type SitePlan } from '@automattic/data-stores';
@@ -33,7 +33,7 @@ const StudentPlansPage = ( {
 	pluginSlug,
 }: StudentPlansPageProps ) => {
 	const translate = useTranslate();
-	const studentPlan = getPlan( PLAN_STUDENT );
+	const studentPlan = applyTestFiltersToPlansList( PLAN_STUDENT, undefined );
 
 	const selectedInterval = UPGRADE_INTERVALS.includes( intervalType as UpgradeInterval )
 		? ( intervalType as UpgradeInterval )
@@ -79,9 +79,9 @@ const StudentPlansPage = ( {
 			<Card className="student-plans-page__price-card">
 				<div className="student-plans-page__price-card-text">
 					<span className="student-plans-page__price-card-label">{ translate( 'My Plan' ) }</span>
-					<span className="student-plans-page__price-card-title">{ studentPlan?.getTitle() }</span>
+					<span className="student-plans-page__price-card-title">{ studentPlan.getTitle() }</span>
 					<span className="student-plans-page__price-card-subtitle">
-						{ studentPlan?.getPlanTagline?.() }
+						{ studentPlan.getPlanTagline?.() }
 					</span>
 				</div>
 				<div className="student-plans-page__price-card-conditions">{ priceContent }</div>

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -23,6 +23,7 @@ interface StudentPlansPageProps {
 	coupon?: string;
 	redirectTo?: string;
 	pluginSlug?: string;
+	discountEndDate?: Date;
 }
 
 const StudentPlansPage = ( {
@@ -33,6 +34,7 @@ const StudentPlansPage = ( {
 	coupon,
 	redirectTo,
 	pluginSlug,
+	discountEndDate,
 }: StudentPlansPageProps ) => {
 	const translate = useTranslate();
 	const studentPlan = applyTestFiltersToPlansList( PLAN_STUDENT, undefined );
@@ -42,9 +44,11 @@ const StudentPlansPage = ( {
 		: 'yearly';
 
 	// The current plan's pricing comes from the site's plans (it is not a publicly-priced catalog plan).
-	const annualPlanPrice = currentPlan?.pricing?.originalPrice?.full ?? null;
-	const annualPlanMonthlyPrice = currentPlan?.pricing?.originalPrice?.monthly ?? null;
-	const currencyCode = currentPlan?.pricing?.currencyCode ?? '';
+	const pricing = currentPlan?.pricing;
+	const annualPlanPrice = pricing?.discountedPrice?.full ?? pricing?.originalPrice?.full ?? null;
+	const annualPlanMonthlyPrice =
+		pricing?.discountedPrice?.monthly ?? pricing?.originalPrice?.monthly ?? null;
+	const currencyCode = pricing?.currencyCode ?? '';
 
 	// Owners with a linked purchase can manage billing; everyone else views the read-only plan page.
 	const canManagePlan = Boolean( isOwner && currentPlan.purchaseId );
@@ -111,6 +115,7 @@ const StudentPlansPage = ( {
 					coupon={ coupon }
 					redirectTo={ redirectTo }
 					pluginSlug={ pluginSlug }
+					discountEndDate={ discountEndDate }
 				/>
 			</div>
 		</>

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -9,14 +9,23 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 
 import './style.scss';
 
+// Students can only upgrade to yearly terms; the student plan itself is annual-only.
+const UPGRADE_INTERVALS = [ 'yearly', '2yearly', '3yearly' ] as const;
+type UpgradeInterval = ( typeof UPGRADE_INTERVALS )[ number ];
+
 interface StudentPlansPageProps {
 	currentPlan: SitePlan;
 	selectedSite: SiteDetails;
+	intervalType?: string;
 }
 
-const StudentPlansPage = ( { currentPlan, selectedSite }: StudentPlansPageProps ) => {
+const StudentPlansPage = ( { currentPlan, selectedSite, intervalType }: StudentPlansPageProps ) => {
 	const translate = useTranslate();
 	const studentPlan = getPlan( PLAN_STUDENT );
+
+	const selectedInterval = UPGRADE_INTERVALS.includes( intervalType as UpgradeInterval )
+		? ( intervalType as UpgradeInterval )
+		: 'yearly';
 
 	// The current plan's pricing comes from the site's plans (it is not a publicly-priced catalog plan).
 	const annualPlanPrice = currentPlan?.pricing?.originalPrice?.full ?? 0;
@@ -75,9 +84,10 @@ const StudentPlansPage = ( { currentPlan, selectedSite }: StudentPlansPageProps 
 			<div className="student-plans-page__grid is-2023-pricing-grid">
 				<PlansFeaturesMain
 					siteId={ selectedSite.ID }
-					intervalType="yearly"
+					intervalType={ selectedInterval }
 					intent="plans-student"
-					hidePlanTypeSelector
+					displayedIntervals={ [ ...UPGRADE_INTERVALS ] }
+					showPlanTypeSelectorDropdown
 					hideUnavailableFeatures
 					hidePlansFeatureComparison
 				/>

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -1,0 +1,103 @@
+import { getPlan, PLAN_STUDENT } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { Button, Card } from '@automattic/components';
+import { Plans, type SiteDetails, type SitePlan } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useTranslate } from 'i18n-calypso';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
+
+import './style.scss';
+
+interface StudentPlansPageProps {
+	currentPlan: SitePlan;
+	selectedSite: SiteDetails;
+}
+
+const StudentPlansPage = ( { currentPlan, selectedSite }: StudentPlansPageProps ) => {
+	const translate = useTranslate();
+	const studentPlan = getPlan( PLAN_STUDENT );
+
+	const pricingMeta = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ PLAN_STUDENT ],
+		siteId: null,
+		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
+	} );
+
+	// Using `discountedPrice` below will give us the price with any currency/conversion discounts applied.
+	const annualPlanPrice =
+		pricingMeta?.[ PLAN_STUDENT ]?.discountedPrice?.full ??
+		pricingMeta?.[ PLAN_STUDENT ]?.originalPrice?.full ??
+		0;
+	const annualPlanMonthlyPrice =
+		pricingMeta?.[ PLAN_STUDENT ]?.discountedPrice?.monthly ??
+		pricingMeta?.[ PLAN_STUDENT ]?.originalPrice?.monthly ??
+		0;
+	const currencyCode = pricingMeta?.[ PLAN_STUDENT ]?.currencyCode ?? '';
+
+	const goToSubscriptionPage = () => {
+		if ( selectedSite?.slug && currentPlan?.purchaseId ) {
+			page( `/purchases/subscriptions/${ selectedSite.slug }/${ currentPlan.purchaseId }` );
+		}
+	};
+
+	const monthlyPriceWrapper = <span className="student-plans-page__price-card-value" />;
+	const priceDescription = <span className="student-plans-page__price-card-interval" />;
+
+	const priceContent = translate(
+		'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
+		{
+			args: {
+				monthlyPrice: formatCurrency( annualPlanMonthlyPrice, currencyCode, {
+					stripZeros: true,
+					isSmallestUnit: true,
+				} ),
+				annualPrice: formatCurrency( annualPlanPrice, currencyCode, {
+					stripZeros: true,
+					isSmallestUnit: true,
+				} ),
+			},
+			components: {
+				monthlyPriceWrapper,
+				priceDescription,
+			},
+		}
+	);
+
+	return (
+		<>
+			<BodySectionCssClass bodyClass={ [ 'is-student-plan' ] } />
+			<Card className="student-plans-page__price-card">
+				<div className="student-plans-page__price-card-text">
+					<span className="student-plans-page__price-card-label">{ translate( 'My Plan' ) }</span>
+					<span className="student-plans-page__price-card-title">{ studentPlan?.getTitle() }</span>
+					<span className="student-plans-page__price-card-subtitle">
+						{ studentPlan?.getPlanTagline?.() }
+					</span>
+				</div>
+				<div className="student-plans-page__price-card-conditions">{ priceContent }</div>
+				<div className="student-plans-page__price-card-cta-wrapper">
+					{ currentPlan && selectedSite && (
+						<Button className="student-plans-page__price-card-cta" onClick={ goToSubscriptionPage }>
+							{ translate( 'Manage my plan' ) }
+						</Button>
+					) }
+				</div>
+			</Card>
+			<div className="student-plans-page__grid is-2023-pricing-grid">
+				<PlansFeaturesMain
+					siteId={ selectedSite.ID }
+					intervalType="yearly"
+					intent="plans-student"
+					hidePlanTypeSelector
+					hideUnavailableFeatures
+					hidePlansFeatureComparison
+				/>
+			</div>
+		</>
+	);
+};
+
+export default StudentPlansPage;

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -1,12 +1,11 @@
 import { getPlan, PLAN_STUDENT } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card } from '@automattic/components';
-import { Plans, type SiteDetails, type SitePlan } from '@automattic/data-stores';
+import { type SiteDetails, type SitePlan } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
-import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 
 import './style.scss';
 
@@ -19,23 +18,10 @@ const StudentPlansPage = ( { currentPlan, selectedSite }: StudentPlansPageProps 
 	const translate = useTranslate();
 	const studentPlan = getPlan( PLAN_STUDENT );
 
-	const pricingMeta = Plans.usePricingMetaForGridPlans( {
-		planSlugs: [ PLAN_STUDENT ],
-		siteId: null,
-		coupon: undefined,
-		useCheckPlanAvailabilityForPurchase,
-	} );
-
-	// Using `discountedPrice` below will give us the price with any currency/conversion discounts applied.
-	const annualPlanPrice =
-		pricingMeta?.[ PLAN_STUDENT ]?.discountedPrice?.full ??
-		pricingMeta?.[ PLAN_STUDENT ]?.originalPrice?.full ??
-		0;
-	const annualPlanMonthlyPrice =
-		pricingMeta?.[ PLAN_STUDENT ]?.discountedPrice?.monthly ??
-		pricingMeta?.[ PLAN_STUDENT ]?.originalPrice?.monthly ??
-		0;
-	const currencyCode = pricingMeta?.[ PLAN_STUDENT ]?.currencyCode ?? '';
+	// The current plan's pricing comes from the site's plans (it is not a publicly-priced catalog plan).
+	const annualPlanPrice = currentPlan?.pricing?.originalPrice?.full ?? 0;
+	const annualPlanMonthlyPrice = currentPlan?.pricing?.originalPrice?.monthly ?? 0;
+	const currencyCode = currentPlan?.pricing?.currencyCode ?? '';
 
 	const goToSubscriptionPage = () => {
 		if ( selectedSite?.slug && currentPlan?.purchaseId ) {

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -17,9 +17,21 @@ interface StudentPlansPageProps {
 	currentPlan: SitePlan;
 	selectedSite: SiteDetails;
 	intervalType?: string;
+	isOwner?: boolean;
+	coupon?: string;
+	redirectTo?: string;
+	pluginSlug?: string;
 }
 
-const StudentPlansPage = ( { currentPlan, selectedSite, intervalType }: StudentPlansPageProps ) => {
+const StudentPlansPage = ( {
+	currentPlan,
+	selectedSite,
+	intervalType,
+	isOwner,
+	coupon,
+	redirectTo,
+	pluginSlug,
+}: StudentPlansPageProps ) => {
 	const translate = useTranslate();
 	const studentPlan = getPlan( PLAN_STUDENT );
 
@@ -76,7 +88,7 @@ const StudentPlansPage = ( { currentPlan, selectedSite, intervalType }: StudentP
 				<div className="student-plans-page__price-card-cta-wrapper">
 					{ currentPlan && selectedSite && (
 						<Button className="student-plans-page__price-card-cta" onClick={ goToSubscriptionPage }>
-							{ translate( 'Manage my plan' ) }
+							{ isOwner ? translate( 'Manage my plan' ) : translate( 'View plan' ) }
 						</Button>
 					) }
 				</div>
@@ -90,6 +102,9 @@ const StudentPlansPage = ( { currentPlan, selectedSite, intervalType }: StudentP
 					showPlanTypeSelectorDropdown
 					hideUnavailableFeatures
 					hidePlansFeatureComparison
+					coupon={ coupon }
+					redirectTo={ redirectTo }
+					pluginSlug={ pluginSlug }
 				/>
 			</div>
 		</>

--- a/client/my-sites/plans/student-plans-page/index.tsx
+++ b/client/my-sites/plans/student-plans-page/index.tsx
@@ -12,6 +12,8 @@ import './style.scss';
 // Students can only upgrade to yearly terms; the student plan itself is annual-only.
 const UPGRADE_INTERVALS = [ 'yearly', '2yearly', '3yearly' ] as const;
 type UpgradeInterval = ( typeof UPGRADE_INTERVALS )[ number ];
+const DISPLAYED_INTERVALS: UpgradeInterval[] = [ ...UPGRADE_INTERVALS ];
+const BODY_CLASS = [ 'is-student-plan' ];
 
 interface StudentPlansPageProps {
 	currentPlan: SitePlan;
@@ -40,42 +42,45 @@ const StudentPlansPage = ( {
 		: 'yearly';
 
 	// The current plan's pricing comes from the site's plans (it is not a publicly-priced catalog plan).
-	const annualPlanPrice = currentPlan?.pricing?.originalPrice?.full ?? 0;
-	const annualPlanMonthlyPrice = currentPlan?.pricing?.originalPrice?.monthly ?? 0;
+	const annualPlanPrice = currentPlan?.pricing?.originalPrice?.full ?? null;
+	const annualPlanMonthlyPrice = currentPlan?.pricing?.originalPrice?.monthly ?? null;
 	const currencyCode = currentPlan?.pricing?.currencyCode ?? '';
 
-	const goToSubscriptionPage = () => {
-		if ( selectedSite?.slug && currentPlan?.purchaseId ) {
-			page( `/purchases/subscriptions/${ selectedSite.slug }/${ currentPlan.purchaseId }` );
-		}
-	};
+	// Owners with a linked purchase can manage billing; everyone else views the read-only plan page.
+	const canManagePlan = Boolean( isOwner && currentPlan.purchaseId );
+	const planActionHref = canManagePlan
+		? `/purchases/subscriptions/${ selectedSite.slug }/${ currentPlan.purchaseId }`
+		: `/plans/my-plan/${ selectedSite.slug }`;
 
 	const monthlyPriceWrapper = <span className="student-plans-page__price-card-value" />;
 	const priceDescription = <span className="student-plans-page__price-card-interval" />;
 
-	const priceContent = translate(
-		'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
-		{
-			args: {
-				monthlyPrice: formatCurrency( annualPlanMonthlyPrice, currencyCode, {
-					stripZeros: true,
-					isSmallestUnit: true,
-				} ),
-				annualPrice: formatCurrency( annualPlanPrice, currencyCode, {
-					stripZeros: true,
-					isSmallestUnit: true,
-				} ),
-			},
-			components: {
-				monthlyPriceWrapper,
-				priceDescription,
-			},
-		}
-	);
+	const priceContent =
+		annualPlanPrice !== null && annualPlanMonthlyPrice !== null && currencyCode
+			? translate(
+					'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
+					{
+						args: {
+							monthlyPrice: formatCurrency( annualPlanMonthlyPrice, currencyCode, {
+								stripZeros: true,
+								isSmallestUnit: true,
+							} ),
+							annualPrice: formatCurrency( annualPlanPrice, currencyCode, {
+								stripZeros: true,
+								isSmallestUnit: true,
+							} ),
+						},
+						components: {
+							monthlyPriceWrapper,
+							priceDescription,
+						},
+					}
+			  )
+			: null;
 
 	return (
 		<>
-			<BodySectionCssClass bodyClass={ [ 'is-student-plan' ] } />
+			<BodySectionCssClass bodyClass={ BODY_CLASS } />
 			<Card className="student-plans-page__price-card">
 				<div className="student-plans-page__price-card-text">
 					<span className="student-plans-page__price-card-label">{ translate( 'My Plan' ) }</span>
@@ -86,11 +91,12 @@ const StudentPlansPage = ( {
 				</div>
 				<div className="student-plans-page__price-card-conditions">{ priceContent }</div>
 				<div className="student-plans-page__price-card-cta-wrapper">
-					{ currentPlan && selectedSite && (
-						<Button className="student-plans-page__price-card-cta" onClick={ goToSubscriptionPage }>
-							{ isOwner ? translate( 'Manage my plan' ) : translate( 'View plan' ) }
-						</Button>
-					) }
+					<Button
+						className="student-plans-page__price-card-cta"
+						onClick={ () => page( planActionHref ) }
+					>
+						{ canManagePlan ? translate( 'Manage my plan' ) : translate( 'View plan' ) }
+					</Button>
 				</div>
 			</Card>
 			<div className="student-plans-page__grid is-2023-pricing-grid">
@@ -98,7 +104,7 @@ const StudentPlansPage = ( {
 					siteId={ selectedSite.ID }
 					intervalType={ selectedInterval }
 					intent="plans-student"
-					displayedIntervals={ [ ...UPGRADE_INTERVALS ] }
+					displayedIntervals={ DISPLAYED_INTERVALS }
 					showPlanTypeSelectorDropdown
 					hideUnavailableFeatures
 					hidePlansFeatureComparison

--- a/client/my-sites/plans/student-plans-page/style.scss
+++ b/client/my-sites/plans/student-plans-page/style.scss
@@ -1,0 +1,85 @@
+@import "@wordpress/base-styles/breakpoints";
+
+body.is-section-plans.is-student-plan {
+	.student-plans-page__price-card {
+		display: flex;
+		flex-wrap: wrap;
+		border-radius: 2px 2px 0 0;
+		padding: 24px 32px;
+		margin-block: 40px;
+
+		@media (max-width: $break-mobile) {
+			flex-direction: column;
+			margin: 0 20px 40px;
+			padding: 32px 20px;
+		}
+	}
+
+	.student-plans-page__price-card-text {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.student-plans-page__price-card-label {
+		font-size: 0.75rem;
+		font-weight: 500;
+		background-color: var(--color-neutral-0);
+		border-radius: 4px;
+		margin-block-end: 8px;
+		padding-inline: 10px;
+		width: fit-content;
+	}
+
+	.student-plans-page__price-card-title {
+		font-size: 1.5rem;
+	}
+
+	.student-plans-page__price-card-subtitle {
+		flex: 1;
+		font-size: 0.875rem;
+		color: var(--color-neutral-80);
+	}
+
+	.student-plans-page__price-card-conditions {
+		display: flex;
+		flex-direction: column;
+		text-align: end;
+
+		@media (max-width: $break-mobile) {
+			text-align: start;
+		}
+	}
+
+	.student-plans-page__price-card-value {
+		font-size: 2rem;
+		font-weight: 500;
+
+		@media (max-width: $break-mobile) {
+			margin-block-start: 30px;
+			font-weight: 400;
+		}
+	}
+
+	.student-plans-page__price-card-interval {
+		color: var(--color-neutral-50);
+		font-size: 0.75rem;
+	}
+
+	.student-plans-page__price-card-cta-wrapper {
+		width: 100%;
+		margin-block-start: 20px;
+
+		@media (max-width: $break-mobile) {
+			margin-block-start: 0;
+		}
+	}
+
+	.student-plans-page__price-card-cta {
+		@media (max-width: $break-mobile) {
+			width: 100%;
+			margin-block-start: 25px;
+			line-height: 30px;
+		}
+	}
+}

--- a/client/my-sites/plans/student-plans-page/style.scss
+++ b/client/my-sites/plans/student-plans-page/style.scss
@@ -10,7 +10,8 @@ body.is-section-plans.is-student-plan {
 
 		@media (max-width: $break-mobile) {
 			flex-direction: column;
-			margin: 0 20px 40px;
+			margin-block: 0 40px;
+			margin-inline: 20px;
 			padding: 32px 20px;
 		}
 	}

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -260,6 +260,9 @@ export const usePlanTypesWithIntent = ( {
 		case 'plans-business-trial':
 			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
+		case 'plans-student':
+			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			break;
 		case 'plans-videopress':
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -77,6 +77,7 @@ export type PlansIntent =
 	| 'plans-p2'
 	| 'plans-default-wpcom'
 	| 'plans-business-trial'
+	| 'plans-student'
 	| 'plans-videopress'
 	| 'plans-guided-segment-developer-or-agency'
 	| 'plans-guided-segment-merchant'


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17726

## Proposed Changes

* Introduces a current plan page with a trimmed-down pricing grid for valid upgrade paths for the `http://calypso.localhost:3000/plans/<site>` route
* Introduces a feature list similar to that of other plans for the `http://calypso.localhost:3000/plans/my-plan/<site>` route
* Note: we could reuse another intent from the plans grid, and achieve the same (such as the business trial one), but IMO it's better to introduce a new (and semantically correct) one, which also makes any future changes easier, and keeps this intent independent.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Without these, sites on the plan will "fall through" to the default behavior, which makes it pretty bland. This ensures that we at least have some content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For a site with the student plan
* Go to the two routes above
* For the plans path, you should see the Business and Commerce plans, and be able to select any of the one, two, and three-year terms. These should correctly re-render/update the plans grid below.
* The my-plan route should show some features, so as not to render an empty feature set.

<img width="5120" height="2186" alt="CleanShot 2026-06-29 at 15 28 28@2x" src="https://github.com/user-attachments/assets/0fdbc6fc-5a68-4eea-a2ff-567d2f37d9a3" />
<img width="5120" height="2188" alt="CleanShot 2026-06-29 at 15 28 37@2x" src="https://github.com/user-attachments/assets/cc5799bb-8c23-4957-8465-1a88897de181" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
