### PR TITLE
Reader Spaces: highlight the last-opened post across feed layouts

### DIFF
--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -77,19 +77,16 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 	const isDiscover = variant === 'discover';
 	const streamKey = isDiscover ? `space_discover:${ spaceId }` : `space:${ spaceId }`;
 	const isLegacy = layout === 'legacy';
+	const rawLocale = useSelector( getCurrentLocaleSlug );
+	const localeSlug = rawLocale && ! isDefaultLocale( rawLocale ) ? rawLocale : null;
 	const stream = useInfiniteStream( {
 		streamKey,
+		localeSlug,
 		perPage: getLayoutPageSize( layout ),
 		options: { enabled: ! isLegacy },
 	} );
 	const posts = useMemo( () => collectPosts( stream.pages ), [ stream.pages ] );
 
-	// Post selection is shared across layouts via the stream selection cache (keyed by
-	// stream + normalized locale, matching `<Stream>`/full-post navigation). The legacy
-	// layout wires this itself through `ReaderStreamV2`; the curated layouts get these
-	// helpers so the post the user opened stays highlighted when they return.
-	const rawLocale = useSelector( getCurrentLocaleSlug );
-	const localeSlug = rawLocale && ! isDefaultLocale( rawLocale ) ? rawLocale : null;
 	const { selectedPostKey, selectPostKey } = useStreamPostKeySelection( { streamKey, localeSlug } );
 	const isPostSelected = useCallback(
 		( post: ReadStreamPost ) =>

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -1,9 +1,14 @@
+import { isDefaultLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useSpace } from 'calypso/reader/data/spaces';
 import { useInfiniteStream } from 'calypso/reader/data/stream';
 import { ScrollDebugOverlay } from 'calypso/reader/hooks/use-infinite-list';
+import { keyForPost, keysAreEqual } from 'calypso/reader/post-key';
+import { useStreamPostKeySelection } from 'calypso/reader/stream/use-stream-post-key-selection';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { SpaceFeedSourceNotice } from './components/source-notice';
 import {
 	SpaceFeedEmpty,
@@ -79,6 +84,28 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 	} );
 	const posts = useMemo( () => collectPosts( stream.pages ), [ stream.pages ] );
 
+	// Post selection is shared across layouts via the stream selection cache (keyed by
+	// stream + normalized locale, matching `<Stream>`/full-post navigation). The legacy
+	// layout wires this itself through `ReaderStreamV2`; the curated layouts get these
+	// helpers so the post the user opened stays highlighted when they return.
+	const rawLocale = useSelector( getCurrentLocaleSlug );
+	const localeSlug = rawLocale && ! isDefaultLocale( rawLocale ) ? rawLocale : null;
+	const { selectedPostKey, selectPostKey } = useStreamPostKeySelection( { streamKey, localeSlug } );
+	const isPostSelected = useCallback(
+		( post: ReadStreamPost ) =>
+			selectedPostKey != null && keysAreEqual( keyForPost( post ), selectedPostKey ),
+		[ selectedPostKey ]
+	);
+	const selectPost = useCallback(
+		( post: ReadStreamPost ) => {
+			const postKey = keyForPost( post );
+			if ( postKey ) {
+				selectPostKey( postKey );
+			}
+		},
+		[ selectPostKey ]
+	);
+
 	// Scroll on the Reader's main bounded container (`.layout__primary > div`, which
 	// has a fixed height) — the same scrollbar the rest of the Reader uses — instead
 	// of a nested viewport. The virtualizer needs a height-bounded element here: an
@@ -122,6 +149,8 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 					isLoadingMore={ false }
 					loadMore={ () => {} }
 					restoreKey={ `${ spaceId }:${ variant }:${ layout }` }
+					isPostSelected={ isPostSelected }
+					selectPost={ selectPost }
 				/>
 			);
 		}
