### PR TITLE
Agents Manager: fix invisible dropdown icons in docked mode

### DIFF
--- a/packages/agents-manager/src/components/chat-header/style.scss
+++ b/packages/agents-manager/src/components/chat-header/style.scss
@@ -49,8 +49,15 @@
 		// from @wordpress/components, which makes SVGs invisible in dark mode.
 		// Descendant selector handles DropdownMenu (class on wrapper div),
 		// compound selector handles Button (class directly on element).
+		//
+		// Exclude the DropdownMenu popover items: with `inline: true` the popover
+		// renders inside the docked (dark) panel, so its menu-item buttons become
+		// descendants here and inherit --color-foreground (#FFF in dark mode). But
+		// the popover surface stays WP-default white, so forcing the fill paints the
+		// icons white-on-white and they vanish (WOOAI-698). Menu-item icons keep the
+		// default currentColor and track their own (dark) label instead.
 		&.components-button,
-		.components-button {
+		.components-button:not( .components-dropdown-menu__menu-item ) {
 			svg {
 				fill: var( --color-foreground );
 			}

--- a/packages/agents-manager/src/components/chat-header/style.scss
+++ b/packages/agents-manager/src/components/chat-header/style.scss
@@ -50,12 +50,8 @@
 		// Descendant selector handles DropdownMenu (class on wrapper div),
 		// compound selector handles Button (class directly on element).
 		//
-		// Exclude the DropdownMenu popover items: with `inline: true` the popover
-		// renders inside the docked (dark) panel, so its menu-item buttons become
-		// descendants here and inherit --color-foreground (#FFF in dark mode). But
-		// the popover surface stays WP-default white, so forcing the fill paints the
-		// icons white-on-white and they vanish (WOOAI-698). Menu-item icons keep the
-		// default currentColor and track their own (dark) label instead.
+		// Exclude DropdownMenu popover items: they render inline on WP's white
+		// popover, so the white fill would hide them. Keep currentColor.
 		&.components-button,
 		.components-button:not( .components-dropdown-menu__menu-item ) {
 			svg {


### PR DESCRIPTION
Part of WOOAI-698

## Proposed Changes

* In `chat-header/style.scss`, exclude the `DropdownMenu` popover's menu items (`.components-dropdown-menu__menu-item`) from the header's dark-panel icon rule, so their icons keep the default `currentColor` fill instead of being forced to `var(--color-foreground)`.

One-line change: `.components-button` → `.components-button:not( .components-dropdown-menu__menu-item )`.

## Why are these changes being made?

The three-dot menu in the chat header (`New chat`, `Pop out sidebar` / `Move to sidebar`, split-screen) showed its **labels but no icons** when the sidebar is **docked**. It worked fine when floating (undocked).

Root cause is white-on-white in the docked dark theme:

1. Docked applies the dark theme — `agent-chat/index.tsx`: `clsx('agenttic', { dark: isDocked })`. In agenttic-ui, `.dark` sets `--color-foreground: #FFFFFF` (light mode: `#1F1F1F`).
2. The dropdown popover renders **inside** that dark panel — `chat-header/index.tsx` passes `popoverProps={{ inline: true }}` (added in #111790 to stop the menu blurring the panel). With `inline`, WP's `Popover` renders in place, so the menu-item buttons become descendants of `.agents-manager-chat-header__more-options`.
3. The header's icon rule `.components-button svg { fill: var(--color-foreground) }` — added so the header's own icons (toggle/history/close) stay visible on the dark panel — now also matches those menu items.
4. The popover surface itself is **not** themed by agenttic-ui, so it keeps WP's default **white** background.
5. `@wordpress/icons` paths carry no intrinsic `fill`, so they follow whatever CSS wins.

Net effect in docked mode: labels use WP's default dark text (visible on white), but the icons get forced to `--color-foreground` = `#FFF` → **white icons on a white popover** → invisible. In undocked/light mode `--color-foreground` is `#1F1F1F`, so the same icons render dark-on-white and show fine — which is why the bug is docked-only.

The header rule is meant only for icons sitting on the dark panel; menu items live on the light popover surface and should track their own label color. Excluding them restores the correct `currentColor` fill in both modes.

## Testing Instructions

1. Open a WooCommerce admin page with the Woo AI assistant, and **dock** the sidebar (`Move to sidebar`).
2. Open the three-dot (`More Options`) menu in the chat header.
3. **Before:** menu text is visible but the icons next to `New chat` / `Pop out sidebar` are missing. **After:** the icons render.
4. Verify no regression when **undocked** (floating): the same menu icons still show.
5. Verify the header's own icons (three-dot toggle, history, close) remain visible while docked.

CSS-only change. Also relevant to any other host that docks the Agents Manager sidebar (e.g. Jetpack), since this lives in the shared `agents-manager` package.


## Screenshots (docked / dark mode)

Verified live in wp-admin with the sidebar docked (dark theme, `--color-foreground: #FFFFFF`). Before the fix, both menu-item icons compute to `fill: rgb(255,255,255)` on the popover's WP-default **white** surface (white-on-white → invisible); after, they follow their label colour (`currentColor`) and render.

### Before (icons missing)
<img width="1403" height="876" alt="wooai698-docked-before" src="https://github.com/user-attachments/assets/40ad8ef1-19d0-4ff9-b73e-7ab0a2cbcd78" />

### After (icons visible) 
<img width="1403" height="876" alt="wooai698-docked-after" src="https://github.com/user-attachments/assets/98cb371a-8f82-42a2-91d8-9399b75d0183" />

<sub>Reproduced on the WooCommerce dashboard with the assistant docked; the same code path serves any host that docks the Agents Manager sidebar.</sub>
