### PR TITLE
[Tooling] Secure Claude workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,8 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
-
+  id-token: write # Required by claude-code-action for GitHub App token exchange.
 jobs:
   claude:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,11 @@ jobs:
           fi
 
           pr_number="${PULL_REQUEST_NUMBER:-$ISSUE_NUMBER}"
-          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '.head.repo.full_name' 2>/dev/null || true)"
+          if ! head_repo="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '.head.repo.full_name')"; then
+            echo "Unable to determine PR head repository for #${pr_number}; skipping Claude."
+            echo "is_internal=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ "$head_repo" = "$REPOSITORY" ]; then
             echo "is_internal=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,7 +10,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   claude:
@@ -20,12 +19,42 @@ jobs:
       contains(github.event.comment.body, '@claude') &&
       github.event.comment.user.login == 'matticbot'
     steps:
+      # issue_comment payloads identify PR comments, but do not include the PR
+      # head repo. Query the PR before allowing Claude to run on fork PRs.
+      - name: Check PR origin
+        id: pr-origin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ -z "$ISSUE_PULL_REQUEST_URL" ]; then
+            echo "is_internal=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_number="${PULL_REQUEST_NUMBER:-$ISSUE_NUMBER}"
+          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '.head.repo.full_name' 2>/dev/null || true)"
+
+          if [ "$head_repo" = "$REPOSITORY" ]; then
+            echo "is_internal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_internal=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping Claude for external PR from ${head_repo:-unknown}."
+          fi
+
       - name: Checkout repository
-        uses: actions/checkout@v4
+        if: steps.pr-origin.outputs.is_internal == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Run Claude
+        if: steps.pr-origin.outputs.is_internal == 'true'
         uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -56,6 +56,10 @@ jobs:
 
   review:
     needs: detect
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # Required by the reusable Claude review workflow.
     uses: Automattic/wp-calypso/.github/workflows/pr-review.yml@trunk
     with:
       area: ${{ needs.detect.outputs.area }}

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -30,7 +30,7 @@ jobs:
       ) && github.event.sender.login != 'matticbot' && (
         (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@claude /review')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude /review')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude /review'))
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@claude /review'))
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -18,7 +18,6 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 jobs:
   detect:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
+      id-token: write # Required by claude-code-action for GitHub App token exchange.
     steps:
       - name: Validate area input
         env:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - name: Validate area input
         env:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,7 +39,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - name: Validate area input
         env:


### PR DESCRIPTION
## Summary
- Skip Claude workflows on fork/external PRs before checkout or Claude execution.
- Pin mutable action references and preserve the Claude action's required OIDC permission for GitHub App token exchange.
- Keep review feedback inline-only where the workflow does not grant issue-comment permissions.

