### PR TITLE
Agents Manager: fix translated UI strings text domain

### DIFF
--- a/packages/agents-manager/src/auth/calypso-auth-provider.ts
+++ b/packages/agents-manager/src/auth/calypso-auth-provider.ts
@@ -282,16 +282,16 @@ export const defaultCalypsoErrorHandler = ( error: CalypsoAuthError ): string =>
 	if ( error?.code === 'rest_invalid_nonce' ) {
 		return __(
 			'Your session expired. Please refresh the page and try again.',
-			'__i18n_text_domain__'
+			__i18n_text_domain__
 		);
 	}
 
 	if ( error?.code === 'rest_forbidden' || error?.status === 403 ) {
-		return __( "You don't have permission to access AI features.", '__i18n_text_domain__' );
+		return __( "You don't have permission to access AI features.", __i18n_text_domain__ );
 	}
 
 	if ( error?.code === 'rest_no_route' || error?.status === 404 ) {
-		return __( 'AI service is not available. Please try again later.', '__i18n_text_domain__' );
+		return __( 'AI service is not available. Please try again later.', __i18n_text_domain__ );
 	}
 
 	if (
@@ -301,16 +301,16 @@ export const defaultCalypsoErrorHandler = ( error: CalypsoAuthError ): string =>
 	) {
 		return __(
 			'Network connection issue. Please check your internet connection and try again.',
-			'__i18n_text_domain__'
+			__i18n_text_domain__
 		);
 	}
 
 	if ( error?.status === 401 ) {
 		return __(
 			'Your session expired. Please refresh the page and try again.',
-			'__i18n_text_domain__'
+			__i18n_text_domain__
 		);
 	}
 
-	return __( 'Unable to connect to AI service. Please try again.', '__i18n_text_domain__' );
+	return __( 'Unable to connect to AI service. Please try again.', __i18n_text_domain__ );
 };

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -121,9 +121,9 @@ function getEmptyViewHeading(): string {
 		return override;
 	}
 	if ( isReaderChatHost() ) {
-		return __( 'Ask me anything about this blog.', '__i18n_text_domain__' );
+		return __( 'Ask me anything about this blog.', __i18n_text_domain__ );
 	}
