### PR TITLE
A4A: restore Badge import to unblock trunk type_check_client

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Badge } from '@automattic/components';
 import {
 	category,
 	currencyDollar,

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Badge } from '@automattic/components';
 import {
 	category,
 	currencyDollar,
@@ -245,12 +244,8 @@ const useMainMenuItems = ( path: string ) => {
 							icon: megaphone,
 							path: A4A_AMPLIFY_LINK,
 							link: A4A_AMPLIFY_LINK,
-							title: (
-								<div className="sidebar-menu-item__title-with-badge">
-									<span>{ translate( 'Amplify' ) }</span>
-									<Badge type="info">{ translate( 'Alpha' ) }</Badge>
-								</div>
-							),
+							title: translate( 'Amplify' ),
+							badge: translate( 'Alpha' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Amplify',
 							},


### PR DESCRIPTION
## Proposed Changes

Restore `import { Badge } from '@automattic/components';` in `use-main-menu-items.tsx`.

Automattic/wp-calypso#112119 dropped that import when it refactored the Reports item to a `badge:` prop. Automattic/wp-calypso#111789 (A4A Amplify scaffolding) then added a new `<Badge type="info">Alpha</Badge>` usage without restoring it. Each PR type-checked green against its own base; combined on trunk they do not.

Unblocks trunk `type_check_client`:

```
use-main-menu-items.tsx:251 - error TS2304: Cannot find name 'Badge'.
```

[Failing build](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Run_All_Unit_Tests/18350451)
[Failure message](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Run_All_Unit_Tests/18350451?showLog=18350451_69803_353.69800&logFilter=debug&logView=flowAware)

## Why are these changes being made?

Trunk is red on the required `type_check_client` check, blocking every open PR. Semantic merge conflict between two A4A PRs that landed ~1h apart on 2026-07-01.

## Testing Instructions

* `yarn typecheck-client` no longer reports TS2304 for `Badge` in this file.
* Import is single, alphabetically ordered after `@automattic/calypso-config`; the line 251 `<Badge>` usage resolves.
