### PR TITLE
My Plan: Show "Changing to X at renewal" when downgrade pending

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -140,9 +140,27 @@ class PurchasesListing extends Component {
 	}
 
 	getExpirationInfoForPlan( plan ) {
+		const { purchases, translate } = this.props;
+
 		// No expiration date for free plans.
 		if ( this.isFreePlan( plan ) ) {
 			return null;
+		}
+
+		// When a downgrade is scheduled for the end of the term, surface that in place
+		// of the usual "Renews on ..." line so the user remembers the change is queued.
+		const planPurchase = purchases?.find(
+			( purchase ) => isPlan( purchase ) && purchase.productSlug === plan.productSlug
+		);
+		if ( planPurchase?.isDelayedDowngradePending && planPurchase.delayedDowngradeToProductSlug ) {
+			const targetPlan = getPlan( planPurchase.delayedDowngradeToProductSlug );
+			if ( targetPlan ) {
+				return translate( 'Changing to %(plan)s at renewal', {
+					args: { plan: targetPlan.getTitle() },
+					comment:
+						'%(plan)s is the name of the lower-tier plan the subscription will downgrade to at renewal',
+				} );
+			}
 		}
 
 		const expiryMoment = plan.expiryDate ? this.props.moment( plan.expiryDate ) : null;


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2205/

## Proposed changes

Reflects a scheduled (delayed) downgrade on the legacy "My Plan" page (`/plans/my-plan/{site}`) so users are reminded the change is queued. When the current plan's purchase has a pending delayed downgrade, the card's status line reads "Changing to {Plan} at renewal" (e.g. "Changing to Personal at renewal") instead of the usual "Renews on {date}".

Before             |  After
:-------------------------:|:-------------------------:
<img width="1512" height="389" alt="downgrading-my-plan-before" src="https://github.com/user-attachments/assets/70d41053-b387-40b7-b812-25716f169470" /> | <img width="1512" height="372" alt="downgrading-my-plan-after" src="https://github.com/user-attachments/assets/5192db59-4768-4a70-9e1d-24ab8f5c0641" />


## Why are these changes being made?

The `plans/delayed-downgrade` option lets users schedule a downgrade to a lower-tier plan at the end of the current billing term. Once scheduled, the "My Plan" card still read "Renews on {date}", which is misleading — the plan isn't simply renewing, it's changing to a different plan at that renewal.

This surfaces the scheduled change directly on the card so the user remembers it's queued. The delayed-downgrade fields already ride along on the Redux purchase objects (the assembler builds them via data-stores `createPurchasesArray`, which maps the API's `is_delayed_downgrade_pending` / `delayed_downgrade_to_product_slug`), so the component can read them from the purchases it already has without any new data fetching. It's data-driven rather than flag-gated because `isDelayedDowngradePending` is only ever true when a downgrade was actually scheduled.

## Testing instructions

* Use a site you admin with a paid plan (e.g. Premium) that has a scheduled delayed downgrade (schedule one from the purchase settings page while `plans/delayed-downgrade` is enabled).
* Go to `/plans/my-plan/{your-site}`.
* Confirm the "My Plan" card's status line reads "Changing to {Plan} at renewal" (e.g. "Changing to Personal at renewal") instead of "Renews on {date}".
* Confirm a site with no pending downgrade still shows the normal "Renews on {date}" line.

