### PR TITLE
Fix payment gateway README typo

### DIFF
--- a/client/lib/payment-gateway-loader/README.md
+++ b/client/lib/payment-gateway-loader/README.md
@@ -1,7 +1,7 @@
 # Payment Gateway Loader
 
 Payment gateways often provide JS libraries used to securely generate tokens from credit card details.
-For example, `Paygate` is a library by WordPress.com we can use to send Credit card data to the Paygate server and recieve back a token which we then submit to MoneyPress.
+For example, `Paygate` is a library by WordPress.com we can use to send Credit card data to the Paygate server and receive back a token which we then submit to MoneyPress.
 
 This class, `PaymentGatewayLoader`, takes care of the details of loading the remote payment gateway JS script (i.e. `paygate.js`) asynchronously.
 You can access the `Paygate` class from within the callback of `PaygateLoader.ready` like so:


### PR DESCRIPTION
## Proposed Changes

* Fix a typo in the payment gateway loader README: `recieve` -> `receive`.

## Why are these changes being made?

* This is a tiny documentation-only correction.

## Testing Instructions

* Confirmed the diff only updates `client/lib/payment-gateway-loader/README.md`.
* Ran `git diff --check -- client/lib/payment-gateway-loader/README.md`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
