### PR TITLE
Reader Spaces: split text/icon accent colors and extend color coverage

### DIFF
--- a/client/reader/sidebar/spaces/menu-item.tsx
+++ b/client/reader/sidebar/spaces/menu-item.tsx
@@ -1,5 +1,6 @@
 import { Icon, rss } from '@wordpress/icons';
 import { MenuItem, MenuItemLink } from 'calypso/reader/sidebar/menu';
+import { resolveSpaceIconColor } from 'calypso/reader/spaces/colors';
 import { SPACE_ICONS } from 'calypso/reader/spaces/icons';
 import { getSpacePath } from 'calypso/reader/spaces/routes';
 import type { ReadSpace } from '@automattic/api-core';
@@ -20,7 +21,9 @@ export function SpaceMenuItem( { space, isSelected, onClick, onPrefetch }: Props
 	return (
 		<MenuItem
 			selected={ isSelected }
-			className={ `sidebar-spaces__item sidebar-spaces__item--${ space.layout.color }` }
+			className={ `sidebar-spaces__item sidebar-spaces__item--${ resolveSpaceIconColor(
+				space.layout
+			) }` }
 		>
 			<MenuItemLink
 				className="sidebar__menu-link sidebar-spaces__link"

--- a/client/reader/spaces/AGENTS.md
+++ b/client/reader/spaces/AGENTS.md
@@ -82,10 +82,17 @@ without an action hash.
 ### Model & presentation
 
 - `ReadSpace` is serializable. Presentation settings live grouped under
-  `layout` (a `SpaceLayout`) so they can grow beyond color/icon; `layout.color`
-  and `layout.icon` are **string keys**, never rendered glyphs. Map
-  `layout.icon` → a `@wordpress/icons` element via `SPACE_ICONS` in `icons.ts`;
-  `layout.color` selects a CSS variant.
+  `layout` (a `SpaceLayout`) so they can grow beyond color/icon; `layout.color`,
+  `layout.iconColor` and `layout.icon` are **string keys**, never rendered
+  glyphs. Map `layout.icon` → a `@wordpress/icons` element via `SPACE_ICONS` in
+  `icons.ts`; the color keys select CSS variants.
+- Color is split in two: `layout.color` is the **text accent** (post titles +
+  actions) and can be `'none'` to keep the text neutral like the rest of the
+  Reader; `layout.iconColor` colors the **icon** (sidebar chrome). Resolve the
+  icon color with `resolveSpaceIconColor( layout )` in `colors.ts` — it falls
+  back to `color` (then the default) so spaces created before the split keep a
+  colored icon. The feed only emits the `space-feed--{color}` accent modifier
+  when `color !== 'none'`.
 - Build Spaces URLs with `routes.ts` (`SPACES_BASE_PATH`, `getSpacePath`) —
   never hand-concatenate paths.
 

--- a/client/reader/spaces/color-picker.scss
+++ b/client/reader/spaces/color-picker.scss
@@ -14,13 +14,13 @@
 	inline-size: 36px;
 	block-size: 36px;
 	border-radius: 8px;
-	background: var( --space-color );
+	background: var( --space-color-vivid );
 	cursor: pointer;
 
 	&[data-selected='true'] {
 		box-shadow:
 			0 0 0 2px var( --color-surface ),
-			0 0 0 4px var( --space-color );
+			0 0 0 4px var( --space-color-vivid );
 	}
 }
 

--- a/client/reader/spaces/color-picker.scss
+++ b/client/reader/spaces/color-picker.scss
@@ -31,6 +31,39 @@
 	}
 }
 
+// The "None" swatch clears the accent. It gets no accent mixin, so style it
+// explicitly: a neutral surface with a diagonal strike so it reads as "no color".
+.space-color-picker__swatch--none {
+	background: var( --color-surface );
+	box-shadow: inset 0 0 0 1px var( --color-border-subtle );
+
+	&::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		background: linear-gradient(
+			to top right,
+			transparent calc( 50% - 1px ),
+			var( --color-text-subtle ) calc( 50% - 1px ),
+			var( --color-text-subtle ) calc( 50% + 1px ),
+			transparent calc( 50% + 1px )
+		);
+	}
+
+	&[data-selected='true'] {
+		box-shadow:
+			0 0 0 2px var( --color-surface ),
+			0 0 0 4px var( --color-text-subtle );
+	}
+
+	// The check sits above the strike and needs a dark fill on the light surface.
+	.space-color-picker__check {
+		position: relative;
+		fill: var( --color-text );
+	}
+}
+
 .space-color-picker__check {
 	fill: var( --color-surface );
 	pointer-events: none;

--- a/client/reader/spaces/color-picker.tsx
+++ b/client/reader/spaces/color-picker.tsx
@@ -1,13 +1,22 @@
 import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SPACE_COLORS, useSpaceColorLabels } from './colors';
