### PR TITLE
Reader - fix missing images on feed page

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -43,7 +43,7 @@ class ReaderFeedHeader extends Component {
 			'is-placeholder': ! site && ! feed,
 		} );
 
-		let feedIcon = feed ? feed.site_icon ?? feed.image : null;
+		let feedIcon = feed ? feed.site_icon || feed.image : null;
 		// don't show the default favicon for some sites
 		if ( feedIcon?.endsWith( 'wp.com/i/buttonw-com.png' ) ) {
 			feedIcon = null;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -74,11 +74,13 @@
 
 	// Feed images sourced from an RSS channel image (or a small site icon) can be
 	// tiny. `max-width: 100%` only scales down, so a small source would otherwise
-	// float in the center of the box. Force the image to fill the allocated space.
+	// float in the center of the box. Scale the image up to fill the allocated
+	// space, using `contain` so non-square sources are shown in full rather than
+	// cropped.
 	.site-icon__img {
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
+		object-fit: contain;
 	}
 }
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -71,6 +71,15 @@
 
 .reader-feed-header__site-icon {
 	margin-right: 24px;
+
+	// Feed images sourced from an RSS channel image (or a small site icon) can be
+	// tiny. `max-width: 100%` only scales down, so a small source would otherwise
+	// float in the center of the box. Force the image to fill the allocated space.
+	.site-icon__img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
 }
 
 .reader-feed-header__follow-button-and-settings {

--- a/client/blocks/reader-feed-header/test/index.jsx
+++ b/client/blocks/reader-feed-header/test/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ReaderFeedHeader from '..';
+
+// Render a lightweight stand-in for SiteIcon that exposes the icon URL the
+// header resolved, so we can assert on the fallback logic without pulling in
+// SiteIcon's Redux dependencies.
+jest.mock( 'calypso/blocks/site-icon', () => ( props ) => {
+	const img = props?.site?.icon?.img;
+	return img ? <img alt="site-icon" src={ img } /> : <span data-testid="default-site-icon" />;
+} );
+
+// Connected/query children that are irrelevant to icon resolution.
+jest.mock( 'calypso/components/data/query-user-settings', () => () => null );
+jest.mock( 'calypso/blocks/blog-stickers', () => () => null );
+jest.mock( '../follow', () => () => null );
+jest.mock( '../badge', () => () => null );
+
+const feedImage = 'https://example.com/rss-channel-image.png';
+
+describe( 'ReaderFeedHeader icon fallback', () => {
+	it( 'falls back to the feed image when the subscription site_icon is an empty string', () => {
+		// A followed feed whose site has no WordPress Site Icon returns site_icon: ''
+		// (coerced from null by the follows adapter). The feed still has an RSS
+		// channel image, which should be used.
+		render( <ReaderFeedHeader feed={ { site_icon: '', image: feedImage } } /> );
+
+		expect( screen.getByRole( 'img', { name: 'site-icon' } ) ).toBeVisible();
+		expect( screen.queryByTestId( 'default-site-icon' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to the feed image when the subscription site_icon is null', () => {
+		render( <ReaderFeedHeader feed={ { site_icon: null, image: feedImage } } /> );
+
+		expect( screen.getByRole( 'img', { name: 'site-icon' } ) ).toBeVisible();
+	} );
+
+	it( 'prefers the site_icon over the feed image when both are present', () => {
+		const siteIcon = 'https://example.com/site-icon.png';
+		render( <ReaderFeedHeader feed={ { site_icon: siteIcon, image: feedImage } } /> );
+
+		const img = screen.getByRole( 'img', { name: 'site-icon' } );
+		expect( img ).toBeVisible();
+		expect( img.getAttribute( 'src' ) ).toContain( 'site-icon.png' );
+	} );
+
+	it( 'renders the default icon when neither site_icon nor feed image are available', () => {
+		render( <ReaderFeedHeader feed={ { site_icon: '', image: '' } } /> );
+
+		expect( screen.getByTestId( 'default-site-icon' ) ).toBeVisible();
+		expect( screen.queryByRole( 'img', { name: 'site-icon' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -36,8 +36,10 @@ const FeedStream = ( props ) => {
 	const { site, siteError } = useSite( siteId );
 
 	if ( feed ) {
-		// Add site icon to feed object so have icon for external feeds
-		feed = { ...feed, site_icon: followForFeed?.site_icon };
+		// Add site icon to feed object so have icon for external feeds. Preserve the
+		// feed's own icon when the subscription has none, so the feed image fallback
+		// in ReaderFeedHeader still applies.
+		feed = { ...feed, site_icon: followForFeed?.site_icon || feed.site_icon };
 	}
 
 	const siteTags = useSiteTags( siteId );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # related to but not comprehensive fix to https://linear.app/a8c/issue/READ-117/reader-subscription-management-missing-site-icon 

## Proposed Changes

Updates to reader feed stream + feed stream header:

* adjust image fallback logic from `??` to `||`. Recent changes in other refactors caused a falsy site icon to be an empty string instead of `null`, causing this fallback to never hit. This was a regression from the react query migration.
* Extra safety, when followForFeed.site_icon is used to replace feed.site_icon, only do so if the former is a truthy value.
* adds regression tests.
* adds style rules to size the images to fit the given area. 

BEFORE
<img width="1548" height="532" alt="image" src="https://github.com/user-attachments/assets/1255bd47-cbe0-4c16-b07d-eca3d4911a9d" />
<img width="1656" height="586" alt="image" src="https://github.com/user-attachments/assets/b5c028d4-8fa7-4c6c-9e25-58b27da677f5" />

AFTER (fallback logic)
<img width="544" height="196" alt="Screenshot 2026-07-01 at 9 39 34 AM" src="https://github.com/user-attachments/assets/5ed28a10-1ab4-4e4f-aed9-361aecf9253f" />
<img width="530" height="178" alt="Screenshot 2026-07-01 at 9 39 00 AM" src="https://github.com/user-attachments/assets/2bff5483-c1a3-48aa-b029-def91b7903cb" />

AFTER (sizing rules)
<img width="478" height="192" alt="Screenshot 2026-07-01 at 9 39 20 AM" src="https://github.com/user-attachments/assets/4ea9e92c-d0ae-4d2d-8494-92b84ef9c4ac" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Missing and mis-sized images on feed page header

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test reader feed headers for various sites/feeds and verify no regressions in the image.
* visit `*/reader/feeds/84338077` and `*/reader/feeds/20819159` and verify images are shown in the feed headers with expected size.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
