### PR TITLE
Dashboard MCP hub: enable both Read and Write when MCP access is toggled on

### DIFF
--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -4,10 +4,12 @@ import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { Icon, __experimentalVStack as VStack, ToggleControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { seen, pencil, notAllowed, connection, globe } from '@wordpress/icons';
+import { getOverridesToMatch, groupIntentKey } from '../../../me/mcp/group-intents';
 import {
 	getAccountMcpAbilities,
 	getDisabledSiteIds,
 	getEnabledSiteIds,
+	getGroupDescriptors,
 } from '../../../me/mcp/utils';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -109,28 +111,23 @@ function McpComponent() {
 	} );
 
 	const handleMcpToggle = ( enabled: boolean ) => {
-		const accountAbilities: Record< string, boolean > = {};
-		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
-			const tool = mcpAbilities[ toolId ] as McpAbility;
-			if ( enabled ) {
-				// Only enable read tools by default; write tools start disabled
-				accountAbilities[ toolId ] = ! isWriteTool( toolId, tool );
-			} else {
-				accountAbilities[ toolId ] = false;
-			}
-		} );
+		const overrides = getOverridesToMatch( Object.entries( mcpAbilities ), enabled ) as
+			| Record< string, boolean >
+			| undefined;
 
-		// Clear site-level overrides when toggling on or off
-		const sitesToReset = [
-			...disabledSiteIds.map( ( id ) => ( { blog_id: id, account_tools_enabled: true } ) ),
-			...enabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: false } ) ),
-		];
+		const groupIntents: Record< string, boolean > = { read: enabled, write: enabled };
+		if ( ! enabled ) {
+			getGroupDescriptors( userSettings || {} ).forEach( ( group ) => {
+				groupIntents[ groupIntentKey( 'read', group.name ) ] = false;
+				groupIntents[ groupIntentKey( 'write', group.name ) ] = false;
+			} );
+		}
 
 		mutation.mutate(
 			{
 				mcp_abilities: {
-					account: accountAbilities,
-					...( sitesToReset.length > 0 && { sites: sitesToReset } ),
+					...( overrides && { account: overrides } ),
+					group_intents: groupIntents,
 				},
 			} as any,
 			{


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/112030
Related to https://linear.app/a8c/issue/AIINT-473/calypso-restructure-mywordpresscom-dashboard-site-level-mcp-settings

## Proposed Changes

The Dashboard MCP hub toggle (`/me/preferences/mcp`) was only enabling read tools when MCP access was turned on, leaving write tools disabled. Calypso's equivalent (`/me/mcp`) correctly enables both. This aligns the Dashboard to match.

Specifically, `handleMcpToggle` previously materialised explicit per-tool overrides and set write tools to `false` on enable (a comment even said "write tools start disabled"). This was the pre-AIINT-470 behaviour.

The fix mirrors `client/me/mcp/main.jsx`:

* Write `group_intents: { read: true, write: true }` so both categories are enabled and any future abilities inherit the intent automatically.
* Use `getOverridesToMatch` to force-write explicit overrides for currently-known tools that disagree with the new state (so stale per-op overrides cannot silently win via backend precedence).
* On disable, clear all per-group intents so a future newly-added ability cannot be silently re-enabled by a stale "enable all" intent.

## Why are these changes being made?

Enabling MCP access should turn on both Read and Write tools, matching the AIINT-470 backend default and the Calypso hub behaviour. The Dashboard hub diverged because the old materialised-override approach was never updated after AIINT-470 shipped.

## Testing Instructions

* On the Dashboard (`/me/preferences/mcp`), disable MCP access if currently on, then enable it -- confirm both Read and Write badges show "All enabled".
* Disable MCP access -- confirm all tools are off and group intents are cleared (verify via network tab: request body should include `group_intents: { read: false, write: false }`).
* Repeat the same test on Calypso (`/me/mcp`) and confirm behaviour is identical.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
