### PR TITLE
Themes dark mode: fix flaky Theme detail E2E test and provider remount

### DIFF
--- a/client/lib/color-scheme/classic-provider.tsx
+++ b/client/lib/color-scheme/classic-provider.tsx
@@ -10,7 +10,13 @@ import {
 import type { ColorSchemeContextType } from './shared';
 import type { ReactNode } from 'react';
 
-export function ClassicColorSchemeProvider( { children }: { children: ReactNode } ) {
+export function ClassicColorSchemeProvider( {
+	children,
+	enabled = true,
+}: {
+	children: ReactNode;
+	enabled?: boolean;
+} ) {
 	const isReady = useSelector( hasReceivedRemotePreferences );
 	const savedColorScheme = useSelector( ( state ) => getPreference( state, PREFERENCE_KEY ) );
 	const colorScheme = isColorScheme( savedColorScheme ) ? savedColorScheme : DEFAULT_SCHEME;
@@ -23,6 +29,7 @@ export function ClassicColorSchemeProvider( { children }: { children: ReactNode 
 	return (
 		<ColorSchemeContextProvider
 			colorScheme={ colorScheme }
+			enabled={ enabled }
 			isReady={ isReady }
 			restoreOnUnmount
 			setColorScheme={ setColorScheme }

--- a/client/lib/color-scheme/query-provider.tsx
+++ b/client/lib/color-scheme/query-provider.tsx
@@ -10,8 +10,17 @@ import {
 import type { ColorScheme } from './shared';
 import type { ReactNode } from 'react';
 
-export function ColorSchemeProvider( { children }: { children: ReactNode } ) {
-	const { data: savedColorScheme, isError } = useQuery( userPreferenceQuery( PREFERENCE_KEY ) );
+export function ColorSchemeProvider( {
+	children,
+	enabled = true,
+}: {
+	children: ReactNode;
+	enabled?: boolean;
+} ) {
+	const { data: savedColorScheme, isError } = useQuery( {
+		...userPreferenceQuery( PREFERENCE_KEY ),
+		enabled,
+	} );
 	const { mutate: saveColorScheme, isPending } = useMutation(
 		userPreferenceOptimisticMutation( PREFERENCE_KEY )
 	);
@@ -34,6 +43,7 @@ export function ColorSchemeProvider( { children }: { children: ReactNode } ) {
 	return (
 		<ColorSchemeContextProvider
 			colorScheme={ colorScheme }
+			enabled={ enabled }
 			isReady={ isReady }
 			setColorScheme={ setColorScheme }
 			waitForReady

--- a/client/lib/color-scheme/shared.tsx
+++ b/client/lib/color-scheme/shared.tsx
@@ -19,33 +19,47 @@ const ColorSchemeContext = createContext< ColorSchemeContextType | undefined >( 
 
 function useDocumentColorScheme(
 	colorScheme: ColorScheme,
-	isReady: boolean,
+	active: boolean,
 	restoreOnUnmount: boolean
 ) {
 	const hasAppliedTheme = useRef( false );
 	const previousTheme = useRef< string | undefined >( undefined );
+
+	const restorePreviousTheme = () => {
+		if ( ! hasAppliedTheme.current ) {
+			return;
+		}
+
+		if ( previousTheme.current === undefined ) {
+			delete document.documentElement.dataset.theme;
+		} else {
+			document.documentElement.dataset.theme = previousTheme.current;
+		}
+
+		hasAppliedTheme.current = false;
+	};
 
 	useEffect( () => {
 		if ( ! restoreOnUnmount || typeof document === 'undefined' ) {
 			return;
 		}
 
-		return () => {
-			if ( ! hasAppliedTheme.current ) {
-				return;
-			}
-
-			if ( previousTheme.current === undefined ) {
-				delete document.documentElement.dataset.theme;
-				return;
-			}
-
-			document.documentElement.dataset.theme = previousTheme.current;
-		};
+		return restorePreviousTheme;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ restoreOnUnmount ] );
 
 	useEffect( () => {
-		if ( ! isReady || typeof document === 'undefined' ) {
+		if ( typeof document === 'undefined' ) {
+			return;
+		}
+
+		// When the scheme is turned off without unmounting (e.g. navigating
+		// away from a route that opts into it), put the previous theme back so
+		// the rest of the app isn't left on the applied scheme.
+		if ( ! active ) {
+			if ( restoreOnUnmount ) {
+				restorePreviousTheme();
+			}
 			return;
 		}
 
@@ -55,12 +69,14 @@ function useDocumentColorScheme(
 		}
 
 		document.documentElement.dataset.theme = colorScheme;
-	}, [ colorScheme, isReady, restoreOnUnmount ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ colorScheme, active, restoreOnUnmount ] );
 }
 
 export function ColorSchemeContextProvider( {
 	children,
 	colorScheme,
+	enabled = true,
 	isReady,
 	restoreOnUnmount = false,
 	setColorScheme,
@@ -68,14 +84,18 @@ export function ColorSchemeContextProvider( {
 }: {
 	children: ReactNode;
 	colorScheme: ColorScheme;
+	enabled?: boolean;
 	isReady: boolean;
 	restoreOnUnmount?: boolean;
 	setColorScheme: ColorSchemeContextType[ 'setColorScheme' ];
 	waitForReady: boolean;
 } ) {
-	useDocumentColorScheme( colorScheme, isReady, restoreOnUnmount );
+	useDocumentColorScheme( colorScheme, enabled && isReady, restoreOnUnmount );
 
-	if ( waitForReady && ! isReady ) {
+	// Keep children mounted when the scheme is disabled so toggling `enabled`
+	// (e.g. once remote preferences load) doesn't unmount and remount the
+	// wrapped subtree. The document side effects above are gated on `enabled`.
+	if ( enabled && waitForReady && ! isReady ) {
 		return null;
 	}
 

--- a/client/lib/color-scheme/with-color-scheme.tsx
+++ b/client/lib/color-scheme/with-color-scheme.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { ColorSchemeProvider } from './query-provider';
 import type { ComponentType, ReactNode } from 'react';
 
-type ColorSchemeProviderComponent = ComponentType< { children: ReactNode } >;
+type ColorSchemeProviderComponent = ComponentType< { children: ReactNode; enabled?: boolean } >;
 
 function BodyClass( { className }: { className: string } ) {
 	useEffect( () => {
@@ -32,13 +32,13 @@ export function withColorScheme(
 		Provider?: ColorSchemeProviderComponent;
 	} = {}
 ) {
-	if ( ! enabled ) {
-		return children;
-	}
-
+	// Always render the provider so toggling `enabled` (for example once remote
+	// preferences load) doesn't re-parent and remount `children`. The provider
+	// gates its document side effects on `enabled`, and the body class is only
+	// mounted while enabled.
 	return (
-		<Provider>
-			{ bodyClass && <BodyClass className={ bodyClass } /> }
+		<Provider enabled={ enabled }>
+			{ enabled && bodyClass && <BodyClass className={ bodyClass } /> }
 			{ children }
 		</Provider>
 	);

--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -168,6 +168,20 @@ async function expectDarkModeRoot(
 	}
 }
 
+// The themes dark-mode body class is applied only after remote preferences
+// (dark scheme + dashboard opt-in) load and re-render the page. On a cold
+// `visitTheme` navigation that can take longer than the default expect
+// timeout, so wait on the gated class explicitly before asserting downstream
+// surfaces, matching the readiness waits used elsewhere in this suite.
+async function waitForThemesDarkModeReady( page: Page ) {
+	await expect( page.locator( 'html' ) ).toHaveAttribute( 'data-theme', 'dark', {
+		timeout: 30_000,
+	} );
+	await expect( page.locator( 'body' ) ).toHaveClass( /(^|\s)is-themes-dark-mode(\s|$)/, {
+		timeout: 30_000,
+	} );
+}
+
 async function resolveCssColorToken( page: Page, tokenName: TokenName ) {
 	return await page.evaluate( ( token ) => {
 		const probe = document.createElement( 'span' );
@@ -557,7 +571,8 @@ test.describe( 'Themes dark-mode surfaces', { tag: [ tags.CALYPSO_PR ] }, () => 
 
 		await test.step( 'Then the Primarium detail route renders download and support cards in dark mode', async () => {
 			await pageThemeDetails.visitTheme( 'primarium' );
-			await page.locator( '.theme-download-card' ).waitFor();
+			await waitForThemesDarkModeReady( page );
+			await page.locator( '.theme-download-card' ).waitFor( { timeout: 30_000 } );
 			await expectDarkModeRoot( page, {
 				bodyClasses: [ 'is-themes-dark-mode' ],
 				expectColorSchemeBodyClass: true,
@@ -582,7 +597,8 @@ test.describe( 'Themes dark-mode surfaces', { tag: [ tags.CALYPSO_PR ] }, () => 
 
 		await test.step( 'And the Lente detail route keeps premium badge colors dark-compatible', async () => {
 			await pageThemeDetails.visitTheme( 'lente' );
-			await page.locator( '.premium-badge' ).first().waitFor();
+			await waitForThemesDarkModeReady( page );
+			await page.locator( '.premium-badge' ).first().waitFor( { timeout: 30_000 } );
 			await expectDarkModeRoot( page, {
 				bodyClasses: [ 'is-themes-dark-mode' ],
 				expectColorSchemeBodyClass: true,


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/wp-calypso/pull/112095
Task-related: DOTCOM-17552

## Proposed Changes

Fix the intermittently-failing `dark-mode-surfaces.spec.ts › Themes dark-mode surfaces › applies shared dark-mode tokens on Theme detail pages` E2E test, plus the underlying churn that makes it fragile. Two commits:

1. **Keep the color-scheme provider mounted when toggling `enabled`.** `withColorScheme` returned bare `children` when disabled and a provider-wrapped tree when enabled. On a cold Themes detail load, `isThemesColorSchemeEnabled` starts `false` (it requires the dashboard opt-in, which arrives with remote preferences) and flips `true` once preferences load — re-parenting and **remounting** the wrapped Theme sheet subtree, restarting its data fetches at the worst moment. Now the provider is always rendered and an `enabled` flag is threaded through it; the `data-theme` side effect and the body class are gated on `enabled`, and `useDocumentColorScheme` restores the previous theme when `enabled` flips off *without* an unmount — preserving the existing restore-on-leave behavior (e.g. navigating away from Reader).

2. **De-flake the test.** The Theme detail steps asserted dark-mode surfaces immediately after a cold `visitTheme` navigation, racing the remote-preferences round-trip against the default 10s expect timeout. They now wait explicitly for the preference-gated dark state (`data-theme=dark` + `is-themes-dark-mode`) with the same 30s budget the other steps in this suite already use, before asserting downstream surfaces.

## Why are these changes being made?

The test waits only on theme *content* elements but separately asserts preference-gated dark-mode body state, so it races the full app cold-boot + `/me/preferences` fetch. The provider remount on the `enabled` flip amplifies the race. Both the missing readiness wait and the remount are addressed here. (The flake surfaces most often on the React 19 upgrade branch, where cold-boot timing shifts, but the race exists on trunk too — these fixes are independent of that upgrade.)

## Testing Instructions

Enable the Dark Mode at http://my.wordpress.com/me/preferences/appearance?flags=dark-mode

And make sure all MSD internal pages work, and the /themes page renders as expected:

<img width="1619" height="969" alt="image" src="https://github.com/user-attachments/assets/590a6cfd-4084-48d9-ac20-2b5f0c4beeca" />



* Run the affected suite (requires a local Calypso instance): `yarn playwright test specs/color-scheme/dark-mode-surfaces.spec.ts --reporter=list`
* Verify dark mode still applies on the Dashboard, Reader, and Themes routes, and that navigating **away** from Reader/Themes correctly drops `data-theme` (the restore-on-leave path exercised by commit 1).



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
