### PR TITLE
Fix lost password blackbox error handling and enable on prod

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -118,6 +118,7 @@ const LostPasswordForm = ( {
 			const result = await lostPasswordRequest();
 			setBusy( false );
 			if ( result.includes( 'Unable to reset password' ) ) {
+				blackbox.reset();
 				return setError(
 					translate( "I'm sorry, but we weren't able to find a user with that login information." )
 				);

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -299,4 +299,29 @@ describe( 'LostPasswordForm', () => {
 			expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
+
+	test( 'resets Blackbox when the lost password request cannot find a user', async () => {
+		window.Blackbox = { reset: jest.fn() };
+
+		mockFetch.mockResolvedValueOnce( {
+			ok: true,
+			status: 200,
+			text: jest
+				.fn()
+				.mockResolvedValue( 'Lost Password [...] Unable to reset password [...] More help' ),
+		} );
+
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
+			'user@example.com'
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Reset my password/i } ) );
+
+		await waitFor( () => {
+			expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
 } );

--- a/config/production.json
+++ b/config/production.json
@@ -27,7 +27,7 @@
 		"bilmur-script": true,
 		"blackbox": true,
 		"blackbox-login": true,
-		"blackbox-lost-password": false,
+		"blackbox-lost-password": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,


### PR DESCRIPTION
Refs BBOX-44.

## Proposed Changes

Blackbox does not properly reset when the lost password form fails, since the underlying request fails with a 200 and the error is recognized by checking the content for a specific error message (not by status code).

Unfortunately, I missed this during testing because on my local machine the reset password requests always fail with 404, so they trigger the existing `reset()` call in the catch block. This is because I didn't run it with `MOCK_WORDPRESSDOTCOM`. Requests went to `http://calypso.localhost:3000/wp-login.php?action=lostpassword`.

This PR adds a test covering this case and fixes the implementation.

With this done we can enable the feature for production.

## Testing Instructions

1. Go to http://calypso.localhost:3000/log-in/lostpassword
2. Expected: /collect call to Blackbox
3. Enter some value and submit
4. Expected: /collect/#session_id call to Blackbox
5. [On failure] -> expected: fresh /collect call to Blackbox