### PR TITLE
WOOAI-682 Read Agents Manager provider id from the loaded module only

### DIFF
--- a/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
+++ b/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
@@ -19,7 +19,6 @@ const mockRegisterPlugin = jest.fn();
 jest.mock( '@wordpress/plugins', () => ( { registerPlugin: mockRegisterPlugin } ) );
 
 const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
-const JETPACK_PROVIDER_ENTRY = { providerId: 'jetpack-ai-sidebar', url: JETPACK_PROVIDER };
 
 const loadRender = () => {
 	let render;
@@ -56,7 +55,7 @@ describe( 'agents-manager-gutenberg entry', () => {
 	it( 'renders nothing when the gate suppresses the mount', () => {
 		globalThis.agentsManagerData = {
 			sectionName: 'gutenberg',
-			agentProviders: [ JETPACK_PROVIDER_ENTRY ],
+			agentProviders: [ JETPACK_PROVIDER ],
 		};
 
 		const render = loadRender();

--- a/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
+++ b/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
@@ -5,7 +5,6 @@
 import { shouldSuppressJetpackAiSidebarPreview } from '../jetpack-ai-sidebar-preview-gate';
 
 const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
-const JETPACK_PROVIDER_ENTRY = { providerId: 'jetpack-ai-sidebar', url: JETPACK_PROVIDER };
 const BIG_SKY_PROVIDER =
 	'https://example.com/wp-content/plugins/big-sky/build/calypso-agent-provider/index.js';
 const BLOCK_NOTES_PROVIDER = 'block-notes/headless-agent-provider';
@@ -68,16 +67,6 @@ describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
 		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
 	} );
 
-	it( 'suppresses metadata provider entries on self-hosted sites', () => {
-		setAgentsManagerData( {
-			sectionName: 'gutenberg',
-			agentProviders: [ JETPACK_PROVIDER_ENTRY ],
-		} );
-
-		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
-		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
-	} );
-
 	it( 'suppresses on Atomic when no providers remain', () => {
 		window._currentSiteType = 'atomic';
 		setAgentsManagerData( {
@@ -93,7 +82,7 @@ describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
 		const objectProvider = { toolProvider: {} };
 		setAgentsManagerData( {
 			sectionName: 'gutenberg',
-			agentProviders: [ objectProvider, BIG_SKY_PROVIDER, JETPACK_PROVIDER_ENTRY ],
+			agentProviders: [ objectProvider, BIG_SKY_PROVIDER, JETPACK_PROVIDER ],
 		} );
 
 		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( false );

--- a/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
+++ b/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
@@ -17,18 +17,6 @@
 
 const JETPACK_AI_SIDEBAR_PROVIDER_FILE = 'jetpack-ai-sidebar.provider.mjs';
 
-function getProviderUrl( provider ) {
-	if ( typeof provider === 'string' ) {
-		return provider;
-	}
-
-	if ( provider && typeof provider === 'object' && typeof provider.url === 'string' ) {
-		return provider.url;
-	}
-
-	return '';
-}
-
 /**
  * @returns {boolean} True when Agents Manager should not mount at all — the legacy
  *                    Jetpack sidebar was the only provider.
@@ -45,7 +33,8 @@ export function shouldSuppressJetpackAiSidebarPreview() {
 	// Legacy Jetpack: drop only its provider, keep the rest.
 	const providers = Array.isArray( data.agentProviders ) ? data.agentProviders : [];
 	const remaining = providers.filter(
-		( provider ) => ! getProviderUrl( provider ).includes( JETPACK_AI_SIDEBAR_PROVIDER_FILE )
+		( provider ) =>
+			! ( typeof provider === 'string' && provider.includes( JETPACK_AI_SIDEBAR_PROVIDER_FILE ) )
 	);
 	data.agentProviders = remaining;
 

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -7,12 +7,12 @@
  * in Jetpack's Agents Manager feature.
  *
  * `agentProviders` entries may be URL strings (dynamically imported as ES
- * modules), URL metadata objects, or already-loaded `LoadedProviders` objects
- * with the same shape.
+ * modules) or already-loaded `LoadedProviders` objects with the same shape.
+ * A provider's stable ID is read from the loaded module's `providerId` export.
  */
 declare const agentsManagerData:
 	| {
-			agentProviders?: import('./utils/load-external-providers').AgentProviderEntry[];
+			agentProviders?: ( string | import('./utils/load-external-providers').LoadedProviders )[];
 			useUnifiedExperience?: boolean;
 			agentId?: string;
 			helpCenterUrl?: string;

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -178,13 +178,6 @@ export interface LoadedProviders {
 	capabilities?: ProviderCapabilities;
 }
 
-export interface ProviderUrlEntry {
-	url: string;
-	providerId?: string;
-}
-
-export type AgentProviderEntry = string | ProviderUrlEntry | LoadedProviders;
-
 type LoadedProviderModule = {
 	module: LoadedProviders;
 	providerId?: string;
@@ -221,18 +214,6 @@ function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
 }
 
-function getProviderUrl( providerEntry: AgentProviderEntry ): string | undefined {
-	if ( typeof providerEntry === 'string' ) {
-		return providerEntry;
-	}
-
-	if ( ! isRecord( providerEntry ) ) {
-		return undefined;
-	}
-
-	return typeof providerEntry.url === 'string' ? providerEntry.url : undefined;
-}
-
 function getValidProviderId( providerId: unknown ): string | undefined {
 	if ( typeof providerId !== 'string' ) {
 		return undefined;
@@ -242,9 +223,7 @@ function getValidProviderId( providerId: unknown ): string | undefined {
 	return trimmedProviderId ? trimmedProviderId : undefined;
 }
 
-function getProviderEntryId(
-	providerEntry: AgentProviderEntry | LoadedProviders
-): string | undefined {
+function getProviderEntryId( providerEntry: string | LoadedProviders ): string | undefined {
 	if ( ! isRecord( providerEntry ) ) {
 		return undefined;
 	}
@@ -491,30 +470,27 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	// Results are processed in registration order to preserve first-write-wins semantics.
 	const loadedModules = ( await Promise.all(
 		agentProviders.map( async ( providerEntry ) => {
-			const providerEntryId = getProviderEntryId( providerEntry );
-			const providerUrl = getProviderUrl( providerEntry );
-
-			if ( typeof providerEntry === 'object' && providerEntry !== null && ! providerUrl ) {
-				return { module: providerEntry as LoadedProviders, providerId: providerEntryId };
-			}
-
-			if ( ! providerUrl ) {
-				return null;
+			// Already-loaded provider object: use it directly and read its own ID.
+			if ( typeof providerEntry === 'object' && providerEntry !== null ) {
+				return {
+					module: providerEntry as LoadedProviders,
+					providerId: getProviderEntryId( providerEntry ),
+				};
 			}
 
 			try {
 				// Dynamic import of registered script module
 				// The webpackIgnore comment tells webpack not to bundle this - it's loaded at runtime
-				const module = ( await import( /* webpackIgnore: true */ providerUrl ) ) as LoadedProviders;
+				const module = ( await import(
+					/* webpackIgnore: true */ providerEntry
+				) ) as LoadedProviders;
 				// eslint-disable-next-line no-console
-				console.log( `[AgentsManager] Loaded provider "${ providerUrl }"` );
-				return {
-					module,
-					providerId: getProviderEntryId( module ) || providerEntryId,
-				};
+				console.log( `[AgentsManager] Loaded provider "${ providerEntry }"` );
+				// The provider module is the source of truth for its own stable ID.
+				return { module, providerId: getProviderEntryId( module ) };
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
-				console.warn( `[AgentsManager] Failed to load provider "${ providerUrl }":`, error );
+				console.warn( `[AgentsManager] Failed to load provider "${ providerEntry }":`, error );
 				return null;
 			}
 		} )


### PR DESCRIPTION
Part of WOOAI-682

## Proposed Changes

* Stop treating `{ providerId, url }` metadata objects as a provider entry shape in Agents Manager. `agentProviders` entries are once again just URL strings (dynamically imported) or already-loaded provider objects.
* Read each provider's stable id solely from the **loaded module's** `providerId` export (or the `providerId` property of an already-loaded object) — no registration-time fallback.
* `load-external-providers.ts`: removed `ProviderUrlEntry` / `AgentProviderEntry` and the `getProviderUrl` URL-extraction helper; the loader now imports the string entry and reads `module.providerId`.
* `jetpack-ai-sidebar-preview-gate.js`: dropped the `getProviderUrl` object handling and reverted to the plain string filter.
* `global.d.ts`: `agentProviders` is back to `( string | LoadedProviders )[]`.
* Reverted the tests that had been switched to object entries; kept the `providerIds` / `loadedProviderIds` coverage (which already exercises ids via already-loaded provider objects).

`loadedProviderIds` in `clientContext` is unchanged — this only simplifies how the ids get there.

## Why are these changes being made?

WOOAI-659 added `loadedProviderIds` to the agent's `clientContext` so backend routing/debugging can tell which providers actually loaded. To carry the id, provider registration was extended from a plain URL to a `{ providerId, url }` metadata object — applied to both the Woo AI and Jetpack AI providers.

That metadata id turned out to be redundant. The provider **module** already exports its own `providerId`, and Agents Manager reads it from the loaded module when it builds `loadedProviderIds`. The registration-time id was only ever a fallback, so it just duplicated the source of truth and forced the loader, the preview gate, and provider filtering to each handle two entry shapes.

This PR collapses that back to one shape — plain provider URLs — and makes the provider module the single source of truth for its id. The companion woocommerce-ai PR reverts its PHP registration to a plain URL; Jetpack needs no change (trunk already registers a plain URL, and the unmerged metadata PR is being discarded).

## Testing Instructions

* `yarn jest -c test/packages/jest.config.js --runTestsByPath packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts` — 30 pass.
* `yarn jest -c test/apps/jest.config.js --runTestsByPath apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js apps/agents-manager/__tests__/agents-manager-gutenberg.test.js` — 12 pass.
* `yarn eslint` on the five changed files — clean.
* Behaviourally: register the Jetpack AI Sidebar (and/or Woo AI) provider as a plain URL; confirm `loadedProviderIds` in the outbound `message/stream` `clientContext` still contains the provider id (read from the module's `providerId` export).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhgZbt4Li4w4yvscs73LuE
