### PR TITLE
React 19: ref-type fixes (forward-compatible with React 18)

### DIFF
--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -167,21 +167,22 @@ function ResponsiveMenu( {
 			<Menu>
 				{ React.Children.map( children, ( child ) => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
-						if ( child.props.target === '_blank' ) {
+						const item = child as React.ReactElement< ResponsiveMenuItemProps >;
+						if ( item.props.target === '_blank' ) {
 							return (
 								<Button
 									className="dashboard-menu__item"
 									variant="tertiary"
-									{ ...child.props }
-									onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
-										child.props.onClick?.( e );
+									{ ...item.props }
+									onClick={ () => {
+										item.props.onClick?.();
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-											to: child.props.href ?? '',
+											to: item.props.href ?? '',
 										} );
 									} }
 								>
 									<HStack justify="flex-start" spacing={ 1 }>
-										<span>{ child.props.children }</span>
+										<span>{ item.props.children }</span>
 										<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
 									</HStack>
 								</Button>
@@ -190,11 +191,11 @@ function ResponsiveMenu( {
 
 						return (
 							<Menu.Item
-								{ ...child.props }
-								onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
-									child.props.onClick?.( e );
+								{ ...item.props }
+								onClick={ () => {
+									item.props.onClick?.();
 									recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-										to: child.props.to ?? '',
+										to: item.props.to ?? '',
 									} );
 								} }
 							/>
@@ -266,19 +267,20 @@ function ResponsiveMenu( {
 				<>
 					{ React.Children.map( children, ( child ) => {
 						if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
-							if ( child.props.target === '_blank' ) {
+							const item = child as React.ReactElement< ResponsiveMenuItemProps >;
+							if ( item.props.target === '_blank' ) {
 								return (
 									<Menu.ItemLink
-										{ ...child.props }
+										{ ...item.props }
 										onClick={ () => {
-											child.props.onClick?.();
+											item.props.onClick?.();
 											recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-												to: child.props.href ?? '',
+												to: item.props.href ?? '',
 											} );
 										} }
 									>
 										<HStack justify="flex-start" spacing={ 1 }>
-											<span>{ child.props.children }</span>
+											<span>{ item.props.children }</span>
 											<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
 										</HStack>
 									</Menu.ItemLink>
@@ -287,12 +289,12 @@ function ResponsiveMenu( {
 
 							return (
 								<RouterLinkMenuItem
-									{ ...child.props }
-									onClick={ ( e ) => {
+									{ ...item.props }
+									onClick={ () => {
 										onClose();
-										child.props.onClick?.( e );
+										item.props.onClick?.();
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-											to: child.props.to ?? '',
+											to: item.props.to ?? '',
 										} );
 									} }
 								/>

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -25,7 +25,7 @@ type ResponsiveMenuItemProps = Omit<
 	'children' | 'onClick' | 'ref'
 > & {
 	children: React.ReactNode;
-	onClick?: ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
+	onClick?: ( event?: React.MouseEvent< Element > ) => void;
 };
 
 // The children of ResponsiveMenu can be any usual ReactNode, but if it _is_ an element
@@ -174,8 +174,8 @@ function ResponsiveMenu( {
 									className="dashboard-menu__item"
 									variant="tertiary"
 									{ ...item.props }
-									onClick={ () => {
-										item.props.onClick?.();
+									onClick={ ( event: React.MouseEvent< Element > ) => {
+										item.props.onClick?.( event );
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 											to: item.props.href ?? '',
 										} );
@@ -192,8 +192,8 @@ function ResponsiveMenu( {
 						return (
 							<Menu.Item
 								{ ...item.props }
-								onClick={ () => {
-									item.props.onClick?.();
+								onClick={ ( event: React.MouseEvent< Element > ) => {
+									item.props.onClick?.( event );
 									recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 										to: item.props.to ?? '',
 									} );
@@ -272,8 +272,8 @@ function ResponsiveMenu( {
 								return (
 									<Menu.ItemLink
 										{ ...item.props }
-										onClick={ () => {
-											item.props.onClick?.();
+										onClick={ ( event ) => {
+											item.props.onClick?.( event );
 											recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 												to: item.props.href ?? '',
 											} );
@@ -290,9 +290,9 @@ function ResponsiveMenu( {
 							return (
 								<RouterLinkMenuItem
 									{ ...item.props }
-									onClick={ () => {
+									onClick={ ( event ) => {
 										onClose();
-										item.props.onClick?.();
+										item.props.onClick?.( event );
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 											to: item.props.to ?? '',
 										} );

--- a/client/site-profiler/components/advanced-metrics/index.tsx
+++ b/client/site-profiler/components/advanced-metrics/index.tsx
@@ -2,8 +2,8 @@ import { useTranslate } from 'i18n-calypso';
 import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
 
 interface AdvancedMetricsProps {
-	performanceMetricsRef?: React.RefObject< HTMLObjectElement >;
-	healthScoresRef?: React.RefObject< HTMLObjectElement >;
+	performanceMetricsRef?: React.RefObject< HTMLElement | null >;
+	healthScoresRef?: React.RefObject< HTMLElement | null >;
 }
 
 export const AdvancedMetrics: React.FC< AdvancedMetricsProps > = ( props ) => {

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -72,7 +72,7 @@ export const BasicMetrics = forwardRef(
 			domain,
 			isWpCom,
 		}: { basicMetrics: BasicMetricsScored; domain: string; isWpCom: boolean },
-		ref: ForwardedRef< HTMLObjectElement >
+		ref: ForwardedRef< HTMLElement >
 	) => {
 		const translate = useTranslate();
 
@@ -82,7 +82,7 @@ export const BasicMetrics = forwardRef(
 		);
 
 		return (
-			<Container className="basic-metrics" ref={ ref }>
+			<Container className="basic-metrics" ref={ ref as ForwardedRef< HTMLDivElement > }>
 				<div className="basic-metric-details result-list">
 					{ ( Object.entries( copies ) as CopiesReturnValueList ).map(
 						( [ metricKey, metricCopies ] ) => {

--- a/client/site-profiler/components/domain-section/index.tsx
+++ b/client/site-profiler/components/domain-section/index.tsx
@@ -11,7 +11,7 @@ interface DomainSectionProps {
 	whois: WhoIs;
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
-	domainRef: React.RefObject< HTMLObjectElement >;
+	domainRef: React.RefObject< HTMLElement | null >;
 }
 
 export const DomainSection: React.FC< DomainSectionProps > = ( props ) => {

--- a/client/site-profiler/components/health-section/index.tsx
+++ b/client/site-profiler/components/health-section/index.tsx
@@ -13,7 +13,7 @@ interface HealthSectionProps {
 	url?: string;
 	hash?: string;
 	hostingProvider?: HostingProvider;
-	healthMetricsRef: React.RefObject< HTMLObjectElement >;
+	healthMetricsRef: React.RefObject< HTMLElement | null >;
 	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
 }
 

--- a/client/site-profiler/components/hosting-section/index.tsx
+++ b/client/site-profiler/components/hosting-section/index.tsx
@@ -11,7 +11,7 @@ interface HostingSectionProps {
 	url?: string;
 	urlData?: UrlData;
 	hostingProvider?: HostingProvider;
-	hostingRef: React.RefObject< HTMLObjectElement >;
+	hostingRef: React.RefObject< HTMLElement | null >;
 }
 
 export const HostingSection: React.FC< HostingSectionProps > = ( props ) => {

--- a/client/site-profiler/components/metrics-menu/index.tsx
+++ b/client/site-profiler/components/metrics-menu/index.tsx
@@ -20,9 +20,9 @@ const SectionNavbar = styled( SectionNav )`
 `;
 
 interface MetricsMenuProps {
-	basicMetricsRef?: React.RefObject< HTMLObjectElement >;
-	performanceMetricsRef?: React.RefObject< HTMLObjectElement >;
-	healthScoresRef?: React.RefObject< HTMLObjectElement >;
+	basicMetricsRef?: React.RefObject< HTMLElement | null >;
+	performanceMetricsRef?: React.RefObject< HTMLElement | null >;
+	healthScoresRef?: React.RefObject< HTMLElement | null >;
 	onCTAClick: () => void;
 }
 

--- a/client/site-profiler/components/metrics-section/index.tsx
+++ b/client/site-profiler/components/metrics-section/index.tsx
@@ -79,12 +79,12 @@ const Content = styled.div`
 	margin-top: 64px;
 `;
 
-export const MetricsSection = forwardRef< HTMLObjectElement, MetricsSectionProps >(
-	( props, ref: ForwardedRef< HTMLObjectElement > ) => {
+export const MetricsSection = forwardRef< HTMLElement, MetricsSectionProps >(
+	( props, ref: ForwardedRef< HTMLElement > ) => {
 		const { name, title, subtitle, children, subtitleOnClick } = props;
 
 		return (
-			<Container ref={ ref }>
+			<Container ref={ ref as ForwardedRef< HTMLDivElement > }>
 				<NameSpan>{ name }</NameSpan>
 				<Title>{ title }</Title>
 				{ subtitle && (

--- a/client/site-profiler/components/nav-menu/index.tsx
+++ b/client/site-profiler/components/nav-menu/index.tsx
@@ -7,13 +7,13 @@ import './style.scss';
 interface NavMenuProps {
 	navItems: {
 		label: string;
-		ref: React.RefObject< HTMLObjectElement >;
+		ref: React.RefObject< HTMLElement | null >;
 	}[];
 	showMigrationCta?: boolean;
 	domain: string;
 }
 
-const executeScroll = ( ref: React.RefObject< HTMLObjectElement > ) => {
+const executeScroll = ( ref: React.RefObject< HTMLElement | null > ) => {
 	if ( ref.current ) {
 		ref.current.scrollIntoView( { behavior: 'smooth' } );
 	}

--- a/client/site-profiler/components/performance-section/index.tsx
+++ b/client/site-profiler/components/performance-section/index.tsx
@@ -13,7 +13,7 @@ interface PerformanceSectionProps {
 	url?: string;
 	hash?: string;
 	hostingProvider?: HostingProvider;
-	performanceMetricsRef: React.RefObject< HTMLObjectElement >;
+	performanceMetricsRef: React.RefObject< HTMLElement | null >;
 	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
 }
 

--- a/client/site-profiler/components/security-section/index.tsx
+++ b/client/site-profiler/components/security-section/index.tsx
@@ -13,7 +13,7 @@ interface SecuritySectionProps {
 	url?: string;
 	hash?: string;
 	hostingProvider?: HostingProvider;
-	securityMetricsRef: React.RefObject< HTMLObjectElement >;
+	securityMetricsRef: React.RefObject< HTMLElement | null >;
 	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
 }
 

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -44,11 +44,11 @@ interface Props {
 
 export default function SiteProfilerV2( props: Props ) {
 	const { routerDomain, hash, routerOrigin } = props;
-	const hostingRef = useRef( null );
-	const domainRef = useRef( null );
-	const perfomanceMetricsRef = useRef( null );
-	const healthMetricsRef = useRef( null );
-	const securityMetricsRef = useRef( null );
+	const hostingRef = useRef< HTMLElement >( null );
+	const domainRef = useRef< HTMLElement >( null );
+	const perfomanceMetricsRef = useRef< HTMLElement >( null );
+	const healthMetricsRef = useRef< HTMLElement >( null );
+	const securityMetricsRef = useRef< HTMLElement >( null );
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
 
 	const {

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -36,9 +36,9 @@ interface Props {
 
 export default function SiteProfiler( props: Props ) {
 	const { routerDomain } = props;
-	const basicMetricsRef = useRef( null );
-	const performanceMetricsRef = useRef( null );
-	const healthScoresRef = useRef( null );
+	const basicMetricsRef = useRef< HTMLElement >( null );
+	const performanceMetricsRef = useRef< HTMLElement >( null );
+	const healthScoresRef = useRef< HTMLElement >( null );
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
 
 	const {

--- a/client/site-profiler/hooks/use-is-menu-section-visible.ts
+++ b/client/site-profiler/hooks/use-is-menu-section-visible.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { calculateMetricsSectionScrollOffset } from '../utils/calculate-metrics-section-scroll-offset';
 
-export function useIsMenuSectionVisible( ref: React.RefObject< HTMLObjectElement > | undefined ) {
+export function useIsMenuSectionVisible( ref: React.RefObject< HTMLElement | null > | undefined ) {
 	const [ isIntersecting, setIntersecting ] = useState( false );
 
 	useEffect( () => {

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/desktop-dropdown.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/desktop-dropdown.tsx
@@ -4,7 +4,7 @@ import { ClickableItem } from '../menu-items';
 import type { Nav2026Menu } from './types';
 
 interface Nav2026DesktopDropdownProps {
-	dropdownRef: React.RefObject< HTMLDivElement >;
+	dropdownRef: React.RefObject< HTMLDivElement | null >;
 	activeDropdown: string | null;
 	nav2026Menus: Nav2026Menu[];
 	onMouseLeave?: React.MouseEventHandler< HTMLDivElement >;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -104,7 +104,7 @@ interface UseFooterHeightArgs {
 	isMobileMenuOpen: boolean;
 	isLoggedIn: boolean;
 	mobilePlatform: 'ios' | 'android' | null;
-	footerRef: React.RefObject< HTMLDivElement >;
+	footerRef: React.RefObject< HTMLDivElement | null >;
 }
 
 // Publish the overlaid footer's height so the scroller can clear it.
@@ -147,7 +147,7 @@ interface UseDropdownFlipArgs {
 export function useDropdownFlip( {
 	nav2026,
 	activeDropdown,
-}: UseDropdownFlipArgs ): React.RefObject< HTMLDivElement > {
+}: UseDropdownFlipArgs ): React.RefObject< HTMLDivElement | null > {
 	const dropdownRef = useRef< HTMLDivElement >( null );
 	const prevDropdownRef = useRef< string | null >( null );
 	// React has already rendered the next panel, so cache previous panel heights.

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -35,7 +35,7 @@ interface Nav2026MobileMenuProps {
 	__: Translate;
 	variant: 'default' | 'minimal';
 	mobilePlatform: 'ios' | 'android' | null;
-	mobileFooterRef: React.RefObject< HTMLDivElement >;
+	mobileFooterRef: React.RefObject< HTMLDivElement | null >;
 	closeMobileMenu: ( reason: string ) => void;
 	setCurrentDropdown: ( name: string | null ) => void;
 }


### PR DESCRIPTION
## Proposed Changes

Splits the forward-compatible type & ref fixes out of the React 19 upgrade PR (#112095) so they can land on their own, ahead of the actual React 19 build/package bump.

This PR contains **only** source-level fixes that compile and behave identically under both React 18 and React 19:

- Widen ref receivers (e.g. `useRef< HTMLElement >( null )`, `HTMLObjectElement` → `HTMLElement`).
- Drop redundant JSDoc prop-type annotations and unused JSX type imports.
- Make optional props optional.
- Forward the click event through `ResponsiveMenu` item `onClick` (restores an argument a future consumer may want).

Touches `client/components`, `layout`, `my-sites`, `me`, `site-profiler`, `dashboard`, and the `components` / `wpcom-template-parts` packages.

The React-19-*only* pieces are intentionally **not** here — the reader thread-node `forwardRef` → ref-as-prop conversions and the theme test snapshot only hold once React 19 is active, so they stay with the build/package bump (#112095).

## Why are these changes being made?

Per review feedback on #112095, we're splitting the build/package changes (the actual React 19 flip — dependency bumps, patches, tsconfig/jest config, peer-warning filters) from the "leftover" type and ref error fixes, and merging them separately.

The goal is a **cleaner revert for the build/package changes if things go awry**: because these type/ref fixes are forward-compatible with React 18, they can merge to `trunk` first and stay green. That leaves the React 19 bump as a small, self-contained change stacked on top (#112095, rebased onto this branch) — reverting it becomes an isolated diff over `package.json` / `yarn.lock` / `.yarnrc.yml` / patches / config, with no source churn and nothing depending on it.

Stack: `trunk` ← **this PR** ← #112095 (build/package) ← #112169 (`@wordpress/element` polyfill).

## Testing Instructions

- CI `type_check_client` should pass on `trunk` (React 18) — these changes are compile-time only.
- Nothing user-visible should change; the `ResponsiveMenu` item `onClick` now receives the click event again.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
