### PR TITLE
A4A: add Beta tag to AI and MCP sidebar menu item

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Badge } from '@automattic/components';
 import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { brush, chartBar, pages, tool } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -23,9 +24,9 @@ const useLearnMenuItems = ( path: string ) => {
 	const isBenchmarksEnabled = isEnabled( 'a4a-benchmarks' );
 
 	const menuItems = useMemo( () => {
-		const items = isAgentStudioEnabled
-			? [
-					createItem(
+		return [
+			...( isAgentStudioEnabled
+				? [
 						{
 							icon: brush,
 							path: A4A_AGENT_STUDIO_LINK,
@@ -35,76 +36,58 @@ const useLearnMenuItems = ( path: string ) => {
 								menu_item: 'Automattic for Agencies / Resources and tools / Agent studio',
 							},
 						},
-						path
-					),
-			  ]
-			: [];
-
-		if ( isBenchmarksEnabled ) {
-			items.push(
-				createItem(
-					{
-						icon: chartBar,
-						path: A4A_BENCHMARKS_LINK,
-						link: A4A_BENCHMARKS_LINK,
-						title: translate( 'Benchmarks' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Resources and tools / Benchmarks',
+				  ]
+				: [] ),
+			...( isBenchmarksEnabled
+				? [
+						{
+							icon: chartBar,
+							path: A4A_BENCHMARKS_LINK,
+							link: A4A_BENCHMARKS_LINK,
+							title: translate( 'Benchmarks' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Resources and tools / Benchmarks',
+							},
 						},
-					},
-					path
-				)
-			);
-		}
-
-		if ( isAiMcpEnabled ) {
-			items.push(
-				createItem(
-					{
-						icon: <BigSkyLogo.CentralLogo heartless size={ 24 } />,
-						path: A4A_AI_MCP_LINK,
-						link: A4A_AI_MCP_LINK,
-						title: translate( 'AI and MCP' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
+				  ]
+				: [] ),
+			...( isAiMcpEnabled
+				? [
+						{
+							icon: <BigSkyLogo.CentralLogo heartless size={ 24 } />,
+							path: A4A_AI_MCP_LINK,
+							link: A4A_AI_MCP_LINK,
+							title: (
+								<div className="sidebar-menu-item__title-with-badge">
+									<span>{ translate( 'AI and MCP' ) }</span>
+									<Badge type="info">{ translate( 'Beta' ) }</Badge>
+								</div>
+							),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
+							},
 						},
-					},
-					path
-				)
-			);
-		}
-
-		items.push(
-			createItem(
-				{
-					icon: tool,
-					path: A4A_DEV_TOOLS_LINK,
-					link: A4A_DEV_TOOLS_LINK,
-					title: translate( 'Developer tools' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Resources and tools / Developer tools',
-					},
+				  ]
+				: [] ),
+			{
+				icon: tool,
+				path: A4A_DEV_TOOLS_LINK,
+				link: A4A_DEV_TOOLS_LINK,
+				title: translate( 'Developer tools' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Resources and tools / Developer tools',
 				},
-				path
-			)
-		);
-
-		items.push(
-			createItem(
-				{
-					icon: pages,
-					path: A4A_RESOURCES_LINK,
-					link: A4A_LEARN_LINK,
-					title: translate( 'Learn' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Resources and tools / Learn',
-					},
+			},
+			{
+				icon: pages,
+				path: A4A_RESOURCES_LINK,
+				link: A4A_LEARN_LINK,
+				title: translate( 'Learn' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Resources and tools / Learn',
 				},
-				path
-			)
-		);
-
-		return items;
+			},
+		].map( ( item ) => createItem( item, path ) );
 	}, [ path, translate, isAgentStudioEnabled, isAiMcpEnabled, isBenchmarksEnabled ] );
 
 	return menuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Badge } from '@automattic/components';
 import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { brush, chartBar, pages, tool } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -57,12 +56,8 @@ const useLearnMenuItems = ( path: string ) => {
 							icon: <BigSkyLogo.CentralLogo heartless size={ 24 } />,
 							path: A4A_AI_MCP_LINK,
 							link: A4A_AI_MCP_LINK,
-							title: (
-								<div className="sidebar-menu-item__title-with-badge">
-									<span>{ translate( 'AI and MCP' ) }</span>
-									<Badge type="info">{ translate( 'Beta' ) }</Badge>
-								</div>
-							),
+							title: translate( 'AI and MCP' ),
+							badge: translate( 'Beta' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
 							},

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Badge } from '@automattic/components';
 import {
 	category,
 	currencyDollar,
@@ -155,12 +154,8 @@ const useMainMenuItems = ( path: string ) => {
 				icon: chartBar,
 				path: A4A_REPORTS_LINK,
 				link: A4A_REPORTS_LINK,
-				title: (
-					<div className="sidebar-menu-item__title-with-badge">
-						<span>{ translate( 'Reports' ) }</span>
-						<Badge type="info">{ translate( 'Beta' ) }</Badge>
-					</div>
-				),
+				title: translate( 'Reports' ),
+				badge: translate( 'Beta' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Reports',
 				},

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
@@ -8,6 +8,7 @@ type MenuItemProps = {
 	link: string;
 	path: string;
 	title: string;
+	badge?: string;
 	withChevron?: boolean;
 	isExternalLink?: boolean;
 	isSelected?: boolean;

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -30,6 +30,7 @@ type Props = {
 		path: string;
 		link: string;
 		title: string;
+		badge?: string;
 		onClickMenuItem?: ( path: string ) => void;
 		withChevron?: boolean;
 		isExternalLink?: boolean;

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/components';
 import {
 	__experimentalNavigatorButton as NavigatorButton,
 	__experimentalItem as Item,
@@ -18,6 +19,7 @@ interface Props {
 	path: string;
 	link: string;
 	title: TranslateResult;
+	badge?: string;
 	onClickMenuItem: ( path: string ) => void;
 	withChevron?: boolean;
 	isExternalLink?: boolean;
@@ -32,6 +34,7 @@ export const SidebarNavigatorMenuItem = ( {
 	path,
 	link,
 	title,
+	badge,
 	onClickMenuItem,
 	withChevron = false,
 	isExternalLink = false,
@@ -74,7 +77,9 @@ export const SidebarNavigatorMenuItem = ( {
 	return (
 		<li>
 			<NavigatorButton as={ SidebarItem } path={ path }>
-				{ title }
+				<div className="sidebar-menu-item__title-with-badge">
+					{ title } { badge && <Badge type="info">{ badge }</Badge> }
+				</div>
 			</NavigatorButton>
 		</li>
 	);


### PR DESCRIPTION
## Proposed Changes

* Add a reusable `badge` prop to the shared sidebar menu item (`SidebarNavigatorMenuItem`), rendered next to the title via the existing `sidebar-menu-item__title-with-badge` + `<Badge type="info">` pattern.
* Use it to flag the “AI and MCP” item in the A4A “Resources and tools” sidebar as “Beta”.
* Migrate the existing Reports “Beta” badge to the same `badge` prop instead of a hand-built JSX title.

## Why are these changes being made?

* The AI and MCP feature is currently in Beta. Surfacing a Beta tag in the sidebar sets the right expectations for agencies trying it out.
* Introducing a `badge` prop keeps badge styling consistent across sidebar items and avoids duplicating the title-with-badge markup per call site.

## Testing Instructions

* In A4A, ensure your agency has MCP enabled (`agency.mcp.allowed`).
* Open the “Resources and tools” sidebar and confirm the “AI and MCP” item shows a “Beta” badge.
* Confirm the existing “Reports” item still shows its “Beta” badge and that other sidebar items render unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
