### PR TITLE
Pass TeamCity merge queue branches early

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,6 +1,8 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
+import _self.lib.utils.passMergeQueueBranchesEarly
+import _self.lib.utils.skipOnMergeQueueBranch
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -54,7 +56,8 @@ object CalypsoE2ETestsBuildTemplate : Template({
 	}
 
   	steps {
-		mergeTrunk( skipIfConflict = true )
+		passMergeQueueBranchesEarly()
+		mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
 
     	bashNodeScript {
 			name = "Prepare environment"
@@ -70,7 +73,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Determine Calypso URL"
@@ -109,7 +112,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "##teamcity[setParameter name='CALYPSO_BASE_URL' value='${'$'}FINAL_URL']"
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Determine Dashboard URL"
@@ -151,7 +154,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "##teamcity[setParameter name='DASHBOARD_BASE_URL' value='${'$'}FINAL_URL']"
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Determine test group"
@@ -174,7 +177,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 				"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Set extra environment variables"
@@ -191,7 +194,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Run e2e tests"
@@ -220,7 +223,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				yarn test:pw:%PROJECT% ${'$'}GREP_FLAG
 				"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Check for E2E teardown leaks"
@@ -243,7 +246,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 				""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Upload CTRF report"
@@ -266,7 +269,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
   }
 
   	artifactRules = """

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -3,6 +3,8 @@ package _self.lib.customBuildType
 import Settings
 import _self.bashNodeScript
 import _self.lib.utils.mergeTrunk
+import _self.lib.utils.passMergeQueueBranchesEarly
+import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -102,11 +104,12 @@ open class E2EBuildType(
 		}
 
 		steps {
+			passMergeQueueBranchesEarly()
 			// IMPORTANT! This step MUST match what the docker image does. If trunk
 			// is merged when building the docker image, it must also be merged
 			// to run the tests, or they may not be compatible. See the "mergeTrunk"
 			// step in BuildDockerImage in WebApp.kt.
-			mergeTrunk( skipIfConflict = true )
+			mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
 
 			bashNodeScript {
 				name = "Prepare environment"
@@ -122,7 +125,7 @@ open class E2EBuildType(
 					yarn workspace @automattic/calypso-e2e build
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-			}
+			}.skipOnMergeQueueBranch()
 
 			bashNodeScript {
 				name = "Run tests"
@@ -162,7 +165,7 @@ open class E2EBuildType(
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"
-			}
+			}.skipOnMergeQueueBranch()
 
 			bashNodeScript {
 				name = "Collect results"
@@ -180,7 +183,7 @@ open class E2EBuildType(
 					find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-			}
+			}.skipOnMergeQueueBranch()
 			buildSteps()
 		}
 

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -1,0 +1,40 @@
+package _self.lib.utils
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+
+const val MERGE_QUEUE_BRANCH_SKIP_PARAM = "mergeQueueBranch.skipBuild"
+
+fun BuildSteps.passMergeQueueBranchesEarly(): ScriptBuildStep {
+	return script {
+		name = "Pass merge queue branch early"
+		scriptContent = """
+			#!/usr/bin/env bash
+			set -euo pipefail
+
+			branch="%teamcity.build.branch%"
+
+			case "${'$'}branch" in
+				gh-readonly-queue/*|refs/heads/gh-readonly-queue/*)
+					;;
+				*)
+					exit 0
+					;;
+			esac
+
+			echo "Merge queue branch detected: ${'$'}branch"
+			echo "Skipping TeamCity work for merge queue validation."
+			echo "##teamcity[setParameter name='$MERGE_QUEUE_BRANCH_SKIP_PARAM' value='true']"
+			echo "##teamcity[buildStatus status='SUCCESS' text='Passed early for GitHub merge queue branch']"
+		""".trimIndent()
+	}
+}
+
+fun <T : BuildStep> T.skipOnMergeQueueBranch(): T {
+	conditions {
+		doesNotEqual(MERGE_QUEUE_BRANCH_SKIP_PARAM, "true")
+	}
+	return this
+}

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -6,6 +6,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 const val MERGE_QUEUE_BRANCH_SKIP_PARAM = "mergeQueueBranch.skipBuild"
+const val MERGE_QUEUE_BRANCH_SKIP_MESSAGE =
+	"This check was skipped because this is a merge queue and the check has already been run " +
+		"in the pull request. See: p4TIVU-b5I-p2#comment-12211"
 
 fun BuildSteps.passMergeQueueBranchesEarly(): ScriptBuildStep {
 	return script {
@@ -25,9 +28,9 @@ fun BuildSteps.passMergeQueueBranchesEarly(): ScriptBuildStep {
 			esac
 
 			echo "Merge queue branch detected: ${'$'}branch"
-			echo "Skipping TeamCity work for merge queue validation."
+			echo "$MERGE_QUEUE_BRANCH_SKIP_MESSAGE"
 			echo "##teamcity[setParameter name='$MERGE_QUEUE_BRANCH_SKIP_PARAM' value='true']"
-			echo "##teamcity[buildStatus status='SUCCESS' text='Passed early for GitHub merge queue branch']"
+			echo "##teamcity[buildStatus status='SUCCESS' text='$MERGE_QUEUE_BRANCH_SKIP_MESSAGE']"
 		""".trimIndent()
 	}
 }

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -2,6 +2,8 @@ package _self.projects
 
 import Settings
 import _self.bashNodeScript
+import _self.lib.utils.passMergeQueueBranchesEarly
+import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
@@ -48,6 +50,7 @@ object ToSAcceptanceTracking: BuildType ({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -62,7 +65,7 @@ object ToSAcceptanceTracking: BuildType ({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Capture screenshots"
@@ -79,7 +82,7 @@ object ToSAcceptanceTracking: BuildType ({
 				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=legal
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Collect results"
@@ -99,7 +102,7 @@ object ToSAcceptanceTracking: BuildType ({
 				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	features {

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -2,6 +2,8 @@ package _self.projects
 
 import _self.bashNodeScript
 import _self.lib.utils.mergeTrunk
+import _self.lib.utils.passMergeQueueBranchesEarly
+import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -118,14 +120,15 @@ object CalypsoApps: BuildType({
 	""".trimIndent()
 
 	steps {
-		mergeTrunk()
+		passMergeQueueBranchesEarly()
+		mergeTrunk().skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Install dependencies"
 			scriptContent = """
 				composer install
 				yarn install
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 
 		// Automatically generate a list of apps to build by scanning the directories,
 		// then build every app in parallel using xargs for proper error handling.
@@ -154,7 +157,7 @@ object CalypsoApps: BuildType({
 					yarn workspace "{}" run teamcity:build-app || exit 1
 				'
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 
 		// After the artifacts are built, we process them. This includes comparing
 		// with each previous release (to determine if a new release is needed),
@@ -176,7 +179,7 @@ object CalypsoApps: BuildType({
 
 				node ./bin/process-calypso-app-artifacts.mjs
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	failureConditions {
@@ -218,6 +221,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 		}
 
 		steps {
+			passMergeQueueBranchesEarly()
 			bashNodeScript {
 				name = "Upload Gutenberg source maps to Sentry"
 				scriptContent = """
@@ -234,17 +238,17 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 							--project wpcom-gutenberg-wp-admin \
 							--url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
 				"""
-			}
+			}.skipOnMergeQueueBranch()
 
 			uploadPluginSourceMaps(
 				slug = "wpcom-block-editor",
 				wpcomURL = "~/wpcom-block-editor"
-			)
+			).skipOnMergeQueueBranch()
 
 			uploadPluginSourceMaps(
 				slug = "notifications",
 				wpcomURL = "~/notifications"
-			)
+			).skipOnMergeQueueBranch()
 		}
 	}
 }

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -155,14 +155,14 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 				path = "./bin/post-threaded-slack-message.sh"
 				arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The $buildName passed successfully! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-			}
+			}.skipOnMergeQueueBranch()
 
 			exec {
 				name = "Post Failure Message to Slack"
 				executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 				path = "./bin/post-threaded-slack-message.sh"
 				arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The $buildName failed! Could you have a look?! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-			}
+			}.skipOnMergeQueueBranch()
 		},
 		buildFeatures = {
 			notifyAllFailuresAndFirstSuccess("#gutenberg-e2e")
@@ -204,11 +204,12 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		}
 
 		steps {
-			prepareE2eEnvironment()
+			passMergeQueueBranchesEarly()
+			prepareE2eEnvironment().skipOnMergeQueueBranch()
 
-			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration")
+			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration").skipOnMergeQueueBranch()
 
-			collectE2eResults()
+			collectE2eResults().skipOnMergeQueueBranch()
 		}
 
 		features {
@@ -266,7 +267,8 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		}
 
 		steps {
-			prepareE2eEnvironment()
+			passMergeQueueBranchesEarly()
+			prepareE2eEnvironment().skipOnMergeQueueBranch()
 
 			atomicVariations.forEach { variation ->
 				runE2eTestsWithRetry(
@@ -276,10 +278,10 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 						"RUN_ID" to "Atomic: $variation"
 					),
 					stepName = "Run Atomic Jetpack E2E Tests: $variation",
-				)
+				).skipOnMergeQueueBranch()
 			}
 
-			collectE2eResults()
+			collectE2eResults().skipOnMergeQueueBranch()
 		}
 
 		features {
@@ -339,11 +341,12 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 		}
 
 		steps {
-			prepareE2eEnvironment()
+			passMergeQueueBranchesEarly()
+			prepareE2eEnvironment().skipOnMergeQueueBranch()
 
-			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration")
+			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration").skipOnMergeQueueBranch()
 
-			collectE2eResults()
+			collectE2eResults().skipOnMergeQueueBranch()
 		}
 
 		features {
@@ -487,19 +490,20 @@ private object GutenbergPlaywrightTests : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		exec {
 			name = "Post Successful Message to Slack"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 			path = "./bin/post-threaded-slack-message.sh"
 			arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The Gutenberg E2E Tests matrix leg passed successfully: %PROJECT%, %EXTRA_ENV_VARS%. <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-		}
+		}.skipOnMergeQueueBranch()
 
 		exec {
 			name = "Post Failure Message to Slack"
 			executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 			path = "./bin/post-threaded-slack-message.sh"
 			arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The Gutenberg E2E Tests failed: %PROJECT%, %EXTRA_ENV_VARS%. Could you have a look?! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	features {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -4,6 +4,8 @@ import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
 import _self.lib.utils.mergeTrunk
+import _self.lib.utils.passMergeQueueBranchesEarly
+import _self.lib.utils.skipOnMergeQueueBranch
 import _self.CalypsoE2ETestsBuildTemplate
 
 import jetbrains.buildServer.configs.kotlin.*
@@ -149,6 +151,7 @@ object BuildDockerImage : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		script {
 			name = "Webhook Start"
 			conditions {
@@ -167,7 +170,7 @@ object BuildDockerImage : BuildType({
 
 				curl -s -X POST -d "${'$'}payload" -H "TEAMCITY-SIGNATURE: ${'$'}signature" "%mc_teamcity_webhook%calypso/?build_id=%teamcity.build.id%"
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 
 		script {
 			name = "Post PR comment"
@@ -184,13 +187,13 @@ object BuildDockerImage : BuildType({
 				Please wait a few minutes and refresh this page.
 				EOF
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 
 		// We want calypso.live and Calypso e2e tests to run even if there's a merge conflict,
 		// just to keep things going. However, if we can merge, the webpack cache
 		// can be better utilized, since it's kept up-to-date for trunk commits.
 		// Note that this only happens on non-trunk
-		mergeTrunk( skipIfConflict = true )
+		mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
 
 		script {
 			name = "Check Docker workspace COPY globs"
@@ -201,7 +204,7 @@ object BuildDockerImage : BuildType({
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID%"
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
-		}
+		}.skipOnMergeQueueBranch()
 
 		val commonArgs = """
 			--label com.a8c.image-builder=teamcity
@@ -233,7 +236,7 @@ object BuildDockerImage : BuildType({
 				commandArgs = "--pull --label com.a8c.target=calypso-live $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 
 		dockerCommand {
 			commandType = push {
@@ -242,7 +245,7 @@ object BuildDockerImage : BuildType({
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()
 			}
-		}
+		}.skipOnMergeQueueBranch()
 
 		script {
 			name = "Webhook fail OR webhook done and push trunk tag for deploy"
@@ -270,7 +273,7 @@ object BuildDockerImage : BuildType({
 
 				curl -s -X POST -d "${'$'}payload" -H "TEAMCITY-SIGNATURE: ${'$'}signature" "%mc_teamcity_webhook%calypso/?build_id=%teamcity.build.id%"
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 
 		script {
 			name = "Post PR comment with link"
@@ -286,7 +289,7 @@ object BuildDockerImage : BuildType({
 				$htmlBlock
 				EOF
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 
 		// TODO: Cache rebuilding is currently disabled. It takes a long time and
 		// causes timeouts on trunk. It needs to run more quickly to be worth it.
@@ -333,7 +336,7 @@ object BuildDockerImage : BuildType({
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 
 		dockerCommand {
 			name = "Push cache image"
@@ -345,7 +348,7 @@ object BuildDockerImage : BuildType({
 			commandType = push {
 				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
 			}
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	failureConditions {
@@ -418,7 +421,8 @@ object RunAllUnitTests : BuildType({
 	}
 
 	steps {
-		mergeTrunk()
+		passMergeQueueBranchesEarly()
+		mergeTrunk().skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -463,7 +467,7 @@ object RunAllUnitTests : BuildType({
 					exit 1
 				fi
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Check for yarn.lock changes and duplicated packages"
 			scriptContent = """
@@ -497,7 +501,7 @@ object RunAllUnitTests : BuildType({
 				prevent_uncommitted_changes & prevent_duplicated_packages
 				wait
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Check DataViews changelog"
 			scriptContent = """
@@ -517,12 +521,12 @@ object RunAllUnitTests : BuildType({
 					fi
 				fi
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Run parallelized tests"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = "./bin/unit-test-suite.mjs"
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Tag build"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
@@ -534,7 +538,7 @@ object RunAllUnitTests : BuildType({
 
 				curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" "%teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/"
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -624,6 +628,7 @@ object CheckCodeStyleBranch : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -632,7 +637,7 @@ object CheckCodeStyleBranch : BuildType({
 				# Install modules
 				${_self.yarn_install_cmd}
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Run eslint"
 			scriptContent = """
@@ -723,14 +728,14 @@ object CheckCodeStyleBranch : BuildType({
 						' yarn-batch # Arbitrary name to be used as each batch's progname
 				fi
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Run code quality linters"
 			scriptContent = """
 				yarn run lint:unused-state-action-types
 				yarn run lint:config-defaults
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Run stylelint"
 			scriptContent = """
@@ -738,7 +743,7 @@ object CheckCodeStyleBranch : BuildType({
 				yarn run lint:css
 				yarn run lint:mixedindent
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -803,6 +808,7 @@ object Translate : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -810,7 +816,7 @@ object Translate : BuildType({
 				${_self.yarn_install_cmd}
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Extract strings"
 			scriptContent = """
@@ -825,7 +831,7 @@ object Translate : BuildType({
 				echo "##teamcity[publishArtifacts './translate/calypso-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Build New Strings .pot"
 			scriptContent = """
@@ -846,7 +852,7 @@ object Translate : BuildType({
 				echo "##teamcity[publishArtifacts './translate/localci-new-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Notify GlotPress Translate build is ready"
 			scriptContent = """
@@ -867,7 +873,7 @@ object Translate : BuildType({
 							}
 						}'
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -1214,6 +1220,7 @@ object JestPreReleaseE2ETests : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -1228,7 +1235,7 @@ object JestPreReleaseE2ETests : BuildType({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Run tests"
@@ -1254,7 +1261,7 @@ object JestPreReleaseE2ETests : BuildType({
 				RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=calypso-release --onlyFailures --json --outputFile=pre-release-test-results.json
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 
 		bashNodeScript {
 			name = "Collect results"
@@ -1275,7 +1282,7 @@ object JestPreReleaseE2ETests : BuildType({
 				find test/e2e/allure-results -name '*.json' -print0 | xargs -r -0 mv -t allure-results
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	failureConditions {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,6 +2,9 @@
 import _self.bashNodeScript
 import _self.yarn_install_cmd
 import _self.CalypsoE2ETestsBuildTemplate
+import _self.lib.utils.MERGE_QUEUE_BRANCH_SKIP_PARAM
+import _self.lib.utils.passMergeQueueBranchesEarly
+import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
@@ -66,6 +69,7 @@ project {
 
 	params {
 		param("env.CI", "true")
+		param(MERGE_QUEUE_BRANCH_SKIP_PARAM, "false")
 		// Force color support in chalk. For some reason it doesn't detect TeamCity
 		// as supported (even though both TeamCity and chalk support that.)
 		param("env.FORCE_COLOR", "1")
@@ -129,13 +133,14 @@ object YarnInstall : BuildType({
 		cleanCheckout = true
 	}
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Yarn Install"
 			scriptContent = """
 				# Install modules
 				${_self.yarn_install_cmd}
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 	}
 	features {
 		perfmon {
@@ -168,6 +173,7 @@ object BuildBaseImages : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		dockerCommand {
 			name = "Build base image"
 			commandType = build {
@@ -178,7 +184,7 @@ object BuildBaseImages : BuildType({
 				commandArgs = "--no-cache --target base --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Build CI e2e image"
 			commandType = build {
@@ -189,7 +195,7 @@ object BuildBaseImages : BuildType({
 				commandArgs = "--target ci-e2e --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Build CI wpcom image"
 			commandType = build {
@@ -200,7 +206,7 @@ object BuildBaseImages : BuildType({
 				commandArgs = "--target ci-wpcom --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Retag images for publish"
 			scriptContent = """
@@ -232,7 +238,7 @@ object BuildBaseImages : BuildType({
 				retag_image registry.a8c.com/calypso/ci-e2e
 				retag_image registry.a8c.com/calypso/ci-wpcom
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Push images"
 			commandType = push {
@@ -241,7 +247,7 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/base:%build.number%
 				""".trimIndent()
 			}
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -306,6 +312,7 @@ object BuildToolchainPreviewImages : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		val commonArgs = "--pull --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 
 		dockerCommand {
@@ -318,7 +325,7 @@ object BuildToolchainPreviewImages : BuildType({
 				commandArgs = "--target toolchain $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Build CI e2e image"
 			commandType = build {
@@ -329,7 +336,7 @@ object BuildToolchainPreviewImages : BuildType({
 				commandArgs = "--target ci-e2e $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Build CI wpcom image"
 			commandType = build {
@@ -340,7 +347,7 @@ object BuildToolchainPreviewImages : BuildType({
 				commandArgs = "--target ci-wpcom $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Smoke test toolchain image"
 			scriptContent = """
@@ -350,7 +357,7 @@ object BuildToolchainPreviewImages : BuildType({
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/toolchain:%build.number% -lc \
 					'node --version && yarn --version && git --version && jq --version'
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Smoke test CI e2e image"
 			scriptContent = """
@@ -363,7 +370,7 @@ object BuildToolchainPreviewImages : BuildType({
 					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null
 				'
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Smoke test CI wpcom image"
 			scriptContent = """
@@ -373,7 +380,7 @@ object BuildToolchainPreviewImages : BuildType({
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-wpcom:%build.number% -lc \
 					'php -v && composer --version && docker-compose version && sentry-cli --version'
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Retag images for publish"
 			scriptContent = """
@@ -405,7 +412,7 @@ object BuildToolchainPreviewImages : BuildType({
 				retag_image registry.a8c.com/calypso/ci-e2e
 				retag_image registry.a8c.com/calypso/ci-wpcom
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Push images"
 			commandType = push {
@@ -418,7 +425,7 @@ object BuildToolchainPreviewImages : BuildType({
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 			}
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -486,6 +493,7 @@ object BuildCacheSeedImages : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 
 		dockerCommand {
@@ -498,7 +506,7 @@ object BuildCacheSeedImages : BuildType({
 				commandArgs = "--target cache-seed $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Build cache-seed debug smoke image"
 			commandType = build {
@@ -509,7 +517,7 @@ object BuildCacheSeedImages : BuildType({
 				commandArgs = "--target cache-seed-debug $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Smoke test cache-seed debug image"
 			scriptContent = """
@@ -521,7 +529,7 @@ object BuildCacheSeedImages : BuildType({
 				docker run --rm --entrypoint /bin/bash calypso/cache-seed-smoke:%build.number% -lc \
 					'du -sh /calypso/.cache /calypso/.yarn'
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Retag image for publish"
 			scriptContent = """
@@ -541,7 +549,7 @@ object BuildCacheSeedImages : BuildType({
 					exit 1
 				fi
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Push images"
 			commandType = push {
@@ -550,7 +558,7 @@ object BuildCacheSeedImages : BuildType({
 					registry.a8c.com/calypso/cache-seed:%build.number%
 				""".trimIndent()
 			}
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -614,6 +622,7 @@ object BuildCacheSeedPreviewImage : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 
 		dockerCommand {
@@ -626,7 +635,7 @@ object BuildCacheSeedPreviewImage : BuildType({
 				commandArgs = "--target cache-seed $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Build cache-seed debug smoke image"
 			commandType = build {
@@ -637,7 +646,7 @@ object BuildCacheSeedPreviewImage : BuildType({
 				commandArgs = "--target cache-seed-debug $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}
+		}.skipOnMergeQueueBranch()
 		script {
 			name = "Smoke test cache-seed debug image"
 			scriptContent = """
@@ -649,13 +658,13 @@ object BuildCacheSeedPreviewImage : BuildType({
 				docker run --rm --entrypoint /bin/bash calypso/cache-seed-smoke:%build.number% -lc \
 					'du -sh /calypso/.cache /calypso/.yarn'
 			""".trimIndent()
-		}
+		}.skipOnMergeQueueBranch()
 		dockerCommand {
 			name = "Push preview image"
 			commandType = push {
 				namesAndTags = "registry.a8c.com/calypso/cache-seed:%build.number%"
 			}
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	failureConditions {
@@ -690,13 +699,14 @@ object CheckCodeStyle : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
 				# Install modules
 				${_self.yarn_install_cmd}
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Run linters"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
@@ -704,7 +714,7 @@ object CheckCodeStyle : BuildType({
 				# Lint files
 				yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" .
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 	}
 
 	triggers {
@@ -802,19 +812,20 @@ object SmartBuildLauncher : BuildType({
 	}
 
 	steps {
+		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Install and build dependencies"
 			scriptContent = """
 				$yarn_install_cmd
 				yarn workspace @automattic/dependency-finder build
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Launch relevant builds"
 			scriptContent = """
 				node ./packages/dependency-finder/dist/esm/index.js
 			"""
-		}
+		}.skipOnMergeQueueBranch()
 	}
 })
 


### PR DESCRIPTION
Related p4TIVU-b5I-p2 

## Proposed Changes

* Add a shared TeamCity merge-queue helper that detects `gh-readonly-queue/...` branches, marks the build status successful, and sets a shared skip parameter.
* Gate TeamCity build steps with the shared skip condition so merge queue branch runs avoid the expensive install, build, test, upload, and notification work.
* Apply the helper across the TeamCity root settings, WebApp checks, shared E2E templates, WPCom plugin/test jobs, and MarTech jobs.

## Why are these changes being made?

* GitHub merge queue branches require a re-run of all the required checks in the PR. But in our casa we don't need this yet. Because the checks run on the internal deploy page. 
* The only check that will actually run in the merge queue is the check of the Calypso Slack Channel status. It will reject the PR when the channel is red.
* Once the queue is in place, we'll add more checks in it.

## Testing Instructions

- Merge this.
- Enable the merge group requirement on the trunk.
- Make a test PR. 
- Make the channel red.
- Merge it. 
- The PR should be rejected.
- Make the channel green.
- Merge the PR, should go through.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?