### PR TITLE
Remove lodash `get` in favor of native optional chaining

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -610,6 +610,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/foldl': 'error',
 		'you-dont-need-lodash-underscore/foldr': 'error',
 		'you-dont-need-lodash-underscore/for-each': 'error',
+		'you-dont-need-lodash-underscore/get': 'error',
 		'you-dont-need-lodash-underscore/includes': 'error',
 		'you-dont-need-lodash-underscore/index-of': 'error',
 		'you-dont-need-lodash-underscore/inject': 'error',

--- a/client/__mocks__/is-my-json-valid.js
+++ b/client/__mocks__/is-my-json-valid.js
@@ -1,6 +1,5 @@
 import { isEmpty } from '@automattic/js-utils';
 import imjv from 'is-my-json-valid';
-import { get } from 'lodash';
 import jsonSchemaDraft04 from './lib/json-schema-draft-04.json';
 
 const validateSchema = imjv( jsonSchemaDraft04, { verbose: true, greedy: true } );
@@ -33,7 +32,11 @@ function throwOnInvalidSchema( schema ) {
 
 			// Violates rule: { type: 'boolean' }
 			if ( ! isEmpty( schemaPath ) ) {
-				msg.push( `Violates rule: ${ JSON.stringify( get( jsonSchemaDraft04, schemaPath ) ) }` );
+				msg.push(
+					`Violates rule: ${ JSON.stringify(
+						schemaPath.reduce( ( node, key ) => node?.[ key ], jsonSchemaDraft04 )
+					) }`
+				);
 			}
 			msg.push( '' );
 		} );

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
 export const GUTENBERG = 'gutenberg-editor';
 export const NOTES = 'notifications';
@@ -95,7 +93,7 @@ export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
 			// Dismiss all other sections for a shorter period, but make sure that we preserve previous dismiss time
 			// if it was longer than that (e.g. if other section was also dismissed for a month).
 			result[ section ] =
-				get( currentDismissTimes, section, -Infinity ) > dismissTimes.shorterDuration
+				( currentDismissTimes?.[ section ] ?? -Infinity ) > dismissTimes.shorterDuration
 					? currentDismissTimes?.[ section ]
 					: dismissTimes.shorterDuration;
 		}
@@ -105,4 +103,4 @@ export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
 }
 
 export const isDismissed = ( dismissedUntil, section ) =>
