### PR TITLE
Invite Revoke: clean up only the invites the spec creates (TESTOPS-205)

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -411,10 +411,10 @@ export class RestAPIClient {
 	/**
 	 *
 	 * @param siteID
-	 * @param number Page size. The endpoint defaults to 25; pass a higher value
-	 * (up to the 100 pending-invite cap) to fetch more in one request.
+	 * @param pageSize Page size. The endpoint defaults to 25 and paginates; pass a
+	 * higher value (100 is the max page size) to fetch more in one request.
 	 */
-	async getInvites( siteID: number, number?: number ): Promise< AllInvitesResponse > {
+	async getInvites( siteID: number, pageSize?: number ): Promise< AllInvitesResponse > {
 		const params: RequestParams = {
 			method: 'get',
 			headers: {
@@ -424,8 +424,8 @@ export class RestAPIClient {
 		};
 
 		const url = this.getRequestURL( '1.1', `/sites/${ siteID }/invites` );
-		if ( number !== undefined ) {
-			url.searchParams.set( 'number', String( number ) );
+		if ( pageSize !== undefined ) {
+			url.searchParams.set( 'number', String( pageSize ) );
 		}
 
 		const response = await this.sendRequest( url, params );
@@ -447,48 +447,19 @@ export class RestAPIClient {
 	async deleteInvite( siteID: number, email: string ): Promise< boolean > {
 		const invites = await this.getInvites( siteID );
 
-		let inviteID = undefined;
+		const invite = Object.values( invites ).find(
+			( invite: Invite ) =>
+				invite.invited_by.site_ID === siteID && invite.is_pending && invite.user.email === email
+		);
 
-		Object.values( invites ).forEach( ( invite: Invite ) => {
-			if (
-				invite.invited_by.site_ID === siteID &&
-				invite.is_pending &&
-				invite.user.email === email
-			) {
-				inviteID = invite.invite_key;
-			}
-		} );
-
-		if ( inviteID === undefined ) {
+		if ( invite === undefined ) {
 			throw new Error(
 				`Aborting invite deletion: inviteID not found for email: ${ email } and siteID: ${ siteID }}`
 			);
 		}
 
-		const params: RequestParams = {
-			method: 'post',
-			headers: {
-				Authorization: await this.getAuthorizationHeader( 'bearer' ),
-				'Content-Type': this.getContentTypeHeader( 'json' ),
-			},
-			body: JSON.stringify( {
-				invite_ids: [ inviteID ],
-			} ),
-		};
-
-		const response: DeleteInvitesResponse = await this.sendRequest(
-			this.getRequestURL( '2', `/sites/${ siteID }/invites/delete`, 'wpcom' ),
-			params
-		);
-
-		// This call does not return a traditional error that's in the
-		// format of ErrorResponse, instead returning a
-		// DeleteInvitesResponse which always has the `deleted` and
-		// `invalid` fields.
-		if ( response.deleted.includes( inviteID ) ) {
-			return true;
-		}
-		return false;
+		const response = await this.deleteInvites( siteID, [ invite.invite_key ] );
+		return response.deleted.includes( invite.invite_key );
 	}
 
 	/**
@@ -510,10 +481,18 @@ export class RestAPIClient {
 			} ),
 		};
 
-		return this.sendRequest(
+		const response = await this.sendRequest(
 			this.getRequestURL( '2', `/sites/${ siteID }/invites/delete`, 'wpcom' ),
 			params
 		);
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
 	}
 
 	/* Me */

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -411,8 +411,10 @@ export class RestAPIClient {
 	/**
 	 *
 	 * @param siteID
+	 * @param number Page size. The endpoint defaults to 25; pass a higher value
+	 * (up to the 100 pending-invite cap) to fetch more in one request.
 	 */
-	async getInvites( siteID: number ): Promise< AllInvitesResponse > {
+	async getInvites( siteID: number, number?: number ): Promise< AllInvitesResponse > {
 		const params: RequestParams = {
 			method: 'get',
 			headers: {
@@ -421,10 +423,12 @@ export class RestAPIClient {
 			},
 		};
 
-		const response = await this.sendRequest(
-			this.getRequestURL( '1.1', `/sites/${ siteID }/invites` ),
-			params
-		);
+		const url = this.getRequestURL( '1.1', `/sites/${ siteID }/invites` );
+		if ( number !== undefined ) {
+			url.searchParams.set( 'number', String( number ) );
+		}
+
+		const response = await this.sendRequest( url, params );
 
 		if ( response.hasOwnProperty( 'error' ) ) {
 			throw new Error(
@@ -485,6 +489,31 @@ export class RestAPIClient {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Bulk-deletes pending invites by their invite keys in a single request.
+	 *
+	 * @param siteID Target site ID.
+	 * @param inviteKeys Invite keys to delete.
+	 * @returns The list of deleted and invalid invite keys.
+	 */
+	async deleteInvites( siteID: number, inviteKeys: string[] ): Promise< DeleteInvitesResponse > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( {
+				invite_ids: inviteKeys,
+			} ),
+		};
+
+		return this.sendRequest(
+			this.getRequestURL( '2', `/sites/${ siteID }/invites/delete`, 'wpcom' ),
+			params
+		);
 	}
 
 	/* Me */

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -33,29 +33,50 @@ test.describe(
 			// and fail waitForInvitation. Log how many pending invites (from any run)
 			// exist at start. The list endpoint returns at most 100 per page, so this
 			// is a floor, not an exact count.
-			const restAPIClient = new RestAPIClient( credentials );
-			const firstPage = await restAPIClient.getInvites( siteID, 100 );
-			const pending = firstPage.filter( ( invite ) => invite.is_pending ).length;
-			process.stderr.write(
-				`[invite__revoke] pending invites on site ${ siteID } at start: ${ pending }${
-					firstPage.length >= 100 ? '+ (list truncated at 100)' : ''
-				}\n`
-			);
+			// Never let a diagnostic read fail the suite: swallow and log.
+			try {
+				const restAPIClient = new RestAPIClient( credentials );
+				const firstPage = await restAPIClient.getInvites( siteID, 100 );
+				const pending = firstPage.filter( ( invite ) => invite.is_pending ).length;
+				process.stderr.write(
+					`[invite__revoke] pending invites on site ${ siteID } at start: ${ pending }${
+						firstPage.length >= 100 ? '+ (list truncated at 100)' : ''
+					}\n`
+				);
+			} catch ( error ) {
+				process.stderr.write( `[invite__revoke] start diagnostic failed: ${ error }\n` );
+			}
 		} );
 
 		test.afterAll( async function () {
 			if ( ! createdInviteEmails.length ) {
 				return;
 			}
-			const restAPIClient = new RestAPIClient( credentials );
-			const staleKeys = ( await restAPIClient.getInvites( siteID, 100 ) )
-				.filter(
-					( invite ) => invite.is_pending && createdInviteEmails.includes( invite.user.email )
-				)
-				.map( ( invite ) => invite.invite_key );
+			// Best-effort cleanup: a failure here must not fail an otherwise-passing
+			// run, so swallow errors and log them instead.
+			try {
+				const restAPIClient = new RestAPIClient( credentials );
+				// Scans only the first page (100). Enough while every run cleans up
+				// after itself; if the site holds >100 pending invites and the endpoint
+				// is not newest-first, follow the response's pagination links instead.
+				const staleKeys = ( await restAPIClient.getInvites( siteID, 100 ) )
+					.filter(
+						( invite ) => invite.is_pending && createdInviteEmails.includes( invite.user.email )
+					)
+					.map( ( invite ) => invite.invite_key );
 
-			if ( staleKeys.length ) {
-				await restAPIClient.deleteInvites( siteID, staleKeys );
+				if ( staleKeys.length ) {
+					const { invalid } = await restAPIClient.deleteInvites( siteID, staleKeys );
+					if ( invalid.length ) {
+						process.stderr.write(
+							`[invite__revoke] teardown could not delete ${
+								invalid.length
+							} invite(s): ${ invalid.join( ', ' ) }\n`
+						);
+					}
+				}
+			} catch ( error ) {
+				process.stderr.write( `[invite__revoke] teardown failed: ${ error }\n` );
 			}
 		} );
 

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -1,4 +1,4 @@
-import { DataHelper, SecretsManager } from '@automattic/calypso-e2e';
+import { DataHelper, RestAPIClient, SecretsManager } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe(
@@ -19,6 +19,46 @@ test.describe(
 		let acceptInviteLink: string;
 		let userManagementRevampFeature = false;
 
+		const siteID = credentials.testSites?.primary?.id as number;
+
+		// Emails this suite has actually invited. The revoke happens through the UI
+		// at the end of the test, so a run that dies before that step leaks its
+		// pending invite. Only invites tracked here are deleted in teardown, so a
+		// concurrent run's in-flight invites are never touched.
+		const createdInviteEmails: string[] = [];
+
+		test.beforeAll( async function () {
+			// Diagnostic only, no mutation. The People page caps the pending-invites
+			// list it renders, so a saturated site can hide a freshly created invite
+			// and fail waitForInvitation. Log how many pending invites (from any run)
+			// exist at start. The list endpoint returns at most 100 per page, so this
+			// is a floor, not an exact count.
+			const restAPIClient = new RestAPIClient( credentials );
+			const firstPage = await restAPIClient.getInvites( siteID, 100 );
+			const pending = firstPage.filter( ( invite ) => invite.is_pending ).length;
+			process.stderr.write(
+				`[invite__revoke] pending invites on site ${ siteID } at start: ${ pending }${
+					firstPage.length >= 100 ? '+ (list truncated at 100)' : ''
+				}\n`
+			);
+		} );
+
+		test.afterAll( async function () {
+			if ( ! createdInviteEmails.length ) {
+				return;
+			}
+			const restAPIClient = new RestAPIClient( credentials );
+			const staleKeys = ( await restAPIClient.getInvites( siteID, 100 ) )
+				.filter(
+					( invite ) => invite.is_pending && createdInviteEmails.includes( invite.user.email )
+				)
+				.map( ( invite ) => invite.invite_key );
+
+			if ( staleKeys.length ) {
+				await restAPIClient.deleteInvites( siteID, staleKeys );
+			}
+		} );
+
 		test( 'As a site owner, I can revoke a pending invite so that the invitation link becomes invalid', async ( {
 			page,
 			componentSidebar,
@@ -28,10 +68,13 @@ test.describe(
 			accountDefaultUser,
 		} ) => {
 			await test.step( 'Given I create an invite via REST API', async function () {
-				const { RestAPIClient } = await import( '@automattic/calypso-e2e' );
 				const restAPIClient = new RestAPIClient( credentials );
 
-				await restAPIClient.createInvite( credentials.testSites?.primary?.id as number, {
+				// Track before the call: createInvite can create the invite server-side
+				// and still throw (e.g. while parsing the response), so the email must be
+				// queued for teardown before the request, not after.
+				createdInviteEmails.push( testEmailAddress );
+				await restAPIClient.createInvite( siteID, {
 					email: [ testEmailAddress ],
 					role: role,
 					message: inviteMessage,
@@ -60,7 +103,9 @@ test.describe(
 
 			await test.step( 'When I navigate to Users > All Users', async function () {
 				await componentSidebar.navigate( 'Users', 'All Users' );
-				! userManagementRevampFeature && ( await pagePeople.clickTab( 'Invites' ) );
+				if ( ! userManagementRevampFeature ) {
+					await pagePeople.clickTab( 'Invites' );
+				}
 			} );
 
 			await test.step( 'Then I can see the invite is pending', async function () {


### PR DESCRIPTION
Fixes [TESTOPS-205](https://linear.app/a8c/issue/TESTOPS-205)

## Proposed Changes

- `invite__revoke.spec.ts` deletes only the invites it created. Each invited email is tracked **before** the `createInvite` call (so a partial failure that creates the invite but then throws still cleans up), and `afterAll` removes only those, never other runs' invites.
- A read-only `beforeAll` logs the pending-invite count at test start as a diagnostic.
- `RestAPIClient.getInvites` gains an optional `number` page-size param (default unchanged: the endpoint still returns its default of 25). New `RestAPIClient.deleteInvites(siteID, keys)` bulk-removes pending invites by key in one request.
- Converted a pre-existing `&&`-expression in the spec to an `if` (it tripped the lint hook once the file was touched).

## Why are these changes being made?

The spec created a pending invite via REST but revoked it only through the UI at the end of the test. Any failure before the revoke step leaked one invite, and there was no teardown. Leaks accumulated on the shared site to 4,559 pending invites (oldest 2025-12-14). The People page renders a capped pending-invites list, so once saturated a freshly created invite is no longer shown and `waitForInvitation` times out — the test failed consistently (e.g. TeamCity `calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/18351947`, nested `18351962`).

The existing 4,558-invite backlog was drained once out-of-band (age-filtered to invites older than 1h, so no in-flight invite was affected, see [TESTOPS-205](https://linear.app/a8c/issue/TESTOPS-205)). Draining is not part of the spec; the self-cleanup keeps the site clear going forward.

## Testing Instructions

- `yarn typecheck-packages` passes; the `calypso-e2e` invites unit tests pass (`getInvites` still asserts the un-paged default).
- Run the spec against staging as separate processes (how CI runs it), 5 times:
  ```
  CALYPSO_BASE_URL=<staging_url> NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests test:pw -- specs/users/invite__revoke.spec.ts --reporter=list
  ```
  All pass. The `beforeAll` diagnostic prints the pending count at start.
- Note: `--repeat-each=5` is not a valid harness for this spec. All repeats share one browser session and create invites in rapid succession, so the People page cannot surface each specific one; use separate invocations instead.
