### PR TITLE
MSD Emails: Wire the Professional Email tier upgrade to checkout

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -97,6 +97,7 @@ export function TitanPlanGrid( {
 	hasProFreeTrial,
 	proTrialMonths,
 	currentTier,
+	onUpgrade,
 }: {
 	domain?: Domain;
 	domainName: string;
@@ -108,6 +109,8 @@ export function TitanPlanGrid( {
 	// upgrade mode: lower tiers are hidden, the current tier is labeled, and higher
 	// tiers offer an upgrade.
 	currentTier?: TitanPlanTier;
+	// Called when a higher tier is selected in upgrade mode (currentTier set).
+	onUpgrade?: ( tier: TitanPlanTier ) => void;
 } ) {
 	const navigate = useNavigate();
 
@@ -254,7 +257,13 @@ export function TitanPlanGrid( {
 							className="email-provider-action"
 							variant={ plan.isPopular ? 'primary' : 'secondary' }
 							disabled={ ! available || isCurrentPlan }
-							onClick={ () =>
+							onClick={ () => {
+								// Upgrade mode goes to checkout for the picked tier; otherwise the
+								// grid is buying a new plan, so collect mailboxes first.
+								if ( currentTier ) {
+									onUpgrade?.( plan.tier );
+									return;
+								}
 								navigate( {
 									to: addMailboxRoute.to,
 									params: {
@@ -263,8 +272,8 @@ export function TitanPlanGrid( {
 										interval,
 									},
 									search: { tier: plan.tier },
-								} )
-							}
+								} );
+							} }
 						>
 							{ actionLabel }
 						</Button>

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -21,6 +21,7 @@ import { PriceDisplay } from '../../components/price-display';
 import { Text } from '../../components/text';
 import GoogleLogo from '../../images/google-logo.svg';
 import {
+	getMaxTitanMailboxCount,
 	hasEmailForwards,
 	hasGSuiteWithUs,
 	hasTitanMailWithUs,
@@ -32,6 +33,7 @@ import { useDomainFromUrlParam } from '../hooks/use-domain-from-url-param';
 import { useEmailProduct } from '../hooks/use-email-product';
 import poweredByTitanLogo from '../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../types';
+import { getTitanTierUpgradeUrl } from '../utils/get-tier-upgrade-url';
 import { isEligibleForIntroductoryOffer } from '../utils/is-eligible-for-introductory-offer';
 import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
 import { getTitanTierFromSlug } from '../utils/titan-tiers';
@@ -45,7 +47,7 @@ const getTrialMonths = ( product?: Product ) =>
 	product?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
 
 export default function ChooseEmailSolution() {
-	const { domain, domainName } = useDomainFromUrlParam();
+	const { domain, domainName, site } = useDomainFromUrlParam();
 	const { user } = useAuth();
 
 	const isTitanPlanSelectionEnabled = config.isEnabled( 'emails/titan-tiers' );
@@ -141,6 +143,23 @@ export default function ChooseEmailSolution() {
 	if ( redirectTo ) {
 		return null;
 	}
+
+	// In upgrade mode, picking a higher tier goes straight to checkout with the
+	// target product, keeping the existing domain, billing interval, and mailbox
+	// count so the backend upgrades the current subscription in place.
+	const handleTierUpgrade = ( tier: TitanPlanTier ) => {
+		if ( ! site ) {
+			return;
+		}
+
+		window.location.href = getTitanTierUpgradeUrl( {
+			siteSlug: site.slug,
+			domain: domainName,
+			tier,
+			interval: billingInterval,
+			quantity: getMaxTitanMailboxCount( domain ),
+		} );
+	};
 
 	const providers = {
 		[ MailboxProvider.Titan ]: {
@@ -273,6 +292,7 @@ export default function ChooseEmailSolution() {
 								? getTitanTierFromSlug( titanEmailSubscription?.product_slug )
 								: undefined
 						}
+						onUpgrade={ handleTierUpgrade }
 					/>
 					{ ! isUpgradeIntent && (
 						<GoogleWorkspaceCard

--- a/client/dashboard/emails/utils/get-tier-upgrade-url.ts
+++ b/client/dashboard/emails/utils/get-tier-upgrade-url.ts
@@ -1,0 +1,35 @@
+import { addQueryArgs } from '@wordpress/url';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { IntervalLength, TitanPlanTier } from '../types';
+import { TITAN_TIER_SLUGS } from './titan-tiers';
+
+/**
+ * Builds the checkout URL for upgrading an existing Titan subscription to a
+ * higher tier. Mirrors the generic product-upgrade flow (getSitePurchaseUpgradeUrl):
+ * go straight to /checkout with the target product and redirect back to the
+ * dashboard. The product alias encodes the domain and the existing mailbox count
+ * so the backend upgrades the current subscription in place rather than creating
+ * a new one (alias format parsed by use-prepare-products-for-cart).
+ */
+export function getTitanTierUpgradeUrl( {
+	siteSlug,
+	domain,
+	tier,
+	interval,
+	quantity,
+}: {
+	siteSlug: string;
+	domain: string;
+	tier: TitanPlanTier;
+	interval: IntervalLength;
+	quantity: number;
+} ): string {
+	const productSlug = TITAN_TIER_SLUGS[ tier ][ interval ];
+	const productAlias = `${ productSlug }:${ domain }:-q-${ quantity }`;
+	const backUrl = redirectToDashboardLink();
+
+	return addQueryArgs( wpcomLink( `/checkout/${ siteSlug }/${ productAlias }` ), {
+		redirect_to: backUrl,
+		cancel_to: backUrl,
+	} );
+}


### PR DESCRIPTION
Part of DOTEMP-112

Follow-up to #111588, which added the "Upgrade plan" entry point on the Dashboard email plan purchase page.

## Proposed Changes

* Let people upgrade their Professional Email plan to a higher tier. Picking a higher tier now takes them to checkout for that tier and upgrades their existing subscription in place, keeping their domain, mailboxes, and billing cycle. Previously this entry point dead-ended in the add-mailbox flow.

## Why are these changes being made?

The upgrade entry point shipped as a placeholder. Now that the backend tier-change flow is in place, the front end should complete the path so upgrading a Professional Email plan behaves like any other product upgrade.

## Testing Instructions

1. Enable the `emails/titan-tiers` feature flag.
2. Have a domain with an existing Professional Email (Titan) subscription.
3. Go to the Dashboard purchase page for that email plan and click "Upgrade plan".
4. Confirm you land on the tier grid showing the current tier (labeled) and higher tiers offering "Upgrade".
5. Click "Upgrade" on a higher tier and confirm you are sent to checkout for that tier, with the existing mailbox count and billing interval preserved.
6. Confirm the new-purchase flow (no existing subscription) still routes through the add-mailbox form.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
