### PR TITLE
odie-client: fix Sass division deprecation warning in attachment preview

### DIFF
--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -42,8 +42,8 @@
 		position: absolute;
 		height: $height;
 		width: $width;
-		top: -$height / 2;
-		right: -$width / 2;
+		top: calc(-1 * $height / 2);
+		right: calc(-1 * $width / 2);
 		margin: 0;
 		padding: 0;
 


### PR DESCRIPTION
## Proposed Changes

* Wrap the cancel-button offset calculations in `calc()` in `packages/odie-client/src/components/attachment-preview/style.scss`, so `/` is interpreted as CSS division rather than the deprecated Sass division operator.

## Why are these changes being made?

Running `yarn start-dashboard` produced a Dart Sass deprecation warning during webpack compilation:

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
packages/odie-client/src/components/attachment-preview/style.scss:44 & :45
```

This was the only SCSS warning in the dashboard build. Wrapping the expressions in `calc()` resolves the deprecation without changing the computed values (`-9px` and `-7px` respectively).

## Testing Instructions

* Run `yarn start-dashboard` (or build the `entry-dashboard-dotcom` entry) and confirm the build now reports `compiled successfully` with no Sass deprecation warnings (previously "compiled with 2 warnings").
* Verify the odie attachment preview cancel button is still positioned correctly in its top-right corner.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
