### PR TITLE
Account recovery interstitial: don't show to fully-secured users

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -31,7 +31,7 @@ type SecurityLevel = 'none' | 'partial' | 'strong';
 const SNOOZE_DAYS: Record< SecurityLevel, number > = {
 	none: 14, // no recovery method or 2FA set up
 	partial: 30, // a recovery method but no 2FA or vice-versa
-	strong: 365, // fully set up -> yearly periodic check
+	strong: 365, // recovery method and 2FA in place (the only nudge left is backup codes)
 };
 
 /** Maps the user's account-recovery setup to a SecurityLevel. */
@@ -85,19 +85,25 @@ export default function AccountRecoveryInterstitial() {
 	const hasRecoveryPhone = !! accountRecovery?.phone_validated;
 	const hasTwoFactor = !! userSettings?.two_step_enabled;
 	const hasBackupCodes = !! userSettings?.two_step_backup_codes_printed;
+	const hasRecoveryMethod = hasRecoveryEmail || hasRecoveryPhone;
 
 	const securityLevel = getSecurityLevel( hasRecoveryEmail, hasRecoveryPhone, hasTwoFactor );
 	const snoozeDays = SNOOZE_DAYS[ securityLevel ];
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
 
-	// Every user is nudged once their snooze (if any) has elapsed and the data has loaded
+	// Selects the copy variant depending on the user's account recovery settings.
+	const variant = getInterstitialVariant( hasRecoveryMethod, hasTwoFactor, hasBackupCodes );
+
+	// Eligible once the data has loaded and the snooze (if any) has elapsed.
 	const isEligible =
 		isAccountRecoveryLoaded && isUserSettingsLoaded && isSnoozeLoaded && ! isSnoozed;
 
-	const hasRecoveryMethod = hasRecoveryEmail || hasRecoveryPhone;
-	// Selects the copy variant depending on the user's account recovery settings
-	const variant = getInterstitialVariant( hasRecoveryMethod, hasTwoFactor, hasBackupCodes );
+	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
+	// missing a recovery method, 2FA, or backup codes.
+	if ( isDismissed || ! isEligible || variant === 'strong' ) {
+		return null;
+	}
 
 	// Shared Tracks properties for every interstitial event. The coarse `security_level` and 5-way
 	// `recovery_status` summarize the setup; the `has_*` booleans expose exactly which methods are
@@ -110,12 +116,6 @@ export default function AccountRecoveryInterstitial() {
 		has_two_factor: hasTwoFactor,
 		has_backup_codes: hasBackupCodes,
 	};
-
-	const shouldDisplay = ! isDismissed && isEligible;
-
-	if ( ! shouldDisplay ) {
-		return null;
-	}
 
 	const copy = getInterstitialCopy( {
 		recoveryEmail: accountRecovery?.email_validated ? accountRecovery.email : undefined,
@@ -140,17 +140,16 @@ export default function AccountRecoveryInterstitial() {
 			...tracksProperties,
 			cta_id: cta.id,
 		} );
-		// Snooze for this security level's window in all cases, so the user isn't re-prompted
-		// on their next page load — whether they head off to set up a recovery method or positively
-		// confirm ("Yes, all good").
+		// Snooze for this security level's window so the user isn't re-prompted on their next
+		// page load while they head off to set up the missing recovery method.
 		snooze();
 		if ( cta.route ) {
 			router.navigate( { to: cta.route } );
 		}
 	};
 
-	// Fully-secured users are on the yearly check-in; a "remind me in 365 days" nudge reads as
-	// a permanent dismissal, so label it as such.
+	// Users who already have a recovery method and 2FA in place get a year-long snooze, so a
+	// "remind me in 365 days" nudge would read as a permanent dismissal — label it as such.
 	const remindLabel =
 		securityLevel === 'strong'
 			? __( 'Dismiss' )

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -161,74 +161,17 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		);
 	} );
 
-	test( 'shows the strong-tier modal with masked recovery details for a fully-covered user', async () => {
+	test( 'does not show for a fully-secured user (recovery method, 2FA, and backup codes)', async () => {
 		mockAccountRecovery( STRONG_RECOVERY );
 		mockUserSettings( { two_step_enabled: true, two_step_backup_codes_printed: true } );
 		mockPreferences();
 
 		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
-
-		const dialog = await screen.findByRole( 'dialog', { name: 'Still have access to these?' } );
-		expect( dialog ).toBeVisible();
-		// Recovery email is masked in the body copy.
-		expect( screen.getByText( /r••••@example\.com/ ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Yes, all good' } ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Update recovery information' } ) ).toBeVisible();
-		// The fully-secured tier offers a plain "Dismiss" instead of a long "remind me" reminder.
-		expect( screen.getByRole( 'button', { name: 'Dismiss' } ) ).toBeVisible();
-		expect( screen.queryByRole( 'button', { name: /Remind me/ } ) ).not.toBeInTheDocument();
-
-		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			'calypso_account_recovery_nudge_interstitial_impression',
-			{
-				security_level: 'strong',
-				recovery_status: 'strong',
-				has_recovery_email: true,
-				has_recovery_phone: false,
-				has_two_factor: true,
-				has_backup_codes: true,
-			}
-		);
-	} );
-
-	test( 'confirming "Yes, all good" snoozes for the strong window and records a cta_click', async () => {
-		const user = userEvent.setup();
-		mockAccountRecovery( STRONG_RECOVERY );
-		mockUserSettings( { two_step_enabled: true, two_step_backup_codes_printed: true } );
-		mockPreferences();
-
-		let snoozedValue: number | undefined;
-		const savePost = nock( 'https://public-api.wordpress.com' )
-			.post( '/rest/v1.1/me/preferences', ( body ) => {
-				snoozedValue = body.calypso_preferences?.[ 'account-recovery-interstitial-snoozed-until' ];
-				return typeof snoozedValue === 'number';
-			} )
-			.query( true )
-			.reply( 200, {} );
-
-		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
-
-		await screen.findByRole( 'dialog', { name: 'Still have access to these?' } );
-		await user.click( screen.getByRole( 'button', { name: 'Yes, all good' } ) );
 
 		await waitFor( () => {
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 		} );
-		expect( savePost.isDone() ).toBe( true );
-		// strong-tier window is 365 days into the future.
-		expect( snoozedValue ).toBeGreaterThan( Math.floor( Date.now() / 1000 ) + 300 * 86400 );
-		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			'calypso_account_recovery_nudge_interstitial_cta_click',
-			{
-				security_level: 'strong',
-				recovery_status: 'strong',
-				has_recovery_email: true,
-				has_recovery_phone: false,
-				has_two_factor: true,
-				has_backup_codes: true,
-				cta_id: 'confirm_recovery',
-			}
-		);
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not show when the user is currently snoozed', async () => {


### PR DESCRIPTION
Part of DOTOBRD-372

Follow-up to #111546.

## Proposed Changes

* Don't show the account recovery interstitial to users who already have everything set up (a recovery method, 2FA, and backup codes). `getInterstitialVariant` still classifies them as `strong` so the nudge can be re-enabled later; the component just declines to render that case.

## Why are these changes being made?

* Per discussion, the support-queue pain comes from users with no recovery method, not from fully-secured users. Showing them a yearly check-in nudge isn't worth the annoyance for now; a lightweight periodic check can be considered separately later.

## Testing Instructions

* Sign in as a user with a validated recovery email/phone, 2FA enabled, and backup codes downloaded → the interstitial should not appear.
* Sign in as a user missing any of those → the relevant nudge still appears as before.
* `yarn test-client client/dashboard/app/account-recovery-interstitial`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)