### PR TITLE
Lodash: replace map() with native Array.prototype.map

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -620,6 +620,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/keys': 'error',
 		'you-dont-need-lodash-underscore/last': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',
+		'you-dont-need-lodash-underscore/map': 'error',
 		'you-dont-need-lodash-underscore/pad-end': 'error',
 		'you-dont-need-lodash-underscore/pad-start': 'error',
 		'you-dont-need-lodash-underscore/reduce': 'error',

--- a/apps/o2-blocks/src/p2-autocomplete/editor.jsx
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.jsx
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addFilter } from '@wordpress/hooks';
-import { map, unescape } from 'lodash';
+import { unescape } from 'lodash';
 
 import './editor.scss';
 
@@ -15,7 +15,7 @@ const stripCommonWords = ( str ) => str.replace( COMMON_PREFIXES, ' ' );
 const p2s = apiFetch( {
 	path: '/internal/P2s?skip_description=true',
 } ).then( ( result ) =>
-	map( result.list, ( p2, subdomain ) => {
+	Object.entries( result.list ?? {} ).map( ( [ subdomain, p2 ] ) => {
 		const keywords = [ subdomain ];
 		const stripped = stripCommonWords( subdomain );
 		if ( subdomain !== stripped ) {

--- a/client/blocks/conversation-caterpillar/docs/fixtures.js
+++ b/client/blocks/conversation-caterpillar/docs/fixtures.js
@@ -1,5 +1,4 @@
 import { keyBy } from '@automattic/js-utils';
-import { map } from 'lodash';
 
 export const comments = [
 	{
@@ -176,5 +175,5 @@ export const comments = [
 
 export const commentsTree = {
 	...keyBy( comments, 'ID' ),
-	children: map( comments, 'ID' ),
+	children: comments.map( ( c ) => c?.ID ),
 };

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,6 +1,5 @@
 import { uniqBy } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { isAncestor } from 'calypso/blocks/comments/utils';
@@ -47,14 +46,14 @@ class ConversationCaterpillarComponent extends Component {
 		this.props.expandComments( {
 			siteId: blogId,
 			postId,
-			commentIds: map( commentsToExpand, 'ID' ),
+			commentIds: commentsToExpand.map( ( c ) => c?.ID ),
 			displayType: POST_COMMENT_DISPLAY_TYPES.excerpt,
 		} );
 		// for each of those comments, expand the comment's parent to singleLine
 		this.props.expandComments( {
 			siteId: blogId,
 			postId,
-			commentIds: map( commentsToExpand, ( c ) => c?.parent?.ID ?? null ).filter( Boolean ),
+			commentIds: commentsToExpand.map( ( c ) => c?.parent?.ID ?? null ).filter( Boolean ),
 			displayType: POST_COMMENT_DISPLAY_TYPES.excerpt,
 		} );
 		recordAction( 'comment_caterpillar_click' );
@@ -76,7 +75,10 @@ class ConversationCaterpillarComponent extends Component {
 			: allExpandableComments.length;
 
 		// Only display each author once
-		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'avatar_URL' );
+		const uniqueAuthors = uniqBy(
+			expandableComments.map( ( c ) => c?.author ),
+			'avatar_URL'
+		);
 		const uniqueAuthorsCount = uniqueAuthors.length;
 		const lastAuthorName = uniqueAuthors.at( -1 )?.name;
 

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -1,4 +1,3 @@
-import { map } from 'lodash';
 import { commentsTree } from 'calypso/blocks/conversations/docs/fixtures';
 import { ConversationCommentList } from 'calypso/blocks/conversations/list';
 import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
@@ -16,7 +15,9 @@ const ConversationCommentListExample = () => {
 				blogId={ 123 }
 				postId={ 12 }
 				commentIds={ [ 1, 2, 3 ] }
-				sortedComments={ map( commentsTree, 'data' ).filter( Boolean ) }
+				sortedComments={ Object.values( commentsTree ?? {} )
+					.map( ( comment ) => comment?.data )
+					.filter( Boolean ) }
 				post={ post }
 				enableCaterpillar={ false }
 				shouldRequestComments={ false }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,5 +1,4 @@
 import { keyBy, partition, pickBy } from '@automattic/js-utils';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
@@ -168,7 +167,7 @@ export class ConversationCommentList extends Component {
 		}
 
 		const withParents = commentIds.filter( ( id ) => this.commentHasParent( commentsTree, id ) );
-		const parentIds = map( withParents, ( id ) => this.getParentId( commentsTree, id ) );
+		const parentIds = withParents.map( ( id ) => this.getParentId( commentsTree, id ) );
 
 		const [ accessible, inaccessible ] = partition( parentIds, ( id ) =>
 			this.commentIsLoaded( commentsTree, id )
@@ -288,7 +287,7 @@ export class ConversationCommentList extends Component {
 							recordReaderTracksEvent={ this.props.recordReaderTracksEvent }
 						/>
 					) }
-					{ map( commentsTree.children, ( commentId ) => {
+					{ commentsTree.children.map( ( commentId ) => {
 						return (
 							<PostComment
 								showNestingReplyArrow

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -4,7 +4,6 @@ import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
 import ExcessiveDiskSpace from 'calypso/blocks/eligibility-warnings/excessive-disk-space';
 import CardHeading from 'calypso/components/card-heading';
 import Notice, { NoticeStatus } from 'calypso/components/notice';
@@ -306,7 +305,7 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 					</div>
 				) }
 				{ ! isPlaceholder &&
-					map( holds, ( hold ) =>
+					holds.map( ( hold ) =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
 								<div className="eligibility-warnings__message">

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { pencil as edit, external, Icon, seen, published, unseen } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -169,9 +168,9 @@ class ReaderPostEllipsisMenu extends Component {
 		let globalIds = [ post.global_ID ];
 
 		if ( posts.length ) {
-			postIds = map( posts, 'ID' );
-			feedItemIds = map( posts, 'feed_item_ID' );
-			globalIds = map( posts, 'global_ID' );
+			postIds = posts.map( ( item ) => item?.ID );
+			feedItemIds = posts.map( ( item ) => item?.feed_item_ID );
+			globalIds = posts.map( ( item ) => item?.global_ID );
 		}
 
 		if ( post.feed_item_ID ) {
@@ -211,9 +210,9 @@ class ReaderPostEllipsisMenu extends Component {
 		let globalIds = [ post.global_ID ];
 
 		if ( posts.length ) {
-			postIds = map( posts, 'ID' );
-			feedItemIds = map( posts, 'feed_item_ID' );
-			globalIds = map( posts, 'global_ID' );
+			postIds = posts.map( ( item ) => item?.ID );
+			feedItemIds = posts.map( ( item ) => item?.feed_item_ID );
+			globalIds = posts.map( ( item ) => item?.global_ID );
 		}
 
 		if ( post.feed_item_ID ) {

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -1,5 +1,4 @@
 import { Card } from '@automattic/components';
-import { map } from 'lodash';
 import { PureComponent } from 'react';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
@@ -20,7 +19,7 @@ export default class ReaderSubscriptionListItemExample extends PureComponent {
 	render() {
 		return (
 			<Card>
-				{ map( sites, ( site ) => (
+				{ Object.values( sites ).map( ( site ) => (
 					<ConnectedReaderSubscriptionListItem key={ site.feedId || site.siteId } { ...site } />
 				) ) }
 				<ReaderSubscriptionListItemPlaceholder />

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -5,7 +5,7 @@ import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { map, merge, isEmpty } from 'lodash';
+import { merge, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -532,7 +532,7 @@ class SignupForm extends Component {
 			return;
 		}
 
-		return map( messages, ( message, error_code ) => {
+		return Object.entries( messages ).map( ( [ error_code, message ] ) => {
 			if ( error_code === 'taken' ) {
 				const fieldValue = formState.getFieldValue( this.state.form, fieldName );
 				const link = addQueryArgs( { email_address: fieldValue }, this.getLoginLink() );

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { CalendarEvent } from './event';
@@ -59,8 +58,7 @@ class EventsTooltip extends Component {
 				<span>{ title }</span>
 				<hr className="date-picker__division" />
 				<ul>
-					{ map(
-						events,
+					{ events.map(
 						( event, i ) =>
 							i < maxEvents && (
 								<li key={ event.id }>

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -1,7 +1,7 @@
 import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { merge, map, get } from 'lodash';
+import { merge, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import DayPicker from 'react-day-picker';
@@ -215,10 +215,9 @@ class DatePicker extends PureComponent {
 		}
 
 		if ( this.props.events && this.props.events.length ) {
-			modifiers.events = map(
-				this.props.events.filter( ( event ) => event.date ),
-				( event ) => this.getDateInstance( event.date )
-			);
+			modifiers.events = this.props.events
+				.filter( ( event ) => event.date )
+				.map( ( event ) => this.getDateInstance( event.date ) );
 		}
 
 		const numMonths = this.props.numberOfMonths || 1;

--- a/client/components/domains/registrant-extra-info/ca-form.tsx
+++ b/client/components/domains/registrant-extra-info/ca-form.tsx
@@ -1,7 +1,7 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { camelCase, pick } from '@automattic/js-utils';
 import { LocalizeProps, localize } from 'i18n-calypso';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -80,7 +80,7 @@ export class RegistrantExtraInfoCaForm extends PureComponent<
 			} ),
 			MAJ: translate( 'His Majesty the King' ),
 		};
-		const legalTypeOptions = map( legalTypes, ( text, optionValue ) => (
+		const legalTypeOptions = Object.entries( legalTypes ).map( ( [ optionValue, text ] ) => (
 			<option value={ optionValue } key={ optionValue }>
 				{ text }
 			</option>

--- a/client/components/domains/registrant-extra-info/fr-form.tsx
+++ b/client/components/domains/registrant-extra-info/fr-form.tsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { LocalizeProps, TranslateResult, localize } from 'i18n-calypso';
-import { get, isEmpty, map } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { PureComponent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
@@ -168,7 +168,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 			if ( registrantVatIdIsNotEmpty ) {
 				return validationErrors.registrantVatId?.length === 0
 					? null
-					: map( [ ...new Set( validationErrors.registrantVatId ) ], renderValidationError );
+					: [ ...new Set( validationErrors.registrantVatId ) ].map( renderValidationError );
 			}
 
 			return null;
@@ -191,7 +191,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 		);
 
 		const sirenSiretValidationMessage = () => {
-			return map( [ ...new Set( validationErrors.sirenSiret ) ], renderValidationError );
+			return [ ...new Set( validationErrors.sirenSiret ) ].map( renderValidationError );
 		};
 
 		const sirenSiretIsError = () => {
@@ -210,9 +210,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 		);
 
 		const trademarkNumberValidationMessage = () => {
-			return map( [ ...new Set( validationErrors.trademarkNumber ) ], ( error: string ) =>
-				renderValidationError( error )
-			);
+			return [ ...new Set( validationErrors.trademarkNumber ) ].map( renderValidationError );
 		};
 
 		const trademarkNumberIsError = () => {

--- a/client/components/domains/registrant-extra-info/uk-form.tsx
+++ b/client/components/domains/registrant-extra-info/uk-form.tsx
@@ -2,8 +2,8 @@ import { FormInputValidation, FormLabel } from '@automattic/components';
 import { camelCase, pick } from '@automattic/js-utils';
 import { DomainContactDetails } from '@automattic/shopping-cart';
 import { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
-import { LocalizeProps, localize } from 'i18n-calypso';
-import { isEmpty, map } from 'lodash';
+import { LocalizeProps, TranslateResult, localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 import { PureComponent, ReactNode } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -50,11 +50,13 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 			OTHER: translate( 'UK Entity that does not fit another category' ),
 			FOTHER: translate( 'Non-UK Entity that does not fit another category' ),
 		};
-		this.registrantTypeOptions = map( registrantTypes, ( text, optionValue ) => (
-			<option value={ optionValue } key={ optionValue }>
-				{ text }
-			</option>
-		) );
+		this.registrantTypeOptions = Object.entries( registrantTypes ).map(
+			( [ optionValue, text ] ) => (
+				<option value={ optionValue } key={ optionValue }>
+					{ text }
+				</option>
+			)
+		);
 	}
 
 	componentDidMount() {
@@ -121,7 +123,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 						onChange={ this.handleChangeEvent }
 						isError={ isError }
 					/>
-					{ map( tradingNameErrors, this.renderValidationError ) }
+					{ tradingNameErrors.map( this.renderValidationError ) }
 				</FormFieldset>
 			</div>
 		);
@@ -154,7 +156,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 						onChange={ this.handleChangeEvent }
 						isError={ isError }
 					/>
-					{ map( registrationNumberErrors, this.renderValidationError ) }
+					{ registrationNumberErrors.map( this.renderValidationError ) }
 				</FormFieldset>
 			</div>
 		);
@@ -165,7 +167,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent< FormProps & Locali
 		errorMessage,
 	}: {
 		errorCode: string;
-		errorMessage: string;
+		errorMessage: string | TranslateResult;
 	} ) => {
 		const { translate } = this.props;
 		return (

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -1,5 +1,4 @@
 import { uniqBy } from '@automattic/js-utils';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Gravatar from 'calypso/components/gravatar';
@@ -30,7 +29,7 @@ class GravatarCaterpillar extends Component {
 
 		return (
 			<div className="gravatar-caterpillar" onClick={ onClick } aria-hidden="true">
-				{ map( displayedUsers, ( user, index ) => {
+				{ displayedUsers.map( ( user, index ) => {
 					let gravClasses = 'gravatar-caterpillar__gravatar';
 					// If we have more than x gravs,
 					// add a additional class so we can hide some on small screens

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -1,5 +1,4 @@
 import { flow, sortBy } from '@automattic/js-utils';
-import { map } from 'lodash';
 import { PureComponent } from 'react';
 import PaymentLogo, { POSSIBLE_TYPES } from '../index';
 
@@ -7,7 +6,7 @@ const genVendors = flow(
 	// 'placeholder' is a special case that needs to be demonstrated separately
 	( arr ) => arr.filter( ( type ) => type !== 'placeholder' ),
 
-	( arr ) => map( arr, ( type ) => ( { type, isCompact: false } ) ),
+	( arr ) => arr.map( ( type ) => ( { type, isCompact: false } ) ),
 	( arr ) => arr.concat( [ { type: 'paypal', isCompact: true } ] ),
 	( arr ) => sortBy( arr, [ 'type', 'isCompact' ] )
 );

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -30,7 +30,7 @@
 //
 
 import { camelCase, mapKeys, mapValues, snakeCase } from '@automattic/js-utils';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 
 // Right-to-left composition of unary functions. Kept local so this pure mapping
 // module doesn't take on a dependency it otherwise has no need for.
@@ -52,7 +52,7 @@ const mergeStringPieces = ( a, b ) => ( {
  * @returns {Array} List of native format pieces
  */
 export const rawToNative = ( list ) =>
-	map( list, ( p ) =>
+	list.map( ( p ) =>
 		'string' === p.type ? { type: 'string', value: p.value } : { type: camelCase( p.value ) }
 	);
 
@@ -76,7 +76,7 @@ export const nativeToRaw = compose(
 			return [ ...format, piece ];
 		}, [] ),
 	( list ) =>
-		map( list, ( p ) => ( {
+		list.map( ( p ) => ( {
 			type: p.type === 'string' ? 'string' : 'token',
 			value: get( p, 'value', snakeCase( p.type ) ),
 		} ) )

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,5 +1,5 @@
 import { omit } from '@automattic/js-utils';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
@@ -26,7 +26,7 @@ class SortedGrid extends PureComponent {
 
 		for ( let i = 0; i < this.props.items.length; i += this.props.itemsPerRow ) {
 			const row = this.props.items.slice( i, i + this.props.itemsPerRow );
-			const groups = map( row, this.props.getItemGroup ).reduce( ( results, group ) => {
+			const groups = row.map( this.props.getItemGroup ).reduce( ( results, group ) => {
 				results[ group ] = get( results, group, 0 ) + 1;
 				return results;
 			}, {} );
@@ -40,7 +40,7 @@ class SortedGrid extends PureComponent {
 	renderLabels( row ) {
 		return (
 			<div key={ `header_${ row.id }` } className="sorted-grid__header">
-				{ map( row.groups, ( count, group ) => {
+				{ Object.entries( row.groups ).map( ( [ group, count ] ) => {
 					const labelText = this.props.getGroupLabel( group );
 					return (
 						'' !== labelText && (

--- a/client/components/split-button/docs/example.jsx
+++ b/client/components/split-button/docs/example.jsx
@@ -1,5 +1,4 @@
 import { Card } from '@automattic/components';
-import { map } from 'lodash';
 import { PureComponent } from 'react';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
@@ -36,56 +35,53 @@ class SplitButtonExample extends PureComponent {
 					{ this.state.compactButtons ? 'Normal Buttons' : 'Compact Buttons' }
 				</button>
 				<Card>
-					{ map(
+					{ [
 						[
-							[
-								{ label: 'Split Button', icon: 'history' },
-								{ label: 'Split Button', primary: true },
-								{ label: 'Split Button with white separator', primary: true, whiteSeparator: true },
-								{ icon: 'globe' },
-							],
-							[
-								{ label: 'Split Button', primary: true, disableMain: true },
-								{ label: 'Split Button', icon: 'history', primary: true, disableMenu: true },
-							],
-							[
-								{ label: 'Split Button', primary: true, disabled: true },
-								{ icon: 'globe', primary: true, disabled: true },
-							],
-							[
-								{ label: 'Split Button', icon: 'history', scary: true },
-								{ label: 'Split Button', primary: true, scary: true },
-								{ icon: 'globe', scary: true },
-							],
-							[
-								{ label: 'Split Button', primary: true, disableMain: true, scary: true },
-								{
-									label: 'Split Button',
-									icon: 'history',
-									primary: true,
-									disableMenu: true,
-									scary: true,
-								},
-							],
-							[
-								{ label: 'Split Button', primary: true, disabled: true, scary: true },
-								{ icon: 'globe', primary: true, disabled: true, scary: true },
-							],
+							{ label: 'Split Button', icon: 'history' },
+							{ label: 'Split Button', primary: true },
+							{ label: 'Split Button with white separator', primary: true, whiteSeparator: true },
+							{ icon: 'globe' },
 						],
-						( row, rowIndex ) => (
-							<div className="docs__design-button-row" key={ `split-button-row-${ rowIndex }` }>
-								{ map( row, ( item, itemIndex ) => (
-									<SplitButton
-										key={ `split-button-item-${ rowIndex }-${ itemIndex }` }
-										{ ...item }
-										{ ...compact }
-									>
-										{ popoverItems }
-									</SplitButton>
-								) ) }
-							</div>
-						)
-					) }
+						[
+							{ label: 'Split Button', primary: true, disableMain: true },
+							{ label: 'Split Button', icon: 'history', primary: true, disableMenu: true },
+						],
+						[
+							{ label: 'Split Button', primary: true, disabled: true },
+							{ icon: 'globe', primary: true, disabled: true },
+						],
+						[
+							{ label: 'Split Button', icon: 'history', scary: true },
+							{ label: 'Split Button', primary: true, scary: true },
+							{ icon: 'globe', scary: true },
+						],
+						[
+							{ label: 'Split Button', primary: true, disableMain: true, scary: true },
+							{
+								label: 'Split Button',
+								icon: 'history',
+								primary: true,
+								disableMenu: true,
+								scary: true,
+							},
+						],
+						[
+							{ label: 'Split Button', primary: true, disabled: true, scary: true },
+							{ icon: 'globe', primary: true, disabled: true, scary: true },
+						],
+					].map( ( row, rowIndex ) => (
+						<div className="docs__design-button-row" key={ `split-button-row-${ rowIndex }` }>
+							{ row.map( ( item, itemIndex ) => (
+								<SplitButton
+									key={ `split-button-item-${ rowIndex }-${ itemIndex }` }
+									{ ...item }
+									{ ...compact }
+								>
+									{ popoverItems }
+								</SplitButton>
+							) ) }
+						</div>
+					) ) }
 				</Card>
 			</div>
 		);

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -18,12 +17,12 @@ class Timezone extends Component {
 	renderOptionsByContinent() {
 		const { timezones } = this.props;
 
-		return map( timezones, ( timezoneContinent ) => {
+		return timezones.map( ( timezoneContinent ) => {
 			const [ continent, countries ] = timezoneContinent;
 
 			return (
 				<optgroup label={ continent } key={ continent }>
-					{ map( countries, ( timezone, index ) => {
+					{ countries.map( ( timezone, index ) => {
 						const [ value, label ] = timezone;
 
 						return (
@@ -42,7 +41,7 @@ class Timezone extends Component {
 
 		return (
 			<optgroup label={ translate( 'Manual Offsets' ) }>
-				{ map( rawOffsets, ( label, value ) => {
+				{ Object.entries( rawOffsets ?? {} ).map( ( [ value, label ] ) => {
 					return (
 						<option value={ value } key={ value }>
 							{ label }

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -1,5 +1,5 @@
 import { convertFromRaw, convertToRaw } from 'draft-js';
-import { get, map, matchesProperty } from 'lodash';
+import { get, matchesProperty } from 'lodash';
 import { compose } from 'redux';
 
 /*
@@ -198,7 +198,7 @@ export const toEditor = ( format, tokens ) => {
 	return convertFromRaw( {
 		blocks: [ blocks ],
 		entityMap: Object.fromEntries(
-			map( entityGuide, ( name, key ) => [
+			entityGuide.map( ( name, key ) => [
 				key, // entity key is position in list
 				{
 					type: 'TOKEN',

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -5,7 +5,6 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testOnBlur", "expect.*"] }] */
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { map } from 'lodash';
 import fixtures from './lib/fixtures';
 import TokenFieldWrapper, { suggestions } from './lib/token-field-wrapper';
 
@@ -77,12 +76,9 @@ describe( 'TokenField', () => {
 		const div = document.createElement( 'div' );
 		div.innerHTML = node.querySelector( 'span' ).outerHTML;
 
-		return map(
-			Array.from( div.firstChild.childNodes ).filter(
-				( childNode ) => childNode.nodeType !== window.Node.COMMENT_NODE
-			),
-			( childNode ) => childNode.textContent
-		);
+		return Array.from( div.firstChild.childNodes )
+			.filter( ( childNode ) => childNode.nodeType !== window.Node.COMMENT_NODE )
+			.map( ( childNode ) => childNode.textContent );
 	}
 
 	function getSelectedSuggestion( container ) {

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { Button, Card, Dialog, Gridicon } from '@automattic/components';
 import debugModule from 'debug';
 import { localize, fixMe } from 'i18n-calypso';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -341,7 +341,7 @@ class JetpackSsoForm extends Component {
 		return (
 			<table className="jetpack-connect__sso-shared-details-table">
 				<tbody>
-					{ map( sharedDetails, ( value, key ) => {
+					{ Object.entries( sharedDetails ).map( ( [ key, value ] ) => {
 						return (
 							<tr key={ key } className="jetpack-connect__sso-shared-detail-row">
 								<td className="jetpack-connect__sso-shared-detail-label">

--- a/client/lib/embed-frame-markup/index.jsx
+++ b/client/lib/embed-frame-markup/index.jsx
@@ -1,7 +1,6 @@
 // Here be dragons...
 /* eslint-disable react/no-danger */
 
-import { map } from 'lodash';
 import { renderToStaticMarkup } from 'react-dom/server.browser';
 
 /**
@@ -18,7 +17,7 @@ export default function generateEmbedFrameMarkup( { body, scripts, styles } = {}
 		// eslint-disable-next-line jsx-a11y/html-has-lang -- this is an embed frame, not the main document.
 		<html>
 			<head>
-				{ map( styles, ( { media, src }, key ) => (
+				{ Object.entries( styles || {} ).map( ( [ key, { media, src } ] ) => (
 					<link key={ key } rel="stylesheet" media={ media } href={ src } />
 				) ) }
 				<style dangerouslySetInnerHTML={ { __html: 'a { cursor: default; }' } } />

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -1,7 +1,7 @@
 import { camelCase, mapValues, pickBy } from '@automattic/js-utils';
 import { debounce } from '@wordpress/compose';
 import update from 'immutability-helper';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {
@@ -306,7 +306,7 @@ function getInvalidFields( formState ) {
 function getErrorMessages( formState ) {
 	const invalidFields = getInvalidFields( formState );
 
-	return map( invalidFields, 'errors' ).flat();
+	return invalidFields.flatMap( ( field ) => field?.errors );
 }
 
 function isSubmitButtonDisabled( formState ) {

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { map } from 'lodash';
 import { ValidationErrors as MediaValidationErrors } from '../constants';
 import * as MediaUtils from '../utils';
 
@@ -280,7 +279,7 @@ describe( 'MediaUtils', () => {
 		} );
 
 		test( 'should return a new array array, sorted descending by date', () => {
-			expect( map( MediaUtils.sortItemsByDate( items ), 'ID' ) ).toEqual( [ 2, 1 ] );
+			expect( MediaUtils.sortItemsByDate( items ).map( ( item ) => item?.ID ) ).toEqual( [ 2, 1 ] );
 		} );
 
 		test( 'should return the item with the greater ID if the dates are not set', () => {
@@ -289,7 +288,7 @@ describe( 'MediaUtils', () => {
 				return item;
 			} );
 
-			expect( map( MediaUtils.sortItemsByDate( items ), 'ID' ) ).toEqual( [ 2, 1 ] );
+			expect( MediaUtils.sortItemsByDate( items ).map( ( item ) => item?.ID ) ).toEqual( [ 2, 1 ] );
 		} );
 
 		test( 'should return the item with the greater ID if the dates are equal', () => {
@@ -298,7 +297,7 @@ describe( 'MediaUtils', () => {
 				return item;
 			} );
 
-			expect( map( MediaUtils.sortItemsByDate( items ), 'ID' ) ).toEqual( [ 2, 1 ] );
+			expect( MediaUtils.sortItemsByDate( items ).map( ( item ) => item?.ID ) ).toEqual( [ 2, 1 ] );
 		} );
 
 		test( 'should parse dates in string format', () => {
@@ -307,12 +306,12 @@ describe( 'MediaUtils', () => {
 				return item;
 			} );
 
-			expect( map( MediaUtils.sortItemsByDate( items ), 'ID' ) ).toEqual( [ 2, 1 ] );
+			expect( MediaUtils.sortItemsByDate( items ).map( ( item ) => item?.ID ) ).toEqual( [ 2, 1 ] );
 		} );
 
 		test( 'should not mutate the original array', () => {
 			MediaUtils.sortItemsByDate( items );
-			expect( map( items, 'ID' ) ).toEqual( [ 1, 2 ] );
+			expect( items.map( ( item ) => item?.ID ) ).toEqual( [ 1, 2 ] );
 		} );
 	} );
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -12,7 +12,6 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 } from '@automattic/calypso-products';
 import { pick, sortBy } from '@automattic/js-utils';
-import { map } from 'lodash';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -152,7 +151,7 @@ export function extractScreenshots( screenshotsHtml ) {
 	if ( ! list ) {
 		return null;
 	}
-	let screenshots = map( list, function ( li ) {
+	let screenshots = Array.from( list ).map( function ( li ) {
 		const img = li.querySelectorAll( 'img' );
 		const captionP = li.querySelectorAll( 'p' );
 
@@ -272,7 +271,7 @@ export function normalizePluginsList( pluginsList ) {
 	if ( ! pluginsList ) {
 		return [];
 	}
-	return map( pluginsList, ( pluginData ) => normalizePluginData( pluginData ) );
+	return pluginsList.map( ( pluginData ) => normalizePluginData( pluginData ) );
 }
 
 /**

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -271,7 +271,7 @@ export function normalizePluginsList( pluginsList ) {
 	if ( ! pluginsList ) {
 		return [];
 	}
-	return pluginsList.map( ( pluginData ) => normalizePluginData( pluginData ) );
+	return Object.values( pluginsList ).map( ( pluginData ) => normalizePluginData( pluginData ) );
 }
 
 /**

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,6 +1,5 @@
 /* eslint-disable jsdoc/no-undefined-types */
 
-import { map } from 'lodash';
 import getEmbedMetadata from 'calypso/lib/get-video-id';
 import { READER_CONTENT_WIDTH } from 'calypso/reader/data/post/sizes';
 import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
@@ -147,7 +146,7 @@ export default function detectMedia( post, dom ) {
 	const embedSelector = 'iframe';
 	const media = dom.querySelectorAll( `${ imageSelector }, ${ embedSelector }` );
 
-	const contentMedia = map( media, ( element ) => {
+	const contentMedia = Array.from( media ).map( ( element ) => {
 		const nodeName = element.nodeName.toLowerCase();
 
 		if ( nodeName === 'iframe' ) {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { map } from 'lodash';
 import { deduceImageWidthAndHeight, thumbIsLikelyImage } from './utils';
 
 const debug = debugFactory( 'calypso:post-normalizer:wait-for-images-to-load' );
@@ -47,12 +46,12 @@ export default function waitForImagesToLoad( post ) {
 
 			post.images = images.map( convertImageToObject );
 
-			post.content_images = map( post.content_images, ( image ) =>
-				post.images.find( ( img ) => img.src === image.src )
-			).filter( Boolean );
+			post.content_images = ( post.content_images ?? [] )
+				.map( ( image ) => post.images.find( ( img ) => img.src === image.src ) )
+				.filter( Boolean );
 
 			// this adds adds height/width to images
-			post.content_media = map( post.content_media, ( media ) => {
+			post.content_media = ( post.content_media ?? [] ).map( ( media ) => {
 				if ( media.mediaType === 'image' ) {
 					const img = post.images.find( ( image ) => image.src === media.src );
 					return { ...media, ...img };

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,6 +1,5 @@
 import { omit } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { map } from 'lodash';
 import QueryKey from './key';
 
 /**
@@ -288,7 +287,7 @@ export default class QueryManager {
 		}
 
 		if ( options.query ) {
-			const receivedItemKeys = map( items, this.options.itemKey );
+			const receivedItemKeys = items.map( ( item ) => item?.[ this.options.itemKey ] );
 			receivedQueryKey = this.constructor.QueryKey.stringify( options.query );
 			isNewlyReceivedQueryKey = ! this.data.queries[ receivedQueryKey ];
 

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -5,7 +5,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import { useState, useEffect, Fragment } from 'react';
 import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
@@ -177,7 +176,7 @@ const AccountSettingsClose = ( {
 										'You will also lose access to the following premium themes you have purchased:'
 									) }
 									<ul className="account-close__theme-list">
-										{ map( purchasedPremiumThemes, ( purchasedPremiumTheme ) => {
+										{ purchasedPremiumThemes.map( ( purchasedPremiumTheme ) => {
 											return (
 												<li key={ purchasedPremiumTheme.id }>
 													{ purchasedPremiumTheme.productName }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -6,7 +6,7 @@ import { ExternalLink } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import debugFactory from 'debug';
 import { fixMe, localize } from 'i18n-calypso';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -716,7 +716,7 @@ class Account extends Component {
 				<FormLabel>{ translate( 'Would you like a matching blog address too?' ) }</FormLabel>
 				{
 					// message is translated in the API
-					map( actions, ( message, key ) => (
+					Object.entries( actions ?? {} ).map( ( [ key, message ] ) => (
 						<FormLabel key={ key }>
 							<FormRadio
 								name="usernameAction"

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -2,7 +2,6 @@ import { isDomainRegistration } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, CompactCard, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -297,7 +296,7 @@ class ConfirmCancelDomain extends Component {
 						<option disabled="disabled" value="disabled" key="disabled">
 							{ this.props.translate( 'Please let us know why you wish to cancel.' ) }
 						</option>
-						{ map( cancellationReasons, ( { value, label } ) => (
+						{ cancellationReasons.map( ( { value, label } ) => (
 							<option value={ value } key={ value }>
 								{ label }
 							</option>

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -12,7 +12,6 @@ import {
 } from '@automattic/urls';
 import _debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -210,7 +209,7 @@ export class DomainWarnings extends PureComponent {
 					) ) }
 				</ul>
 			);
-			if ( map( wrongMappedDomains, 'name' ).every( isSubdomain ) ) {
+			if ( wrongMappedDomains.map( ( domain ) => domain?.name ).every( isSubdomain ) ) {
 				text = translate( "Some of your domains' DNS records need to be configured.", {
 					context: 'Notice for mapped subdomain that has DNS records need to set up',
 				} );

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { removeQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { map } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import ConnectDomainStep from 'calypso/components/domains/connect-domain-step';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
@@ -282,7 +281,7 @@ const redirectIfNoSite = ( redirectTo ) => {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const sites = getSites( state );
-		const siteIds = map( sites, 'ID' );
+		const siteIds = sites.map( ( site ) => site?.ID );
 
 		if ( ! siteIds.includes( siteId ) ) {
 			const user = getCurrentUser( state );

--- a/client/my-sites/importer/site-importer/site-importer-importable-content.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-importable-content.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
@@ -11,7 +11,7 @@ const SiteImporterImportableContent = ( { translate, importData = {} } ) => (
 			<Fragment>
 				<p>{ translate( 'We will import:' ) }</p>
 				<ul>
-					{ map( importData.supported, ( supportedApp, index ) => (
+					{ importData.supported.map( ( supportedApp, index ) => (
 						<li key={ index + supportedApp }>{ supportedApp }</li>
 					) ) }
 				</ul>

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -5,7 +5,7 @@ import { groupBy } from '@automattic/js-utils';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -141,125 +141,127 @@ export class MediaLibraryContent extends Component {
 
 	renderErrors() {
 		const { isJetpack, mediaValidationErrorTypes, site, siteSlug, translate } = this.props;
-		return map( groupBy( mediaValidationErrorTypes ), ( occurrences, errorType ) => {
-			let message;
-			let onDismiss;
-			const i18nOptions = {
-				count: occurrences.length,
-				args: {
-					occurrences: occurrences.length,
-					planName: getPlan( PLAN_PREMIUM )?.getTitle(),
-				},
-			};
+		return Object.entries( groupBy( mediaValidationErrorTypes ) ).map(
+			( [ errorType, occurrences ] ) => {
+				let message;
+				let onDismiss;
+				const i18nOptions = {
+					count: occurrences.length,
+					args: {
+						occurrences: occurrences.length,
+						planName: getPlan( PLAN_PREMIUM )?.getTitle(),
+					},
+				};
 
-			if ( site ) {
-				onDismiss = () => this.props.clearMediaErrors( site.ID, errorType );
-			}
+				if ( site ) {
+					onDismiss = () => this.props.clearMediaErrors( site.ID, errorType );
+				}
 
-			let status = 'is-error';
-			let upgradeNudgeName = undefined;
-			let upgradeNudgeFeature = undefined;
-			let actionText = undefined;
-			let actionLink = undefined;
-			let tryAgain = false;
-			let externalAction = false;
+				let status = 'is-error';
+				let upgradeNudgeName = undefined;
+				let upgradeNudgeFeature = undefined;
+				let actionText = undefined;
+				let actionLink = undefined;
+				let tryAgain = false;
+				let externalAction = false;
 
-			switch ( errorType ) {
-				case MediaValidationErrors.FILE_TYPE_NOT_IN_PLAN:
-					status = 'is-warning';
-					upgradeNudgeName = 'plan-media-storage-error-video';
-					upgradeNudgeFeature = 'video-upload';
-					message = translate(
-						'%(occurrences)d file could not be uploaded because your site does not support video files. Upgrade to the %(planName)s plan for video support.',
-						'%(occurrences)d files could not be uploaded because your site does not support video files. Upgrade to the %(planName)s plan for video support.',
-						i18nOptions
-					);
-					break;
-				case MediaValidationErrors.FILE_TYPE_UNSUPPORTED:
-					message = translate(
-						'%(occurrences)d file could not be uploaded because the file type is not supported.',
-						'%(occurrences)d files could not be uploaded because their file types are unsupported.',
-						i18nOptions
-					);
-					actionText = translate( 'See supported file types' );
-					actionLink = localizeUrl( 'https://wordpress.com/support/accepted-filetypes/' );
-					externalAction = true;
-					break;
-				case MediaValidationErrors.UPLOAD_VIA_URL_404:
-					message = translate(
-						'%(occurrences)d file could not be uploaded because no image exists at the specified URL.',
-						'%(occurrences)d files could not be uploaded because no images exist at the specified URLs',
-						i18nOptions
-					);
-					break;
-				case MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE:
-					message = translate(
-						'%(occurrences)d file could not be uploaded because it exceeds the maximum upload size.',
-						'%(occurrences)d files could not be uploaded because they exceed the maximum upload size.',
-						i18nOptions
-					);
-					break;
-				case MediaValidationErrors.NOT_ENOUGH_SPACE:
-					upgradeNudgeName = 'plan-media-storage-error';
-					upgradeNudgeFeature = 'extra-storage';
-					message = translate(
-						'%(occurrences)d file could not be uploaded because there is not enough space left.',
-						'%(occurrences)d files could not be uploaded because there is not enough space left.',
-						i18nOptions
-					);
-					break;
-				case MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT:
-					if ( isJetpack ) {
-						actionText = translate( 'Upgrade Plan' );
-						actionLink = `/checkout/${ siteSlug }/jetpack_videopress`;
+				switch ( errorType ) {
+					case MediaValidationErrors.FILE_TYPE_NOT_IN_PLAN:
+						status = 'is-warning';
+						upgradeNudgeName = 'plan-media-storage-error-video';
+						upgradeNudgeFeature = 'video-upload';
+						message = translate(
+							'%(occurrences)d file could not be uploaded because your site does not support video files. Upgrade to the %(planName)s plan for video support.',
+							'%(occurrences)d files could not be uploaded because your site does not support video files. Upgrade to the %(planName)s plan for video support.',
+							i18nOptions
+						);
+						break;
+					case MediaValidationErrors.FILE_TYPE_UNSUPPORTED:
+						message = translate(
+							'%(occurrences)d file could not be uploaded because the file type is not supported.',
+							'%(occurrences)d files could not be uploaded because their file types are unsupported.',
+							i18nOptions
+						);
+						actionText = translate( 'See supported file types' );
+						actionLink = localizeUrl( 'https://wordpress.com/support/accepted-filetypes/' );
 						externalAction = true;
-					} else {
+						break;
+					case MediaValidationErrors.UPLOAD_VIA_URL_404:
+						message = translate(
+							'%(occurrences)d file could not be uploaded because no image exists at the specified URL.',
+							'%(occurrences)d files could not be uploaded because no images exist at the specified URLs',
+							i18nOptions
+						);
+						break;
+					case MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE:
+						message = translate(
+							'%(occurrences)d file could not be uploaded because it exceeds the maximum upload size.',
+							'%(occurrences)d files could not be uploaded because they exceed the maximum upload size.',
+							i18nOptions
+						);
+						break;
+					case MediaValidationErrors.NOT_ENOUGH_SPACE:
 						upgradeNudgeName = 'plan-media-storage-error';
 						upgradeNudgeFeature = 'extra-storage';
-					}
-					message = translate(
-						'%(occurrences)d file could not be uploaded because you have reached your plan storage limit.',
-						'%(occurrences)d files could not be uploaded because you have reached your plan storage limit.',
-						i18nOptions
-					);
-					break;
-				case MediaValidationErrors.SERVICE_AUTH_FAILED:
-					message = this.getAuthFailMessageForSource();
-					status = 'is-warning';
-					tryAgain = false;
-					break;
+						message = translate(
+							'%(occurrences)d file could not be uploaded because there is not enough space left.',
+							'%(occurrences)d files could not be uploaded because there is not enough space left.',
+							i18nOptions
+						);
+						break;
+					case MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT:
+						if ( isJetpack ) {
+							actionText = translate( 'Upgrade Plan' );
+							actionLink = `/checkout/${ siteSlug }/jetpack_videopress`;
+							externalAction = true;
+						} else {
+							upgradeNudgeName = 'plan-media-storage-error';
+							upgradeNudgeFeature = 'extra-storage';
+						}
+						message = translate(
+							'%(occurrences)d file could not be uploaded because you have reached your plan storage limit.',
+							'%(occurrences)d files could not be uploaded because you have reached your plan storage limit.',
+							i18nOptions
+						);
+						break;
+					case MediaValidationErrors.SERVICE_AUTH_FAILED:
+						message = this.getAuthFailMessageForSource();
+						status = 'is-warning';
+						tryAgain = false;
+						break;
 
-				case MediaValidationErrors.SERVICE_FAILED:
-					message = translate( 'We are unable to retrieve your full media library.' );
-					tryAgain = true;
-					break;
+					case MediaValidationErrors.SERVICE_FAILED:
+						message = translate( 'We are unable to retrieve your full media library.' );
+						tryAgain = true;
+						break;
 
-				case MediaValidationErrors.SERVICE_UNAVAILABLE:
-					message = this.getServiceUnavailableMessageForSource();
-					tryAgain = true;
-					break;
+					case MediaValidationErrors.SERVICE_UNAVAILABLE:
+						message = this.getServiceUnavailableMessageForSource();
+						tryAgain = true;
+						break;
 
-				default:
-					message = translate(
-						'%(occurrences)d file could not be uploaded because an error occurred while uploading.',
-						'%(occurrences)d files could not be uploaded because errors occurred while uploading.',
-						i18nOptions
-					);
-					break;
+					default:
+						message = translate(
+							'%(occurrences)d file could not be uploaded because an error occurred while uploading.',
+							'%(occurrences)d files could not be uploaded because errors occurred while uploading.',
+							i18nOptions
+						);
+						break;
+				}
+
+				return (
+					<Notice key={ errorType } status={ status } text={ message } onDismissClick={ onDismiss }>
+						{ this.renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) }
+						{ actionText && (
+							<NoticeAction href={ actionLink } external={ externalAction }>
+								{ actionText }
+							</NoticeAction>
+						) }
+						{ tryAgain && this.renderTryAgain() }
+					</Notice>
+				);
 			}
-
-			return (
-				<Notice key={ errorType } status={ status } text={ message } onDismissClick={ onDismiss }>
-					{ this.renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) }
-					{ actionText && (
-						<NoticeAction href={ actionLink } external={ externalAction }>
-							{ actionText }
-						</NoticeAction>
-					) }
-					{ tryAgain && this.renderTryAgain() }
-				</Notice>
-			);
-		} );
+		);
 	}
 
 	getAuthFailMessageForSource() {

--- a/client/my-sites/migrate/components/import-type-choice/index.jsx
+++ b/client/my-sites/migrate/components/import-type-choice/index.jsx
@@ -1,6 +1,5 @@
 import { Badge } from '@automattic/components';
 import clsx from 'clsx';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -96,7 +95,7 @@ export default class ImportTypeChoice extends Component {
 
 		return (
 			<div className="import-type-choice__wrapper">
-				{ map( items, ( item, key ) => this.renderOption( item, key ) ) }
+				{ Object.entries( items ?? {} ).map( ( [ key, item ] ) => this.renderOption( item, key ) ) }
 			</div>
 		);
 	}

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -1,6 +1,5 @@
 import { Card, Button, Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -56,7 +55,10 @@ class PeopleInvites extends PureComponent {
 			return;
 		}
 
-		this.props.deleteInvites( site.ID, map( acceptedInvites, 'key' ) );
+		this.props.deleteInvites(
+			site.ID,
+			( acceptedInvites ?? [] ).map( ( invite ) => invite?.key )
+		);
 		this.toggleClearAllConfirmation();
 	};
 

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -3,7 +3,6 @@ import { loadScript } from '@automattic/load-script';
 import { throttle } from '@wordpress/compose';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -334,7 +333,7 @@ class StatsGeochart extends Component {
 		chartData.addColumn( 'string', 'Location' );
 		chartData.addColumn( 'number', numberLabel || translate( 'Views' ).toString() );
 		chartData.addRows(
-			map( data, ( location ) => {
+			data.map( ( location ) => {
 				return [
 					{
 						v: location.countryCode,
@@ -407,7 +406,7 @@ class StatsGeochart extends Component {
 			options.height = customHeight;
 		}
 
-		const regions = [ ...new Set( map( data, 'region' ) ) ];
+		const regions = [ ...new Set( data.map( ( location ) => location?.region ) ) ];
 
 		if ( 1 === regions.length ) {
 			options.region = regions[ 0 ];

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -1,6 +1,5 @@
 import { sortBy } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -51,7 +50,7 @@ class EditorMediaModalGalleryEdit extends Component {
 		return (
 			<div>
 				<EllipsisMenu popoverClassName="gallery__order-popover" position="bottom right">
-					{ map( orders, ( orderedItems, name ) => {
+					{ Object.entries( orders ).map( ( [ name, orderedItems ] ) => {
 						const boundAction = () => onUpdateSetting( { items: orderedItems } );
 						return (
 							<PopoverMenuItem key={ name } onClick={ boundAction }>

--- a/client/reader/data/stream/normalization/helpers.ts
+++ b/client/reader/data/stream/normalization/helpers.ts
@@ -1,4 +1,3 @@
-import { map } from 'lodash';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -82,7 +81,7 @@ export function createStreamItemFromPost( post: RawPost, dateProperty: string ) 
 		...keyForPost( post ),
 		date: post[ dateProperty ],
 		// Include comments for conversations
-		...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ),
+		...( post.comments && { comments: post.comments.map( ( comment ) => comment?.ID ).reverse() } ),
 		url: post.URL,
 		site_icon: post.site_icon?.ico,
 		site_description: post.description,
@@ -148,7 +147,7 @@ function createStreamItemFromSiteAndPost(
 		...keyForPost( post ),
 		date: post[ dateProperty ],
 		// Include comments for conversations.
-		...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ),
+		...( post.comments && { comments: post.comments.map( ( comment ) => comment?.ID ).reverse() } ),
 		url: post.URL,
 		site_icon: site.icon?.ico,
 		site_description: site.description,

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -1,5 +1,5 @@
 import { times } from '@automattic/js-utils';
-import { map, sampleSize } from 'lodash';
+import { sampleSize } from 'lodash';
 import { Component } from 'react';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { useFollowedTags } from 'calypso/reader/data/tags';
@@ -31,7 +31,7 @@ function suggestionsFromTags( count, tags ) {
 		if ( tags.length <= count ) {
 			return [];
 		}
-		return map( sampleSize( tags, count ), ( tag, i ) => {
+		return sampleSize( tags, count ).map( ( tag, i ) => {
 			const text = ( tag.displayName || tag.slug ).replace( /-/g, ' ' );
 			const ui_algo = 'read:search-suggestions:tags/1';
 			return suggestionWithRailcar( text, ui_algo, i );
@@ -46,7 +46,7 @@ function suggestionsFromTags( count, tags ) {
  * @returns {Array} An array of tag objects
  */
 function trendingTagsToTags( trendingTags ) {
-	return map( trendingTags, ( tag ) => ( {
+	return ( trendingTags ?? [] ).map( ( tag ) => ( {
 		displayName: tag.tag.display_name,
 		slug: tag.tag.slug,
 	} ) );
@@ -55,7 +55,7 @@ function trendingTagsToTags( trendingTags ) {
 function suggestionsFromPicks( count ) {
 	const lang = getLocaleSlug().split( '-' )[ 0 ];
 	if ( suggestions[ lang ] ) {
-		return map( sampleSize( suggestions[ lang ], count ), ( tag, i ) => {
+		return sampleSize( suggestions[ lang ], count ).map( ( tag, i ) => {
 			const ui_algo = 'read:search-suggestions:picks/1';
 			return suggestionWithRailcar( tag, ui_algo, i );
 		} );

--- a/client/reader/sidebar/reader-sidebar-organizations/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/index.jsx
@@ -1,4 +1,3 @@
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderSidebarOrganizationsList from './list';
@@ -12,7 +11,7 @@ export class ReaderSidebarOrganizations extends Component {
 
 	renderItems() {
 		const { organizations, path } = this.props;
-		return map( organizations, ( organization ) => (
+		return organizations.map( ( organization ) => (
 			<li key={ organization.id }>
 				<ReaderSidebarOrganizationsList
 					key={ organization.id }

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -2,7 +2,6 @@ import page from '@automattic/calypso-router';
 import { Count } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -74,8 +73,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 
 	renderSites() {
 		const { sites, path } = this.props;
-		return map(
-			sites,
+		return sites.map(
 			( site ) =>
 				site && <ReaderSidebarOrganizationsListItem key={ site.ID } path={ path } site={ site } />
 		);

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
@@ -18,7 +17,7 @@ export class ReaderSidebarTagsList extends Component {
 
 	renderItems() {
 		const { path, currentTag, tags } = this.props;
-		return map( tags, ( tag ) => (
+		return ( tags ?? [] ).map( ( tag ) => (
 			<ReaderSidebarTagsListItem
 				key={ tag.id }
 				tag={ tag }

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -1,7 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useQueryClient } from '@tanstack/react-query';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { useDispatch } from 'react-redux';
@@ -57,7 +56,7 @@ export class RecommendedPosts extends PureComponent {
 					{ this.props.translate( 'Recommended Posts' ) }
 				</h1>
 				<ul className="reader-stream__recommended-posts-list">
-					{ map( posts, ( post, index ) => {
+					{ posts.map( ( post, index ) => {
 						const uiIndex = this.props.index + index;
 						const recommendationKey = this.props.recommendations?.[ index ];
 						return (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -13,7 +13,7 @@ import * as oauthToken from '@automattic/oauth-token';
 import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
 import isEqual from 'fast-deep-equal/es6';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -558,12 +558,12 @@ class Signup extends Component {
 		const stepsToProcess =
 			currentStepIndex >= 0 ? flowSteps.slice( 0, currentStepIndex + 1 ) : flowSteps;
 		const previouslyExcludedSteps = [ ...flows.excludedSteps ];
-		map( previouslyExcludedSteps, ( flowStepName ) => {
+		previouslyExcludedSteps.forEach( ( flowStepName ) => {
 			if ( stepsToProcess.includes( flowStepName ) ) {
 				this.processFulfilledSteps( flowStepName, nextProps );
 			}
 		} );
-		map( stepsToProcess, ( flowStepName ) =>
+		stepsToProcess.forEach( ( flowStepName ) =>
 			this.processFulfilledSteps( flowStepName, nextProps )
 		);
 

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -3,7 +3,7 @@ import { FormLabel } from '@automattic/components';
 import { getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
@@ -205,10 +205,10 @@ class Site extends Component {
 			return;
 		}
 
-		return map( messages, ( message, error_code ) => {
+		return Object.entries( messages ).map( ( [ error_code, message ] ) => {
 			if ( error_code === 'blog_name_reserved' ) {
 				return (
-					<span>
+					<span key={ error_code }>
 						<p>
 							{ message }
 							&nbsp;

--- a/client/sites/logs/hooks/use-site-logs-downloader.ts
+++ b/client/sites/logs/hooks/use-site-logs-downloader.ts
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { get, isEmpty, map } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { useReducer } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { FilterType, LogType } from 'calypso/data/hosting/use-site-logs-query';
@@ -204,7 +204,7 @@ export const useSiteLogsDownloader = ( {
 
 					logs = [
 						...logs,
-						...map( newLogData, ( entry ) => {
+						...newLogData.map( ( entry ) => {
 							const cleanedEntry = Object.fromEntries(
 								Object.entries( entry ).filter( ( [ key ] ) => key !== 'atomic_site_id' )
 							);

--- a/client/sites/marketing/connections/services/instagram.jsx
+++ b/client/sites/marketing/connections/services/instagram.jsx
@@ -1,5 +1,4 @@
 import isEqual from 'fast-deep-equal/es6';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import SocialLogo from 'calypso/components/social-logo';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
@@ -26,7 +25,9 @@ export class Instagram extends SharingService {
 	 */
 	removeConnection = ( connections ) => {
 		this.setState( { isDisconnecting: true } );
-		map( connections || this.props.keyringConnections, this.props.deleteStoredKeyringConnection );
+		( connections || this.props.keyringConnections || [] ).map(
+			this.props.deleteStoredKeyringConnection
+		);
 	};
 
 	renderLogo = () => (

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,7 +1,7 @@
 import { omit, orderBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { map, get } from 'lodash';
+import { get } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,
@@ -96,19 +96,19 @@ export function items( state = {}, action ) {
 			const { status } = action;
 			return {
 				...state,
-				[ stateKey ]: map( state[ stateKey ], updateComment( commentId, { status } ) ),
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).map( updateComment( commentId, { status } ) ),
 			};
 		}
 		case COMMENTS_EDIT: {
 			const { comment } = action;
 			return {
 				...state,
-				[ stateKey ]: map( state[ stateKey ], updateComment( commentId, comment ) ),
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).map( updateComment( commentId, comment ) ),
 			};
 		}
 		case COMMENTS_RECEIVE: {
 			const { skipSort } = action;
-			const comments = map( action.comments, ( _comment ) => ( {
+			const comments = action.comments.map( ( _comment ) => ( {
 				..._comment,
 				contiguous: ! action.commentById,
 				has_link: commentHasLink( _comment.content, _comment.has_link ),
@@ -127,16 +127,14 @@ export function items( state = {}, action ) {
 		case COMMENTS_LIKE:
 			return {
 				...state,
-				[ stateKey ]: map(
-					state[ stateKey ],
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).map(
 					updateComment( commentId, { i_like: true, like_count } )
 				),
 			};
 		case COMMENTS_UNLIKE:
 			return {
 				...state,
-				[ stateKey ]: map(
-					state[ stateKey ],
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).map(
 					updateComment( commentId, { i_like: false, like_count } )
 				),
 			};
@@ -145,8 +143,7 @@ export function items( state = {}, action ) {
 			const { error, errorType } = action;
 			return {
 				...state,
-				[ stateKey ]: map(
-					state[ stateKey ],
+				[ stateKey ]: ( state[ stateKey ] ?? [] ).map(
 					updateComment( commentId, {
 						placeholderState: PLACEHOLDER_STATE.ERROR,
 						placeholderError: error,
@@ -193,7 +190,7 @@ export function pendingItems( state = {}, action ) {
 
 	switch ( type ) {
 		case COMMENTS_UPDATES_RECEIVE: {
-			const comments = map( action.comments, ( _comment ) => ( {
+			const comments = action.comments.map( ( _comment ) => ( {
 				..._comment,
 				contiguous: ! action.commentById,
 				has_link: commentHasLink( _comment.content, _comment.has_link ),
@@ -206,7 +203,7 @@ export function pendingItems( state = {}, action ) {
 		}
 
 		case COMMENTS_RECEIVE: {
-			const receivedCommentIds = map( action.comments, 'ID' );
+			const receivedCommentIds = action.comments.map( ( comment ) => comment?.ID );
 			return {
 				...state,
 				[ stateKey ]: ( state[ stateKey ] ?? [] ).filter(

--- a/client/state/comments/selectors/get-post-comments-tree.js
+++ b/client/state/comments/selectors/get-post-comments-tree.js
@@ -1,6 +1,5 @@
 import { groupBy, keyBy, mapValues, partition } from '@automattic/js-utils';
 import treeSelect from '@automattic/tree-select';
-import { map } from 'lodash';
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';
@@ -43,7 +42,7 @@ export const getPostCommentsTree = treeSelect(
 		// Generate a new map of parent ID to an array of chilren IDs
 		// Reverse the order to keep it in chrono order
 		const parentToChildIdMap = mapValues( childrenGroupedByParent, ( _children ) =>
-			map( _children, 'ID' ).reverse()
+			_children.map( ( child ) => child?.ID ).reverse()
 		);
 
 		// convert all of the comments to comment nodes for our tree structure
@@ -52,11 +51,11 @@ export const getPostCommentsTree = treeSelect(
 			children: parentToChildIdMap[ item.ID ] || [],
 		} );
 
-		const commentsByIdMap = keyBy( map( items, transformItemToNode ), ( node ) => node.data.ID );
+		const commentsByIdMap = keyBy( items.map( transformItemToNode ), ( node ) => node.data.ID );
 
 		return {
 			...commentsByIdMap,
-			children: map( roots, ( root ) => root.ID ).reverse(),
+			children: roots.map( ( root ) => root.ID ).reverse(),
 		};
 	}
 );

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -1,5 +1,4 @@
 import deepFreeze from 'deep-freeze';
-import { map } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_LIKE,
@@ -49,7 +48,7 @@ describe( 'reducer', () => {
 				postId: 1,
 				comments: [ ...commentsNestedTree ].sort( () => ( ( Math.random() * 2 ) % 2 ? -1 : 1 ) ),
 			} );
-			const ids = map( response[ '1-1' ], 'ID' );
+			const ids = response[ '1-1' ].map( ( comment ) => comment?.ID );
 
 			expect( response[ '1-1' ] ).toHaveLength( 6 );
 			expect( ids ).toEqual( [ 11, 10, 9, 8, 7, 6 ] );
@@ -223,7 +222,7 @@ describe( 'reducer', () => {
 				postId: 1,
 				comments: [ ...commentsNestedTree ].sort( () => ( ( Math.random() * 2 ) % 2 ? -1 : 1 ) ),
 			} );
-			const ids = map( response[ '1-1' ], 'ID' );
+			const ids = response[ '1-1' ].map( ( comment ) => comment?.ID );
 
 			expect( response[ '1-1' ] ).toHaveLength( 6 );
 			expect( ids ).toEqual( [ 11, 10, 9, 8, 7, 6 ] );

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,4 +1,4 @@
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -91,7 +91,11 @@ export const queries = ( state = {}, action ) => {
 		case COMMENTS_QUERY_UPDATE:
 			return typeof action?.query?.page === 'undefined'
 				? state
-				: deepUpdateComments( state, map( action.comments, 'ID' ), action.query );
+				: deepUpdateComments(
+						state,
+						action.comments.map( ( comment ) => comment?.ID ),
+						action.query
+				  );
 		default:
 			return state;
 	}

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,6 +1,5 @@
 import { camelCase, set, snakeCase } from '@automattic/js-utils';
 import { extendAction } from '@automattic/state-utils';
-import { map } from 'lodash';
 
 const doBypassDataLayer = {
 	meta: {
@@ -20,7 +19,7 @@ export const bypassDataLayer = ( action ) => extendAction( action, doBypassDataL
  */
 export function convertKeysBy( obj, fn ) {
 	if ( Array.isArray( obj ) ) {
-		return map( obj, ( v ) => convertKeysBy( v, fn ) );
+		return obj.map( ( v ) => convertKeysBy( v, fn ) );
 	}
 
 	if ( typeof obj === 'object' && obj !== null ) {

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { pickBy } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { map } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import {
 	COMMENTS_REQUEST,
@@ -30,7 +29,7 @@ import { getSitePost } from 'calypso/state/posts/selectors';
 const isDate = ( date ) => date instanceof Date && ! isNaN( date );
 
 export const commentsFromApi = ( comments ) =>
-	map( comments, ( comment ) =>
+	( comments ?? [] ).map( ( comment ) =>
 		comment.author
 			? {
 					...comment,

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -1,4 +1,4 @@
-import { get, isEmpty, map } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST } from 'calypso/state/action-types';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { updateEligibility } from 'calypso/state/automated-transfer/actions';
@@ -93,8 +93,8 @@ const trackEligibility = ( data ) => {
 
 	const eventProps = {
 		has_warnings: hasEligibilityWarnings,
-		plugins: map( pluginWarnings, 'id' ).join( ',' ),
-		widgets: map( widgetWarnings, 'id' ).join( ',' ),
+		plugins: pluginWarnings.map( ( warning ) => warning?.id ).join( ',' ),
+		widgets: widgetWarnings.map( ( warning ) => warning?.id ).join( ',' ),
 	};
 
 	if ( isEligible ) {

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -1,5 +1,4 @@
 import { mapValues } from '@automattic/js-utils';
-import { map } from 'lodash';
 import { TIMEZONES_REQUEST } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -18,7 +17,7 @@ const noop = () => {};
  * @returns {Object} object whose keys are timezone values, values are timezone labels
  */
 const timezonePairsToMap = ( pairs ) =>
-	Object.fromEntries( map( pairs, ( { label, value } ) => [ value, label ] ) );
+	Object.fromEntries( ( pairs ?? [] ).map( ( { label, value } ) => [ value, label ] ) );
 
 /**
  * Normalize data gotten from the REST API making them more Calypso friendly.
@@ -28,7 +27,7 @@ export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent
 	rawOffsets: timezonePairsToMap( manual_utc_offsets ),
 	labels: timezonePairsToMap( timezones ),
 	byContinents: mapValues( timezones_by_continent, ( zones ) =>
-		map( zones, ( { value } ) => value )
+		( zones ?? [] ).map( ( { value } ) => value )
 	),
 } );
 

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -1,6 +1,6 @@
 import { omit, omitBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 import {
 	IMPORTS_AUTHORS_SET_MAPPING,
 	IMPORTS_AUTHORS_START_MAPPING,
@@ -126,8 +126,7 @@ function importerStatus( state = {}, action ) {
 					...state[ action.importerId ],
 					customData: {
 						...state[ action.importerId ]?.customData,
-						sourceAuthors: map(
-							state[ action.importerId ]?.customData?.sourceAuthors,
+						sourceAuthors: ( state[ action.importerId ]?.customData?.sourceAuthors ?? [] ).map(
 							( author ) =>
 								action.sourceAuthor.id === author.id
 									? {

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { pick } from '@automattic/js-utils';
 import { throttle } from '@wordpress/compose';
 import debugModule from 'debug';
-import { map } from 'lodash';
 import { setStoredItem } from 'calypso/lib/browser-storage';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import { APPLY_STORED_STATE } from './action-types';
@@ -107,7 +106,7 @@ export function persistOnChange( reduxStore, currentUserId ) {
 			const _timestamp = Date.now();
 			const reduxStateKey = getPersistenceKey( currentUserId );
 
-			const storeTasks = map( serializedState.get(), ( data, storageKey ) =>
+			const storeTasks = Object.entries( serializedState.get() ).map( ( [ storageKey, data ] ) =>
 				persistentStoreState( reduxStateKey, storageKey, data, _timestamp )
 			);
 

--- a/client/state/posts/utils/apply-post-edits.js
+++ b/client/state/posts/utils/apply-post-edits.js
@@ -1,4 +1,4 @@
-import { map, mergeWith } from 'lodash';
+import { mergeWith } from 'lodash';
 
 /*
  * Applies a metadata edit operation (either update or delete) to an existing array of
@@ -10,7 +10,7 @@ function applyMetadataEdit( metadata, edit ) {
 			// Either update existing key's value or append a new one at the end
 			const { key, value } = edit;
 			if ( ( Array.isArray( metadata ) ? metadata : [] ).find( ( m ) => m.key === key ) ) {
-				return map( metadata, ( m ) => ( m.key === key ? { key, value } : m ) );
+				return metadata.map( ( m ) => ( m.key === key ? { key, value } : m ) );
 			}
 			return ( Array.isArray( metadata ) ? metadata : [] ).concat( { key, value } );
 		}

--- a/client/state/posts/utils/get-term-ids-from-edits.js
+++ b/client/state/posts/utils/get-term-ids-from-edits.js
@@ -1,5 +1,5 @@
 import { mapValues } from '@automattic/js-utils';
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Takes existing term post edits and updates the `terms_by_id` attribute
@@ -38,7 +38,7 @@ export function getTermIdsFromEdits( post ) {
 	return {
 		...post,
 		terms_by_id: mapValues( taxonomies, ( taxonomy ) => {
-			const termIds = map( taxonomy, 'ID' );
+			const termIds = taxonomy.map( ( t ) => t?.ID );
 
 			// Hack: qs omits empty arrays in wpcom.js request, which prevents
 			// removing all terms for a given taxonomy since the empty array is not sent to the API

--- a/client/state/posts/utils/normalize-post-for-state.js
+++ b/client/state/posts/utils/normalize-post-for-state.js
@@ -1,5 +1,3 @@
-import { map } from 'lodash';
-
 /**
  * Recursively unset a value in an object by its path, represented by an array.
  * Intentionally mutates `object` to mirror native `delete` operator's behavior.
@@ -30,12 +28,12 @@ export function normalizePostForState( post ) {
 		[],
 		...Object.entries( post.terms ?? {} ).reduce(
 			( memo, [ taxonomy, terms ] ) =>
-				memo.concat( map( terms, ( term, slug ) => [ 'terms', taxonomy, slug ] ) ),
+				memo.concat( Object.keys( terms ?? {} ).map( ( slug ) => [ 'terms', taxonomy, slug ] ) ),
 			[]
 		),
-		...map( post.categories, ( category, slug ) => [ 'categories', slug ] ),
-		...map( post.tags, ( tag, slug ) => [ 'tags', slug ] ),
-		...map( post.attachments, ( attachment, id ) => [ 'attachments', id ] ),
+		...Object.keys( post.categories ?? {} ).map( ( slug ) => [ 'categories', slug ] ),
+		...Object.keys( post.tags ?? {} ).map( ( slug ) => [ 'tags', slug ] ),
+		...Object.keys( post.attachments ?? {} ).map( ( id ) => [ 'attachments', id ] ),
 	].reduce( ( memo, path ) => {
 		recursiveUnset( memo, path.concat( 'meta', 'links' ) );
 		return memo;

--- a/client/state/reader/site-blocks/selectors/get-blocked-sites.js
+++ b/client/state/reader/site-blocks/selectors/get-blocked-sites.js
@@ -1,6 +1,5 @@
 import { pickBy } from '@automattic/js-utils';
 import { createSelector } from '@automattic/state-utils';
-import { map } from 'lodash';
 
 import 'calypso/state/reader/init';
 
@@ -10,6 +9,6 @@ import 'calypso/state/reader/init';
  * @returns {Array}        Blocked site IDs
  */
 export default createSelector(
-	( state ) => map( Object.keys( pickBy( state.reader.siteBlocks.items ) ), Number ),
+	( state ) => Object.keys( pickBy( state.reader.siteBlocks.items ) ).map( Number ),
 	( state ) => [ state.reader.siteBlocks.items ]
 );

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -1,6 +1,5 @@
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
-import { map } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import {
 	DOMAIN_CONTACT_INFO_DISCLOSE,
@@ -45,7 +44,7 @@ export const domainsReceiveAction = ( siteId, domains ) => {
 	const action = {
 		type: SITE_DOMAINS_RECEIVE,
 		siteId,
-		domains: map( domains, createSiteDomainObject ),
+		domains: domains.map( createSiteDomainObject ),
 	};
 
 	debug( 'returning action: %o', action );

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -1,6 +1,5 @@
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
-import { map } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import {
 	SITE_PLANS_FETCH,
@@ -74,7 +73,7 @@ export function fetchSitePlansCompleted( siteId, plans ) {
 	return {
 		type: SITE_PLANS_FETCH_COMPLETED,
 		siteId,
-		plans: map( plans, createSitePlanObject ),
+		plans: Object.values( plans ?? {} ).map( createSitePlanObject ),
 	};
 }
 

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,6 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
 import treeSelect from '@automattic/tree-select';
-import { map } from 'lodash';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSerializedStatsQuery, normalizers, buildExportArray } from './utils';
@@ -175,9 +174,9 @@ export function getSiteStatsCSVData( state, siteId, statType, query, modifierFn 
 		return [];
 	}
 
-	return map( data, ( item ) => {
+	return data.flatMap( ( item ) => {
 		return buildExportArray( item, null, modifierFn );
-	} ).flat();
+	} );
 }
 
 /**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,6 +1,6 @@
 import { camelCase, capitalize, sortBy } from '@automattic/js-utils';
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
@@ -137,7 +137,7 @@ export function buildExportArray( data, parent = null, modifierFn = null ) {
 	}
 
 	if ( data.children ) {
-		const childData = map( data.children, ( child ) => {
+		const childData = data.children.map( ( child ) => {
 			return buildExportArray( child, label, modifierFn );
 		} );
 
@@ -391,7 +391,7 @@ export const normalizers = {
 			: [ 'days', startOf, 'postviews' ];
 		const viewData = get( data, dataPath, [] );
 
-		return map( viewData, ( item ) => {
+		return viewData.map( ( item ) => {
 			// To avoid showing a detail page for the Homepage set as latest posts.
 			const detailPage = site && item.href ? `/stats/post/${ item.id }/${ site.slug }` : null;
 			let inPeriod = false;
@@ -565,7 +565,7 @@ export const normalizers = {
 			return countryInfo[ viewData.country_code ];
 		} );
 
-		return map( countryData, ( viewData ) => {
+		return countryData.map( ( viewData ) => {
 			const country = countryInfo[ viewData.country_code ];
 
 			// ’ in country names causes google's geo viz to break

--- a/client/state/themes/actions/request-theme-on-atomic.js
+++ b/client/state/themes/actions/request-theme-on-atomic.js
@@ -1,4 +1,3 @@
-import { map } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { THEME_REQUEST, THEME_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
 import { receiveThemes } from 'calypso/state/themes/actions/receive-themes';
@@ -26,7 +25,7 @@ export function requestThemeOnAtomic( themeId, siteId ) {
 				path: `/sites/${ siteId }/themes/${ themeId }`,
 				apiNamespace: 'wp/v2',
 			} );
-			dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
+			dispatch( receiveThemes( ( themes ?? [] ).map( normalizeJetpackTheme ), siteId ) );
 			dispatch( {
 				type: THEME_REQUEST_SUCCESS,
 				siteId,

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -1,4 +1,3 @@
-import { map } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { fetchThemeInformation as fetchWporgThemeInformation } from 'calypso/lib/wporg';
 import {
@@ -89,7 +88,7 @@ export function requestTheme( themeId, siteId, locale ) {
 		return wpcom.req
 			.post( `/sites/${ siteId }/themes`, { themes: themeId } )
 			.then( ( { themes } ) => {
-				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
+				dispatch( receiveThemes( ( themes ?? [] ).map( normalizeJetpackTheme ), siteId ) );
 				dispatch( {
 					type: THEME_REQUEST_SUCCESS,
 					siteId,

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -1,4 +1,3 @@
-import { map } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { fetchThemesList as fetchWporgThemesList } from 'calypso/lib/wporg';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -80,18 +79,19 @@ export function requestThemes( siteId, query = {}, locale ) {
 		// and use it as default value for `found`.
 		return request()
 			.then( ( { themes: rawThemes, info: { results } = {}, found = results } ) => {
+				const themesList = rawThemes ?? [];
 				let themes;
 				if ( siteId === 'wporg' ) {
 					const communityThemeTier = getThemeTier( getState(), 'community' );
-					themes = map( rawThemes, ( theme ) => normalizeWporgTheme( theme, communityThemeTier ) );
+					themes = themesList.map( ( theme ) => normalizeWporgTheme( theme, communityThemeTier ) );
 				} else if ( siteId === 'wpcom' ) {
-					themes = map( rawThemes, normalizeWpcomTheme );
+					themes = themesList.map( normalizeWpcomTheme );
 				} else if ( isAtomic || isJetpack ) {
 					// Jetpack or Atomic Site
-					themes = map( rawThemes, normalizeJetpackTheme );
+					themes = themesList.map( normalizeJetpackTheme );
 				} else {
 					// WPCOM Site
-					themes = map( rawThemes, normalizeWpcomTheme );
+					themes = themesList.map( normalizeWpcomTheme );
 				}
 
 				if ( ( query.search || query.filter ) && query.page === 1 ) {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -1,7 +1,6 @@
 import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import { mapValues, omit } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
-import { map } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
@@ -340,7 +339,7 @@ const queriesReducer = ( state = {}, action ) => {
 				// Always 'patch' to avoid overwriting existing fields when receiving
 				// from a less rich endpoint such as /mine
 				( m ) =>
-					m.receive( map( themes, fromApi ), {
+					m.receive( themes.map( fromApi ), {
 						query,
 						found,
 						patch: true,

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -1,5 +1,4 @@
 import { omit, omitBy } from '@automattic/js-utils';
-import { map } from 'lodash';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -50,7 +49,7 @@ export function normalizeJetpackTheme( theme = {} ) {
 		...omit( theme, 'tags' ),
 		taxonomies: {
 			// Map slugs only since JP sites give us no names
-			theme_feature: map( theme.tags, ( slug ) => ( { slug } ) ),
+			theme_feature: theme.tags.map( ( slug ) => ( { slug } ) ),
 		},
 	};
 }
@@ -120,7 +119,10 @@ export function normalizeWporgTheme( theme, tier ) {
 	return {
 		...omit( normalizedTheme, 'tags' ),
 		taxonomies: {
-			theme_feature: map( normalizedTheme.tags, ( name, slug ) => ( { name, slug } ) ),
+			theme_feature: Object.entries( normalizedTheme.tags ?? {} ).map( ( [ slug, name ] ) => ( {
+				name,
+				slug,
+			} ) ),
 		},
 	};
 }

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -131,6 +131,12 @@ const FILTER_MESSAGE =
 	'Please use native `array.filter( ( item ) => … )` (or `Object.values( obj ).filter( … )` for objects) ' +
 	'instead of lodash `filter`. Expand iteratee shorthands to a predicate, use `Array.from( … )` for DOM ' +
 	'collections (a NodeList has no native `.filter`), and guard nullable collections with `?? []`.';
+const MAP_MESSAGE =
+	'Please use native `array.map( ( item ) => … )` instead of lodash `map`. For objects use ' +
+	'`Object.values( obj ).map( … )`, or `Object.entries( obj ).map( ( [ key, value ] ) => … )` when the ' +
+	'callback uses the key (lodash passes `( value, key )`). Expand pluck shorthands with optional chaining ' +
+	'(a property-name iteratee becomes `( item ) => item?.prop`), use `Array.from( … )` for DOM collections, ' +
+	'and guard nullable collections with `?? []`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -165,6 +171,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'some' ], message: SOME_MESSAGE },
 	{ name: 'lodash', importNames: [ 'forEach' ], message: FOREACH_MESSAGE },
 	{ name: 'lodash', importNames: [ 'filter' ], message: FILTER_MESSAGE },
+	{ name: 'lodash', importNames: [ 'map' ], message: MAP_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -201,6 +208,7 @@ const patterns = [
 	{ group: [ 'lodash/some' ], message: SOME_MESSAGE },
 	{ group: [ 'lodash/forEach' ], message: FOREACH_MESSAGE },
 	{ group: [ 'lodash/filter' ], message: FILTER_MESSAGE },
+	{ group: [ 'lodash/map' ], message: MAP_MESSAGE },
 ];
 
 module.exports = { paths, patterns };


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `map` with native `Array.prototype.map` across `client/`, `packages/`, and `apps/`.
* Add an eslint guard so lodash `map` cannot be reintroduced: a detailed `no-restricted-imports` message for the named/deep-import path, and `you-dont-need-lodash-underscore/map` for the namespace shape.

## Why are these changes being made?

* Part of the incremental, one-function-at-a-time removal of lodash in favor of native JS. Native methods are well-supported, drop a dependency, and reduce bundle size.
* The conversions are faithful to lodash's collection semantics rather than naive find-and-replace: object collections use `Object.values()` / `Object.entries()` (lodash passes `( value, key )`), DOM collections use `Array.from()`, pluck shorthands expand to optional-chained accessors, and nullable collections are guarded with `?? []` so a missing or null collection still yields `[]` instead of throwing.

## Testing Instructions

* CI: lint, type-check, and unit tests should pass.
* Locally: `yarn eslint` is clean on the changed files; `yarn typecheck-client` reports no new errors; the related `client/state`, `client/lib`, `client/blocks`, and `client/components` unit suites pass.
* The eslint guard can be verified by adding `import { map } from 'lodash'` to any file — it is reported with a migration message.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
