### PR TITLE
Subscriptions table - ensure email frequency column reflects email state.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -140,7 +140,11 @@ const SiteSubscriptionRow = ( {
 	}, [ url ] );
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel(
-		delivery_methods.email?.post_delivery_frequency as Reader.EmailDeliveryFrequency | undefined
+		delivery_methods.email?.send_posts
+			? ( delivery_methods.email?.post_delivery_frequency as
+					| Reader.EmailDeliveryFrequency
+					| undefined )
+			: undefined
 	);
 	const sanitizedBlogId = Reader.isValidId( blogId ) ? Number( blogId ) : undefined;
 

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -35,7 +35,10 @@ import { SiteSettingsPopover } from '../settings';
 import { useSubscriptionManagerContext } from '../subscription-manager-context';
 import UnsubscribePaidConfirmModal from './unsubscribe-paid-confirm-modal';
 
-const useDeliveryFrequencyLabel = ( deliveryFrequencyValue?: Reader.EmailDeliveryFrequency ) => {
+const useDeliveryFrequencyLabel = (
+	deliveryFrequencyValue?: Reader.EmailDeliveryFrequency,
+	sendPosts?: boolean
+) => {
 	const translate = useTranslate();
 
 	const deliveryFrequencyLabels = useMemo(
@@ -47,9 +50,15 @@ const useDeliveryFrequencyLabel = ( deliveryFrequencyValue?: Reader.EmailDeliver
 		[ translate ]
 	);
 
+	if ( ! sendPosts ) {
+		return translate( 'Paused' );
+	}
+
+	// An active email subscription always has a cadence; fall back to the backend's
+	// default ("instantly") when the stored value isn't available yet.
 	return (
 		deliveryFrequencyLabels[ deliveryFrequencyValue as Reader.EmailDeliveryFrequency ] ??
-		translate( 'Paused' )
+		deliveryFrequencyLabels.instantly
 	);
 };
 
@@ -140,11 +149,8 @@ const SiteSubscriptionRow = ( {
 	}, [ url ] );
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel(
+		delivery_methods.email?.post_delivery_frequency as Reader.EmailDeliveryFrequency | undefined,
 		delivery_methods.email?.send_posts
-			? ( delivery_methods.email?.post_delivery_frequency as
-					| Reader.EmailDeliveryFrequency
-					| undefined )
-			: undefined
 	);
 	const sanitizedBlogId = Reader.isValidId( blogId ) ? Number( blogId ) : undefined;
 

--- a/client/landing/subscriptions/components/site-subscriptions-list/test/site-subscription-row.test.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/test/site-subscription-row.test.tsx
@@ -233,6 +233,20 @@ describe( 'SiteSubscriptionRow', () => {
 		expect( screen.getByText( 'Instantly' ) ).toBeVisible();
 	} );
 
+	it( 'defaults the email frequency column to Instantly when enabled without a stored frequency', () => {
+		const queryClient = makeQueryClient();
+
+		renderRow( queryClient, {
+			delivery_methods: {
+				email: {
+					send_posts: true,
+				},
+			},
+		} );
+
+		expect( screen.getByText( 'Instantly' ) ).toBeVisible();
+	} );
+
 	it( 'shows Paused in the email frequency column when email delivery is disabled', () => {
 		const queryClient = makeQueryClient();
 

--- a/client/landing/subscriptions/components/site-subscriptions-list/test/site-subscription-row.test.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/test/site-subscription-row.test.tsx
@@ -186,14 +186,14 @@ const makeSiteSubscription = (
 	...overrides,
 } );
 
-const renderRow = ( queryClient: QueryClient ) => {
+const renderRow = ( queryClient: QueryClient, overrides: Partial< SiteSubscriptionItem > = {} ) => {
 	const store = createStore( ( state = {} ) => state );
 
 	return render(
 		<Provider store={ store }>
 			<QueryClientProvider client={ queryClient }>
 				<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
-					<SiteSubscriptionRow { ...makeSiteSubscription() } />
+					<SiteSubscriptionRow { ...makeSiteSubscription( overrides ) } />
 				</SubscriptionManagerContextProvider>
 			</QueryClientProvider>
 		</Provider>
@@ -216,5 +216,35 @@ describe( 'SiteSubscriptionRow', () => {
 		await user.click( screen.getByTitle( 'Unsubscribe' ) );
 
 		expect( getCachedFollow( queryClient )?.is_following ).toBe( false );
+	} );
+
+	it( 'shows the delivery frequency in the email frequency column when email delivery is enabled', () => {
+		const queryClient = makeQueryClient();
+
+		const { container } = renderRow( queryClient, {
+			delivery_methods: {
+				email: {
+					post_delivery_frequency: Reader.EmailDeliveryFrequency.Instantly,
+					send_posts: true,
+				},
+			},
+		} );
+
+		expect( container.querySelector( '.email-frequency-cell' ) ).toHaveTextContent( 'Instantly' );
+	} );
+
+	it( 'shows Paused in the email frequency column when email delivery is disabled', () => {
+		const queryClient = makeQueryClient();
+
+		const { container } = renderRow( queryClient, {
+			delivery_methods: {
+				email: {
+					post_delivery_frequency: Reader.EmailDeliveryFrequency.Instantly,
+					send_posts: false,
+				},
+			},
+		} );
+
+		expect( container.querySelector( '.email-frequency-cell' ) ).toHaveTextContent( 'Paused' );
 	} );
 } );

--- a/client/landing/subscriptions/components/site-subscriptions-list/test/site-subscription-row.test.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/test/site-subscription-row.test.tsx
@@ -221,7 +221,7 @@ describe( 'SiteSubscriptionRow', () => {
 	it( 'shows the delivery frequency in the email frequency column when email delivery is enabled', () => {
 		const queryClient = makeQueryClient();
 
-		const { container } = renderRow( queryClient, {
+		renderRow( queryClient, {
 			delivery_methods: {
 				email: {
 					post_delivery_frequency: Reader.EmailDeliveryFrequency.Instantly,
@@ -230,13 +230,13 @@ describe( 'SiteSubscriptionRow', () => {
 			},
 		} );
 
-		expect( container.querySelector( '.email-frequency-cell' ) ).toHaveTextContent( 'Instantly' );
+		expect( screen.getByText( 'Instantly' ) ).toBeVisible();
 	} );
 
 	it( 'shows Paused in the email frequency column when email delivery is disabled', () => {
 		const queryClient = makeQueryClient();
 
-		const { container } = renderRow( queryClient, {
+		renderRow( queryClient, {
 			delivery_methods: {
 				email: {
 					post_delivery_frequency: Reader.EmailDeliveryFrequency.Instantly,
@@ -245,6 +245,6 @@ describe( 'SiteSubscriptionRow', () => {
 			},
 		} );
 
-		expect( container.querySelector( '.email-frequency-cell' ) ).toHaveTextContent( 'Paused' );
+		expect( screen.getByText( 'Paused' ) ).toBeVisible();
 	} );
 } );

--- a/packages/data-stores/src/reader/mutations/test/use-site-email-me-new-posts-mutation.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-email-me-new-posts-mutation.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	getSiteSubscriptionsQueryKey,
+	type SiteSubscriptionsInfiniteData,
+} from '@automattic/api-queries';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { EmailDeliveryFrequency } from '../../constants';
+import { callApi } from '../../helpers';
+import useSiteEmailMeNewPostsMutation from '../../mutations/use-site-email-me-new-posts-mutation';
+import type { SiteSubscriptionItem } from '../../types';
+import type { ReactNode } from 'react';
+
+jest.mock( '../../hooks', () => ( {
+	useIsLoggedIn: jest.fn().mockReturnValue( { isLoggedIn: true, id: 1 } ),
+	useCacheKey: jest.fn( ( key ) => [ ...key, true, 1 ] ),
+} ) );
+
+jest.mock( '../../helpers', () => ( {
+	...jest.requireActual( '../../helpers' ),
+	callApi: jest.fn(),
+} ) );
+
+const makeQueryClient = () => new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+
+const makeWrapper = ( queryClient: QueryClient ) =>
+	function Wrapper( { children }: { children: ReactNode } ) {
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
+
+const makeSubscription = (
+	overrides: Partial< SiteSubscriptionItem > = {}
+): SiteSubscriptionItem =>
+	( {
+		ID: 123,
+		URL: 'https://example.com',
+		feed_URL: 'https://example.com/feed',
+		blog_ID: 123,
+		feed_ID: 456,
+		is_following: true,
+		isDeleted: false,
+		delivery_methods: {
+			email: {
+				send_posts: true,
+				post_delivery_frequency: EmailDeliveryFrequency.Weekly,
+			},
+		},
+		...overrides,
+	} ) as SiteSubscriptionItem;
+
+const makeSiteSubscriptionsData = (
+	subscriptions: SiteSubscriptionItem[]
+): SiteSubscriptionsInfiniteData => ( {
+	pages: [
+		{
+			subscriptions,
+			totalCount: subscriptions.length,
+			page: 1,
+			number: 200,
+		},
+	],
+	pageParams: [ 1 ],
+} );
+
+const getCachedEmail = ( queryClient: QueryClient ) =>
+	queryClient.getQueryData< SiteSubscriptionsInfiniteData >( getSiteSubscriptionsQueryKey() )
+		?.pages[ 0 ]?.subscriptions[ 0 ]?.delivery_methods?.email;
+
+describe( 'useSiteEmailMeNewPostsMutation()', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'clears the stored delivery frequency when email delivery is turned off', async () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData(
+			getSiteSubscriptionsQueryKey(),
+			makeSiteSubscriptionsData( [ makeSubscription() ] )
+		);
+		( callApi as jest.Mock ).mockResolvedValue( { success: true, subscribed: false } );
+
+		const { result } = renderHook( () => useSiteEmailMeNewPostsMutation(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		act( () => {
+			result.current.mutate( { blog_id: 123, send_posts: false, subscriptionId: 123 } );
+		} );
+
+		await waitFor( () => expect( callApi ).toHaveBeenCalled() );
+		const email = getCachedEmail( queryClient );
+		expect( email?.send_posts ).toBe( false );
+		expect( email?.post_delivery_frequency ).toBeUndefined();
+	} );
+
+	it( 'preserves the stored delivery frequency when email delivery is turned on', async () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData(
+			getSiteSubscriptionsQueryKey(),
+			makeSiteSubscriptionsData( [
+				makeSubscription( {
+					delivery_methods: {
+						email: { send_posts: false, post_delivery_frequency: EmailDeliveryFrequency.Weekly },
+					},
+				} ),
+			] )
+		);
+		( callApi as jest.Mock ).mockResolvedValue( { success: true, subscribed: true } );
+
+		const { result } = renderHook( () => useSiteEmailMeNewPostsMutation(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		act( () => {
+			result.current.mutate( { blog_id: 123, send_posts: true, subscriptionId: 123 } );
+		} );
+
+		await waitFor( () => expect( callApi ).toHaveBeenCalled() );
+		const email = getCachedEmail( queryClient );
+		expect( email?.send_posts ).toBe( true );
+		expect( email?.post_delivery_frequency ).toBe( EmailDeliveryFrequency.Weekly );
+	} );
+
+	it( 'rolls back the optimistic update when the request fails', async () => {
+		const queryClient = makeQueryClient();
+		const previousData = makeSiteSubscriptionsData( [ makeSubscription() ] );
+		queryClient.setQueryData( getSiteSubscriptionsQueryKey(), previousData );
+		( callApi as jest.Mock ).mockRejectedValue( new Error( 'request failed' ) );
+
+		const { result } = renderHook( () => useSiteEmailMeNewPostsMutation(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		act( () => {
+			result.current.mutate( { blog_id: 123, send_posts: false, subscriptionId: 123 } );
+		} );
+
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+		expect( queryClient.getQueryData( getSiteSubscriptionsQueryKey() ) ).toEqual( previousData );
+	} );
+} );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -75,6 +75,10 @@ const useSiteEmailMeNewPostsMutation = () => {
 											email: {
 												...siteSubscription.delivery_methods?.email,
 												send_posts: send_posts,
+												// Pausing deletes the subscription server-side, dropping the
+												// stored cadence. Mirror that so the cached frequency doesn't
+												// linger as stale data once email delivery is off.
+												...( ! send_posts && { post_delivery_frequency: undefined } ),
 											},
 										},
 									};
@@ -102,6 +106,7 @@ const useSiteEmailMeNewPostsMutation = () => {
 							email: {
 								...siteSubscriptionDetails.delivery_methods?.email,
 								send_posts: send_posts,
+								...( ! send_posts && { post_delivery_frequency: undefined } ),
 							},
 						},
 					} as SiteSubscriptionDetails;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # https://linear.app/a8c/issue/READ-116/changing-the-subscription-level-doesnt-immediately-reflect-on-the-list

## Proposed Changes

Updates the "Email Frequency" column of the subscriptions table to ensure it reflects when emails are paused, instead of stalely showing the delivery frequency it would have if unpaused.
* Updates the label helper for this column to also consider the `send_posts` flag, to reflect column as "paused" when send_posts is false. It also reflects the column as "Instantly" if send_posts flag is true but frequency is still undefined (resets to default "instantly" setting on back-end).
* Updates the mutation data layer to set the frequency as undefined in optimistic update when send_posts is set to false. This reflects what happens on the backend when we disable emails - the email subscription is deleted along with its frequency setting.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When changing the "email me new posts" toggle on the subscriptions table, this row does not update to change between "paused" and the set delivery cadence and shows stale data for too long. Every other column seems to optimistically update, so does this column when changing the cadence itself, now we ensure it will also do so for this case of turning off/on email altogether.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to subscriptions management
* Toggle a subscription to send emails vs. not.
* verify the "email frequency" column updates immediately, instead of persisting stale information.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
