### PR TITLE
A4A: Add agency site detail view with agency-scoped site switcher

### DIFF
--- a/client/dashboard/agency/sites/dataviews/site.tsx
+++ b/client/dashboard/agency/sites/dataviews/site.tsx
@@ -1,41 +1,10 @@
+import { Link } from '@tanstack/react-router';
 import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { getAdminUrl, getDisplayUrl, getSiteName, getSiteUrl } from './site-data';
+import AgencySiteIcon from '../site-icon';
+import { getDisplayUrl, getSiteName, getSiteUrl } from './site-data';
 import type { AgencySite } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
-
-// TODO: make this fallback themeable (incl. dark mode) once A4A supports dark mode.
-const FALLBACK_SITE_COLOR = 'linear-gradient( 45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4 )';
-
-function AgencySiteIcon( { site, size }: { site: AgencySite; size: number } ) {
-	const ico = site.icon?.img || site.icon?.ico;
-
-	if ( ico ) {
-		return (
-			<img
-				src={ ico }
-				alt=""
-				width={ size }
-				height={ size }
-				loading="lazy"
-				style={ { borderRadius: 4, objectFit: 'cover', display: 'block' } }
-			/>
-		);
-	}
-
-	return (
-		<span
-			aria-hidden="true"
-			style={ {
-				display: 'block',
-				width: size,
-				height: size,
-				borderRadius: 4,
-				background: site.site_color || FALLBACK_SITE_COLOR,
-			} }
-		/>
-	);
-}
 
 export function getSiteIconField( viewType?: string ): Field< AgencySite > {
 	const isGrid = viewType === 'grid';
@@ -64,18 +33,15 @@ export function getSiteNameField(
 		enableSorting: true,
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => getSiteName( item ),
-		// TODO: temporary raw link to wp-admin; replace with the full site-link
-		// implementation once the agency site detail experience exists.
 		render: ( { item } ) => (
-			<a
-				href={ getAdminUrl( item ) }
-				target="_blank"
-				rel="noreferrer"
+			<Link
+				to="/sites/$siteId"
+				params={ { siteId: String( item.blog_id ) } }
 				style={ { color: 'inherit', textDecoration: 'none' } }
 				onClick={ () => onSiteClick?.( item ) }
 			>
 				{ getSiteName( item ) }
-			</a>
+			</Link>
 		),
 	};
 }