@@ -161,6 +190,8 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 				isLoadingMore={ stream.isFetchingNextPage }
 				loadMore={ stream.fetchNextPage }
 				restoreKey={ `${ spaceId }:${ variant }:${ layout }` }
+				isPostSelected={ isPostSelected }
+				selectPost={ selectPost }
 			/>
 		);
 	};

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -97,10 +97,13 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 		( post: ReadStreamPost ) => {
 			const postKey = keyForPost( post );
 			if ( postKey ) {
-				selectPostKey( postKey );
+				const streamItem = stream.items.find(
+					( item ) => keysAreEqual( item, postKey ) || keysAreEqual( item.xPostMetadata, postKey )
+				);
+				selectPostKey( streamItem ?? postKey );
 			}
 		},
-		[ selectPostKey ]
+		[ selectPostKey, stream.items ]
 	);
 
 	// Scroll on the Reader's main bounded container (`.layout__primary > div`, which

--- a/client/reader/spaces/feed/layouts/board/index.tsx
+++ b/client/reader/spaces/feed/layouts/board/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 const LANES = 2;
 const ESTIMATED_SIZE = 260;
 
-function BoardCard( { post }: { post: ReadStreamPost } ) {
+function BoardCard( { post, onOpen }: { post: ReadStreamPost; onOpen: () => void } ) {
 	const fields = getPostFields( post );
 	return (
 		<div className="space-feed-board__card">
@@ -27,7 +27,7 @@ function BoardCard( { post }: { post: ReadStreamPost } ) {
 			</div>
 			<div className="space-feed-board__body">
 				<h3 className="space-feed-board__title">
-					<a className="space-feed-board__title-link" href={ fields.postHref }>
+					<a className="space-feed-board__title-link" href={ fields.postHref } onClick={ onOpen }>
 						{ fields.title }
 					</a>
 				</h3>
@@ -52,7 +52,10 @@ function BoardCard( { post }: { post: ReadStreamPost } ) {
 				<div className="space-feed-board__actions">
 					<ReaderPostActions
 						post={ post }
-						onCommentClick={ () => page( getPostUrl( post ) ) }
+						onCommentClick={ () => {
+							onOpen();
+							page( getPostUrl( post ) );
+						} }
 						iconSize={ 18 }
 					/>
 				</div>
@@ -68,6 +71,8 @@ export function BoardLayout( {
 	isLoadingMore,
 	loadMore,
 	restoreKey,
+	isPostSelected,
+	selectPost,
 }: SpaceFeedLayoutProps ) {
 	const { getListProps, items, measureElement, scrollMargin } = useInfiniteList( {
 		scrollElement,
@@ -88,6 +93,7 @@ export function BoardLayout( {
 				<div
 					key={ virtualItem.key }
 					data-index={ virtualItem.index }
+					data-selected={ isPostSelected( posts[ virtualItem.index ] ) || undefined }
 					ref={ measureElement }
 					className="space-feed-board__item"
 					style={ {
@@ -96,7 +102,10 @@ export function BoardLayout( {
 						transform: `translateY(${ virtualItem.start - scrollMargin }px)`,
 					} }
 				>
-					<BoardCard post={ posts[ virtualItem.index ] } />
+					<BoardCard
+						post={ posts[ virtualItem.index ] }
+						onOpen={ () => selectPost( posts[ virtualItem.index ] ) }
+					/>
 				</div>
 			) ) }
 		</div>

--- a/client/reader/spaces/feed/layouts/board/style.scss
+++ b/client/reader/spaces/feed/layouts/board/style.scss
@@ -23,6 +23,19 @@
 	color: inherit;
 }
 
+// The post opened last stays highlighted with an accent bar just outside the
+// card's leading edge (matching the classic post card), so it's easy to spot on
+// return from the full-post view. Anchored on the item wrapper because the card
+// clips its own overflow.
+.space-feed-board__item[data-selected]::before {
+	content: '';
+	position: absolute;
+	inset-block: 20px;
+	inset-inline-start: 8px;
+	inline-size: 2px;
+	background: var(--color-primary);
+}
+
 .space-feed-board__actions {
 	margin-block-start: 12px;
 }

--- a/client/reader/spaces/feed/layouts/board/style.scss
+++ b/client/reader/spaces/feed/layouts/board/style.scss
@@ -23,10 +23,6 @@
 	color: inherit;
 }
 
-// The post opened last stays highlighted with an accent bar just outside the
-// card's leading edge (matching the classic post card), so it's easy to spot on
-// return from the full-post view. Anchored on the item wrapper because the card
-// clips its own overflow.
 .space-feed-board__item[data-selected]::before {
 	content: '';
 	position: absolute;

--- a/client/reader/spaces/feed/layouts/gallery/index.tsx
+++ b/client/reader/spaces/feed/layouts/gallery/index.tsx
@@ -34,11 +34,29 @@ function useGalleryColumns(): number {
 	return 1;
 }
 
-function GalleryCard( { post }: { post: ReadStreamPost } ) {
+function GalleryCard( {
+	post,
+	isSelected,
+	onOpen,
+}: {
+	post: ReadStreamPost;
+	isSelected: boolean;
+	onOpen: () => void;
+} ) {
 	const fields = getPostFields( post );
 	return (
-		<VStack className="space-feed-gallery__card" spacing={ 1.5 } alignment="stretch">
-			<a className="space-feed-gallery__thumb" href={ fields.postHref } aria-label={ fields.title }>
+		<VStack
+			className="space-feed-gallery__card"
+			spacing={ 1.5 }
+			alignment="stretch"
+			data-selected={ isSelected || undefined }
+		>
+			<a
+				className="space-feed-gallery__thumb"
+				href={ fields.postHref }
+				aria-label={ fields.title }
+				onClick={ onOpen }
+			>
 				{ fields.imageUrl ? (
 					<img
 						className="space-feed-gallery__image"
@@ -72,7 +90,11 @@ function GalleryCard( { post }: { post: ReadStreamPost } ) {
 						) }
 					</HStack>
 					<h3 className="space-feed-gallery__title">
-						<a className="space-feed-gallery__title-link" href={ fields.postHref }>
+						<a
+							className="space-feed-gallery__title-link"
+							href={ fields.postHref }
+							onClick={ onOpen }
+						>
 							{ fields.title }
 						</a>
 					</h3>
@@ -81,7 +103,10 @@ function GalleryCard( { post }: { post: ReadStreamPost } ) {
 					variant="discreet"
 					split
 					post={ post }
-					onCommentClick={ () => page( getPostUrl( post ) ) }
+					onCommentClick={ () => {
+						onOpen();
+						page( getPostUrl( post ) );
+					} }
 					iconSize={ 18 }
 				/>
 			</VStack>
@@ -112,6 +137,8 @@ export function GalleryLayout( {
 	isLoadingMore,
 	loadMore,
 	restoreKey,
+	isPostSelected,
+	selectPost,
 }: SpaceFeedLayoutProps ) {
 	const columns = useGalleryColumns();
 
@@ -165,7 +192,12 @@ export function GalleryLayout( {
 					>
 						{ rows[ virtualRow.index ].map( ( cell, cellIndex ) =>
 							cell ? (
-								<GalleryCard key={ getPostFieldKey( cell ) } post={ cell } />
+								<GalleryCard
+									key={ getPostFieldKey( cell ) }
+									post={ cell }
+									isSelected={ isPostSelected( cell ) }
+									onOpen={ () => selectPost( cell ) }
+								/>
 							) : (
 								// eslint-disable-next-line react/no-array-index-key
 								<GallerySkeletonCard key={ `skeleton-${ cellIndex }` } />

--- a/client/reader/spaces/feed/layouts/gallery/style.scss
+++ b/client/reader/spaces/feed/layouts/gallery/style.scss
@@ -23,9 +23,22 @@
 }
 
 .space-feed-gallery__card {
+	position: relative;
 	min-inline-size: 0;
 	block-size: 270px;
 	color: inherit;
+}
+
+// The post opened last stays highlighted with an accent bar just outside the
+// card's leading edge (matching the classic post card), so it's easy to spot on
+// return from the full-post view.
+.space-feed-gallery__card[data-selected]::before {
+	content: '';
+	position: absolute;
+	inset-block: 0;
+	inset-inline-start: -16px;
+	inline-size: 2px;
+	background: var(--color-primary);
 }
 
 .space-feed-gallery__thumb {

--- a/client/reader/spaces/feed/layouts/gallery/style.scss
+++ b/client/reader/spaces/feed/layouts/gallery/style.scss
@@ -29,9 +29,6 @@
 	color: inherit;
 }
 
-// The post opened last stays highlighted with an accent bar just outside the
-// card's leading edge (matching the classic post card), so it's easy to spot on
-// return from the full-post view.
 .space-feed-gallery__card[data-selected]::before {
 	content: '';
 	position: absolute;

--- a/client/reader/spaces/feed/layouts/standard-list/index.tsx
+++ b/client/reader/spaces/feed/layouts/standard-list/index.tsx
@@ -24,13 +24,32 @@ type Row =
 const HEADER_SIZE = 44;
 const ROW_SIZE = 170;
 
-function PostRow( { fields, post }: { fields: SpaceFeedPostFields; post: ReadStreamPost } ) {
+function PostRow( {
+	fields,
+	post,
+	isSelected,
+	onOpen,
+}: {
+	fields: SpaceFeedPostFields;
+	post: ReadStreamPost;
+	isSelected: boolean;
+	onOpen: () => void;
+} ) {
 	return (
-		<HStack className="space-feed-standard-list__row" spacing={ 3 } alignment="flex-start">
+		<HStack
+			className="space-feed-standard-list__row"
+			spacing={ 3 }
+			alignment="flex-start"
+			data-selected={ isSelected || undefined }
+		>
 			<VStack className="space-feed-standard-list__body" spacing={ 3 } alignment="stretch">
 				<VStack className="space-feed-standard-list__headline" spacing={ 1 } alignment="stretch">
 					<h3 className="space-feed-standard-list__title">
-						<a className="space-feed-standard-list__title-link" href={ fields.postHref }>
+						<a
+							className="space-feed-standard-list__title-link"
+							href={ fields.postHref }
+							onClick={ onOpen }
+						>
 							{ fields.title }
 						</a>
 					</h3>
@@ -59,7 +78,10 @@ function PostRow( { fields, post }: { fields: SpaceFeedPostFields; post: ReadStr
 				</HStack>
 				<ReaderPostActions
 					post={ post }
-					onCommentClick={ () => page( getPostUrl( post ) ) }
+					onCommentClick={ () => {
+						onOpen();
+						page( getPostUrl( post ) );
+					} }
 					iconSize={ 18 }
 					variant="discreet"
 				/>
@@ -82,6 +104,8 @@ export function StandardListLayout( {
 	isLoadingMore,
 	loadMore,
 	restoreKey,
+	isPostSelected,
+	selectPost,
 }: SpaceFeedLayoutProps ) {
 	const translate = useTranslate();
 
@@ -149,7 +173,12 @@ export function StandardListLayout( {
 						{ row.kind === 'header' ? (
 							<h2 className="space-feed-standard-list__group">{ row.label }</h2>
 						) : (
-							<PostRow fields={ row.fields } post={ row.post } />
+							<PostRow
+								fields={ row.fields }
+								post={ row.post }
+								isSelected={ isPostSelected( row.post ) }
+								onOpen={ () => selectPost( row.post ) }
+							/>
 						) }
 					</div>
 				);

--- a/client/reader/spaces/feed/layouts/standard-list/style.scss
+++ b/client/reader/spaces/feed/layouts/standard-list/style.scss
@@ -20,8 +20,21 @@
 }
 
 .space-feed-standard-list__row {
+	position: relative;
 	padding-block: 18px;
 	border-block-end: 1px solid var(--color-border-subtle);
+}
+
+// The post opened last stays highlighted with an accent bar just outside the
+// leading edge (matching the classic post card), so it's easy to spot on return
+// from the full-post view.
+.space-feed-standard-list__row[data-selected]::before {
+	content: '';
+	position: absolute;
+	inset-block: 0;
+	inset-inline-start: -16px;
+	inline-size: 2px;
+	background: var(--color-primary);
 }
 
 .space-feed-standard-list__item[data-first='true'] .space-feed-standard-list__row {

--- a/client/reader/spaces/feed/layouts/standard-list/style.scss
+++ b/client/reader/spaces/feed/layouts/standard-list/style.scss
@@ -25,9 +25,6 @@
 	border-block-end: 1px solid var(--color-border-subtle);
 }
 
-// The post opened last stays highlighted with an accent bar just outside the
-// leading edge (matching the classic post card), so it's easy to spot on return
-// from the full-post view.
 .space-feed-standard-list__row[data-selected]::before {
 	content: '';
 	position: absolute;

--- a/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
+++ b/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
@@ -61,6 +61,8 @@ describe( 'StandardListLayout', () => {
 				isLoadingMore={ false }
 				loadMore={ jest.fn() }
 				restoreKey="work-id:standard-list"
+				isPostSelected={ () => false }
+				selectPost={ jest.fn() }
 			/>
 		);
 
@@ -87,6 +89,8 @@ describe( 'StandardListLayout', () => {
 				isLoadingMore={ false }
 				loadMore={ jest.fn() }
 				restoreKey="work-id:standard-list"
+				isPostSelected={ () => false }
+				selectPost={ jest.fn() }
 			/>
 		);
 
@@ -113,6 +117,8 @@ describe( 'StandardListLayout', () => {
 				isLoadingMore={ false }
 				loadMore={ jest.fn() }
 				restoreKey="work-id:standard-list"
+				isPostSelected={ () => false }
+				selectPost={ jest.fn() }
 			/>
 		);
 

--- a/client/reader/spaces/feed/layouts/types.ts
+++ b/client/reader/spaces/feed/layouts/types.ts
@@ -24,13 +24,9 @@ export interface SpaceFeedLayoutProps {
 	loadMore: () => void;
 	/** Stable key (`${spaceId}:${layout}`) for saving/restoring scroll on Back. */
 	restoreKey: string;
-	/**
-	 * Whether a post is the currently selected one. The shell derives this from the
-	 * shared stream selection cache, so the post the user opened stays highlighted
-	 * when they return from the full-post view.
-	 */
+	/** Whether a post is the currently selected one. */
 	isPostSelected: ( post: ReadStreamPost ) => boolean;
-	/** Mark a post as selected; call it when opening a post so the highlight persists on Back. */
+	/** Mark a post as selected. */
 	selectPost: ( post: ReadStreamPost ) => void;
 }
 

--- a/client/reader/spaces/feed/layouts/types.ts
+++ b/client/reader/spaces/feed/layouts/types.ts
@@ -24,6 +24,14 @@ export interface SpaceFeedLayoutProps {
 	loadMore: () => void;
 	/** Stable key (`${spaceId}:${layout}`) for saving/restoring scroll on Back. */
 	restoreKey: string;
+	/**
+	 * Whether a post is the currently selected one. The shell derives this from the
+	 * shared stream selection cache, so the post the user opened stays highlighted
+	 * when they return from the full-post view.
+	 */
+	isPostSelected: ( post: ReadStreamPost ) => boolean;
+	/** Mark a post as selected; call it when opening a post so the highlight persists on Back. */
+	selectPost: ( post: ReadStreamPost ) => void;
 }
 
 /**

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -16,12 +16,16 @@ import type {
 	SpaceFeedLayout,
 } from '@automattic/api-core';
 
+let mockCurrentLocaleSlug: string | null = null;
+
 jest.mock( 'calypso/reader/data/stream', () => ( {
 	useInfiniteStream: jest.fn(),
-	// The shell derives the shared post selection via `useStreamPostKeySelection`,
-	// which reads cached stream items from this module.
 	getCachedStreamItems: jest.fn( () => [] ),
 } ) );
+
+jest.mock( 'calypso/state/selectors/get-current-locale-slug', () =>
+	jest.fn( () => mockCurrentLocaleSlug )
+);
 
 jest.mock( 'calypso/state/reader/site-blocks/selectors', () => {
 	const blockedSites: number[] = [];
@@ -94,6 +98,7 @@ function renderWithLayoutViewFallback( space: ReadSpaceDetails, layoutView: Spac
 describe( 'SpaceFeed', () => {
 	beforeEach( () => {
 		window.history.replaceState( {}, '', '/reader/spaces/work-id' );
+		mockCurrentLocaleSlug = null;
 		mockUseInfiniteStream.mockReturnValue( streamResult() );
 	} );
 
@@ -181,6 +186,24 @@ describe( 'SpaceFeed', () => {
 
 		expect( mockUseInfiniteStream ).toHaveBeenCalledWith(
 			expect.objectContaining( { streamKey: `space:${ WORK.id }` } )
+		);
+	} );
+
+	it( 'passes the non-default locale to the stream request', () => {
+		mockCurrentLocaleSlug = 'pt-br';
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
+
+		renderWithProvider( <SpaceFeed spaceId={ WORK.id } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		expect( mockUseInfiniteStream ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				streamKey: `space:${ WORK.id }`,
+				localeSlug: 'pt-br',
+			} )
 		);
 	} );
 

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -18,6 +18,9 @@ import type {
 
 jest.mock( 'calypso/reader/data/stream', () => ( {
 	useInfiniteStream: jest.fn(),
+	// The shell derives the shared post selection via `useStreamPostKeySelection`,
+	// which reads cached stream items from this module.
+	getCachedStreamItems: jest.fn( () => [] ),
 } ) );
 
 jest.mock( 'calypso/state/reader/site-blocks/selectors', () => {

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -23,6 +23,21 @@ jest.mock( 'calypso/reader/data/stream', () => ( {
 	getCachedStreamItems: jest.fn( () => [] ),
 } ) );
 
+jest.mock( 'calypso/reader/hooks/use-infinite-list', () => ( {
+	ScrollDebugOverlay: () => null,
+	useInfiniteList: jest.fn( ( { count } ) => ( {
+		getListProps: ( props = {} ) => props,
+		items: Array.from( { length: count }, ( _value, index ) => ( {
+			index,
+			key: `item-${ index }`,
+			start: index * 100,
+			lane: 0,
+		} ) ),
+		measureElement: jest.fn(),
+		scrollMargin: 0,
+	} ) ),
+} ) );
+
 jest.mock( 'calypso/state/selectors/get-current-locale-slug', () =>
 	jest.fn( () => mockCurrentLocaleSlug )
 );
@@ -205,6 +220,38 @@ describe( 'SpaceFeed', () => {
 				localeSlug: 'pt-br',
 			} )
 		);
+	} );
+
+	it( 'stores the full stream item when selecting a post', async () => {
+		const user = userEvent.setup();
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
+		const post = makePost();
+		const streamItem = {
+			feedId: post.feed_ID,
+			postId: post.feed_item_ID,
+			url: post.URL,
+			site_name: post.site_name,
+		};
+		mockUseInfiniteStream.mockReturnValue(
+			streamResult( {
+				items: [ streamItem ],
+				pages: [ { posts: [ post ] } as unknown as ReadStreamResponse ],
+			} )
+		);
+
+		renderWithProvider( <SpaceFeed spaceId={ WORK.id } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		const link = screen.getByRole( 'link', { name: 'A layout-sensitive post' } );
+		link.addEventListener( 'click', ( event ) => event.preventDefault() );
+		await user.click( link );
+
+		expect(
+			queryClient.getQueryData( [ 'read', 'stream', 'selected', `space:${ WORK.id }`, null ] )
+		).toEqual( streamItem );
 	} );
 
 	it( 'requests the discover stream keyed by the space id for the discover variant', () => {

--- a/client/reader/stream/stream-v2.tsx
+++ b/client/reader/stream/stream-v2.tsx
@@ -60,9 +60,6 @@ export function ReaderStreamV2( {
 }: ReaderStreamV2Props ) {
 	const translate = useTranslate();
 	const blockedSites = useSelector( getBlockedSites );
-	// Normalize the default locale to `null` (mirroring `<Stream>` and full-post navigation) and
-	// thread it into the fetch and the selection key, so all Reader consumers share the same
-	// cache entries for a given stream variant.
 	const rawLocale = useSelector( getCurrentLocaleSlug );
 	const localeSlug = rawLocale && ! isDefaultLocale( rawLocale ) ? rawLocale : null;
 	const { items, isLoading, error, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } =
@@ -71,9 +68,6 @@ export function ReaderStreamV2( {
 			localeSlug,
 		} );
 
-	// Selection lives in the React Query cache (not Redux or the URL), keyed by
-	// `[streamKey, localeSlug]` with a long gcTime — so the post the user opened stays
-	// highlighted when they return from the full-post view. Mirrors the classic stream.
 	const { selectedPostKey, selectPostKey } = useStreamPostKeySelection( {
 		streamKey,
 		localeSlug,
@@ -85,8 +79,6 @@ export function ReaderStreamV2( {
 	// invoke it directly with the clicked item's post key.
 	const openPost = useCallback(
 		( postKey: StreamItem, comments?: boolean ) => {
-			// Mark the opened post as selected so it stays highlighted when the user returns
-			// from the full-post view (the selection persists in the React Query cache).
 			selectPostKey( postKey );
 			showSelectedPost( {
 				postKey: {

--- a/client/reader/stream/stream-v2.tsx
+++ b/client/reader/stream/stream-v2.tsx
@@ -1,14 +1,17 @@
+import { isDefaultLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { INITIAL_FETCH, PER_FETCH, useInfiniteStream } from 'calypso/reader/data/stream';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
-import { keyToString } from 'calypso/reader/post-key';
+import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
 import { showSelectedPost } from 'calypso/reader/utils';
 import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import PostLifecycleUntyped from './post-lifecycle';
 import PostPlaceholderUntyped from './post-placeholder';
+import { useStreamPostKeySelection } from './use-stream-post-key-selection';
 import type { StreamItem } from 'calypso/reader/data/stream/types';
 import type { ComponentType } from 'react';
 
@@ -24,6 +27,7 @@ const PostLifecycle = PostLifecycleUntyped as ComponentType< {
 	blockedSites: number[];
 	index: number;
 	handleClick: ( args?: PostClickArgs ) => void;
+	isSelected?: boolean;
 } >;
 const PostPlaceholder = PostPlaceholderUntyped as ComponentType;
 
@@ -56,24 +60,45 @@ export function ReaderStreamV2( {
 }: ReaderStreamV2Props ) {
 	const translate = useTranslate();
 	const blockedSites = useSelector( getBlockedSites );
+	// Normalize the default locale to `null` (mirroring `<Stream>` and full-post navigation) and
+	// thread it into the fetch and the selection key, so all Reader consumers share the same
+	// cache entries for a given stream variant.
+	const rawLocale = useSelector( getCurrentLocaleSlug );
+	const localeSlug = rawLocale && ! isDefaultLocale( rawLocale ) ? rawLocale : null;
 	const { items, isLoading, error, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } =
 		useInfiniteStream( {
 			streamKey,
+			localeSlug,
 		} );
+
+	// Selection lives in the React Query cache (not Redux or the URL), keyed by
+	// `[streamKey, localeSlug]` with a long gcTime — so the post the user opened stays
+	// highlighted when they return from the full-post view. Mirrors the classic stream.
+	const { selectedPostKey, selectPostKey } = useStreamPostKeySelection( {
+		streamKey,
+		localeSlug,
+		items,
+	} );
 
 	// Open the full-post view on click, mirroring the classic stream. `showSelectedPost`
 	// returns a thunk that navigates via the router (no Redux dispatch needed), so we
 	// invoke it directly with the clicked item's post key.
-	const openPost = useCallback( ( postKey: StreamItem, comments?: boolean ) => {
-		showSelectedPost( {
-			postKey: {
-				blogId: postKey.blogId ? Number( postKey.blogId ) : undefined,
-				feedId: postKey.feedId ? Number( postKey.feedId ) : undefined,
-				postId: Number( postKey.postId ),
-			},
-			comments,
-		} )();
-	}, [] );
+	const openPost = useCallback(
+		( postKey: StreamItem, comments?: boolean ) => {
+			// Mark the opened post as selected so it stays highlighted when the user returns
+			// from the full-post view (the selection persists in the React Query cache).
+			selectPostKey( postKey );
+			showSelectedPost( {
+				postKey: {
+					blogId: postKey.blogId ? Number( postKey.blogId ) : undefined,
+					feedId: postKey.feedId ? Number( postKey.feedId ) : undefined,
+					postId: Number( postKey.postId ),
+				},
+				comments,
+			} )();
+		},
+		[ selectPostKey ]
+	);
 
 	// While a next page loads, append PER_FETCH skeleton rows at the tail (v1 showed
 	// these via InfiniteList's renderLoadingPlaceholders). Indices past the real
@@ -153,6 +178,10 @@ export function ReaderStreamV2( {
 							index={ virtualItem.index }
 							handleClick={ ( args?: PostClickArgs ) =>
 								openPost( items[ virtualItem.index ], args?.comments )
+							}
+							isSelected={
+								selectedPostKey != null &&
+								keysAreEqual( items[ virtualItem.index ], selectedPostKey )
 							}
 						/>
 					) : (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes RSM-4590
## Proposed Changes

* Wire the experimental Reader Stream V2 (`client/reader/stream/stream-v2.tsx`, used by the Spaces "Classic"/legacy layout) into the shared `useStreamPostKeySelection` hook — the same selection mechanism the classic stream uses — marking the opened post and passing `isSelected` down to the card.
* Extend the selected-post highlight to the other Spaces feed layouts (standard-list, board, gallery): the feed shell derives the selection once and passes `isPostSelected`/`selectPost` down through `SpaceFeedLayoutProps`; each layout marks the opened post on click and renders a selected accent bar just outside the card, matching the classic post card.
* Selection is stored in the React Query cache (keyed by stream + normalized locale, matching `<Stream>`/full-post navigation), so it survives navigating to the full post and back.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The legacy Redux + `InfiniteList` stream clearly marked the post you had just opened when you returned to the list; the newer Spaces feed lost that cue. Reusing the shared in-memory selection restores it consistently across every layout without adding a parallel mechanism.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Scenario 1 - Opened post is highlighted after returning (each layout):
- Go to a Reader Space (`/reader/spaces/:id`) and, via Customize, try each layout: Classic, Standard list, Board, Gallery
- Click a post to open it, then use the browser Back button
- Check that the post you opened is highlighted with a primary-color accent bar just outside the leading edge of the card/row

### Scenario 2 - Highlight follows the last-opened post:
- From the same feed, open a different post and press Back again
- Check that the highlight has moved to the most recently opened post

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


