### PR TITLE
MSD Emails: Add Titan plan selection grid and email solution chooser

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -108,6 +108,11 @@ export const chooseEmailSolutionRoute = createRoute( {
 	} ),
 	getParentRoute: () => emailsRoute,
 	path: 'choose-email-solution/$domain',
+	validateSearch: ( search ): { intent?: 'upgrade' } => {
+		return {
+			intent: search.intent === 'upgrade' ? 'upgrade' : undefined,
+		};
+	},
 	beforeLoad: async ( { params: { domain: domainName } } ) => {
 		await redirectIfInvalidDomain( domainName );
 	},

--- a/client/dashboard/emails/choose-email-solution/components/google-workspace-card.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/google-workspace-card.tsx
@@ -1,0 +1,116 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { chevronDown, chevronUp } from '@wordpress/icons';
+import { useState } from 'react';
+import { Card, CardBody } from '../../../components/card';
+import { Text } from '../../../components/text';
+import GoogleLogo from '../../../images/google-logo.svg';
+import { IntervalLength } from '../../types';
+import type { Product } from '@automattic/api-core';
+
+export function GoogleWorkspaceCard( {
+	product,
+	interval,
+	available,
+	hasFreeTrial,
+	onSelect,
+}: {
+	product?: Product;
+	interval: IntervalLength;
+	available: boolean;
+	hasFreeTrial: boolean;
+	onSelect: () => void;
+} ) {
+	const [ showFeatures, setShowFeatures ] = useState( false );
+	const featuresId = useInstanceId( GoogleWorkspaceCard, 'google-workspace-features' );
+
+	// Placeholder feature list, final copy pending (DOTEMP-111).
+	const features = [
+		__( 'Send and receive from your custom domain' ),
+		__( '30 GB storage' ),
+		__( 'Email, calendar, and contacts' ),
+		__( 'Video calls, docs, spreadsheets, and more' ),
+		__( 'Real-time collaboration' ),
+		__( 'Store and share files in the cloud' ),
+		__( '24/7 support via email' ),
+	];
+
+	const name = product?.product_name ?? __( 'Google Workspace' );
+	const price = formatCurrency( product?.cost ?? 0, product?.currency_code ?? 'USD', {
+		stripZeros: true,
+	} );
+
+	return (
+		<Card>
+			<CardBody>
+				<HStack alignment="topLeft" justify="flex-start" spacing={ 4 } style={ { minWidth: 0 } }>
+					<img src={ GoogleLogo } alt="" width={ 30 } height={ 30 } />
+					<VStack spacing={ 2 } justify="flex-start" style={ { minWidth: 0, flex: 1 } }>
+						<Text as="h2" size={ 16 } weight={ 600 }>
+							{ name }
+						</Text>
+						<HStack alignment="center" justify="space-between" spacing={ 4 }>
+							<HStack
+								justify="flex-start"
+								spacing={ 1 }
+								expanded={ false }
+								style={ { minWidth: 0 } }
+							>
+								<Text>
+									{ __(
+										'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
+									) }
+								</Text>
+								<Button
+									size="small"
+									label={ showFeatures ? __( 'Hide features' ) : __( 'Show features' ) }
+									icon={ showFeatures ? chevronUp : chevronDown }
+									aria-expanded={ showFeatures }
+									aria-controls={ featuresId }
+									onClick={ () => setShowFeatures( ! showFeatures ) }
+								/>
+							</HStack>
+							<Button
+								__next40pxDefaultSize
+								className="google-workspace-card-action"
+								variant="secondary"
+								disabled={ ! available }
+								onClick={ onSelect }
+								style={ { flexShrink: 0 } }
+							>
+								{ __( 'Get Google Workspace' ) }
+							</Button>
+						</HStack>
+						{ showFeatures && (
+							<ul id={ featuresId } className="email-provider-features">
+								{ features.map( ( feature, featureIndex ) => (
+									<li key={ `feature-google-${ featureIndex }` }>{ feature }</li>
+								) ) }
+							</ul>
+						) }
+						<HStack justify="flex-start" spacing={ 1 } expanded={ false }>
+							<Text size={ 16 } weight={ 600 }>
+								{ price }
+							</Text>
+							<Text variant="muted">
+								{ interval === IntervalLength.Annually ? __( '/year' ) : __( '/month' ) }
+							</Text>
+						</HStack>
+						{ ! available && (
+							<Text variant="muted">{ __( 'Not available for this domain name.' ) }</Text>
+						) }
+						{ available && hasFreeTrial && (
+							<div className="email-provider-trial">{ __( '3 month free trial' ) }</div>
+						) }
+					</VStack>
+				</HStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -198,17 +198,24 @@ export function TitanPlanGrid( {
 						key={ `titan-plan-${ plan.tier }` }
 						spacing={ 4 }
 					>
-						<Text
-							as="h2"
-							size={ 28 }
-							lineHeight="36px"
-							className="email-provider-name email-titan-plan-name"
-						>
-							{ planName }
-						</Text>
-						<Text className="email-titan-plan-description">{ details.description }</Text>
-						<VStack spacing={ 2 } justify="flex-start">
-							<HStack alignment="bottomLeft" spacing={ 1 } expanded={ false }>
+						<VStack spacing={ 2 }>
+							<Text
+								as="h2"
+								size={ 28 }
+								lineHeight="36px"
+								className="email-provider-name email-titan-plan-name"
+							>
+								{ planName }
+							</Text>
+							<Text className="email-titan-plan-description">{ details.description }</Text>
+						</VStack>
+						<VStack spacing={ 2 } justify="flex-start" className="email-titan-plan-pricing">
+							<HStack
+								alignment="topLeft"
+								spacing={ 1 }
+								expanded={ false }
+								className="email-titan-plan-price"
+							>
 								<PriceDisplay
 									price={ plan.hasFreeTrial ? 0 : getMonthlyPrice( plan.product ) }
 									currency={ plan.product?.currency_code ?? 'USD' }

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -1,0 +1,289 @@
+import { useNavigate } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { addMailboxRoute } from '../../../app/router/emails';
+import { PriceDisplay } from '../../../components/price-display';
+import { Text } from '../../../components/text';
+import { useEmailProduct } from '../../hooks/use-email-product';
+import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
+import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
+import type { Domain, Product } from '@automattic/api-core';
+
+interface TitanPlan {
+	tier: TitanPlanTier;
+	product?: Product;
+	hasFreeTrial: boolean;
+	isPopular: boolean;
+	everythingInName?: string;
+}
+
+const getTierName = ( tier: TitanPlanTier ): string => {
+	switch ( tier ) {
+		case TitanPlanTier.Pro:
+			return __( 'Pro' );
+		case TitanPlanTier.Premium:
+			return __( 'Premium' );
+		case TitanPlanTier.Ultra:
+			return __( 'Ultra' );
+	}
+};
+
+// Placeholder descriptions and feature lists, final copy pending (DOTEMP-111).
+const getTierDetails = ( tier: TitanPlanTier ): { description: string; features: string[] } => {
+	switch ( tier ) {
+		case TitanPlanTier.Pro:
+			return {
+				description: __( 'Everything you need to get started with professional, secure email.' ),
+				features: [
+					__( '30 GB storage' ),
+					__( 'Rich email' ),
+					__( 'Native mobile apps' ),
+					__( 'Integrated calendar' ),
+					__( 'Integrated contacts' ),
+					__( 'Guaranteed email delivery' ),
+					__( 'Advanced anti-spam' ),
+					__( 'Advanced anti-virus' ),
+				],
+			};
+		case TitanPlanTier.Premium:
+			return {
+				description: __(
+					'Smarter tools to help your growing business stay organized and productive.'
+				),
+				features: [
+					__( '50 GB storage' ),
+					__( 'Unlimited read receipts' ),
+					__( 'Unlimited email templates' ),
+					__( 'Unlimited contact groups' ),
+					__( 'Follow up reminders' ),
+					__( 'Send later' ),
+					__( 'Grammar & spell check' ),
+					__( 'Priority inbox' ),
+				],
+			};
+		case TitanPlanTier.Ultra:
+			return {
+				description: __( 'AI-powered email to scale your business and boost marketing impact.' ),
+				features: [
+					__( '100 GB storage' ),
+					__( 'AI email writer' ),
+					__( 'Appointment booking' ),
+					__( 'Email campaigns' ),
+					__( 'Attachment and link tracking' ),
+					__( 'Email designer' ),
+					__( 'Signature designer' ),
+				],
+			};
+	}
+};
+
+// Tiers ordered from lowest to highest, used to hide tiers below the current one
+// when upgrading.
+const TIER_ORDER: TitanPlanTier[] = [
+	TitanPlanTier.Pro,
+	TitanPlanTier.Premium,
+	TitanPlanTier.Ultra,
+];
+
+export function TitanPlanGrid( {
+	domain,
+	domainName,
+	interval,
+	available,
+	hasProFreeTrial,
+	proTrialMonths,
+	currentTier,
+}: {
+	domain?: Domain;
+	domainName: string;
+	interval: IntervalLength;
+	available: boolean;
+	hasProFreeTrial: boolean;
+	proTrialMonths: number;
+	// The tier the user is currently subscribed to. When set, the grid is in
+	// upgrade mode: lower tiers are hidden, the current tier is labeled, and higher
+	// tiers offer an upgrade.
+	currentTier?: TitanPlanTier;
+} ) {
+	const navigate = useNavigate();
+
+	const { product: proProduct } = useEmailProduct(
+		MailboxProvider.Titan,
+		interval,
+		domain,
+		TitanPlanTier.Pro
+	);
+	const { product: premiumProduct } = useEmailProduct(
+		MailboxProvider.Titan,
+		interval,
+		domain,
+		TitanPlanTier.Premium
+	);
+	const { product: ultraProduct } = useEmailProduct(
+		MailboxProvider.Titan,
+		interval,
+		domain,
+		TitanPlanTier.Ultra
+	);
+
+	const plans: TitanPlan[] = [
+		{
+			tier: TitanPlanTier.Pro,
+			product: proProduct,
+			hasFreeTrial: hasProFreeTrial,
+			isPopular: false,
+		},
+		{
+			tier: TitanPlanTier.Premium,
+			product: premiumProduct,
+			hasFreeTrial: false,
+			isPopular: true,
+			everythingInName: getTierName( TitanPlanTier.Pro ),
+		},
+		{
+			tier: TitanPlanTier.Ultra,
+			product: ultraProduct,
+			hasFreeTrial: false,
+			isPopular: false,
+			everythingInName: getTierName( TitanPlanTier.Premium ),
+		},
+	];
+
+	// When upgrading, only offer the current plan (labeled below) and higher tiers,
+	// since this flow cannot downgrade.
+	const visiblePlans = currentTier
+		? plans.filter(
+				( plan ) => TIER_ORDER.indexOf( plan.tier ) >= TIER_ORDER.indexOf( currentTier )
+		  )
+		: plans;
+
+	const getMonthlyPrice = ( product?: Product ) => {
+		if ( ! product?.cost ) {
+			return 0;
+		}
+
+		const baseCost = product.sale_cost ?? product.cost;
+		return interval === IntervalLength.Annually ? baseCost / 12 : baseCost;
+	};
+
+	return (
+		<div className="email-providers">
+			{ visiblePlans.map( ( plan ) => {
+				const planName = getTierName( plan.tier );
+				const details = getTierDetails( plan.tier );
+				const isCurrentPlan = plan.tier === currentTier;
+
+				let actionLabel;
+				if ( isCurrentPlan ) {
+					actionLabel = __( 'Current plan' );
+				} else if ( currentTier ) {
+					actionLabel = __( 'Upgrade' );
+				} else if ( plan.hasFreeTrial ) {
+					actionLabel = __( 'Start trial' );
+				} else {
+					actionLabel = sprintf(
+						/* translators: %s is the email plan name. */
+						__( 'Get %s' ),
+						planName
+					);
+				}
+
+				return (
+					<VStack
+						className="email-provider email-titan-plan"
+						key={ `titan-plan-${ plan.tier }` }
+						spacing={ 4 }
+					>
+						<Text
+							as="h2"
+							size={ 28 }
+							lineHeight="36px"
+							className="email-provider-name email-titan-plan-name"
+						>
+							{ planName }
+						</Text>
+						<Text className="email-titan-plan-description">{ details.description }</Text>
+						<VStack spacing={ 2 } justify="flex-start">
+							<HStack alignment="bottomLeft" spacing={ 1 } expanded={ false }>
+								<PriceDisplay
+									price={ plan.hasFreeTrial ? 0 : getMonthlyPrice( plan.product ) }
+									currency={ plan.product?.currency_code ?? 'USD' }
+								/>
+								{ plan.hasFreeTrial && (
+									<PriceDisplay
+										price={ getMonthlyPrice( plan.product ) }
+										currency={ plan.product?.currency_code ?? 'USD' }
+										discounted
+									/>
+								) }
+								<Text variant="muted" size={ 16 } lineHeight="24px">
+									{ __( '/month' ) }
+								</Text>
+							</HStack>
+							<Text variant="muted">
+								{ interval === IntervalLength.Annually
+									? __( 'per month, per mailbox, billed every 12 months.' )
+									: __( 'per month, per mailbox, billed monthly.' ) }
+							</Text>
+							{ plan.hasFreeTrial && (
+								<div className="email-provider-trial">
+									{ sprintf(
+										/* translators: %d is the number of free trial months. */
+										__( '%d month free trial' ),
+										proTrialMonths
+									) }
+								</div>
+							) }
+							{ ! available && (
+								<Text variant="muted">{ __( 'Not available for this domain name.' ) }</Text>
+							) }
+						</VStack>
+						<Button
+							__next40pxDefaultSize
+							className="email-provider-action"
+							variant={ plan.isPopular ? 'primary' : 'secondary' }
+							disabled={ ! available || isCurrentPlan }
+							onClick={ () =>
+								navigate( {
+									to: addMailboxRoute.to,
+									params: {
+										domain: domainName,
+										provider: MailboxProvider.Titan,
+										interval,
+									},
+									search: { tier: plan.tier },
+								} )
+							}
+						>
+							{ actionLabel }
+						</Button>
+						<VStack spacing={ 1 }>
+							<Text weight={ 600 } className="email-titan-plan-everything-in">
+								{ plan.everythingInName &&
+									sprintf(
+										/* translators: %s is the name of the previous, cheaper email plan. */
+										__( 'Everything in %s' ),
+										plan.everythingInName
+									) }
+							</Text>
+							<ul className="email-provider-features">
+								{ details.features.map( ( feature, featureIndex ) => (
+									<li key={ `feature-${ plan.tier }-${ featureIndex }` }>{ feature }</li>
+								) ) }
+							</ul>
+						</VStack>
+						<img
+							className="email-provider-powered-by"
+							src={ poweredByTitanLogo }
+							alt={ __( 'Powered by Titan' ) }
+						/>
+					</VStack>
+				);
+			} ) }
+		</div>
+	);
+}

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -1,4 +1,5 @@
 import { EmailSubscription, Product } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
@@ -13,7 +14,7 @@ import { wordpress } from '@wordpress/icons';
 import { useEffect, useState } from 'react';
 import { useAuth } from '../../app/auth';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { addMailboxRoute } from '../../app/router/emails';
+import { addMailboxRoute, chooseEmailSolutionRoute } from '../../app/router/emails';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { PriceDisplay } from '../../components/price-display';
@@ -35,6 +36,8 @@ import { isEligibleForIntroductoryOffer } from '../utils/is-eligible-for-introdu
 import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
 import { getTitanTierFromSlug } from '../utils/titan-tiers';
 import { ExistingForwardsNotice } from './components/existing-forwards-notice';
+import { GoogleWorkspaceCard } from './components/google-workspace-card';
+import { TitanPlanGrid } from './components/titan-plan-grid';
 
 import './style.scss';
 
@@ -43,9 +46,26 @@ const getTrialMonths = ( product?: Product ) =>
 
 export default function ChooseEmailSolution() {
 	const { domain, domainName } = useDomainFromUrlParam();
+	const { user } = useAuth();
 
+	const isTitanPlanSelectionEnabled = config.isEnabled( 'emails/titan-tiers' );
+
+	const googleEmailSubscription = domain.google_apps_subscription as EmailSubscription;
+	const titanEmailSubscription = domain.titan_mail_subscription as EmailSubscription;
+
+	// When arriving with the "upgrade" intent (from the email plan purchase page),
+	// keep existing Professional Email subscribers on the plan grid so they can pick
+	// a higher tier instead of being redirected to the add-mailbox flow. Upgrade only
+	// applies to Professional Email (Titan); Google Workspace has no tiers to upgrade.
+	const { intent } = chooseEmailSolutionRoute.useSearch();
+	const isUpgradeIntent = intent === 'upgrade' && hasTitanMailWithUs( domain );
+
+	// An upgrade keeps the existing subscription's billing cycle, so lock the
+	// interval to it (the billing-interval toggle is hidden during an upgrade).
 	const [ billingInterval, setBillingInterval ] = useState< IntervalLength >(
-		IntervalLength.Annually
+		isUpgradeIntent && isMonthlyEmailProduct( titanEmailSubscription )
+			? IntervalLength.Monthly
+			: IntervalLength.Annually
 	);
 
 	const { bestAnnualSavings } = useAnnualSavings( domain );
@@ -63,9 +83,6 @@ export default function ChooseEmailSolution() {
 
 	const canAddEmail = domain.current_user_can_add_email;
 
-	const googleEmailSubscription = domain.google_apps_subscription as EmailSubscription;
-	const titanEmailSubscription = domain.titan_mail_subscription as EmailSubscription;
-
 	const hasGoogleFreeTrial = isEligibleForIntroductoryOffer( {
 		emailSubscription: googleEmailSubscription,
 		product: googleProduct,
@@ -78,7 +95,6 @@ export default function ChooseEmailSolution() {
 
 	const isTitanAvailable = canAddEmail && ! hasGSuiteWithUs( domain );
 
-	const { user } = useAuth();
 	const isGoogleAvailable =
 		canAddEmail &&
 		( user.is_valid_google_apps_country ?? false ) &&
@@ -87,7 +103,7 @@ export default function ChooseEmailSolution() {
 
 	const navigate = useNavigate();
 	let redirectTo = null;
-	if ( hasTitanMailWithUs( domain ) && isTitanAvailable ) {
+	if ( ! isUpgradeIntent && hasTitanMailWithUs( domain ) && isTitanAvailable ) {
 		const subscriptionTier = getTitanTierFromSlug( titanEmailSubscription?.product_slug );
 		redirectTo = {
 			to: addMailboxRoute.to,
@@ -176,128 +192,194 @@ export default function ChooseEmailSolution() {
 		},
 	};
 
+	const pageHeader = (
+		<PageHeader
+			prefix={ <Breadcrumbs length={ 2 } /> }
+			description={
+				isUpgradeIntent
+					? __( 'Choose a Professional Email plan that fits your needs.' )
+					: __( 'Choose between Professional Email and Google Workspace for your domain.' )
+			}
+		/>
+	);
+
+	const pageNotices = (
+		<>
+			{ ! canAddEmail && <EmailNonDomainOwnerNotice domain={ domain } /> }
+			{ hasEmailForwards( domain ) && <ExistingForwardsNotice /> }
+		</>
+	);
+
+	const intervalSelector = (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			isBlock
+			label={ __( 'Billing interval' ) }
+			hideLabelFromVision
+			value={ billingInterval }
+			onChange={ ( newBillingInterval ) =>
+				setBillingInterval( newBillingInterval as IntervalLength )
+			}
+		>
+			<ToggleGroupControlOption label={ __( 'Monthly' ) } value={ IntervalLength.Monthly } />
+			<ToggleGroupControlOption
+				/* translators: %d is the annual savings percentage. */
+				label={ sprintf( __( 'Annually (save up to %d%%)' ), bestAnnualSavings ) }
+				value={ IntervalLength.Annually }
+			/>
+		</ToggleGroupControl>
+	);
+
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					description={ __(
-						'Choose between Professional Email and Google Workspace for your domain.'
-					) }
-				/>
+				// Same narrow-header/wide-content pattern as client/dashboard/sites/site-plans.
+				isTitanPlanSelectionEnabled ? (
+					<div className="choose-email-solution-narrow">{ pageHeader }</div>
+				) : (
+					pageHeader
+				)
 			}
-			size="small"
+			size={ isTitanPlanSelectionEnabled ? 'large' : 'small' }
 			notices={
-				<>
-					{ ! canAddEmail && <EmailNonDomainOwnerNotice domain={ domain } /> }
-					{ hasEmailForwards( domain ) && <ExistingForwardsNotice /> }
-				</>
+				isTitanPlanSelectionEnabled ? (
+					<div className="choose-email-solution-narrow">{ pageNotices }</div>
+				) : (
+					pageNotices
+				)
 			}
 		>
 			{ /* Billing interval selector */ }
-			<ToggleGroupControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				isBlock
-				label={ __( 'Billing interval' ) }
-				hideLabelFromVision
-				value={ billingInterval }
-				onChange={ ( newBillingInterval ) =>
-					setBillingInterval( newBillingInterval as IntervalLength )
-				}
-			>
-				<ToggleGroupControlOption label={ __( 'Monthly' ) } value={ IntervalLength.Monthly } />
-				<ToggleGroupControlOption
-					/* translators: %d is the annual savings percentage. */
-					label={ sprintf( __( 'Annually (save up to %d%%)' ), bestAnnualSavings ) }
-					value={ IntervalLength.Annually }
-				/>
-			</ToggleGroupControl>
+			{ ! isUpgradeIntent &&
+				( isTitanPlanSelectionEnabled ? (
+					<div className="choose-email-solution-narrow">{ intervalSelector }</div>
+				) : (
+					intervalSelector
+				) ) }
 
-			{ /* Split card for providers */ }
-			<div className="email-providers">
-				{ Object.entries( providers ).map( ( [ providerId, provider ] ) => (
-					<VStack className="email-provider" key={ `provider-${ providerId }` } spacing={ 4 }>
-						<Icon icon={ provider.logo } size={ 30 } className="email-provider-logo" />
-						<Text as="h2" size={ 28 } lineHeight="40px" className="email-provider-name">
-							{ provider.name }
-						</Text>
-						<Text>{ provider.description }</Text>
-						<VStack
-							spacing={ 2 }
-							justify="flex-start"
-							style={ { minHeight: hasFreeTrial ? '96px' : '76px' } }
-						>
-							{ provider.available ? (
-								<>
-									<HStack alignment="bottomLeft">
-										<PriceDisplay
-											price={ provider.hasFreeTrial ? 0 : provider.product?.cost ?? 0 }
-											currency={ provider.product?.currency_code ?? 'USD' }
-										/>
-										{ provider.hasFreeTrial && (
-											<PriceDisplay
-												price={ provider.product?.cost ?? 0 }
-												currency={ provider.product?.currency_code ?? 'USD' }
-												discounted
-											/>
-										) }
-									</HStack>
-									<Text variant="muted">
-										{ billingInterval === 'annually'
-											? __( 'per year, per mailbox, excl. taxes.' )
-											: __( 'per month, per mailbox, excl. taxes.' ) }
-									</Text>
-									{ provider.hasFreeTrial && (
-										<div className="email-provider-trial">
-											{ provider.trialMonths === 12
-												? sprintf(
-														/* translators: %d is the number of free trial months. */
-														__( '%d month free trial' ),
-														provider.trialMonths
-												  )
-												: __( '3 month free trial' ) }
-										</div>
-									) }
-								</>
-							) : (
-								<Text size={ 20 } weight={ 500 }>
-									{ __( 'Not available for this domain name' ) }
-								</Text>
-							) }
-						</VStack>
-						<Button
-							className="email-provider-action"
-							variant="primary"
-							disabled={ ! provider.available }
-							onClick={ () =>
+			{ isTitanPlanSelectionEnabled && (
+				<VStack className="choose-email-solution-wide" spacing={ 6 }>
+					<TitanPlanGrid
+						domain={ domain }
+						domainName={ domainName }
+						interval={ billingInterval }
+						available={ isTitanAvailable }
+						hasProFreeTrial={ hasTitanFreeTrial }
+						proTrialMonths={ getTrialMonths( titanProduct ) }
+						currentTier={
+							isUpgradeIntent
+								? getTitanTierFromSlug( titanEmailSubscription?.product_slug )
+								: undefined
+						}
+					/>
+					{ ! isUpgradeIntent && (
+						<GoogleWorkspaceCard
+							product={ googleProduct }
+							interval={ billingInterval }
+							available={ isGoogleAvailable }
+							hasFreeTrial={ hasGoogleFreeTrial }
+							onSelect={ () =>
 								navigate( {
 									to: addMailboxRoute.to,
 									params: {
-										domainName: domainName,
-										provider: providerId,
+										domain: domainName,
+										provider: MailboxProvider.Google,
 										interval: billingInterval,
 									},
 								} )
 							}
-						>
-							{ provider.action }
-						</Button>
-						<ul className="email-provider-features">
-							{ provider.features.map( ( feature, featureIndex ) => (
-								<li key={ `feature-${ providerId }-${ featureIndex }` }>{ feature }</li>
-							) ) }
-						</ul>
-						{ provider.poweredBy && (
-							<img
-								className="email-provider-powered-by"
-								src={ provider.poweredBy.logo }
-								alt={ provider.poweredBy.text }
-							/>
-						) }
-					</VStack>
-				) ) }
-			</div>
+						/>
+					) }
+				</VStack>
+			) }
+
+			{ /* Split card for providers */ }
+			{ ! isTitanPlanSelectionEnabled && (
+				<div className="email-providers">
+					{ Object.entries( providers ).map( ( [ providerId, provider ] ) => (
+						<VStack className="email-provider" key={ `provider-${ providerId }` } spacing={ 4 }>
+							<Icon icon={ provider.logo } size={ 30 } className="email-provider-logo" />
+							<Text as="h2" size={ 28 } lineHeight="40px" className="email-provider-name">
+								{ provider.name }
+							</Text>
+							<Text>{ provider.description }</Text>
+							<VStack
+								spacing={ 2 }
+								justify="flex-start"
+								style={ { minHeight: hasFreeTrial ? '96px' : '76px' } }
+							>
+								{ provider.available ? (
+									<>
+										<HStack alignment="bottomLeft">
+											<PriceDisplay
+												price={ provider.hasFreeTrial ? 0 : provider.product?.cost ?? 0 }
+												currency={ provider.product?.currency_code ?? 'USD' }
+											/>
+											{ provider.hasFreeTrial && (
+												<PriceDisplay
+													price={ provider.product?.cost ?? 0 }
+													currency={ provider.product?.currency_code ?? 'USD' }
+													discounted
+												/>
+											) }
+										</HStack>
+										<Text variant="muted">
+											{ billingInterval === 'annually'
+												? __( 'per year, per mailbox, excl. taxes.' )
+												: __( 'per month, per mailbox, excl. taxes.' ) }
+										</Text>
+										{ provider.hasFreeTrial && (
+											<div className="email-provider-trial">
+												{ provider.trialMonths === 12
+													? sprintf(
+															/* translators: %d is the number of free trial months. */
+															__( '%d month free trial' ),
+															provider.trialMonths
+													  )
+													: __( '3 month free trial' ) }
+											</div>
+										) }
+									</>
+								) : (
+									<Text size={ 20 } weight={ 500 }>
+										{ __( 'Not available for this domain name' ) }
+									</Text>
+								) }
+							</VStack>
+							<Button
+								className="email-provider-action"
+								variant="primary"
+								disabled={ ! provider.available }
+								onClick={ () =>
+									navigate( {
+										to: addMailboxRoute.to,
+										params: {
+											domainName: domainName,
+											provider: providerId,
+											interval: billingInterval,
+										},
+									} )
+								}
+							>
+								{ provider.action }
+							</Button>
+							<ul className="email-provider-features">
+								{ provider.features.map( ( feature, featureIndex ) => (
+									<li key={ `feature-${ providerId }-${ featureIndex }` }>{ feature }</li>
+								) ) }
+							</ul>
+							{ provider.poweredBy && (
+								<img
+									className="email-provider-powered-by"
+									src={ provider.poweredBy.logo }
+									alt={ provider.poweredBy.text }
+								/>
+							) }
+						</VStack>
+					) ) }
+				</div>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -123,7 +123,7 @@ export default function ChooseEmailSolution() {
 		redirectTo = {
 			to: addMailboxRoute.to,
 			params: {
-				domainName: domainName,
+				domain: domainName,
 				provider: MailboxProvider.Google,
 				interval: isMonthlyEmailProduct( googleEmailSubscription )
 					? IntervalLength.Monthly
@@ -355,7 +355,7 @@ export default function ChooseEmailSolution() {
 									navigate( {
 										to: addMailboxRoute.to,
 										params: {
-											domainName: domainName,
+											domain: domainName,
 											provider: providerId,
 											interval: billingInterval,
 										},

--- a/client/dashboard/emails/choose-email-solution/style.scss
+++ b/client/dashboard/emails/choose-email-solution/style.scss
@@ -73,6 +73,17 @@
 	min-height: 3rem;
 }
 
+// The card stacks its sections with a 1rem (spacing={ 4 }) gap; the pricing block
+// adds another 1rem so it sits 2rem below the title and description.
+.email-titan-plan-pricing {
+	margin-block-start: 1rem;
+}
+
+// Match the price to the plan header typeface.
+.email-titan-plan-price {
+	font-family: Recoleta, sans-serif;
+}
+
 .email-provider-features {
 	padding: 0;
 	margin: 0;

--- a/client/dashboard/emails/choose-email-solution/style.scss
+++ b/client/dashboard/emails/choose-email-solution/style.scss
@@ -19,7 +19,7 @@
 	padding: 20px;
 	justify-content: flex-start;
 
-	&:not(:first-child) {
+	&:not( :first-child ) {
 		border-top: 1px solid var( --dashboard-surface__border-color, #{$gray-200} );
 
 		@include break-small {
@@ -52,12 +52,48 @@
 	justify-content: center;
 }
 
+.choose-email-solution-narrow {
+	width: 100%;
+	max-width: 660px;
+	margin-inline: auto;
+}
+
+.choose-email-solution-wide {
+	width: 100%;
+	max-width: 1032px;
+	margin-inline: auto;
+}
+
+.email-titan-plan {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+.email-titan-plan-description {
+	min-height: 3rem;
+}
+
 .email-provider-features {
 	padding: 0;
+	margin: 0;
 	line-height: 28px;
 	list-style: none;
 }
 
+// Reserve the row so lists stay aligned when the first tier omits the title.
+.email-titan-plan-everything-in {
+	min-height: 1.5rem;
+}
+
 .email-provider-powered-by {
 	width: 145px;
+}
+
+// Negative margin so the CTA overlaps its row instead of inflating it.
+.google-workspace-card-action {
+	margin-block: -10px;
+}
+
+.email-titan-plan .email-provider-powered-by {
+	margin-block-start: auto;
 }


### PR DESCRIPTION
Closes DOTEMP-111

## Proposed Changes

<img width="738" height="666" alt="Captura de Tela 2026-06-30 às 10 08 19" src="https://github.com/user-attachments/assets/cd747557-e13b-4eb9-82b3-723bcf52bbca" />

* Add a three-tier Titan plan selection grid (Pro, Premium, Ultra) and a Google Workspace card to the Dashboard email solution chooser, behind the `emails/titan-tiers` feature flag.
* Support an `?intent=upgrade` search param on the chooser route so existing Titan subscribers land in upgrade mode: lower tiers are hidden and higher tiers offer an upgrade.
* Prices show a monthly-equivalent figure (sale-aware), all plan copy is localized, and columns align across tiers.

## Why are these changes being made?

* The MSD email flow previously offered only a single Titan tier. This adds the tier selection UI users need to choose between Pro, Premium, and Ultra, and the upgrade-mode entry point consumed by the manage-purchase page (DOTEMP-112). Feature and description copy is placeholder pending final copy.

## Testing Instructions

* Enable the `emails/titan-tiers` feature flag.
* Open the email solution chooser for a domain: `/emails/choose-email-solution/<domain>`. Confirm the Titan grid (Pro / Premium / Ultra) and the Google Workspace card render.
* Append `?intent=upgrade` and confirm lower tiers are hidden and higher tiers show an "Upgrade" action.
* Verify the monthly price, the `/month` suffix, and that the price/feature rows align across the three columns.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
