### PR TITLE
Education: restrict free-domain badge to bundled TLDs (.blog, .art)

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -536,6 +536,89 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		} );
 	} );
 
+	describe( 'config.priceRules.freeForFirstYearTlds', () => {
+		it( 'passes through the flow-provided list while the credit is still available in the stepper', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( { responseCart: { products: [] } } )
+			);
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( {
+					...defaultProps,
+					isFirstDomainFreeForFirstYear: true,
+					config: { priceRules: { freeForFirstYearTlds: [ 'blog', 'art' ] } },
+				} )
+			);
+
+			expect( result.current.config.priceRules.freeForFirstYearTlds ).toEqual( [ 'blog', 'art' ] );
+		} );
+
+		it( 'clears the flow-provided list once the free slot is taken in the stepper', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [
+							buildProduct( {
+								uuid: 'dotblog',
+								product_slug: 'blog_domain',
+								meta: 'my-domain.blog',
+								is_domain_registration: true,
+								item_original_cost_integer: 1000,
+								item_subtotal_integer: 1000,
+							} ),
+						],
+					},
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( {
+					...defaultProps,
+					isFirstDomainFreeForFirstYear: true,
+					config: { priceRules: { freeForFirstYearTlds: [ 'blog', 'art' ] } },
+				} )
+			);
+
+			expect( result.current.config.priceRules.freeForFirstYearTlds ).toBeUndefined();
+		} );
+
+		it( 'derives the list from next_domain_condition when the plan is in the cart and the credit is available', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						next_domain_is_free: true,
+						next_domain_condition: 'blog,art',
+						products: [ buildProduct( { product_slug: 'business-bundle' } ) ],
+					},
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( { ...defaultProps, isFirstDomainFreeForFirstYear: true } )
+			);
+
+			expect( result.current.config.priceRules.freeForFirstYearTlds ).toEqual( [ 'blog', 'art' ] );
+		} );
+
+		it( 'does not restrict by TLD when the plan is in the cart but the credit has already been used', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						next_domain_is_free: false,
+						next_domain_condition: 'blog,art',
+						products: [ buildProduct( { product_slug: 'business-bundle' } ) ],
+					},
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( { ...defaultProps, isFirstDomainFreeForFirstYear: true } )
+			);
+
+			expect( result.current.config.priceRules.freeForFirstYearTlds ).toBeUndefined();
+		} );
+	} );
+
 	describe( 'total price', () => {
 		it( 'returns the total price for the cart', () => {
 			mockUseShoppingCart.mockReturnValue(

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -279,13 +279,16 @@ export const useWPCOMDomainSearchCart = ( {
 			},
 		};
 
+		const isNextDomainFree = forceFirstNonPremiumDomainToBeFree
+			? freeDomainName === undefined
+			: responseCart.next_domain_is_free;
+
 		return {
 			cart,
-			isNextDomainFree: forceFirstNonPremiumDomainToBeFree
-				? freeDomainName === undefined
-				: responseCart.next_domain_is_free,
+			isNextDomainFree,
 			freeDomainName,
-			freeForFirstYearTlds: effectiveFreeForFirstYearTlds,
+			// Only restrict by TLD while the credit is actually available.
+			freeForFirstYearTlds: isNextDomainFree ? effectiveFreeForFirstYearTlds : undefined,
 			onContinue: () => onContinue( domainItems ),
 		};
 	}, [

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -55,6 +55,7 @@ interface UseWPCOMDomainSearchCartOptions {
 	flowName?: string;
 	flowAllowsMultipleDomainsInCart: boolean;
 	isFirstDomainFreeForFirstYear: boolean;
+	freeForFirstYearTlds?: string[];
 	onContinue( cartItems: ResponseCartProduct[] ): void;
 	beforeAddDomainToCart?: ( domain: MinimalRequestCartProduct ) => MinimalRequestCartProduct;
 }
@@ -64,6 +65,7 @@ export const useWPCOMDomainSearchCart = ( {
 	flowName,
 	flowAllowsMultipleDomainsInCart,
 	isFirstDomainFreeForFirstYear,
+	freeForFirstYearTlds,
 	onContinue,
 	beforeAddDomainToCart = ( domain ) => domain,
 }: UseWPCOMDomainSearchCartOptions ) => {
@@ -104,9 +106,13 @@ export const useWPCOMDomainSearchCart = ( {
 				! item.extra?.premium &&
 				! item.extra?.domain_bundle_group_id
 		);
-		const freeDomainName = forceFirstNonPremiumDomainToBeFree
-			? firstNonPremiumDomain?.meta
-			: undefined;
+		let freeDomainName: string | undefined;
+		if ( forceFirstNonPremiumDomainToBeFree && firstNonPremiumDomain?.meta ) {
+			const isBundledTld =
+				! freeForFirstYearTlds ||
+				freeForFirstYearTlds.some( ( tld ) => firstNonPremiumDomain.meta.endsWith( '.' + tld ) );
+			freeDomainName = isBundledTld ? firstNonPremiumDomain.meta : undefined;
+		}
 
 		const rawTotal = domainItems.reduce(
 			( acc, item ) => acc + ( freeDomainName === item.meta ? 0 : item.item_subtotal_integer ),

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -86,6 +86,14 @@ export const useWPCOMDomainSearchCart = ( {
 		// when they start a domain search flow.
 		const forceFirstNonPremiumDomainToBeFree = isFirstDomainFreeForFirstYear && ! isPlanInCart;
 
+		// Stepper: use flow config. Checkout (plan in real cart): derive from next_domain_condition.
+		let effectiveFreeForFirstYearTlds: string[] | undefined;
+		if ( forceFirstNonPremiumDomainToBeFree ) {
+			effectiveFreeForFirstYearTlds = freeForFirstYearTlds;
+		} else if ( responseCart.next_domain_condition ) {
+			effectiveFreeForFirstYearTlds = responseCart.next_domain_condition.split( ',' );
+		}
+
 		// Order domains from most expensive to least expensive
 		domainItems.sort( ( a, b ) => {
 			// Put the bundled domain at the top, if there's one
@@ -109,8 +117,10 @@ export const useWPCOMDomainSearchCart = ( {
 		let freeDomainName: string | undefined;
 		if ( forceFirstNonPremiumDomainToBeFree && firstNonPremiumDomain?.meta ) {
 			const isBundledTld =
-				! freeForFirstYearTlds ||
-				freeForFirstYearTlds.some( ( tld ) => firstNonPremiumDomain.meta.endsWith( '.' + tld ) );
+				! effectiveFreeForFirstYearTlds ||
+				effectiveFreeForFirstYearTlds.some( ( tld ) =>
+					firstNonPremiumDomain.meta.endsWith( '.' + tld )
+				);
 			freeDomainName = isBundledTld ? firstNonPremiumDomain.meta : undefined;
 		}
 
@@ -275,6 +285,7 @@ export const useWPCOMDomainSearchCart = ( {
 				? freeDomainName === undefined
 				: responseCart.next_domain_is_free,
 			freeDomainName,
+			freeForFirstYearTlds: effectiveFreeForFirstYearTlds,
 			onContinue: () => onContinue( domainItems ),
 		};
 	}, [

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -10,6 +10,7 @@ import {
 	CartActionError,
 	type CartKey,
 	type MinimalRequestCartProduct,
+	parseNextDomainCondition,
 	type ResponseCartProduct,
 	useShoppingCart,
 } from '@automattic/shopping-cart';
@@ -91,7 +92,9 @@ export const useWPCOMDomainSearchCart = ( {
 		if ( forceFirstNonPremiumDomainToBeFree ) {
 			effectiveFreeForFirstYearTlds = freeForFirstYearTlds;
 		} else if ( responseCart.next_domain_condition ) {
-			effectiveFreeForFirstYearTlds = responseCart.next_domain_condition.split( ',' );
+			effectiveFreeForFirstYearTlds = parseNextDomainCondition(
+				responseCart.next_domain_condition
+			);
 		}
 
 		// Order domains from most expensive to least expensive

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -294,6 +294,7 @@ export const useWPCOMDomainSearchCart = ( {
 		replaceProductsInCart,
 		flowName,
 		isFirstDomainFreeForFirstYear,
+		freeForFirstYearTlds,
 		flowAllowsMultipleDomainsInCart,
 		onContinue,
 		beforeAddDomainToCart,

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
@@ -73,6 +73,7 @@ export const useWPCOMDomainSearchProps = ( {
 		cartKey: getCartKey( { isLoggedIn, currentSiteId } ),
 		flowName,
 		isFirstDomainFreeForFirstYear,
+		freeForFirstYearTlds: externalConfig?.priceRules?.freeForFirstYearTlds,
 		flowAllowsMultipleDomainsInCart,
 		onContinue: onContinueWithStepSubmissionTracking,
 		beforeAddDomainToCart: externalBeforeAddDomainToCart,

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
@@ -69,15 +69,16 @@ export const useWPCOMDomainSearchProps = ( {
 		[ dispatch, analyticsSection, externalOnContinue ]
 	);
 
-	const { cart, isNextDomainFree, freeDomainName, onContinue } = useWPCOMDomainSearchCart( {
-		cartKey: getCartKey( { isLoggedIn, currentSiteId } ),
-		flowName,
-		isFirstDomainFreeForFirstYear,
-		freeForFirstYearTlds: externalConfig?.priceRules?.freeForFirstYearTlds,
-		flowAllowsMultipleDomainsInCart,
-		onContinue: onContinueWithStepSubmissionTracking,
-		beforeAddDomainToCart: externalBeforeAddDomainToCart,
-	} );
+	const { cart, isNextDomainFree, freeDomainName, freeForFirstYearTlds, onContinue } =
+		useWPCOMDomainSearchCart( {
+			cartKey: getCartKey( { isLoggedIn, currentSiteId } ),
+			flowName,
+			isFirstDomainFreeForFirstYear,
+			freeForFirstYearTlds: externalConfig?.priceRules?.freeForFirstYearTlds,
+			flowAllowsMultipleDomainsInCart,
+			onContinue: onContinueWithStepSubmissionTracking,
+			beforeAddDomainToCart: externalBeforeAddDomainToCart,
+		} );
 
 	const config = useMemo( () => {
 		// Bundles are fixed one-year registrations of multiple TLDs, so they
@@ -98,9 +99,10 @@ export const useWPCOMDomainSearchProps = ( {
 				// Keep the already-added free domain showing as $0 in the suggestion list,
 				// matching what the user saw when they clicked and what appears in their cart.
 				freeForFirstYearDomains: freeDomainName ? [ freeDomainName ] : undefined,
+				freeForFirstYearTlds,
 			},
 		};
-	}, [ externalConfig, isNextDomainFree, freeDomainName, flowName ] );
+	}, [ externalConfig, isNextDomainFree, freeDomainName, freeForFirstYearTlds, flowName ] );
 
 	const analyticsEvents = useWPCOMDomainSearchEvents( {
 		vendor: config.vendor,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -10,6 +10,7 @@ import {
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,
 	isOnboardingFlow,
+	EDUCATION_FLOW,
 	Step,
 	StepContainer,
 } from '@automattic/onboarding';
@@ -58,6 +59,7 @@ import type { HelpCenterSelect, OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const HUNDRED_YEAR_DOMAIN_TLDS = [ 'com', 'net', 'org', 'blog' ];
+const EDUCATION_BUNDLED_TLDS = [ 'blog', 'art' ];
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
@@ -188,6 +190,7 @@ const DomainSearchStep: StepType< {
 			priceRules: {
 				hidePrice: isHundredYearPlanFlow( flow ),
 				oneTimePrice: isHundredYearDomainFlow( flow ),
+				freeForFirstYearTlds: flow === EDUCATION_FLOW ? EDUCATION_BUNDLED_TLDS : undefined,
 			},
 			skippable:
 				! isHundredYearPlanFlow( flow ) &&

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -708,8 +708,9 @@ export function isNextDomainFree( cart?: ResponseCart, domain = '' ): boolean {
 		return false;
 	}
 
-	if ( cart.next_domain_condition === 'blog' ) {
-		if ( getTld( domain ) !== 'blog' ) {
+	if ( cart.next_domain_condition ) {
+		const eligibleTlds = cart.next_domain_condition.split( ',' );
+		if ( ! eligibleTlds.includes( getTld( domain ) ) ) {
 			return false;
 		}
 	}

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -46,6 +46,7 @@ import {
 } from '@automattic/calypso-products';
 import { getTld } from '@automattic/domain-search';
 import { isDomainForGravatarFlow, isHundredYearDomainFlow } from '@automattic/onboarding';
+import { parseNextDomainCondition } from '@automattic/shopping-cart';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
 import type { WithCamelCaseSlug, WithSnakeCaseSlug } from '@automattic/calypso-products';
@@ -709,7 +710,7 @@ export function isNextDomainFree( cart?: ResponseCart, domain = '' ): boolean {
 	}
 
 	if ( cart.next_domain_condition ) {
-		const eligibleTlds = cart.next_domain_condition.split( ',' );
+		const eligibleTlds = parseNextDomainCondition( cart.next_domain_condition );
 		if ( ! eligibleTlds.includes( getTld( domain ) ) ) {
 			return false;
 		}

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -227,6 +227,30 @@ describe( 'isNextDomainFree()', () => {
 			)
 		).toBe( true );
 	} );
+	test( 'should return true when condition is "blog,art" and requested domain is .blog', () => {
+		expect(
+			isNextDomainFree(
+				{ next_domain_is_free: true, next_domain_condition: 'blog,art' },
+				'domain.blog'
+			)
+		).toBe( true );
+	} );
+	test( 'should return true when condition is "blog,art" and requested domain is .art', () => {
+		expect(
+			isNextDomainFree(
+				{ next_domain_is_free: true, next_domain_condition: 'blog,art' },
+				'domain.art'
+			)
+		).toBe( true );
+	} );
+	test( 'should return false when condition is "blog,art" and requested domain is .com', () => {
+		expect(
+			isNextDomainFree(
+				{ next_domain_is_free: true, next_domain_condition: 'blog,art' },
+				'domain.com'
+			)
+		).toBe( false );
+	} );
 	test( 'should return false when cart.next_domain_is_free is false', () => {
 		expect( isNextDomainFree( { next_domain_is_free: false } ) ).toBe( false );
 	} );

--- a/packages/domain-search/src/components/suggestion-price/test/index.tsx
+++ b/packages/domain-search/src/components/suggestion-price/test/index.tsx
@@ -137,6 +137,67 @@ describe( 'DomainSuggestionPrice', () => {
 		expect( await screen.findByLabelText( 'Sale price: $0' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders FREE_FOR_FIRST_YEAR when the domain TLD is in priceRules.freeForFirstYearTlds', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-free-tld.blog' },
+			suggestions: [
+				buildSuggestion( {
+					domain_name: 'test-free-tld.blog',
+					cost: '$5',
+				} ),
+			],
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestions
+				query="test-free-tld.blog"
+				config={ {
+					priceRules: {
+						freeForFirstYearTlds: [ 'blog', 'art' ],
+					},
+				} }
+			>
+				<DomainSuggestionsList>
+					<DomainSuggestionPrice domainName="test-free-tld.blog" />
+				</DomainSuggestionsList>
+			</TestDomainSearchWithSuggestions>
+		);
+
+		expect( await screen.findByLabelText( 'Original price: $5' ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Sale price: $0' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the regular price when the domain TLD is not in priceRules.freeForFirstYearTlds', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-not-free-tld.com' },
+			suggestions: [
+				buildSuggestion( {
+					domain_name: 'test-not-free-tld.com',
+					cost: '$5',
+					sale_cost: 1,
+				} ),
+			],
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestions
+				query="test-not-free-tld.com"
+				config={ {
+					priceRules: {
+						freeForFirstYearTlds: [ 'blog', 'art' ],
+					},
+				} }
+			>
+				<DomainSuggestionsList>
+					<DomainSuggestionPrice domainName="test-not-free-tld.com" />
+				</DomainSuggestionsList>
+			</TestDomainSearchWithSuggestions>
+		);
+
+		expect( await screen.findByLabelText( 'Original price: $5' ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Sale price: $1' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders the renew price if priceRule is FREE_FOR_FIRST_YEAR and renew cost is provided', async () => {
 		mockGetSuggestionsQuery( {
 			params: { query: 'test-free-for-first-year-renew-cost.com' },

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -22,6 +22,11 @@ export interface PriceRulesConfig {
 	 * the suggestion list after it has been added to the cart with a free-domain promotion.
 	 */
 	freeForFirstYearDomains?: string[];
+	/**
+	 * When set, only domains whose TLD is in this list get FREE_FOR_FIRST_YEAR pricing.
+	 * All other TLDs show their real price. Takes precedence over freeForFirstYear.
+	 */
+	freeForFirstYearTlds?: string[];
 }
 
 const getPriceRuleForSuggestion = ( {
@@ -47,10 +52,19 @@ const getPriceRuleForSuggestion = ( {
 		return DomainPriceRule.PRICE;
 	}
 
-	if (
-		priceRules.freeForFirstYear ||
-		priceRules.freeForFirstYearDomains?.includes( suggestion.domain_name )
-	) {
+	if ( priceRules.freeForFirstYearDomains?.includes( suggestion.domain_name ) ) {
+		return DomainPriceRule.FREE_FOR_FIRST_YEAR;
+	}
+
+	if ( priceRules.freeForFirstYearTlds ) {
+		return priceRules.freeForFirstYearTlds.some( ( tld ) =>
+			suggestion.domain_name.endsWith( '.' + tld )
+		)
+			? DomainPriceRule.FREE_FOR_FIRST_YEAR
+			: DomainPriceRule.PRICE;
+	}
+
+	if ( priceRules.freeForFirstYear ) {
 		return DomainPriceRule.FREE_FOR_FIRST_YEAR;
 	}
 

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -215,6 +215,17 @@ export function doesCartLocationDifferFromResponseCartLocation(
 	return false;
 }
 
+// Tolerates whitespace and empty entries (e.g. 'blog, art' or a trailing comma). Returns []
+// for '' — callers must treat a falsy condition as "no restriction", not an empty allow-list.
+export function parseNextDomainCondition(
+	condition: ResponseCart[ 'next_domain_condition' ]
+): string[] {
+	return condition
+		.split( ',' )
+		.map( ( tld ) => tld.trim() )
+		.filter( Boolean );
+}
+
 export function convertRawResponseCartToResponseCart(
 	rawResponseCart: Partial< ResponseCart >
 ): ResponseCart {

--- a/packages/shopping-cart/src/index.ts
+++ b/packages/shopping-cart/src/index.ts
@@ -10,4 +10,5 @@ export * from './errors';
 export {
 	convertResponseCartToRequestCart,
 	convertTaxLocationToLocationUpdate,
+	parseNextDomainCondition,
 } from './cart-functions';

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -493,7 +493,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	cart_generated_at_timestamp: number;
 	tax: ResponseCartTaxData;
 	next_domain_is_free: boolean;
-	next_domain_condition: '' | 'blog';
+	next_domain_condition: '' | 'blog' | 'blog,art' | ( string & {} );
 	bundled_domain?: string;
 
 	/**

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -493,6 +493,11 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	cart_generated_at_timestamp: number;
 	tax: ResponseCartTaxData;
 	next_domain_is_free: boolean;
+	/**
+	 * Comma-separated TLD allow-list the free-domain credit applies to ('' means no restriction).
+	 * The listed literals document known values for autocomplete; `string & {}` keeps the type from
+	 * collapsing to plain `string` so new backend values don't require a type change here.
+	 */
 	next_domain_condition: '' | 'blog' | 'blog,art' | ( string & {} );
 	bundled_domain?: string;
 

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -8,6 +8,7 @@ import {
 	doesCartLocationDifferFromResponseCartLocation,
 	convertResponseCartToRequestCart,
 	convertRawResponseCartToResponseCart,
+	parseNextDomainCondition,
 } from '../src/cart-functions';
 
 const cart = {
@@ -582,5 +583,23 @@ describe( 'convertRawResponseCartToResponseCart', function () {
 		} );
 		expect( Array.isArray( result.tax.location ) ).toBeFalsy();
 		expect( typeof result.tax.location === 'object' ).toBeTruthy();
+	} );
+} );
+
+describe( 'parseNextDomainCondition', function () {
+	it( 'splits a comma-separated list into TLDs', function () {
+		expect( parseNextDomainCondition( 'blog,art' ) ).toEqual( [ 'blog', 'art' ] );
+	} );
+
+	it( 'trims whitespace around entries', function () {
+		expect( parseNextDomainCondition( 'blog, art' ) ).toEqual( [ 'blog', 'art' ] );
+	} );
+
+	it( 'drops empty entries such as trailing commas', function () {
+		expect( parseNextDomainCondition( 'blog,art,' ) ).toEqual( [ 'blog', 'art' ] );
+	} );
+
+	it( 'returns an empty array for an empty string', function () {
+		expect( parseNextDomainCondition( '' ) ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

* Handles the next domain condition for Student plans. This has been done previously for the Blogger plan, but with 220526-ghe-Automattic/wpcom shipped, this has been generalized for other TLD conditions/restrictions. E.g. for the Blogger plan, we offer .blog, and for the Student plan we offer (for now) .art and .blog.
* The comma separated approach means that we in the future can change this condition in the backend (e.g. adding additional TLDs), and the Domain step + the frontend shopping cart logic will be aware of the TLDs.

* For Stepper (before a real cartr exist): `freeForFirstYearTlds: [ 'blog', 'art' ]` only when `flow === EDUCATION_FLOW`
* For checkout ("real cart"): `responseCart.next_domain_condition`, parsed via `parseNextDomainCondition`.
* `effectiveFreeForFirstYearTlds` is undefined when no condition exists. This means that the `''` (most cases in prod) will not be affected, as we check truthiness in the consumers (`client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts` and `client/lib/cart-values/cart-items.ts`). The Blogger plan will keep it's current behavior, and the Student plan will be filtered (both have a non empty condition from the backend cart serializer).


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep UX consistent with what's actually being offered. This logic already lives in the frontend, as by the time we hit the domains step, we don't have a cart yet (for `next_domain_is_free`), and just the onboarding store.
* For example, the domains step will show the actual price (instead of 0) for domains that are not included. The actual logic for what's bundled is handled in the backend, but this PR ensures that the frontend visuals match.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Code review
- Via the live view links, or a local Calypso, go to /setup/education. From there, you can use an invite code (please don't share it here). See: DOTCOM-17536

<img width="3374" height="2772" alt="CleanShot 2026-06-30 at 15 39 00@2x" src="https://github.com/user-attachments/assets/eb6b8794-ed05-4e42-bf58-a5f7110ab9ef" />

<img width="2350" height="1156" alt="CleanShot 2026-07-09 at 10 07 08@2x" src="https://github.com/user-attachments/assets/81988f89-58f5-48e9-98ef-0dc22cc690b3" />


- Though this change should be inert for any other flows, or the cases where there is no condition (all TLDs bundled, and no bundle for regular old domain purchases), you can also check /start/ and /start/domain/domain-only, the domain-only flow, and the domain search from a free site. These should all work as they do currently in production.

The "regular" signup flow:
<img width="2764" height="2836" alt="CleanShot 2026-07-09 at 10 09 11@2x" src="https://github.com/user-attachments/assets/15218c0b-532b-47c8-89fd-f2274a44483a" />

Domain only flow, no bundle:
<img width="2816" height="2738" alt="CleanShot 2026-07-09 at 10 07 54@2x" src="https://github.com/user-attachments/assets/a3ddf10f-1293-4046-a1a1-e220f533aa9b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
