### PR TITLE
Dashboard: prevent non-owners from clicking owner-only overview cards

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -127,13 +127,13 @@ export default function OverviewCard( {
 							{ title }
 						</Text>
 					</HStack>
-					{ ( relativeLink || onboardingLink ) && ! progress && (
+					{ ( relativeLink || onboardingLink ) && ! progress && ! disabled && (
 						<Icon
 							className="dashboard-overview-card__link-icon"
 							icon={ isRTL() ? chevronLeft : chevronRight }
 						/>
 					) }
-					{ externalLink && ! progress && (
+					{ externalLink && ! progress && ! disabled && (
 						<span
 							className="dashboard-overview-card__link-icon components-external-link__icon"
 							aria-label={
@@ -203,6 +203,10 @@ export default function OverviewCard( {
 	};
 
 	const renderContent = () => {
+		if ( disabled ) {
+			return topContent;
+		}
+
 		if ( relativeLink ) {
 			return (
 				<Link to={ relativeLink } className="dashboard-overview-card__link" onClick={ handleClick }>

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -63,6 +63,7 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 
 	return (
 		<OverviewCard
+			disabled={ ! domain.current_user_is_owner }
 			title={ mailboxes.length > 0 ? __( 'Emails' ) : __( 'Add mailbox' ) }
 			heading={
 				<Truncate tooltip={ email } numberOfLines={ 1 }>

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -32,7 +32,11 @@ const getAdditionlMailboxesLabel = ( count: number ) => {
 		  );
 };
 
-const getDescription = ( mailboxes: Mailbox[] ) => {
+const getDescription = ( mailboxes: Mailbox[], disabled: boolean ) => {
+	if ( disabled ) {
+		return __( 'Only the domain owner can add email.' );
+	}
+
 	const additionalMailboxes = mailboxes.length - 1;
 
 	if ( mailboxes.length === 0 ) {
@@ -56,6 +60,8 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 		return <OverviewCard icon={ <Icon icon={ envelope } /> } title={ __( 'Emails' ) } isLoading />;
 	}
 
+	const disabled = ! domain.current_user_is_owner;
+
 	const email = mailboxes.length
 		? `${ mailboxes[ 0 ].mailbox }@${ domain.domain }`
 		: // translators: %s is the mailbox name: youremail@example.com
@@ -63,7 +69,7 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 
 	return (
 		<OverviewCard
-			disabled={ ! domain.current_user_is_owner }
+			disabled={ disabled }
 			title={ mailboxes.length > 0 ? __( 'Emails' ) : __( 'Add mailbox' ) }
 			heading={
 				<Truncate tooltip={ email } numberOfLines={ 1 }>
@@ -82,7 +88,7 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 					  } ).href
 			}
 			icon={ <Icon icon={ envelope } /> }
-			description={ getDescription( mailboxes ) }
+			description={ getDescription( mailboxes, disabled ) }
 			intent={ mailboxes.length > 0 ? 'success' : 'upsell' }
 		/>
 	);

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+import { useAuth } from '../../app/auth';
 import { commerceGardenPlan } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
@@ -55,10 +56,12 @@ function JetpackPlanCard( {
 	site,
 	purchase,
 	isLoading,
+	disabled,
 }: {
 	site: Site;
 	purchase?: Purchase;
 	isLoading: boolean;
+	disabled?: boolean;
 } ) {
 	const products = getJetpackProductsForSite( site );
 	const productsToDisplay = products.length > 0 ? products : JETPACK_PRODUCTS;
@@ -68,10 +71,11 @@ function JetpackPlanCard( {
 			title={ __( 'Subscriptions' ) }
 			icon={ <JetpackLogo /> }
 			heading={ getSitePlanDisplayName( site ) }
-			description={ getCardDescription( site, purchase ) }
+			description={ getCardDescription( site, purchase, disabled ) }
 			link={ getSitePlanUrl( site ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
+			disabled={ disabled }
 			bottom={
 				<VStack spacing={ 3 }>
 					<Grid
@@ -101,20 +105,23 @@ function WpcomPlanCard( {
 	site,
 	purchase,
 	isLoading,
+	disabled,
 }: {
 	site: Site;
 	purchase?: Purchase;
 	isLoading: boolean;
+	disabled?: boolean;
 } ) {
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
-			description={ getCardDescription( site, purchase ) }
+			description={ getCardDescription( site, purchase, disabled ) }
 			link={ getSitePlanUrl( site, purchase ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
+			disabled={ disabled }
 			bottom={ <SitePlanStats site={ site } /> }
 		/>
 	);
@@ -144,7 +151,15 @@ function WpcomStagingSitePlanCard( { site }: { site: Site } ) {
 	);
 }
 
-function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean } ) {
+function AgencyPlanCard( {
+	site,
+	isLoading,
+	disabled,
+}: {
+	site: Site;
+	isLoading: boolean;
+	disabled?: boolean;
+} ) {
 	return (
 		<OverviewCard
 			title={ __( 'Development license' ) }
@@ -154,6 +169,7 @@ function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean }
 			link={ getSitePlanUrl( site ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
+			disabled={ disabled }
 			bottom={ <SitePlanStats site={ site } /> }
 		/>
 	);
@@ -163,25 +179,29 @@ function CommerceGardenPlanCard( {
 	site,
 	purchase,
 	isLoading,
+	disabled,
 }: {
 	site: Site;
 	purchase?: Purchase;
 	isLoading: boolean;
+	disabled?: boolean;
 } ) {
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ commerceGardenPlan }
 			heading={ getSitePlanDisplayName( site ) }
-			description={ getCardDescription( site, purchase ) }
+			description={ getCardDescription( site, purchase, disabled ) }
 			link={ getSitePlanUrl( site, purchase ) }
 			tracksId="plan"
 			isLoading={ isLoading }
+			disabled={ disabled }
 		/>
 	);
 }
 
 export default function PlanCard( { site }: { site: Site } ) {
+	const { user } = useAuth();
 	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
 		...purchaseQuery( plan?.id ?? 0 ),
@@ -189,27 +209,53 @@ export default function PlanCard( { site }: { site: Site } ) {
 	} );
 
 	const isLoading = isLoadingPlan || isLoadingPurchase;
+	const disabled = site.site_owner !== user.ID && !! site.plan?.is_free;
 
 	if ( site.is_a4a_dev_site ) {
-		return <AgencyPlanCard site={ site } isLoading={ isLoading } />;
+		return <AgencyPlanCard site={ site } isLoading={ isLoading } disabled={ disabled } />;
 	}
 
 	if ( isCommerceGarden( site ) ) {
-		return <CommerceGardenPlanCard site={ site } purchase={ purchase } isLoading={ isLoading } />;
+		return (
+			<CommerceGardenPlanCard
+				site={ site }
+				purchase={ purchase }
+				isLoading={ isLoading }
+				disabled={ disabled }
+			/>
+		);
 	}
 
 	if ( isSelfHostedJetpackConnected( site ) ) {
-		return <JetpackPlanCard site={ site } purchase={ purchase } isLoading={ isLoading } />;
+		return (
+			<JetpackPlanCard
+				site={ site }
+				purchase={ purchase }
+				isLoading={ isLoading }
+				disabled={ disabled }
+			/>
+		);
 	}
 
 	if ( site.is_wpcom_staging_site ) {
 		return <WpcomStagingSitePlanCard site={ site } />;
 	}
 
-	return <WpcomPlanCard site={ site } purchase={ purchase } isLoading={ isLoading } />;
+	return (
+		<WpcomPlanCard
+			site={ site }
+			purchase={ purchase }
+			isLoading={ isLoading }
+			disabled={ disabled }
+		/>
+	);
 }
 
-function getCardDescription( site: Site, purchase?: Purchase ) {
+function getCardDescription( site: Site, purchase?: Purchase, disabled?: boolean ) {
+	if ( disabled ) {
+		return __( 'Only the site owner can upgrade this plan.' );
+	}
+
 	switch ( site.plan?.product_slug ) {
 		case DotcomPlans.FREE_PLAN:
 			return __( 'Upgrade to access all hosting features.' );


### PR DESCRIPTION
Related to: DOTMSD-1127

## Proposed Changes

* Non-owners can no longer click into owner-only purchase/upgrade flows from the site and domain Overview cards.
* **Site Overview — Plan card:** on a free plan, a non-owner now sees the card disabled with the description **"Only the site owner can upgrade this plan."** instead of the upgrade prompt. Owners, and any paid plan, are unaffected.
* **Domain Overview — Emails card:** disabled for users who don't own the domain, so they can't start the email purchase flow.
* **Shared OverviewCard:** a disabled card is now genuinely non-interactive — no link, chevron affordance, or hover state. Previously `disabled` only greyed the card while still rendering a clickable link.


| Before | After |
|--------|--------|
| <img width="1360" height="428" alt="Screenshot 2026-07-01 at 2 46 35 PM" src="https://github.com/user-attachments/assets/ecc23667-db4f-41c6-817c-221770a18e14" /> | <img width="1377" height="426" alt="Screenshot 2026-07-01 at 2 46 26 PM" src="https://github.com/user-attachments/assets/0c98048f-b008-4f20-9247-2d7568e21c8e" /> |
| <img width="713" height="728" alt="Screenshot 2026-07-01 at 2 47 17 PM" src="https://github.com/user-attachments/assets/9cf9f3eb-3e1d-4e5c-a834-02266d907b33" /> | <img width="724" height="744" alt="Screenshot 2026-07-01 at 2 48 59 PM" src="https://github.com/user-attachments/assets/874b73fe-bd5a-41a2-acaa-bdd1afc35b9e" /> | 




## Why are these changes being made?

* Non-owners could click cards that lead to purchase/upgrade flows they can't complete, landing them on dead-ends or owner-only screens. For a free plan the "Upgrade…" prompt was also misleading to someone who can't upgrade.

## Testing Instructions

* As a user who is **not** the site owner, open a **free-plan** site's Overview. The Plan card should be greyed out, non-clickable, and read "Only the site owner can upgrade this plan."
* As the **site owner**, the Plan card behaves as before (clickable, normal description).
* On a **paid plan**, the Plan card stays clickable regardless of owner.
* Open a domain's Overview as a user who does **not** own that domain: the Emails / "Add mailbox" card should be non-clickable.

## Considerations

* Making `disabled` non-interactive is a shared change. The only other card passing `disabled` directly is the domain privacy card, which already nulls its own internal link when disabled; its external "learn about privacy protection" link is now also non-interactive while the card is disabled (TLD maintenance), consistent with a disabled card being fully non-interactive.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?