--- a/client/dashboard/agency/sites/dataviews/site.tsx
+++ b/client/dashboard/agency/sites/dataviews/site.tsx
@@ -35,8 +35,8 @@ export function getSiteNameField(
 		getValue: ( { item } ) => getSiteName( item ),
 		render: ( { item } ) => (
 			<Link
-				to="/sites/$siteId"
-				params={ { siteId: String( item.blog_id ) } }
+				to="/sites/$siteSlug"
+				params={ { siteSlug: item.url } }
 				style={ { color: 'inherit', textDecoration: 'none' } }
 				onClick={ () => onSiteClick?.( item ) }
 			>

--- a/client/dashboard/agency/sites/site-icon.tsx
+++ b/client/dashboard/agency/sites/site-icon.tsx
@@ -1,0 +1,48 @@
+import type { AgencySite } from '@automattic/api-core';
+
+// TODO: make this fallback themeable (incl. dark mode) once A4A supports dark mode.
+const FALLBACK_SITE_COLOR = 'linear-gradient( 45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4 )';
+
+export default function AgencySiteIcon( { site, size }: { site: AgencySite; size: number } ) {
+	const ico = site.icon?.img || site.icon?.ico;
+
+	if ( ico ) {
+		return (
+			<img
+				src={ ico }
+				alt=""
+				width={ size }
+				height={ size }
+				loading="lazy"
+				style={ {
+					display: 'block',
+					boxSizing: 'border-box',
+					flexShrink: 0,
+					width: size,
+					height: size,
+					minWidth: size,
+					borderRadius: 4,
+					objectFit: 'cover',
+					outline: '1px solid rgba( 0, 0, 0, 0.04 )',
+					outlineOffset: -1,
+				} }
+			/>
+		);
+	}
+
+	return (
+		<span
+			aria-hidden="true"
+			style={ {
+				display: 'block',
+				boxSizing: 'border-box',
+				flexShrink: 0,
+				width: size,
+				height: size,
+				minWidth: size,
+				borderRadius: 4,
+				background: site.site_color || FALLBACK_SITE_COLOR,
+			} }
+		/>
+	);
+}

--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -8,8 +8,8 @@ import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../../compon
 import AgencySiteSwitcherItem from './site-switcher-item';
 
 export default function AgencySiteSidebar() {
-	const { siteId } = agencySiteRoute.useParams();
-	const { data: site } = useQuery( agencySiteQuery( Number( siteId ) ) );
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useQuery( agencySiteQuery( siteSlug ) );
 
 	if ( ! site ) {
 		return null;
@@ -25,7 +25,7 @@ export default function AgencySiteSidebar() {
 				<SidebarMenu>
 					<SidebarMenuItem
 						icon={ category }
-						to={ `/sites/${ siteId }` }
+						to={ `/sites/${ siteSlug }` }
 						activeOptions={ { exact: true } }
 					>
 						{ __( 'Overview' ) }

--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -11,27 +11,25 @@ export default function AgencySiteSidebar() {
 	const { siteSlug } = agencySiteRoute.useParams();
 	const { data: site } = useQuery( agencySiteQuery( siteSlug ) );
 
-	if ( ! site ) {
-		return null;
-	}
-
 	return (
 		<VStack spacing={ 2 }>
 			<SidebarBackButton to="/sites">{ __( 'Back to Sites' ) }</SidebarBackButton>
-			<VStack spacing={ 4 }>
-				<SidebarMenu>
-					<AgencySiteSwitcherItem site={ site } />
-				</SidebarMenu>
-				<SidebarMenu>
-					<SidebarMenuItem
-						icon={ category }
-						to={ `/sites/${ siteSlug }` }
-						activeOptions={ { exact: true } }
-					>
-						{ __( 'Overview' ) }
-					</SidebarMenuItem>
-				</SidebarMenu>
-			</VStack>
+			{ site && (
+				<VStack spacing={ 4 }>
+					<SidebarMenu>
+						<AgencySiteSwitcherItem site={ site } />
+					</SidebarMenu>
+					<SidebarMenu>
+						<SidebarMenuItem
+							icon={ category }
+							to={ `/sites/${ siteSlug }` }
+							activeOptions={ { exact: true } }
+						>
+							{ __( 'Overview' ) }
+						</SidebarMenuItem>
+					</SidebarMenu>
+				</VStack>
+			) }
 		</VStack>
 	);
 }

--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -1,0 +1,37 @@
+import { agencySiteQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { category } from '@wordpress/icons';
+import { agencySiteRoute } from '../../../app/router/agency';
+import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../../components/sidebar';
+import AgencySiteSwitcherItem from './site-switcher-item';
+
+export default function AgencySiteSidebar() {
+	const { siteId } = agencySiteRoute.useParams();
+	const { data: site } = useQuery( agencySiteQuery( Number( siteId ) ) );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 2 }>
+			<SidebarBackButton to="/sites">{ __( 'Back to Sites' ) }</SidebarBackButton>
+			<VStack spacing={ 4 }>
+				<SidebarMenu>
+					<AgencySiteSwitcherItem site={ site } />
+				</SidebarMenu>
+				<SidebarMenu>
+					<SidebarMenuItem
+						icon={ category }
+						to={ `/sites/${ siteId }` }
+						activeOptions={ { exact: true } }
+					>
+						{ __( 'Overview' ) }
+					</SidebarMenuItem>
+				</SidebarMenu>
+			</VStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/sites/site-sidebar/site-switcher-item.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/site-switcher-item.tsx
@@ -1,0 +1,58 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	ExternalLink,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronUpDown } from '@wordpress/icons';
+import { SidebarMenuSwitcherItem } from '../../../components/sidebar';
+import { Text } from '../../../components/text';
+import { getDisplayUrl, getSiteName, getSiteUrl } from '../dataviews/site-data';
+import AgencySiteIcon from '../site-icon';
+import AgencySiteSwitcher from '../site-switcher';
+import type { AgencySite } from '@automattic/api-core';
+
+export default function AgencySiteSwitcherItem( { site }: { site: AgencySite } ) {
+	return (
+		<SidebarMenuSwitcherItem
+			switcher={
+				<AgencySiteSwitcher
+					site={ site }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							variant="tertiary"
+							onClick={ onToggle }
+							onKeyDown={ ( event: React.KeyboardEvent ) => {
+								if ( ! isOpen && event.code === 'ArrowDown' ) {
+									event.preventDefault();
+									onToggle();
+								}
+							} }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ __( 'Switch site' ) }
+							icon={ chevronUpDown }
+							size="small"
+						/>
+					) }
+				/>
+			}
+		>
+			<HStack justify="flex-start" alignment="center">
+				<AgencySiteIcon site={ site } size={ 36 } />
+				<VStack spacing={ 0 }>
+					<Text weight={ 500 } truncate numberOfLines={ 1 }>
+						{ getSiteName( site ) }
+					</Text>
+					<ExternalLink
+						href={ getSiteUrl( site ) }
+						style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+					>
+						{ getDisplayUrl( site ) }
+					</ExternalLink>
+				</VStack>
+			</HStack>
+		</SidebarMenuSwitcherItem>
+	);
+}

--- a/client/dashboard/agency/sites/site-switcher/index.tsx
+++ b/client/dashboard/agency/sites/site-switcher/index.tsx
@@ -56,9 +56,7 @@ export default function AgencySiteSwitcher( props: AgencySiteSwitcherProps ) {
 			items={ sites }
 			value={ site }
 			searchableFields={ searchableFields }
-			getItemUrl={ ( item ) =>
-				buildCurrentRouteLink( { params: { siteId: String( item.blog_id ) } } )
-			}
+			getItemUrl={ ( item ) => buildCurrentRouteLink( { params: { siteSlug: item.url } } ) }
 			open={ isOpen }
 			onToggle={ setIsOpen }
 		/>

--- a/client/dashboard/agency/sites/site-switcher/index.tsx
+++ b/client/dashboard/agency/sites/site-switcher/index.tsx
@@ -1,0 +1,66 @@
+import { agencySitesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import useBuildCurrentRouteLink from '../../../app/hooks/use-build-current-route-link';
+import Switcher from '../../../components/switcher';
+import { Text } from '../../../components/text';
+import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
+import AgencySiteIcon from '../site-icon';
+import type { SwitcherProps } from '../../../components/switcher';
+import type { AgencySite } from '@automattic/api-core';
+
+export type AgencySiteSwitcherProps = Pick< SwitcherProps< AgencySite >, 'renderToggle' > & {
+	site: AgencySite;
+};
+
+const searchableFields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: AgencySite } ) => getSiteName( item ),
+	},
+	{
+		id: 'URL',
+		getValue: ( { item }: { item: AgencySite } ) => getDisplayUrl( item ),
+	},
+];
+
+export default function AgencySiteSwitcher( props: AgencySiteSwitcherProps ) {
+	const { site, ...switcherProps } = props;
+	const [ isOpen, setIsOpen ] = useState( false );
+	const { data: sites } = useQuery( {
+		...agencySitesQuery( { per_page: 100 } ),
+		enabled: isOpen,
+	} );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	return (
+		<Switcher< AgencySite >
+			{ ...switcherProps }
+			renderItem={ ( { item, context } ) => (
+				<Switcher.Item
+					media={ <AgencySiteIcon site={ item } size={ context === 'list' ? 32 : 16 } /> }
+					title={
+						<Text weight={ 500 } truncate numberOfLines={ 1 } style={ { color: 'inherit' } }>
+							{ getSiteName( item ) }
+						</Text>
+					}
+					description={
+						context === 'list' ? (
+							<Text variant="muted" truncate numberOfLines={ 1 }>
+								{ getDisplayUrl( item ) }
+							</Text>
+						) : undefined
+					}
+				/>
+			) }
+			items={ sites }
+			value={ site }
+			searchableFields={ searchableFields }
+			getItemUrl={ ( item ) =>
+				buildCurrentRouteLink( { params: { siteId: String( item.blog_id ) } } )
+			}
+			open={ isOpen }
+			onToggle={ setIsOpen }
+		/>
+	);
+}

