### PR TITLE
Agents Manager: show editor Ask AI button whenever enabled, not just in dev mode

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
@@ -62,43 +62,31 @@ describe( 'isEditorAiEntryEnabled', () => {
 	}
 
 	afterEach( () => {
-		mockInlineData.mockReset();
 		mockIsEditorPage.mockReset();
 		delete ( window as TestWindow ).__experimentalAdminBarInEditor;
 		window.matchMedia = originalMatchMedia;
 	} );
 
-	it( 'returns true on an editor page, in a dev context, on desktop, with the omnibar off', () => {
+	it( 'returns true on an editor page, on desktop, with the omnibar off', () => {
 		mockIsEditorPage.mockReturnValue( true );
-		mockInlineData.mockReturnValue( { isDevMode: true } );
 		setDesktop( true );
 		expect( isEditorAiEntryEnabled() ).toBe( true );
 	} );
 
 	it( 'returns false outside an editor page', () => {
 		mockIsEditorPage.mockReturnValue( false );
-		mockInlineData.mockReturnValue( { isDevMode: true } );
-		setDesktop( true );
-		expect( isEditorAiEntryEnabled() ).toBe( false );
-	} );
-
-	it( 'returns false outside dev mode', () => {
-		mockIsEditorPage.mockReturnValue( true );
-		mockInlineData.mockReturnValue( { isDevMode: false } );
 		setDesktop( true );
 		expect( isEditorAiEntryEnabled() ).toBe( false );
 	} );
 
 	it( 'returns false on mobile', () => {
 		mockIsEditorPage.mockReturnValue( true );
-		mockInlineData.mockReturnValue( { isDevMode: true } );
 		setDesktop( false );
 		expect( isEditorAiEntryEnabled() ).toBe( false );
 	} );
 
 	it( 'returns false when the omnibar experiment is active', () => {
 		mockIsEditorPage.mockReturnValue( true );
-		mockInlineData.mockReturnValue( { isDevMode: true } );
 		setDesktop( true );
 		setOmnibarActive( true );
 		expect( isEditorAiEntryEnabled() ).toBe( false );

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -33,8 +33,8 @@ function isEditorEntryVisible(): boolean {
 }
 
 /**
- * Whether the editor toolbar Ask AI button should show. The bundle only loads when `is_enabled()`
- * is true server-side, so editor-entry visibility is the only gate left to check here.
+ * Whether the editor toolbar Ask AI button should show. The host only loads the Agents Manager
+ * bundle when the feature is enabled, so editor-entry visibility is the only gate left to check here.
  */
 export function isEditorAiEntryEnabled(): boolean {
 	return isEditorEntryVisible();

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -33,10 +33,11 @@ function isEditorEntryVisible(): boolean {
 }
 
 /**
- * Whether the editor toolbar Ask AI button should show — only in a dev/internal context.
+ * Whether the editor toolbar Ask AI button should show. The bundle only loads when `is_enabled()`
+ * is true server-side, so editor-entry visibility is the only gate left to check here.
  */
 export function isEditorAiEntryEnabled(): boolean {
-	return isEditorEntryVisible() && !! getAgentsManagerInlineData()?.isDevMode;
+	return isEditorEntryVisible();
 }
 
 /**


### PR DESCRIPTION
Fixes #

## Proposed Changes

* `isEditorAiEntryEnabled()` (which gates the editor **Toolbar** Ask AI button — the `PinnedItems/core` Fill in the block-editor header, and `hasAiChatEntryButton()`) no longer reads the `isDevMode` inline-data flag. It now returns `isEditorEntryVisible()` (block-editor page + desktop + omnibar off), so the button shows whenever Agents Manager is enabled in the editor, not only in dev/internal contexts.
* Updated `editor-entry-points` tests accordingly (dropped the dev-mode assertions; visibility cases unchanged).
* `isDevMode` is untouched and still used by `tracks` (drives `is_test`).

## Why are these changes being made?

The Ask AI button was restricted to dev/internal contexts while the feature was in development. The Agents Manager bundle only loads when `is_enabled()` is true server-side (Jetpack), so on the frontend "enabled" is already implied — editor-entry visibility is the only gate left. This matches the Jetpack-side change that gates the **Omnibar** Ask AI button on `is_enabled()` instead of `is_dev_mode()` (Automattic/jetpack#50075).

## Testing Instructions

* Sandbox this PR
* Go to the editor, and the AI entry button will be shown in the toolbar
  * Ensure the omni-bar is disabled

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
