### PR TITLE
Purchases: show downgrading notice in purchase list

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -1,4 +1,4 @@
-import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { SubscriptionBillPeriod, getPlanNames } from '@automattic/api-core';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -236,6 +236,38 @@ export function PurchaseExpiryStatus( {
 					}
 				) }
 			</Text>
+		);
+	}
+
+	// When a downgrade is scheduled for the next renewal, the plan won't simply
+	// renew at its current price — it changes to a lower-tier plan. Say so instead
+	// of the usual "Renews ... on <date>" line.
+	if ( isRenewingOnDate && purchase.is_delayed_downgrade_pending ) {
+		const slug = purchase.delayed_downgrade_to_product_slug;
+		const planNames = getPlanNames() as Record< string, string | undefined >;
+		const targetPlanName = slug ? planNames[ slug ] ?? null : null;
+		const renewalDate = formatDate( new Date( purchase.renew_date ), locale, {
+			dateStyle: 'long',
+		} );
+		if ( targetPlanName ) {
+			return (
+				<span>
+					{ sprintf(
+						// translators: %(plan)s is the plan being downgraded to (e.g. "Personal"); %(date)s is a formatted date
+						__( 'Changing to %(plan)s on %(date)s' ),
+						{ plan: targetPlanName, date: renewalDate }
+					) }
+				</span>
+			);
+		}
+		return (
+			<span>
+				{ sprintf(
+					// translators: %(date)s is a formatted date
+					__( 'Changing plan on %(date)s' ),
+					{ date: renewalDate }
+				) }
+			</span>
 		);
 	}
 

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -9,6 +9,7 @@ import {
 	PLAN_TRIENNIAL_PERIOD,
 	isJetpackPlan,
 	isJetpackProduct,
+	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Gridicon } from '@automattic/components';
@@ -501,6 +502,34 @@ export function PurchaseItemStatus( {
 
 		if ( isInExpirationGracePeriod( purchase ) ) {
 			return <span className="purchase-item__is-error">{ translate( 'Pending renewal' ) }</span>;
+		}
+
+		// When a downgrade is scheduled for the next renewal, the plan won't simply
+		// renew at its current price — it changes to a lower-tier plan. Say so instead
+		// of the usual "Renews ... on <date>" line.
+		if ( purchase.isDelayedDowngradePending ) {
+			const targetPlanName = purchase.delayedDowngradeToProductSlug
+				? getPlan( purchase.delayedDowngradeToProductSlug )?.getTitle()
+				: null;
+			if ( targetPlanName ) {
+				return translate( 'Changing to %(plan)s on {{span}}%(date)s{{/span}}', {
+					args: {
+						plan: targetPlanName,
+						date: renewDate.format( 'LL' ),
+					},
+					components: {
+						span: <span className="purchase-item__date" />,
+					},
+				} );
+			}
+			return translate( 'Changing plan on {{span}}%(date)s{{/span}}', {
+				args: {
+					date: renewDate.format( 'LL' ),
+				},
+				components: {
+					span: <span className="purchase-item__date" />,
+				},
+			} );
 		}
 
 		if ( purchase.billPeriodDays ) {

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -342,11 +342,26 @@ export const getDataCenterOptions = (): Record< DataCenterOption, string > => ( 
 	ams: __( 'EU West (Amsterdam, Netherlands)' ),
 } );
 
+// Every billing-period variant of a plan maps to the same display name, so that
+// looking up a name by product slug works regardless of term (monthly, annual,
+// 2-year, 3-year).
 export const getPlanNames = () => ( {
 	[ DotcomPlans.PERSONAL ]: __( 'Personal' ),
+	[ DotcomPlans.PERSONAL_MONTHLY ]: __( 'Personal' ),
+	[ DotcomPlans.PERSONAL_2_YEARS ]: __( 'Personal' ),
+	[ DotcomPlans.PERSONAL_3_YEARS ]: __( 'Personal' ),
 	[ DotcomPlans.PREMIUM ]: __( 'Premium' ),
+	[ DotcomPlans.PREMIUM_MONTHLY ]: __( 'Premium' ),
+	[ DotcomPlans.PREMIUM_2_YEARS ]: __( 'Premium' ),
+	[ DotcomPlans.PREMIUM_3_YEARS ]: __( 'Premium' ),
 	[ DotcomPlans.BUSINESS ]: __( 'Business' ),
+	[ DotcomPlans.BUSINESS_MONTHLY ]: __( 'Business' ),
+	[ DotcomPlans.BUSINESS_2_YEARS ]: __( 'Business' ),
+	[ DotcomPlans.BUSINESS_3_YEARS ]: __( 'Business' ),
 	[ DotcomPlans.ECOMMERCE ]: __( 'Commerce' ),
+	[ DotcomPlans.ECOMMERCE_MONTHLY ]: __( 'Commerce' ),
+	[ DotcomPlans.ECOMMERCE_2_YEARS ]: __( 'Commerce' ),
+	[ DotcomPlans.ECOMMERCE_3_YEARS ]: __( 'Commerce' ),
 } );
 
 export const PaymentPartners = {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2205/

## Proposed changes

Reflects a scheduled (delayed) downgrade in the "Renewal/expiry" line of both purchases lists so users are reminded the plan is changing rather than simply renewing. When an auto-renewing purchase has a pending delayed downgrade, the line now reads "Changing to {Plan} on {date}" (e.g. "Changing to Personal on May 9, 2027") instead of "Renews yearly at {amount} (excludes tax) on {date}".

* Dashboard list (`/me/billing/purchases`): in `PurchaseExpiryStatus` (`client/dashboard/components/purchase-expiry-status/index.tsx`), add a branch before the auto-renew text that returns "Changing to {Plan} on {date}" when `purchase.is_delayed_downgrade_pending`, resolving the target name via `getPlanNames()` from `@automattic/api-core`.
* Legacy list (`/me/purchases`): in `PurchaseItemStatus` (`client/me/purchases/purchase-item/index.tsx`), add the same branch before the `billPeriodDays` switch when `purchase.isDelayedDowngradePending`, resolving the target name via `getPlan(delayedDowngradeToProductSlug).getTitle()`.
* Both fall back to "Changing plan on {date}" when the target plan name can't be resolved, and leave credit-card-expired / grace-period ("Pending renewal") states taking precedence.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1098" height="393" alt="Screenshot 2026-07-01 at 2 09 40 PM" src="https://github.com/user-attachments/assets/b77ee973-245b-4fa9-a459-c7b5a8aec1b4" /> | <img width="1106" height="399" alt="Screenshot 2026-07-01 at 2 09 46 PM" src="https://github.com/user-attachments/assets/f89b3fa0-4985-417b-ad2f-5c06dfb9a5ab" />
<img width="1509" height="426" alt="dash-upgrades-downgrade-before" src="https://github.com/user-attachments/assets/a158a4a8-b0fd-41a1-8790-9b0f718e7fcc" /> | <img width="1511" height="432" alt="dash-upgrades-downgrade-after" src="https://github.com/user-attachments/assets/75785452-9c1c-4e54-a039-8e1497cca361" />


## Why are these changes being made?

The `plans/delayed-downgrade` option lets users schedule a downgrade to a lower-tier plan at the end of the current billing term. In that state, both purchases lists still said "Renews yearly at {amount} …", which is misleading twice over: the plan isn't just renewing (it's switching to a different plan), and the amount shown is the current plan's price, not what the customer will actually pay after the downgrade. Showing "Changing to {Plan} on {date}" keeps the renewal date the column is built around while making the scheduled change explicit and avoiding a price that no longer applies.

The two lists live in separate architectures with separate `Purchase` types — the Dashboard uses `@automattic/api-core` (snake_case, `is_delayed_downgrade_pending`) and Classic uses `@automattic/data-stores` (camelCase, `isDelayedDowngradePending`) — so the branch is implemented once per list against the correct field names rather than shared. The behavior is data-driven (not flag-gated), since the pending fields are only ever set when a downgrade was actually scheduled; this matches the Dashboard's existing scheduled-downgrade notice in `purchase-settings/purchase-notice.tsx`.

## Testing instructions

* Use an account with a paid plan (e.g. Premium) that has a scheduled delayed downgrade (schedule one from the purchase settings page while `plans/delayed-downgrade` is enabled).
* Dashboard: go to `/me/billing/purchases` and confirm the plan's "Renewal/expiry" column reads "Changing to {Plan} on {date}" instead of "Renews yearly at {amount} (excludes tax) on {date}".
* Legacy: go to `/me/purchases` and confirm the same purchase's renewal line reads "Changing to {Plan} on {date}".
* Confirm purchases with no pending downgrade still show the normal "Renews …" line on both pages.

