### PR TITLE
Reader Spaces: highlight the active space in the sidebar

### DIFF
--- a/client/reader/sidebar/spaces/index.tsx
+++ b/client/reader/sidebar/spaces/index.tsx
@@ -10,8 +10,9 @@ import { prefetchInfiniteStream } from 'calypso/reader/data/stream';
 import { AddMenuItem } from 'calypso/reader/sidebar/menu';
 import { CreateSpaceModal } from 'calypso/reader/spaces/create-modal';
 import { getSpacePath, SPACES_BASE_PATH } from 'calypso/reader/spaces/routes';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { SpaceMenuItem } from './menu-item';
 import type { ReadSpace } from '@automattic/api-core';
 
@@ -21,12 +22,36 @@ interface Props {
 	path: string;
 }
 
-function getActiveSpaceId( path: string ): string | null {
-	// Space ids are URL-safe (base36), so the path segment is the id verbatim —
-	// no decoding is needed, and there is nothing for a bad URL to throw on.
-	// Mirrors getActiveConnection in the Social Feeds section.
+// Space ids are URL-safe (base36), so the path segment is the id verbatim — no
+// decoding is needed, and there is nothing for a bad URL to throw on. Mirrors
+// getActiveConnection in the Social Feeds section.
+function parseSpaceId( path: string ): string | null {
 	const match = path.match( /^\/reader\/spaces\/([^/?]+)/ );
 	return match ? match[ 1 ] : null;
+}
+
+// A full-post route (`/reader/feeds/:id/posts/:id` or `/reader/blogs/...`), where
+// no top-level sidebar stream is active.
+const READER_POST_PATH = /^\/reader\/(?:feeds|blogs)\/[^/]+\/posts\/[^/?]+/;
+
+/**
+ * The space whose row should read as active. Normally that's the space route
+ * we're on. But opening a post navigates to a post route that carries no space,
+ * so the highlight would drop the moment you start reading. While on a post
+ * route, fall back to the route we came from: if we arrived from a space, keep
+ * that space highlighted so the reading session still reads as "in" it. The
+ * fallback is scoped to post routes, so landing on another stream (Following,
+ * a tag, …) highlights that stream instead, never a stale space.
+ */
+function getActiveSpaceId( path: string, previousRoute: string ): string | null {
+	const direct = parseSpaceId( path );
+	if ( direct ) {
+		return direct;
+	}
+	if ( READER_POST_PATH.test( path ) ) {
+		return parseSpaceId( previousRoute );
+	}
+	return null;
 }
 
 export function ReaderSidebarSpaces( { path }: Props ) {
@@ -34,18 +59,23 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const spaces = useSpaces();
+	const previousRoute = useSelector( getPreviousRoute );
 
-	const activeId = getActiveSpaceId( path );
+	const activeId = getActiveSpaceId( path, previousRoute );
 	const isOnSpaces = path === SPACES_BASE_PATH || path.startsWith( `${ SPACES_BASE_PATH }/` );
+	// Expand the section whenever a space is active — on a space route, or while
+	// reading a post opened from one — so the highlighted space stays in view
+	// (including on a direct load of such a post, where there's no open state yet).
+	const hasActiveSpace = isOnSpaces || activeId !== null;
 
-	const [ isOpen, setIsOpen ] = useState( () => isOnSpaces );
+	const [ isOpen, setIsOpen ] = useState( () => hasActiveSpace );
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
 
 	useEffect( () => {
-		if ( isOnSpaces ) {
+		if ( hasActiveSpace ) {
 			setIsOpen( true );
 		}
-	}, [ isOnSpaces ] );
+	}, [ hasActiveSpace ] );
 
 	const recordSpaceClick = ( id: string ) => {
 		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_space_clicked', { space: id } ) );

--- a/client/reader/sidebar/spaces/style.scss
+++ b/client/reader/sidebar/spaces/style.scss
@@ -44,7 +44,30 @@
 	}
 }
 
