### PR TITLE
Run unit tests on merge queue instead of trunk

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -422,8 +422,6 @@ object RunAllUnitTests : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
-		mergeTrunk().skipOnMergeQueueBranch()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -468,7 +466,7 @@ object RunAllUnitTests : BuildType({
 					exit 1
 				fi
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Check for yarn.lock changes and duplicated packages"
 			scriptContent = """
@@ -502,7 +500,7 @@ object RunAllUnitTests : BuildType({
 				prevent_uncommitted_changes & prevent_duplicated_packages
 				wait
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Check DataViews changelog"
 			scriptContent = """
@@ -522,24 +520,12 @@ object RunAllUnitTests : BuildType({
 					fi
 				fi
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Run parallelized tests"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = "./bin/unit-test-suite.mjs"
-		}.skipOnMergeQueueBranch()
-		bashNodeScript {
-			name = "Tag build"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
-			conditions {
-				equals("teamcity.build.branch.is_default", "true")
-			}
-			scriptContent = """
-				set -x
-
-				curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" "%teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/"
-			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {
@@ -547,6 +533,7 @@ object RunAllUnitTests : BuildType({
 			branchFilter = """
 				+:*
 				-:pull*
+				-:trunk
 			""".trimIndent()
 		}
 	}
@@ -587,7 +574,7 @@ object RunAllUnitTests : BuildType({
 				messageFormat = simpleMessageFormat()
 			}
 			branchFilter = """
-				+:trunk
+				+:gh-readonly-queue/*
 			""".trimIndent()
 			buildFailedToStart = true
 			buildFailed = true


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Update the TeamCity `Unit tests` build trigger so it runs on regular PR/feature branches and GitHub merge queue branches.
* Exclude `trunk` from the `Unit tests` VCS trigger to avoid rerunning the same checks after merge queue validation has already passed.
* Remove the merge queue early-pass behavior from the `Unit tests` build so merge queue refs run the real unit test steps.
* Remove the obsolete successful-build `release-candidate` TeamCity tagging step from Unit Tests.
* Scope Unit Test Slack notifications to merge queue refs instead of `trunk`.

## Why are these changes being made?

* With merge queue enabled, Unit Tests should validate both PR updates and the exact merge queue commit that is about to land on `trunk`.
* Running Unit Tests again after that merge queue commit lands on `trunk` duplicates CI work without adding meaningful merge protection.
* Merge queue refs previously matched the build but passed early; this change makes them perform the real validation.
* The `release-candidate` TeamCity tag was added in [#59348](https://github.com/Automattic/wp-calypso/pull/59348) so branch builds could compare TypeScript errors against the latest tagged trunk build as a baseline. That baseline is no longer used, so the tagging step can be removed instead of moved to the merge queue path.

## Testing Instructions

* Verified the TeamCity DSL change diff locally.
* Ran `git diff --check HEAD~1..HEAD`.
* Did not run TeamCity DSL generation locally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?