-	get( dismissedUntil, section, -Infinity ) > Date.now();
+	( dismissedUntil?.[ section ] ?? -Infinity ) > Date.now();

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
 
 /**
@@ -16,7 +15,7 @@ import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-edi
  */
 export function getDefaultAspectRatio( aspectRatio = null, aspectRatios = AspectRatiosValues ) {
 	if ( ! aspectRatios?.includes( aspectRatio ) ) {
-		aspectRatio = get( aspectRatios, '0', AspectRatios.FREE );
+		aspectRatio = aspectRatios?.[ 0 ] ?? AspectRatios.FREE;
 	}
 
 	return AspectRatiosValues.includes( aspectRatio )

--- a/client/blocks/site-icon/index.tsx
+++ b/client/blocks/site-icon/index.tsx
@@ -1,7 +1,6 @@
 import './style.scss';
 import { Gridicon, Spinner } from '@automattic/components';
 import clsx from 'clsx';
-import { get } from 'lodash';
 import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -111,7 +110,7 @@ type SiteIconContainerProps = {
 
 export default connect( ( state, { site, siteId }: SiteIconContainerProps ) => {
 	// Always prefer site from Redux state if available
-	const stateSite = getSite( state as object, get( site, 'ID', siteId ) );
+	const stateSite = getSite( state as object, site?.ID ?? siteId );
 
 	// Until all sites state is within Redux, we provide compatibility in cases
 	// where sites-list object is passed to use the icon.img property as URL.

--- a/client/blocks/subscribers-count/index.jsx
+++ b/client/blocks/subscribers-count/index.jsx
@@ -1,6 +1,5 @@
 import { Button, Count } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -38,7 +37,7 @@ export default connect( ( state ) => {
 
 	return {
 		slug: getSiteSlug( state, siteId ),
-		subscribers: get( data, 'followersBlog', siteSubscribers ),
+		subscribers: data?.followersBlog ?? siteSubscribers,
 		siteId,
 	};
 } )( localize( SubscribersCount ) );

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -1,7 +1,7 @@
 import { debounce } from '@wordpress/compose';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { merge, get } from 'lodash';
+import { merge } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import DayPicker from 'react-day-picker';
@@ -123,7 +123,7 @@ class DatePicker extends PureComponent {
 			},
 
 			formatWeekdayShort: function ( day ) {
-				return get( weekdaysMin, day, ' ' )[ 0 ];
+				return ( weekdaysMin?.[ day ] ?? ' ' )[ 0 ];
 			},
 
 			formatWeekdayLong: function ( day ) {

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -4,7 +4,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { MAP_EXISTING_DOMAIN, INCOMING_DOMAIN_TRANSFER } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -233,8 +232,8 @@ class MapDomainStep extends Component {
 		checkDomainAvailability(
 			{ domainName: domain, blogId: this.props?.selectedSite?.ID ?? null },
 			( error, result ) => {
-				const mappableStatus = get( result, 'mappable', error );
-				const status = get( result, 'status', error );
+				const mappableStatus = result?.mappable ?? error;
+				const status = result?.status ?? error;
 				const { AVAILABLE, AVAILABILITY_CHECK_ERROR, MAPPABLE, MAPPED, NOT_REGISTRABLE, UNKNOWN } =
 					domainAvailability;
 

--- a/client/components/domains/registrant-extra-info/fr-form.tsx
+++ b/client/components/domains/registrant-extra-info/fr-form.tsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { LocalizeProps, TranslateResult, localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { PureComponent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
@@ -110,7 +109,7 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 
 	render() {
 		const { ccTldDetails, translate } = this.props;
-		const registrantType = get( ccTldDetails, 'registrantType', defaultRegistrantType );
+		const registrantType = ccTldDetails?.registrantType ?? defaultRegistrantType;
 
 		return (
 			<form className="registrant-extra-info__form">
@@ -154,11 +153,8 @@ class RegistrantExtraInfoFrForm extends PureComponent< FormProps & LocalizeProps
 			ccTldDetails,
 			emptyValues
 		);
-		const validationErrors: FrDomainContactExtraDetailsErrors = get(
-			contactDetailsValidationErrors,
-			'extra.fr',
-			{}
-		);
+		const validationErrors: FrDomainContactExtraDetailsErrors =
+			contactDetailsValidationErrors?.extra?.fr ?? {};
 
 		const registrantVatIdIsNotEmpty = Boolean(
 			ccTldDetails.registrantVatId && ccTldDetails.registrantVatId !== ''

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -8,7 +8,6 @@ import { withShoppingCart } from '@automattic/shopping-cart';
 import { INCOMING_DOMAIN_TRANSFER } from '@automattic/urls';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { Component } from 'react';
@@ -343,11 +342,8 @@ class TransferDomainStep extends Component {
 	transferIsRestricted = () => {
 		const { submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
-		const transferRestrictionStatus = get(
-			this.state,
-			'inboundTransferStatus.transferRestrictionStatus',
-			false
-		);
+		const transferRestrictionStatus =
+			this.state?.inboundTransferStatus?.transferRestrictionStatus ?? false;
 
 		return (
 			! submitting && transferRestrictionStatus && 'not_restricted' !== transferRestrictionStatus
@@ -543,7 +539,7 @@ class TransferDomainStep extends Component {
 			checkDomainAvailability(
 				{ domainName: domain, blogId: this.props?.selectedSite?.ID ?? null },
 				( error, result ) => {
-					const status = get( result, 'status', error );
+					const status = result?.status ?? error;
 					const tld = result.tld || getTld( domain );
 					switch ( status ) {
 						case domainAvailability.AVAILABLE:
@@ -610,7 +606,7 @@ class TransferDomainStep extends Component {
 							} );
 							break;
 						case domainAvailability.UNKNOWN: {
-							const mappableStatus = get( result, 'mappable', error );
+							const mappableStatus = result?.mappable ?? error;
 
 							if ( domainAvailability.MAPPABLE === mappableStatus ) {
 								this.setState( {

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -5,7 +5,6 @@ import { Button, FormInputValidation, FormLabel, Gridicon } from '@automattic/co
 import { isEmpty } from '@automattic/js-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -164,7 +163,7 @@ export class RewindCredentialsForm extends Component {
 					<FormSelect
 						name="protocol"
 						id="protocol-type"
-						value={ get( this.state.form, 'protocol', 'ssh' ) }
+						value={ this.state.form?.protocol ?? 'ssh' }
 						onChange={ this.handleFieldChange }
 						disabled={ formIsSubmitting }
 					>

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -8,7 +8,6 @@ import {
 	TYPE_ARTICLE,
 } from '@automattic/social-previews';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import SeoPreviewUpgradeNudge from 'calypso/components/seo/preview-upgrade-nudge';
@@ -54,11 +53,8 @@ const getPostImage = ( post ) => {
 	}
 
 	const imgElements = parseHtml( content ).querySelectorAll( 'img' );
-	const imageUrl = get(
-		Array.from( imgElements ).find( ( { width } ) => width >= PREVIEW_IMAGE_WIDTH ),
-		'src',
-		null
-	);
+	const imageUrl =
+		Array.from( imgElements ).find( ( { width } ) => width >= PREVIEW_IMAGE_WIDTH )?.src ?? null;
 
 	return imageUrl ? `${ imageUrl }?s=${ PREVIEW_IMAGE_WIDTH }` : null;
 };
@@ -225,26 +221,20 @@ export class SeoPreviewPane extends PureComponent {
 				<div className="seo-preview-pane__preview-area">
 					<div className="seo-preview-pane__preview">
 						{ post &&
-							get(
-								{
-									wordpress: ReaderPost( site, post, frontPageMetaDescription ),
-									facebook: FacebookPost( site, post, frontPageMetaDescription ),
-									google: GooglePost( site, post, frontPageMetaDescription ),
-									x: TwitterPost( site, post, frontPageMetaDescription ),
-								},
-								selectedService,
-								ComingSoonMessage( translate )
-							) }
+							( {
+								wordpress: ReaderPost( site, post, frontPageMetaDescription ),
+								facebook: FacebookPost( site, post, frontPageMetaDescription ),
+								google: GooglePost( site, post, frontPageMetaDescription ),
+								x: TwitterPost( site, post, frontPageMetaDescription ),
+							}?.[ selectedService ] ??
+								ComingSoonMessage( translate ) ) }
 						{ ! post &&
-							get(
-								{
-									facebook: FacebookSite( site, frontPageMetaDescription ),
-									google: GoogleSite( site, frontPageMetaDescription ),
-									x: TwitterSite( site, frontPageMetaDescription ),
-								},
-								selectedService,
-								ComingSoonMessage( translate )
-							) }
+							( {
+								facebook: FacebookSite( site, frontPageMetaDescription ),
+								google: GoogleSite( site, frontPageMetaDescription ),
+								x: TwitterSite( site, frontPageMetaDescription ),
+							}?.[ selectedService ] ??
+								ComingSoonMessage( translate ) ) }
 					</div>
 				</div>
 			</div>

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -226,14 +226,14 @@ export class SeoPreviewPane extends PureComponent {
 								facebook: FacebookPost( site, post, frontPageMetaDescription ),
 								google: GooglePost( site, post, frontPageMetaDescription ),
 								x: TwitterPost( site, post, frontPageMetaDescription ),
-							}?.[ selectedService ] ??
+							}[ selectedService ] ??
 								ComingSoonMessage( translate ) ) }
 						{ ! post &&
 							( {
 								facebook: FacebookSite( site, frontPageMetaDescription ),
 								google: GoogleSite( site, frontPageMetaDescription ),
 								x: TwitterSite( site, frontPageMetaDescription ),
-							}?.[ selectedService ] ??
+							}[ selectedService ] ??
 								ComingSoonMessage( translate ) ) }
 					</div>
 				</div>

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import TitleFormatEditor from 'calypso/components/title-format-editor';
@@ -35,10 +34,10 @@ const tokenMap = {
 };
 
 const getTokensForType = ( type, translate ) => {
-	return get( tokenMap, type, [] ).reduce(
+	return ( tokenMap?.[ type ] ?? [] ).reduce(
 		( allTokens, name ) => ( {
 			...allTokens,
-			[ name ]: get( getValidTokens( translate ), name, '' ),
+			[ name ]: getValidTokens( translate )?.[ name ] ?? '',
 		} ),
 		{}
 	);
@@ -82,7 +81,7 @@ export class MetaTitleEditor extends Component {
 						onChange={ this.updateTitleFormat }
 						placeholder={ site && site.title }
 						type={ type }
-						titleFormats={ get( titleFormats, type.value, [] ) }
+						titleFormats={ titleFormats?.[ type.value ] ?? [] }
 						tokens={ getTokensForType( type.value, translate ) }
 					/>
 				) ) }

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -30,7 +30,6 @@
 //
 
 import { camelCase, mapKeys, mapValues, snakeCase } from '@automattic/js-utils';
-import { get } from 'lodash';
 
 // Right-to-left composition of unary functions. Kept local so this pure mapping
 // module doesn't take on a dependency it otherwise has no need for.
@@ -78,7 +77,7 @@ export const nativeToRaw = compose(
 	( list ) =>
 		list.map( ( p ) => ( {
 			type: p.type === 'string' ? 'string' : 'token',
-			value: get( p, 'value', snakeCase( p.type ) ),
+			value: p?.value ?? snakeCase( p.type ),
 		} ) )
 );
 

--- a/client/components/site-selector/utils.ts
+++ b/client/components/site-selector/utils.ts
@@ -1,10 +1,12 @@
-import { get } from 'lodash';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import type { UserData } from 'calypso/lib/user/user';
 
-const prependKeyForJetpackCloud = ( key: string ): string => `jetpack_${ key }`;
+type SiteCountKey = 'site_count' | 'visible_site_count';
 
-const chooseKeyForPlatform = ( key: string ): string =>
+const prependKeyForJetpackCloud = < K extends SiteCountKey >( key: K ): `jetpack_${ K }` =>
+	`jetpack_${ key }`;
+
+const chooseKeyForPlatform = < K extends SiteCountKey >( key: K ): K | `jetpack_${ K }` =>
 	isJetpackCloud() ? prependKeyForJetpackCloud( key ) : key;
 
 /**
@@ -14,7 +16,7 @@ const chooseKeyForPlatform = ( key: string ): string =>
  * @returns {number} Site count
  */
 export function getUserSiteCountForPlatform( user: UserData ): number {
-	return get( user, chooseKeyForPlatform( 'site_count' ), 0 );
+	return user?.[ chooseKeyForPlatform( 'site_count' ) ] ?? 0;
 }
 
 /**
@@ -24,5 +26,5 @@ export function getUserSiteCountForPlatform( user: UserData ): number {
  * @returns {number} Visible site count
  */
 export function getUserVisibleSiteCountForPlatform( user: UserData ): number {
-	return get( user, chooseKeyForPlatform( 'visible_site_count' ), 0 );
+	return user?.[ chooseKeyForPlatform( 'visible_site_count' ) ] ?? 0;
 }

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -197,5 +196,5 @@ export class SitesDropdown extends PureComponent {
 
 export default connect( ( state ) => ( {
 	primarySiteId: getPrimarySiteId( state ),
-	hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 1,
+	hasMultipleSites: ( getCurrentUser( state )?.site_count ?? 1 ) > 1,
 } ) )( SitesDropdown );

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,5 +1,4 @@
 import { omit } from '@automattic/js-utils';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
@@ -27,7 +26,7 @@ class SortedGrid extends PureComponent {
 		for ( let i = 0; i < this.props.items.length; i += this.props.itemsPerRow ) {
 			const row = this.props.items.slice( i, i + this.props.itemsPerRow );
 			const groups = row.map( this.props.getItemGroup ).reduce( ( results, group ) => {
-				results[ group ] = get( results, group, 0 ) + 1;
+				results[ group ] = ( results?.[ group ] ?? 0 ) + 1;
 				return results;
 			}, {} );
 

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -1,5 +1,5 @@
 import { convertFromRaw, convertToRaw } from 'draft-js';
-import { get, matchesProperty } from 'lodash';
+import { matchesProperty } from 'lodash';
 import { compose } from 'redux';
 
 /*
@@ -131,7 +131,7 @@ export const mapTokenTitleForEditor = ( title ) => `\u205f\u205f${ title }\u205f
  * @param {Object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
  * @returns {string} translated chip name
  */
-const tokenTitle = ( type, tokens ) => mapTokenTitleForEditor( get( tokens, type, '' ).trim() );
+const tokenTitle = ( type, tokens ) => mapTokenTitleForEditor( ( tokens?.[ type ] ?? '' ).trim() );
 
 /**
  * Creates a new entity reference for a blockMap

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import SocialLogo from 'calypso/components/social-logo';
 
@@ -26,7 +25,7 @@ const noop = () => {};
 export const SocialItem = ( props ) => {
 	const { isSelected = false, onClick = noop, service, translate } = props;
 
-	const { icon, label } = get( services( translate ), service );
+	const { icon, label } = services( translate )?.[ service ] ?? {};
 	const classes = clsx( 'vertical-menu__social-item', 'vertical-menu__items', {
 		'is-selected': isSelected,
 	} );

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { Button, Card, Dialog, Gridicon } from '@automattic/components';
 import debugModule from 'debug';
 import { localize, fixMe } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -200,7 +199,7 @@ class JetpackSsoForm extends Component {
 				url: this.props?.blogDetails?.URL ?? '',
 				admin_url: this.props?.blogDetails?.admin_url ?? '',
 				domain: this.props?.blogDetails?.domain ?? '',
-				icon: get( this.props, 'blogDetails.icon', { img: '', ico: '' } ),
+				icon: this.props?.blogDetails?.icon ?? { img: '', ico: '' },
 				is_vip: false,
 				title: decodeEntities( this.props?.blogDetails?.title ?? '' ),
 			};

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { addLocaleToPath, isDefaultLocale } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
-import { get } from 'lodash';
 import {
 	isAkismetOAuth2Client,
 	isCrowdsignalOAuth2Client,
@@ -97,7 +96,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	}
 
 	if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
-		const gravatarFrom = get( currentQuery, 'gravatar_from', 'signup' );
+		const gravatarFrom = currentQuery?.gravatar_from ?? 'signup';
 
 		// Gravatar powered clients signup via the magic login page
 		return login( {

--- a/client/lib/make-json-schema-parser/index.js
+++ b/client/lib/make-json-schema-parser/index.js
@@ -1,5 +1,4 @@
 import schemaValidator from 'is-my-json-valid';
-import { get } from 'lodash';
 
 export class SchemaError extends Error {
 	constructor( errors ) {
@@ -70,7 +69,7 @@ export function makeJsonSchemaParser(
 							message: error.message,
 							value: error.value,
 							actualType: error.type,
-							expectedType: get( schema, error.schemaPath ),
+							expectedType: error.schemaPath?.reduce( ( node, key ) => node?.[ key ], schema ),
 						} )
 					);
 

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -88,8 +88,13 @@ export default class PostQueryManager extends PaginatedQueryManager {
 
 					return true;
 
-				case 'author':
-					return ( post?.author?.ID ?? post.author ) === value;
+				case 'author': {
+					// Use the nested `author.ID` whenever it exists — even when it is
+					// `null` — and only fall back to `author` itself (which may be a
+					// bare id) when there is no `ID`.
+					const authorId = post?.author?.ID;
+					return ( authorId === undefined ? post.author : authorId ) === value;
+				}
 
 				case 'status':
 					return (

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import moment from 'moment';
 import PaginatedQueryManager from '../paginated';
 import { DEFAULT_POST_QUERY } from './constants';
@@ -90,7 +89,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 					return true;
 
 				case 'author':
-					return get( post, 'author.ID', post.author ) === value;
+					return ( post?.author?.ID ?? post.author ) === value;
 
 				case 'status':
 					return (

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -717,6 +717,20 @@ describe( 'PostQueryManager', () => {
 
 				expect( isMatch ).toBe( true );
 			} );
+
+			test( 'should preserve a null nested author.ID rather than falling back to the author object', () => {
+				const postWithNullAuthorId = Object.assign( {}, DEFAULT_POST, {
+					author: { ID: null },
+				} );
+				const isMatch = PostQueryManager.matches(
+					{
+						author: null,
+					},
+					postWithNullAuthorId
+				);
+
+				expect( isMatch ).toBe( true );
+			} );
 		} );
 
 		describe( 'query.status', () => {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -9,7 +9,6 @@ import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { pick, isEmpty } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { get } from 'lodash';
 import { buildUpgradeFunction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import {
@@ -159,7 +158,7 @@ export const getNewSiteParams = ( {
 		themeSlugWithRepo ||
 		( signupDependencies?.themeSlugWithRepo ?? false );
 
-	const launchAsComingSoon = get( signupDependencies, 'comingSoon', 1 );
+	const launchAsComingSoon = signupDependencies?.comingSoon ?? 1;
 
 	// We will use the default annotation instead of theme annotation as fallback,
 	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
@@ -210,7 +209,7 @@ export const getNewSiteParams = ( {
 };
 
 function saveToLocalStorageAndProceed( state, domainItem, themeItem, newSiteParams, callback ) {
-	const cartItem = get( getSignupDependencyStore( state ), 'cartItem', undefined );
+	const cartItem = getSignupDependencyStore( state )?.cartItem;
 	const newCartItems = [ cartItem, domainItem ].filter( ( item ) => item );
 
 	const newCartItemsToAdd = newCartItems.map( ( item ) =>
@@ -261,10 +260,10 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	const state = reduxStore.getState();
 	const bearerToken = getSignupDependencyStore( state )?.bearer_token ?? null;
 
-	const isManageSiteFlow = get( getSignupDependencyStore( state ), 'isManageSiteFlow', false );
+	const isManageSiteFlow = getSignupDependencyStore( state )?.isManageSiteFlow ?? false;
 
 	if ( isManageSiteFlow ) {
-		const siteSlug = get( getSignupDependencyStore( state ), 'siteSlug', undefined );
+		const siteSlug = getSignupDependencyStore( state )?.siteSlug;
 		const siteId = getSiteId( state, siteSlug );
 		const providedDependencies = { domainItem, siteId, siteSlug, themeItem };
 		addDomainToCart( callback, dependencies, stepData, reduxStore, siteSlug, providedDependencies );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -6,7 +6,6 @@ import { ExternalLink } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import debugFactory from 'debug';
 import { fixMe, localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -137,13 +136,12 @@ class Account extends Component {
 
 	getUserSetting( settingName ) {
 		return (
-			get( this.props.unsavedUserSettings, settingName ) ??
-			this.getUserOriginalSetting( settingName )
+			this.props.unsavedUserSettings?.[ settingName ] ?? this.getUserOriginalSetting( settingName )
 		);
 	}
 
 	getUserOriginalSetting( settingName ) {
-		return get( this.props.userSettings, settingName );
+		return this.props.userSettings?.[ settingName ];
 	}
 
 	hasUnsavedUserSetting( settingName ) {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -8,7 +8,6 @@ import { useQuery } from '@tanstack/react-query';
 import { Page } from '@wordpress/admin-ui';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment, createRef } from 'react';
 import { connect, useSelector } from 'react-redux';
@@ -446,7 +445,7 @@ class ActivityLog extends Component {
 			[ 'queued', 'running' ].includes( this.props?.restoreProgress?.status ) ||
 			( ! isAtomic && areCredentialsInvalid ) ||
 			'active' !== rewindState.state;
-		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
+		const disableBackup = 0 <= ( this.props?.backupProgress?.progress ?? -Infinity );
 
 		const pageCount = Math.ceil( logs.length / PAGE_SIZE );
 		const actualPage = Math.max( 1, Math.min( requestedPage, pageCount ) );

--- a/client/my-sites/checkout/src/test/wpcom-store-state.ts
+++ b/client/my-sites/checkout/src/test/wpcom-store-state.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { get } from 'lodash';
 import {
 	updateManagedContactDetailsShape,
 	mapManagedContactDetailsShape,
@@ -7,25 +6,38 @@ import {
 } from '../types/wpcom-store-state';
 import type { ManagedContactDetailsShape } from '@automattic/wpcom-checkout';
 
+// Reads a value at a lodash-style dotted path (e.g. `extra.ca.lang`).
+const getPath = ( object, accessor ) =>
+	accessor.split( '.' ).reduce( ( value, key ) => value?.[ key ], object );
+
 describe( 'updateManagedContactDetailsShape', function () {
 	const testPropertyWithAccessor = ( merge, construct, update, data ) => ( accessor ) => {
-		const value = get(
+		const value = getPath(
 			updateManagedContactDetailsShape( merge, construct, update, data ),
 			accessor
 		);
-		if ( get( update, accessor ) !== undefined && get( data, accessor ) !== undefined ) {
+		if ( getPath( update, accessor ) !== undefined && getPath( data, accessor ) !== undefined ) {
 			it( 'update.A and data.A are both defined at ' + accessor, function () {
-				expect( value ).toEqual( merge( get( update, accessor ), get( data, accessor ) ) );
+				expect( value ).toEqual( merge( getPath( update, accessor ), getPath( data, accessor ) ) );
 			} );
-		} else if ( get( update, accessor ) !== undefined && get( data, accessor ) === undefined ) {
+		} else if (
+			getPath( update, accessor ) !== undefined &&
+			getPath( data, accessor ) === undefined
+		) {
 			it( 'update.A is defined, data.A is undefined at ' + accessor, function () {
-				expect( value ).toEqual( construct( get( update, accessor ) ) );
+				expect( value ).toEqual( construct( getPath( update, accessor ) ) );
 			} );
-		} else if ( get( update, accessor ) === undefined && get( data, accessor ) !== undefined ) {
+		} else if (
+			getPath( update, accessor ) === undefined &&
+			getPath( data, accessor ) !== undefined
+		) {
 			it( 'data.A is defined, update.A is undefined at ' + accessor, function () {
-				expect( value ).toEqual( get( data, accessor ) );
+				expect( value ).toEqual( getPath( data, accessor ) );
 			} );
-		} else if ( get( update, accessor ) === undefined && get( data, accessor ) === undefined ) {
+		} else if (
+			getPath( update, accessor ) === undefined &&
+			getPath( data, accessor ) === undefined
+		) {
 			it( 'data.A and update.A are both undefined at ' + accessor, function () {
 				expect( value ).toBeUndefined();
 			} );
@@ -208,12 +220,12 @@ describe( 'updateManagedContactDetailsShape', function () {
 
 describe( 'mapManagedContactDetailsShape', function () {
 	const testPropertyWithAccessor = ( f, data ) => ( accessor ) => {
-		const value = get( mapManagedContactDetailsShape( f, data ), accessor );
-		if ( get( data, accessor ) !== undefined ) {
+		const value = getPath( mapManagedContactDetailsShape( f, data ), accessor );
+		if ( getPath( data, accessor ) !== undefined ) {
 			it( 'data.A is defined at ' + accessor, function () {
-				expect( value ).toEqual( f( get( data, accessor ) ) );
+				expect( value ).toEqual( f( getPath( data, accessor ) ) );
 			} );
-		} else if ( get( data, accessor ) === undefined ) {
+		} else if ( getPath( data, accessor ) === undefined ) {
 			it( 'data.A is undefined at ' + accessor, function () {
 				expect( value ).toBeUndefined();
 			} );

--- a/client/my-sites/checkout/src/test/wpcom-store-state.ts
+++ b/client/my-sites/checkout/src/test/wpcom-store-state.ts
@@ -6,7 +6,7 @@ import {
 } from '../types/wpcom-store-state';
 import type { ManagedContactDetailsShape } from '@automattic/wpcom-checkout';
 
-// Reads a value at a lodash-style dotted path (e.g. `extra.ca.lang`).
+// Reads a value at a dotted path (e.g. `extra.ca.lang`).
 const getPath = ( object, accessor ) =>
 	accessor.split( '.' ).reduce( ( value, key ) => value?.[ key ], object );
 

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -1,7 +1,6 @@
 import { Button, Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -55,7 +54,7 @@ class EmailVerificationCard extends Component {
 
 		resendVerification( selectedDomainName, ( error ) => {
 			if ( error ) {
-				const message = get( error, 'message', errorMessage );
+				const message = error?.message ?? errorMessage;
 				this.props.errorNotice( message );
 			} else if ( compact ) {
 				this.props.successNotice(

--- a/client/my-sites/earn/paid-subscriptions/index.tsx
+++ b/client/my-sites/earn/paid-subscriptions/index.tsx
@@ -49,7 +49,7 @@ const PaidSubscriptionsSection = ( { query }: PaidSubscriptionsSectionProps ) =>
 	const paid_subscriptions = useSelector(
 		( state ) => getOwnershipsForSiteId( state, site?.ID ),
 		shallowEqual
-	);
+	) as Record< string, PaidSubscription >;
 
 	const totalSubscribers = useSelector( ( state ) =>
 		getTotalSubscribersForSiteId( state, site?.ID )

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -785,7 +785,7 @@ export const connector = connect(
 			isTargetSiteAtomic: !! isSiteAutomatedTransfer( state, targetSiteId ),
 			isTargetSiteJetpack: !! isJetpackSite( state, targetSiteId ),
 			sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
-			startMigration: !! ( getCurrentQueryArguments( state )?.start ?? false ),
+			startMigration: !! getCurrentQueryArguments( state )?.start,
 			sourceSiteHasJetpack: false,
 			targetSite: getSelectedSite( state ),
 			targetSiteId,

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -9,7 +9,6 @@ import page from '@automattic/calypso-router';
 import { Button, Card, CompactCard, ProgressBar, Gridicon, Spinner } from '@automattic/components';
 import { omit, isEmpty } from '@automattic/js-utils';
 import { getLocaleSlug, localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import moment from 'moment';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -72,7 +71,7 @@ export class SectionMigrate extends Component {
 
 	componentDidMount() {
 		const { targetSite, targetSiteId, targetSiteSlug, sourceSite, sourceSiteId } = this.props;
-		const sourceSiteUrl = get( sourceSite, 'URL', sourceSiteId );
+		const sourceSiteUrl = sourceSite?.URL ?? sourceSiteId;
 		clearMigrationStatus();
 
 		if ( this.isNonAtomicJetpack() ) {
@@ -773,7 +772,7 @@ export class SectionMigrate extends Component {
 const navigateToSelectedSourceSite = ( sourceSiteId ) => ( dispatch, getState ) => {
 	const state = getState();
 	const sourceSite = getSite( state, sourceSiteId );
-	const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
+	const sourceSiteSlug = sourceSite?.slug ?? sourceSiteId;
 	const targetSiteSlug = getSelectedSiteSlug( state );
 
 	page( `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }` );
@@ -786,7 +785,7 @@ export const connector = connect(
 			isTargetSiteAtomic: !! isSiteAutomatedTransfer( state, targetSiteId ),
 			isTargetSiteJetpack: !! isJetpackSite( state, targetSiteId ),
 			sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
-			startMigration: !! get( getCurrentQueryArguments( state ), 'start', false ),
+			startMigration: !! ( getCurrentQueryArguments( state )?.start ?? false ),
 			sourceSiteHasJetpack: false,
 			targetSite: getSelectedSite( state ),
 			targetSiteId,

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -9,7 +9,6 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -38,8 +37,8 @@ class StepConfirmMigration extends Component {
 		const { sourceSite, startMigration, targetSiteSlug, targetSite } = this.props;
 		const sourceSiteId = sourceSite?.ID;
 		const targetSiteId = targetSite?.ID;
-		const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
-		const sourceSiteUrl = get( sourceSite, 'URL', sourceSiteId );
+		const sourceSiteSlug = sourceSite?.slug ?? sourceSiteId;
+		const sourceSiteUrl = sourceSite?.URL ?? sourceSiteId;
 
 		const hasCompatiblePlan = this.isTargetSitePlanCompatible();
 

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Button, Card, CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -62,7 +61,7 @@ class StepSourceSelect extends Component {
 						url: result.site_url,
 						engine: result.site_engine,
 						has_jetpack: !! ( result?.site_meta?.jetpack_version ?? false ),
-						jetpack_version: get( result, 'site_meta.jetpack_version', 'no jetpack' ),
+						jetpack_version: result?.site_meta?.jetpack_version ?? 'no jetpack',
 						is_wpcom: result?.site_meta?.wpcom_site ?? false,
 					} );
 

--- a/client/my-sites/purchase-product/controller.jsx
+++ b/client/my-sites/purchase-product/controller.jsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import Debug from 'debug';
-import { get } from 'lodash';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { login } from 'calypso/lib/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -40,7 +39,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 		},
 	};
 
-	return get( planSlugs, [ interval, type ], '' );
+	return planSlugs?.[ interval ]?.[ type ] ?? '';
 };
 
 export function redirectToLogin( context, next ) {
@@ -83,7 +82,7 @@ export function setMasterbar( context, next ) {
 export function purchase( context, next ) {
 	const { path, pathname, params, query } = context;
 	const { type = false, interval } = params;
-	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
+	const analyticsPageTitle = analyticsPageTitleByType?.[ type ] ?? 'Jetpack Connect';
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 
 	planSlug && storePlan( planSlug );

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -1,7 +1,6 @@
 import { Button, FormInputValidation, ExternalLink } from '@automattic/components';
 import { omit } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -98,11 +97,8 @@ class SiteVerification extends Component {
 		const stateItems = {};
 
 		supportedServices.forEach( ( service ) => {
-			stateItems[ service.slug ] = get(
-				site,
-				`options.verification_services_codes.${ service.slug }`,
-				''
-			);
+			stateItems[ service.slug ] =
+				site?.options?.verification_services_codes?.[ service.slug ] ?? '';
 		} );
 		stateItems.isFetchingSettings = site?.fetchingSettings ?? false;
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -2,7 +2,6 @@ import { omit, pick } from '@automattic/js-utils';
 import debugFactory from 'debug';
 import isEqual from 'fast-deep-equal/es6';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose, bindActionCreators } from 'redux';
@@ -114,7 +113,11 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			const launchpadTasksToComplete = [];
 
 			Object.entries( FIELDS_TO_LAUNCHPAD_TASKS ).forEach( ( [ field, taskSlugs ] ) => {
-				if ( get( this.state.modifiedFields, field ) ) {
+				// `field` can be a dotted path (e.g. `subscription_options.welcome`)
+				// into the nested `modifiedFields` map, so walk each segment.
+				if (
+					field.split( '.' ).reduce( ( value, key ) => value?.[ key ], this.state.modifiedFields )
+				) {
 					const slugs = Array.isArray( taskSlugs ) ? taskSlugs : [ taskSlugs ];
 					launchpadTasksToComplete.push( ...slugs );
 				}

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -2,7 +2,6 @@ import { ComponentSwapper, SegmentedControl, SelectDropdown } from '@automattic/
 import { Icon, lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { compose } from 'redux';
@@ -172,7 +171,7 @@ export const StatsModuleSummaryLinks = ( props ) => {
 		},
 	];
 
-	const numberDays = get( query, 'num', '0' );
+	const numberDays = query?.num ?? '0';
 	let selected = options.find( ( option ) => option.value === numberDays );
 	selected = selected || options[ 0 ];
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -14,7 +14,6 @@ import {
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
 import express from 'express';
-import { get } from 'lodash';
 import { stringify } from 'qs';
 // eslint-disable-next-line no-restricted-imports
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
@@ -1040,7 +1039,7 @@ function wpcomPages( app ) {
 
 			ctx.clientData = config.clientData;
 			ctx.domainsLandingData = {
-				action: get( req, [ 'params', 'action' ], 'unknown-action' ),
+				action: req?.params?.action ?? 'unknown-action',
 				query: req?.query ?? {},
 			};
 

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -1,6 +1,5 @@
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -179,7 +178,7 @@ export default connect(
 		const originSiteName = site?.name ?? '';
 
 		return {
-			originBlogId: get( site, 'ID', -Infinity ),
+			originBlogId: site?.ID ?? -Infinity,
 			originSiteName,
 			originSiteSlug,
 		};

--- a/client/sites/logs/hooks/use-site-logs-downloader.ts
+++ b/client/sites/logs/hooks/use-site-logs-downloader.ts
@@ -1,6 +1,5 @@
 import { isEmpty } from '@automattic/js-utils';
 import { useTranslate } from 'i18n-calypso';
-import { get } from 'lodash';
 import { useReducer } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { FilterType, LogType } from 'calypso/data/hosting/use-site-logs-query';
@@ -186,7 +185,7 @@ export const useSiteLogsDownloader = ( {
 					}
 				)
 				.then( ( response: LogsAPIResponse ) => {
-					const newLogData = get( response, 'data.logs', [] );
+					const newLogData = response?.data?.logs ?? [];
 					scrollId = response?.data?.scroll_id ?? null;
 
 					if ( isEmpty( logs ) ) {
@@ -199,7 +198,7 @@ export const useSiteLogsDownloader = ( {
 									.filter( ( key ) => key !== 'atomic_site_id' )
 									.join( ',' ) + '\n',
 							];
-							totalLogs = get( response, 'data.total_results', 1 );
+							totalLogs = response?.data?.total_results ?? 1;
 						}
 					}
 
@@ -227,7 +226,7 @@ export const useSiteLogsDownloader = ( {
 				} )
 				.catch( ( error: { message: string; status: number } ) => {
 					isError = true;
-					let message = get( error, 'message', 'Could not retrieve logs.' );
+					let message = error?.message ?? 'Could not retrieve logs.';
 					if ( error?.status === 500 ) {
 						message = translate( 'Could not retrieve logs. Please try again in a few minutes.' );
 					} else if ( error?.status === 400 ) {

--- a/client/state/automated-transfer/selectors/index.ts
+++ b/client/state/automated-transfer/selectors/index.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getAutomatedTransfer } from 'calypso/state/automated-transfer/selectors/get-automated-transfer';
 import type { AppState } from 'calypso/types';
 
@@ -39,7 +38,7 @@ export interface EligibilityData {
  * @returns eligibility information for site
  */
 export const getEligibilityData = ( state: AppState ): EligibilityData =>
-	get( state, 'eligibility', { lastUpdate: 0 } );
+	state?.eligibility ?? { lastUpdate: 0 };
 
 /**
  * Returns eligibility info for transfer
@@ -56,7 +55,7 @@ export const getEligibility = ( state: AppState, siteId: number | null ) =>
  * @returns {boolean} eligibility status for site
  */
 export const getEligibilityStatus = ( state: AppState ): boolean =>
-	!! get( state, 'lastUpdate', 0 ) && ! get( state, 'eligibilityHolds', [] ).length;
+	!! ( state?.lastUpdate ?? 0 ) && ! ( state?.eligibilityHolds ?? [] ).length;
 
 /**
  * Returns eligibility status for transfer

--- a/client/state/automated-transfer/selectors/index.ts
+++ b/client/state/automated-transfer/selectors/index.ts
@@ -55,7 +55,7 @@ export const getEligibility = ( state: AppState, siteId: number | null ) =>
  * @returns {boolean} eligibility status for site
  */
 export const getEligibilityStatus = ( state: AppState ): boolean =>
-	!! ( state?.lastUpdate ?? 0 ) && ! ( state?.eligibilityHolds ?? [] ).length;
+	!! state?.lastUpdate && ! state?.eligibilityHolds?.length;
 
 /**
  * Returns eligibility status for transfer

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,7 +1,6 @@
 import { omit, orderBy } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { get } from 'lodash';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,
@@ -311,7 +310,7 @@ export const fetchStatus = ( state = {}, action ) => {
 				direction === 'before' ? 'hasReceivedBefore' : 'hasReceivedAfter';
 
 			const nextState = {
-				...get( state, stateKey, fetchStatusInitialState ),
+				...( state?.[ stateKey ] ?? fetchStatusInitialState ),
 				[ direction ]: action.comments.length === NUMBER_OF_COMMENTS_PER_FETCH,
 				[ hasReceivedDirection ]: true,
 			};

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -14,8 +13,8 @@ const deepUpdateComments = ( state, comments, query ) => {
 	const parent = postId || 'site';
 	const filter = getFiltersKey( query );
 
-	const parentObject = get( state, parent, {} );
-	const filterObject = get( parentObject, filter, {} );
+	const parentObject = state?.[ parent ] ?? {};
+	const filterObject = parentObject?.[ filter ] ?? {};
 
 	return {
 		...state,

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -1,6 +1,5 @@
 import { extendAction } from '@automattic/state-utils';
 import debugModule from 'debug';
-import { get } from 'lodash';
 import wpcom, { wpcomJetpackLicensing } from 'calypso/lib/wp';
 import { WPCOM_HTTP_REQUEST } from 'calypso/state/action-types';
 import {
@@ -21,13 +20,11 @@ const debug = debugModule( 'calypso:data-layer:wpcom-http' );
 const fetcherMap = function ( method, fetcher = 'wpcom' ) {
 	const req = 'wpcomJetpackLicensing' === fetcher ? wpcomJetpackLicensing.req : wpcom.req;
 
-	return get(
+	return (
 		{
 			GET: req.get.bind( req ),
 			POST: req.post.bind( req ),
-		},
-		method,
-		null
+		}?.[ method ] ?? null
 	);
 };
 
@@ -58,7 +55,7 @@ export const queueRequest =
 			query = {},
 		} = action;
 		const { responseType, isLocalApiCall } = options || {};
-		const fetcher = get( options, 'options.fetcher', 'wpcom' );
+		const fetcher = options?.options?.fetcher ?? 'wpcom';
 
 		const onStreamRecord =
 			rawOnStreamRecord &&

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -24,7 +24,7 @@ const fetcherMap = function ( method, fetcher = 'wpcom' ) {
 		{
 			GET: req.get.bind( req ),
 			POST: req.post.bind( req ),
-		}?.[ method ] ?? null
+		}[ method ] ?? null
 	);
 };
 

--- a/client/state/data-layer/wpcom/domains/privacy/index.js
+++ b/client/state/data-layer/wpcom/domains/privacy/index.js
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import {
 	DOMAIN_PRIVACY_ENABLE,
 	DOMAIN_PRIVACY_DISABLE,
@@ -62,11 +61,8 @@ const handleDomainPrivacySettingsSuccess =
 const handleDomainPrivacySettingsFailure =
 	( type ) =>
 	( { siteId, domain }, data ) => {
-		const notice = get(
-			data,
-			'message',
-			translate( 'Unknown error when updating the domain privacy settings' )
-		);
+		const notice =
+			data?.message ?? translate( 'Unknown error when updating the domain privacy settings' );
 		return [
 			{
 				type: type,

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { parseActivityLogEntryContent } from 'calypso/dashboard/components/logs-activity-formatted-block/api-core-parser';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
 import apiResponseSchema from './schema';
@@ -15,7 +14,7 @@ export const DEFAULT_GRIDICON = 'info-outline';
  * @returns {Object}             Object with an entry for proccessed item objects and another for oldest item timestamp
  */
 export function transformer( apiResponse ) {
-	return get( apiResponse, [ 'current', 'orderedItems' ], [] ).map( processItem );
+	return ( apiResponse?.current?.orderedItems ?? [] ).map( processItem );
 }
 
 /**
@@ -43,7 +42,7 @@ export function processItem( item ) {
 	return Object.assign(
 		{
 			/* activity actor */
-			actorAvatarUrl: get( actor, 'icon.url', DEFAULT_GRAVATAR_URL ),
+			actorAvatarUrl: actor?.icon?.url ?? DEFAULT_GRAVATAR_URL,
 			actorName: actor?.name ?? '',
 			actorRemoteId: actor?.external_user_id ?? 0,
 			actorRole: actor?.role ?? '',
@@ -55,7 +54,7 @@ export function processItem( item ) {
 			/* base activity info */
 			activityDate,
 			activityGroup: ( item.name || '' ).split( '__', 1 )[ 0 ], // split always returns at least one item
-			activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
+			activityIcon: item?.gridicon ?? DEFAULT_GRIDICON,
 			activityId: item.activity_id,
 			activityIsRewindable: item.is_rewindable,
 			activityName: item.name,

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -1,5 +1,4 @@
 import { isEmpty } from '@automattic/js-utils';
-import { get } from 'lodash';
 import { AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST } from 'calypso/state/action-types';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { updateEligibility } from 'calypso/state/automated-transfer/actions';
@@ -47,7 +46,7 @@ export const eligibilityHoldsFromApi = ( { errors = [] }, options = {} ) =>
 			if ( options.sitePrivateUnlaunched && code === 'site_private' ) {
 				return eligibilityHolds.SITE_UNLAUNCHED;
 			}
-			return get( statusMapping, code, '' );
+			return statusMapping?.[ code ] ?? '';
 		} )
 		.filter( Boolean );
 

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -1,6 +1,5 @@
 import { groupBy, omit } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_LIST_REQUEST,
@@ -73,7 +72,7 @@ const announceStatusChangeFailure = ( action ) => ( dispatch ) => {
 	const defaultErrorMessage = translate( "We couldn't update this comment." );
 
 	dispatch(
-		errorNotice( get( errorMessage, status, defaultErrorMessage ), {
+		errorNotice( errorMessage?.[ status ] ?? defaultErrorMessage, {
 			button: translate( 'Try again' ),
 			id: `comment-notice-error-${ commentId }`,
 			onClick: () =>

--- a/client/state/domains/management/selectors.js
+++ b/client/state/domains/management/selectors.js
@@ -1,9 +1,7 @@
-import { get } from 'lodash';
-
 import 'calypso/state/domains/init';
 
 export function isUpdatingWhois( state, domain ) {
-	return get( state, [ 'domains', 'management', 'isSaving', `${ domain }`, 'saving' ], false );
+	return state?.domains?.management?.isSaving?.[ `${ domain }` ]?.saving ?? false;
 }
 
 export function getWhoisData( state, domain ) {
@@ -14,11 +12,7 @@ export function getWhoisSaveError( state, domain ) {
 	const status = state?.domains?.management?.isSaving?.[ `${ domain }` ]?.status ?? null;
 
 	if ( ! isUpdatingWhois( state, domain ) && 'error' === status ) {
-		return get(
-			state,
-			[ 'domains', 'management', 'isSaving', `${ domain }`, 'error' ],
-			'unknown error'
-		);
+		return state?.domains?.management?.isSaving?.[ `${ domain }` ]?.error ?? 'unknown error';
 	}
 
 	return null;

--- a/client/state/editor/selectors.ts
+++ b/client/state/editor/selectors.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getEditedPost } from 'calypso/state/posts/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
@@ -63,7 +62,7 @@ export function getEditorPath(
 		return 'post';
 	}
 	const editedPost = getEditedPost( state, siteId, postId );
-	const type = get( editedPost, 'type', defaultType );
+	const type = editedPost?.type ?? defaultType;
 	let path = getEditorNewPostPath( state, siteId, type );
 
 	if ( postId ) {

--- a/client/state/google-my-business/ui/selectors.js
+++ b/client/state/google-my-business/ui/selectors.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/google-my-business/init';
 
 /**
@@ -11,5 +9,5 @@ import 'calypso/state/google-my-business/init';
  * @returns {string} interval 'week' | 'month' | 'quarter'
  */
 export function getStatsInterval( state, siteId, statType ) {
-	return get( state.googleMyBusiness, [ siteId, 'statsInterval', statType ], 'week' );
+	return state.googleMyBusiness?.[ siteId ]?.statsInterval?.[ statType ] ?? 'week';
 }

--- a/client/state/login/utils.jsx
+++ b/client/state/login/utils.jsx
@@ -1,7 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { omit } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import { lostPassword } from 'calypso/lib/paths';
 
 export function getSMSMessageFromResponse( response ) {
@@ -117,7 +116,7 @@ export function getErrorFromHTTPError( httpError ) {
 	let message = httpError?.response?.body?.data?.errors?.[ 0 ]?.message;
 
 	if ( ! message ) {
-		message = get( httpError, 'response.body.data', httpError.message );
+		message = httpError?.response?.body?.data ?? httpError.message;
 	}
 
 	return { code, message, field };

--- a/client/state/memberships/settings/reducer.js
+++ b/client/state/memberships/settings/reducer.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { MEMBERSHIPS_SETTINGS_RECEIVE } from '../../action-types';
 
 export default ( state = {}, action ) => {
@@ -8,11 +7,8 @@ export default ( state = {}, action ) => {
 				...state,
 
 				[ action.siteId ]: {
-					isConnected: get(
-						action,
-						'data.is_connected',
-						( action?.data?.connected_account_id ?? null ) > 0
-					),
+					isConnected:
+						action?.data?.is_connected ?? ( action?.data?.connected_account_id ?? null ) > 0,
 					connectedAccountDescription: action?.data?.connected_account_description ?? null,
 					connectedAccountDefaultCurrency: action?.data?.connected_account_default_currency ?? null,
 					connectedAccountMinimumCurrency: action?.data?.connected_account_minimum_currency ?? null,

--- a/client/state/memberships/subscribers/selectors.js
+++ b/client/state/memberships/subscribers/selectors.js
@@ -1,13 +1,11 @@
-import { get } from 'lodash';
-
 import 'calypso/state/memberships/init';
 
 const emptyObject = {};
 
 export function getTotalSubscribersForSiteId( state, siteId ) {
-	return get( state, [ 'memberships', 'subscribers', 'list', siteId, 'total' ], 0 );
+	return state?.memberships?.subscribers?.list?.[ siteId ]?.total ?? 0;
 }
 
 export function getOwnershipsForSiteId( state, siteId ) {
-	return get( state, [ 'memberships', 'subscribers', 'list', siteId, 'ownerships' ], emptyObject );
+	return state?.memberships?.subscribers?.list?.[ siteId ]?.ownerships ?? emptyObject;
 }

--- a/client/state/reader/site-blocks/selectors/get-site-blocks-current-page.js
+++ b/client/state/reader/site-blocks/selectors/get-site-blocks-current-page.js
@@ -1,9 +1,7 @@
-import { get } from 'lodash';
-
 import 'calypso/state/reader/init';
 
 export const getSiteBlocksCurrentPage = ( state ) => {
-	const page = get( state, [ 'reader', 'siteBlocks', 'currentPage' ], 1 );
+	const page = state?.reader?.siteBlocks?.currentPage ?? 1;
 
 	if ( ! page ) {
 		return 1;

--- a/client/state/selectors/get-jetpack-credentials-update-status.js
+++ b/client/state/selectors/get-jetpack-credentials-update-status.js
@@ -1,7 +1,5 @@
-import { get } from 'lodash';
-
 import 'calypso/state/jetpack/init';
 
 export default function getJetpackCredentialsUpdateStatus( state, siteId ) {
-	return get( state, [ 'jetpack', 'credentials', 'updateRequestStatus', siteId ], 'unsubmitted' );
+	return state?.jetpack?.credentials?.updateRequestStatus?.[ siteId ] ?? 'unsubmitted';
 }

--- a/client/state/signup/dependency-store/selectors.js
+++ b/client/state/signup/dependency-store/selectors.js
@@ -1,12 +1,10 @@
-import { get } from 'lodash';
-
 import 'calypso/state/signup/init';
 
 const initialState = {};
 export function getSignupDependencyStore( state ) {
-	return get( state, 'signup.dependencyStore', initialState );
+	return state?.signup?.dependencyStore ?? initialState;
 }
 
 export function getSignupDependencyProgress( state ) {
-	return get( state, 'signup.progress', initialState );
+	return state?.signup?.progress ?? initialState;
 }

--- a/client/state/signup/progress/selectors.ts
+++ b/client/state/signup/progress/selectors.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
 import { ProgressState } from './schema';
 import 'calypso/state/signup/init';
@@ -6,7 +5,7 @@ import 'calypso/state/signup/init';
 const initialState: ProgressState = {};
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getSignupProgress( state: any ): ProgressState {
-	return get( state, 'signup.progress', initialState );
+	return state?.signup?.progress ?? initialState;
 }
 
 /**

--- a/client/state/stats/chart-tabs/selectors.js
+++ b/client/state/stats/chart-tabs/selectors.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { QUERY_FIELDS } from 'calypso/state/stats/chart-tabs/constants';
 
 import 'calypso/state/stats/init';
@@ -17,7 +16,7 @@ const EMPTY_RESULT = [];
 export function getCountRecords( state, siteId, date, period, quantity ) {
 	const requestKey = `${ date }-${ period }-${ quantity }`;
 
-	return get( state, [ 'stats', 'chartTabs', 'counts', siteId, requestKey ], EMPTY_RESULT );
+	return state?.stats?.chartTabs?.counts?.[ siteId ]?.[ requestKey ] ?? EMPTY_RESULT;
 }
 
 /**

--- a/client/state/stats/emails/selectors.js
+++ b/client/state/stats/emails/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { get } from 'lodash';
 import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import 'calypso/state/stats/init';
 
@@ -33,11 +32,10 @@ function getDataPath( siteId, postId, period, statType, date = null ) {
  */
 export function isRequestingEmailStats( state, siteId, postId, period, statType, date ) {
 	return state.stats.emails
-		? get(
-				state.stats.emails.requests,
-				[ ...getDataPath( siteId, postId, period, statType, date ), 'requesting' ],
-				false
-		  )
+		? [ ...getDataPath( siteId, postId, period, statType, date ), 'requesting' ].reduce(
+				( value, key ) => value?.[ key ],
+				state.stats.emails.requests
+		  ) ?? false
 		: false;
 }
 
@@ -54,11 +52,11 @@ export function isRequestingEmailStats( state, siteId, postId, period, statType,
  * @returns {boolean}        Whether email stat is being requested
  */
 export function shouldShowLoadingIndicator( state, siteId, postId, period, statType, date, path ) {
-	const stats = get(
-		state.stats.emails.items,
-		getDataPath( siteId, postId, period, statType, date, path ),
-		null
-	);
+	const stats =
+		getDataPath( siteId, postId, period, statType, date, path ).reduce(
+			( value, key ) => value?.[ key ],
+			state.stats.emails.items
+		) ?? null;
 	// if we have redux stats ready return false
 	if ( stats ) {
 		return false;
@@ -145,10 +143,9 @@ export function getEmailStat( state, siteId, postId, period, statType ) {
  */
 export function getEmailStatsNormalizedData( state, siteId, postId, period, statType, date, path ) {
 	return state.stats.emails.items
-		? get(
-				state.stats.emails.items,
-				[ ...getDataPath( siteId, postId, period, statType ), path ],
-				null
-		  )
+		? [ ...getDataPath( siteId, postId, period, statType ), path ].reduce(
+				( value, key ) => value?.[ key ],
+				state.stats.emails.items
+		  ) ?? null
 		: null;
 }

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,6 +1,5 @@
 import { camelCase, capitalize, sortBy } from '@automattic/js-utils';
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { get } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
@@ -389,7 +388,7 @@ export const normalizers = {
 		const dataPath = query.summarize
 			? [ 'summary', 'postviews' ]
 			: [ 'days', startOf, 'postviews' ];
-		const viewData = get( data, dataPath, [] );
+		const viewData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
 
 		return viewData.map( ( item ) => {
 			// To avoid showing a detail page for the Homepage set as latest posts.
@@ -440,7 +439,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
-		const archivesData = get( data, dataPath, {} );
+		const archivesData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? {};
 
 		// Add null check for archivesData
 		// TODO: ensure API always returns an object here. Now it return an empty array when there's no items.
@@ -542,28 +541,30 @@ export const normalizers = {
 			return null;
 		}
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const countryInfo = get( data, [ 'country-info' ], {} );
+		const countryInfo = data?.[ 'country-info' ] ?? {};
 
 		// the API response object shape depends on if this is a summary request or not
 		const dataPath = query.summarize ? [ 'summary', 'views' ] : [ 'days', startOf, 'views' ];
 
 		// filter out country views that have no legitimate country data associated with them
-		const countryData = get( data, dataPath, [] ).filter( ( viewData ) => {
-			// Ignore the unknown location of sources from the legacy stats geoviews table.
-			if ( [ 'A1', 'A2', 'ZZ' ].includes( viewData.country_code ) ) {
-				return false;
-			}
+		const countryData = ( dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [] ).filter(
+			( viewData ) => {
+				// Ignore the unknown location of sources from the legacy stats geoviews table.
+				if ( [ 'A1', 'A2', 'ZZ' ].includes( viewData.country_code ) ) {
+					return false;
+				}
 
-			// TODO: Investigate ignored countries that have `false` as the country_full data.
-			if (
-				countryInfo[ viewData.country_code ] &&
-				! countryInfo[ viewData.country_code ].country_full
-			) {
-				return false;
-			}
+				// TODO: Investigate ignored countries that have `false` as the country_full data.
+				if (
+					countryInfo[ viewData.country_code ] &&
+					! countryInfo[ viewData.country_code ].country_full
+				) {
+					return false;
+				}
 
-			return countryInfo[ viewData.country_code ];
-		} );
+				return countryInfo[ viewData.country_code ];
+			}
+		);
 
 		return countryData.map( ( viewData ) => {
 			const country = countryInfo[ viewData.country_code ];
@@ -609,11 +610,11 @@ export const normalizers = {
 		}
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const videoPlaysData = get(
-			data,
-			query.summarize ? [ 'days', 'summary', 'data' ] : [ 'days', startOf, 'data' ],
-			[]
-		);
+		const videoPlaysData =
+			( query.summarize ? [ 'days', 'summary', 'data' ] : [ 'days', startOf, 'data' ] ).reduce(
+				( value, key ) => value?.[ key ],
+				data
+			) ?? [];
 
 		const normalizedData = videoPlaysData.map( ( item ) => {
 			return {
@@ -651,11 +652,11 @@ export const normalizers = {
 			return normalizers.statsVideoPlaysCompleteStats( data, query, siteId, site );
 		}
 
-		const videoPlaysData = get(
-			data,
-			query.summarize ? [ 'days', 'summary', 'plays' ] : [ 'days', startOf, 'plays' ],
-			[]
-		);
+		const videoPlaysData =
+			( query.summarize ? [ 'days', 'summary', 'plays' ] : [ 'days', startOf, 'plays' ] ).reduce(
+				( value, key ) => value?.[ key ],
+				data
+			) ?? [];
 
 		return videoPlaysData.map( ( item ) => {
 			const detailPage = site
@@ -685,7 +686,7 @@ export const normalizers = {
 			return null;
 		}
 		const { total_wpcom, total_email, total } = data;
-		const subscriberData = get( data, [ 'subscribers' ], [] );
+		const subscriberData = data?.subscribers ?? [];
 
 		const subscribers = subscriberData.map( ( item ) => {
 			return {
@@ -860,7 +861,7 @@ export const normalizers = {
 		}
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'authors' ] : [ 'days', startOf, 'authors' ];
-		const authorsData = get( data, dataPath, [] );
+		const authorsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
 
 		return authorsData.map( ( item ) => {
 			const record = {
@@ -953,7 +954,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'clicks' ] : [ 'days', startOf, 'clicks' ];
-		const statsData = get( data, dataPath, [] );
+		const statsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
 
 		const output = statsData.map( ( item ) => {
 			const hasChildren = item.children && item.children.length > 0;
@@ -1000,7 +1001,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'groups' ] : [ 'days', startOf, 'groups' ];
-		let statsData = get( data, dataPath, [] );
+		let statsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
 
 		const parseItem = ( item ) => {
 			let children;
@@ -1127,7 +1128,8 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
-		const searchTerms = get( data, dataPath.concat( [ 'search_terms' ] ), [] );
+		const searchTerms =
+			dataPath.concat( [ 'search_terms' ] ).reduce( ( value, key ) => value?.[ key ], data ) ?? [];
 
 		return searchTerms.map( ( day ) => {
 			return {
@@ -1152,7 +1154,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'files' ] : [ 'days', startOf, 'files' ];
-		const statsData = get( data, dataPath, [] );
+		const statsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
 
 		return statsData.map( ( item ) => {
 			return {
@@ -1180,7 +1182,7 @@ export const normalizers = {
 			return [];
 		}
 
-		const emailsData = get( data, [ 'posts' ], [] );
+		const emailsData = data?.posts ?? [];
 
 		return emailsData.map(
 			( {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -3,6 +3,14 @@ import { translate, getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
+/**
+ * Reads the value at a path (array of keys) in an object, or `undefined` if any
+ * segment along the way is missing.
+ * @param {Object} object Object to read from
+ * @param {Array}  path   Array of keys to walk
+ */
+const getFromPath = ( object, path ) => path.reduce( ( value, key ) => value?.[ key ], object );
+
 /** @type ( key: string ) => string */
 function getArchiveKeyLabel( key ) {
 	const archiveKeyLabelMap = {
@@ -388,7 +396,7 @@ export const normalizers = {
 		const dataPath = query.summarize
 			? [ 'summary', 'postviews' ]
 			: [ 'days', startOf, 'postviews' ];
-		const viewData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
+		const viewData = getFromPath( data, dataPath ) ?? [];
 
 		return viewData.map( ( item ) => {
 			// To avoid showing a detail page for the Homepage set as latest posts.
@@ -439,7 +447,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
-		const archivesData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? {};
+		const archivesData = getFromPath( data, dataPath ) ?? {};
 
 		// Add null check for archivesData
 		// TODO: ensure API always returns an object here. Now it return an empty array when there's no items.
@@ -547,24 +555,22 @@ export const normalizers = {
 		const dataPath = query.summarize ? [ 'summary', 'views' ] : [ 'days', startOf, 'views' ];
 
 		// filter out country views that have no legitimate country data associated with them
-		const countryData = ( dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [] ).filter(
-			( viewData ) => {
-				// Ignore the unknown location of sources from the legacy stats geoviews table.
-				if ( [ 'A1', 'A2', 'ZZ' ].includes( viewData.country_code ) ) {
-					return false;
-				}
-
-				// TODO: Investigate ignored countries that have `false` as the country_full data.
-				if (
-					countryInfo[ viewData.country_code ] &&
-					! countryInfo[ viewData.country_code ].country_full
-				) {
-					return false;
-				}
-
-				return countryInfo[ viewData.country_code ];
+		const countryData = ( getFromPath( data, dataPath ) ?? [] ).filter( ( viewData ) => {
+			// Ignore the unknown location of sources from the legacy stats geoviews table.
+			if ( [ 'A1', 'A2', 'ZZ' ].includes( viewData.country_code ) ) {
+				return false;
 			}
-		);
+
+			// TODO: Investigate ignored countries that have `false` as the country_full data.
+			if (
+				countryInfo[ viewData.country_code ] &&
+				! countryInfo[ viewData.country_code ].country_full
+			) {
+				return false;
+			}
+
+			return countryInfo[ viewData.country_code ];
+		} );
 
 		return countryData.map( ( viewData ) => {
 			const country = countryInfo[ viewData.country_code ];
@@ -611,9 +617,9 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const videoPlaysData =
-			( query.summarize ? [ 'days', 'summary', 'data' ] : [ 'days', startOf, 'data' ] ).reduce(
-				( value, key ) => value?.[ key ],
-				data
+			getFromPath(
+				data,
+				query.summarize ? [ 'days', 'summary', 'data' ] : [ 'days', startOf, 'data' ]
 			) ?? [];
 
 		const normalizedData = videoPlaysData.map( ( item ) => {
@@ -653,9 +659,9 @@ export const normalizers = {
 		}
 
 		const videoPlaysData =
-			( query.summarize ? [ 'days', 'summary', 'plays' ] : [ 'days', startOf, 'plays' ] ).reduce(
-				( value, key ) => value?.[ key ],
-				data
+			getFromPath(
+				data,
+				query.summarize ? [ 'days', 'summary', 'plays' ] : [ 'days', startOf, 'plays' ]
 			) ?? [];
 
 		return videoPlaysData.map( ( item ) => {
@@ -861,7 +867,7 @@ export const normalizers = {
 		}
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'authors' ] : [ 'days', startOf, 'authors' ];
-		const authorsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
+		const authorsData = getFromPath( data, dataPath ) ?? [];
 
 		return authorsData.map( ( item ) => {
 			const record = {
@@ -954,7 +960,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'clicks' ] : [ 'days', startOf, 'clicks' ];
-		const statsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
+		const statsData = getFromPath( data, dataPath ) ?? [];
 
 		const output = statsData.map( ( item ) => {
 			const hasChildren = item.children && item.children.length > 0;
@@ -1001,7 +1007,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'groups' ] : [ 'days', startOf, 'groups' ];
-		let statsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
+		let statsData = getFromPath( data, dataPath ) ?? [];
 
 		const parseItem = ( item ) => {
 			let children;
@@ -1128,8 +1134,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
-		const searchTerms =
-			dataPath.concat( [ 'search_terms' ] ).reduce( ( value, key ) => value?.[ key ], data ) ?? [];
+		const searchTerms = getFromPath( data, dataPath.concat( [ 'search_terms' ] ) ) ?? [];
 
 		return searchTerms.map( ( day ) => {
 			return {
@@ -1154,7 +1159,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'files' ] : [ 'days', startOf, 'files' ];
-		const statsData = dataPath.reduce( ( value, key ) => value?.[ key ], data ) ?? [];
+		const statsData = getFromPath( data, dataPath ) ?? [];
 
 		return statsData.map( ( item ) => {
 			return {

--- a/client/state/stats/module-toggles/selectors.ts
+++ b/client/state/stats/module-toggles/selectors.ts
@@ -1,5 +1,4 @@
-import { get } from 'lodash';
-
+import type { AppState } from 'calypso/types';
 import 'calypso/state/stats/init';
 
 const EMPTY_RESULT = {};
@@ -10,8 +9,8 @@ const EMPTY_RESULT = {};
  * @param   {number}  siteId   Site ID
  * @returns {Object}           Highlights object; see schema.
  */
-export function getModuleToggles( state: object, siteId: number, pageName: string ) {
-	return get( state, [ 'stats', 'moduleToggles', 'data', siteId, pageName ], EMPTY_RESULT );
+export function getModuleToggles( state: AppState, siteId: number, pageName: string ) {
+	return state?.stats?.moduleToggles?.data?.[ siteId ]?.[ pageName ] ?? EMPTY_RESULT;
 }
 
 /**
@@ -20,6 +19,6 @@ export function getModuleToggles( state: object, siteId: number, pageName: strin
  * @param   {number}  siteId   Site ID
  * @returns {boolean}          	 Array of stat types as strings
  */
-export function isLoading( state: object, siteId: number ) {
-	return get( state, [ 'stats', 'moduleToggles', 'isLoading', siteId ] );
+export function isLoading( state: AppState, siteId: number ) {
+	return state?.stats?.moduleToggles?.isLoading?.[ siteId ];
 }

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -1,4 +1,4 @@
-import { get, merge } from 'lodash';
+import { merge } from 'lodash';
 import {
 	POST_STATS_RECEIVE,
 	POST_STATS_REQUEST,
@@ -45,9 +45,9 @@ export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) =
 			return {
 				...state,
 				[ action.siteId ]: {
-					...get( state, [ action.siteId ], {} ),
+					...( state?.[ action.siteId ] ?? {} ),
 					[ action.postId ]: {
-						...get( state, [ action.siteId, action.postId ], {} ),
+						...( state?.[ action.siteId ]?.[ action.postId ] ?? {} ),
 						...action.stats,
 					},
 				},

--- a/client/state/stats/utm-metrics/selectors.ts
+++ b/client/state/stats/utm-metrics/selectors.ts
@@ -1,5 +1,5 @@
-import { get } from 'lodash';
 import { UTMMetricItem } from './types';
+import type { AppState } from 'calypso/types';
 import 'calypso/state/stats/init';
 
 const EMPTY_RESULT = [] as Array< UTMMetricItem >;
@@ -10,16 +10,16 @@ const EMPTY_RESULT = [] as Array< UTMMetricItem >;
  * @param   {number}  siteId   Site ID
  * @returns {Object}           Highlights object; see schema.
  */
-export function getMetrics( state: object, siteId: number, postId?: number ) {
+export function getMetrics( state: AppState, siteId: number, postId?: number ) {
 	const metrics = postId
-		? get( state, [ 'stats', 'utmMetrics', 'data', siteId, 'metricsByPost', postId ], EMPTY_RESULT )
-		: get( state, [ 'stats', 'utmMetrics', 'data', siteId, 'metrics' ], EMPTY_RESULT );
+		? state?.stats?.utmMetrics?.data?.[ siteId ]?.metricsByPost?.[ postId ] ?? EMPTY_RESULT
+		: state?.stats?.utmMetrics?.data?.[ siteId ]?.metrics ?? EMPTY_RESULT;
 
 	return metrics;
 }
 
-export function getTopPosts( state: object, siteId: number ) {
-	return get( state, [ 'stats', 'utmMetrics', 'data', siteId, 'topPosts' ], {} );
+export function getTopPosts( state: AppState, siteId: number ) {
+	return state?.stats?.utmMetrics?.data?.[ siteId ]?.topPosts ?? {};
 }
 
 /**
@@ -28,6 +28,6 @@ export function getTopPosts( state: object, siteId: number ) {
  * @param   {number}  siteId   Site ID
  * @returns {boolean}          	 Array of stat types as strings
  */
-export function isLoading( state: object, siteId: number ) {
-	return get( state, [ 'stats', 'utmMetrics', 'isLoading', siteId ] );
+export function isLoading( state: AppState, siteId: number ) {
+	return state?.stats?.utmMetrics?.isLoading?.[ siteId ];
 }

--- a/client/state/themes/selectors/get-theme-filter-term.js
+++ b/client/state/themes/selectors/get-theme-filter-term.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getThemeFilterTerms } from 'calypso/state/themes/selectors/get-theme-filter-terms';
 
 import 'calypso/state/themes/init';
@@ -11,5 +10,5 @@ import 'calypso/state/themes/init';
  * @returns {Object}         A filter term object
  */
 export function getThemeFilterTerm( state, filter, term ) {
-	return get( getThemeFilterTerms( state, filter ), term );
+	return getThemeFilterTerms( state, filter )?.[ term ];
 }

--- a/client/state/themes/selectors/get-theme-filter-terms.js
+++ b/client/state/themes/selectors/get-theme-filter-terms.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getThemeFilters } from 'calypso/state/themes/selectors/get-theme-filters';
 
 import 'calypso/state/themes/init';
@@ -10,5 +9,5 @@ import 'calypso/state/themes/init';
  * @returns {Object}         A list of filter terms, keyed by term slug
  */
 export function getThemeFilterTerms( state, filter ) {
-	return get( getThemeFilters( state ), filter );
+	return getThemeFilters( state )?.[ filter ];
 }

--- a/client/state/themes/upload-theme/selectors.js
+++ b/client/state/themes/upload-theme/selectors.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/themes/init';
 
 /**
@@ -9,7 +7,7 @@ import 'calypso/state/themes/init';
  * @returns {boolean} -- True if upload is in progress
  */
 export function isUploadInProgress( state, siteId ) {
-	return get( state.themes.uploadTheme.inProgress, siteId, false );
+	return state.themes.uploadTheme.inProgress?.[ siteId ] ?? false;
 }
 
 /**
@@ -29,7 +27,7 @@ export function isUploadComplete( state, siteId ) {
  * @returns {boolean} -- True if upload has failed
  */
 export function hasUploadFailed( state, siteId ) {
-	return !! get( state.themes.uploadTheme.uploadError, siteId, false );
+	return !! ( state.themes.uploadTheme.uploadError?.[ siteId ] ?? false );
 }
 
 /**
@@ -98,7 +96,7 @@ export function isInstallInProgress( state, siteId ) {
  * @returns {boolean} -- True if transfer is completed
  */
 export function isTransferComplete( state, siteId ) {
-	return get( state.themes.uploadTheme.isTransferComplete, siteId, false );
+	return state.themes.uploadTheme.isTransferComplete?.[ siteId ] ?? false;
 }
 
 /**
@@ -108,5 +106,5 @@ export function isTransferComplete( state, siteId ) {
  * @returns {boolean} -- True if transfer is in progress.
  */
 export function isTransferInProgress( state, siteId ) {
-	return get( state.themes.uploadTheme.isTransferInProgress, siteId, false );
+	return state.themes.uploadTheme.isTransferInProgress?.[ siteId ] ?? false;
 }

--- a/client/state/themes/upload-theme/selectors.js
+++ b/client/state/themes/upload-theme/selectors.js
@@ -27,7 +27,7 @@ export function isUploadComplete( state, siteId ) {
  * @returns {boolean} -- True if upload has failed
  */
 export function hasUploadFailed( state, siteId ) {
-	return !! ( state.themes.uploadTheme.uploadError?.[ siteId ] ?? false );
+	return !! state.themes.uploadTheme.uploadError?.[ siteId ];
 }
 
 /**

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -1,5 +1,4 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { get } from 'lodash';
 import {
 	USER_SETTINGS_SAVE,
 	USER_SETTINGS_UNSAVED_CLEAR,
@@ -40,7 +39,7 @@ export const unsavedSettings = ( state = {}, action ) => {
 			return removeValue( state, settingNames );
 		}
 		case USER_SETTINGS_UNSAVED_SET: {
-			if ( get( state, action.settingName ) === action.value ) {
+			if ( state?.[ action.settingName ] === action.value ) {
 				return state;
 			}
 			return setValue( state, action.settingName, action.value );

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -39,7 +39,11 @@ export const unsavedSettings = ( state = {}, action ) => {
 			return removeValue( state, settingNames );
 		}
 		case USER_SETTINGS_UNSAVED_SET: {
-			if ( state?.[ action.settingName ] === action.value ) {
+			// `settingName` may be a nested path (array of keys), matching `setValue`.
+			const path = Array.isArray( action.settingName )
+				? action.settingName
+				: [ action.settingName ];
+			if ( path.reduce( ( value, key ) => value?.[ key ], state ) === action.value ) {
 				return state;
 			}
 			return setValue( state, action.settingName, action.value );

--- a/client/state/user-settings/thunks/set-user-setting.js
+++ b/client/state/user-settings/thunks/set-user-setting.js
@@ -1,6 +1,5 @@
 import { isEmpty } from '@automattic/js-utils';
 import debugFactory from 'debug';
-import { get } from 'lodash';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import {
 	removeUnsavedUserSetting,
@@ -57,7 +56,7 @@ export default function setUserSetting( settingName, value ) {
 		const settings = getUserSettings( getState() );
 		const settingPath = castPath( settingName );
 
-		const originalSetting = get( settings, settingPath );
+		const originalSetting = settingPath.reduce( ( node, key ) => node?.[ key ], settings );
 
 		if ( originalSetting === undefined ) {
 			debug( settingName + ' does not exist in user-settings data module.' );

--- a/client/state/user-suggestions/selectors.js
+++ b/client/state/user-suggestions/selectors.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/user-suggestions/init';
 
 const emptyArray = [];
@@ -12,7 +10,7 @@ const emptyArray = [];
  * @returns {boolean}         Whether user suggestions are being requested
  */
 export function isRequestingUserSuggestions( state, siteId ) {
-	return get( state.userSuggestions.requesting, [ siteId ], false );
+	return state.userSuggestions.requesting?.[ siteId ] ?? false;
 }
 
 /**
@@ -23,5 +21,5 @@ export function isRequestingUserSuggestions( state, siteId ) {
  */
 export function getUserSuggestions( state, siteId ) {
 	// Use a defined array as the default value to prevent unnecessary rerenders.
-	return get( state.userSuggestions.items, [ siteId ], emptyArray );
+	return state.userSuggestions.items?.[ siteId ] ?? emptyArray;
 }

--- a/client/state/utils/keyed-reducer.ts
+++ b/client/state/utils/keyed-reducer.ts
@@ -83,19 +83,18 @@ export const keyedReducer = < TState, TAction extends AnyAction = Action >(
 
 	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
 
+	// Parse the dot-separated `keyPath` once, rather than on every dispatched action.
+	const keyPathSegments = keyPath.split( '.' );
+
 	const combinedReducer = (
 		state: Record< string | number, TState > = {},
 		action: KeyedReducerAction< TAction >
 	) => {
-		// don't allow coercion of key name: null => 0
-		// `keyPath` is a lodash-style path (e.g. `meta.dataLayer.requestKey`), so
-		// walk each `.`-separated segment.
-		const itemKey = keyPath
-			.split( '.' )
-			.reduce< unknown >(
-				( value, key ) => ( value as Record< string, unknown > )?.[ key ],
-				action
-			) as string | number | undefined | null;
+		// don't allow coercion of key name: null => 0; walk each path segment.
+		const itemKey = keyPathSegments.reduce< unknown >(
+			( value, key ) => ( value as Record< string, unknown > )?.[ key ],
+			action
+		) as string | number | undefined | null;
 
 		// if the action doesn't contain a valid reference
 		// then return without any updates

--- a/client/state/utils/keyed-reducer.ts
+++ b/client/state/utils/keyed-reducer.ts
@@ -3,7 +3,6 @@ import isEqual from 'fast-deep-equal/es6';
 import { SerializationResult } from 'calypso/state/serialization-result';
 import { serialize, deserialize, SerializableReducer } from './serialize';
 import { withPersistence } from './with-persistence';
-import type { PropertyPath } from 'lodash';
 import type { Action, AnyAction } from 'redux';
 
 type CalypsoInitAction = Action< '@@calypso/INIT' >;
@@ -22,7 +21,7 @@ export type KeyedReducerAction< TAction extends Action > = TAction | CalypsoInit
  * Note! This will only apply the supplied reducer to
  * the item referenced by the supplied key in the action.
  *
- * If no key exists whose name matches the given lodash style keyPath
+ * If no key exists whose name matches the given dot-separated keyPath
  * then this super-reducer will abort and return the
  * previous state.
  *
@@ -55,12 +54,12 @@ export type KeyedReducerAction< TAction extends Action > = TAction | CalypsoInit
  *         title: 'grunt',
  *     }
  * }
- * @param {string} keyPath lodash-style path to the key in action referencing item in state map
+ * @param {string} keyPath dot-separated path to the key in action referencing item in state map (e.g. `meta.dataLayer.requestKey`); bracket/quoted lodash path syntax is not supported
  * @param {Function} reducer applied to referenced item in state map
  * @returns {Function} super-reducer applying reducer over map of keyed items
  */
 export const keyedReducer = < TState, TAction extends AnyAction = Action >(
-	keyPath: PropertyPath,
+	keyPath: string,
 	reducer: SerializableReducer< TState, Action >
 ): SerializableReducer< Record< string | number, TState >, TAction > => {
 	// some keys are invalid

--- a/client/state/utils/keyed-reducer.ts
+++ b/client/state/utils/keyed-reducer.ts
@@ -1,6 +1,5 @@
 import { mapValues, omit, omitBy } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { get } from 'lodash';
 import { SerializationResult } from 'calypso/state/serialization-result';
 import { serialize, deserialize, SerializableReducer } from './serialize';
 import { withPersistence } from './with-persistence';
@@ -90,7 +89,14 @@ export const keyedReducer = < TState, TAction extends AnyAction = Action >(
 		action: KeyedReducerAction< TAction >
 	) => {
 		// don't allow coercion of key name: null => 0
-		const itemKey = get( action, keyPath, undefined );
+		// `keyPath` is a lodash-style path (e.g. `meta.dataLayer.requestKey`), so
+		// walk each `.`-separated segment.
+		const itemKey = keyPath
+			.split( '.' )
+			.reduce< unknown >(
+				( value, key ) => ( value as Record< string, unknown > )?.[ key ],
+				action
+			) as string | number | undefined | null;
 
 		// if the action doesn't contain a valid reference
 		// then return without any updates
@@ -124,7 +130,7 @@ export const keyedReducer = < TState, TAction extends AnyAction = Action >(
 
 	return withPersistence( combinedReducer, {
 		serialize: ( state ) =>
-			Object.entries( state ?? {} ).reduce(
+			Object.entries< TState >( state ?? {} ).reduce(
 				( result, [ itemKey, itemValue ] ) => {
 					const serializedValue = serialize( reducer, itemValue );
 					if ( serializedValue !== undefined && ! isEqual( serializedValue, initialState ) ) {

--- a/client/state/utils/keyed-reducer.ts
+++ b/client/state/utils/keyed-reducer.ts
@@ -54,7 +54,7 @@ export type KeyedReducerAction< TAction extends Action > = TAction | CalypsoInit
  *         title: 'grunt',
  *     }
  * }
- * @param {string} keyPath dot-separated path to the key in action referencing item in state map (e.g. `meta.dataLayer.requestKey`); bracket/quoted lodash path syntax is not supported
+ * @param {string} keyPath dot-separated path to the key in action referencing item in state map (e.g. `meta.dataLayer.requestKey`); bracket or quoted path syntax (e.g. `a[0].b`) is not supported
  * @param {Function} reducer applied to referenced item in state map
  * @returns {Function} super-reducer applying reducer over map of keyed items
  */

--- a/client/state/utils/reducer-utils.ts
+++ b/client/state/utils/reducer-utils.ts
@@ -1,5 +1,4 @@
 import { mapValues } from '@automattic/js-utils';
-import { get } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line no-restricted-imports
 import { APPLY_STORED_STATE } from 'calypso/state/action-types';
 import { SerializationResult } from 'calypso/state/serialization-result';
@@ -175,7 +174,7 @@ function applyStoredState< TState, TAction extends AnyAction = Action >(
 		}
 
 		// Descend into nested state levels, possibly the storageKey will be found there?
-		const prevStateForKey = get( state, key );
+		const prevStateForKey = ( state as Record< string, unknown > )?.[ key ];
 		const nextStateForKey = reducer( prevStateForKey, action );
 		hasChanged = hasChanged || nextStateForKey !== prevStateForKey;
 		return nextStateForKey;

--- a/client/state/utils/schema-utils.js
+++ b/client/state/utils/schema-utils.js
@@ -3,7 +3,6 @@ import { getInitialState } from '@automattic/state-utils';
 import warn from '@wordpress/warning';
 import isEqual from 'fast-deep-equal/es6';
 import validator from 'is-my-json-valid';
-import { get } from 'lodash';
 import { serialize, deserialize } from './serialize';
 import { withPersistence } from './with-persistence';
 
@@ -29,7 +28,7 @@ export function isValidStateWithSchema( state, schema, debugInfo ) {
 			// Violates rule: { type: 'boolean' }
 			if ( ! isEmpty( schemaPath ) ) {
 				msgLines.push( 'Violates rule: %o' );
-				substitutions.push( get( schema, schemaPath ) );
+				substitutions.push( schemaPath.reduce( ( node, key ) => node?.[ key ], schema ) );
 			}
 			msgLines.push( '' );
 		} );


### PR DESCRIPTION
## Proposed Changes

* Replace all `lodash` `get` usages (69 files) with native optional chaining. Simple paths become `obj?.a?.b ?? default`; dynamic array or dotted-string paths use a native `path.reduce( ( value, key ) => value?.[ key ], obj )`.
* Enable the `you-dont-need-lodash-underscore/get` ESLint rule to prevent reintroductions.

## Why are these changes being made?

* Part of the incremental effort to remove `lodash` from the codebase in favor of native JavaScript, trimming bundle weight and standardizing on modern syntax.
* `_.get`'s default applies only for `undefined`; `?? default` also applies for `null`. This matches the intended behavior at every migrated site (a `null` value is treated the same as a missing one).

## Notable behavior change (please confirm)

* One call in the Jetpack purchase-product analytics path previously had reversed `_.get` arguments, so it always recorded the page title `Jetpack Connect`. The conversion fixes the swap, so each flow now records its correct title (e.g. `Jetpack Search`). This is the only behavior change in the PR; everything else is a faithful mechanical replacement.

## Testing Instructions

* CI should be green: ESLint, `typecheck-client`, and the unit + E2E matrices.
* Existing unit tests cover the migrated selectors, reducers, and utilities (including the keyed-reducer dotted-path handling).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
