### PR TITLE
DOTCOM-17731: Update the plans grid to be more resilient to unknown products

### DIFF
--- a/packages/data-stores/src/plans/queries/test/use-plans.test.tsx
+++ b/packages/data-stores/src/plans/queries/test/use-plans.test.tsx
@@ -84,6 +84,9 @@ describe( 'plans query hooks', () => {
 		expect( result.current.isError ).toBe( false );
 		expect( Object.keys( result.current.data ?? {} ) ).toEqual( [ PLAN_PERSONAL ] );
 		expect( result.current.data?.[ PLAN_PERSONAL ].pricing.originalPrice.monthly ).toBe( 1000 );
+		expect( queryClient.getQueryData< PricedAPIPlan[] >( [ 'plans', undefined ] ) ).toHaveLength(
+			2
+		);
 	} );
 
 	it( 'ignores API site plans that are not defined in calypso-products', async () => {
@@ -104,5 +107,14 @@ describe( 'plans query hooks', () => {
 		expect( result.current.isError ).toBe( false );
 		expect( Object.keys( result.current.data ?? {} ) ).toEqual( [ PLAN_BUSINESS ] );
 		expect( result.current.data?.[ PLAN_BUSINESS ].pricing.originalPrice.monthly ).toBe( 2500 );
+		expect(
+			Object.keys(
+				queryClient.getQueryData< Record< string, PricedAPISitePlan > >( [
+					'site-plans',
+					123,
+					undefined,
+				] ) ?? {}
+			)
+		).toEqual( [ '1001', '9999' ] );
 	} );
 } );

--- a/packages/data-stores/src/plans/queries/test/use-plans.test.tsx
+++ b/packages/data-stores/src/plans/queries/test/use-plans.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PLAN_BUSINESS, PLAN_PERSONAL } from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcomRequest from '../../../wpcom-request';
+import usePlans from '../use-plans';
+import useSitePlans from '../use-site-plans';
+import type { PricedAPIPlan, PricedAPISitePlan } from '../../types';
+import type { ReactNode } from 'react';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useLocale: jest.fn( () => 'en' ),
+} ) );
+
+jest.mock( '../../../wpcom-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockWpcomRequest = wpcomRequest as jest.Mock;
+
+const makeQueryClient = () => new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+
+const makeWrapper = ( queryClient: QueryClient ) =>
+	function Wrapper( { children }: { children: ReactNode } ) {
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
+
+const makeAPIPlan = ( overrides: Partial< PricedAPIPlan > = {} ): PricedAPIPlan => ( {
+	bill_period: 365,
+	currency_code: 'USD',
+	formatted_price: '$120',
+	orig_cost_integer: 12000,
+	path_slug: 'personal',
+	product_display_price: '$120',
+	product_id: 1001,
+	product_name: 'Personal',
+	product_name_short: 'Personal',
+	product_slug: PLAN_PERSONAL,
+	raw_price: 120,
+	raw_price_integer: 12000,
+	...overrides,
+} );
+
+const makeAPISitePlan = ( overrides: Partial< PricedAPISitePlan > = {} ): PricedAPISitePlan => ( {
+	currency_code: 'USD',
+	formatted_price: '$300',
+	product_display_price: '$300',
+	product_slug: PLAN_BUSINESS,
+	raw_discount_integer: 0,
+	raw_price: 300,
+	raw_price_integer: 30000,
+	...overrides,
+} );
+
+describe( 'plans query hooks', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'ignores API plans that are not defined in calypso-products', async () => {
+		mockWpcomRequest.mockResolvedValue( [
+			makeAPIPlan(),
+			makeAPIPlan( {
+				product_id: 9999,
+				product_slug: 'api-only-plan' as PricedAPIPlan[ 'product_slug' ],
+			} ),
+		] );
+
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => usePlans( { coupon: undefined } ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.isError ).toBe( false );
+		expect( Object.keys( result.current.data ?? {} ) ).toEqual( [ PLAN_PERSONAL ] );
+		expect( result.current.data?.[ PLAN_PERSONAL ].pricing.originalPrice.monthly ).toBe( 1000 );
+	} );
+
+	it( 'ignores API site plans that are not defined in calypso-products', async () => {
+		mockWpcomRequest.mockResolvedValue( {
+			1001: makeAPISitePlan(),
+			9999: makeAPISitePlan( {
+				product_slug: 'api-only-plan' as PricedAPISitePlan[ 'product_slug' ],
+			} ),
+		} );
+
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useSitePlans( { coupon: undefined, siteId: 123 } ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.isError ).toBe( false );
+		expect( Object.keys( result.current.data ?? {} ) ).toEqual( [ PLAN_BUSINESS ] );
+		expect( result.current.data?.[ PLAN_BUSINESS ].pricing.originalPrice.monthly ).toBe( 2500 );
+	} );
+} );

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
+import { calculateMonthlyPriceForPlan, getPlan } from '@automattic/calypso-products';
 import { useLocale } from '@automattic/i18n-utils';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from '../../wpcom-request';
