### PR TITLE
Plans: show expiry notice for expired plans

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -231,10 +231,9 @@ class CurrentPlan extends Component {
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;
 
 		let showExpiryNotice = false;
-		let purchase = null;
 		const isJetpackLegacy = JETPACK_LEGACY_PLANS.includes( currentPlanSlug );
+		const purchase = getPurchaseByProductSlug( purchases, currentPlanSlug );
 
-		purchase = getPurchaseByProductSlug( purchases, currentPlanSlug );
 		if ( isJetpackLegacy ) {
 			showExpiryNotice = purchase && isCloseToExpiration( purchase );
 		} else {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -209,6 +209,7 @@ class CurrentPlan extends Component {
 	render() {
 		const {
 			domains,
+			currentPlan,
 			purchases,
 			hasDomainsLoaded,
 			path,
@@ -231,10 +232,13 @@ class CurrentPlan extends Component {
 
 		let showExpiryNotice = false;
 		let purchase = null;
+		const isJetpackLegacy = JETPACK_LEGACY_PLANS.includes( currentPlanSlug );
 
-		if ( JETPACK_LEGACY_PLANS.includes( currentPlanSlug ) ) {
-			purchase = getPurchaseByProductSlug( purchases, currentPlanSlug );
+		purchase = getPurchaseByProductSlug( purchases, currentPlanSlug );
+		if ( isJetpackLegacy ) {
 			showExpiryNotice = purchase && isCloseToExpiration( purchase );
+		} else {
+			showExpiryNotice = !! currentPlan?.expired;
 		}
 
 		const planDescription = isJetpackNotAtomic
@@ -291,7 +295,13 @@ class CurrentPlan extends Component {
 							) }
 
 							{ showExpiryNotice && (
-								<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>
+								<Notice
+									status={ isJetpackLegacy ? 'is-info' : 'is-error' }
+									text={
+										isJetpackLegacy ? <PlanRenewalMessage /> : translate( 'Your plan has expired.' )
+									}
+									showDismiss={ false }
+								>
 									<NoticeAction href={ `/plans/${ selectedSite.slug || '' }` }>
 										{ translate( 'View plans' ) }
 									</NoticeAction>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,6 +6,7 @@ import {
 	is100Year,
 	isFreePlanProduct,
 	isStudentPlan,
+	isPlan,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
@@ -33,18 +34,20 @@ import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
-import { isPartnerPurchase } from 'calypso/lib/purchases';
+import { isExpired, isInExpirationGracePeriod, isPartnerPurchase } from 'calypso/lib/purchases';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { FeatureBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-feature-breadcrumb';
 import CurrentPlanPanel from 'calypso/sites/plan/components/current-plan-panel';
 import { useSelector } from 'calypso/state';
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
+import { getByPurchaseId, getSitePurchases } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
@@ -69,6 +72,10 @@ import './style.scss';
 
 // Plan tiers from lowest to highest, used to filter the visible plans list
 const PLAN_TIERS = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+
+const getExpiredPlanPurchase = ( purchases ) =>
+	purchases?.find( ( p ) => isPlan( p ) && ( isExpired( p ) || isInExpirationGracePeriod( p ) ) ) ??
+	null;
 
 class PlansComponent extends Component {
 	static propTypes = {
@@ -315,12 +322,24 @@ class PlansComponent extends Component {
 	}
 
 	render() {
-		const { isUntangled, selectedSite, translate } = this.props;
+		const { isUntangled, selectedSite, translate, expiredPlanPurchase } = this.props;
 		return (
 			<>
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
+				{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				{ isUntangled && (
 					<FeatureBreadcrumb siteId={ selectedSite.ID } title={ translate( 'Plan' ) } />
+				) }
+				{ expiredPlanPurchase && selectedSite && (
+					<Notice
+						status="is-error"
+						text={ translate( 'Your plan has expired.' ) }
+						showDismiss={ false }
+					>
+						<NoticeAction href={ `/purchases/subscriptions/${ selectedSite.slug }` }>
+							{ translate( 'Renew now' ) }
+						</NoticeAction>
+					</Notice>
 				) }
 				{ this.renderContent() }
 			</>
@@ -439,6 +458,9 @@ const ConnectedPlans = connect(
 		return {
 			currentPlan,
 			purchase: currentPlan ? getByPurchaseId( state, currentPlan.purchaseId ) : null,
+			expiredPlanPurchase: getExpiredPlanPurchase(
+				getSitePurchases( state, props.selectedSiteId )
+			),
 			selectedSite: getSelectedSite( state ),
 			canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 			isUntangled: isPlansPageUntangled( state ),

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,7 +6,6 @@ import {
 	is100Year,
 	isFreePlanProduct,
 	isStudentPlan,
-	isPlan,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
@@ -47,7 +46,7 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { FeatureBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-feature-breadcrumb';
 import CurrentPlanPanel from 'calypso/sites/plan/components/current-plan-panel';
 import { useSelector } from 'calypso/state';
-import { getByPurchaseId, getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
@@ -72,10 +71,6 @@ import './style.scss';
 
 // Plan tiers from lowest to highest, used to filter the visible plans list
 const PLAN_TIERS = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
-
-const getExpiredPlanPurchase = ( purchases ) =>
-	purchases?.find( ( p ) => isPlan( p ) && ( isExpired( p ) || isInExpirationGracePeriod( p ) ) ) ??
-	null;
 
 class PlansComponent extends Component {
 	static propTypes = {
@@ -326,7 +321,6 @@ class PlansComponent extends Component {
 		return (
 			<>
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
-				{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				{ isUntangled && (
 					<FeatureBreadcrumb siteId={ selectedSite.ID } title={ translate( 'Plan' ) } />
 				) }
@@ -454,13 +448,15 @@ class PlansComponent extends Component {
 const ConnectedPlans = connect(
 	( state, props ) => {
 		const { currentPlan, selectedSiteId } = props;
+		const purchase = currentPlan ? getByPurchaseId( state, currentPlan.purchaseId ) : null;
 
 		return {
 			currentPlan,
-			purchase: currentPlan ? getByPurchaseId( state, currentPlan.purchaseId ) : null,
-			expiredPlanPurchase: getExpiredPlanPurchase(
-				getSitePurchases( state, props.selectedSiteId )
-			),
+			purchase,
+			expiredPlanPurchase:
+				purchase && ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) )
+					? purchase
+					: null,
 			selectedSite: getSelectedSite( state ),
 			canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 			isUntangled: isPlansPageUntangled( state ),


### PR DESCRIPTION
Part of DSGCOM-669

## Proposed Changes

* Show an error notice on the My Plan tab when the current plan has expired
* Show an error notice on the Plans grid when the current plan has expired or is in its grace period

These are separate commits so either can be reverted independently if the notice isn't wanted on one of the views.

## Why are these changes being made?

The Plans page gives no signal that a plan is expired other than the Renew CTA. This adds a notice consistent with the expiry messaging shown elsewhere in the product.

## Testing Instructions

* With a site on an expired plan, navigate to `/plans/:site`
* The Plans tab should show a red "Your plan has expired." notice at the top with a "Renew now" link to the purchases page
* Switch to the My Plan tab — the same notice should appear above the plan features card
* On a site with an active plan, neither notice should appear

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?