### PR TITLE
Agents Manager: Do not populate the input once the response ends if the suggestion has the autoSubmit flag

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -33,6 +33,18 @@ const mockAgentChat = jest.fn(
 			<button onClick={ () => onSuggestionClick( 'Check the grammar and spelling of this text' ) }>
 				Click string suggestion
 			</button>
+			<button
+				onClick={ () =>
+					onSuggestionClick( {
+						id: 'weekly-brief',
+						label: 'Walk me through the attached weekly brief',
+						prompt: 'Walk me through the attached weekly brief',
+						autoSubmit: true,
+					} )
+				}
+			>
+				Click auto-submit suggestion
+			</button>
 			<button onClick={ () => onSubmit( 'Describe these images' ) }>Submit with images</button>
 			<ul data-testid="empty-view-suggestions">
 				{ emptyViewSuggestions.map( ( suggestion ) => (
@@ -162,6 +174,7 @@ describe( 'OrchestratorChat', () => {
 		expect( listener ).toHaveBeenCalledTimes( 1 );
 		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
 			value: 'Simplify this text to make it easier to read',
+			autoSubmit: false,
 		} );
 
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
@@ -191,7 +204,45 @@ describe( 'OrchestratorChat', () => {
 		expect( listener ).toHaveBeenCalledTimes( 1 );
 		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
 			value: 'Check the grammar and spelling of this text',
+			autoSubmit: false,
 		} );
+
+		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
+	} );
+
+	it( 'flags auto-submit suggestions so the input is not repopulated', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Click auto-submit suggestion' ) );
+
+		// The event still fires so click listeners (e.g. the Jetpack sidebar hiding the
+		// clicked chip) keep working, but it carries `autoSubmit` so the input listener
+		// skips repopulating the composer the AgentUI already submitted and cleared.
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
+			value: 'Walk me through the attached weekly brief',
+			autoSubmit: true,
+		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'chat_suggestion_click',
+			expect.objectContaining( { suggestion_id: 'weekly-brief' } )
+		);
 
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
 	} );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -562,8 +562,10 @@ export default function OrchestratorChat( {
 	// Listen for inline suggestion clicks dispatched by external providers or the Agenttic bridge below.
 	useEffect( () => {
 		const handleInlineSuggestionClick = ( event: Event ) => {
-			const { value } = ( event as CustomEvent ).detail;
-			if ( value ) {
+			const { value, autoSubmit } = ( event as CustomEvent ).detail;
+			// Auto-submit suggestions are already sent and the input cleared by the
+			// AgentUI; repopulating it here would leave the prompt stuck in the composer.
+			if ( value && ! autoSubmit ) {
 				const inputValue = value.endsWith( ' ' ) ? value : `${ value } `;
 				setInputValue( inputValue );
 
@@ -589,6 +591,8 @@ export default function OrchestratorChat( {
 			const value =
 				typeof suggestion === 'string' ? suggestion : suggestion.prompt ?? suggestion.label;
 
+			const autoSubmit = typeof suggestion !== 'string' && !! suggestion.autoSubmit;
+
 			if ( typeof suggestion !== 'string' ) {
 				recordBigSkyTracksEvent( 'chat_suggestion_click', {
 					suggestion_text: suggestion.prompt || '',
@@ -597,8 +601,11 @@ export default function OrchestratorChat( {
 				} );
 			}
 
+			// Always dispatch so click listeners (e.g. the Jetpack sidebar hiding the
+			// clicked chip) still fire. `autoSubmit` tells the input listener to skip
+			// repopulating the composer, which the AgentUI already submitted and cleared.
 			window.dispatchEvent(
-				new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value } } )
+				new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value, autoSubmit } } )
 			);
 		},
 		[]


### PR DESCRIPTION
Part of WOOAI-668.

## Proposed Changes

When clicking an empty view suggestion with `autoSubmit: true`, we should not add the prompt back within the assistant input after the model stops responding. This is a bug that this PR fixes.

## Testing Instructions

In the current trunk, click one of the empty view suggestions (woocommerce-ai/pull/277 restores it), and verify that at the end of the model's response, the prompt is added within the input again.

Sync the version from this branch to your sandbox and verify that this behavior no longer occurs after picking an empty view suggestion.