### PR TITLE
React 19: patch block-editor iframe to adopt the body singleton

### DIFF
--- a/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch
+++ b/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch
@@ -15,3 +15,33 @@ index a127d31c1fbdc56301fe78f2c0713f135afce2a1..d2121720e3a94873a104f79931c3ccb7
  	},
  	"react-native": "src/index",
  	"wpScript": true,
+diff --git a/build-module/components/iframe/index.mjs b/build-module/components/iframe/index.mjs
+index 721cd25a3cd88e2cf8ab52bae027ce4584f9c266..4bd3783687be37f301dc17b7e1501c8fca1a12f7 100644
+--- a/build-module/components/iframe/index.mjs
++++ b/build-module/components/iframe/index.mjs
+@@ -85,9 +85,7 @@ function getIframeSrc(resolvedAssets) {
+ 		${resolvedAssets.styles ?? ""}
+ 		${resolvedAssets.scripts ?? ""}
+ 	</head>
+-	<body>
+-		<script>document.currentScript.parentElement.remove()</script>
+-	</body>
++	<body></body>
+ </html>`;
+   src = URL.createObjectURL(new Blob([html], { type: "text/html" }));
+   iframeSrcCache.set(resolvedAssets, src);
+diff --git a/build/components/iframe/index.cjs b/build/components/iframe/index.cjs
+index 8287e32cb414cf543972e7db9945a8f34d5f728b..e3bb13d803241584e73651f418c27d3cc9f56f52 100644
+--- a/build/components/iframe/index.cjs
++++ b/build/components/iframe/index.cjs
+@@ -119,9 +119,7 @@ function getIframeSrc(resolvedAssets) {
+ 		${resolvedAssets.styles ?? ""}
+ 		${resolvedAssets.scripts ?? ""}
+ 	</head>
+-	<body>
+-		<script>document.currentScript.parentElement.remove()</script>
+-	</body>
++	<body></body>
+ </html>`;
+   src = URL.createObjectURL(new Blob([html], { type: "text/html" }));
+   iframeSrcCache.set(resolvedAssets, src);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11158,7 +11158,7 @@ __metadata:
 
 "@wordpress/block-editor@patch:@wordpress/block-editor@^15.21.0#~/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch":
   version: 15.21.0
-  resolution: "@wordpress/block-editor@patch:@wordpress/block-editor@npm%3A15.21.0#~/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch::version=15.21.0&hash=ae8e93"
+  resolution: "@wordpress/block-editor@patch:@wordpress/block-editor@npm%3A15.21.0#~/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch::version=15.21.0&hash=78fee8"
   dependencies:
     "@react-spring/web": "npm:^9.4.5"
     "@wordpress/a11y": "npm:^4.48.0"
@@ -11215,7 +11215,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 7c59c682d878b67db6545d5d9d8bebd9f575e12cf9a0144ded0bcc1f91cec0861db2f97e043108951fc074202fa952183e980f4479baa6a3068a4f49403259af
+  checksum: 6e90a5410de78b312f763def5f34aedd00d7db906e6165e602694799cff4ce3900a84632b68301a7ec1d163fe1d07f1ae17813b8c448c76fc24bd1e2655d1f8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of the React 19 upgrade (targets `update/react-19`, not `trunk`).

## Proposed Changes

* Extend the existing `@wordpress/block-editor` yarn patch so the iframe's `srcDoc` keeps an empty `<body>` instead of self-removing it via `<script>document.currentScript.parentElement.remove()</script>` (patched in both `build-module/.../iframe/index.mjs` and `build/.../iframe/index.cjs`).
* The pre-existing `get-compatibility-styles` export-map hunk is preserved in the same patch file; `yarn.lock` is updated with the new patch hash.

This will make sure the xxx screen renders and no longer throws exceptions:

<img width="1648" height="829" alt="image" src="https://github.com/user-attachments/assets/728276af-173c-43d6-96e6-010788bdd915" />

Note, this screen also has rendering issues on prod, so this is a compatibility work before we remove that code entirely in a follow-up:

<img width="1657" height="845" alt="image" src="https://github.com/user-attachments/assets/75d896ee-fd6c-4dee-9525-9cc8a4e6a526" />



## Why are these changes being made?

On `update/react-19`, opening a page that mounts a Gutenberg iframe — e.g. the theme detail sheet at `/theme/:slug`, whose style-variation previews render `__unstableIframe` — threw on every load:

> Uncaught Error: React expected a `<body>` element (document.body) to exist in the Document but one was not found.

Root cause: React 19 promoted `<html>`/`<head>`/`<body>` to **host singletons**. Instead of *creating* a `<body>`, React now *adopts* the existing `document.body` of the owner document (`resolveSingletonInstance`). Gutenberg's iframe renders a `<body>` via `createPortal` into the iframe document, and its `srcDoc` deliberately removed the placeholder body (a trick that was correct under React 18, where React created a fresh body and the placeholder would have been a duplicate). Under React 19 the iframe document then had no `body`, so singleton resolution threw.

Keeping an empty `<body>` lets React 19 adopt it, apply the class/ref, and mount the portal children into it — no duplicate body, no crash. This is a patch (not a version bump) because no published `@wordpress/block-editor` supports React 19 yet (latest `15.22.1` still declares React 18 peer deps and ships the same iframe code), and the whole `@wordpress/*` set is version-locked together via `resolutions`. It mirrors the existing `@wordpress/element` React-19 patch on this branch.

## Testing Instructions

1. Check out this branch and run `yarn install` (applies the updated patch).
2. `yarn start`, then open `/theme/primarium` (works logged out).
3. Before the patch: the console throws `React expected a <body> element (document.body) to exist…` on load and the style-variation previews fail to render.
4. After the patch: no such error; the theme sheet renders and the style-variation preview iframes mount (verified: the two `.global-styles-variation-container__iframe` frames are present and each has a `contentDocument.body`).

Verified locally with a headless browser load of `/theme/primarium`: no `<body>`/`resolveSingletonInstance` error, theme sheet fully rendered, `gsvIframes: 2` each with a body. (Remaining console output — report-only CSP on blob frames and a nav `<li>` nesting warning — is pre-existing and unrelated.)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Compatibility

⚠️ **React 19 only — do not cherry-pick onto `trunk` while `trunk` is React 18.** Under React 18, `<body>` is a normal host element (not a singleton), so the portal would create a *second* `<body>` in every Gutenberg iframe. This must land as part of the React 19 cutover (`update/react-19`), where `<html>`/`<head>`/`<body>` are singletons React adopts.
