### PR TITLE
Account recovery interstitial: refine CTA copy and dismiss label

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/copy.ts
+++ b/client/dashboard/app/account-recovery-interstitial/copy.ts
@@ -163,7 +163,7 @@ export function getInterstitialCopy(
 			},
 			secondaryCta: {
 				id: 'review_two_factor',
-				label: __( 'Review two-step authentication and add backup codes' ),
+				label: __( 'Download backup codes' ),
 				route: securityTwoStepAuthRoute.fullPath,
 			},
 		},
@@ -176,7 +176,7 @@ export function getInterstitialCopy(
 			),
 			primaryCta: {
 				id: 'download_backup_codes',
-				label: __( 'Review two-step authentication and download backup codes' ),
+				label: __( 'Download backup codes' ),
 				route: securityTwoStepAuthRoute.fullPath,
 			},
 			secondaryCta: {

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useId, useState } from 'react';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Text } from '../../components/text';
@@ -149,11 +149,16 @@ export default function AccountRecoveryInterstitial() {
 		}
 	};
 
-	const remindLabel = sprintf(
-		// translators: %d is the number of days until the reminder reappears.
-		_n( 'Remind me in %d day', 'Remind me in %d days', snoozeDays ),
-		snoozeDays
-	);
+	// Fully-secured users are on the yearly check-in; a "remind me in 365 days" nudge reads as
+	// a permanent dismissal, so label it as such.
+	const remindLabel =
+		securityLevel === 'strong'
+			? __( 'Dismiss' )
+			: sprintf(
+					// translators: %d is the number of days until the reminder reappears.
+					_n( 'Remind me in %d day', 'Remind me in %d days', snoozeDays ),
+					snoozeDays
+			  );
 
 	return (
 		<Modal

--- a/client/dashboard/app/account-recovery-interstitial/style.scss
+++ b/client/dashboard/app/account-recovery-interstitial/style.scss
@@ -32,12 +32,5 @@
 	.components-button {
 		width: 100%;
 		justify-content: center;
-
-		// Let long CTA labels wrap onto multiple lines instead of overflowing the fixed-width modal.
-		height: auto;
-		min-height: $grid-unit-50;
-		white-space: normal;
-		text-align: center;
-		padding-block: $grid-unit-15;
 	}
 }

--- a/client/dashboard/app/account-recovery-interstitial/style.scss
+++ b/client/dashboard/app/account-recovery-interstitial/style.scss
@@ -5,13 +5,13 @@
 	overflow: hidden;
 
 	// Let the hero bleed to the modal edges instead of sitting inside the default padding.
-	// `overflow: visible` (rather than the default `auto`) stops the content box from becoming
-	// its own scroll container: the modal is sized to fit its content, and the sub-pixel rounding
-	// of the full-bleed hero would otherwise surface a phantom scrollbar when the OS/browser is set
-	// to always show scrollbars. The frame still clips to its rounded corners.
+	// Clip the hero's sub-pixel horizontal rounding (which would otherwise surface a phantom
+	// scrollbar), but keep vertical scrolling so the action buttons stay reachable when the modal
+	// is taller than a short viewport. The frame still clips to its rounded corners.
 	.components-modal__content {
 		padding: 0;
-		overflow: visible;
+		overflow-x: hidden;
+		overflow-y: auto;
 	}
 }
 

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -126,9 +126,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Set up recovery email or phone' } )
 		).toBeVisible();
-		expect(
-			screen.getByRole( 'button', { name: 'Review two-step authentication and add backup codes' } )
-		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Download backup codes' } ) ).toBeVisible();
 	} );
 
 	test( 'shows the "download backup codes" copy when 2FA + recovery are set but backup codes are not', async () => {
@@ -143,7 +141,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		).toBeVisible();
 		expect(
 			screen.getByRole( 'button', {
-				name: 'Review two-step authentication and download backup codes',
+				name: 'Download backup codes',
 			} )
 		).toBeVisible();
 		expect(
@@ -176,6 +174,9 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		expect( screen.getByText( /r••••@example\.com/ ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Yes, all good' } ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Update recovery information' } ) ).toBeVisible();
+		// The fully-secured tier offers a plain "Dismiss" instead of a long "remind me" reminder.
+		expect( screen.getByRole( 'button', { name: 'Dismiss' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: /Remind me/ } ) ).not.toBeInTheDocument();
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_account_recovery_nudge_interstitial_impression',


### PR DESCRIPTION
Part of DOTOBRD-372

## Proposed Changes

Follow up to #111546. Refines the copy and layout of the account-recovery login interstitial, based on feedback:

- Shortens the two long backup-codes CTAs to simply **"Download backup codes"**:
  - `add-recovery-method` variant secondary CTA (was "Review two-step authentication and add backup codes").
  - `add-backup-codes` variant primary CTA (was "Review two-step authentication and download backup codes").
- For fully-secured users (the yearly check-in), relabels the tertiary button from "Remind me in 365 days" to **"Dismiss"**, since a year-out reminder reads as a permanent dismissal. All other tiers keep their "Remind me in %d days" wording.
- Removes the CSS that allowed CTA labels to wrap onto multiple lines, now that the labels are short enough to fit on one line.
- Lets the modal content scroll vertically (while still clipping the hero's horizontal overflow) so the action buttons stay reachable on short viewports.

| Before | After |
| --- | --- |
| <img width="334" height="442" alt="Screenshot 2026-06-29 at 16 07 35" src="https://github.com/user-attachments/assets/35e88da7-d586-471a-95e6-a6122ac24cc1" /> | <img width="335" height="441" alt="Screenshot 2026-06-29 at 15 59 37" src="https://github.com/user-attachments/assets/cd7df4fd-6633-41e5-80b2-4dcc7db1184a" /> |
| <img width="349" height="454" alt="Screenshot 2026-06-29 at 14 39 43" src="https://github.com/user-attachments/assets/30896aef-99d5-4951-9744-dac40c317f61" /> | <img width="342" height="448" alt="Screenshot 2026-06-29 at 14 34 46" src="https://github.com/user-attachments/assets/9cd9fca1-2d82-4691-9c77-342cc9f39ea2" /> |
| <img width="347" height="445" alt="Screenshot 2026-06-29 at 14 38 59" src="https://github.com/user-attachments/assets/7c9c7856-ca7e-4e47-8a36-78faebe51638" /> | <img width="345" height="445" alt="Screenshot 2026-06-29 at 14 46 05" src="https://github.com/user-attachments/assets/5be9d5e3-0c6e-491e-a192-925b9cab2950" /> |

## Why are these changes being made?

Feedback on the login interstitial flagged that the backup-codes CTAs were too long and that the 365-day reminder label was misleading for users who are already fully secured.

## Testing Instructions

- Run this PR locally with `yarn start-dashboard`
- Clear your user's `account-recovery-interstitial-snoozed-until` Calypso preference if needed
- In any page in the Multi-Site Dashboard, add the `?flags=dashboard/account-recovery-interstitial` query parameter to enable the account recovery interstitial
- Force different security settings and ensure they look correct
- Shrink the browser window so the modal is taller than the viewport, and confirm the modal content scrolls vertically and the tertiary button stays reachable

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
