### PR TITLE
Agents Manager: Suppress unhandled tool message warning for wp-admin/navigate ability

### DIFF
--- a/packages/agents-manager/src/utils/tool-message-utils.ts
+++ b/packages/agents-manager/src/utils/tool-message-utils.ts
@@ -6,6 +6,7 @@ const DISPLAYABLE_TOOL_MESSAGE_TOOL_IDS = new Set( [
 	'big_sky__editor_navigate',
 	'big_sky__restore_checkpoint',
 	'big_sky__open_help_center',
+	'wp_admin__navigate',
 ] );
 
 export function isDisplayableToolMessageTool( toolId: unknown ): toolId is string {


### PR DESCRIPTION
## Proposed Changes

Adds the `wp_admin__navigate` tool ID to the set of displayable tool messages in the Agents Manager. Previously, when an agent invoked the `wp-admin/navigate` ability, the client logged an "unhandled tool message" warning because the tool does not produce a user-facing message immediately.

By registering it in the suppression list, the message is now handled and rendered as intended, and the warning goes away.

## Testing Instructions

1. Run `yarn build` within `packages/agents-manager`.
2. Run `yarn dev --sync` within `apps/agents-manager`.
3. Enter your sandbox, enable writes, and proxy `widgets.wp.com` to your sandbox's IP address.
4. Check out woocommerce-ai/pull/275 and run `pnpm start`.
5. Open your Woo AI site (and devtools, with preserve log ticked) and trigger the navigation ability within the assistant: "navigate to orders" should do.

Verify the navigation ability works and you don't see the "Unhandled tool message with tool_id` console warn entry.