### PR TITLE
Onboarding: clear stale domain search query on fresh flow entry

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
@@ -3,7 +3,7 @@
  */
 
 import { act, renderHook } from '@testing-library/react';
-import { useQueryHandler } from '../use-query-handler';
+import { clearSessionStorageQuery, useQueryHandler } from '../use-query-handler';
 
 describe( 'useQueryHandler', () => {
 	beforeEach( () => {
@@ -81,6 +81,14 @@ describe( 'useQueryHandler', () => {
 		act( () => {
 			result.current.clearQuery();
 		} );
+
+		expect( sessionStorage.getItem( 'domain-search-query' ) ).toBeNull();
+	} );
+
+	it( 'should clear a stored query when clearSessionStorageQuery is called directly', () => {
+		sessionStorage.setItem( 'domain-search-query', 'stored-domain' );
+
+		clearSessionStorageQuery();
 
 		expect( sessionStorage.getItem( 'domain-search-query' ) ).toBeNull();
 	} );

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -14,7 +14,7 @@ const setSessionStorageQuery = ( query: string ) => {
 	sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, query );
 };
 
-const clearSessionStorageQuery = () => {
+export const clearSessionStorageQuery = () => {
 	sessionStorage.removeItem( SESSION_STORAGE_QUERY_KEY );
 };
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,6 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
@@ -384,6 +385,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				resetOnboardStore();
 				reduxDispatch( setSelectedSiteId( null ) );
 				clearStepPersistedState( this.name );
+				clearSessionStorageQuery();
 				clearSignupDestinationCookie();
 				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
+import onboarding from '../onboarding';
+
+jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
+	clearSessionStorageQuery: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { resetOnboardStore: jest.fn() } ),
+	useSelect: jest.fn(),
+	resolveSelect: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/survicate', () => ( {
+	addSurvicate: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/signup', () => ( {
+	SIGNUP_DOMAIN_ORIGIN: {},
+} ) );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'ONBOARD_STORE',
+	SITE_STORE: 'SITE_STORE',
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {} ) );
+
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification',
+	() => ( {
+		usePurchasePlanNotification: jest.fn(),
+	} )
+);
+
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	persistSignupDestination: jest.fn(),
+	setSignupCompleteFlowName: jest.fn(),
+	setSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteFlowName: jest.fn(),
+	clearSignupDestinationCookie: jest.fn(),
+	clearSignupCompleteSiteID: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	ONBOARDING_FLOW: 'onboarding',
+	SITE_SETUP_FLOW: 'site-setup',
+	clearStepPersistedState: jest.fn(),
+} ) );
+
+describe( 'onboarding flow side effects', () => {
+	const navigate = jest.fn();
+	const renderSideEffect = ( currentStepSlug: string | null ) =>
+		renderHook(
+			() =>
+				// `useSideEffect` reads `this.name`, so it must be invoked bound to the flow.
+				onboarding.useSideEffect?.call(
+					onboarding,
+					currentStepSlug as Parameters< NonNullable< typeof onboarding.useSideEffect > >[ 0 ],
+					navigate
+				)
+		);
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		sessionStorage.clear();
+	} );
+
+	it( 'clears the stored domain-search query when the flow is freshly entered', () => {
+		renderSideEffect( null );
+
+		expect( clearSessionStorageQuery ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'preserves the stored domain-search query when navigating back within the flow', () => {
+		renderSideEffect( 'domains' );
+
+		expect( clearSessionStorageQuery ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Part of DOMENG-358

## Proposed Changes

* Clear the persisted domain search query (`sessionStorage['domain-search-query']`) when the `onboarding` stepper flow is freshly initiated, so each new site starts with a clean domain search.
* Export the existing `clearSessionStorageQuery` helper from `use-query-handler` and call it inside the flow's fresh-entry reset block (the `! currentStepSlug` guard in `useSideEffect`), alongside the existing `resetOnboardStore()` / `clearStepPersistedState()` calls.
* Add a unit test covering the exported `clearSessionStorageQuery` helper.

## Why are these changes being made?

In the "create a site yourself" flow (Add new site → "Create it yourself"), the domain search query was persisted in `sessionStorage` and carried over into the next onboarding run. When a user created a second site in succession, the domain search still showed the previous query and re-recommended the same (now-taken) free `*.wordpress.com` subdomain.

The free subdomain suggestion is derived from the query rather than separately cached, so clearing the query on fresh entry resolves both the stale query and the re-recommended subdomain.

The reset is placed in the flow's existing fresh-entry side effect, which runs only when no step is active (`! currentStepSlug`). Back-navigation within the same flow (domains → plans → back to domains) keeps a step active, so the user's current query is preserved.

## Testing Instructions

* Start the "create a site yourself" flow (Add new site → "Create it yourself") and enter a domain query (e.g. `my-first-site`).
* Complete or abandon the flow, then start "Create it yourself" again. The domain search should be empty — not pre-filled with the previous query/suggestion.
* Within a single flow run, go domains → plans → back to domains and confirm the query you typed is still preserved.
* `yarn test-client client/components/domains/wpcom-domain-search/test/use-query-handler.ts` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
