### PR TITLE
React 19: raise checkout-extra-tax-fields jest timeout for CI

### DIFF
--- a/client/my-sites/checkout/src/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/src/test/checkout-extra-tax-fields.tsx
@@ -45,12 +45,12 @@ jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
-// These tests seem to be particularly slow (it might be because of using
-// it.each; it's not clear but the timeout might apply to the whole loop
-// rather that each iteration?), so we need to increase the timeout for their
-// operation. The standard timeout (at the time of writing) is 5 seconds so
-// we are increasing this to 12 seconds.
-jest.setTimeout( 12000 );
+// These tests are particularly slow: each case renders the full checkout tree
+// and drives it through many userEvent interactions, every one of which forces a
+// re-render. Under React 19's (slower) dev-mode renderer the heaviest cases creep
+// up further, and on CI agents they cross the previous 12s cap, so we give them
+// more headroom here.
+jest.setTimeout( 30000 );
 
 type TestProductType = 'google workspace' | 'plan' | 'plan with domain';
 


### PR DESCRIPTION
Part of the React 19 upgrade (targets `update/react-19`, not `trunk`).

## Proposed Changes

* Raise the per-test `jest.setTimeout` in `client/my-sites/checkout/src/test/checkout-extra-tax-fields.tsx` from 12s to 30s, and refresh the explanatory comment.

## Why are these changes being made?

On `update/react-19` this suite times out in CI:

> Error: thrown: "Exceeded timeout of 12000 ms for a test."

The tests are not broken — every case renders the **full checkout tree** and drives it through many `userEvent` interactions (each keystroke/selection forces a re-render of a heavy component tree). React 19's dev-mode renderer is slower than React 18's, so the heaviest cases (the VAT `it.each` cases) creep up and, on slower CI agents, cross the previous 12s per-test cap that was chosen under React 18.

Locally all 19 cases pass; the slowest are ~4s. Raising the cap to 30s gives comfortable headroom on CI without changing any behavior. This matches the existing precedent in the checkout test suite (`checkout-vat-form.tsx`, `composite-checkout-variant-picker-dropdown.tsx`, `checkout-contact-autocomplete.tsx` all already bump to 12s for the same reason).

## Testing Instructions

1. Check out this branch.
2. Run `yarn test-client client/my-sites/checkout/src/test/checkout-extra-tax-fields.tsx`.
3. All 19 cases pass. (Verified locally: 19/19 green.)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
