### PR TITLE
A4A Dashboard: add Earn section information architecture

### DIFF
--- a/client/dashboard/agency/earn/migrations/index.tsx
+++ b/client/dashboard/agency/earn/migrations/index.tsx
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+
+export default function EarnMigrations() {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Migrations' ) }
+					description={ __( 'Earn commissions for migrating sites to Automattic hosting.' ) }
+				/>
+			}
+		>
+			{ /* TODO: Build the Earn migrations screen. */ }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/overview/index.tsx
+++ b/client/dashboard/agency/earn/overview/index.tsx
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+
+export default function EarnOverview() {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Overview' ) }
+					description={ __( 'Track and manage the ways your agency earns with Automattic.' ) }
+				/>
+			}
+		>
+			{ /* TODO: Build the Earn overview screen. */ }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/payout-settings/index.tsx
+++ b/client/dashboard/agency/earn/payout-settings/index.tsx
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+
+export default function EarnPayoutSettings() {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Payout settings' ) }
+					description={ __( 'Manage where and how your agency gets paid.' ) }
+				/>
+			}
+		>
+			{ /* TODO: Build the Earn payout settings screen. */ }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/index.tsx
+++ b/client/dashboard/agency/earn/referrals/index.tsx
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+
+export default function EarnReferrals() {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Referrals' ) }
+					description={ __( 'Refer products and services and earn commissions.' ) }
+				/>
+			}
+		>
+			{ /* TODO: Build the Earn referrals screen. */ }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/woopayments/index.tsx
+++ b/client/dashboard/agency/earn/woopayments/index.tsx
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+
+export default function EarnWooPayments() {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'WooPayments' ) }
+					description={ __( 'Earn revenue share from WooPayments on your clients’ stores.' ) }
+				/>
+			}
+		>
+			{ /* TODO: Build the Earn WooPayments screen. */ }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -28,6 +28,7 @@ boot( {
 			learn: true,
 			mcp: true,
 			sites: true,
+			earn: true,
 		},
 		agencyClient: { subscriptions: true },
 		sites: false,

--- a/client/dashboard/app-a4a/section.ts
+++ b/client/dashboard/app-a4a/section.ts
@@ -14,6 +14,11 @@ export const A4A_DASHBOARD_SECTION_PATHS = [
 	'/resources/ai-mcp',
 	'/resources/ai-mcp/tools',
 	'/resources/ai-mcp/connect',
+	'/earn',
+	'/earn/referrals',
+	'/earn/woopayments',
+	'/earn/migrations',
+	'/earn/payout-settings',
 	'/client',
 	'/client/subscriptions',
 ];

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -21,6 +21,7 @@ export type AgencySupports = {
 	learn: boolean;
 	mcp: boolean;
 	sites: boolean;
+	earn: boolean;
 };
 
 export type AgencyClientSupports = {

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -1,7 +1,7 @@
 import { agencyQuery, activeAgencyQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { home, globe, layout, pages, tag } from '@wordpress/icons';
+import { home, globe, layout, pages, tag, currencyDollar } from '@wordpress/icons';
 import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sidebar';
 import { useAppContext } from '../context';
 
@@ -49,6 +49,17 @@ export default function AgencySidebar() {
 					{ canAccessMcp && (
 						<SidebarMenuItem to="/resources/ai-mcp">{ __( 'MCP' ) }</SidebarMenuItem>
 					) }
+				</SidebarExpandableMenuItem>
+			) }
+			{ supports.agency.earn && (
+				<SidebarExpandableMenuItem label={ __( 'Earn' ) } icon={ currencyDollar } to="/earn">
+					<SidebarMenuItem to="/earn" activeOptions={ { exact: true } }>
+						{ __( 'Overview' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem to="/earn/referrals">{ __( 'Referrals' ) }</SidebarMenuItem>
+					<SidebarMenuItem to="/earn/woopayments">{ __( 'WooPayments' ) }</SidebarMenuItem>
+					<SidebarMenuItem to="/earn/migrations">{ __( 'Migrations' ) }</SidebarMenuItem>
+					<SidebarMenuItem to="/earn/payout-settings">{ __( 'Payout settings' ) }</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
 		</>

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -180,6 +180,61 @@ export const agencySitesRoute = createRoute( {
 	)
 );
 
+// `/earn` – summary of the agency's earning programs (default Earn screen)
+const earnOverviewRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Overview' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'earn',
+} ).lazy( () =>
+	import( '../../agency/earn/overview' ).then( ( d ) =>
+		createLazyRoute( 'earn-overview' )( { component: d.default } )
+	)
+);
+
+// `/earn/referrals` – referral commissions
+const earnReferralsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Referrals' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'earn/referrals',
+} ).lazy( () =>
+	import( '../../agency/earn/referrals' ).then( ( d ) =>
+		createLazyRoute( 'earn-referrals' )( { component: d.default } )
+	)
+);
+
+// `/earn/woopayments` – WooPayments revenue share
+const earnWooPaymentsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'WooPayments' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'earn/woopayments',
+} ).lazy( () =>
+	import( '../../agency/earn/woopayments' ).then( ( d ) =>
+		createLazyRoute( 'earn-woopayments' )( { component: d.default } )
+	)
+);
+
+// `/earn/migrations` – migration commissions
+const earnMigrationsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Migrations' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'earn/migrations',
+} ).lazy( () =>
+	import( '../../agency/earn/migrations' ).then( ( d ) =>
+		createLazyRoute( 'earn-migrations' )( { component: d.default } )
+	)
+);
+
+// `/earn/payout-settings` – where and how the agency gets paid
+const earnPayoutSettingsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Payout settings' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'earn/payout-settings',
+} ).lazy( () =>
+	import( '../../agency/earn/payout-settings' ).then( ( d ) =>
+		createLazyRoute( 'earn-payout-settings' )( { component: d.default } )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -188,5 +243,10 @@ export const createAgencyRoutes = () => [
 		learnRoute,
 		mcpRoute.addChildren( [ mcpOverviewRoute, mcpAvailableToolsRoute, mcpConnectRoute ] ),
 		agencySitesRoute,
+		earnOverviewRoute,
+		earnReferralsRoute,
+		earnWooPaymentsRoute,
+		earnMigrationsRoute,
+		earnPayoutSettingsRoute,
 	] ),
 ];


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2906/add-earn-information-architecture

