### PR TITLE
Agents Manager: thread provider onTaskUpdate into useAgentChat

### DIFF
--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -179,6 +179,7 @@ function AgentSetup( {
 				environment: sectionName || 'calypso',
 				agentId,
 				version,
+				onTaskUpdate: providers.onTaskUpdate,
 			} );
 
 			setAgentConfig( config );

--- a/packages/agents-manager/src/components/headless-agent-initializer.tsx
+++ b/packages/agents-manager/src/components/headless-agent-initializer.tsx
@@ -57,6 +57,7 @@ export default function HeadlessAgentInitializer( {
 				contextProvider: providers.contextProvider,
 				providerIds: providers.providerIds,
 				environment: 'wp-admin',
+				onTaskUpdate: providers.onTaskUpdate,
 			} );
 
 			setAgentConfig( config );

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -323,6 +323,44 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [] );
 	} );
 
+	it( 'renders stream-page-design tool summary as plain text', () => {
+		const summaryText = 'A bold hero with three airy feature sections in the theme accent colors.';
+		const message = createToolMessage( 'big_sky__stream_page_design', {
+			summary: summaryText,
+			isCurrent: true,
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: summaryText,
+		} );
+	} );
+
+	it( 'renders stream-page-design structured result message as plain text', () => {
+		const message = createToolMessage( 'big_sky__stream_page_design', {
+			result: {
+				success: true,
+				message: 'The generated page content has been staged in the editor for review.',
+			},
+			returnToAgent: true,
+		} );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: 'The generated page content has been staged in the editor for review.',
+		} );
+	} );
+
 	it( 'suppresses transient thinking for converted apply-block-edits messages', () => {
 		const message = createToolMessage( 'big_sky__apply_block_edits', {
 			followUpTasks: true,

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -28,6 +28,12 @@ export interface CreateAgentConfigOptions {
 	agentId?: string;
 	/** Override the agent version (e.g., from query string). Passed via constructorArguments. */
 	version?: string;
+	/**
+	 * Streamed task-update callback (from a provider). Forwarded to useAgentChat's
+	 * `onTaskUpdate` so streamed tool-argument deltas reach the provider — e.g. to
+	 * paint streamed page-design markup into the editor as it arrives.
+	 */
+	onTaskUpdate?: ( update: unknown ) => void | Promise< void >;
 }
 
 /**
@@ -247,6 +253,7 @@ export async function createAgentConfig(
 		environment = 'calypso',
 		agentId = ORCHESTRATOR_AGENT_ID,
 		version,
+		onTaskUpdate,
 	} = options;
 
 	const config: UseAgentChatConfig = {
@@ -259,6 +266,10 @@ export async function createAgentConfig(
 		} ),
 		enableStreaming: true,
 	};
+
+	if ( onTaskUpdate ) {
+		config.onTaskUpdate = onTaskUpdate;
+	}
 
 	if ( toolProvider ) {
 		config.toolProvider = wrapToolProvider( toolProvider );

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -175,6 +175,14 @@ export interface LoadedProviders {
 	siteBuildUtils?: SiteBuildUtils;
 	useImageUpload?: ImageUploadHook;
 	useCheckpoint?: UseCheckpointHook;
+	/**
+	 * Streamed task-update callback, forwarded to useAgentChat's `onTaskUpdate`.
+	 * Lets a provider react to streamed tool-argument deltas as they arrive — e.g.
+	 * paint streamed page-design block markup into the editor. First-write-wins
+	 * across providers (a singleton: the delta stream must be processed once, not
+	 * fanned out to every provider).
+	 */
+	onTaskUpdate?: ( update: unknown ) => void | Promise< void >;
 	capabilities?: ProviderCapabilities;
 }
 
@@ -451,6 +459,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedSiteBuildUtils: SiteBuildUtils | undefined;
 	let mergedImageUpload: ImageUploadHook | undefined;
 	let mergedUseCheckpoint: UseCheckpointHook | undefined;
+	let mergedOnTaskUpdate: LoadedProviders[ 'onTaskUpdate' ] | undefined;
 	// OR-merged across all providers.
 	const mergedCapabilities: ProviderCapabilities = {};
 	let mergedSuppressEmptyViewDefaults = false;
@@ -542,6 +551,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 		if ( module.useCheckpoint && ! mergedUseCheckpoint ) {
 			mergedUseCheckpoint = module.useCheckpoint;
+		}
+		if ( module.onTaskUpdate && ! mergedOnTaskUpdate ) {
+			mergedOnTaskUpdate = module.onTaskUpdate;
 		}
 
 		mergeCapabilitiesInto( mergedCapabilities, module.capabilities );
@@ -674,6 +686,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		providerIds: allProviderIds.length ? allProviderIds : undefined,
 		useNavigationContinuation: mergedNavigationContinuation,
 		useAbilitiesSetup: mergedAbilitiesSetup,
+		onTaskUpdate: mergedOnTaskUpdate,
 		useSuggestions: mergedUseSuggestions,
 		getChatComponent: mergedGetChatComponent,
 		siteBuildUtils: mergedSiteBuildUtils,

--- a/packages/agents-manager/src/utils/tool-message-utils.ts
+++ b/packages/agents-manager/src/utils/tool-message-utils.ts
@@ -6,6 +6,7 @@ const DISPLAYABLE_TOOL_MESSAGE_TOOL_IDS = new Set( [
 	'big_sky__editor_navigate',
 	'big_sky__restore_checkpoint',
 	'big_sky__open_help_center',
+	'big_sky__stream_page_design',
 	'wp_admin__navigate',
 ] );
 


### PR DESCRIPTION
Adds an `onTaskUpdate` transport so an external provider can react to streamed tool-argument deltas — needed to paint streamed page-design block markup into the editor as it arrives.

## Why
`createAgentConfig` set `enableStreaming: true` but never forwarded a task-update callback, so streamed deltas had nowhere to go. Big Sky's page-design streaming needs the provider's `onTaskUpdate` (which accumulates the markup and drives the shared renderer) to reach `useAgentChat`.

## Changes
- `LoadedProviders` gains an optional `onTaskUpdate`; `loadExternalProviders` merges it **first-write-wins** (a singleton — the delta stream must be processed once, not fanned out to every provider, unlike `useAbilitiesSetup`).
- `CreateAgentConfigOptions` accepts `onTaskUpdate`; `createAgentConfig` sets `config.onTaskUpdate`.
- Both call sites pass `providers.onTaskUpdate`: the dock/site-editor chat (`agents-manager.tsx`) and the headless initializer.

## Requires
`@automattic/agenttic-client` ≥0.1.70 (the `onTaskUpdate` option on `useAgentChat`, present in source 0.1.72). Refresh the install off the `^0.1.72` pin.

## Coordinated deploy
Pairs with the big-sky-plugin `calypso-agent-provider` (which exports `onTaskUpdate = handleStreamPageDesignTaskUpdate`) and the wpcom page-design server changes.