### PR TITLE
Dashboard: recover from chunk load errors with a one-shot reload

### DIFF
--- a/client/dashboard/app/logger/chunk-reload.ts
+++ b/client/dashboard/app/logger/chunk-reload.ts
@@ -1,0 +1,61 @@
+import { bumpStat } from '../analytics';
+
+// Marks a page load as a chunk-load retry. Mirrors the classic Calypso
+// mechanism in client/layout/error.jsx: the flag lives in the URL for the whole
+// retried load, so a chunk that is still missing afterwards surfaces the error
+// instead of looping, no matter how long the failed fetch took.
+const RETRY_PARAM = 'retry';
+
+/**
+ * Whether an error is a webpack chunk / dynamic import load failure.
+ *
+ * These happen when a lazily-loaded route or component chunk can't be fetched,
+ * typically because a deploy replaced the chunk the running app is asking for.
+ */
+export function isChunkLoadError( error: Error ): boolean {
+	if ( ! error ) {
+		return false;
+	}
+
+	// Webpack tags these failures with structured properties, which are more
+	// stable than matching the error message: `name` is set on JS, ESM, and
+	// native CSS chunk failures, while mini-css-extract uses `code` instead.
+	return (
+		error.name === 'ChunkLoadError' ||
+		( error as { code?: string } ).code === 'CSS_CHUNK_LOAD_FAILED'
+	);
+}
+
+function isRetry(): boolean {
+	try {
+		return new URLSearchParams( window.location.search ).get( RETRY_PARAM ) === '1';
+	} catch {
+		// If we can't read the URL, assume we already retried so we never loop.
+		return true;
+	}
+}
+
+/**
+ * Recover from a chunk load failure by reloading the page once.
+ *
+ * A full reload pulls fresh script tags, so the chunk the app is asking for
+ * matches what the server now serves. We only attempt this once per page load,
+ * tracked by a `retry` URL param: if the chunk is still missing after the
+ * reload the error surfaces normally instead of looping.
+ *
+ * Returns `true` if a reload was triggered, so callers can stop further error
+ * handling for this error.
+ */
+export function maybeReloadForChunkError( error: Error ): boolean {
+	if ( ! isChunkLoadError( error ) || isRetry() ) {
+		return false;
+	}
+
+	bumpStat( 'calypso_chunk_retry', 'dashboard' );
+
+	// Reload with the retry flag set so the fresh load serves the current chunks.
+	const url = new URL( window.location.href );
+	url.searchParams.set( RETRY_PARAM, '1' );
+	window.location.replace( url.toString() );
+	return true;
+}

