### PR TITLE
Plans page: show different button and badge when downgrade pending

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -76,6 +76,9 @@ export default function useGenerateActionHook( {
 	enableCategorisedFeatures,
 	redirectTo,
 	pluginSlug,
+	isDelayedDowngradePending,
+	delayedDowngradeToProductSlug,
+	onRenewCurrentPlan,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -89,6 +92,12 @@ export default function useGenerateActionHook( {
 	enableCategorisedFeatures?: boolean;
 	redirectTo?: string;
 	pluginSlug?: string;
+	/** True when a downgrade has been scheduled for the current plan's renewal. */
+	isDelayedDowngradePending?: boolean;
+	/** The product slug the scheduled downgrade will land on, if any. */
+	delayedDowngradeToProductSlug?: string | null;
+	/** Routes the current plan's CTA to a renewal checkout when a downgrade is pending. */
+	onRenewCurrentPlan?: () => void;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -229,6 +238,9 @@ export default function useGenerateActionHook( {
 			setIsLoading,
 			isLoading,
 			plansIntent,
+			isDelayedDowngradePending,
+			delayedDowngradeToProductSlug,
+			onRenewCurrentPlan,
 		} );
 		return {
 			...action,
@@ -430,6 +442,9 @@ function getLoggedInPlansAction( {
 	isLoading,
 	setIsLoading,
 	plansIntent,
+	isDelayedDowngradePending,
+	delayedDowngradeToProductSlug,
+	onRenewCurrentPlan,
 }: {
 	getActionCallback: UseActionCallback;
 	planSlug: PlanSlug;
@@ -442,6 +457,9 @@ function getLoggedInPlansAction( {
 	setIsLoading: ( value: boolean ) => void;
 	plansIntent?: PlansIntent | null;
 	availableForDowngrade?: boolean;
+	isDelayedDowngradePending?: boolean;
+	delayedDowngradeToProductSlug?: string | null;
+	onRenewCurrentPlan?: () => void;
 } & UseActionHookProps ): GridAction {
 	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
 	// This allows monthly/yearly versions of the same plan to be considered "current"
@@ -490,8 +508,23 @@ function getLoggedInPlansAction( {
 
 	// All actions for the current plan
 	if ( current ) {
-		// For the plans-upgrade intent, show "Your plan" as a non-clickable indicator
+		// For the plans-upgrade intent, show "Your plan" as a non-clickable indicator,
+		// unless a downgrade is scheduled — then offer to renew the current plan so
+		// the user is reminded they can keep it instead of letting the downgrade apply.
 		if ( isUpgradeFlow ) {
+			if ( isDelayedDowngradePending && onRenewCurrentPlan ) {
+				return {
+					primary: {
+						callback: onRenewCurrentPlan,
+						status: 'enabled',
+						text: translate( 'Renew %(plan)s', {
+							args: { plan: planTitle ?? '' },
+							comment: '%(plan)s is the name of the current plan, e.g. "Renew Premium"',
+						} ),
+						variant: 'primary',
+					},
+				};
+			}
 			return {
 				primary: {
 					callback: () => {},
@@ -503,13 +536,19 @@ function getLoggedInPlansAction( {
 		}
 
 		if ( isFreePlan( planSlug ) ) {
-			return createLoggedInPlansAction( translate( 'Manage add-ons', { context: 'verb' } ) );
+			return createLoggedInPlansAction(
+				translate( 'Manage add-ons', { context: 'verb' } ),
+				'secondary'
+			);
 		}
 		if ( domainFromHomeUpsellFlow ) {
-			return createLoggedInPlansAction( translate( 'Keep my plan', { context: 'verb' } ) );
+			return createLoggedInPlansAction(
+				translate( 'Keep my plan', { context: 'verb' } ),
+				'secondary'
+			);
 		}
 		if ( canUserManageCurrentPlan && isPlanExpired ) {
-			return createLoggedInPlansAction( translate( 'Renew plan' ) );
+			return createLoggedInPlansAction( translate( 'Renew plan' ), 'secondary' );
 		}
 
 		if ( canUserManageCurrentPlan ) {
@@ -522,6 +561,21 @@ function getLoggedInPlansAction( {
 	// Downgrade action if the plan is not available for purchase and is available for downgrade
 	if ( ! availableForPurchase ) {
 		if ( availableForDowngrade ) {
+			// When this is the plan a scheduled downgrade will land on, surface that it
+			// is already queued rather than offering to downgrade again.
+			const isDelayedDowngradeTarget =
+				isUpgradeFlow &&
+				isDelayedDowngradePending &&
+				delayedDowngradeToProductSlug &&
+				getPlanClass( planSlug ) === getPlanClass( delayedDowngradeToProductSlug as PlanSlug );
+			if ( isDelayedDowngradeTarget ) {
+				return createLoggedInPlansAction(
+					translate( 'Downgrade at renewal' ),
+					'secondary',
+					undefined,
+					'disabled'
+				);
+			}
 			return createLoggedInPlansAction(
 				translate( 'Downgrade', { context: 'verb' } ),
 				'secondary',

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -768,6 +768,39 @@ const PlansFeaturesMain = ( {
 		return false;
 	};
 
+	const isUpgradeOrDowngradeFlow =
+		intent === 'plans-upgrade' || intent === 'plans-upgrade-or-downgrade';
+	const isDelayedDowngradePending =
+		isUpgradeOrDowngradeFlow && !! currentPurchase?.is_delayed_downgrade_pending;
+	const delayedDowngradeToProductSlug = isDelayedDowngradePending
+		? currentPurchase?.delayed_downgrade_to_product_slug ?? null
+		: null;
+
+	// When a delayed downgrade is scheduled, the current plan's CTA renews the
+	// existing plan (rather than passively reading "Your plan") so the user is
+	// reminded they can keep their plan instead of letting the downgrade apply.
+	const renewCurrentPlanWithPendingDowngrade = () => {
+		if ( ! siteSlug || ! currentPlanPurchaseId || ! currentPurchase?.product_slug ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_plan_features_renew_pending_downgrade_click', {
+			current_plan: sitePlanSlug,
+		} );
+		const redirectTarget = redirectTo ?? getQueryArg( window.location.href, 'redirect_to' );
+		const cancelTarget = getQueryArg( window.location.href, 'cancel_to' );
+		const checkoutQuery: Record< string, string > = {};
+		if ( typeof redirectTarget === 'string' ) {
+			checkoutQuery.redirect_to = redirectTarget;
+		}
+		if ( typeof cancelTarget === 'string' ) {
+			checkoutQuery.cancel_to = cancelTarget;
+		}
+		window.location.href = addQueryArgs(
+			checkoutQuery,
+			`/checkout/${ currentPurchase.product_slug }/renew/${ currentPlanPurchaseId }/${ siteSlug }`
+		);
+	};
+
 	const useAction = useGenerateActionHook( {
 		siteId,
 		cartHandler: onUpgradeClick,
@@ -781,6 +814,9 @@ const PlansFeaturesMain = ( {
 		enableCategorisedFeatures: showSimplifiedFeatures,
 		redirectTo,
 		pluginSlug,
+		isDelayedDowngradePending,
+		delayedDowngradeToProductSlug,
+		onRenewCurrentPlan: renewCurrentPlanWithPendingDowngrade,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>
@@ -796,6 +832,19 @@ const PlansFeaturesMain = ( {
 		hideEnterprisePlan,
 	};
 
+	// Badge the plan a scheduled downgrade will land on so the user remembers it
+	// is queued. The term selector is hidden while a downgrade is pending, so the
+	// target product slug always matches the displayed plan slug.
+	const highlightLabelOverridesWithDowngrade = useMemo( () => {
+		if ( ! delayedDowngradeToProductSlug ) {
+			return highlightLabelOverrides;
+		}
+		return {
+			...highlightLabelOverrides,
+			[ delayedDowngradeToProductSlug as PlanSlug ]: translate( 'Downgrade scheduled' ),
+		};
+	}, [ highlightLabelOverrides, delayedDowngradeToProductSlug, translate ] );
+
 	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)
 	const gridPlansForComparisonGrid = useGridPlansForComparisonGrid( {
 		allFeaturesList: getFeaturesList(),
@@ -803,7 +852,7 @@ const PlansFeaturesMain = ( {
 		eligibleForFreeHostingTrial,
 		hasRedeemedDomainCredit: currentPlan?.hasRedeemedDomainCredit,
 		hiddenPlans,
-		highlightLabelOverrides,
+		highlightLabelOverrides: highlightLabelOverridesWithDowngrade,
 		intent: shouldForceDefaultPlansBasedOnIntent( intent ) ? defaultWpcomPlansIntent : intent,
 		isDisplayingPlansNeededForFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
@@ -830,7 +879,7 @@ const PlansFeaturesMain = ( {
 		coupon,
 		eligibleForFreeHostingTrial,
 		hasRedeemedDomainCredit: currentPlan?.hasRedeemedDomainCredit,
-		highlightLabelOverrides,
+		highlightLabelOverrides: highlightLabelOverridesWithDowngrade,
 		hiddenPlans,
 		hideCurrentPlan: isInSiteDashboard,
 		intent,

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -200,7 +200,10 @@ const ActionButton = ( {
 						disabled={ ! callback || 'disabled' === status }
 						busy={ busy }
 						onClick={ callback }
-						current={ current }
+						// A primary variant on the current plan (e.g. renewing when a downgrade
+						// is scheduled) should render as a plan-colored CTA, not the muted
+						// current-plan style.
+						current={ current && variant !== 'primary' }
 						ariaLabel={ String( ariaLabel || '' ) }
 					>
 						{ text }


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2205/

## Proposed changes

Reflects a scheduled (delayed) downgrade on the stepper plans page (`/setup/plan-upgrade/plans`) so users are reminded it's queued. When the current plan's purchase has a pending delayed downgrade, the current plan's CTA becomes a clickable "Renew {Plan}" that routes to a renewal checkout, and the plan the downgrade will land on shows a disabled "Downgrade at renewal" button with a "Downgrade scheduled" badge.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1511" height="659" alt="downgrading-plans-before" src="https://github.com/user-attachments/assets/cd519b15-9beb-4050-a8f7-5a1f1954ef42" /> | <img width="1503" height="659" alt="downgrading-plans-after" src="https://github.com/user-attachments/assets/d6cdbd50-dac4-46b1-8cd3-3418b3e9682c" />


## Why are these changes being made?

The `plans/delayed-downgrade` option lets users schedule a downgrade to a lower-tier plan at the end of the current billing term. Once scheduled, the plans page gave no indication that a downgrade was pending — the current plan still read "Your plan" and the target plan still offered "Downgrade", so users could forget a downgrade was queued or attempt to re-trigger it.

This surfaces the pending state directly on the plan cards: the current plan invites a renewal (the way to keep the plan instead of letting the downgrade apply), and the target plan clearly shows the downgrade is already scheduled. The logic keys off the purchase data rather than local state so it reflects the true server-side schedule, and is scoped to the upgrade/downgrade intents to avoid changing the classic `/plans` page in this first step. The renew button intentionally only routes to checkout without cancelling the scheduled downgrade, so abandoning checkout can't leave the account in an inconsistent state.

## Testing instructions

* Use a site you admin that has a paid plan (e.g. Premium) with a scheduled delayed downgrade (schedule one via the purchase settings page while `plans/delayed-downgrade` is enabled).
* Go to `/setup/plan-upgrade/plans?siteSlug=<your-site>&allow_downgrade=true`.
* Confirm the current plan card shows a solid/primary "Renew {Plan}" button (e.g. "Renew Premium") that opens a renewal checkout for the current plan.
* Confirm the plan the downgrade is scheduled for shows a disabled "Downgrade at renewal" button and a "Downgrade scheduled" badge.
* Confirm other plans still show "Upgrade"/"Downgrade" as before, and that a site with no pending downgrade is unchanged.