-	return __( 'Howdy! How can I help you today?', '__i18n_text_domain__' );
+	return __( 'Howdy! How can I help you today?', __i18n_text_domain__ );
 }
 
 function getEmptyViewHelp(): string {
@@ -132,9 +132,9 @@ function getEmptyViewHelp(): string {
 		return override;
 	}
 	if ( isReaderChatHost() ) {
-		return __( 'Or type your own question below.', '__i18n_text_domain__' );
+		return __( 'Or type your own question below.', __i18n_text_domain__ );
 	}
-	return __( 'Got a different request? Ask away.', '__i18n_text_domain__' );
+	return __( 'Got a different request? Ask away.', __i18n_text_domain__ );
 }
 
 export default function AgentChat( {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -245,7 +245,7 @@ export default function AgentDock( {
 		return [
 			{
 				icon: comment,
-				title: __( 'New chat', '__i18n_text_domain__' ),
+				title: __( 'New chat', __i18n_text_domain__ ),
 				isDisabled: pathname === '/chat' && isOrchestratorChatEmpty,
 				onClick: () => {
 					recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
@@ -260,7 +260,7 @@ export default function AgentDock( {
 			! isReaderChat &&
 				isDocked && {
 					icon: login,
-					title: __( 'Pop out sidebar', '__i18n_text_domain__' ),
+					title: __( 'Pop out sidebar', __i18n_text_domain__ ),
 					onClick: () => {
 						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
 							type: 'undock',
@@ -273,7 +273,7 @@ export default function AgentDock( {
 				! isDocked &&
 				canDock && {
 					icon: drawerRight,
-					title: __( 'Move to sidebar', '__i18n_text_domain__' ),
+					title: __( 'Move to sidebar', __i18n_text_domain__ ),
 					onClick: () => {
 						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
 							type: 'dock',
@@ -289,8 +289,8 @@ export default function AgentDock( {
 				capabilities?.supportsSplitScreen && {
 					icon: columns,
 					title: isSplitScreen
-						? __( 'Exit split screen', '__i18n_text_domain__' )
-						: __( 'Split screen sidebar', '__i18n_text_domain__' ),
+						? __( 'Exit split screen', __i18n_text_domain__ )
+						: __( 'Split screen sidebar', __i18n_text_domain__ ),
 					onClick: () => setIsSplitScreen( ! isSplitScreen ),
 				},
 		].filter( Boolean ) as ChatHeaderOptions;

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -46,7 +46,7 @@ export default function AgentHistory( {
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
 	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
-	const title = __( 'Past chats', '__i18n_text_domain__' );
+	const title = __( 'Past chats', __i18n_text_domain__ );
 
 	const handleBack = () => resumeActiveChat();
 

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -37,7 +37,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 				<Button
 					className="agents-manager-chat-header__back-btn"
 					onClick={ onBack }
-					aria-label={ __( 'Go Back', '__i18n_text_domain__' ) }
+					aria-label={ __( 'Go Back', __i18n_text_domain__ ) }
 					size="small"
 				>
 					<Icon icon={ chevronLeft } />
@@ -54,7 +54,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 					className="agents-manager-chat-header__more-options"
 					controls={ options }
 					icon={ moreVertical }
-					label={ __( 'More Options', '__i18n_text_domain__' ) }
+					label={ __( 'More Options', __i18n_text_domain__ ) }
 					// Render inside the panel node so opening the menu doesn't blur the panel
 					popoverProps={ {
 						className: 'agents-manager-chat-header__menu-popover',
@@ -74,7 +74,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 							recordAgentsManagerTracksEvent( 'chat_history_open' );
 							navigate( '/history' );
 						} }
-						label={ __( 'View history', '__i18n_text_domain__' ) }
+						label={ __( 'View history', __i18n_text_domain__ ) }
 						size="small"
 					/>
 				) }
@@ -86,7 +86,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 							recordAgentsManagerTracksEvent( 'chat_minimize' );
 							setIsMinimized( true );
 						} }
-						label={ __( 'Minimize', '__i18n_text_domain__' ) }
+						label={ __( 'Minimize', __i18n_text_domain__ ) }
 						size="small"
 					/>
 				) }
@@ -94,7 +94,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 					className="agents-manager-chat-header__close-btn"
 					icon={ close }
 					onClick={ onClose }
-					label={ __( 'Close', '__i18n_text_domain__' ) }
+					label={ __( 'Close', __i18n_text_domain__ ) }
 					size="small"
 				/>
 			</div>

--- a/packages/agents-manager/src/components/concluded-conversation-footer/index.tsx
+++ b/packages/agents-manager/src/components/concluded-conversation-footer/index.tsx
@@ -8,7 +8,7 @@ export default function ConcludedConversationFooter() {
 	return (
 		<div className="concluded-conversation-footer">
 			<Button variant="primary" onClick={ () => navigate( '/' ) }>
-				{ __( 'Still need help? Start a new chat', '__i18n_text_domain__' ) }
+				{ __( 'Still need help? Start a new chat', __i18n_text_domain__ ) }
 			</Button>
 		</div>
 	);

--- a/packages/agents-manager/src/components/context-cards/index.tsx
+++ b/packages/agents-manager/src/components/context-cards/index.tsx
@@ -82,7 +82,7 @@ export default function ContextCards( { onAction, onDismiss }: Props ) {
 	return (
 		<div
 			className="agents-manager-context-cards"
-			aria-label={ __( 'Chat context', '__i18n_text_domain__' ) }
+			aria-label={ __( 'Chat context', __i18n_text_domain__ ) }
 		>
 			{ rendered.map( ( { card, leaving } ) => (
 				<div
@@ -99,10 +99,10 @@ export default function ContextCards( { onAction, onDismiss }: Props ) {
 								variant="tertiary"
 								size="small"
 								onClick={ () => onDismiss( card ) }
-								aria-label={ __( 'Dismiss context card', '__i18n_text_domain__' ) }
+								aria-label={ __( 'Dismiss context card', __i18n_text_domain__ ) }
 								disabled={ leaving }
 							>
-								{ __( 'Dismiss', '__i18n_text_domain__' ) }
+								{ __( 'Dismiss', __i18n_text_domain__ ) }
 							</Button>
 						) }
 						<div className="agents-manager-context-card__body">{ card.body }</div>

--- a/packages/agents-manager/src/components/conversation-history-view/index.tsx
+++ b/packages/agents-manager/src/components/conversation-history-view/index.tsx
@@ -32,16 +32,14 @@ export default function ConversationHistoryView( { onSelectConversation }: Props
 				) }
 				{ ! isLoading && isError && (
 					<div className="agents-manager-conversation-history-view__error">
-						<p>
-							{ __( 'Failed to load conversations. Please try again.', '__i18n_text_domain__' ) }
-						</p>
+						<p>{ __( 'Failed to load conversations. Please try again.', __i18n_text_domain__ ) }</p>
 					</div>
 				) }
 				{ ! isLoading && ! isError && conversations.length === 0 && (
 					<div className="agents-manager-conversation-history-view__empty">
-						<p>{ __( 'No past conversations', '__i18n_text_domain__' ) }</p>
+						<p>{ __( 'No past conversations', __i18n_text_domain__ ) }</p>
 						<p className="agents-manager-conversation-history-view__empty-hint">
-							{ __( 'Start a new chat to begin', '__i18n_text_domain__' ) }
+							{ __( 'Start a new chat to begin', __i18n_text_domain__ ) }
 						</p>
 					</div>
 				) }
@@ -65,7 +63,7 @@ export default function ConversationHistoryView( { onSelectConversation }: Props
 					onClick={ () => navigate( '/' ) }
 					className="agents-manager-conversation-history-view__new-chat-btn"
 				>
-					{ __( 'Start a new chat', '__i18n_text_domain__' ) }
+					{ __( 'Start a new chat', __i18n_text_domain__ ) }
 				</Button>
 			</div>
 		</div>

--- a/packages/agents-manager/src/components/conversation-list-item/index.tsx
+++ b/packages/agents-manager/src/components/conversation-list-item/index.tsx
@@ -30,7 +30,7 @@ export default function ConversationListItem( { conversation, onClick }: Props )
 			disabled={ disabled }
 			aria-label={ sprintf(
 				/* translators: %1$s: conversation title, %2$s: conversation subtitle */
-				__( 'Load conversation: %1$s, %2$s', '__i18n_text_domain__' ),
+				__( 'Load conversation: %1$s, %2$s', __i18n_text_domain__ ),
 				title,
 				subtitle
 			) }

--- a/packages/agents-manager/src/components/conversation-list-skeleton/index.tsx
+++ b/packages/agents-manager/src/components/conversation-list-skeleton/index.tsx
@@ -27,7 +27,7 @@ export default function ConversationListSkeleton( { count = 3 }: Props ) {
 		<div
 			className="agents-manager-conversation-list-skeleton"
 			role="status"
-			aria-label={ __( 'Loading conversations', '__i18n_text_domain__' ) }
+			aria-label={ __( 'Loading conversations', __i18n_text_domain__ ) }
 			aria-busy="true"
 		>
 			{ Array.from( { length: count } ).map( ( _, index ) => (

--- a/packages/agents-manager/src/components/copy-action-button/index.tsx
+++ b/packages/agents-manager/src/components/copy-action-button/index.tsx
@@ -30,9 +30,7 @@ export default function CopyActionButton( { text }: Props ) {
 		<Button
 			className="agents-manager-copy-action-button"
 			icon={ isCopied ? check : copy }
-			label={
-				isCopied ? __( 'Copied', '__i18n_text_domain__' ) : __( 'Copy', '__i18n_text_domain__' )
-			}
+			label={ isCopied ? __( 'Copied', __i18n_text_domain__ ) : __( 'Copy', __i18n_text_domain__ ) }
 			onClick={ handleClick }
 			size="compact"
 		/>

--- a/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
+++ b/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
@@ -58,7 +58,7 @@ export default function EditorAiChatButton( { onClose, onOpenChat }: Props ) {
 				} ) }
 				onClick={ handleToggle }
 				icon={ <AI /> }
-				label={ __( 'Ask AI', '__i18n_text_domain__' ) }
+				label={ __( 'Ask AI', __i18n_text_domain__ ) }
 				aria-pressed={ isChatVisible }
 				aria-expanded={ isChatVisible }
 				size="compact"

--- a/packages/agents-manager/src/components/editor-help-center-button/index.tsx
+++ b/packages/agents-manager/src/components/editor-help-center-button/index.tsx
@@ -66,12 +66,12 @@ export default function EditorHelpCenterButton( { onClose, onOpenChat }: Props )
 	const controls = [
 		[
 			{
-				title: __( 'Chat support', '__i18n_text_domain__' ),
+				title: __( 'Chat support', __i18n_text_domain__ ),
 				icon: comment,
 				onClick: () => selectChatRoute( 'agents-manager-chat', '/chat', resumeActiveChat ),
 			},
 			{
-				title: __( 'Chat history', '__i18n_text_domain__' ),
+				title: __( 'Chat history', __i18n_text_domain__ ),
 				icon: backup,
 				onClick: () =>
 					selectChatRoute( 'agents-manager-history', '/history', () => navigate( '/history' ) ),
@@ -79,7 +79,7 @@ export default function EditorHelpCenterButton( { onClose, onOpenChat }: Props )
 		],
 		[
 			{
-				title: __( 'Support guides', '__i18n_text_domain__' ),
+				title: __( 'Support guides', __i18n_text_domain__ ),
 				icon: page,
 				onClick: () =>
 					selectChatRoute( 'agents-manager-support-guides', '/support-guides', () =>
@@ -87,12 +87,12 @@ export default function EditorHelpCenterButton( { onClose, onOpenChat }: Props )
 					),
 			},
 			{
-				title: __( 'Courses', '__i18n_text_domain__' ),
+				title: __( 'Courses', __i18n_text_domain__ ),
 				icon: video,
 				onClick: () => openExternalLink( localizeUrl( 'https://wordpress.com/support/courses/' ) ),
 			},
 			{
-				title: __( 'Product updates', '__i18n_text_domain__' ),
+				title: __( 'Product updates', __i18n_text_domain__ ),
 				icon: rss,
 				onClick: () =>
 					openExternalLink(
@@ -107,7 +107,7 @@ export default function EditorHelpCenterButton( { onClose, onOpenChat }: Props )
 			<DropdownMenu
 				className="entry-point-button agents-manager-help-center"
 				icon={ help }
-				label={ __( 'Help Center', '__i18n_text_domain__' ) }
+				label={ __( 'Help Center', __i18n_text_domain__ ) }
 				controls={ controls }
 				popoverProps={ { position: 'bottom left' } }
 				// Match the Ask AI button (and editor-header convention) so the icon/button size lines up.

--- a/packages/agents-manager/src/components/feedback-input/index.tsx
+++ b/packages/agents-manager/src/components/feedback-input/index.tsx
@@ -48,9 +48,7 @@ export default function FeedbackInput( { onSubmit, onCancel }: Props ) {
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( '[FeedbackInput] Error submitting feedback:', error );
-			setSubmitError(
-				__( 'Failed to submit feedback. Please try again.', '__i18n_text_domain__' )
-			);
+			setSubmitError( __( 'Failed to submit feedback. Please try again.', __i18n_text_domain__ ) );
 
 			timeoutRef.current = setTimeout( () => {
 				onCancel();
@@ -75,7 +73,7 @@ export default function FeedbackInput( { onSubmit, onCancel }: Props ) {
 			<div className="agents-manager-feedback-input">
 				<div className="agents-manager-feedback-input__inner">
 					<div className="agents-manager-feedback-input__success">
-						{ __( 'Feedback submitted, thank you!', '__i18n_text_domain__' ) }
+						{ __( 'Feedback submitted, thank you!', __i18n_text_domain__ ) }
 					</div>
 				</div>
 			</div>
@@ -96,20 +94,20 @@ export default function FeedbackInput( { onSubmit, onCancel }: Props ) {
 		<div className="agents-manager-feedback-input">
 			<div className="agents-manager-feedback-input__inner" ref={ textareaContainerRef }>
 				<TextareaControl
-					label={ __( 'What could be improved?', '__i18n_text_domain__' ) }
+					label={ __( 'What could be improved?', __i18n_text_domain__ ) }
 					value={ feedbackText }
 					onChange={ ( value: string ) => setFeedbackText( value ) }
 					onKeyDown={ handleKeyDown }
 					placeholder={ __(
 						'Help us understand what you expected or what went wrong.',
-						'__i18n_text_domain__'
+						__i18n_text_domain__
 					) }
 					rows={ 3 }
 					disabled={ isSubmitting }
 				/>
 				<div className="agents-manager-feedback-input__actions">
 					<Button variant="tertiary" onClick={ onCancel } disabled={ isSubmitting }>
-						{ __( 'Cancel', '__i18n_text_domain__' ) }
+						{ __( 'Cancel', __i18n_text_domain__ ) }
 					</Button>
 					<Button
 						variant="primary"
@@ -118,8 +116,8 @@ export default function FeedbackInput( { onSubmit, onCancel }: Props ) {
 					>
 						{ isSubmitting && <Spinner className="agents-manager-feedback-input__spinner" /> }
 						{ isSubmitting
-							? __( 'Submitting\u2026', '__i18n_text_domain__' )
-							: __( 'Submit', '__i18n_text_domain__' ) }
+							? __( 'Submitting\u2026', __i18n_text_domain__ )
+							: __( 'Submit', __i18n_text_domain__ ) }
 					</Button>
 				</div>
 			</div>

--- a/packages/agents-manager/src/components/next-step-button/index.tsx
+++ b/packages/agents-manager/src/components/next-step-button/index.tsx
@@ -15,7 +15,7 @@ export default function NextStepButton( { onMoveToNextStep }: Props ) {
 
 	return (
 		<Button className="agents-manager-next-step-button" variant="primary" onClick={ handleClick }>
-			{ __( 'Move to next step', '__i18n_text_domain__' ) }
+			{ __( 'Move to next step', __i18n_text_domain__ ) }
 		</Button>
 	);
 }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -460,7 +460,7 @@ export default function OrchestratorChat( {
 					await onSubmit( message, { imageUrls: imageData } );
 				} catch ( uploadError ) {
 					throw new Error(
-						__( 'Failed to upload images. Please try again.', '__i18n_text_domain__' )
+						__( 'Failed to upload images. Please try again.', __i18n_text_domain__ )
 					);
 				}
 			} else {

--- a/packages/agents-manager/src/components/selected-block/index.tsx
+++ b/packages/agents-manager/src/components/selected-block/index.tsx
@@ -70,7 +70,7 @@ export default function SelectedBlock() {
 				icon={ close }
 				iconSize={ 16 }
 				onClick={ handleClearSelectedBlock }
-				label={ __( 'Clear selection', 'big-sky' ) }
+				label={ __( 'Clear selection', __i18n_text_domain__ ) }
 			/>
 		</motion.div>
 	);

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -54,9 +54,9 @@ export default function SourcesDisplay( { sources }: Props ) {
 	return (
 		<FoldableCard
 			className="agents-manager-sources-display"
-			summary={ __( 'Sources', '__i18n_text_domain__' ) }
-			expandedSummary={ __( 'Sources', '__i18n_text_domain__' ) }
-			screenReaderText={ __( 'More', '__i18n_text_domain__' ) }
+			summary={ __( 'Sources', __i18n_text_domain__ ) }
+			expandedSummary={ __( 'Sources', __i18n_text_domain__ ) }
+			screenReaderText={ __( 'More', __i18n_text_domain__ ) }
 			iconSize={ 16 }
 			clickableHeader
 			useInert

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -47,7 +47,7 @@ export default function SupportGuide( {
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
 	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
 	const isFromChat = !! ( state?.sessionId || state?.conversationId );
-	const title = __( 'Support Guides', '__i18n_text_domain__' );
+	const title = __( 'Support Guides', __i18n_text_domain__ );
 
 	// Navigate back to the source route, preserving relevant state.
 	const handleBack = () => {
@@ -100,7 +100,7 @@ export default function SupportGuide( {
 					{ ! isFromChat && (
 						<div className="agent-manager-support-guide-footer">
 							<Button variant="primary" onClick={ () => navigate( '/' ) }>
-								{ __( 'Start a new chat', '__i18n_text_domain__' ) }
+								{ __( 'Start a new chat', __i18n_text_domain__ ) }
 							</Button>
 						</div>
 					) }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -42,20 +42,20 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 		if ( isRecommended ) {
 			return (
 				<div className="agent-manager-support-guides__status">
-					{ __( 'Search guides to find answers to your questions.', '__i18n_text_domain__' ) }
+					{ __( 'Search guides to find answers to your questions.', __i18n_text_domain__ ) }
 				</div>
 			);
 		}
 
 		return (
 			<div className="agent-manager-support-guides__status">
-				{ __( 'Something went wrong.', '__i18n_text_domain__' ) }{ ' ' }
+				{ __( 'Something went wrong.', __i18n_text_domain__ ) }{ ' ' }
 				<Button
 					className="agent-manager-support-guides__retry"
 					variant="link"
 					onClick={ () => refetch() }
 				>
-					{ __( 'Try again', '__i18n_text_domain__' ) }
+					{ __( 'Try again', __i18n_text_domain__ ) }
 				</Button>
 			</div>
 		);
@@ -64,7 +64,7 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 	if ( ! data?.length ) {
 		return (
 			<div className="agent-manager-support-guides__status">
-				{ __( 'No results found.', '__i18n_text_domain__' ) }
+				{ __( 'No results found.', __i18n_text_domain__ ) }
 			</div>
 		);
 	}
@@ -73,8 +73,8 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 		<>
 			<h3 className="agent-manager-support-guides__title">
 				{ isRecommended
-					? __( 'Recommended Guides', '__i18n_text_domain__' )
-					: __( 'Search Results', '__i18n_text_domain__' ) }
+					? __( 'Recommended Guides', __i18n_text_domain__ )
+					: __( 'Search Results', __i18n_text_domain__ ) }
 			</h3>
 			<ItemGroup isSeparated isBordered isRounded>
 				{ data?.map( ( item ) => (
@@ -128,7 +128,7 @@ export default function SupportGuides( {
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
 	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
-	const title = __( 'Support Guides', '__i18n_text_domain__' );
+	const title = __( 'Support Guides', __i18n_text_domain__ );
 
 	return (
 		<AgentUI.Container
@@ -163,7 +163,7 @@ export default function SupportGuides( {
 					justify="stretch"
 				>
 					<SearchControl
-						placeholder={ __( 'Search guides…', '__i18n_text_domain__' ) }
+						placeholder={ __( 'Search guides…', __i18n_text_domain__ ) }
 						onChange={ setSearchInput }
 						// The click event is highjacked by the drag-handlers of the floating chat container.
 						onClick={ ( e ) => e.currentTarget.focus() }

--- a/packages/agents-manager/src/components/zoom-action-button/index.tsx
+++ b/packages/agents-manager/src/components/zoom-action-button/index.tsx
@@ -15,9 +15,7 @@ export default function ZoomActionButton() {
 			className="agents-manager-zoom-action-button"
 			icon={ zoomIcon }
 			label={
-				isZoomOut
-					? __( 'Zoom in', '__i18n_text_domain__' )
-					: __( 'Zoom out', '__i18n_text_domain__' )
+				isZoomOut ? __( 'Zoom in', __i18n_text_domain__ ) : __( 'Zoom out', __i18n_text_domain__ )
 			}
 			onClick={ toggleZoom }
 			isPressed={ isZoomOut }

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -3,6 +3,16 @@
  */
 
 /**
+ * Text domain placeholder, replaced at build time by webpack's DefinePlugin
+ * with `'default'`. Must be used as the bare identifier (not a quoted
+ * `__i18n_text_domain__` string) so DefinePlugin can substitute it — a quoted
+ * literal is never rewritten and resolves to a dead text domain at runtime,
+ * leaving strings untranslated. Matches the convention in other Calypso
+ * packages (help-center, odie-client, components, …).
+ */
+declare const __i18n_text_domain__: string;
+
+/**
  * `agentsManagerData` is set as a global const via wp_add_inline_script
  * in Jetpack's Agents Manager feature.
  *

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -353,7 +353,7 @@ export default function useAgentLayoutManager( {
 							className="agents-manager-sidebar-fab"
 							icon={ AI }
 							onClick={ handleOpenSidebar }
-							label={ __( 'Open Chat', '__i18n_text_domain__' ) }
+							label={ __( 'Open Chat', __i18n_text_domain__ ) }
 						/>
 					</>
 				) : (

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -60,7 +60,7 @@ export default function useCheckpointAction(
 				return [
 					{
 						id: 'checkpoint',
-						label: __( 'Undo', '__i18n_text_domain__' ),
+						label: __( 'Undo', __i18n_text_domain__ ),
 						icon: createElement( Icon, {
 							icon: undo,
 							className: 'agents-manager-message-action-icon',

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -144,18 +144,18 @@ export function useEmptyViewSuggestions( {
 		() => [
 			{
 				id: 'getting-started',
-				label: __( 'Getting started with WordPress', '__i18n_text_domain__' ),
-				prompt: __( 'How do I get started with WordPress?', '__i18n_text_domain__' ),
+				label: __( 'Getting started with WordPress', __i18n_text_domain__ ),
+				prompt: __( 'How do I get started with WordPress?', __i18n_text_domain__ ),
 			},
 			{
 				id: 'create-post',
-				label: __( 'Create a blog post', '__i18n_text_domain__' ),
-				prompt: __( 'How do I create a blog post?', '__i18n_text_domain__' ),
+				label: __( 'Create a blog post', __i18n_text_domain__ ),
+				prompt: __( 'How do I create a blog post?', __i18n_text_domain__ ),
 			},
 			{
 				id: 'customize-site',
-				label: __( 'Customize my site', '__i18n_text_domain__' ),
-				prompt: __( 'How can I customize my site?', '__i18n_text_domain__' ),
+				label: __( 'Customize my site', __i18n_text_domain__ ),
+				prompt: __( 'How can I customize my site?', __i18n_text_domain__ ),
 			},
 		],
 		[]

--- a/packages/agents-manager/src/hooks/use-regenerate-action.ts
+++ b/packages/agents-manager/src/hooks/use-regenerate-action.ts
@@ -59,8 +59,8 @@ export default function useRegenerateAction( {
 			return [
 				{
 					id: 'regenerate',
-					label: __( 'Regenerate', '__i18n_text_domain__' ),
-					tooltip: __( 'Regenerate response', '__i18n_text_domain__' ),
+					label: __( 'Regenerate', __i18n_text_domain__ ),
+					tooltip: __( 'Regenerate response', __i18n_text_domain__ ),
 					icon: createElement( RegenerateAltIcon, {
 						className: 'agents-manager-message-action-icon',
 					} ),

--- a/packages/agents-manager/src/utils/conversation-history-formatters.ts
+++ b/packages/agents-manager/src/utils/conversation-history-formatters.ts
@@ -47,14 +47,14 @@ function formatConversationDate( dateTime: string ): string {
 	const today = new Date();
 
 	if ( isSameLocalDay( date, today ) ) {
-		return __( 'Today', '__i18n_text_domain__' );
+		return __( 'Today', __i18n_text_domain__ );
 	}
 
 	const yesterday = new Date( today );
 	yesterday.setDate( yesterday.getDate() - 1 );
 
 	if ( isSameLocalDay( date, yesterday ) ) {
-		return __( 'Yesterday', '__i18n_text_domain__' );
+		return __( 'Yesterday', __i18n_text_domain__ );
 	}
 
 	return getShortDateString( date.getTime(), getLocaleSlug() ?? 'en' );
@@ -70,7 +70,7 @@ export function generateConversationTitle( messageContent: string ): string {
 	const title = messageContent?.trim();
 
 	if ( ! title ) {
-		return __( 'Untitled conversation', '__i18n_text_domain__' );
+		return __( 'Untitled conversation', __i18n_text_domain__ );
 	}
 
 	return title;
@@ -88,7 +88,7 @@ export function generateConversationSubtitle( dateTime: string, isHe?: boolean )
 	if ( isHe ) {
 		return sprintf(
 			/* translators: %s: date of the conversation */
-			__( 'Happiness chat · %s', '__i18n_text_domain__' ),
+			__( 'Happiness chat · %s', __i18n_text_domain__ ),
 			date
 		);
 	}

--- a/packages/agents-manager/src/utils/orchestrator-error-message.ts
+++ b/packages/agents-manager/src/utils/orchestrator-error-message.ts
@@ -11,7 +11,7 @@ export function getOrchestratorErrorMessage( error: string | null ): string | nu
 	if ( error.includes( 'review_mediator_over_limit' ) || /jetpack ai usage limit/i.test( error ) ) {
 		return __(
 			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.',
-			'__i18n_text_domain__'
+			__i18n_text_domain__
 		);
 	}
 

--- a/packages/agents-manager/src/utils/reader-chat-error-message.ts
+++ b/packages/agents-manager/src/utils/reader-chat-error-message.ts
@@ -170,14 +170,14 @@ export function getReaderChatErrorMessage( error: unknown ): string | null {
 	if ( hasSearchLimitCode || hasSearchLimitMessage ) {
 		return __(
 			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.',
-			'__i18n_text_domain__'
+			__i18n_text_domain__
 		);
 	}
 
 	const hasUnavailableCode = code && UNAVAILABLE_ERROR_CODES.has( code );
 	const hasUnavailableMessage = isUnavailableMessage( message );
 	if ( hasUnavailableCode || hasUnavailableMessage ) {
-		return __( 'Reader Chat is not available for this site.', '__i18n_text_domain__' );
+		return __( 'Reader Chat is not available for this site.', __i18n_text_domain__ );
 	}
 
 	if (
@@ -185,8 +185,8 @@ export function getReaderChatErrorMessage( error: unknown ): string | null {
 		429 === getErrorStatus( error ) ||
 		isRateLimitMessage( message )
 	) {
-		return __( 'Too many requests. Please try again later.', '__i18n_text_domain__' );
+		return __( 'Too many requests. Please try again later.', __i18n_text_domain__ );
 	}
 
-	return __( 'Reader Chat is unavailable. Please try again later.', '__i18n_text_domain__' );
+	return __( 'Reader Chat is unavailable. Please try again later.', __i18n_text_domain__ );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORNO-373

## Proposed Changes
 
* Update the text domain to the Calypso standard `__i18n_text_domain__` token.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Every string in the package passed the text domain as a quoted string (`'__i18n_text_domain__'`). DefinePlugin only rewrites the bare `__i18n_text_domain__` token to `'default'`, so the quoted literal stayed as-is and every `__()` call looked up an empty `__i18n_text_domain__` domain instead of `'default'`, rendering English.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install this JP branch
  * `bin/jetpack-downloader test jetpack add/agents-manager-translations`
  * `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/agents-manager-translations`
* Install this AM version: `install-plugin.sh am fix/agents-manager-text-domain`
* Sandbox widgets.wp.com and a test simple site
* Change your preferred language to one of the MAG16 https://my.wordpress.com/me/preferences/language
* Open the page editor and check the agents manager is translated
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