-// Active row: the name takes on the space's own foreground colour.
-.sidebar-spaces__item.selected .sidebar-spaces__name {
-	color: var( --space-color );
+// Active row: tint the whole row with the space's own accent so the current
+// space is unmistakable. The shared sidebar only paints a selected background in
+// dark mode, so in light mode this is the only active-state cue — without it the
+// current space reads no differently from the rest until hovered. A leading
+// accent bar reinforces it; the name takes on the space's foreground colour.
+.sidebar-spaces__item.selected {
+	.sidebar-spaces__link {
+		position: relative;
+		background-color: var( --space-color-bg );
+	}
+
+	.sidebar-spaces__link::before {
+		content: '';
+		position: absolute;
+		inset-inline-start: 0;
+		inset-block: 6px;
+		inline-size: 3px;
+		border-start-end-radius: 2px;
+		border-end-end-radius: 2px;
+		background: var( --space-color );
+	}
+
+	.sidebar-spaces__name {
+		color: var( --space-color );
+		font-weight: 600;
+	}
 }

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -17,6 +17,14 @@ jest.mock( '@automattic/calypso-router', () => ( {
 	default: Object.assign( jest.fn(), { replace: jest.fn() } ),
 } ) );
 
+// Drives the "space a post was opened from" fallback. Mutable so each test can
+// set the route the user navigated from before opening the current post.
+let mockPreviousRoute = '';
+jest.mock( 'calypso/state/selectors/get-previous-route', () => ( {
+	__esModule: true,
+	default: () => mockPreviousRoute,
+} ) );
+
 // The create modal is backed by the shared upsert modal, which imports the
 // Sources tab. Sidebar tests never exercise the sources list, so stub its heavy
 // dependencies here.
@@ -53,6 +61,7 @@ describe( 'ReaderSidebarSpaces', () => {
 	beforeEach( () => {
 		jest.mocked( page ).mockClear();
 		jest.mocked( page.replace ).mockClear();
+		mockPreviousRoute = '';
 	} );
 
 	afterEach( () => nock.cleanAll() );
@@ -75,6 +84,25 @@ describe( 'ReaderSidebarSpaces', () => {
 		// The active row carries the space's colour class, which drives the
 		// active link colour via the `--space-color` custom property.
 		expect( selected[ 0 ] ).toHaveClass( `sidebar-spaces__item--${ FIRST_SPACE.layout.color }` );
+	} );
+
+	it( 'keeps the originating space highlighted while reading a post opened from it', () => {
+		// On a post route the URL carries no space; the highlight falls back to the
+		// previous route (the space we came from).
+		mockPreviousRoute = OPEN_PATH;
+		const { container } = render( <ReaderSidebarSpaces path="/reader/feeds/123/posts/456" /> );
+
+		const selected = container.querySelectorAll( 'li.sidebar__menu-item.selected' );
+		expect( selected ).toHaveLength( 1 );
+		expect( selected[ 0 ].textContent ).toContain( FIRST_SPACE.name );
+	} );
+
+	it( 'does not highlight a space on a post route not reached from a space', () => {
+		// Came from Following, opened a post: no space should read as active.
+		mockPreviousRoute = '/reader';
+		const { container } = render( <ReaderSidebarSpaces path="/reader/feeds/123/posts/456" /> );
+
+		expect( container.querySelector( 'li.sidebar__menu-item.selected' ) ).toBeNull();
 	} );
 
 	it( 'does not crash or falsely select on an unexpected space id in the path', () => {


### PR DESCRIPTION
Part of RSM-4510

## Proposed Changes

* Give the active space a clear active state in the sidebar, in its own accent colour: a background tint (`--space-color-bg`), a leading accent bar, and the name in the accent foreground (`--space-color`). Reuses the existing space-accent custom properties — no new tokens.
* Keep the highlight while reading a post: on a post route (which carries no space in its URL), the active-space lookup falls back to the previous route (`getPreviousRoute`). If the reader arrived from a space, that space stays highlighted. Scoped to post routes, so landing on another stream (Following, a tag, …) highlights that stream instead, never a stale space.
* Expand the Spaces section whenever a space is active so the highlighted row stays in view, including on a direct load of a post opened from a space.
* New tests cover the persist-from-space case and the don't-falsely-persist case.

## Why are these changes being made?

The shared sidebar only paints a selected background in dark mode, so in light mode the current space was visually indistinguishable from the rest until hovered — there was no active-state cue at all. And the moment you opened a post to read it, the URL no longer referenced the space, so even the faint name-colour cue dropped. This makes the current space obvious and keeps it obvious through a reading session.

## Testing Instructions

1. Open a Reader Space. Its row in the sidebar should now stand out in the space's accent colour — a tinted background, a leading accent bar, and a coloured name.
2. Click into a post to read it. The originating space should stay highlighted in the sidebar (and the Spaces section stays expanded).
3. Navigate to Following, or a tag stream, instead. No space should be highlighted.
4. `yarn test-client client/reader/sidebar/spaces` — all green.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
