### PR TITLE
Legacy contact: add a private notes field

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -62,6 +62,16 @@ export default function SecurityLegacyContact() {
 										<Text as="dd" size={ 15 }>
 											{ contact.contact_email }
 										</Text>
+										{ contact.notes && (
+											<>
+												<Text as="dt" upperCase variant="muted" size={ 11 }>
+													{ __( 'Notes' ) }
+												</Text>
+												<Text as="dd" size={ 15 } className="legacy-contact-card__notes">
+													{ contact.notes }
+												</Text>
+											</>
+										) }
 									</dl>
 								</HStack>
 								<Text>

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -39,7 +39,7 @@ const fields: Field< LegacyContactFormData >[] = [
 					onChange={ ( value ) => onChange( { [ id ]: value } ) }
 					label={ hideLabelFromVision ? undefined : field.label }
 					help={ __(
-						'Only you can see these notes — we won’t share them with your legacy contact. Use them to record any wishes, such as which sites to transfer.'
+						'Only you can see these notes. We won’t share them with your legacy contact. Use them to record any wishes, such as which sites to transfer.'
 					) }
 					rows={ 3 }
 				/>

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -1,6 +1,6 @@
 import { addLegacyContactMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button, TextareaControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -13,6 +13,7 @@ import type { Field } from '@wordpress/dataviews';
 
 interface LegacyContactFormData {
 	email: string;
+	notes: string;
 }
 
 const fields: Field< LegacyContactFormData >[] = [
@@ -25,11 +26,31 @@ const fields: Field< LegacyContactFormData >[] = [
 			required: true,
 		},
 	},
+	{
+		id: 'notes',
+		label: __( 'Notes' ),
+		Edit: ( { data, field, onChange, hideLabelFromVision } ) => {
+			const { id, getValue } = field;
+
+			return (
+				<TextareaControl
+					__nextHasNoMarginBottom
+					value={ getValue( { item: data } ) || '' }
+					onChange={ ( value ) => onChange( { [ id ]: value } ) }
+					label={ hideLabelFromVision ? undefined : field.label }
+					help={ __(
+						'Only you can see these notes — we won’t share them with your legacy contact. Use them to record any wishes, such as which sites to transfer.'
+					) }
+					rows={ 3 }
+				/>
+			);
+		},
+	},
 ];
 
 const form = {
 	layout: { type: 'regular' as const },
-	fields: [ 'email' ],
+	fields: [ 'email', 'notes' ],
 };
 
 export default function LegacyContactForm() {
@@ -37,7 +58,7 @@ export default function LegacyContactForm() {
 	const { mutate: addContact, isPending } = useMutation( addLegacyContactMutation() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const [ formData, setFormData ] = useState< LegacyContactFormData >( { email: '' } );
+	const [ formData, setFormData ] = useState< LegacyContactFormData >( { email: '', notes: '' } );
 
 	const { validity, isValid } = useFormValidity( formData, fields, form );
 
@@ -47,16 +68,19 @@ export default function LegacyContactForm() {
 			return;
 		}
 		recordTracksEvent( 'calypso_dashboard_security_legacy_contact_add_click' );
-		addContact( formData.email, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'Legacy contact saved.' ), { type: 'snackbar' } );
-			},
-			onError: ( error: Error ) => {
-				createErrorNotice( error.message || __( 'Failed to save legacy contact.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		addContact(
+			{ email: formData.email, notes: formData.notes.trim() || undefined },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Legacy contact saved.' ), { type: 'snackbar' } );
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message || __( 'Failed to save legacy contact.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
 	};
 
 	return (

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -39,7 +39,8 @@ const fields: Field< LegacyContactFormData >[] = [
 					__nextHasNoMarginBottom
 					value={ getValue( { item: data } ) || '' }
 					onChange={ ( value ) => onChange( { [ id ]: value } ) }
-					label={ hideLabelFromVision ? undefined : field.label }
+					label={ field.label }
+					hideLabelFromVision={ hideLabelFromVision }
 					help={ __(
 						'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
 					) }

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -11,6 +11,8 @@ import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import type { Field } from '@wordpress/dataviews';
 
+const LEGACY_CONTACT_NOTES_MAX_LENGTH = 500;
+
 interface LegacyContactFormData {
 	email: string;
 	notes: string;
@@ -39,8 +41,9 @@ const fields: Field< LegacyContactFormData >[] = [
 					onChange={ ( value ) => onChange( { [ id ]: value } ) }
 					label={ hideLabelFromVision ? undefined : field.label }
 					help={ __(
-						'We won’t share these notes with your legacy contact. Use them to record any wishes, such as which sites to transfer.'
+						'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
 					) }
+					maxLength={ LEGACY_CONTACT_NOTES_MAX_LENGTH }
 					rows={ 3 }
 				/>
 			);
@@ -84,7 +87,7 @@ export default function LegacyContactForm() {
 	};
 
 	return (
-		<form onSubmit={ handleSubmit }>
+		<form className="legacy-contact-form" onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
 				<SectionHeader
 					title={ __( 'Add legacy contact' ) }

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -39,7 +39,7 @@ const fields: Field< LegacyContactFormData >[] = [
 					onChange={ ( value ) => onChange( { [ id ]: value } ) }
 					label={ hideLabelFromVision ? undefined : field.label }
 					help={ __(
-						'Only you can see these notes. We won’t share them with your legacy contact. Use them to record any wishes, such as which sites to transfer.'
+						'We won’t share these notes with your legacy contact. Use them to record any wishes, such as which sites to transfer.'
 					) }
 					rows={ 3 }
 				/>

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -1,3 +1,7 @@
+.legacy-contact-form .components-base-control__help {
+	text-wrap: pretty;
+}
+
 .legacy-contact-card {
 	padding: 12px 16px;
 	border: 1px solid var( --dashboard-surface__border-color );
@@ -11,6 +15,10 @@
 
 	dd {
 		margin: 0;
+	}
+
+	dd + dt {
+		margin-block-start: 12px;
 	}
 }
 

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -14,6 +14,11 @@
 	}
 }
 
+.legacy-contact-card__notes {
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
 .legacy-contact-card__avatar {
 	display: flex;
 	flex-shrink: 0;

--- a/client/dashboard/me/security-legacy-contact/test/index.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/index.test.tsx
@@ -5,9 +5,10 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SecurityLegacyContact from '../index';
+import type { LegacyContact } from '@automattic/api-core';
 
 const API = 'https://public-api.wordpress.com';
-const CONTACT = {
+const CONTACT: LegacyContact = {
 	legacy_contact_id: 123,
 	contact_email: 'trusted@example.com',
 	created_at: '2026-01-01T00:00:00+00:00',
@@ -38,6 +39,14 @@ describe( '<SecurityLegacyContact />', () => {
 
 		expect( await screen.findByText( CONTACT.contact_email ) ).toBeVisible();
 		expect( await removeButton() ).toBeVisible();
+	} );
+
+	test( 'shows the contact notes when present', async () => {
+		interceptContacts( [ { ...CONTACT, notes: 'Please transfer my-blog.com to my sister.' } ] );
+
+		renderScreen();
+
+		expect( await screen.findByText( 'Please transfer my-blog.com to my sister.' ) ).toBeVisible();
 	} );
 
 	test( 'opens a confirmation dialog when removing', async () => {

--- a/client/dashboard/me/security-legacy-contact/test/index.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/index.test.tsx
@@ -49,6 +49,62 @@ describe( '<SecurityLegacyContact />', () => {
 		expect( await screen.findByText( 'Please transfer my-blog.com to my sister.' ) ).toBeVisible();
 	} );
 
+	test( 'submits trimmed notes when adding a contact', async () => {
+		interceptContacts( [] );
+		let requestBody: Record< string, unknown > | undefined;
+		const addScope = nock( API )
+			.post( '/wpcom/v2/me/legacy-contacts', ( body ) => {
+				requestBody = body;
+				return true;
+			} )
+			.query( true )
+			.reply( 200, CONTACT );
+		interceptContacts( [ CONTACT ] );
+
+		renderScreen();
+
+		await userEvent.type(
+			await screen.findByRole( 'textbox', { name: /Email address/ } ),
+			CONTACT.contact_email
+		);
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Notes' } ),
+			'  Please transfer my-blog.com.  '
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: 'Add legacy contact' } ) );
+
+		await waitFor( () => expect( addScope.isDone() ).toBe( true ) );
+		expect( requestBody ).toEqual( {
+			email: CONTACT.contact_email,
+			notes: 'Please transfer my-blog.com.',
+		} );
+	} );
+
+	test( 'omits notes from the request when only whitespace is entered', async () => {
+		interceptContacts( [] );
+		let requestBody: Record< string, unknown > | undefined;
+		const addScope = nock( API )
+			.post( '/wpcom/v2/me/legacy-contacts', ( body ) => {
+				requestBody = body;
+				return true;
+			} )
+			.query( true )
+			.reply( 200, CONTACT );
+		interceptContacts( [ CONTACT ] );
+
+		renderScreen();
+
+		await userEvent.type(
+			await screen.findByRole( 'textbox', { name: /Email address/ } ),
+			CONTACT.contact_email
+		);
+		await userEvent.type( screen.getByRole( 'textbox', { name: 'Notes' } ), '   ' );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Add legacy contact' } ) );
+
+		await waitFor( () => expect( addScope.isDone() ).toBe( true ) );
+		expect( requestBody ).toEqual( { email: CONTACT.contact_email } );
+	} );
+
 	test( 'opens a confirmation dialog when removing', async () => {
 		interceptContacts( [ CONTACT ] );
 

--- a/packages/api-core/src/me-legacy-contacts/mutators.ts
+++ b/packages/api-core/src/me-legacy-contacts/mutators.ts
@@ -1,13 +1,13 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { LegacyContact } from './types';
 
-export async function addLegacyContact( email: string ): Promise< LegacyContact > {
+export async function addLegacyContact( email: string, notes?: string ): Promise< LegacyContact > {
 	return wpcom.req.post(
 		{
 			path: '/me/legacy-contacts',
 			apiNamespace: 'wpcom/v2',
 		},
-		{ email }
+		{ email, notes }
 	);
 }
 

--- a/packages/api-core/src/me-legacy-contacts/mutators.ts
+++ b/packages/api-core/src/me-legacy-contacts/mutators.ts
@@ -7,7 +7,7 @@ export async function addLegacyContact( email: string, notes?: string ): Promise
 			path: '/me/legacy-contacts',
 			apiNamespace: 'wpcom/v2',
 		},
-		{ email, notes }
+		{ email, ...( notes && { notes } ) }
 	);
 }
 

--- a/packages/api-core/src/me-legacy-contacts/types.ts
+++ b/packages/api-core/src/me-legacy-contacts/types.ts
@@ -1,6 +1,7 @@
 export interface LegacyContact {
 	legacy_contact_id: number;
 	contact_email: string;
+	notes?: string;
 	created_at: string;
 }
 

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -28,7 +28,8 @@ export const legacyContactQuery = ( legacyContactId: number ) =>
 
 export const addLegacyContactMutation = () =>
 	mutationOptions( {
-		mutationFn: ( email: string ) => addLegacyContact( email ),
+		mutationFn: ( { email, notes }: { email: string; notes?: string } ) =>
+			addLegacyContact( email, notes ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( legacyContactsQuery() );
 		},


### PR DESCRIPTION
Part of RSM-4532.

## Proposed Changes

* Add an optional **notes** field to the legacy contact, alongside the nominated email address.
* In the add-contact form, notes render as a small (3-row) textarea.
* In the "view contact" card, notes display under the email (only when present), preserving line breaks.
<img width="694" height="257" alt="Screenshot 2026-07-03 at 14 59 27" src="https://github.com/user-attachments/assets/c5688b72-5da1-4f8f-84e7-28b1fe3c3084" />

<img width="720" height="313" alt="Screenshot 2026-07-03 at 14 58 26" src="https://github.com/user-attachments/assets/821a6bd3-0fae-4593-9c5a-82e432bcbcd3" />



## Why are these changes being made?

Users nominating a legacy contact often want to leave instructions - for example, which sites should be transferred. A private notes field lets them record those wishes in one place, without those notes being shared with the nominated contact.

## Testing Instructions

* Go to **Me → Security → Legacy contact**.
* In the add form, confirm the **Notes** textarea appears under the email with the privacy hint, and that you can submit with or without notes.
* Confirm a saved note appears under the email in the view card and that line breaks are preserved.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?