### PR TITLE
Agents Manager: hide chat and its entry buttons on the Site Editor navigation view

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -13,6 +13,7 @@ import { useAgentsManagerContext } from '../../contexts';
 import { useSetupCustomActions } from '../../hooks/custom-actions';
 import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
+import useHideChatOnSiteEditorNavigation from '../../hooks/use-hide-chat-on-site-editor-navigation';
 import useReaderChatPersistence from '../../hooks/use-reader-chat-persistence';
 import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-agent';
 import { AGENTS_MANAGER_STORE } from '../../stores';
@@ -84,7 +85,7 @@ export default function AgentDock( {
 	const [ isCompactMode, setIsCompactMode ] = useState(
 		window.__agentsManagerActions?.isCompactMode ?? false
 	);
-	const [ shouldRenderChat, setShouldRenderChat ] = useState(
+	const [ isChatEnabled, setIsChatEnabled ] = useState(
 		window.__agentsManagerActions?.isChatEnabled ?? true
 	);
 	const [ desktopMediaQuery, setDesktopMediaQuery ] = useState< string | undefined >(
@@ -119,8 +120,14 @@ export default function AgentDock( {
 		[ isReaderChat, setIsOpen ]
 	);
 
+	// The chat can't work on the Site Editor navigation view, so keep the layout
+	// manager idle there — no docking side effects (portal, body classes, tracking)
+	// until the editing canvas opens.
+	const isSiteEditorNavigation = useHideChatOnSiteEditorNavigation();
+
 	const { isDocked, canDock, dock, undock, openSidebar, closeSidebar, createAgentPortal } =
 		useAgentLayoutManager( {
+			isReady: ! isSiteEditorNavigation,
 			defaultDocked: isReaderChat ? false : isPersistedDocked,
 			defaultOpen: isPersistedOpen,
 			desktopMediaQuery,
@@ -194,7 +201,7 @@ export default function AgentDock( {
 		openSidebar,
 		closeSidebar,
 		setIsCompactMode,
-		setShouldRenderChat,
+		setIsChatEnabled,
 		setDesktopMediaQuery,
 	} );
 
@@ -373,9 +380,9 @@ export default function AgentDock( {
 		/>
 	);
 
-	// When chat rendering is disabled there's nothing to open, so render nothing — the editor
-	// entry-point buttons would otherwise be dead.
-	if ( ! shouldRenderChat ) {
+	// Neither case has a chat to open, so render nothing — otherwise the editor
+	// entry-point buttons below would be dead.
+	if ( ! isChatEnabled || isSiteEditorNavigation ) {
 		return null;
 	}
 

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -113,7 +113,7 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		border: 1px solid $admin-border-color;
 		border-bottom: none;
 		box-sizing: border-box;
-		height: calc( var( --masterbar-height, #{$admin-bar-height} ) + 1px );
+		height: calc( #{$admin-bar-height} + 1px );
 	}
 
 	#adminmenuback,

--- a/packages/agents-manager/src/hooks/__tests__/custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/custom-actions.test.ts
@@ -56,7 +56,7 @@ const baseProps = {
 	closeSidebar: jest.fn(),
 	canDock: true,
 	setIsCompactMode: jest.fn(),
-	setShouldRenderChat: jest.fn(),
+	setIsChatEnabled: jest.fn(),
 	setDesktopMediaQuery: jest.fn(),
 };
 

--- a/packages/agents-manager/src/hooks/__tests__/use-hide-chat-on-site-editor-navigation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-hide-chat-on-site-editor-navigation.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import useHideChatOnSiteEditorNavigation, {
+	useIsSiteEditorNavigation,
+} from '../use-hide-chat-on-site-editor-navigation';
+
+// The hook imports a couple of constants from these modules, whose real
+// implementations pull in a heavy dependency graph (stores, data-stores, …).
+// Mock them down to the constants so this stays a lightweight unit test.
+jest.mock( '../use-admin-bar-integration', () => ( {
+	ADMIN_BAR_BUTTON_ID: 'wp-admin-bar-agents-manager',
+	ADMIN_BAR_AI_CHAT_BUTTON_ID: 'wp-admin-bar-agents-manager-ai-chat',
+} ) );
+jest.mock( '../use-agent-layout-manager', () => ( {
+	SIDEBAR_CONTAINER_CLASS: 'agents-manager-sidebar-container',
+	SIDEBAR_OPEN_CLASS: 'agents-manager-sidebar-container--sidebar-open',
+} ) );
+
+const setUrl = ( path: string ) => window.history.replaceState( {}, '', path );
+
+// `replaceState` is patched to notify subscribers, so wrap the reset in `act()`
+// to flush any hook still mounted during teardown.
+const resetUrl = () => act( () => setUrl( '/' ) );
+
+describe( 'useIsSiteEditorNavigation', () => {
+	afterEach( resetUrl );
+
+	it.each( [
+		{ view: 'a non-Site-Editor page', url: '/wp-admin/index.php', expected: false },
+		{
+			view: 'a non-Site-Editor page with `canvas=edit`',
+			url: '/wp-admin/post.php?canvas=edit',
+			expected: false,
+		},
+		{ view: 'the Site Editor navigation view', url: '/wp-admin/site-editor.php', expected: true },
+		{
+			view: 'the Site Editor editing canvas',
+			url: '/wp-admin/site-editor.php?canvas=edit',
+			expected: false,
+		},
+	] )( 'is $expected on $view', ( { url, expected } ) => {
+		setUrl( url );
+		const { result } = renderHook( () => useIsSiteEditorNavigation() );
+		expect( result.current ).toBe( expected );
+	} );
+
+	it( 'reacts to client-side navigation into and out of the canvas', () => {
+		setUrl( '/wp-admin/site-editor.php' );
+		const { result } = renderHook( () => useIsSiteEditorNavigation() );
+		expect( result.current ).toBe( true );
+
+		act( () => window.history.pushState( {}, '', '/wp-admin/site-editor.php?canvas=edit' ) );
+		expect( result.current ).toBe( false );
+
+		act( () => window.history.pushState( {}, '', '/wp-admin/site-editor.php' ) );
+		expect( result.current ).toBe( true );
+	} );
+} );
+
+describe( 'useHideChatOnSiteEditorNavigation', () => {
+	// The two top-level admin-bar entry points the hook targets.
+	const ENTRY_POINT_IDS = [ 'wp-admin-bar-agents-manager', 'wp-admin-bar-agents-manager-ai-chat' ];
+	const SIDEBAR_CLASSES = [
+		'agents-manager-sidebar-container',
+		'agents-manager-sidebar-container--sidebar-open',
+	];
+
+	// Recreate the server-rendered admin-bar entry points and docked-sidebar body
+	// classes the hook acts on.
+	const setUpChatSurfaces = () => {
+		ENTRY_POINT_IDS.forEach( ( id ) => {
+			const entry = document.createElement( 'li' );
+			entry.id = id;
+			document.body.appendChild( entry );
+		} );
+		document.body.classList.add( ...SIDEBAR_CLASSES );
+	};
+
+	afterEach( () => {
+		resetUrl();
+		document.body.className = '';
+		ENTRY_POINT_IDS.forEach( ( id ) => document.getElementById( id )?.remove() );
+	} );
+
+	it.each( [
+		{
+			description:
+				'hides the entry points and strips the docked-sidebar classes on the navigation view',
+			url: '/wp-admin/site-editor.php',
+			hidden: true,
+		},
+		{
+			description: 'leaves the entry points and classes untouched in the editing canvas',
+			url: '/wp-admin/site-editor.php?canvas=edit',
+			hidden: false,
+		},
+	] )( '$description', ( { url, hidden } ) => {
+		setUpChatSurfaces();
+		setUrl( url );
+
+		renderHook( () => useHideChatOnSiteEditorNavigation() );
+
+		ENTRY_POINT_IDS.forEach( ( id ) =>
+			expect( document.getElementById( id )?.style.display ).toBe( hidden ? 'none' : '' )
+		);
+		SIDEBAR_CLASSES.forEach( ( cls ) =>
+			expect( document.body.classList.contains( cls ) ).toBe( ! hidden )
+		);
+	} );
+
+	it( 'restores the entry points and classes when navigating from the navigation view to the canvas', () => {
+		setUpChatSurfaces();
+		setUrl( '/wp-admin/site-editor.php' );
+		renderHook( () => useHideChatOnSiteEditorNavigation() );
+
+		act( () => window.history.pushState( {}, '', '/wp-admin/site-editor.php?canvas=edit' ) );
+
+		ENTRY_POINT_IDS.forEach( ( id ) =>
+			expect( document.getElementById( id )?.style.display ).toBe( '' )
+		);
+		SIDEBAR_CLASSES.forEach( ( cls ) =>
+			expect( document.body.classList.contains( cls ) ).toBe( true )
+		);
+	} );
+} );

--- a/packages/agents-manager/src/hooks/custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/custom-actions/index.ts
@@ -48,7 +48,7 @@ interface SetupProps {
 	closeSidebar: () => void;
 	canDock: boolean;
 	setIsCompactMode: ( isCompact: boolean ) => void;
-	setShouldRenderChat: ( shouldRender: boolean ) => void;
+	setIsChatEnabled: ( isEnabled: boolean ) => void;
 	setDesktopMediaQuery: ( query: string ) => void;
 }
 
@@ -64,7 +64,7 @@ export function useSetupCustomActions( {
 	closeSidebar,
 	canDock,
 	setIsCompactMode,
-	setShouldRenderChat,
+	setIsChatEnabled,
 	setDesktopMediaQuery,
 }: SetupProps ): void {
 	const { hasLoaded, isOpen, isDocked, isMinimized, floatingPosition } = useSelect( ( select ) => {
@@ -156,9 +156,9 @@ export function useSetupCustomActions( {
 				return;
 			}
 
-			setShouldRenderChat( isEnabled );
+			setIsChatEnabled( isEnabled );
 		},
-		[ setShouldRenderChat ]
+		[ setIsChatEnabled ]
 	);
 
 	const setChatDesktopMediaQuery = useCallback(

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -9,14 +9,14 @@ import type { AgentsManagerSelect } from '@automattic/data-stores';
 import './style.scss';
 
 // Admin bar element selectors
-const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
+export const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
 const ADMIN_BAR_CHAT_ITEM_ID = 'wp-admin-bar-agents-manager-chat-support';
 const ADMIN_BAR_HISTORY_ITEM_ID = 'wp-admin-bar-agents-manager-chat-history';
 const ADMIN_BAR_GUIDES_ITEM_ID = 'wp-admin-bar-agents-manager-support-guides';
 
 // The standalone AI chat button — the chat's entry point, separate from the Help
 // menu. The wp-admin bar exposes it by ID; Calypso's masterbar by class.
-const ADMIN_BAR_AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
+export const ADMIN_BAR_AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
 const MASTERBAR_AI_CHAT_BUTTON_SELECTOR = '.masterbar__item-agents-manager-ai-chat';
 
 /**

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -27,6 +27,12 @@ const FULLSCREEN_BODY_CLASS = 'is-fullscreen-mode';
 // `jetpack/projects/packages/agents-manager/src/js/sidebar-docking-gate.ts`.
 const CHAT_PORTAL_CLASS = 'agents-manager-chat';
 
+// Container classes that reserve layout space for the docked sidebar; the Site
+// Editor navigation-view hook imports these to strip and restore them.
+export const SIDEBAR_CONTAINER_CLASS = 'agents-manager-sidebar-container';
+export const SIDEBAR_OPEN_CLASS = 'agents-manager-sidebar-container--sidebar-open';
+const SIDEBAR_CLOSING_CLASS = 'agents-manager-sidebar-container--closing';
+
 function getIsFullscreenGateOpen(): boolean {
 	const { classList } = document.body;
 	const isGated = FULLSCREEN_GATED_BODY_CLASSES.some( ( cls ) => classList.contains( cls ) );
@@ -162,11 +168,11 @@ export default function useAgentLayoutManager( {
 
 			// Apply initial classes
 			if ( shouldRenderSidebar ) {
-				container.classList.add( 'agents-manager-sidebar-container' );
+				container.classList.add( SIDEBAR_CONTAINER_CLASS );
 				portalRef.current.classList.add( 'agents-manager-chat--docked' );
 
 				if ( defaultOpenRef.current ) {
-					container.classList.add( 'agents-manager-sidebar-container--sidebar-open' );
+					container.classList.add( SIDEBAR_OPEN_CLASS );
 				}
 			} else {
 				portalRef.current.classList.add( 'agents-manager-chat--undocked' );
@@ -179,12 +185,12 @@ export default function useAgentLayoutManager( {
 
 		// Handle dock/undock state changes
 		if ( shouldRenderSidebar ) {
-			container.classList.add( 'agents-manager-sidebar-container' );
+			container.classList.add( SIDEBAR_CONTAINER_CLASS );
 			portalRef.current.classList.add( 'agents-manager-chat--docked' );
 			portalRef.current.classList.remove( 'agents-manager-chat--undocked' );
 
 			if ( defaultOpenRef.current ) {
-				container.classList.add( 'agents-manager-sidebar-container--sidebar-open' );
+				container.classList.add( SIDEBAR_OPEN_CLASS );
 			}
 
 			onDockRef.current();
@@ -194,9 +200,9 @@ export default function useAgentLayoutManager( {
 			clearTimeout( openSidebarTimeoutRef.current );
 			clearTimeout( closeSidebarTimeoutRef.current );
 			container.classList.remove(
-				'agents-manager-sidebar-container',
-				'agents-manager-sidebar-container--sidebar-open',
-				'agents-manager-sidebar-container--closing'
+				SIDEBAR_CONTAINER_CLASS,
+				SIDEBAR_OPEN_CLASS,
+				SIDEBAR_CLOSING_CLASS
 			);
 			portalRef.current.classList.add( 'agents-manager-chat--undocked' );
 			portalRef.current.classList.remove( 'agents-manager-chat--docked' );
@@ -265,9 +271,9 @@ export default function useAgentLayoutManager( {
 
 			if ( container ) {
 				container.classList.remove(
-					'agents-manager-sidebar-container',
-					'agents-manager-sidebar-container--sidebar-open',
-					'agents-manager-sidebar-container--closing',
+					SIDEBAR_CONTAINER_CLASS,
+					SIDEBAR_OPEN_CLASS,
+					SIDEBAR_CLOSING_CLASS,
 					'is-split-screen'
 				);
 
@@ -287,8 +293,8 @@ export default function useAgentLayoutManager( {
 		}
 
 		clearTimeout( closeSidebarTimeoutRef.current );
-		container.classList.remove( 'agents-manager-sidebar-container--closing' );
-		container.classList.add( 'agents-manager-sidebar-container--sidebar-open' );
+		container.classList.remove( SIDEBAR_CLOSING_CLASS );
+		container.classList.add( SIDEBAR_OPEN_CLASS );
 
 		onOpenSidebarRef.current();
 	}, [ canDock, container, isReady ] );
@@ -298,18 +304,16 @@ export default function useAgentLayoutManager( {
 			return;
 		}
 
-		const wasSidebarOpen = container.classList.contains(
-			'agents-manager-sidebar-container--sidebar-open'
-		);
+		const wasSidebarOpen = container.classList.contains( SIDEBAR_OPEN_CLASS );
 
-		container.classList.remove( 'agents-manager-sidebar-container--sidebar-open' );
+		container.classList.remove( SIDEBAR_OPEN_CLASS );
 
 		// Only suppress admin bar pointer events during an actual sidebar-close transition.
 		if ( wasSidebarOpen ) {
-			container.classList.add( 'agents-manager-sidebar-container--closing' );
+			container.classList.add( SIDEBAR_CLOSING_CLASS );
 			clearTimeout( closeSidebarTimeoutRef.current );
 			closeSidebarTimeoutRef.current = setTimeout( () => {
-				container?.classList.remove( 'agents-manager-sidebar-container--closing' );
+				container?.classList.remove( SIDEBAR_CLOSING_CLASS );
 			}, SIDEBAR_TRANSITION_DURATION_MS );
 		}
 

--- a/packages/agents-manager/src/hooks/use-hide-chat-on-site-editor-navigation.ts
+++ b/packages/agents-manager/src/hooks/use-hide-chat-on-site-editor-navigation.ts
@@ -1,0 +1,107 @@
+import { useLayoutEffect, useSyncExternalStore } from '@wordpress/element';
+import { isSiteEditorContext, isSiteEditorCanvasEditMode } from '../utils/site-editor-context';
+import { ADMIN_BAR_BUTTON_ID, ADMIN_BAR_AI_CHAT_BUTTON_ID } from './use-admin-bar-integration';
+import { SIDEBAR_CONTAINER_CLASS, SIDEBAR_OPEN_CLASS } from './use-agent-layout-manager';
+
+const LOCATION_CHANGE_EVENT = 'agentsManagerLocationChange';
+
+// The two top-level entry points; hiding them also hides the Help dropdown's children.
+const ADMIN_BAR_ENTRY_SELECTOR = `#${ ADMIN_BAR_BUTTON_ID }, #${ ADMIN_BAR_AI_CHAT_BUTTON_ID }`;
+
+// Docked-sidebar body classes that reserve layout space, set by the layout manager.
+const SIDEBAR_BODY_CLASSES = [ SIDEBAR_CONTAINER_CLASS, SIDEBAR_OPEN_CLASS ];
+
+// `pushState`/`replaceState` fire no event, so Site Editor navigation is invisible.
+// Patch them once to also dispatch `LOCATION_CHANGE_EVENT`; never restored, to
+// avoid clobbering another library's patch.
+let historyPatched = false;
+function patchHistoryOnce(): void {
+	if ( historyPatched ) {
+		return;
+	}
+	historyPatched = true;
+
+	( [ 'pushState', 'replaceState' ] as const ).forEach( ( method ) => {
+		const original = window.history[ method ];
+		window.history[ method ] = function ( ...args ) {
+			const result = original.apply( this, args );
+			window.dispatchEvent( new Event( LOCATION_CHANGE_EVENT ) );
+			return result;
+		};
+	} );
+}
+
+function subscribeToLocation( notify: () => void ): () => void {
+	// Off the Site Editor this value can't change, so skip the listeners and the
+	// history patch entirely.
+	if ( ! isSiteEditorContext() ) {
+		return () => {};
+	}
+
+	patchHistoryOnce();
+	window.addEventListener( 'popstate', notify );
+	window.addEventListener( LOCATION_CHANGE_EVENT, notify );
+
+	return () => {
+		window.removeEventListener( 'popstate', notify );
+		window.removeEventListener( LOCATION_CHANGE_EVENT, notify );
+	};
+}
+
+function getIsSiteEditorNavigation(): boolean {
+	return isSiteEditorContext() && ! isSiteEditorCanvasEditMode();
+}
+
+/**
+ * True on the Site Editor navigation view (`site-editor.php` without
+ * `?canvas=edit`) — the one with the left nav menu, where the chat can't work.
+ * False in the editing canvas and on all other pages. Reacts to the Site Editor's
+ * client-side navigation.
+ */
+export function useIsSiteEditorNavigation(): boolean {
+	return useSyncExternalStore( subscribeToLocation, getIsSiteEditorNavigation );
+}
+
+/**
+ * Hides the chat's surfaces on the Site Editor navigation view (where it can't
+ * work) and restores them in the editing canvas, without touching the docked
+ * state. It hides two things:
+ * - the server-rendered admin-bar entry points (the AI chat button and the Help
+ *   menu, whose items also open the chat), via an inline `!important`;
+ * - the docked sidebar's reserved space, by stripping the layout manager's body
+ *   classes and adding them back.
+ *
+ * Returns whether we're on the navigation view, so the dock can skip its work
+ * there — render nothing and keep its layout manager idle.
+ */
+export default function useHideChatOnSiteEditorNavigation(): boolean {
+	const isSiteEditorNavigation = useIsSiteEditorNavigation();
+
+	useLayoutEffect( () => {
+		if ( ! isSiteEditorNavigation ) {
+			return;
+		}
+
+		const buttons = document.querySelectorAll< HTMLElement >( ADMIN_BAR_ENTRY_SELECTOR );
+		buttons.forEach( ( button ) => button.style.setProperty( 'display', 'none', 'important' ) );
+
+		return () => {
+			buttons.forEach( ( button ) => button.style.removeProperty( 'display' ) );
+		};
+	}, [ isSiteEditorNavigation ] );
+
+	useLayoutEffect( () => {
+		if ( ! isSiteEditorNavigation ) {
+			return;
+		}
+
+		// `agent-dock` keeps the layout manager idle here, so nothing re-adds these classes.
+		const { classList } = document.body;
+		const removed = SIDEBAR_BODY_CLASSES.filter( ( cls ) => classList.contains( cls ) );
+		removed.forEach( ( cls ) => classList.remove( cls ) );
+
+		return () => removed.forEach( ( cls ) => classList.add( cls ) );
+	}, [ isSiteEditorNavigation ] );
+
+	return isSiteEditorNavigation;
+}

--- a/packages/agents-manager/src/utils/site-editor-context.ts
+++ b/packages/agents-manager/src/utils/site-editor-context.ts
@@ -11,6 +11,18 @@ export function isSiteEditorContext( environment?: string, currentRoute?: string
 	);
 }
 
+/**
+ * True when the Site Editor shows its editing canvas (`?canvas=edit`) rather
+ * than the navigation view. Scoped to the Site Editor so other admin pages that
+ * happen to carry `?canvas=edit` aren't treated as canvas edit mode.
+ */
+export function isSiteEditorCanvasEditMode(): boolean {
+	return (
+		isSiteEditorContext() &&
+		new URLSearchParams( window.location.search ).get( 'canvas' ) === 'edit'
+	);
+}
+
 export function getClientConstructorArguments(
 	environment?: string,
 	currentRoute?: string


### PR DESCRIPTION
Part of AI-1044

## Proposed Changes

* Add a `useHideChatOnSiteEditorNavigation` hook: on the Site Editor dashboard (`site-editor.php` without `?canvas=edit`) it hides the chat's admin-bar entry points (the AI chat button and the Help menu, whose items also open the chat) and strips the docked sidebar's reserved-space body classes, restoring both when the editing canvas reopens — without touching the docked state.
* Gate the dock render in `agent-dock` on the new signal, so nothing renders (and the layout manager stays idle, avoiding stray docking side effects) on the dashboard where the chat can't work.
* Add `isSiteEditorCanvasEditMode` to `site-editor-context`.
* Rename the internal `shouldRenderChat` state to `isChatEnabled` (the public `window.__agentsManagerActions` action is unchanged).
* Fix an existing bug where the docked `#wpadminbar` used `--masterbar-height` (the taller Calypso masterbar) instead of the admin-bar height, overlapping the editor toolbar.

## Why are these changes being made?

The Site Editor dashboard has a left navigation menu where the chat can't function, but the dock, its admin-bar entry points, and the docked sidebar's reserved space still appeared there. This hides them on the dashboard and restores them in the editing canvas. Paired with a Jetpack PR that skips pre-rendering the docked sidebar shell server-side on the dashboard.

| Before | After |
| - | - |
| <img width="1988" height="1289" alt="截圖 2026-07-02 凌晨12 05 30" src="https://github.com/user-attachments/assets/b49dc5c1-4553-464d-b0be-6fdf3ace6e4c" /> | <img width="1988" height="1289" alt="截圖 2026-07-02 凌晨12 09 14" src="https://github.com/user-attachments/assets/2477db04-8b2f-4e71-b6fd-279253c1f7cf" /> |

## Testing Instructions

1. Sandbox Automattic/jetpack#50120.
2. Sandbox this PR.
3. Enable the unified AI experience option.
4. Go to `/wp-admin/admin.php?page=experiments-wp-admin` and enable the **Toolbar in editor** option.
5. Test the sidebar/docked chat.

### Server-side rendered navigation view

1. Go to `/wp-admin/site-editor.php`.
2. Confirm that the chat and its related toolbar entries are hidden.
3. Confirm that the undocked chat should work the same.

### Client-side navigation flow

1. Go to `/wp-admin/site-editor.php`.
2. Click the canvas to enter editing mode.
3. Confirm that the chat and its related toolbar entries are shown.
4. Click the top-left arrow button to return to the navigation view.
5. Confirm that the chat and its related toolbar entries are hidden again. Note: The entry buttons are hidden client-side with CSS because they will be shown again later.
6. Confirm that the undocked chat should work the same.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?



