### PR TITLE
Legacy contact: improve view page with guidance and a contact card

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -19,6 +19,7 @@ import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 import LegacyContactForm from './legacy-contact-form';
 import RemoveContactDialog from './remove-contact-dialog';
+
 import './style.scss';
 
 export default function SecurityLegacyContact() {

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -10,6 +10,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
+import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 import LegacyContactForm from './legacy-contact-form';
 import RemoveContactDialog from './remove-contact-dialog';
@@ -36,11 +37,16 @@ export default function SecurityLegacyContact() {
 					<VStack spacing={ 4 }>
 						{ contact ? (
 							<>
-								<Text>
-									{ createInterpolateElement( __( 'Your legacy contact is <contactEmail />.' ), {
-										contactEmail: <strong>{ contact.contact_email }</strong>,
-									} ) }
-								</Text>
+								<SectionHeader
+									title={ __( 'Your legacy contact' ) }
+									level={ 3 }
+									description={ createInterpolateElement(
+										__( 'Your legacy contact is <contactEmail />.' ),
+										{
+											contactEmail: <strong>{ contact.contact_email }</strong>,
+										}
+									) }
+								/>
 								<Text>
 									{ __(
 										'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,7 +1,6 @@
 import { legacyContactsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -37,16 +36,13 @@ export default function SecurityLegacyContact() {
 					<VStack spacing={ 4 }>
 						{ contact ? (
 							<>
-								<SectionHeader
-									title={ __( 'Your legacy contact' ) }
-									level={ 3 }
-									description={ createInterpolateElement(
-										__( 'Your legacy contact is <contactEmail />.' ),
-										{
-											contactEmail: <strong>{ contact.contact_email }</strong>,
-										}
-									) }
-								/>
+								<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
+								<VStack spacing={ 1 } alignment="flex-start">
+									<Text upperCase variant="muted" size={ 11 }>
+										{ __( 'Legacy contact email' ) }
+									</Text>
+									<Text size={ 15 }>{ contact.contact_email }</Text>
+								</VStack>
 								<Text>
 									{ __(
 										'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,7 +1,13 @@
 import { legacyContactsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	Icon,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
@@ -13,6 +19,7 @@ import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 import LegacyContactForm from './legacy-contact-form';
 import RemoveContactDialog from './remove-contact-dialog';
+import './style.scss';
 
 export default function SecurityLegacyContact() {
 	const { data: [ contact ] = [] } = useSuspenseQuery( legacyContactsQuery() );
@@ -37,12 +44,23 @@ export default function SecurityLegacyContact() {
 						{ contact ? (
 							<>
 								<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
-								<VStack spacing={ 1 } alignment="flex-start">
-									<Text upperCase variant="muted" size={ 11 }>
-										{ __( 'Legacy contact email' ) }
-									</Text>
-									<Text size={ 15 }>{ contact.contact_email }</Text>
-								</VStack>
+								<HStack
+									className="legacy-contact-card"
+									spacing={ 3 }
+									justify="flex-start"
+									alignment="center"
+									expanded={ false }
+								>
+									<div className="legacy-contact-card__avatar">
+										<Icon icon={ people } size={ 28 } />
+									</div>
+									<VStack spacing={ 0 } alignment="flex-start">
+										<Text upperCase variant="muted" size={ 11 }>
+											{ __( 'Legacy contact email' ) }
+										</Text>
+										<Text size={ 15 }>{ contact.contact_email }</Text>
+									</VStack>
+								</HStack>
 								<Text>
 									{ __(
 										'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -53,7 +53,7 @@ export default function SecurityLegacyContact() {
 								</Text>
 								<ButtonStack justify="flex-start">
 									<RouterLinkButton variant="secondary" to="/me/security/legacy-contact/print">
-										{ __( 'View printable details' ) }
+										{ __( 'View printable copy' ) }
 									</RouterLinkButton>
 									<Button
 										variant="secondary"

--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -41,6 +41,16 @@ export default function SecurityLegacyContact() {
 										contactEmail: <strong>{ contact.contact_email }</strong>,
 									} ) }
 								</Text>
+								<Text>
+									{ __(
+										'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'
+									) }
+								</Text>
+								<Text>
+									{ __(
+										'Treat the access key like a password and only share it with your legacy contact when you’re ready. We won’t contact them or send them the key on your behalf.'
+									) }
+								</Text>
 								<ButtonStack justify="flex-start">
 									<RouterLinkButton variant="secondary" to="/me/security/legacy-contact/print">
 										{ __( 'View printable details' ) }

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -8,6 +8,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
+import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 import './style.scss';
 
@@ -22,6 +23,7 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 
 	return (
 		<VStack spacing={ 6 }>
+			<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
 			<VStack spacing={ 2 }>
 				<Text>
 					{ __(

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -23,7 +23,7 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 	return (
 		<VStack spacing={ 6 }>
 			<VStack spacing={ 4 }>
-				<Text>
+				<Text className="legacy-contact-print__note">
 					{ __(
 						'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'
 					) }

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -22,15 +22,10 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 
 	return (
 		<VStack spacing={ 6 }>
-			<VStack spacing={ 4 }>
-				<Text className="legacy-contact-print__note">
+			<VStack spacing={ 2 }>
+				<Text>
 					{ __(
-						'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'
-					) }
-				</Text>
-				<Text className="legacy-contact-print__note">
-					{ __(
-						'Treat the access key like a password and only share it with your legacy contact when you’re ready. We won’t contact them or send them the key on your behalf.'
+						'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
 					) }
 				</Text>
 			</VStack>
@@ -47,9 +42,6 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 					{ __( 'Access key' ) }
 				</Text>
 				<div className="legacy-contact-print__key">{ contact.access_key }</div>
-				<Text variant="muted">
-					{ __( 'Treat your access key like a password and keep it private.' ) }
-				</Text>
 			</VStack>
 
 			<ButtonStack justify="flex-start" className="legacy-contact-print__actions">

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -22,15 +22,15 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 
 	return (
 		<VStack spacing={ 6 }>
-			<VStack spacing={ 2 }>
+			<VStack spacing={ 4 }>
 				<Text>
 					{ __(
-						'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
+						'The printable copy contains the access key your legacy contact will need. We recommend printing it and storing it with your estate planning documents, or saving it securely in a password manager.'
 					) }
 				</Text>
-				<Text>
+				<Text className="legacy-contact-print__note">
 					{ __(
-						'We recommend printing this page or storing it somewhere secure, like a password manager.'
+						'Treat the access key like a password and only share it with your legacy contact when you’re ready. We won’t contact them or send them the key on your behalf.'
 					) }
 				</Text>
 			</VStack>

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -28,6 +28,11 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 						'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
 					) }
 				</Text>
+				<Text>
+					{ __(
+						'We recommend printing this page or storing it somewhere secure, like a password manager.'
+					) }
+				</Text>
 			</VStack>
 
 			<VStack spacing={ 1 } alignment="flex-start">
@@ -42,6 +47,9 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 					{ __( 'Access key' ) }
 				</Text>
 				<div className="legacy-contact-print__key">{ contact.access_key }</div>
+				<Text variant="muted">
+					{ __( 'Treat your access key like a password and keep it private.' ) }
+				</Text>
 			</VStack>
 
 			<ButtonStack justify="flex-start" className="legacy-contact-print__actions">

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -1,3 +1,24 @@
+.legacy-contact-card {
+	padding: 12px 16px;
+	border: 1px solid var( --dashboard-surface__border-color );
+	border-radius: 8px;
+}
+
+.legacy-contact-card__avatar {
+	display: flex;
+	flex-shrink: 0;
+	align-items: center;
+	justify-content: center;
+	inline-size: 48px;
+	block-size: 48px;
+	border-radius: 50%;
+	background: var( --dashboard-background-color__elevated, var( --color-surface ) );
+
+	svg {
+		fill: var( --color-primary );
+	}
+}
+
 .legacy-contact-print__key {
 	font-family: monospace;
 	font-size: 1.5rem;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -40,12 +40,6 @@
 			display: none;
 		}
 
-		// Hide the on-screen guidance; it's instructions for the account owner,
-		// not part of the printed record.
-		.legacy-contact-print__note {
-			display: none;
-		}
-
 		// Hide the breadcrumbs; keep the page title as the document heading.
 		.dashboard-section-header__prefix {
 			display: none;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -40,7 +40,7 @@
 			display: none;
 		}
 
-		// Hide the on-screen security note; it's guidance for the account owner,
+		// Hide the on-screen guidance; it's instructions for the account owner,
 		// not part of the printed record.
 		.legacy-contact-print__note {
 			display: none;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -40,6 +40,12 @@
 			display: none;
 		}
 
+		// Hide the on-screen security note; it's guidance for the account owner,
+		// not part of the printed record.
+		.legacy-contact-print__note {
+			display: none;
+		}
+
 		// Hide the breadcrumbs; keep the page title as the document heading.
 		.dashboard-section-header__prefix {
 			display: none;


### PR DESCRIPTION
Fixes RSM-4563

## Proposed Changes

Enriches the legacy contact view page (`/me/security/legacy-contact`) when a legacy contact is already set up:

* Adds a "Your legacy contact" section header (matching the add-contact form), and presents the contact in a small card — the `people` icon in an avatar tile alongside the contact's email.
* Adds guidance text:
  * Explains that the printable copy contains the access key and recommends printing it (to store with estate planning documents) or saving it in a password manager.
  * Notes to treat the access key like a password and only share it with the legacy contact when ready, clarifying that we won't contact them or send them the key on the owner's behalf.
* Renames the action button from "View printable details" to "View printable copy" to match the new wording.
* Adds the same "Your legacy contact" section header to the printable copy page for consistency.

<img width="706" height="456" alt="Screenshot 2026-06-30 at 15 45 37" src="https://github.com/user-attachments/assets/2dbd84c0-2952-4f58-be30-a1c1717fe509" />

## Why are these changes being made?

The view page previously showed only the contact's email and action buttons. Because the access key grants account access, the page should set clearer expectations about how to store the printable copy and how to handle the key, and present the contact itself more clearly.

## Testing Instructions

1. Go to **Me → Security → Legacy contact** with a legacy contact already set up.
2. Confirm the page shows the "Your legacy contact" header, the contact card (people icon + email), and the two guidance paragraphs above the action buttons.
3. Confirm the email is shown prominently (not greyed out) and the card colors look correct in both light and dark mode.
4. Click **View printable copy** and confirm the printable page also shows the "Your legacy contact" header.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
