### PR TITLE
MSD: tester allow-list + new-user ID threshold for rollout cohort

### DIFF
--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -1,16 +1,32 @@
 import config from '@automattic/calypso-config';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 
+export const ROLLOUT_TESTER_USER_IDS = [
+	27056099, // p-jackson
+];
+
+// When rollout begins, users registered after this ID (i.e. new users) are enrolled.
+// TODO update on release day DOTMSD-1357
+const NEW_USER_ID_THRESHOLD = Infinity;
+
 /**
  * Whether the user belongs to the percentage-rollout cohort. Membership is
  * derived from the user ID so it is stable across sessions and reproducible
  * in analytics queries; nothing is ever persisted.
  */
 function isInRolloutCohort( userId: number | undefined ): boolean {
+	if ( userId === undefined ) {
+		return false;
+	}
+
+	// Allow-listed testers bypass the rollout flag entirely.
+	if ( ROLLOUT_TESTER_USER_IDS.includes( userId ) ) {
+		return true;
+	}
+
 	return (
 		config.isEnabled( 'dashboard/enable-percentage-rollout' ) &&
-		userId !== undefined &&
-		userId % 100 < 50
+		( userId % 100 < 50 || userId > NEW_USER_ID_THRESHOLD )
 	);
 }
 


### PR DESCRIPTION
Part of DOTMSD-1357

## Proposed Changes

* Add `ROLLOUT_TESTER_USER_IDS` — an allow-list of user IDs that always get the forced hosting-dashboard experience, bypassing the `dashboard/enable-percentage-rollout` flag. Lets us test the forced behaviour before rollout.
* Add `NEW_USER_ID_THRESHOLD` (currently `Infinity`, a no-op) so that once rollout begins, users registered after a chosen ID (i.e. new users) are enrolled alongside the existing 50% modulo bucket. To be set on release day.
* `isInRolloutCohort` now early-returns for the allow-list and folds the new-user criterion into the flag-gated check.

## Why are these changes being made?

Gets the DOTMSD-1357 launch task mostly ready: new users should all be part of the MSD rollout cohort. Wiring the threshold in now (as `Infinity`) means release day is a one-line change. The tester allow-list unblocks advanced testing of the forced experience today, without flipping the rollout flag for anyone else.

## Testing Instructions

* `yarn test-client client/dashboard/utils/test/hosting-dashboard-enrollment.ts` — passes.
* With `dashboard/enable-percentage-rollout` off, log in as an allow-listed user and confirm the hosting dashboard is forced and the opt-in toggle is hidden.
* Non-allow-listed users are unaffected while the flag is off.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
