### PR TITLE
Social E2E: adapt to resolver-based connection loading

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -140,12 +140,18 @@ export class SocialConnectionsManager {
 
 	/**
 	 * Wait for the connection test results response.
+	 *
+	 * The connections resolver fires the request during editor load, so callers arm
+	 * this before navigating; the timeout must cover navigation + hydration + fetch.
 	 */
-	async waitForConnectionTests() {
-		await this.page.waitForResponse( ( response ) => {
-			const url = new URL( response.url() );
+	async waitForConnectionTests( { timeout = 60 * 1000 }: { timeout?: number } = {} ) {
+		await this.page.waitForResponse(
+			( response ) => {
+				const url = new URL( response.url() );
 
-			return this.isSimpleConnectionTestUrl( url ) || this.isAtomicConnectionTestUrl( url );
-		} );
+				return this.isSimpleConnectionTestUrl( url ) || this.isAtomicConnectionTestUrl( url );
+			},
+			{ timeout }
+		);
 	}
 }

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -116,23 +116,24 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await testAccount.authenticate( page );
 			} );
 
-			beforeEach( async () => {
+			// Connections load via a resolver that fetches on editor load, so mock before
+			// navigating. Used by tests asserting on connection-dependent UI.
+			async function visitPostWithMockedConnections() {
+				await socialConnectionsManager.mockSocialConnections();
+				const connectionTestsReceived = socialConnectionsManager.waitForConnectionTests();
 				await editorPage.visit( 'post', { siteSlug } );
-			} );
+				await connectionTestsReceived;
+			}
 
 			afterEach( async () => {
 				await socialConnectionsManager.clearIntercepts();
 			} );
 
 			it( 'Should verify that auto-sharing is available for new posts', async function () {
-				await socialConnectionsManager.mockSocialConnections();
+				await visitPostWithMockedConnections();
 
-				await Promise.all( [
-					// Open the Jetpack sidebar.
-					editorPage.openSettings( 'Jetpack' ),
-					// Wait for the connection test results to finish
-					socialConnectionsManager.waitForConnectionTests(),
-				] );
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
 
 				// Expand the Publicize panel.
 				const section = await editorPage.expandSection( 'Share to social media' );
@@ -153,15 +154,10 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 			it( `Should verify that resharing ${
 				features.resharing ? 'IS' : 'is NOT'
 			} available`, async function () {
-				let connectionTestPromise = Promise.resolve();
-				await socialConnectionsManager.mockSocialConnections();
-
-				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+				await visitPostWithMockedConnections();
 
 				// Open the Jetpack sidebar.
 				await editorPage.openSettings( 'Jetpack' );
-
-				await connectionTestPromise;
 
 				// Expand the Publicize panel.
 				let section = await editorPage.expandSection( 'Share to social media' );
@@ -195,7 +191,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 
 				// Publish the post.
 				await editorPage.publish();
-				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+				const connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
 				await dismissPodcastPostPublishPromo( editorPage );
 				await editorPage.closeAllPanels();
 
@@ -256,6 +252,8 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 			it( `Should verify that manual sharing ${
 				features.manualSharing ? 'IS' : 'is NOT'
 			} available`, async function () {
+				await editorPage.visit( 'post', { siteSlug } );
+
 				// Open the Jetpack sidebar.
 				await editorPage.openSettings( 'Jetpack' );
 
@@ -304,14 +302,10 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 			skipItIf( ! features.socialImageGenerator )(
 				'Should verify that Social Image Generator is available',
 				async function () {
-					await socialConnectionsManager.mockSocialConnections();
-
-					const connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+					await visitPostWithMockedConnections();
 
 					// Open the Jetpack sidebar.
 					await editorPage.openSettings( 'Jetpack' );
-
-					await connectionTestPromise;
 
 					// Expand the Publicize panel.
 					const section = await editorPage.expandSection( 'Share to social media' );


### PR DESCRIPTION
## Proposed Changes

Adapt the `social__editor-features.ts` Jetpack E2E spec to the new resolver-based Publicize connection loading in Jetpack.

- Set up the connection mock and arm the `test_connections` response wait **before** navigating to the editor, via a `visitPostWithMockedConnections()` helper. Only the tests that assert on connection-dependent UI (auto-sharing, resharing, Social Image Generator) use it; the manual-sharing test keeps its original mock-free `visit()`.
- Give `SocialConnectionsManager.waitForConnectionTests()` a generous default timeout (60s) so its budget covers navigation + editor hydration + the fetch, instead of racing a tight 15s window that also included navigation time.

## Why are these changes being made?

The Jetpack Social change [Automattic/jetpack#50115](https://github.com/Automattic/jetpack/pull/50115) moved initial Publicize connection loading from a component-mount effect (in `ConnectionManagement` / `useRefreshConnections`, which mounted when the Jetpack sidebar opened) to the `getConnections` store resolver.

The resolver fetches as soon as the always-mounted pre-publish panel first reads connections — i.e. **during editor load**, not when `openSettings( 'Jetpack' )` is called. The spec armed `waitForConnectionTests()` in the test body, after navigation, so the load-time response was frequently missed, and the resolution cache prevented a re-fetch on sidebar open. This surfaced as intermittent `waitForResponse` timeouts (e.g. the "auto-sharing" and "Social Image Generator" cases) in the `jetpack_simple_deployment_e2e_desktop` suite.

Arming the mock and the wait before navigation makes the request deterministically observable; the larger timeout removes the remaining marginal-budget flake.

No production code changes — this is a test-only adaptation.

## Testing Instructions

Requires the Jetpack change from #50115 to be present in the target environment (e.g. via `bin/jetpack-downloader test jetpack 50115` on a sandbox).

```
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" \
  yarn workspace wp-e2e-tests test "test/e2e/specs/jetpack/social__editor-features.ts"
```

All cases in "Social: Editor features › For Simple Sites with Business plan" should pass:
- Should verify that auto-sharing is available for new posts
- Should verify that resharing IS available
- Should verify that manual sharing IS available
- Should verify that Social Image Generator is available

> **Note:** the `waitForConnectionTests()` timeout change lives in `@automattic/calypso-e2e`; rebuild the package if your runner consumes its built output.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Verified on Simple (Business plan) against Jetpack #50115; Atomic/self-hosted not run. -->

- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
