### PR TITLE
Billing history: format receipt dates in user's locale

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -15,6 +15,10 @@ This is the new hosting dashboard for WordPress.com.
   2. If the behavior genuinely differs per dashboard variant, add a property to `AppConfig` that each variant provides, and branch on that property instead of the name.
   3. Before doing either, ask: if this UX is better for one variant, wouldn't it be better for all users? Prefer a single code path when possible.
 
+### Internationalization
+
+- When calling locale-aware formatting functions (`toLocaleDateString`, `toLocaleString`, `Intl.*`, etc.), prefer passing the user's locale from `useLocale()` (`app/locale`) rather than `undefined`. Passing `undefined` falls back to the browser/OS locale, so output silently drifts from the user's WordPress.com language setting.
+
 ### Testing
 
 - Read [docs/testing.md](./docs/testing.md) before writing or modifying tests.

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -98,7 +98,8 @@ export function useActions() {
 export function getFields(
 	receipts: Receipt[],
 	countryList: CountryListItem[] = [],
-	visibleFields: string[] = WIDE_FIELDS
+	visibleFields: string[] = WIDE_FIELDS,
+	locale: string
 ): Fields< Receipt > {
 	return [
 		{
@@ -116,12 +117,12 @@ export function getFields(
 			filterBy: {
 				operators: [ 'is' as Operator ],
 			},
-			elements: getDatesForFiltering( receipts ),
+			elements: getDatesForFiltering( receipts, locale ),
 			getValue: ( { item }: { item: Receipt } ) => {
-				return getDateForFiltering( item );
+				return getDateForFiltering( item, locale );
 			},
 			render: ( { item }: { item: Receipt } ) => {
-				return <time>{ formatReceiptDate( item ) }</time>;
+				return <time>{ formatReceiptDate( item, locale ) }</time>;
 			},
 		},
 		{
@@ -156,7 +157,7 @@ export function getFields(
 						>
 							{ renderServiceNameDescription( item ) }
 						</Link>
-						{ renderInlineHiddenFields( item, visibleFields ) }
+						{ renderInlineHiddenFields( item, visibleFields, locale ) }
 					</VStack>
 				);
 			},
@@ -229,14 +230,14 @@ export function getFields(
 				// Date field: Add the full date in a couple of formats, so
 				// it's possible to search for e.g. "October 23" or "Oct 23".
 				search_data.push(
-					new Date( item.date ).toLocaleDateString( undefined, {
+					new Date( item.date ).toLocaleDateString( locale, {
 						year: 'numeric',
 						month: 'long',
 						day: 'numeric',
 					} )
 				);
 				search_data.push(
-					new Date( item.date ).toLocaleDateString( undefined, {
+					new Date( item.date ).toLocaleDateString( locale, {
 						year: 'numeric',
 						month: 'short',
 						day: 'numeric',
@@ -271,11 +272,14 @@ export function getFields(
 	];
 }
 
-function getDatesForFiltering( receipts: Receipt[] ): Array< { value: string; label: string } > {
+function getDatesForFiltering(
+	receipts: Receipt[],
+	locale: string
+): Array< { value: string; label: string } > {
 	const datesForFiltering = new Map< string, Date >();
 
 	receipts.forEach( ( receipt ) => {
-		const key = getDateForFiltering( receipt );
+		const key = getDateForFiltering( receipt, locale );
 		const date = new Date( receipt.date );
 		datesForFiltering.set( key, date );
 	} );
@@ -288,16 +292,16 @@ function getDatesForFiltering( receipts: Receipt[] ): Array< { value: string; la
 		} ) );
 }
 
-function getDateForFiltering( receipt: Receipt ): string {
+function getDateForFiltering( receipt: Receipt, locale: string ): string {
 	// Filter by year and month only.
-	return new Date( receipt.date ).toLocaleDateString( undefined, {
+	return new Date( receipt.date ).toLocaleDateString( locale, {
 		year: 'numeric',
 		month: 'long',
 	} );
 }
 
-function formatReceiptDate( receipt: Receipt ): string {
-	return new Date( receipt.date ).toLocaleDateString( undefined, {
+function formatReceiptDate( receipt: Receipt, locale: string ): string {
+	return new Date( receipt.date ).toLocaleDateString( locale, {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',
@@ -372,11 +376,13 @@ function renderInlineHiddenField( key: string, label: string, value: string ) {
 	);
 }
 
-function renderInlineHiddenFields( receipt: Receipt, visibleFields: string[] ) {
+function renderInlineHiddenFields( receipt: Receipt, visibleFields: string[], locale: string ) {
 	const lines: JSX.Element[] = [];
 
 	if ( ! visibleFields.includes( 'date' ) ) {
-		lines.push( renderInlineHiddenField( 'date', __( 'Date' ), formatReceiptDate( receipt ) ) );
+		lines.push(
+			renderInlineHiddenField( 'date', __( 'Date' ), formatReceiptDate( receipt, locale ) )
+		);
 	}
 	if ( ! visibleFields.includes( 'type' ) ) {
 		lines.push(

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
+import { useLocale } from '../../app/locale';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { billingHistoryRoute } from '../../app/router/me';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
@@ -28,6 +29,7 @@ export default function BillingHistory() {
 	const { data: receipts = emptyReceipts, isLoading } = useQuery( userReceiptsQuery() );
 	const { data: countryList = [] } = useQuery( countryListQuery() );
 
+	const locale = useLocale();
 	const searchParams = billingHistoryRoute.useSearch();
 	const [ defaultView, setDefaultView ] = useState( DEFAULT_VIEW );
 	const { view, updateView, resetView } = usePersistentView( {
@@ -50,8 +52,8 @@ export default function BillingHistory() {
 	} );
 
 	const fields = useMemo(
-		() => getFields( receipts, countryList, view.fields ?? WIDE_FIELDS ),
-		[ receipts, countryList, view.fields ]
+		() => getFields( receipts, countryList, view.fields ?? WIDE_FIELDS, locale ),
+		[ receipts, countryList, view.fields, locale ]
 	);
 
 	const { data: filteredReceipts, paginationInfo } = useMemo( () => {

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -22,6 +22,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { type ReactNode, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { useLocale } from '../../app/locale';
 import { receiptRoute, taxDetailsRoute } from '../../app/router/me';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
@@ -76,11 +77,13 @@ export default function Receipt() {
 		tax_state: receipt.tax_state || historyReceipt?.tax_state,
 	};
 
+	const locale = useLocale();
+
 	const handlePrint = () => {
 		window.print();
 	};
 
-	const formattedDate = new Date( displayReceipt.date ).toLocaleDateString( undefined, {
+	const formattedDate = new Date( displayReceipt.date ).toLocaleDateString( locale, {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',

--- a/client/dashboard/me/billing-history/test/dataviews.test.tsx
+++ b/client/dashboard/me/billing-history/test/dataviews.test.tsx
@@ -5,7 +5,7 @@ import { screen } from '@testing-library/react';
 import { type ComponentType } from 'react';
 import { render } from '../../../test-utils';
 import { getFields } from '../dataviews';
-import type { Receipt } from '@automattic/api-core';
+import type { Receipt, User } from '@automattic/api-core';
 
 const receipt = {
 	id: 1,
@@ -60,11 +60,14 @@ const receipt = {
 	],
 } as unknown as Receipt;
 
+const LOCALE = 'en-gb';
+const testUser = { ID: 1, username: 'testuser', language: LOCALE } as User;
+
 function renderServiceCell( visibleFields: string[] ) {
-	const fields = getFields( [ receipt ], [], visibleFields );
+	const fields = getFields( [ receipt ], [], visibleFields, LOCALE );
 	const serviceField = fields.find( ( field ) => field.id === 'service' )!;
 	const ServiceCell = serviceField.render as ComponentType< { item: Receipt } >;
-	return render( <ServiceCell item={ receipt } /> );
+	return render( <ServiceCell item={ receipt } />, { user: testUser } );
 }
 
 describe( '<BillingHistory>', () => {
@@ -80,7 +83,7 @@ describe( '<BillingHistory>', () => {
 	test( 'shows Date inline when only the App column is visible', async () => {
 		renderServiceCell( [ 'service' ] );
 		expect( await screen.findByText( 'Date' ) ).toBeVisible();
-		expect( screen.getByText( 'May 21, 2026' ) ).toBeVisible();
+		expect( screen.getByText( '21 May 2026' ) ).toBeVisible(); // Matches locale of the `testUser`
 		expect( screen.getByText( 'Type' ) ).toBeVisible();
 		expect( screen.getByText( 'Refund' ) ).toBeVisible();
 		expect( screen.getByText( 'Amount' ) ).toBeVisible();


### PR DESCRIPTION
## Proposed Changes

* Billing history receipt dates now format using the signed-in user's locale via `useLocale()`, instead of relying on the host/browser locale.
* Local comes from `useLocale()` and it gets propagated through `getFields()` etc. down to the call to `toLocaleDateString( undefined, ... )` call, which not uses `toLocaleDateString( locale, ... )`
* Updated the DataViews unit test to pass an explicit `locale`/`user` (`en-gb`) and assert the concrete localized string (`21 May 2026`), so the test verifies real output rather than depending on the the runner's locale.

## Why are these changes being made?

While this test was passing in CI, I discovered that it failed when I ran locally. That's because I don't use `en` locale.

But I believe this PR is fixing a latent bug. We should have always been relying on the logged in user's locale rather than the host machine's locale. CC @sirbrillig 

## Testing Instructions

* Run `yarn test-client client/dashboard/me/billing-history/test/dataviews.test.tsx` — passes regardless of the environment's default locale.
* In the app, open **Me → Billing History** as a user with a non-English locale (e.g. `en-gb`) and confirm receipt dates render in that locale (e.g. `21 May 2026`) in the Date column and the inline mobile lines.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
