### PR TITLE
Notifications: render a load-more spinner for the grouped note list

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -82,9 +82,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	// never bound and scroll-driven loading stays dead until the list
 	// remounts (e.g. on a tab switch). Defer mounting DataViews until the
 	// first load settles so it always mounts with the container present.
-	const hasRenderedDataViews = useRef( false );
+	const hasInitiallyLoaded = useRef( false );
 	if ( ! isLoading ) {
-		hasRenderedDataViews.current = true;
+		hasInitiallyLoaded.current = true;
 	}
 
 	// Drive the client's server-side filter from the active tab. Only "unread"
@@ -177,57 +177,72 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
-	// Loader only until DataViews first mounts, then never again: it binds its
-	// scroll listener once, on mount, only if the container exists, so a remount
-	// mid-load leaves scrolling dead. In-flight loading uses the `empty` slot.
-	const showInitialLoader = ! hasRenderedDataViews.current;
-
 	// Spinner instead of an empty message while the view may still be filling: more
 	// cache pages to search, or the Unread fetch in flight. Unread keys off the
 	// in-flight filter, not the shared `isLoading` the background poll also toggles.
 	const showEmptyLoader = hasMoreNotes || ( filterName === 'unread' && !! filteredLoading?.unread );
 
-	return (
-		<div ref={ noteListRef } className="wpnc__note-list">
-			{ ! showInitialLoader ? (
-				<DataViews< Note >
-					data={ data }
-					fields={ fields }
-					view={ view }
-					isLoading={ isLoading }
-					defaultLayouts={ DEFAULT_LAYOUTS }
-					paginationInfo={ effectivePaginationInfo }
-					empty={
-						// Spinner while still filling; the real message once settled.
-						showEmptyLoader ? (
-							<VStack alignment="center" style={ { padding: '40px 0' } }>
-								<Spinner />
-							</VStack>
-						) : (
-							<VStack alignment="center">
-								<Text size={ 15 } weight={ 500 }>
-									{ filter.emptyMessage }
-								</Text>
-								<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
-							</VStack>
-						)
-					}
-					getItemId={ ( item ) => item.id.toString() }
-					// Keep selection empty so DataViews applies none of its own selected-row
-					// styling; the open note is highlighted via our `is-active` marker
-					// instead. `onChangeSelection` is still the list layout's only row-click
-					// hook, so it stays — it's what opens the note.
-					selection={ NO_SELECTION }
-					onChangeView={ handleChangeView }
-					onChangeSelection={ onChangeSelection }
-				>
-					<DataViews.Layout />
-				</DataViews>
-			) : (
+	// `groupBy` forces DataViews' list layout off its infinite-scroll path, which
+	// is the only path that renders its built-in load-more spinner — so we render
+	// our own at the foot of the list while a page is in flight over an
+	// already-populated list. An empty list uses the `empty` slot above instead.
+	const showLoadMore = isLoading && data.length > 0;
+
+	// Loader only until DataViews first mounts, then never again: it binds its
+	// scroll listener once, on mount, only if the container exists, so a remount
+	// mid-load leaves scrolling dead. In-flight loading uses the `empty` slot.
+	if ( ! hasInitiallyLoaded.current ) {
+		return (
+			<div ref={ noteListRef } className="wpnc__note-list">
 				<VStack alignment="center" style={ { padding: '40px 0' } }>
 					<Spinner />
 				</VStack>
-			) }
+			</div>
+		);
+	}
+
+	return (
+		<div ref={ noteListRef } className="wpnc__note-list">
+			<DataViews< Note >
+				data={ data }
+				fields={ fields }
+				view={ view }
+				isLoading={ isLoading }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				paginationInfo={ effectivePaginationInfo }
+				empty={
+					// Spinner while still filling; the real message once settled.
+					showEmptyLoader ? (
+						<VStack alignment="center" style={ { padding: '40px 0' } }>
+							<Spinner />
+						</VStack>
+					) : (
+						<VStack alignment="center">
+							<Text size={ 15 } weight={ 500 }>
+								{ filter.emptyMessage }
+							</Text>
+							<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
+						</VStack>
+					)
+				}
+				getItemId={ ( item ) => item.id.toString() }
+				// Keep selection empty so DataViews applies none of its own selected-row
+				// styling; the open note is highlighted via our `is-active` marker
+				// instead. `onChangeSelection` is still the list layout's only row-click
+				// hook, so it stays — it's what opens the note.
+				selection={ NO_SELECTION }
+				onChangeView={ handleChangeView }
+				onChangeSelection={ onChangeSelection }
+			>
+				<DataViews.Layout />
+				{ showLoadMore && (
+					// DataViews suppresses its own load-more spinner when notes are
+					// grouped, so this stands in for it, pinned below the list rows.
+					<VStack alignment="center" style={ { flexShrink: 0, padding: '12px 0' } }>
+						<Spinner />
+					</VStack>
+				) }
+			</DataViews>
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

* Render a load-more spinner at the foot of the notifications list while a page of older notes is being fetched.
* Flatten the initial-load branch into an early return and rename the mount latch to `hasInitiallyLoaded`.

## Why are these changes being made?

The note list groups notes into time sections ("Today", "Yesterday", …) via DataViews `groupBy`. DataViews only renders its built-in load-more spinner on its infinite-scroll code path, and grouping turns that path off — so paging older notes happened with no loading affordance at all. This adds our own spinner for the grouped case. An empty list still uses the existing `empty` slot, so this only covers paging over an already-populated list.

## Testing Instructions

* Open the notifications panel with enough notes to scroll (more than one page).
* Scroll to the bottom to trigger loading older notes.
* A spinner appears beneath the list rows while the next page is in flight, and disappears once it arrives.
* Confirm it does not flash during steady-state background polling of a settled list.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