--- a/client/dashboard/agency/sites/site-switcher/index.tsx
+++ b/client/dashboard/agency/sites/site-switcher/index.tsx
@@ -1,7 +1,6 @@
 import { agencySitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import useBuildCurrentRouteLink from '../../../app/hooks/use-build-current-route-link';
 import Switcher from '../../../components/switcher';
 import { Text } from '../../../components/text';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
@@ -31,7 +30,6 @@ export default function AgencySiteSwitcher( props: AgencySiteSwitcherProps ) {
 		...agencySitesQuery( { per_page: 100 } ),
 		enabled: isOpen,
 	} );
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
 	return (
 		<Switcher< AgencySite >
@@ -56,7 +54,7 @@ export default function AgencySiteSwitcher( props: AgencySiteSwitcherProps ) {
 			items={ sites }
 			value={ site }
 			searchableFields={ searchableFields }
-			getItemUrl={ ( item ) => buildCurrentRouteLink( { params: { siteSlug: item.url } } ) }
+			getItemUrl={ ( item ) => `/sites/${ item.url }` }
 			open={ isOpen }
 			onToggle={ setIsOpen }
 		/>

--- a/client/dashboard/agency/sites/site/index.tsx
+++ b/client/dashboard/agency/sites/site/index.tsx
@@ -7,8 +7,8 @@ import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 
 export default function AgencySite() {
-	const { siteId } = agencySiteRoute.useParams();
-	const { data: site } = useSuspenseQuery( agencySiteQuery( Number( siteId ) ) );
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
 
 	if ( ! site ) {
 		return (

--- a/client/dashboard/agency/sites/site/index.tsx
+++ b/client/dashboard/agency/sites/site/index.tsx
@@ -1,27 +1,7 @@
-import { agencySiteQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
-import { agencySiteRoute } from '../../../app/router/agency';
-import { PageHeader } from '../../../components/page-header';
-import PageLayout from '../../../components/page-layout';
 
+// The route loader throws `notFound()` when the site isn't in the agency's
+// list, so children can rely on the site existing.
 export default function AgencySite() {
-	const { siteSlug } = agencySiteRoute.useParams();
-	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
-
-	if ( ! site ) {
-		return (
-			<PageLayout
-				header={
-					<PageHeader
-						title={ __( 'Site not found' ) }
-						description={ __( 'This site is no longer managed by your agency.' ) }
-					/>
-				}
-			/>
-		);
-	}
-
 	return <Outlet />;
 }

--- a/client/dashboard/agency/sites/site/index.tsx
+++ b/client/dashboard/agency/sites/site/index.tsx
@@ -1,0 +1,27 @@
+import { agencySiteQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Outlet } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { agencySiteRoute } from '../../../app/router/agency';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+
+export default function AgencySite() {
+	const { siteId } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( agencySiteQuery( Number( siteId ) ) );
+
+	if ( ! site ) {
+		return (
+			<PageLayout
+				header={
+					<PageHeader
+						title={ __( 'Site not found' ) }
+						description={ __( 'This site is no longer managed by your agency.' ) }
+					/>
+				}
+			/>
+		);
+	}
+
+	return <Outlet />;
+}

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -1,0 +1,21 @@
+import { agencySiteQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { agencySiteRoute } from '../../../app/router/agency';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
+
+export default function AgencySiteOverview() {
+	const { siteId } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( agencySiteQuery( Number( siteId ) ) );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return (
+		<PageLayout
+			header={ <PageHeader title={ getSiteName( site ) } description={ getDisplayUrl( site ) } /> }
+		/>
+	);
+}

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -6,8 +6,8 @@ import PageLayout from '../../../components/page-layout';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
 
 export default function AgencySiteOverview() {
-	const { siteId } = agencySiteRoute.useParams();
-	const { data: site } = useSuspenseQuery( agencySiteQuery( Number( siteId ) ) );
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
 
 	if ( ! site ) {
 		return null;

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -1,17 +1,10 @@
-import { agencySiteQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { agencySiteRoute } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
 
 export default function AgencySiteOverview() {
-	const { siteSlug } = agencySiteRoute.useParams();
-	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
-
-	if ( ! site ) {
-		return null;
-	}
+	const site = agencySiteRoute.useLoaderData();
 
 	return (
 		<PageLayout

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -50,8 +50,7 @@ boot( {
 	},
 	optIn: false,
 	components: {
-		// Temporary: reuse the generic site switcher until it's agency-scoped.
-		siteSwitcher: () => import( '../sites/site-switcher' ),
+		siteSwitcher: () => import( '../agency/sites/site-switcher' ),
 	},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -49,9 +49,7 @@ boot( {
 		darkMode: false,
 	},
 	optIn: false,
-	components: {
-		siteSwitcher: () => import( '../agency/sites/site-switcher' ),
-	},
+	components: {},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
 		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -79,7 +79,7 @@ export type AppConfig = {
 	components: {
 		sites?: () => Promise< { default: React.FC } >;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		siteSwitcher: () => Promise< { default: React.FC< any > } >;
+		siteSwitcher?: () => Promise< { default: React.FC< any > } >;
 	};
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => ReturnType< typeof sitesQuery >;

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -2,6 +2,7 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
+import AgencySiteSidebar from '../../agency/sites/site-sidebar';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import SidebarNavigator from '../../components/sidebar-navigator';
@@ -46,6 +47,9 @@ export default function Sidebar( { scrollSyncEnabled = false }: { scrollSyncEnab
 				</SidebarNavigator.Screen>
 				<SidebarNavigator.Screen path="/sites/$siteSlug">
 					<SiteSidebar />
+				</SidebarNavigator.Screen>
+				<SidebarNavigator.Screen path="/agency/sites/$siteId">
+					<AgencySiteSidebar />
 				</SidebarNavigator.Screen>
 				<SidebarNavigator.Screen path="/domains/$domainName">
 					<DomainSidebar />

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -48,7 +48,7 @@ export default function Sidebar( { scrollSyncEnabled = false }: { scrollSyncEnab
 				<SidebarNavigator.Screen path="/sites/$siteSlug">
 					<SiteSidebar />
 				</SidebarNavigator.Screen>
-				<SidebarNavigator.Screen path="/agency/sites/$siteId">
+				<SidebarNavigator.Screen path="/agency/sites/$siteSlug">
 					<AgencySiteSidebar />
 				</SidebarNavigator.Screen>
 				<SidebarNavigator.Screen path="/domains/$domainName">

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -2,6 +2,7 @@ import {
 	activeAgencyQuery,
 	agencyQuery,
 	agencyResourcesQuery,
+	agencySiteQuery,
 	mcpSettingsQuery,
 	queryClient,
 	rawUserPreferencesQuery,
@@ -235,6 +236,31 @@ const earnPayoutSettingsRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteId` – agency site detail (a layout that hosts the section routes)
+export const agencySiteRoute = createRoute( {
+	getParentRoute: () => agencyRoute,
+	path: 'sites/$siteId',
+	loader: ( { params: { siteId } } ) =>
+		queryClient.ensureQueryData( agencySiteQuery( Number( siteId ) ) ),
+} ).lazy( () =>
+	import( '../../agency/sites/site' ).then( ( d ) =>
+		createLazyRoute( 'agency-site' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteOverviewRoute = createRoute( {
+	getParentRoute: () => agencySiteRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../agency/sites/site/overview' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-overview' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -248,5 +274,6 @@ export const createAgencyRoutes = () => [
 		earnWooPaymentsRoute,
 		earnMigrationsRoute,
 		earnPayoutSettingsRoute,
+		agencySiteRoute.addChildren( [ agencySiteOverviewRoute ] ),
 	] ),
 ];

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -7,7 +7,7 @@ import {
 	queryClient,
 	rawUserPreferencesQuery,
 } from '@automattic/api-queries';
-import { createRoute, createLazyRoute } from '@tanstack/react-router';
+import { createRoute, createLazyRoute, notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
@@ -240,8 +240,13 @@ const earnPayoutSettingsRoute = createRoute( {
 export const agencySiteRoute = createRoute( {
 	getParentRoute: () => agencyRoute,
 	path: 'sites/$siteSlug',
-	loader: ( { params: { siteSlug } } ) =>
-		queryClient.ensureQueryData( agencySiteQuery( siteSlug ) ),
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( agencySiteQuery( siteSlug ) );
+		if ( ! site ) {
+			throw notFound();
+		}
+		return site;
+	},
 } ).lazy( () =>
 	import( '../../agency/sites/site' ).then( ( d ) =>
 		createLazyRoute( 'agency-site' )( {

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -236,12 +236,12 @@ const earnPayoutSettingsRoute = createRoute( {
 	)
 );
 
-// `/sites/$siteId` – agency site detail (a layout that hosts the section routes)
+// `/sites/$siteSlug` – agency site detail (a layout that hosts the section routes)
 export const agencySiteRoute = createRoute( {
 	getParentRoute: () => agencyRoute,
-	path: 'sites/$siteId',
-	loader: ( { params: { siteId } } ) =>
-		queryClient.ensureQueryData( agencySiteQuery( Number( siteId ) ) ),
+	path: 'sites/$siteSlug',
+	loader: ( { params: { siteSlug } } ) =>
+		queryClient.ensureQueryData( agencySiteQuery( siteSlug ) ),
 } ).lazy( () =>
 	import( '../../agency/sites/site' ).then( ( d ) =>
 		createLazyRoute( 'agency-site' )( {

--- a/client/dashboard/sites/site-sidebar/site-switcher-item.tsx
+++ b/client/dashboard/sites/site-sidebar/site-switcher-item.tsx
@@ -22,9 +22,17 @@ export default function SiteSwitcherItem( { site }: { site: Site } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const SiteSwitcher = useMemo(
 		() =>
-			lazy( components.siteSwitcher ) as React.LazyExoticComponent< React.FC< SiteSwitcherProps > >,
+			components.siteSwitcher
+				? ( lazy( components.siteSwitcher ) as React.LazyExoticComponent<
+						React.FC< SiteSwitcherProps >
+				  > )
+				: null,
 		[ components ]
 	);
+
+	if ( ! SiteSwitcher ) {
+		return null;
+	}
 
 	return (
 		<SidebarMenuSwitcherItem

--- a/packages/api-queries/src/jetpack-agency-sites.ts
+++ b/packages/api-queries/src/jetpack-agency-sites.ts
@@ -26,13 +26,17 @@ export const agencySitesQuery = ( options: FetchAgencySitesOptions = {} ) =>
 		queryFn: async () => ( await fetchAgencySites( await resolveAgencyId(), options ) ).sites,
 	} );
 
-// The endpoint has no single-site lookup, so we fetch the agency's sites and
-// select by URL. TODO: replace with a dedicated single-site endpoint.
+// The endpoint has no single-site lookup, so we search the agency's sites by
+// URL and select the exact match. TODO: replace with a dedicated single-site
+// endpoint.
 export const agencySiteQuery = ( siteUrl: string ) =>
 	queryOptions( {
 		queryKey: [ ...agencySitesQueryKey, 'site', siteUrl ],
 		queryFn: async () => {
-			const { sites } = await fetchAgencySites( await resolveAgencyId(), { per_page: 100 } );
+			const { sites } = await fetchAgencySites( await resolveAgencyId(), {
+				search: siteUrl,
+				per_page: 100,
+			} );
 			return sites.find( ( site ) => site.url === siteUrl ) ?? null;
 		},
 	} );

--- a/packages/api-queries/src/jetpack-agency-sites.ts
+++ b/packages/api-queries/src/jetpack-agency-sites.ts
@@ -25,3 +25,14 @@ export const agencySitesQuery = ( options: FetchAgencySitesOptions = {} ) =>
 		queryKey: [ ...agencySitesQueryKey, options ],
 		queryFn: async () => ( await fetchAgencySites( await resolveAgencyId(), options ) ).sites,
 	} );
+
+// The endpoint has no single-site lookup, so we fetch the agency's sites and
+// select by blog_id. TODO: replace with a dedicated single-site endpoint.
+export const agencySiteQuery = ( blogId: number ) =>
+	queryOptions( {
+		queryKey: [ ...agencySitesQueryKey, 'site', blogId ],
+		queryFn: async () => {
+			const { sites } = await fetchAgencySites( await resolveAgencyId(), { per_page: 100 } );
+			return sites.find( ( site ) => site.blog_id === blogId ) ?? null;
+		},
+	} );

--- a/packages/api-queries/src/jetpack-agency-sites.ts
+++ b/packages/api-queries/src/jetpack-agency-sites.ts
@@ -27,12 +27,12 @@ export const agencySitesQuery = ( options: FetchAgencySitesOptions = {} ) =>
 	} );
 
 // The endpoint has no single-site lookup, so we fetch the agency's sites and
-// select by blog_id. TODO: replace with a dedicated single-site endpoint.
-export const agencySiteQuery = ( blogId: number ) =>
+// select by URL. TODO: replace with a dedicated single-site endpoint.
+export const agencySiteQuery = ( siteUrl: string ) =>
 	queryOptions( {
-		queryKey: [ ...agencySitesQueryKey, 'site', blogId ],
+		queryKey: [ ...agencySitesQueryKey, 'site', siteUrl ],
 		queryFn: async () => {
 			const { sites } = await fetchAgencySites( await resolveAgencyId(), { per_page: 100 } );
-			return sites.find( ( site ) => site.blog_id === blogId ) ?? null;
+			return sites.find( ( site ) => site.url === siteUrl ) ?? null;
 		},
 	} );


### PR DESCRIPTION
Part of [A4A-2904](https://linear.app/a8c/issue/A4A-2904)

## Proposed Changes

* Adds a `/sites/$siteId` detail view for agency-managed sites in the Dashboard client's A4A variant.
* Entering a site swaps the global sidebar for a **site-scoped sidebar** — "Back to Sites", an agency-scoped site switcher, and section navigation — mirroring the multi-site dashboard's site detail experience.
* Adds an **agency-scoped site switcher** built on the shared `Switcher` component but typed to the raw `AgencySite` shape and backed by `agencySitesQuery`. Selecting a site navigates to its detail view while preserving the current section.
* Adds an **Overview** section showing the site name and URL (kept intentionally minimal for this first pass, per data availability).
* The agency sites list's name column now links into the detail view.
* Adds `agencySiteQuery( blogId )` to `@automattic/api-queries`, which selects a single site from the agency sites list (there is no dedicated single-site endpoint yet).

## Why are these changes being made?

* Agencies had no way to drill into an individual managed site from the new Dashboard-based A4A Sites screen. This establishes the detail-view foundation (routing, sidebar, switcher, Overview) that later sections — Backups, Scan, Monitoring — will slot into as sibling routes.
* The A4A variant is self-contained and uses the minimal `AgencySite` shape, so the switcher and site icon are agency-specific rather than reusing the dotcom `Site`-typed components.

## Testing Instructions

1. Build and run the Dashboard client for A4A (`yarn start-dashboard`) or visit the Dashboard (A4A) live link > Append the URL with /overview to view the A4A view.
2. Go to **Sites** and click a site's name in the list.
3. Confirm you land on `/sites/<blogId>` with the sidebar swapped to the site-scoped view: "← Back to Sites", the site switcher (icon + name + URL with the up/down toggle), and an **Overview** item.
4. Open the switcher and confirm it lists the agency's sites; selecting one navigates to that site's detail view and keeps you on the Overview section.
5. Confirm the Overview shows the site name and URL.
6. Click **Back to Sites** and confirm you return to the Sites list.

<img width="1905" height="600" alt="Screenshot 2026-07-01 at 1 12 28 PM" src="https://github.com/user-attachments/assets/5ce41dea-76de-4a39-8112-ab68c7112752" />

<img width="1905" height="600" alt="Screenshot 2026-07-01 at 1 12 58 PM" src="https://github.com/user-attachments/assets/e22ac694-ce5c-4741-aeb0-eaa8120bcacc" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
