### PR TITLE
Legacy contact: add translation calls to untranslated strings

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -37,15 +37,13 @@ export default function SecurityLegacyContact() {
 						{ contact ? (
 							<>
 								<Text>
-									{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
-									{ createInterpolateElement( 'Your legacy contact is <contactEmail />.', {
+									{ createInterpolateElement( __( 'Your legacy contact is <contactEmail />.' ), {
 										contactEmail: <strong>{ contact.contact_email }</strong>,
 									} ) }
 								</Text>
 								<ButtonStack justify="flex-start">
 									<RouterLinkButton variant="secondary" to="/me/security/legacy-contact/print">
-										{ /* TODO: translate this string once the legacy contact UI is finalized. */ }
-										View printable details
+										{ __( 'View printable details' ) }
 									</RouterLinkButton>
 									<Button
 										variant="secondary"

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -69,7 +69,7 @@ export default function SecurityLegacyContactPrint() {
 						<LegacyContactDetails legacyContactId={ contact.legacy_contact_id } />
 					) : (
 						<VStack spacing={ 4 } alignment="flex-start">
-							<Text>{ __( "You don't have a legacy contact set up yet." ) }</Text>
+							<Text>{ __( 'You don’t have a legacy contact set up yet.' ) }</Text>
 							<ButtonStack justify="flex-start">
 								<RouterLinkButton variant="primary" to="/me/security/legacy-contact">
 									{ __( 'Back to legacy contact' ) }

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -24,28 +24,29 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 		<VStack spacing={ 6 }>
 			<VStack spacing={ 2 }>
 				<Text>
-					Keep this information somewhere safe. After your death, your legacy contact can give this
-					key to WordPress.com to request access to your account.
+					{ __(
+						'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
+					) }
 				</Text>
 			</VStack>
 
 			<VStack spacing={ 1 } alignment="flex-start">
 				<Text upperCase variant="muted" size={ 11 }>
-					Legacy contact email
+					{ __( 'Legacy contact email' ) }
 				</Text>
 				<Text size={ 15 }>{ contact.contact_email }</Text>
 			</VStack>
 
 			<VStack spacing={ 1 } alignment="flex-start">
 				<Text upperCase variant="muted" size={ 11 }>
-					Access key
+					{ __( 'Access key' ) }
 				</Text>
 				<div className="legacy-contact-print__key">{ contact.access_key }</div>
 			</VStack>
 
 			<ButtonStack justify="flex-start" className="legacy-contact-print__actions">
 				<Button variant="primary" onClick={ handlePrint }>
-					Print
+					{ __( 'Print' ) }
 				</Button>
 			</ButtonStack>
 		</VStack>
@@ -64,15 +65,14 @@ export default function SecurityLegacyContactPrint() {
 		>
 			<Card>
 				<CardBody>
-					{ /* TODO: translate these strings once the legacy contact UI is finalized. */ }
 					{ contact ? (
 						<LegacyContactDetails legacyContactId={ contact.legacy_contact_id } />
 					) : (
 						<VStack spacing={ 4 } alignment="flex-start">
-							<Text>You don’t have a legacy contact set up yet.</Text>
+							<Text>{ __( "You don't have a legacy contact set up yet." ) }</Text>
 							<ButtonStack justify="flex-start">
 								<RouterLinkButton variant="primary" to="/me/security/legacy-contact">
-									Back to legacy contact
+									{ __( 'Back to legacy contact' ) }
 								</RouterLinkButton>
 							</ButtonStack>
 						</VStack>


### PR DESCRIPTION
Fixes RSM-4413

## Proposed Changes

* Wrap the remaining hardcoded strings in the legacy contact feature (`client/dashboard/me/security-legacy-contact/`) with `__()` so they are picked up for translation.
* Removed the stale `TODO: translate` comments now that the strings are translated.

<img width="694" height="257" alt="Screenshot 2026-06-30 at 15 05 35" src="https://github.com/user-attachments/assets/664f8179-cf00-4762-af0f-d43222b386c4" />

## Why are these changes being made?

We didn't want to make the strings translatable until the feature was finalized.

## Testing Instructions

* Navigate to `/me/security/legacy-contact` (and the printable details page at `/me/security/legacy-contact/print`).
* Confirm the UI renders identically to before.
* Confirm there are no remaining untranslated strings in the feature.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


