### PR TITLE
Help Center: fix loading for users who sign up mid-onboarding

### DIFF
--- a/client/components/help-center/async-help-center-app.tsx
+++ b/client/components/help-center/async-help-center-app.tsx
@@ -1,4 +1,6 @@
 import AsyncLoad from 'calypso/components/async-load';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import type { HelpCenterAppProps } from './help-center-app';
 
 const loadHelpCenterApp = () =>
@@ -6,16 +8,30 @@ const loadHelpCenterApp = () =>
 		/* webpackChunkName: "async-load-calypso-components-help-center-help-center-app" */ './help-center-app'
 	);
 
-const AsyncHelpCenterApp = ( props: HelpCenterAppProps ) => {
-	if ( props.requireLogin && ! props.currentUser ) {
+type AsyncHelpCenterAppProps = Omit< HelpCenterAppProps, 'currentUser' > & {
+	currentUser?: HelpCenterAppProps[ 'currentUser' ];
+};
+
+const AsyncHelpCenterApp = ( {
+	currentUser: currentUserProp,
+	...props
+}: AsyncHelpCenterAppProps ) => {
+	// When login is required, detect it from the live store rather than the passed prop, which a
+	// caller may have captured before the user authenticated (e.g. signing up mid-onboarding).
+	const reduxCurrentUser = useSelector( getCurrentUser );
+	const currentUser = props.requireLogin ? reduxCurrentUser ?? currentUserProp : currentUserProp;
+
+	if ( props.requireLogin && ! currentUser ) {
 		return null;
 	}
+
 	return (
 		<AsyncLoad
 			require={ loadHelpCenterApp }
 			placeholder={ null }
 			{ ...props }
-			locale={ props.locale ?? props.currentUser.language }
+			currentUser={ currentUser }
+			locale={ props.locale ?? currentUser?.language }
 		/>
 	);
 };

--- a/client/components/help-center/async-help-center-app.tsx
+++ b/client/components/help-center/async-help-center-app.tsx
@@ -8,9 +8,14 @@ const loadHelpCenterApp = () =>
 		/* webpackChunkName: "async-load-calypso-components-help-center-help-center-app" */ './help-center-app'
 	);
 
-type AsyncHelpCenterAppProps = Omit< HelpCenterAppProps, 'currentUser' > & {
-	currentUser?: HelpCenterAppProps[ 'currentUser' ];
-};
+// When requireLogin is set, currentUser is derived from the store and the prop is optional;
+// otherwise the caller must supply it, as the underlying Help Center requires one.
+type AsyncHelpCenterAppProps =
+	| ( Omit< HelpCenterAppProps, 'currentUser' | 'requireLogin' > & {
+			requireLogin: true;
+			currentUser?: HelpCenterAppProps[ 'currentUser' ];
+	  } )
+	| ( HelpCenterAppProps & { requireLogin?: false } );
 
 const AsyncHelpCenterApp = ( {
 	currentUser: currentUserProp,

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -284,11 +284,22 @@ async function main() {
 							<LazyHelpCenter currentUser={ user as UserStore.CurrentUser } />
 						) : (
 							<>
-								<AsyncHelpCenterApp
-									requireLogin
-									currentUser={ user as UserStore.CurrentUser }
-									sectionName="stepper"
-								/>
+								{ /* Boot-authed users (auth cookie present) get the full Help Center.
+								   New users who sign up mid-flow have a bearer token but no cookie yet,
+								   so authed requests would 401 — give them the logged-out Help Center
+								   (docs/search/AI) until a full page load (e.g. checkout) sets the cookie. */ }
+								{ user ? (
+									<AsyncHelpCenterApp
+										requireLogin
+										currentUser={ user as UserStore.CurrentUser }
+										sectionName="stepper"
+									/>
+								) : (
+									<AsyncHelpCenterApp
+										locale={ defaultCalypsoI18n.getLocaleSlug() ?? undefined }
+										sectionName="stepper"
+									/>
+								) }
 								<AsyncLoad
 									require={ loadAgentsManagerLoader }
 									placeholder={ null }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -284,22 +284,7 @@ async function main() {
 							<LazyHelpCenter currentUser={ user as UserStore.CurrentUser } />
 						) : (
 							<>
-								{ /* Boot-authed users (auth cookie present) get the full Help Center.
-								   New users who sign up mid-flow have a bearer token but no cookie yet,
-								   so authed requests would 401 — give them the logged-out Help Center
-								   (docs/search/AI) until a full page load (e.g. checkout) sets the cookie. */ }
-								{ user ? (
-									<AsyncHelpCenterApp
-										requireLogin
-										currentUser={ user as UserStore.CurrentUser }
-										sectionName="stepper"
-									/>
-								) : (
-									<AsyncHelpCenterApp
-										locale={ defaultCalypsoI18n.getLocaleSlug() ?? undefined }
-										sectionName="stepper"
-									/>
-								) }
+								<AsyncHelpCenterApp requireLogin sectionName="stepper" />
 								<AsyncLoad
 									require={ loadAgentsManagerLoader }
 									placeholder={ null }

--- a/packages/data-stores/src/help-center/test/utils.ts
+++ b/packages/data-stores/src/help-center/test/utils.ts
@@ -14,6 +14,11 @@ jest.mock( '../../wpcom-request', () => ( {
 	canAccessWpcomApis: jest.fn(),
 } ) );
 
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	isCookieAuthMissing: jest.fn( () => false ),
+} ) );
+
 describe( 'help-center utils — localStorage persistence (logged out)', () => {
 	let utils: typeof import('../utils');
 
@@ -95,5 +100,41 @@ describe( 'getPersistedPreference — server preferences (logged in)', () => {
 		utils.setHelpCenterAppId( undefined );
 
 		await expect( utils.getPersistedPreference( 'help_center_open' ) ).resolves.toBe( true );
+	} );
+
+	it( 'falls back to localStorage and skips the network when the auth cookie is missing', async () => {
+		const utils = await setup( { help_center_open: false } );
+		window.localStorage.clear();
+		window.localStorage.setItem( PREFERENCES_KEY + 'help_center_open', 'true' );
+
+		const { isCookieAuthMissing } = await import( 'wpcom-proxy-request' );
+		( isCookieAuthMissing as jest.Mock ).mockReturnValue( true );
+		const wpcomRequest = await import( '../../wpcom-request' );
+
+		await expect( utils.getPersistedPreference( 'help_center_open' ) ).resolves.toBe( true );
+		expect( wpcomRequest.default ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not cache a failed preferences request — a later read retries', async () => {
+		jest.resetModules();
+
+		const { select } = await import( '@wordpress/data' );
+		( select as jest.Mock ).mockReturnValue( { getIsLoggedIn: () => true } );
+
+		const { isCookieAuthMissing } = await import( 'wpcom-proxy-request' );
+		( isCookieAuthMissing as jest.Mock ).mockReturnValue( false );
+
+		const wpcomRequest = await import( '../../wpcom-request' );
+		( wpcomRequest.canAccessWpcomApis as jest.Mock ).mockReturnValue( true );
+		( wpcomRequest.default as jest.Mock )
+			.mockRejectedValueOnce( new Error( '401' ) )
+			.mockResolvedValueOnce( { calypso_preferences: { help_center_open: true } } );
+
+		const utils = await import( '../utils' );
+
+		await expect( utils.getPersistedPreference( 'help_center_open' ) ).rejects.toThrow();
+		// The first failure must not be cached, so the next read issues a fresh request.
+		await expect( utils.getPersistedPreference( 'help_center_open' ) ).resolves.toBe( true );
+		expect( wpcomRequest.default ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/packages/data-stores/src/help-center/utils.ts
+++ b/packages/data-stores/src/help-center/utils.ts
@@ -1,5 +1,6 @@
 import { default as apiFetchPromise } from '@wordpress/api-fetch';
 import { select } from '@wordpress/data';
+import { isCookieAuthMissing } from 'wpcom-proxy-request';
 import { isE2ETest } from '../utils';
 import { default as wpcomRequestPromise, canAccessWpcomApis } from '../wpcom-request';
 import { PREFERENCES_KEY, STORE_KEY } from './constants';
@@ -95,6 +96,11 @@ function getCalypsoPreferences(): Promise< Preferences[ 'calypso_preferences' ] 
 		} as APIFetchOptions );
 	}
 
+	// Don't cache a failed request — clear it so a later read retries.
+	cachedPreferencesPromise.catch( () => {
+		cachedPreferencesPromise = undefined;
+	} );
+
 	return cachedPreferencesPromise;
 }
 
@@ -103,7 +109,9 @@ export async function getPersistedPreference<
 >( key: T ): Promise< Preferences[ 'calypso_preferences' ][ T ] | undefined > {
 	const isLoggedIn = ( select( STORE_KEY ) as unknown as HelpCenterSelect ).getIsLoggedIn();
 
-	if ( isLoggedIn ) {
+	// When the proxy session has no auth cookie (e.g. right after in-stepper signup) the
+	// authed request 401s; fall back to localStorage instead, as for logged-out users.
+	if ( isLoggedIn && ! isCookieAuthMissing() ) {
 		const preferences = await getCalypsoPreferences();
 		return readScoped( preferences, key );
 	}

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -1,6 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
-import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import wpcomRequest, { canAccessWpcomApis, isCookieAuthMissing } from 'wpcom-proxy-request';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { SupportStatus } from '../types';
 
@@ -21,7 +21,7 @@ export function useSupportStatus( enabled = true ) {
 			canAccessWpcomApis()
 				? await wpcomRequest( { path: '/help/support-status', apiNamespace: 'wpcom/v2' } )
 				: await apiFetch( { path: 'help-center/support-status', global: true } as APIFetchOptions ),
-		enabled: enabled && !! currentUser?.ID,
+		enabled: enabled && !! currentUser?.ID && ! isCookieAuthMissing(),
 		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,
 		staleTime: 180000, // 3mins.

--- a/packages/help-center/src/hooks/use-get-support-interactions.ts
+++ b/packages/help-center/src/hooks/use-get-support-interactions.ts
@@ -1,6 +1,7 @@
 import { handleSupportInteractionsFetch } from '@automattic/odie-client/src/data/handle-support-interactions-fetch';
 import { isTestModeEnvironment, useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useQuery } from '@tanstack/react-query';
+import { isCookieAuthMissing } from 'wpcom-proxy-request';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import type { SupportProvider } from '../types';
 
@@ -14,9 +15,12 @@ export const useGetSupportInteractions = (
 ) => {
 	const isTestMode = isTestModeEnvironment();
 	const { currentUser } = useHelpCenterContext();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
+	// No auth cookie yet (e.g. right after in-stepper signup) means these authed requests
+	// would 401 and leave the panel stuck loading; skip them and render the logged-out home.
+	const isAuthed = !! currentUser?.ID && ! isCookieAuthMissing();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( isAuthed );
 
-	let shouldFetch = enabled && !! currentUser?.ID;
+	let shouldFetch = enabled && isAuthed;
 	// Only fetch Zendesk interactions if the user can connect to Zendesk.
 	if ( ( provider === 'zendesk' || provider === 'zendesk-staging' ) && ! canConnectToZendesk ) {
 		shouldFetch = false;

--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -9,7 +9,6 @@ export interface WpcomRequestParams {
 	path?: string;
 	method?: string;
 	apiVersion?: string;
-	// eslint-disable-next-line @typescript-eslint/ban-types
 	body?: object;
 	token?: string;
 	query?: string | Record< string, string | number >;

--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -33,6 +33,8 @@ export function reloadProxy(): void;
 
 export function canAccessWpcomApis(): boolean;
 
+export function isCookieAuthMissing(): boolean;
+
 export function requestAllBlogsAccess(): ReturnType< typeof request >;
 
 export function setCrossOriginStorageItem(

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -54,6 +54,7 @@ global.fetch = jest.fn( () =>
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	canAccessWpcomApis: jest.fn(),
+	isCookieAuthMissing: jest.fn(),
 	reloadProxy: jest.fn(),
 	requestAllBlogsAccess: jest.fn(),
 } ) );

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -54,7 +54,7 @@ global.fetch = jest.fn( () =>
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	canAccessWpcomApis: jest.fn(),
-	isCookieAuthMissing: jest.fn(),
+	isCookieAuthMissing: jest.fn( () => false ),
 	reloadProxy: jest.fn(),
 	requestAllBlogsAccess: jest.fn(),
 } ) );


### PR DESCRIPTION
## Proposed Changes

**The Help Center now opens and loads for users who create their account in the middle of the onboarding flow, instead of staying blank until a page refresh.**

- Mount the stepper Help Center from the reactive Redux current user, so it appears as soon as in-stepper signup logs the user in — the previous code read a user value captured once at app boot, which stayed empty for brand-new users.
- While the WordPress.com proxy has no auth cookie yet (`isCookieAuthMissing()`), fall back to the logged-out data paths: read Help Center preferences from `localStorage` and skip the `support-status` / `support-interactions` requests that would otherwise return `401` and leave the panel stuck on a loading skeleton.
- Clear the cached preferences promise when its request fails, so a later read can retry instead of being poisoned for the whole session.
- Declare the already-exported `isCookieAuthMissing` in the `wpcom-proxy-request` type definitions.

## Why are these changes being made?

When a brand-new user signs up partway through `/setup/onboarding` and clicks “Need help?”, the Help Center did nothing — and only started working after a full page refresh.

Two things go wrong in that moment. First, the panel was tied to the user that existed when the page first loaded; a person who signs up later in the flow was still treated as “nobody”, so the panel never mounted. Second, a freshly created account has a login token but not yet the WordPress.com cookie that the support APIs authenticate with, so those calls fail and the panel hangs while it waits for data it can never load. A refresh fixes both because the reloaded page has the real user and the cookie.

This change makes the panel follow the current user as they sign in mid-flow, and lets it fall back to the same lightweight experience logged-out visitors already get (search and help articles, which need no account) until the cookie is in place — so the new user gets a working Help Center immediately, no refresh required.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. In a logged-out browser (or incognito), go to `/setup/onboarding` and complete the steps until you create a new account in-flow.
3. On the domains step, click “Need help?” **without refreshing**.
4. Confirm the Help Center opens and shows the home view (search + help articles) rather than a blank/forever-loading panel.
5. Refresh the page and confirm the Help Center still works and now shows the full authenticated experience.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center and confirm it loads normally for an established logged-in user (no regression to the cookie-present path).