-import type { SpaceColor } from '@automattic/api-core';
+import type { SpaceColor, SpaceTextColor } from '@automattic/api-core';
 
 import './color-picker.scss';
 
 interface Props {
-	value: SpaceColor;
-	onChange: ( color: SpaceColor ) => void;
+	value: SpaceTextColor;
+	onChange: ( color: SpaceTextColor ) => void;
+	/**
+	 * Prepend a "None" swatch that clears the color (neutral). Used by the text
+	 * accent picker; the icon picker omits it since an icon always has a color.
+	 */
+	allowNone?: boolean;
+	/** Unique radio group name, so multiple pickers on one screen don't collide. */
+	name?: string;
+	/** Accessible label for the group. */
+	label?: string;
 }
 
 /**
@@ -16,18 +25,27 @@ interface Props {
  * single tab stop — matching the layout-preset cards. The selected swatch shows
  * a check; colors are read out via the translated labels in `useSpaceColorLabels`.
  */
-export function SpaceColorPicker( { value, onChange }: Props ) {
+export function SpaceColorPicker( {
+	value,
+	onChange,
+	allowNone = false,
+	name = 'space-accent-color',
+	label,
+}: Props ) {
 	const translate = useTranslate();
 	const labels = useSpaceColorLabels();
+
+	const options: SpaceTextColor[] = allowNone ? [ 'none', ...SPACE_COLORS ] : SPACE_COLORS;
 
 	return (
 		<div
 			className="space-color-picker"
 			role="radiogroup"
-			aria-label={ translate( 'Accent color' ) }
+			aria-label={ label ?? translate( 'Accent color' ) }
 		>
-			{ SPACE_COLORS.map( ( color ) => {
+			{ options.map( ( color ) => {
 				const isSelected = color === value;
+				const isNone = color === 'none';
 				return (
 					<label
 						key={ color }
@@ -37,10 +55,10 @@ export function SpaceColorPicker( { value, onChange }: Props ) {
 						<input
 							type="radio"
 							className="space-color-picker__radio"
-							name="space-accent-color"
+							name={ name }
 							value={ color }
 							checked={ isSelected }
-							aria-label={ labels[ color ] }
+							aria-label={ isNone ? translate( 'None' ) : labels[ color as SpaceColor ] }
 							onChange={ () => onChange( color ) }
 						/>
 						{ isSelected ? (

--- a/client/reader/spaces/colors.scss
+++ b/client/reader/spaces/colors.scss
@@ -16,6 +16,11 @@ $space-colors: 'blue', 'purple', 'red', 'orange', 'green', 'celadon', 'pink', 'g
 	// so the accent reads as a sober default rather than a bright hue.
 	--space-color: var( --studio-#{$color}-80 );
 	--space-color-bg: var( --studio-#{$color}-5 );
+	// Vivid brand step (`-50`) for decorative *fills* like the picker swatches,
+	// where the sober `-80` foreground darkens every hue toward near-black and
+	// makes distinct colors (green/celadon, red/orange) read as similar. Not for
+	// text: `-50` does not guarantee AA contrast on the page surface.
+	--space-color-vivid: var( --studio-#{$color}-50 );
 	// Interaction variants off the same accent: a lighter, more saturated step so
 	// the hue surfaces on hover, and — for the visited / “already read” state —
 	// the accent muted toward the subtle text color so it reads as faded.

--- a/client/reader/spaces/colors.ts
+++ b/client/reader/spaces/colors.ts
@@ -19,6 +19,11 @@ export const SPACE_COLORS: SpaceColor[] = [
 ];
 
 /**
+ * The default accent color for a new space: the first color in the picker.
+ */
+export const DEFAULT_SPACE_COLOR: SpaceColor = SPACE_COLORS[ 0 ];
+
+/**
  * Translated, human-readable labels for each accent color, used as accessible
  * names on the swatches (the swatches are color-only, so they need a text label
  * for screen readers).

--- a/client/reader/spaces/colors.ts
+++ b/client/reader/spaces/colors.ts
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import type { SpaceColor } from '@automattic/api-core';
+import type { SpaceColor, SpaceLayout, SpaceTextColor } from '@automattic/api-core';
 
 /**
  * The accent colors offered by the picker, in display order. The backend only
@@ -19,9 +19,30 @@ export const SPACE_COLORS: SpaceColor[] = [
 ];
 
 /**
- * The default accent color for a new space: the first color in the picker.
+ * The default icon color for a new space: the first color in the picker.
  */
 export const DEFAULT_SPACE_COLOR: SpaceColor = SPACE_COLORS[ 0 ];
+
+/**
+ * The default text accent for a new space: `'none'`, so the feed reads like the
+ * rest of the Reader until the user opts into coloring the post text.
+ */
+export const DEFAULT_SPACE_TEXT_COLOR: SpaceTextColor = 'none';
+
+/**
+ * Resolve the color to render a space's icon with. Uses the dedicated
+ * `iconColor` when set, otherwise the text `color` — so spaces created before
+ * the two were split keep a colored icon — falling back to the default when the
+ * text color is `'none'`.
+ */
+export function resolveSpaceIconColor(
+	layout: Pick< SpaceLayout, 'color' | 'iconColor' >
+): SpaceColor {
+	if ( layout.iconColor ) {
+		return layout.iconColor;
+	}
+	return layout.color === 'none' ? DEFAULT_SPACE_COLOR : layout.color;
+}
 
 /**
  * Translated, human-readable labels for each accent color, used as accessible

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -171,7 +171,11 @@ describe( 'CreateSpaceModal', () => {
 		mockCreateEndpoint( 'Reading', onBody );
 
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
-		await user.click( screen.getByRole( 'radio', { name: 'Green' } ) );
+		await user.click(
+			within( screen.getByRole( 'radiogroup', { name: 'Accent color' } ) ).getByRole( 'radio', {
+				name: 'Green',
+			} )
+		);
 		await user.click( screen.getByRole( 'radio', { name: 'Star' } ) );
 		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
 		await user.click( screen.getByRole( 'radio', { name: /Classic/ } ) );
@@ -186,7 +190,7 @@ describe( 'CreateSpaceModal', () => {
 				title: 'Reading',
 				feeds: [ 456 ],
 				tags: [],
-				layout: { color: 'green', icon: 'star', view: 'legacy' },
+				layout: { color: 'green', iconColor: 'blue', icon: 'star', view: 'legacy' },
 			} )
 		);
 		const spaces = queryClient.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey );

--- a/client/reader/spaces/customize-modal/identity-tab.tsx
+++ b/client/reader/spaces/customize-modal/identity-tab.tsx
@@ -69,14 +69,8 @@ export function IdentityTab( {
 			</VStack>
 
 			<VStack spacing={ 2 }>
-				<span className="customize-space-modal__field-label">{ translate( 'Accent color' ) }</span>
-				<SpaceColorPicker
-					value={ color }
-					onChange={ onColorChange }
-					allowNone
-					name="space-accent-color"
-					label={ translate( 'Accent color' ) }
-				/>
+				<span className="customize-space-modal__field-label">{ translate( 'Icon' ) }</span>
+				<SpaceIconPicker value={ icon } onChange={ onIconChange } />
 			</VStack>
 
 			<VStack spacing={ 2 }>
@@ -90,8 +84,19 @@ export function IdentityTab( {
 			</VStack>
 
 			<VStack spacing={ 2 }>
-				<span className="customize-space-modal__field-label">{ translate( 'Icon' ) }</span>
-				<SpaceIconPicker value={ icon } onChange={ onIconChange } />
+				<span className="customize-space-modal__field-label">{ translate( 'Accent color' ) }</span>
+				<p className="customize-space-modal__field-help">
+					{ translate(
+						'Changes the color of post titles and actions in this space. Choose None to keep the feed neutral.'
+					) }
+				</p>
+				<SpaceColorPicker
+					value={ color }
+					onChange={ onColorChange }
+					allowNone
+					name="space-accent-color"
+					label={ translate( 'Accent color' ) }
+				/>
 			</VStack>
 		</VStack>
 	);

--- a/client/reader/spaces/customize-modal/identity-tab.tsx
+++ b/client/reader/spaces/customize-modal/identity-tab.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { SpaceColorPicker } from 'calypso/reader/spaces/color-picker';
 import { SpaceIconPicker } from 'calypso/reader/spaces/icon-picker';
-import type { SpaceColor, SpaceIcon } from '@automattic/api-core';
+import type { SpaceColor, SpaceIcon, SpaceTextColor } from '@automattic/api-core';
 
 interface Props {
 	name: string;
@@ -11,8 +11,10 @@ interface Props {
 	nameError: string | null;
 	tags: string[];
 	onTagsChange: ( tags: string[] ) => void;
-	color: SpaceColor;
-	onColorChange: ( color: SpaceColor ) => void;
+	color: SpaceTextColor;
+	onColorChange: ( color: SpaceTextColor ) => void;
+	iconColor: SpaceColor;
+	onIconColorChange: ( color: SpaceColor ) => void;
 	icon: SpaceIcon;
 	onIconChange: ( icon: SpaceIcon ) => void;
 }
@@ -25,6 +27,8 @@ export function IdentityTab( {
 	onTagsChange,
 	color,
 	onColorChange,
+	iconColor,
+	onIconColorChange,
 	icon,
 	onIconChange,
 }: Props ) {
@@ -66,7 +70,23 @@ export function IdentityTab( {
 
 			<VStack spacing={ 2 }>
 				<span className="customize-space-modal__field-label">{ translate( 'Accent color' ) }</span>
-				<SpaceColorPicker value={ color } onChange={ onColorChange } />
+				<SpaceColorPicker
+					value={ color }
+					onChange={ onColorChange }
+					allowNone
+					name="space-accent-color"
+					label={ translate( 'Accent color' ) }
+				/>
+			</VStack>
+
+			<VStack spacing={ 2 }>
+				<span className="customize-space-modal__field-label">{ translate( 'Icon color' ) }</span>
+				<SpaceColorPicker
+					value={ iconColor }
+					onChange={ ( value ) => value !== 'none' && onIconColorChange( value ) }
+					name="space-icon-color"
+					label={ translate( 'Icon color' ) }
+				/>
 			</VStack>
 
 			<VStack spacing={ 2 }>

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -26,6 +26,7 @@ import {
 	useSpaces,
 	useUpdateSpace,
 } from 'calypso/reader/data/spaces';
+import { DEFAULT_SPACE_COLOR } from 'calypso/reader/spaces/colors';
 import { getSpaceErrorMessage, validateName } from 'calypso/reader/spaces/form-helpers';
 import { SPACE_ICONS } from 'calypso/reader/spaces/icons';
 import { useDispatch } from 'calypso/state';
@@ -154,7 +155,7 @@ function SpaceUpsertModalContent( {
 	const [ isSeeded, setIsSeeded ] = useState( isCreate );
 	const [ name, setName ] = useState( '' );
 	const [ tags, setTags ] = useState< string[] >( [] );
-	const [ color, setColor ] = useState< SpaceColor >( 'blue' );
+	const [ color, setColor ] = useState< SpaceColor >( DEFAULT_SPACE_COLOR );
 	const [ icon, setIcon ] = useState< SpaceIcon >( 'inbox' );
 	const [ view, setView ] = useState< SpaceFeedLayout >( DEFAULT_SPACE_FEED_LAYOUT );
 	const [ selectedSources, setSelectedSources ] = useState< SourceDraftItem[] >( [] );

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -7,6 +7,7 @@ import {
 	type SpaceFeedLayout,
 	type SpaceIcon,
 	type SpaceSource,
+	type SpaceTextColor,
 } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
 import {
@@ -26,7 +27,11 @@ import {
 	useSpaces,
 	useUpdateSpace,
 } from 'calypso/reader/data/spaces';
-import { DEFAULT_SPACE_COLOR } from 'calypso/reader/spaces/colors';
+import {
+	DEFAULT_SPACE_COLOR,
+	DEFAULT_SPACE_TEXT_COLOR,
+	resolveSpaceIconColor,
+} from 'calypso/reader/spaces/colors';
 import { getSpaceErrorMessage, validateName } from 'calypso/reader/spaces/form-helpers';
 import { SPACE_ICONS } from 'calypso/reader/spaces/icons';
 import { useDispatch } from 'calypso/state';
@@ -155,7 +160,8 @@ function SpaceUpsertModalContent( {
 	const [ isSeeded, setIsSeeded ] = useState( isCreate );
 	const [ name, setName ] = useState( '' );
 	const [ tags, setTags ] = useState< string[] >( [] );
-	const [ color, setColor ] = useState< SpaceColor >( DEFAULT_SPACE_COLOR );
+	const [ color, setColor ] = useState< SpaceTextColor >( DEFAULT_SPACE_TEXT_COLOR );
+	const [ iconColor, setIconColor ] = useState< SpaceColor >( DEFAULT_SPACE_COLOR );
 	const [ icon, setIcon ] = useState< SpaceIcon >( 'inbox' );
 	const [ view, setView ] = useState< SpaceFeedLayout >( DEFAULT_SPACE_FEED_LAYOUT );
 	const [ selectedSources, setSelectedSources ] = useState< SourceDraftItem[] >( [] );
@@ -166,6 +172,7 @@ function SpaceUpsertModalContent( {
 			setName( space.name );
 			setTags( space.tags );
 			setColor( space.layout.color );
+			setIconColor( resolveSpaceIconColor( space.layout ) );
 			setIcon( space.layout.icon );
 			setView( space.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT );
 			setSelectedSources( space.sources.map( getSpaceSourceDraftItem ) );
@@ -204,7 +211,7 @@ function SpaceUpsertModalContent( {
 				{
 					name: name.trim(),
 					tags,
-					layout: { color, icon, view },
+					layout: { color, iconColor, icon, view },
 					feeds: selectedFeeds,
 				},
 				{
@@ -235,7 +242,12 @@ function SpaceUpsertModalContent( {
 		updateSpace.mutate(
 			{
 				spaceId: editSpaceId,
-				params: { name: name.trim(), tags, feeds: selectedFeeds, layout: { color, icon, view } },
+				params: {
+					name: name.trim(),
+					tags,
+					feeds: selectedFeeds,
+					layout: { color, iconColor, icon, view },
+				},
 			},
 			{
 				onSuccess: () => {
@@ -323,6 +335,8 @@ function SpaceUpsertModalContent( {
 				onTagsChange={ setTags }
 				color={ color }
 				onColorChange={ setColor }
+				iconColor={ iconColor }
+				onIconColorChange={ setIconColor }
 				icon={ icon }
 				onIconChange={ setIcon }
 			/>
@@ -390,7 +404,7 @@ function SpaceUpsertModalContent( {
 					expanded={ false }
 				>
 					<span
-						className={ `customize-space-modal__footer-icon customize-space-modal__footer-icon--${ color }` }
+						className={ `customize-space-modal__footer-icon customize-space-modal__footer-icon--${ iconColor }` }
 						aria-hidden="true"
 					>
 						<Icon icon={ SPACE_ICONS[ icon ] } size={ 18 } />

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -79,6 +79,13 @@
 	text-transform: uppercase;
 }
 
+.customize-space-modal__field-help {
+	margin: 0;
+	color: var( --color-text-subtle );
+	font-size: 0.875rem;
+	line-height: 1.4;
+}
+
 .customize-space-modal__error {
 	margin: 8px 0 0;
 	color: var( --color-error );

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -140,7 +140,11 @@ describe( 'CustomizeModal', () => {
 		render();
 
 		expect( screen.getByLabelText( 'Name' ) ).toHaveValue( 'Work' );
-		expect( screen.getByRole( 'radio', { name: 'Blue' } ) ).toBeChecked();
+		expect(
+			within( screen.getByRole( 'radiogroup', { name: 'Accent color' } ) ).getByRole( 'radio', {
+				name: 'Blue',
+			} )
+		).toBeChecked();
 		expect( screen.getByRole( 'radio', { name: 'Inbox' } ) ).toBeChecked();
 	} );
 
@@ -173,7 +177,11 @@ describe( 'CustomizeModal', () => {
 		const name = screen.getByLabelText( 'Name' );
 		await user.clear( name );
 		await user.type( name, 'Reading' );
-		await user.click( screen.getByRole( 'radio', { name: 'Green' } ) );
+		await user.click(
+			within( screen.getByRole( 'radiogroup', { name: 'Accent color' } ) ).getByRole( 'radio', {
+				name: 'Green',
+			} )
+		);
 
 		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
 		await user.click( screen.getByRole( 'radio', { name: /Classic/ } ) );
@@ -186,7 +194,7 @@ describe( 'CustomizeModal', () => {
 			expect.objectContaining( {
 				title: 'Reading',
 				tags: [ 'tech' ],
-				layout: { color: 'green', icon: 'inbox', view: 'legacy' },
+				layout: { color: 'green', iconColor: 'blue', icon: 'inbox', view: 'legacy' },
 			} )
 		);
 		const cached = queryClient.getQueryData< ReadSpaceDetails >(

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -145,7 +145,27 @@ describe( 'CustomizeModal', () => {
 				name: 'Blue',
 			} )
 		).toBeChecked();
+		expect(
+			screen.getByText(
+				'Changes the color of post titles and actions in this space. Choose None to keep the feed neutral.'
+			)
+		).toBeVisible();
 		expect( screen.getByRole( 'radio', { name: 'Inbox' } ) ).toBeChecked();
+	} );
+
+	it( 'shows the accent color picker after the icon controls', () => {
+		render();
+
+		const iconLabel = screen.getByText( 'Icon' );
+		const iconColorLabel = screen.getByText( 'Icon color' );
+		const accentColorLabel = screen.getByText( 'Accent color' );
+
+		expect(
+			iconLabel.compareDocumentPosition( iconColorLabel ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+		expect(
+			iconColorLabel.compareDocumentPosition( accentColorLabel ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
 	} );
 
 	it( 'switches between the Identity, Layout and Sources tabs', async () => {

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -166,7 +166,12 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 	};
 
 	return (
-		<div className={ clsx( 'space-feed', space && `space-feed--${ space.layout.color }` ) }>
+		<div
+			className={ clsx(
+				'space-feed',
+				space && space.layout.color !== 'none' && `space-feed--${ space.layout.color }`
+			) }
+		>
 			{ /* The source notice reports followed-feed failures; Discover isn't built
 			     from followed feeds, so it only applies to the posts feed. */ }
 			{ ! isDiscover && <SpaceFeedSourceNotice failedCount={ 0 } /> }

--- a/client/reader/spaces/feed/layouts/board/style.scss
+++ b/client/reader/spaces/feed/layouts/board/style.scss
@@ -51,7 +51,9 @@
 	font-size: 1rem;
 	font-weight: 700;
 	line-height: 1.3;
-	color: var(--color-text);
+	// Use the space's accent color (set as `--space-color` on `.space-feed`),
+	// falling back to the default text color when no space accent is present.
+	color: var(--space-color, var(--color-text));
 }
 
 .space-feed-board__title-link {
@@ -59,8 +61,16 @@
 	text-decoration: none;
 }
 
+// Already-read posts fade to a lighter shade of the space accent. Ordered
+// before :hover (LVHA). Recoloring the anchor itself is the one styling the
+// browser reliably honors on :visited.
+.space-feed-board__title-link:visited {
+	color: var(--space-color-visited, var(--color-text-subtle));
+}
+
 .space-feed-board__title-link:hover {
 	text-decoration: underline;
+	color: var(--space-color-hover, var(--color-link));
 }
 
 .space-feed-board__excerpt {

--- a/client/reader/spaces/feed/layouts/gallery/style.scss
+++ b/client/reader/spaces/feed/layouts/gallery/style.scss
@@ -53,7 +53,9 @@
 	font-size: 0.875rem;
 	font-weight: 600;
 	line-height: 1.35;
-	color: var(--color-text);
+	// Use the space's accent color (set as `--space-color` on `.space-feed`),
+	// falling back to the default text color when no space accent is present.
+	color: var(--space-color, var(--color-text));
 	overflow: hidden;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
@@ -68,8 +70,16 @@
 	text-decoration: none;
 }
 
+// Already-read posts fade to a lighter shade of the space accent. Ordered
+// before :hover (LVHA). Recoloring the anchor itself is the one styling the
+// browser reliably honors on :visited.
+.space-feed-gallery__title-link:visited {
+	color: var(--space-color-visited, var(--color-text-subtle));
+}
+
 .space-feed-gallery__title-link:hover {
 	text-decoration: underline;
+	color: var(--space-color-hover, var(--color-link));
 }
 
 .space-feed-gallery__meta {

--- a/client/reader/spaces/feed/layouts/legacy/index.tsx
+++ b/client/reader/spaces/feed/layouts/legacy/index.tsx
@@ -1,6 +1,8 @@
 import { ReaderStreamV2 } from 'calypso/reader/stream/stream-v2';
 import type { SpaceFeedLayoutProps } from '../types';
 
+import './style.scss';
+
 /**
  * Legacy layout: the classic vertical reading experience — a single column of
  * post cards — now on the `useInfiniteList` engine via {@link ReaderStreamV2},

--- a/client/reader/spaces/feed/layouts/legacy/style.scss
+++ b/client/reader/spaces/feed/layouts/legacy/style.scss
@@ -1,0 +1,24 @@
+// The classic (legacy) layout renders the shared Reader post cards via
+// `ReaderStreamV2`. Those cards color their titles with a neutral token, so the
+// space accent — exposed as `--space-color*` on `.space-feed` — never reaches
+// them on its own. Recolor the card titles here, scoped to `.space-feed-legacy`
+// so the shared cards elsewhere (Reader, Discover) stay untouched. The extra
+// `.space-feed` in the selector keeps the specificity above the shared
+// `.reader__content .reader-post-card__title-link` rule. Each color falls back
+// to the card's default neutral when no space accent is present.
+.space-feed .space-feed-legacy {
+	.reader-post-card__title,
+	.reader-post-card__title-link {
+		color: var(--space-color, var(--color-neutral-100));
+	}
+
+	// Already-read posts fade to a lighter shade of the space accent. Ordered
+	// before :hover (LVHA).
+	.reader-post-card__title-link:visited {
+		color: var(--space-color-visited, var(--color-neutral-100));
+	}
+
+	.reader-post-card__title-link:hover {
+		color: var(--space-color-hover, var(--color-neutral-70));
+	}
+}

--- a/client/reader/spaces/feed/style.scss
+++ b/client/reader/spaces/feed/style.scss
@@ -12,19 +12,20 @@
 @each $color in space-colors.$space-colors {
 	.space-feed--#{$color} {
 		@include space-colors.space-accent-color( $color );
-	}
-}
 
-// The shared post-action buttons (like, comment, share, save) color their icons
-// and labels from `--color-text-subtle` at rest and `--color-link` on hover /
-// when active. Remap just those two tokens within the actions scope so every
-// button follows the space accent, without reaching into each button's styles.
-// A space feed always sets `--space-color*`, so no fallback is needed; the
-// remap is confined to `.reader-post-actions`, so the rest of the feed (excerpts,
-// meta) keeps the neutral subtle color.
-.space-feed .reader-post-actions {
-	--color-text-subtle: var(--space-color);
-	--color-link: var(--space-color-hover);
+		// The shared post-action buttons (like, comment, share, save) color their
+		// icons and labels from `--color-text-subtle` at rest and `--color-link` on
+		// hover / when active. Remap just those two tokens within the actions scope
+		// so every button follows the space accent, without reaching into each
+		// button's styles. Emitted only under the accent modifier — a feed with no
+		// accent (`color: 'none'`) has no modifier, so the buttons keep the neutral
+		// tokens. The remap is confined to `.reader-post-actions`, so the rest of the
+		// feed (excerpts, meta) keeps the neutral subtle color.
+		.reader-post-actions {
+			--color-text-subtle: var( --space-color );
+			--color-link: var( --space-color-hover );
+		}
+	}
 }
 
 .space-feed__toolbar {

--- a/client/reader/spaces/feed/style.scss
+++ b/client/reader/spaces/feed/style.scss
@@ -15,6 +15,18 @@
 	}
 }
 
+// The shared post-action buttons (like, comment, share, save) color their icons
+// and labels from `--color-text-subtle` at rest and `--color-link` on hover /
+// when active. Remap just those two tokens within the actions scope so every
+// button follows the space accent, without reaching into each button's styles.
+// A space feed always sets `--space-color*`, so no fallback is needed; the
+// remap is confined to `.reader-post-actions`, so the rest of the feed (excerpts,
+// meta) keeps the neutral subtle color.
+.space-feed .reader-post-actions {
+	--color-text-subtle: var(--space-color);
+	--color-link: var(--space-color-hover);
+}
+
 .space-feed__toolbar {
 	display: flex;
 	flex-wrap: wrap;

--- a/client/reader/spaces/test/color-picker.test.tsx
+++ b/client/reader/spaces/test/color-picker.test.tsx
@@ -25,4 +25,22 @@ describe( 'SpaceColorPicker', () => {
 
 		expect( onChange ).toHaveBeenCalledWith( 'pink' );
 	} );
+
+	it( 'adds a "None" swatch and checks it when selected', () => {
+		renderWithProvider( <SpaceColorPicker value="none" onChange={ jest.fn() } allowNone /> );
+
+		// The eight colors plus the extra "None" swatch.
+		expect( screen.getAllByRole( 'radio' ) ).toHaveLength( 9 );
+		expect( screen.getByRole( 'radio', { name: 'None' } ) ).toBeChecked();
+	} );
+
+	it( 'reports "none" when the None swatch is chosen', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		renderWithProvider( <SpaceColorPicker value="blue" onChange={ onChange } allowNone /> );
+
+		await user.click( screen.getByRole( 'radio', { name: 'None' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( 'none' );
+	} );
 } );

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -31,14 +31,18 @@ export interface ReadSpaceApiItem {
 /** Map a wpcom/v2 summary item onto the client `ReadSpace` (list) shape. */
 export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
 	const layout: SpaceLayout = { color: item.layout.color, icon: item.layout.icon };
+	if ( item.layout.iconColor ) {
+		layout.iconColor = item.layout.iconColor;
+	}
 	if ( item.layout.view ) {
 		layout.view = item.layout.view;
 	}
 	return {
 		id: String( item.id ),
 		name: item.title,
-		// `view` is forward-looking: the API does not return it yet (stays
-		// `undefined`), but mapping it now means it flows through once it does.
+		// `iconColor` and `view` are forward-looking: the API does not return them
+		// yet (they stay `undefined`), but mapping them now means they flow through
+		// once it does.
 		layout,
 	};
 }

--- a/packages/api-core/src/read-spaces/constants.ts
+++ b/packages/api-core/src/read-spaces/constants.ts
@@ -9,5 +9,6 @@ export const MAX_SPACE_NAME_LENGTH = 50;
 /** Presentation defaults applied to a freshly-created space. */
 export const DEFAULT_SPACE_LAYOUT: SpaceLayout = {
 	color: 'blue',
+	iconColor: 'blue',
 	icon: 'category',
 };

--- a/packages/api-core/src/read-spaces/constants.ts
+++ b/packages/api-core/src/read-spaces/constants.ts
@@ -8,7 +8,9 @@ export const MAX_SPACE_NAME_LENGTH = 50;
 
 /** Presentation defaults applied to a freshly-created space. */
 export const DEFAULT_SPACE_LAYOUT: SpaceLayout = {
-	color: 'blue',
+	// Neutral post text by default (see `SpaceTextColor`); the icon still carries
+	// a color so the space keeps a visible identity.
+	color: 'none',
 	iconColor: 'blue',
 	icon: 'category',
 };

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -19,6 +19,13 @@ export type SpaceColor =
 	| 'celadon'
 	| 'pink';
 
+/**
+ * Accent applied to a space's post text (titles + actions). `'none'` keeps the
+ * text neutral — the same reading experience as the rest of the Reader — while
+ * the space icon can still carry its own color via `iconColor`.
+ */
+export type SpaceTextColor = SpaceColor | 'none';
+
 export type SpaceIcon =
 	| 'inbox'
 	| 'box'
@@ -50,7 +57,11 @@ export type SpaceFeedLayout = 'standard-list' | 'gallery' | 'board' | 'legacy';
  * icon (e.g. cover image, sort order) without widening `ReadSpace` itself.
  */
 export interface SpaceLayout {
-	color: SpaceColor;
+	// Accent for the space's post text (titles + actions); `'none'` = neutral.
+	color: SpaceTextColor;
+	// Color for the space's icon. Falls back to `color` when absent, so spaces
+	// created before the icon and text colors were split keep a colored icon.
+	iconColor?: SpaceColor;
 	icon: SpaceIcon;
 	// Which feed layout to render.
 	view?: SpaceFeedLayout;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of the Reader Spaces color-customization work.

## Proposed Changes

* Apply a Space's accent color to the post titles in every feed layout — it was only wired up for the compact list, so Classic, Media gallery, and Airy board ignored it. The Classic layout override is scoped to the space feed so the shared Reader post cards elsewhere are untouched.
* Make the post-action buttons (like, comment, share, save) follow the accent by remapping their color tokens within the space feed's `.reader-post-actions` scope.
* Show the picker swatches in a vivid color step (`-50`) instead of the near-black `-80` foreground, so similar hues (green/teal, red/orange) are distinguishable.
* Split the single accent into two independent pickers: **Accent color** now colors only the post text and gains a **None** option (neutral text, like the rest of the Reader), and a new **Icon color** picker colors the icon. In the model, `layout.color` becomes the text accent (`SpaceColor | 'none'`) and a new `layout.iconColor` carries the icon color, resolved with a fallback to `color` so existing spaces keep a colored icon.
* Derive the new-space default color from the first swatch instead of a hardcoded value.

## Why are these changes being made?

The Spaces feature introduced a single accent selector that colored the icon, the post titles, and the post actions all at once, with no way to keep the reading experience neutral like the rest of the Reader. Splitting the icon and text colors (with a None option for text) lets a space keep a colored identity in the sidebar while leaving the feed familiar, and the vivid swatches fix colors that were hard to tell apart in the picker. `iconColor` and the `'none'` text color are mapped client-side now and will persist once the backend stores them, following the existing forward-looking `view` pattern.

## Testing Instructions

### Scenario 1 - Accent reaches every layout:
- Go to `/reader/spaces/:id` for a space whose Accent color is set to a color (not None).
- Open Customize → Layout and switch between Classic, Compact list, Media gallery, and Airy board.
- Check that in each layout the post titles take the space's accent color, and the like/comment/share/save buttons use it too (hover and visited states included).

### Scenario 2 - Distinguishable swatches:
- Open Customize → Identity on any space.
- Check that the Accent color and Icon color swatches render vivid, clearly different colors (green vs teal, red vs orange are no longer near-identical).

### Scenario 3 - Separate icon and text colors:
- In Customize → Identity, pick one color for Accent color and a different one for Icon color, then Save.
- Check the sidebar space icon uses the Icon color while the feed post titles and actions use the Accent color.

### Scenario 4 - Neutral text:
- In Customize → Identity, set Accent color to None and Save.
- Check the feed post titles and actions render in the default Reader text color, while the sidebar icon stays colored.

### Scenario 5 - New space defaults:
- Create a new space.
- Check the Accent color defaults to None (neutral text) and the Icon color defaults to the first swatch.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