--- a/client/dashboard/app/logger/chunk-reload.ts
+++ b/client/dashboard/app/logger/chunk-reload.ts
@@ -13,10 +13,6 @@ const RETRY_PARAM = 'retry';
  * typically because a deploy replaced the chunk the running app is asking for.
  */
 export function isChunkLoadError( error: Error ): boolean {
-	if ( ! error ) {
-		return false;
-	}
-
 	// Webpack tags these failures with structured properties, which are more
 	// stable than matching the error message: `name` is set on JS, ESM, and
 	// native CSS chunk failures, while mini-css-extract uses `code` instead.

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -3,6 +3,7 @@ import calypsoConfig from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { maybeReloadForChunkError } from './chunk-reload';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
@@ -35,6 +36,12 @@ export function handleOnCatch(
 		calypso_section?: string;
 	}
 ) {
+	// A failed chunk load is usually a stale deploy, not a real error. Reload
+	// once to fetch fresh chunks instead of logging and showing an error page.
+	if ( maybeReloadForChunkError( error ) ) {
+		return;
+	}
+
 	if ( isBenignError( error ) ) {
 		return;
 	}

--- a/client/dashboard/app/logger/test/chunk-reload.test.ts
+++ b/client/dashboard/app/logger/test/chunk-reload.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { bumpStat } from '../../analytics';
+import { isChunkLoadError, maybeReloadForChunkError } from '../chunk-reload';
+
+jest.mock( '../../analytics', () => ( {
+	bumpStat: jest.fn(),
+} ) );
+
+const mockedBumpStat = jest.mocked( bumpStat );
+
+const replace = jest.fn();
+
+const setLocation = ( search: string ) => {
+	Object.defineProperty( window, 'location', {
+		configurable: true,
+		value: { href: `https://example.com/emails${ search }`, search, replace },
+	} );
+};
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	setLocation( '' );
+} );
+
+const chunkLoadError = () => {
+	const error = new Error( 'Loading chunk emails failed.' );
+	error.name = 'ChunkLoadError';
+	return error;
+};
+
+describe( 'isChunkLoadError', () => {
+	test( 'detects a webpack chunk failure by its ChunkLoadError name', () => {
+		const error = new Error( 'Loading chunk 123 failed.' );
+		error.name = 'ChunkLoadError';
+		expect( isChunkLoadError( error ) ).toBe( true );
+	} );
+
+	test( 'detects a mini-css-extract chunk failure by its code', () => {
+		const error = Object.assign( new Error( 'Loading CSS chunk 7 failed.' ), {
+			code: 'CSS_CHUNK_LOAD_FAILED',
+		} );
+		expect( isChunkLoadError( error ) ).toBe( true );
+	} );
+
+	test( 'returns false for unrelated errors', () => {
+		expect( isChunkLoadError( new Error( 'Cannot read properties of undefined' ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'maybeReloadForChunkError', () => {
+	test( 'reloads with the retry flag on the first chunk load error', () => {
+		const result = maybeReloadForChunkError( chunkLoadError() );
+
+		expect( result ).toBe( true );
+		expect( replace ).toHaveBeenCalledTimes( 1 );
+		expect( replace ).toHaveBeenCalledWith( 'https://example.com/emails?retry=1' );
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'calypso_chunk_retry', 'dashboard' );
+	} );
+
+	test( 'does not reload again once the retry flag is set', () => {
+		setLocation( '?retry=1' );
+
+		const result = maybeReloadForChunkError( chunkLoadError() );
+
+		expect( result ).toBe( false );
+		expect( replace ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does nothing for non-chunk errors', () => {
+		const result = maybeReloadForChunkError( new Error( 'Boom' ) );
+
+		expect( result ).toBe( false );
+		expect( replace ).not.toHaveBeenCalled();
+		expect( mockedBumpStat ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -4,6 +4,7 @@
 
 import { captureException } from '@automattic/calypso-sentry';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { maybeReloadForChunkError } from '../chunk-reload';
 import { handleOnCatch } from '../index';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
@@ -15,9 +16,18 @@ jest.mock( '@automattic/calypso-sentry', () => ( {
 jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn(),
 } ) );
+jest.mock( '../chunk-reload', () => ( {
+	maybeReloadForChunkError: jest.fn(),
+} ) );
 
 const mockedLogToLogstash = jest.mocked( logToLogstash );
 const mockedCaptureException = jest.mocked( captureException );
+const mockedMaybeReloadForChunkError = jest.mocked( maybeReloadForChunkError );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockedMaybeReloadForChunkError.mockReturnValue( false );
+} );
 
 const createRouter = ( params: Record< string, string > ): AnyRouter =>
 	( {
@@ -86,6 +96,22 @@ describe( 'handleOnCatch', () => {
 				some_id: '123',
 			},
 		} );
+	} );
+
+	it( 'does not log or capture when a chunk load error triggers a reload', () => {
+		mockedMaybeReloadForChunkError.mockReturnValue( true );
+
+		const error = new Error( 'Loading chunk emails failed.' );
+		error.name = 'ChunkLoadError';
+
+		handleOnCatch( error, createErrorInfo(), createRouter( { siteSlug: 'my-site' } ), {
+			severity: 'error',
+			dashboard_backport: false,
+			calypso_section: 'dashboard',
+		} );
+
+		expect( mockedLogToLogstash ).not.toHaveBeenCalled();
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
 	} );
 
 	it( 'logs but does not capture when dashboard_backport is true', () => {


### PR DESCRIPTION
Part of DOTMSD-1344

## Proposed Changes

* Add chunk-load-error recovery to the Dashboard error logger. When a lazily-loaded route or component chunk fails to load, the page now reloads once (guarded by a `retry` URL flag) instead of going straight to the 500 error page.
* The recovery is wired into the shared `handleOnCatch`, so it applies to both the Dashboard and the `sites/v2` TanStack routers that use the same logger.
* If the chunk is still missing after the reload, the error surfaces normally — no reload loop.

## Why are these changes being made?

* Lazily-loaded chunks fail when a deploy replaces the chunk the running app is still asking for (a stale client). In the Dashboard this surfaced as a hard 500 with no recovery — e.g. opening "Add email forwarding" right after a deploy.
* Classic Calypso has handled this for years: on a section chunk failure it does a one-shot full-page reload to pull fresh script tags. The Dashboard had no equivalent. This ports that behavior.

## Considerations

* **One-shot guard.** First attempt used a 10s timestamp in `sessionStorage`, but that can loop on slow-failing fetches (webpack's default chunk-load timeout is 120s, well past 10s) and a single global flag could suppress an unrelated recovery. Switched to classic Calypso's `retry` URL flag: it lives in the URL for the entire failing load (loop-proof regardless of how long the fetch takes), is per-URL, and degrades gracefully to current behavior in the worst case.
* **Telemetry.** A recovered (first) chunk error is counted via the `calypso_chunk_retry` stat rather than logged to Logstash/Sentry; a chunk error that survives the reload falls through to full logging. This matches the classic behavior.

## Testing Instructions

Manual (reproduce a real stale-deploy chunk 404 on the dev server):

  Dev chunks are normally served un-hashed and accumulate in memory, so they never 404. To make a recompile generate a new chunk and 404 the old one, temporarily tweak `client/webpack.config.js` (revert after testing — **not** part of this PR):

  ```js
  // in the `if ( isDevelopment )` block
  outputChunkFilename = '[name].[contenthash].js';

  // in `output: { ... }`
  clean: isDevelopment,
  ```

  Then:

  1. Start the dev server with hot reload off so the open tab stays "stale":
     `CALYPSO_DISABLE_HOT_RELOAD=true yarn start-dashboard`
  2. Open the Dashboard and navigate to `/sites`
  3. Make a trivial edit to `client/dashboard/sites/overview/index.tsx` and save. Webpack recompiles: the chunk gets a new hash and the old one is cleaned (404).
  4. Select any site to navigate to site overview

  Expected: the page reloads once, the URL gains `?retry=1`, the fresh runtime fetches the new chunk, and the screen renders — recovered instead of a 500.

  Loop check: if the chunk stays missing (e.g. keep it 404ing), the post-reload load surfaces the error page normally — it does not reload again.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
