### PR TITLE
desktop: Release 8.2.3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.2.3-beta.2",
+	"version": "8.2.3",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.2.2",
+	"version": "8.2.3-beta.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.2.3-beta.1",
+	"version": "8.2.3-beta1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.2.3-beta1",
+	"version": "8.2.3-beta.2",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",


### PR DESCRIPTION
Merge the `package.json` version bump for release 8.2.3.

Once on `trunk`, we can tag the merge commit and the new Buildkite CI will trigger the packaging and upload to https://github.com/Automattic/wp-desktop/releases