### PR TITLE
Fix isomorphic routing documentation typos

### DIFF
--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -97,8 +97,8 @@ export default function ( router ) {
 }
 ```
 
-Note that you can have multiple error-handling middlewares in your route defintion. When any of the regular middlewares throw an error (or call `next(err)`), only error-handling will be called from that point. This is how error middleware chains skip regular middlewares. The endering middleware that is implicitly called on the server after all other middlewares are invoked uses `err.status` to set the HTTP error status. It will also log an error in the server log, using
-severity `error` if status is >= 500, `info` otherwhise.
+Note that you can have multiple error-handling middlewares in your route definition. When any of the regular middlewares throw an error (or call `next(err)`), only error-handling will be called from that point. This is how error middleware chains skip regular middlewares. The rendering middleware that is implicitly called on the server after all other middlewares are invoked uses `err.status` to set the HTTP error status. It will also log an error in the server log, using
+severity `error` if status is >= 500, `info` otherwise.
 
 ```js
 function details( context, next ) {


### PR DESCRIPTION
No issue.

## Proposed Changes

* Correct typos in the isomorphic routing documentation.

## Why are these changes being made?

* This keeps the documentation prose tidy while providing a tiny merge queue test change.

## Testing Instructions

* Ran `git diff --check -- docs/isomorphic-routing.md`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?