### PR TITLE
Legacy contact: add title and intro to the add contact form

### DIFF
--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -8,6 +8,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
+import { SectionHeader } from '../../components/section-header';
 import type { Field } from '@wordpress/dataviews';
 
 interface LegacyContactFormData {
@@ -18,6 +19,7 @@ const fields: Field< LegacyContactFormData >[] = [
 	{
 		id: 'email',
 		label: __( 'Email address' ),
+		description: __( 'We won’t notify this person that you’ve nominated them.' ),
 		type: 'email' as const,
 		isValid: {
 			required: true,
@@ -60,6 +62,13 @@ export default function LegacyContactForm() {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
+				<SectionHeader
+					title={ __( 'Add legacy contact' ) }
+					level={ 3 }
+					description={ __(
+						'Nominate a trusted person to be your legacy contact. Once nominated, we’ll generate a secure key for you to keep safe.'
+					) }
+				/>
 				<DataForm< LegacyContactFormData >
 					data={ formData }
 					fields={ fields }
@@ -76,7 +85,7 @@ export default function LegacyContactForm() {
 						isBusy={ isPending }
 						disabled={ isPending || ! isValid }
 					>
-						{ __( 'Set up legacy contact' ) }
+						{ __( 'Add legacy contact' ) }
 					</Button>
 				</ButtonStack>
 			</VStack>

--- a/client/dashboard/me/security-legacy-contact/test/index.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/index.test.tsx
@@ -71,7 +71,7 @@ describe( '<SecurityLegacyContact />', () => {
 		await waitFor( () => expect( removeScope.isDone() ).toBe( true ) );
 
 		// The empty state renders the set-up form.
-		expect( await screen.findByRole( 'button', { name: 'Set up legacy contact' } ) ).toBeVisible();
+		expect( await screen.findByRole( 'button', { name: 'Add legacy contact' } ) ).toBeVisible();
 	} );
 
 	test( 'does not remove the contact when the dialog is cancelled', async () => {


### PR DESCRIPTION
Fixes RSM-4562

## Proposed Changes

* Add a section title ("Add legacy contact") and intro copy to the legacy contact form on the dashboard, matching the pattern used by the SSH key form.
* Add a hint under the email field clarifying that we won't notify the nominated person.
* Rename the submit button from "Set up legacy contact" to "Add legacy contact" so the action verb matches the section title.

<img width="699" height="402" alt="Screenshot 2026-06-30 at 14 52 06" src="https://github.com/user-attachments/assets/7c4ae31f-c8da-4f8f-aab0-0296d526c8de" />

## Why are these changes being made?

* The legacy contact form previously had no introduction explaining what setting up a legacy contact does or what happens next, unlike the comparable SSH key form. This adds that context and brings the screen in line with the established form pattern.

## Testing Instructions

* Go to **/me/security/legacy-contact** in the dashboard with no legacy contact set.
* Confirm the form now shows the "Add legacy contact" heading and intro text, the email field has a hint beneath it, and the submit button reads "Add legacy contact".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
