### PR TITLE
Domain search: restyle the bundle card as a featured-card peer

### DIFF
--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -1,13 +1,20 @@
 import {
 	Button,
+	Card,
+	CardBody,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
-import { arrowRight } from '@wordpress/icons';
+import { arrowRight, Icon, plus, shield } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { DomainSearchNotice, DomainSuggestionBadge } from '../../ui';
+import { Fragment, useMemo } from 'react';
+import {
+	DomainSuggestionContainerContext,
+	useDomainSuggestionContainer,
+} from '../../hooks/use-domain-suggestion-container';
+import { DomainSearchNotice, DomainSuggestionBadge, DomainSuggestionPrice } from '../../ui';
 import type { BundleSuggestion } from '@automattic/api-core';
 
 import './style.scss';
@@ -20,6 +27,12 @@ interface BundleCardProps {
 	isBusy?: boolean;
 	disabled?: boolean;
 	errorMessage?: string;
+	/**
+	 * Set when the card is rendered inside the featured suggestions list, so it
+	 * carries the same `listitem` role as its row-mates. Left off when the card
+	 * stands alone in its own row.
+	 */
+	isListItem?: boolean;
 }
 
 export const BundleCard = ( {
@@ -30,8 +43,23 @@ export const BundleCard = ( {
 	isBusy,
 	disabled,
 	errorMessage,
+	isListItem,
 }: BundleCardProps ) => {
 	const { __ } = useI18n();
+
+	const { containerRef, activeQuery, currentWidth } = useDomainSuggestionContainer();
+
+	const contextValue = useMemo(
+		() =>
+			( {
+				activeQuery,
+				priceAlignment: 'left',
+				priceSize: activeQuery === 'large' ? 20 : 18,
+				isFeatured: true,
+				currentWidth,
+			} ) as const,
+		[ activeQuery, currentWidth ]
+	);
 
 	if ( ! suggestion || suggestion.domains.length === 0 ) {
 		return (
@@ -41,97 +69,133 @@ export const BundleCard = ( {
 		);
 	}
 
-	const {
-		sld,
-		domains,
-		bundle_price,
-		bundle_cost,
-		original_price,
-		original_cost,
-		discount_percent,
-	} = suggestion;
+	const { domains, bundle_price, original_price, bundle_cost, original_cost, discount_percent } =
+		suggestion;
 
 	const hasPremiumDomain = domains.some( ( domain ) => domain.is_premium );
-	const displayBundlePrice = bundle_cost ?? bundle_price;
-	const displayOriginalPrice = original_cost ?? original_price;
+
+	// The backend returns preformatted currency strings; fall back to the raw
+	// amount only if the payload predates that contract.
+	const bundleCost = bundle_cost ?? String( bundle_price );
+	const originalCost = original_cost ?? String( original_price );
+
+	// The bundle heading is the set of TLDs (".com + .org + .net"); the shared
+	// SLD is spelled out in the companion list below.
+	const tlds = domains.map( ( { domain } ) => domain.slice( domain.indexOf( '.' ) ) );
+	const domainList = domains.map( ( { domain } ) => domain ).join( ', ' );
 
 	return (
-		<div className="bundle-card">
-			<VStack spacing={ 4 }>
-				<Text as="h3" size={ 24 } weight={ 500 } className="bundle-card__sld">
-					{ sld }
-				</Text>
-
-				<ul className="bundle-card__domains">
-					{ domains.map( ( domain ) => (
-						<li key={ domain.domain } className="bundle-card__domain">
-							<HStack alignment="edge" spacing={ 2 }>
-								<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
-									<Text className="bundle-card__domain-name">{ domain.domain }</Text>
-									{ domain.is_premium && (
-										<DomainSuggestionBadge>{ __( 'Premium' ) }</DomainSuggestionBadge>
-									) }
-								</HStack>
-								<Text className="bundle-card__domain-cost">{ domain.cost }</Text>
+		<DomainSuggestionContainerContext.Provider value={ contextValue }>
+			<Card
+				ref={ containerRef }
+				role={ isListItem ? 'listitem' : undefined }
+				title={ domainList }
+				className="domain-suggestion-featured bundle-card"
+			>
+				<CardBody
+					className="bundle-card__body"
+					style={ { padding: activeQuery === 'large' ? '1.5rem' : '1rem' } }
+				>
+					<VStack spacing={ 4 } className="bundle-card__content">
+						<HStack alignment="center" spacing={ 2 } className="bundle-card__header">
+							<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+								<Icon icon={ shield } size={ 20 } className="bundle-card__header-icon" />
+								<Text weight={ 500 } className="bundle-card__header-title">
+									{ __( 'Protect your brand' ) }
+								</Text>
 							</HStack>
-						</li>
-					) ) }
-				</ul>
+							<DomainSuggestionBadge>
+								{ sprintf(
+									// translators: %(percent)d is the bundle discount percentage, e.g. 78.
+									__( 'Bundle and save %(percent)d%%' ),
+									{ percent: discount_percent }
+								) }
+							</DomainSuggestionBadge>
+						</HStack>
 
-				<div className="bundle-card__pricing">
-					<HStack alignment="center" justify="flex-start" spacing={ 2 } expanded={ false }>
-						<Text size={ 20 } weight={ 500 } className="bundle-card__bundle-price">
-							{ displayBundlePrice }
-						</Text>
-						<Text className="bundle-card__original-price">
-							<s>{ displayOriginalPrice }</s>
-						</Text>
-					</HStack>
-					<Text className="bundle-card__discount">
-						{ sprintf(
-							// translators: %(percent)d is the bundle discount percentage, e.g. 20.
-							__( 'Save %(percent)d%%' ),
-							{ percent: discount_percent }
+						<VStack spacing={ 1 }>
+							<Text
+								size={ activeQuery === 'large' ? 32 : 24 }
+								className="bundle-card__tlds"
+								style={ { wordBreak: 'break-all' } }
+							>
+								{ tlds.map( ( tld, index ) => (
+									<Fragment key={ domains[ index ].domain }>
+										{ index > 0 && (
+											<span className="bundle-card__tld-separator" aria-hidden="true">
+												{ ' + ' }
+											</span>
+										) }
+										<span style={ { whiteSpace: 'nowrap' } }>{ tld }</span>
+									</Fragment>
+								) ) }
+							</Text>
+							<Text variant="muted" className="bundle-card__domain-list">
+								{ domainList }
+							</Text>
+						</VStack>
+
+						<HStack alignment="center" spacing={ 4 } className="bundle-card__pricing-row">
+							<DomainSuggestionPrice
+								price={ originalCost }
+								salePrice={ bundleCost }
+								renewPrice={ originalCost }
+							/>
+							{ isAddedToCart ? (
+								<Button
+									className="bundle-card__cta bundle-card__cta--continue"
+									variant="secondary"
+									isPressed
+									aria-pressed="mixed"
+									__next40pxDefaultSize
+									icon={ arrowRight }
+									label={ __( 'Continue' ) }
+									disabled={ disabled }
+									onClick={ () => onContinue?.() }
+								>
+									{ __( 'Continue' ) }
+								</Button>
+							) : (
+								<Button
+									className="bundle-card__cta"
+									variant="secondary"
+									icon={ plus }
+									__next40pxDefaultSize
+									isBusy={ isBusy }
+									disabled={ disabled }
+									onClick={ () => onAddToCart?.( suggestion ) }
+								>
+									{ __( 'Get bundle' ) }
+								</Button>
+							) }
+						</HStack>
+
+						{ hasPremiumDomain && (
+							<Text size={ 12 } className="bundle-card__premium-notice">
+								{ __(
+									'Premium domains are subject to different pricing and may not be eligible for promotions.'
+								) }
+							</Text>
 						) }
-					</Text>
-				</div>
 
-				{ hasPremiumDomain && (
-					<Text size={ 12 } className="bundle-card__premium-notice">
-						{ __(
-							'Premium domains are subject to different pricing and may not be eligible for promotions.'
+						{ errorMessage && (
+							<DomainSearchNotice status="error">{ errorMessage }</DomainSearchNotice>
 						) }
-					</Text>
-				) }
 
-				{ errorMessage && <DomainSearchNotice status="error">{ errorMessage }</DomainSearchNotice> }
-
-				{ isAddedToCart ? (
-					<Button
-						className="bundle-card__cta bundle-card__cta--continue"
-						isPressed
-						aria-pressed="mixed"
-						__next40pxDefaultSize
-						icon={ arrowRight }
-						label={ __( 'Continue' ) }
-						disabled={ disabled }
-						onClick={ () => onContinue?.() }
-					>
-						{ __( 'Continue' ) }
-					</Button>
-				) : (
-					<Button
-						className="bundle-card__cta"
-						variant="primary"
-						__next40pxDefaultSize
-						isBusy={ isBusy }
-						disabled={ disabled }
-						onClick={ () => onAddToCart?.( suggestion ) }
-					>
-						{ __( 'Get bundle' ) }
-					</Button>
-				) }
-			</VStack>
-		</div>
+						<HStack
+							justify="flex-start"
+							spacing={ 2 }
+							expanded={ false }
+							className="bundle-card__footer"
+						>
+							<Icon icon={ shield } size={ 20 } className="bundle-card__footer-icon" />
+							<Text variant="muted" size={ 13 } className="bundle-card__footer-text">
+								{ __( 'Claim popular domain extensions to avoid copycats' ) }
+							</Text>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</DomainSuggestionContainerContext.Provider>
 	);
 };

--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -1,40 +1,53 @@
-.bundle-card {
+// The border and radius come from the `Card` component; the shared
+// `.domain-suggestion-featured` class adds the flex sizing (flex: 1;
+// align-self: stretch) so the card sits beside the exact-match card as an
+// equal-width pair. Styles here cover only the bundle-specific content.
+
+.bundle-card__body {
+	height: 100% !important;
+}
+
+.bundle-card__content {
+	height: 100%;
+}
+
+.bundle-card__header-icon,
+.bundle-card__footer-icon {
+	flex-shrink: 0;
+	fill: var( --studio-gray-40, #a7aaad );
+}
+
+.bundle-card__tlds {
+	word-break: break-all;
+}
+
+.bundle-card__tld-separator {
+	color: var( --studio-gray-20, #c3c4c7 );
+}
+
+.bundle-card__domain-list {
+	word-break: break-word;
+}
+
+.bundle-card__pricing-row {
+	align-items: flex-end;
+}
+
+.bundle-card__cta {
+	flex-shrink: 0;
+	justify-content: center;
+	white-space: nowrap;
+}
+
+.bundle-card__footer {
+	margin-top: auto;
+	padding-top: 16px;
+	border-top: 1px solid var( --studio-gray-5, rgba( 0, 0, 0, 0.05 ) );
+}
+
+.bundle-card--empty {
 	box-sizing: border-box;
 	padding: 24px;
 	border-radius: 4px;
 	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 );
-}
-
-.bundle-card__sld {
-	word-break: break-all;
-}
-
-.bundle-card__domains {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-}
-
-.bundle-card__domain {
-	padding-block: 8px;
-
-	& + & {
-		border-top: 1px solid rgba( 0, 0, 0, 0.05 );
-	}
-}
-
-.bundle-card__domain-name {
-	word-break: break-all;
-}
-
-.bundle-card__domain-cost {
-	white-space: nowrap;
-}
-
-.bundle-card__original-price s {
-	opacity: 0.7;
-}
-
-.bundle-card__cta {
-	justify-content: center;
 }

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -21,7 +21,9 @@ const buildSuggestion = (
 	sld: 'example',
 	domains,
 	bundle_price: 60,
+	bundle_cost: '$60',
 	original_price: 75,
+	original_cost: '$75',
 	discount_percent: 20,
 	category: 'business',
 	bundle_id: 'bundle-1',
@@ -37,73 +39,55 @@ const twoDomains = [
 
 const threeDomains = [ ...twoDomains, buildDomain( { domain: 'example.org', cost: '$20.00' } ) ];
 
-const fourDomains = [ ...threeDomains, buildDomain( { domain: 'example.io', cost: '$30.00' } ) ];
-
 describe( 'BundleCard', () => {
-	it( 'renders the SLD as a heading', () => {
+	it( 'renders the "Protect your brand" header', () => {
 		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( screen.getByRole( 'heading', { name: 'example' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Protect your brand' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders exactly 2 companion rows for a 2-domain bundle', () => {
-		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
+	it( 'renders the discount percent in the bundle badge', () => {
+		render( <BundleCard suggestion={ buildSuggestion( twoDomains, { discount_percent: 78 } ) } /> );
 
-		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 2 );
+		expect( screen.getByText( 'Bundle and save 78%' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders exactly 3 companion rows for a 3-domain bundle', () => {
+	it( 'renders the TLDs in the heading', () => {
 		render( <BundleCard suggestion={ buildSuggestion( threeDomains ) } /> );
 
-		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 3 );
+		expect( screen.getByText( '.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.net' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.org' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders exactly 4 companion rows for a 4-domain bundle', () => {
-		render( <BundleCard suggestion={ buildSuggestion( fourDomains ) } /> );
+	it( 'renders the full companion domain list', () => {
+		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 4 );
+		expect( screen.getByText( 'example.com, example.net' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the bundle price and the struck-through original price', () => {
+	it( 'renders the formatted bundle price and the struck-through original price', () => {
 		render(
 			<BundleCard
 				suggestion={ buildSuggestion( twoDomains, {
-					bundle_price: 60,
-					original_price: 75,
+					bundle_cost: '$29',
+					original_cost: '$129',
 				} ) }
 			/>
 		);
 
-		expect( screen.getByText( '60' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$29' ) ).toBeInTheDocument();
 
-		const original = screen.getByText( '75' );
-		expect( original.closest( 's' ) ).not.toBeNull();
+		const original = screen.getByText( '$129' );
+		expect( original ).toHaveStyle( { textDecoration: 'line-through' } );
 	} );
 
-	it( 'renders formatted bundle totals when provided', () => {
-		render(
-			<BundleCard
-				suggestion={ buildSuggestion( twoDomains, {
-					bundle_price: 29.9,
-					bundle_cost: '$29.90',
-					original_price: 39,
-					original_cost: '$39',
-				} ) }
-			/>
-		);
+	it( 'renders the footer note about claiming extensions', () => {
+		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( screen.getByText( '$29.90' ) ).toBeInTheDocument();
-
-		const original = screen.getByText( '$39' );
-		expect( original.closest( 's' ) ).not.toBeNull();
-
-		expect( screen.queryByText( '29.9' ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'renders the discount percent text', () => {
-		render( <BundleCard suggestion={ buildSuggestion( twoDomains, { discount_percent: 20 } ) } /> );
-
-		expect( screen.getByText( 'Save 20%' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Claim popular domain extensions to avoid copycats' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'renders the premium badge and legal notice when a domain is premium', () => {
@@ -116,16 +100,14 @@ describe( 'BundleCard', () => {
 			/>
 		);
 
-		expect( screen.getByText( 'Premium' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( /Premium domains are subject to different pricing/ )
 		).toBeInTheDocument();
 	} );
 
-	it( 'does not render the premium badge or notice for a non-premium bundle', () => {
+	it( 'does not render the premium notice for a non-premium bundle', () => {
 		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( screen.queryByText( 'Premium' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByText( /Premium domains are subject to different pricing/ )
 		).not.toBeInTheDocument();
@@ -213,18 +195,20 @@ describe( 'BundleCard', () => {
 		expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeDisabled();
 	} );
 
-	it( 'renders a placeholder with no CTA or domain rows for a null suggestion', () => {
+	it( 'exposes the listitem role only when rendered as a featured-list peer', () => {
+		const { rerender } = render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
+
+		expect( screen.queryByRole( 'listitem' ) ).not.toBeInTheDocument();
+
+		rerender( <BundleCard suggestion={ buildSuggestion( twoDomains ) } isListItem /> );
+
+		expect( screen.getByRole( 'listitem' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a placeholder with no CTA for a null suggestion', () => {
 		render( <BundleCard suggestion={ null } /> );
 
 		expect( screen.getByText( 'No bundle available.' ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'listitem' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'renders a placeholder when the bundle has no domains', () => {
-		render( <BundleCard suggestion={ buildSuggestion( [] ) } /> );
-
-		expect( screen.getByText( 'No bundle available.' ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'listitem' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/domain-search/src/components/featured-search-results/index.tsx
+++ b/packages/domain-search/src/components/featured-search-results/index.tsx
@@ -5,10 +5,14 @@ import { FeaturedSearchResultsPlaceholder } from './placeholder';
 
 const FeaturedSearchResults = ( {
 	suggestions,
+	additionalItem,
 }: {
 	suggestions: FeaturedSuggestionWithReason[];
+	additionalItem?: React.ReactNode;
 } ) => {
-	const isSingleFeaturedSuggestion = suggestions.length === 1;
+	// When a bundle card shares the row, the sole suggestion is no longer alone,
+	// so it uses the compact (paired) layout rather than the wide single layout.
+	const isSingleFeaturedSuggestion = suggestions.length === 1 && ! additionalItem;
 
 	return (
 		<FeaturedDomainSuggestionsList>
@@ -20,6 +24,7 @@ const FeaturedSearchResults = ( {
 					isSingleFeaturedSuggestion={ isSingleFeaturedSuggestion }
 				/>
 			) ) }
+			{ additionalItem }
 		</FeaturedDomainSuggestionsList>
 	);
 };

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -175,6 +175,30 @@ export const ResultsPage = () => {
 
 	const showCompactBanner = !! slots?.BeforeResults;
 
+	const hasBundle = ! isLoadingSuggestions && !! visibleBundleSuggestion;
+
+	// Beside the exact-match card only when it's the lone featured card; with two
+	// featured cards the bundle falls back to its own full-width row below.
+	const renderBundleInline = hasBundle && featuredSuggestions.length === 1;
+
+	const bundleCard =
+		hasBundle && visibleBundleSuggestion ? (
+			<BundleCard
+				suggestion={ visibleBundleSuggestion }
+				onAddToCart={ ( bundle ) => {
+					addBundleToCart( { bundle, query } );
+				} }
+				isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
+					cart.hasItem( domain )
+				) }
+				onContinue={ events.onContinue }
+				isBusy={ isAddingBundle }
+				disabled={ isMutating }
+				errorMessage={ bundleErrorMessage }
+				isListItem={ renderBundleInline }
+			/>
+		) : null;
+
 	return (
 		<VStack spacing={ 8 } className="domain-search--results">
 			{ /* Desktop in-flow SearchBar. CSS-hidden on mobile (the persistent
@@ -211,23 +235,12 @@ export const ResultsPage = () => {
 				{ isLoadingSuggestions ? (
 					<FeaturedSearchResults.Placeholder />
 				) : (
-					<FeaturedSearchResults suggestions={ featuredSuggestions } />
-				) }
-				{ ! isLoadingSuggestions && visibleBundleSuggestion && (
-					<BundleCard
-						suggestion={ visibleBundleSuggestion }
-						onAddToCart={ ( bundle ) => {
-							addBundleToCart( { bundle, query } );
-						} }
-						isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
-							cart.hasItem( domain )
-						) }
-						onContinue={ events.onContinue }
-						isBusy={ isAddingBundle }
-						disabled={ isMutating }
-						errorMessage={ bundleErrorMessage }
+					<FeaturedSearchResults
+						suggestions={ featuredSuggestions }
+						additionalItem={ renderBundleInline ? bundleCard : undefined }
 					/>
 				) }
+				{ ! renderBundleInline && bundleCard }
 				{ isLoadingSuggestions ? (
 					<SearchResults.Placeholder />
 				) : (

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1039,7 +1039,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-permanent.net' ) ).toBeInTheDocument();
+			expect( await screen.findByText( 'Protect your brand' ) ).toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
@@ -1050,7 +1050,7 @@ describe( 'ResultsPage', () => {
 			await waitFor( () => {
 				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
 			} );
-			expect( screen.queryByText( 'test-bundle-permanent.net' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Protect your brand' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'keeps the stale bundle hidden when the permanent-failure refetch returns the same bundle group', async () => {
@@ -1085,7 +1085,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-same-group.net' ) ).toBeInTheDocument();
+			expect( await screen.findByText( 'Protect your brand' ) ).toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
@@ -1096,7 +1096,7 @@ describe( 'ResultsPage', () => {
 			await waitFor( () => {
 				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
 			} );
-			expect( screen.queryByText( 'test-bundle-same-group.net' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Protect your brand' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'does not hide or refetch the next query when an old bundle add fails permanently', async () => {
@@ -1146,7 +1146,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-late-stale.net' ) ).toBeInTheDocument();
+			expect( await screen.findByText( /test-bundle-late-stale\.net/ ) ).toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
@@ -1160,7 +1160,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
+			expect( await screen.findByText( /test-bundle-late-fresh\.net/ ) ).toBeInTheDocument();
 
 			await act( async () => {
 				rejectAddBundle(
@@ -1171,7 +1171,7 @@ describe( 'ResultsPage', () => {
 			} );
 
 			expect( freshRefetchRequest.isDone() ).toBe( false );
-			expect( screen.getByText( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
+			expect( screen.getByText( /test-bundle-late-fresh\.net/ ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
 		} );
 


### PR DESCRIPTION
Related to #DOMAINS-2189

## Summary

Reworks the domain-search bundle suggestion card to match the "Protect your brand" design, so it reads as a matched peer of the exact-match featured card instead of a plain standalone block.

- Renders through the featured card's chrome (`Card`/`CardBody`, `useDomainSuggestionContainer` + context, `.domain-suggestion-featured`) so it sizes and reflows identically to the exact-match card.
- New anatomy: shield + **Protect your brand** header, **Bundle and save N%** badge, a `.com + .org + .net` TLD heading (muted `+`), the companion domain list, a reused `DomainSuggestionPrice` block (struck original + bundle price + "For first year. $X/year renewal."), an outline **Get bundle** CTA, and a footer note.
- **Placement:** the bundle sits inline beside the exact-match card only when that is the lone featured card; with two featured cards it falls back to its own full-width row below. When inline it carries `role="listitem"` to match its row-mates, and the exact-match card drops its wide single-card layout so the two size equally.
- Preserves the existing behaviors: add-to-cart → **Continue** swap, premium-domain notice, error notice, and empty state.

## Notes

- No API or type change: trunk's `BundleSuggestion` already ships preformatted `bundle_cost` / `original_cost`, so no client-side currency formatting is needed. This also fixes the previous card, which rendered raw integer prices (`60` instead of `$60`).
- Renewal price shows the combined pre-discount list price — the bundle discount is first-year-only and renews at list, consistent with the mockup.

## Testing

<details>
<summary>Automated</summary>

```
yarn jest --config packages/domain-search/jest.config.js
# 31 suites, 362 tests pass
yarn tsc --noEmit -p packages/domain-search/tsconfig.json   # clean
```

Rewrote the bundle-card suite for the new markup and updated the results-page assertions that keyed off per-domain text (now a joined list string).
</details>

To see the inline side-by-side layout, search a query with an available exact match (e.g. `thalasso.blog`) so there is one featured card plus the bundle.

Co-Authored-By: Claude <noreply@anthropic.com>