### PR TITLE
Notifications: fetch up to 200 notes and fill load-more to the cap

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -17,7 +17,7 @@ const settings = {
 	// window (NOTES_PER_PAGE); the list fetches as many pages as needed to fill
 	// the window, so the window never outruns the loaded notes.
 	increment_limit: 10,
-	max_limit: 100,
+	max_limit: 200,
 };
 
 export function Client() {
@@ -197,10 +197,11 @@ function getNotes( before ) {
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
-		// Older pages request what's left under the cap; the no-`before` refresh
+		// Older pages request what's left under the cap, plus one for the anchor an
+		// inclusive `before` echoes back (de-duped below); the no-`before` refresh
 		// requests a small fixed head window.
 		number: before
-			? Math.min( settings.increment_limit, settings.max_limit - loaded )
+			? Math.min( settings.increment_limit, settings.max_limit - loaded + 1 )
 			: settings.initial_limit,
 		locale: this.locale,
 	};
@@ -287,8 +288,10 @@ function getNotes( before ) {
 		// The lightweight id/hash list the polling diff compares against.
 		const pageList = data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) );
 		if ( before ) {
-			// An older page appends to the window.
-			this.noteList = this.noteList.concat( pageList );
+			// An older page appends to the window, de-duped so the anchor an inclusive
+			// `before` echoes back isn't double-counted.
+			const known = new Set( this.noteList.map( ( n ) => n.id ) );
+			this.noteList = this.noteList.concat( pageList.filter( ( n ) => ! known.has( n.id ) ) );
 		} else {
 			// Merge the head over the window, keeping the older paged-in tail.
 			const headIds = new Set( pageList.map( ( n ) => n.id ) );
@@ -456,9 +459,10 @@ function getFilteredNotes( before ) {
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
 		// No `before`: re-request a small fixed head window. With it: page an older
-		// slice, capped to what's left under max_limit.
+		// slice, capped to what's left under max_limit plus one for the anchor an
+		// inclusive `before` echoes back (de-duped below).
 		number: before
-			? Math.min( settings.increment_limit, settings.max_limit - unreadIds.length )
+			? Math.min( settings.increment_limit, settings.max_limit - unreadIds.length + 1 )
 			: settings.initial_limit,
 		locale: this.locale,
 		...filter,

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -10,6 +10,9 @@ import getUnreadNoteIds from '../../state/selectors/get-unread-note-ids';
 import Client from '../index';
 import { init } from '../wpcom';
 
+// Mirrors settings.max_limit in the client.
+const MAX_LIMIT = 200;
+
 // Distinct, monotonic timestamps so ordering is unambiguous: a higher id is a
 // newer note, so the lowest id is always the oldest (last) in the sorted list.
 const makeNote = ( id ) => ( {
@@ -123,16 +126,34 @@ describe( 'RestClient', () => {
 			expect( getCalls ).toHaveLength( 0 );
 		} );
 
-		it( 'stops paging when a capped page echoes back only the anchor', () => {
-			// 99 loaded leaves one slot under max_limit, so the next page is capped to
-			// number=1. An inclusive `before` echoes that single anchor note back, so
-			// the page is full-size (1 of 1) yet adds nothing new. Without the no-new-id
-			// check this never latches and the catch-up loop refetches forever.
-			store.dispatch( actions.notes.addNotes( fullPage( 99, 100 ) ) ); // ids 100..2
+		it( 'requests the final slot plus the echoed anchor when one short of the cap', () => {
+			// One short of max_limit leaves a single slot. An inclusive `before` echoes
+			// the anchor back, so the page is sized to the slot plus one for that anchor
+			// (number=2). ids (MAX_LIMIT)..2, oldest is id 2.
+			store.dispatch( actions.notes.addNotes( fullPage( MAX_LIMIT - 1, MAX_LIMIT ) ) );
 
 			client.loadMore();
 			expect( getCalls ).toHaveLength( 1 );
-			expect( getCalls[ 0 ].query.number ).toBe( 1 ); // capped to the remaining slot
+			expect( getCalls[ 0 ].query.number ).toBe( 2 ); // remaining slot + echoed anchor
+
+			// Server echoes the anchor (id 2) and returns the genuinely older note
+			// (id 1), filling the window to the cap.
+			getCalls[ 0 ].callback( null, {
+				notes: [ makeNote( 2 ), makeNote( 1 ) ],
+				last_seen_time: 0,
+			} );
+
+			expect( getAllNotes( store.getState() ) ).toHaveLength( MAX_LIMIT );
+		} );
+
+		it( 'latches when a capped page returns only the echoed anchor', () => {
+			// Same one-short-of-cap setup, but the server is exhausted: the page returns
+			// just the anchor. The no-new guard must latch instead of refetching.
+			// ids (MAX_LIMIT)..2, oldest is id 2.
+			store.dispatch( actions.notes.addNotes( fullPage( MAX_LIMIT - 1, MAX_LIMIT ) ) );
+
+			client.loadMore();
+			expect( getCalls ).toHaveLength( 1 );
 
 			const oldest = getAllNotes( store.getState() ).slice( -1 )[ 0 ]; // id 2
 			getCalls[ 0 ].callback( null, { notes: [ oldest ], last_seen_time: 0 } );
@@ -145,12 +166,46 @@ describe( 'RestClient', () => {
 		} );
 
 		it( 'reports no more notes once the cap is reached', () => {
-			// 100 notes (settings.max_limit) loaded means we never page past the cap.
-			store.dispatch( actions.notes.addNotes( fullPage( 100, 100 ) ) );
+			// A full max_limit window loaded means we never page past the cap.
+			store.dispatch( actions.notes.addNotes( fullPage( MAX_LIMIT, MAX_LIMIT ) ) );
 			expect( client.hasMoreNotes() ).toBe( false );
 
 			client.loadMore();
 			expect( getCalls ).toHaveLength( 0 );
+		} );
+
+		// End-to-end against a server with effectively unlimited notes and an inclusive
+		// `before` cursor (production WP.com behavior): the window must page all the way
+		// to the cap despite each older page echoing the anchor back.
+		it( 'loads exactly max_limit unique notes by paging to the cap', () => {
+			const TOP_ID = 1000; // server has ids 1000..1, far more than the cap.
+			// Map an inclusive `before` (epoch seconds) back to its anchor id and
+			// return the anchor plus the notes immediately older than it.
+			const epochBase = Math.floor( Date.parse( makeNote( 0 ).timestamp ) / 1000 );
+			const respondInclusive = ( call ) => {
+				const { number, before } = call.query;
+				const startId = before === undefined ? TOP_ID : before - epochBase;
+				const notes = [];
+				for ( let i = 0; i < number && startId - i >= 1; i++ ) {
+					notes.push( makeNote( startId - i ) );
+				}
+				call.callback( null, { notes, last_seen_time: 0 } );
+			};
+
+			client.getNotes();
+			respondInclusive( getCalls[ 0 ] );
+
+			for ( let i = 0; i < 100 && client.hasMoreNotes(); i++ ) {
+				getCalls.length = 0;
+				client.loadMore();
+				if ( ! getCalls.length ) {
+					break;
+				}
+				respondInclusive( getCalls[ getCalls.length - 1 ] );
+			}
+
+			const unique = new Set( getAllNotes( store.getState() ).map( ( n ) => n.id ) );
+			expect( unique.size ).toBe( MAX_LIMIT );
 		} );
 
 		// A filtered (Unread) fetch drops older notes into the shared store. The All
@@ -398,14 +453,15 @@ describe( 'RestClient', () => {
 			client.setFilter( { unread: 1 } );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 
-			// Page in full older pages until the list reaches max_limit (100).
-			for ( let oldest = 199; oldest >= 119; oldest -= 10 ) {
+			// Page in full older pages (10 at a time) until the list reaches max_limit.
+			// Starts at 10 loaded (ids 209..200); each page adds the next 10 older ids.
+			for ( let oldest = 199; oldest >= 219 - MAX_LIMIT; oldest -= 10 ) {
 				getCalls.length = 0;
 				client.loadMore();
 				getCalls[ 0 ].callback( null, { notes: fullPage( 10, oldest ), last_seen_time: 0 } );
 			}
 
-			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( 100 );
+			expect( getUnreadNoteIds( store.getState() ) ).toHaveLength( MAX_LIMIT );
 			expect( client.filteredHasMore ).toBe( false );
 
 			// At the cap, load-more must not fire another request.


### PR DESCRIPTION
## Proposed Changes

* Raise `max_limit` from 100 to **200** in the notifications REST client, so the panel can page in up to 200 notes via load-more.
* Fix load-more stalling short of the cap. The `/notifications/` `before` cursor is **inclusive**, so each older page echoes the anchor note back. That echo was (a) double-counted in `noteList`, inflating the window count that gates `hasMoreNotes()` and sizes the per-page request, and (b) consuming the final slot — so the list latched ~9 notes short of the cap. Now the load-more request asks for one extra to cover the echoed anchor and de-dupes it out of `noteList`. Applied to both the All view (`getNotes`) and the Unread view (`getFilteredNotes`).
* Add an end-to-end regression test that pages all the way to `max_limit` against a simulated inclusive-`before` server, plus a `MAX_LIMIT` test constant so the cap-boundary tests track the value.

## Why are these changes being made?

* Heavy users want to see more than 100 notifications in-panel without the list capping early. The rationale for landing on **200** specifically — and for keeping the inclusive `before` cursor for paging, which is acceptable for now — is discussed in [DOTMSD-1321](https://linear.app/a8c/issue/DOTMSD-1321/improve-contrast-for-readunread-state-and-notification-type-icons#comment-4ceef2ce).
* Raising the cap is only safe now because #111927 made the poll/refresh window fixed-size and merge-based (it no longer re-requests the whole window and prunes the overflow). With that in place, a higher total cap no longer causes the background poll to trim notes back down — load-more pages in 10 at a time and accumulates.
* Separately, the inclusive-anchor handling meant the panel never actually reached its own cap. A probe against the current code reached only 91 of 100; with this fix it reaches the full cap.

## Testing Instructions

* `yarn test-apps apps/notifications` — all suites pass (57 tests), including the new "loads exactly max_limit unique notes by paging to the cap" regression test and the updated cap-boundary cases.
* Manually: open the panel and scroll to load notifications. The list should page in 10 at a time and keep going until it has loaded 200 (given enough notifications on the account), rather than stopping in the low 90s. Repeat on the Unread tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