## Proposed Changes

Scaffolds the information architecture for a new **Earn** section in the A4A dashboard (built on the Multi-Site Dashboard architecture — TanStack Router/Query).

- Adds an **Earn** expandable menu to the agency sidebar (positioned below **Resources**, using the dollar-sign icon), gated by a new `supports.agency.earn` flag.
- Sub-items: **Overview** (default, routed to `/earn`), **Referrals** (`/earn/referrals`), **WooPayments** (`/earn/woopayments`), **Migrations** (`/earn/migrations`), and **Payout settings** (`/earn/payout-settings`).
- Registers the routes in `app/router/agency.tsx` and the section paths in `app-a4a/section.ts`.
- Adds placeholder screens under `client/dashboard/agency/earn/*` using the standard `PageLayout` / `PageHeader` pattern — the real page content will follow in separate PRs.

The Overview item uses `activeOptions={ { exact: true } }` so it only highlights on `/earn` itself, not on the sibling sub-pages (TanStack Link matches by prefix by default).

<img width="1221" height="655" alt="Screenshot 2026-07-01 at 7 44 03 PM" src="https://github.com/user-attachments/assets/0feb71ae-ddb4-43a4-9eb3-9139bc311210" />


## Why are these changes being made?

This establishes the navigation and routing skeleton for the Earn section up front, so the individual pages (Referrals, WooPayments, Migrations, Payout settings) can be built independently in follow-up PRs without each one having to touch the shared sidebar, routing, and config wiring.

## Testing Instructions

1. Run the dashboard against the A4A variant (`my.a4a.localhost`).
2. In the agency sidebar, confirm an **Earn** menu appears below **Resources** with a dollar-sign icon.
3. Expand it and confirm the sub-items: Overview, Referrals, WooPayments, Migrations, Payout settings.
4. Navigate to `/earn` and confirm the Overview placeholder renders and the **Overview** sub-item is highlighted.
5. Navigate to each sub-page and confirm its placeholder renders, the correct sub-item is highlighted, and **Overview** is not also highlighted.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)