### PR TITLE
Checkout: remove fixMe calls

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
+++ b/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
@@ -2,7 +2,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows';
 import CheckoutTermsModal from './checkout-terms-modal';
@@ -91,53 +91,28 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 			<Divider />
 
 			<LegalNotice>
-				{ i18n.fixMe( {
-					text: 'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
-					newCopy: translate(
-						'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
-						{
-							components: {
-								tos: (
-									<a
-										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-								pp: (
-									<a
-										href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-								readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
-							},
-						}
-					),
-					oldCopy: translate(
-						'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}Read more{{/readmore}}',
-						{
-							components: {
-								tos: (
-									<a
-										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-								pp: (
-									<a
-										href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-								readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
-							},
-						}
-					),
-				} ) }
+				{ translate(
+					'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+					{
+						components: {
+							tos: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							pp: (
+								<a
+									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
+						},
+					}
+				) }
 			</LegalNotice>
 
 			<CheckoutTermsModal

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -6,7 +6,7 @@ import {
 	getPlanPriceForDuration,
 } from '@automattic/plans-grid-next';
 import { styled } from '@automattic/wpcom-checkout';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
 import type { WPCOMProductVariant } from './types';
@@ -109,18 +109,10 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 
 	const priceDisplay = ( () => {
 		if ( isCheckoutUiRedesignV1 ) {
-			return i18n.fixMe( {
-				text: '%(pricePerMonth)s/mo',
-				newCopy: translate( '%(pricePerMonth)s/mo', {
-					args: {
-						pricePerMonth: pricePerMonthFormatted,
-					},
-				} ),
-				oldCopy: translate( '%(pricePerMonth)s /mo', {
-					args: {
-						pricePerMonth: pricePerMonthFormatted,
-					},
-				} ),
+			return translate( '%(pricePerMonth)s/mo', {
+				args: {
+					pricePerMonth: pricePerMonthFormatted,
+				},
 			} );
 		}
 		return translate( '%(pricePerMonth)s /mo', {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

* Cleanup the code to remove unneeded calls.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve code maintainability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Open https://translate.wordpress.com/developer?path=client/my-sites/checkout/src/components/ and confirm that all the strings are translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
