### PR TITLE
SHILL-2201: Render per-jurisdiction tax breakdown on receipts

### DIFF
--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -206,7 +206,12 @@ export function getFields(
 				return search_data;
 			},
 			render: ( { item }: { item: Receipt } ) =>
-				renderReceiptAmount( item, getTaxName( countryList, item.tax_country_code ) ),
+				renderReceiptAmount(
+					item,
+					item.tax_breakdown?.length
+						? item.tax_breakdown.map( ( e ) => e.label ).join( ' + ' )
+						: getTaxName( countryList, item.tax_country_code )
+				),
 		},
 		{
 			id: 'extra_receipt_data_for_search',

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -460,18 +460,32 @@ function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
 					</VStack>
 					{ ( transactionIncludesTax( receipt ) || hasBusinessUseTaxDetails( receipt ) ) && (
 						<VStack className="receipt-tax-row">
-							<HStack justify="space-between">
-								<Text>
-									{ taxLabel }
-									{ businessTaxSuffixLabel && (
-										<>
-											{ ' (' }
-											<em>{ businessTaxSuffixLabel }</em>)
-										</>
-									) }
-								</Text>
-								<Text>{ formatReceiptTaxAmount( receipt ) }</Text>
-							</HStack>
+							{ receipt.tax_breakdown && receipt.tax_breakdown.length > 0 ? (
+								receipt.tax_breakdown.map( ( entry ) => (
+									<HStack key={ entry.label } justify="space-between">
+										<Text>{ `${ entry.label } ${ entry.rate_display }` }</Text>
+										<Text>
+											{ formatCurrency( entry.local_tax_collected_integer, receipt.currency, {
+												isSmallestUnit: true,
+												stripZeros: true,
+											} ) }
+										</Text>
+									</HStack>
+								) )
+							) : (
+								<HStack justify="space-between">
+									<Text>
+										{ taxLabel }
+										{ businessTaxSuffixLabel && (
+											<>
+												{ ' (' }
+												<em>{ businessTaxSuffixLabel }</em>)
+											</>
+										) }
+									</Text>
+									<Text>{ formatReceiptTaxAmount( receipt ) }</Text>
+								</HStack>
+							) }
 						</VStack>
 					) }
 				</VStack>

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -561,6 +561,24 @@ export function ReceiptItemTaxes( { transaction }: { transaction: BillingTransac
 		return null;
 	}
 
+	if ( transaction.tax_breakdown && transaction.tax_breakdown.length > 0 ) {
+		return (
+			<>
+				{ transaction.tax_breakdown.map( ( entry ) => (
+					<div key={ entry.label } className="billing-history__transaction-tax-amount">
+						<span>{ `${ entry.label } ${ entry.rate_display }` }</span>
+						<span>
+							{ formatCurrency( entry.local_tax_collected_integer, transaction.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ) }
+						</span>
+					</div>
+				) ) }
+			</>
+		);
+	}
+
 	const baseTaxLabel = taxName ?? String( translate( 'Tax' ) );
 	const businessTaxSuffixLabel =
 		transaction.tax_is_for_business && transaction.tax_state

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -118,6 +118,9 @@ export function TransactionAmount( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const taxName = useTaxName( transaction.tax_country_code );
+	const effectiveTaxName = transaction.tax_breakdown?.length
+		? transaction.tax_breakdown.map( ( e ) => e.label ).join( ' + ' )
+		: taxName;
 
 	if ( ! transactionIncludesTax( transaction ) ) {
 		return (
@@ -130,14 +133,14 @@ export function TransactionAmount( {
 		);
 	}
 
-	const includesTaxString = taxName
+	const includesTaxString = effectiveTaxName
 		? translate( '(includes %(taxAmount)s %(taxName)s)', {
 				args: {
 					taxAmount: formatCurrency( transaction.tax_integer, transaction.currency, {
 						isSmallestUnit: true,
 						stripZeros: true,
 					} ),
-					taxName,
+					taxName: effectiveTaxName,
 				},
 				comment:
 					'taxAmount is a localized price, like $12.34 | taxName is a localized tax, like VAT or GST',

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -1,5 +1,5 @@
 import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
-import type { TaxVendorInfo } from '@automattic/wpcom-checkout';
+import type { TaxBreakdownEntry, TaxVendorInfo } from '@automattic/wpcom-checkout';
 
 export interface BillingTransaction {
 	address: string;
@@ -70,6 +70,7 @@ export interface BillingTransaction {
 	url: string;
 
 	tax_vendor_info?: TaxVendorInfo;
+	tax_breakdown?: TaxBreakdownEntry[];
 }
 
 export interface BillingTransactionItem {

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -1,5 +1,13 @@
 import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
 
+export interface TaxBreakdownEntry {
+	label: string;
+	rate: number;
+	rate_display: string;
+	local_tax_collected: number;
+	local_tax_collected_integer: number;
+}
+
 export interface TaxVendorInfo {
 	/**
 	 * The country code for this info.
@@ -111,6 +119,7 @@ export interface Receipt {
 	credit: string;
 	items: ReceiptItem[];
 	tax_vendor_info?: TaxVendorInfo;
+	tax_breakdown?: TaxBreakdownEntry[];
 	checkout_type?: string;
 	/**
 	 * Line items that failed to provision during checkout, keyed by site (blog) ID.

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -57,6 +57,14 @@ export type WPCOMTransactionEndpointResponse =
 	| WPCOMTransactionEndpointResponsePayPal
 	| WPCOMTransactionEndpointResponseRedirect;
 
+export interface TaxBreakdownEntry {
+	label: string;
+	rate: number;
+	rate_display: string;
+	local_tax_collected: number;
+	local_tax_collected_integer: number;
+}
+
 export interface TaxVendorInfo {
 	/**
 	 * The country code for this info.


### PR DESCRIPTION
Part of SHILL-2201

## Proposed Changes

* Add `TaxBreakdownEntry` type to `@automattic/wpcom-checkout` and `@automattic/api-core` with fields matching the PHP DTO (`label`, `rate`, `rate_display`, `local_tax_collected`, `local_tax_collected_integer`)
* Add optional `tax_breakdown?: TaxBreakdownEntry[]` field to `BillingTransaction` (Classic) and `Receipt` (Dashboard) types
* Update `ReceiptItemTaxes` (Classic, `client/me/purchases/billing-history/receipt.tsx`) to render one row per breakdown entry when the array is non-empty
* Update `ReceiptLineItems` (Dashboard, `client/dashboard/me/billing-history/receipt.tsx`) with the same logic

## Why are these changes being made?

BC customers paying GST + PST had both taxes combined into a single "GST" line on the web receipt. The email receipt already shows them separately because `mailer-builder.php` reads `billing_receipt_item_tax_lines`. The API fix (PR #225885 in wpcom) adds a `tax_breakdown` array to the receipt response; this PR consumes it.

When `tax_breakdown` is absent or empty (old receipts, countries with a single tax jurisdiction), both components fall back to the existing single-line display.

## Testing Instructions

* Requires the wpcom backend PR #225885 to be deployed first
* View receipt `118392995` for a BC customer — should show two lines: "GST 5% C$31.95" and "PST 7% C$44.73"
* View a non-Canadian receipt (e.g. EU VAT, US sales tax) — should still show a single tax line
* Check both Classic (`/me/purchases/billing`) and Dashboard billing history

This changes the receipt and the billing history list:

Receipt before:
<img width="939" height="868" alt="Screenshot 2026-07-03 at 11 51 13" src="https://github.com/user-attachments/assets/8dfb52fe-564a-43b0-9e1b-5e2868b0ec87" />

Receipt after: 
<img width="959" height="890" alt="Screenshot 2026-07-03 at 11 50 45" src="https://github.com/user-attachments/assets/d88eb9dd-0278-4cd3-a1ca-71cb08a59b33" />

Billing history before:
<img width="954" height="113" alt="Screenshot 2026-07-03 at 11 44 23" src="https://github.com/user-attachments/assets/9b85c20e-881b-47ba-aff4-6d04464da449" />

Billing history after:
<img width="942" height="108" alt="Screenshot 2026-07-03 at 11 49 00" src="https://github.com/user-attachments/assets/67b94666-5236-4484-bb72-d6da7a8fe499" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?