### PR TITLE
Exclude merge queue branches from non-required TeamCity jobs

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -2,8 +2,6 @@ package _self
 
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.excludeMergeQueueBranches
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -58,8 +56,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 	}
 
   	steps {
-		passMergeQueueBranchesEarly()
-		mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
+		mergeTrunk( skipIfConflict = true )
 
     	bashNodeScript {
 			name = "Prepare environment"
@@ -75,7 +72,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Determine Calypso URL"
@@ -114,7 +111,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "##teamcity[setParameter name='CALYPSO_BASE_URL' value='${'$'}FINAL_URL']"
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Determine Dashboard URL"
@@ -156,7 +153,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "##teamcity[setParameter name='DASHBOARD_BASE_URL' value='${'$'}FINAL_URL']"
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Determine test group"
@@ -179,7 +176,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 				"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Set extra environment variables"
@@ -196,7 +193,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Run e2e tests"
@@ -225,7 +222,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				yarn test:pw:%PROJECT% ${'$'}GREP_FLAG
 				"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Check for E2E teardown leaks"
@@ -246,9 +243,9 @@ object CalypsoE2ETestsBuildTemplate : Template({
 					# (nonZeroExitCode = false). Do NOT add 'exit 1': this ALWAYS step must leave green runs green.
 					echo "##teamcity[buildProblem description='E2E teardown leak: ${'$'}COUNT test user(s) not closed - see %PROJECT%/output' identity='e2e_teardown_leak']"
 				fi
-				""".trimIndent()
+			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Upload CTRF report"
@@ -271,7 +268,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
   }
 
   	artifactRules = """

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,6 +1,7 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
+import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.passMergeQueueBranchesEarly
 import _self.lib.utils.skipOnMergeQueueBranch
 
@@ -16,6 +17,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = "+:*".excludeMergeQueueBranches()
 		cleanCheckout = true
 	}
 

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -61,6 +61,7 @@ open class E2EBuildType(
 	var buildTriggers: Triggers.() -> Unit = {},
 	var buildDependencies: Dependencies.() -> Unit = {},
 	var addWpcomVcsRoot: Boolean = false,
+	var vcsBranchFilter: String? = null,
 	var buildSteps: BuildSteps.() -> Unit = {}
 
 ): BuildType() {
@@ -73,6 +74,7 @@ open class E2EBuildType(
 		val enableCommitStatusPublisher = enableCommitStatusPublisher
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
+		val vcsBranchFilter = vcsBranchFilter
 		val params = params
 		val buildSteps = buildSteps
 
@@ -91,6 +93,7 @@ open class E2EBuildType(
 
 		vcs {
 			root(Settings.WpCalypso)
+			vcsBranchFilter?.let { branchFilter = it }
 			cleanCheckout = true
 		}
 

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -3,8 +3,6 @@ package _self.lib.customBuildType
 import Settings
 import _self.bashNodeScript
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -107,12 +105,11 @@ open class E2EBuildType(
 		}
 
 		steps {
-			passMergeQueueBranchesEarly()
 			// IMPORTANT! This step MUST match what the docker image does. If trunk
 			// is merged when building the docker image, it must also be merged
 			// to run the tests, or they may not be compatible. See the "mergeTrunk"
 			// step in BuildDockerImage in WebApp.kt.
-			mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
+			mergeTrunk( skipIfConflict = true )
 
 			bashNodeScript {
 				name = "Prepare environment"
@@ -128,7 +125,7 @@ open class E2EBuildType(
 					yarn workspace @automattic/calypso-e2e build
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-			}.skipOnMergeQueueBranch()
+			}
 
 			bashNodeScript {
 				name = "Run tests"
@@ -168,7 +165,7 @@ open class E2EBuildType(
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"
-			}.skipOnMergeQueueBranch()
+			}
 
 			bashNodeScript {
 				name = "Collect results"
@@ -186,7 +183,7 @@ open class E2EBuildType(
 					find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-			}.skipOnMergeQueueBranch()
+			}
 			buildSteps()
 		}
 

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -6,7 +6,10 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 const val MERGE_QUEUE_BRANCH_SKIP_PARAM = "mergeQueueBranch.skipBuild"
-const val MERGE_QUEUE_BRANCH_TRIGGER_EXCLUSION = "-:gh-readonly-queue/*"
+const val MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS = """
+-:gh-readonly-queue/*
+-:refs/heads/gh-readonly-queue/*
+"""
 const val MERGE_QUEUE_BRANCH_SKIP_MESSAGE =
 	"This check was skipped because this is a merge queue and the check has already been run " +
 		"in the pull request. See: p4TIVU-b5I-p2#comment-12211"
@@ -46,6 +49,6 @@ fun <T : BuildStep> T.skipOnMergeQueueBranch(): T {
 fun String.excludeMergeQueueBranches(): String {
 	return """
 		${this.trimIndent()}
-		$MERGE_QUEUE_BRANCH_TRIGGER_EXCLUSION
+		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
 	""".trimIndent()
 }

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -792,6 +792,7 @@ object Translate : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = "+:*".excludeMergeQueueBranches()
 		cleanCheckout = true
 	}
 
@@ -929,6 +930,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 				}
 			}
 		},
+		vcsBranchFilter = "+:*".excludeMergeQueueBranches(),
 		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -797,7 +797,6 @@ object Translate : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -805,7 +804,7 @@ object Translate : BuildType({
 				${_self.yarn_install_cmd}
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Extract strings"
 			scriptContent = """
@@ -820,7 +819,7 @@ object Translate : BuildType({
 				echo "##teamcity[publishArtifacts './translate/calypso-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Build New Strings .pot"
 			scriptContent = """
@@ -841,7 +840,7 @@ object Translate : BuildType({
 				echo "##teamcity[publishArtifacts './translate/localci-new-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Notify GlotPress Translate build is ready"
 			scriptContent = """
@@ -862,7 +861,7 @@ object Translate : BuildType({
 							}
 						}'
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {


### PR DESCRIPTION
No issue.

## Proposed Changes

* Expand the shared merge queue branch exclusion to match both logical and fully qualified branch names.
* Apply the exclusion at the build configuration VCS level for non-required Web app TeamCity jobs, so TeamCity filters those branches before triggers and build features.
* Keep the required TeamCity checks triggerable so they can still report success for the GitHub merge queue.

## Why are these changes being made?

* Non-required TeamCity jobs such as Translate and E2E checks were still being enqueued for merge queue branches, even though their steps skipped quickly after start.
* GitHub only requires Docker image, Unit tests, Code style, and check-channel-status on merge queue commits, so the other TeamCity jobs should not create noisy statuses there.

## Testing Instructions

* Ran `git diff --check -- .teamcity`.
* Confirmed GitHub branch protection currently requires only `Docker image (Web app)`, `Unit tests (Web app)`, `Code style (Web app)`, and `check-channel-status`.
* TeamCity settings generation was not run locally because Maven is not installed in this environment.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?