### PR TITLE
Limit TeamCity merge queue builds

### DIFF
--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -6,6 +6,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 const val MERGE_QUEUE_BRANCH_SKIP_PARAM = "mergeQueueBranch.skipBuild"
+const val MERGE_QUEUE_BRANCH_TRIGGER_EXCLUSION = "-:gh-readonly-queue/*"
 const val MERGE_QUEUE_BRANCH_SKIP_MESSAGE =
 	"This check was skipped because this is a merge queue and the check has already been run " +
 		"in the pull request. See: p4TIVU-b5I-p2#comment-12211"
@@ -40,4 +41,11 @@ fun <T : BuildStep> T.skipOnMergeQueueBranch(): T {
 		doesNotEqual(MERGE_QUEUE_BRANCH_SKIP_PARAM, "true")
 	}
 	return this
+}
+
+fun String.excludeMergeQueueBranches(): String {
+	return """
+		${this.trimIndent()}
+		$MERGE_QUEUE_BRANCH_TRIGGER_EXCLUSION
+	""".trimIndent()
 }

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,6 +3,7 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
+import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.passMergeQueueBranchesEarly
 import _self.lib.utils.skipOnMergeQueueBranch
@@ -881,7 +882,7 @@ object Translate : BuildType({
 			branchFilter = """
 				+:*
 				-:pull*
-			""".trimIndent()
+			""".excludeMergeQueueBranches()
 		}
 	}
 
@@ -948,7 +949,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 					+:*
 					-:pull*
 					-:trunk
-				""".trimIndent()
+				""".excludeMergeQueueBranches()
 				triggerRules = """
 					-:**.md
 				""".trimIndent()
@@ -999,7 +1000,7 @@ object PlaywrightTestPRMatrix : BuildType({
 				+:*
 				-:pull*
 				-:trunk
-			""".trimIndent()
+			""".excludeMergeQueueBranches()
 			triggerRules = """
 				-:**.md
 			""".trimIndent()
@@ -1087,7 +1088,7 @@ object PlaywrightTestDashboardPRMatrix : BuildType({
 				+:*
 				-:pull*
 				-:trunk
-			""".trimIndent()
+			""".excludeMergeQueueBranches()
 			triggerRules = """
 				-:**.md
 				+:client/dashboard/**
@@ -1141,7 +1142,7 @@ object PlaywrightTestA4APRMatrix : BuildType({
 				+:*
 				-:pull*
 				-:trunk
-			""".trimIndent()
+			""".excludeMergeQueueBranches()
 			triggerRules = """
 				-:**.md
 				+:client/a8c-for-agencies/**


### PR DESCRIPTION
## Proposed Changes

* Add a shared TeamCity merge-queue branch-filter helper.
* Exclude `gh-readonly-queue/*` from non-required WebApp TeamCity VCS triggers.
* Keep the required TeamCity contexts merge-queue-enabled so they can report early success: `Docker image`, `Unit tests`, and `Code style`.

## Why are these changes being made?

* GitHub merge queue creates temporary `gh-readonly-queue/...` branches.
* TeamCity broad VCS triggers were matching those branches, so non-required WebApp jobs were queued and reported noisy pending statuses during merge queue validation.
* The goal is for merge queue validation to run the GitHub channel status check while TeamCity only reports the required contexts as early-success statuses.

## Testing Instructions

* Ran `git diff --check -- .teamcity`.
* Confirmed the remaining broad WebApp `+:*` TeamCity triggers are the required contexts or call the shared merge-queue exclusion helper.
* TeamCity DSL generation was not run locally because `mvn` is not installed in this environment.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