@@ -47,6 +47,7 @@ function usePlans( {
 	const queryKeys = useQueryKeysFactory();
 	const locale = useLocale();
 	const params = new URLSearchParams();
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	coupon && params.append( 'coupon_code', coupon );
 	params.append( 'locale', locale );
 
@@ -63,9 +64,10 @@ function usePlans( {
 				apiVersion: '1.5',
 				query: params.toString(),
 			} );
+			const knownPlans = data.filter( ( plan ) => getPlan( plan.product_slug ) );
 
 			return Object.fromEntries(
-				data.map( ( plan ) => {
+				knownPlans.map( ( plan ) => {
 					const discountedPriceFull =
 						plan.orig_cost_integer !== plan.raw_price_integer ? plan.raw_price_integer : null;
 

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -47,8 +47,9 @@ function usePlans( {
 	const queryKeys = useQueryKeysFactory();
 	const locale = useLocale();
 	const params = new URLSearchParams();
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	coupon && params.append( 'coupon_code', coupon );
+	if ( coupon ) {
+		params.append( 'coupon_code', coupon );
+	}
 	params.append( 'locale', locale );
 
 	// Auto-detect Jetpack context and use appropriate request function
@@ -58,12 +59,13 @@ function usePlans( {
 
 	return useQuery( {
 		queryKey: queryKeys.plans( coupon ),
-		queryFn: async (): Promise< PlansIndex > => {
-			const data: PricedAPIPlan[] = await requestFn( {
+		queryFn: async (): Promise< PricedAPIPlan[] > =>
+			requestFn( {
 				path: '/plans',
 				apiVersion: '1.5',
 				query: params.toString(),
-			} );
+			} ),
+		select: ( data ): PlansIndex => {
 			// Filter out unknown products in case the API returns products not hardcoded in calypso-products.
 			const knownPlans = data.filter( ( plan ) => getPlan( plan.product_slug ) );
 

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -64,6 +64,7 @@ function usePlans( {
 				apiVersion: '1.5',
 				query: params.toString(),
 			} );
+			// Filter out unknown products in case the API returns products not hardcoded in calypso-products.
 			const knownPlans = data.filter( ( plan ) => getPlan( plan.product_slug ) );
 
 			return Object.fromEntries(

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -41,6 +41,7 @@ function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansInd
 				apiVersion: '1.3',
 				query: params.toString(),
 			} );
+			// Filter out unknown products in case the API returns products not hardcoded in calypso-products.
 			const knownProductIds = Object.keys( data ).filter( ( productId ) =>
 				getPlan( data[ Number( productId ) ].product_slug )
 			);

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -10,7 +10,7 @@ interface SitePlansIndex {
 	[ planSlug: string ]: SitePlan;
 }
 interface PricedAPISitePlansIndex {
-	[ productId: number ]: PricedAPISitePlan;
+	[ productId: string ]: PricedAPISitePlan;
 }
 
 interface Props {
@@ -30,25 +30,27 @@ interface Props {
 function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const params = new URLSearchParams();
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	coupon && params.append( 'coupon_code', coupon );
+	if ( coupon ) {
+		params.append( 'coupon_code', coupon );
+	}
 
 	return useQuery( {
 		queryKey: queryKeys.sitePlans( coupon, siteId ),
-		queryFn: async (): Promise< SitePlansIndex > => {
-			const data: PricedAPISitePlansIndex = await wpcomRequest( {
+		queryFn: async (): Promise< PricedAPISitePlansIndex > =>
+			wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/plans`,
 				apiVersion: '1.3',
 				query: params.toString(),
-			} );
+			} ),
+		select: ( data ): SitePlansIndex => {
 			// Filter out unknown products in case the API returns products not hardcoded in calypso-products.
 			const knownProductIds = Object.keys( data ).filter( ( productId ) =>
-				getPlan( data[ Number( productId ) ].product_slug )
+				getPlan( data[ productId ].product_slug )
 			);
 
 			return Object.fromEntries(
 				knownProductIds.map( ( productId ) => {
-					const plan = data[ Number( productId ) ];
+					const plan = data[ productId ];
 					const originalPriceFull = plan.raw_discount_integer
 						? plan.raw_price_integer + plan.raw_discount_integer
 						: plan.raw_price_integer;

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -1,4 +1,4 @@
-import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
+import { calculateMonthlyPriceForPlan, getPlan } from '@automattic/calypso-products';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from '../../wpcom-request';
 import unpackCostOverrides from './lib/unpack-cost-overrides';
@@ -30,6 +30,7 @@ interface Props {
 function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const params = new URLSearchParams();
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	coupon && params.append( 'coupon_code', coupon );
 
 	return useQuery( {
@@ -40,9 +41,12 @@ function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansInd
 				apiVersion: '1.3',
 				query: params.toString(),
 			} );
+			const knownProductIds = Object.keys( data ).filter( ( productId ) =>
+				getPlan( data[ Number( productId ) ].product_slug )
+			);
 
 			return Object.fromEntries(
-				Object.keys( data ).map( ( productId ) => {
+				knownProductIds.map( ( productId ) => {
 					const plan = data[ Number( productId ) ];
 					const originalPriceFull = plan.raw_discount_integer
 						? plan.raw_price_integer + plan.raw_discount_integer


### PR DESCRIPTION
Fixes DOTCOM-17731

## Proposed Changes

* Update the plans grid to be more resilient to unknown products coming from the API

## Why are these changes being made?

There have been at least two cases of the API returning products not defined in `@automattic/calypso-products` which causes the plans grid to stop rendering.
For the latest case of this, see p58i-qI8-p2

## Testing Instructions

1. Do not check out this PR yet.
2. Sandbox the API and check out 225812-ghe-Automattic/wpcom on your sandbox, which adds a product not defined in calypso-products. If by the time you test this the product is defined, remove that product from calypso-products or locally reverse the changeset of the commit that added it.
3. Open up http://calypso.localhost:3000/setup/onboarding/plans?source=sites-dashboard&ref=new-site-popover - the page should show an infinite loading spinner instead of the plans grid.
4. Apply this PR locally and refresh after building is done.
5. The plans grid should now render.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?