### PR TITLE
Playground import: rotate progress messages and show fake progress bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -1,10 +1,11 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useInterval } from 'calypso/lib/interval';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { SESSION_KEY_FROM_PLAYGROUND_PUBLISH } from '../../lib/constants';
 import { useImportBlueprint } from '../../lib/import-blueprint';
@@ -30,6 +31,23 @@ export const PlaygroundSetupStep: Step< {
 	const { siteId, siteSlug } = useSiteData();
 	const [ query ] = useSearchParams();
 	const { mutateAsync: importBlueprint } = useImportBlueprint();
+
+	const importMessages = [
+		{ title: __( 'Packing up your products and settings' ), duration: 8000 },
+		{ title: __( 'Uploading to WordPress.com' ), duration: 12000 },
+		{ title: __( 'Restoring your store' ), duration: 15000 },
+		{ title: __( 'This usually takes about a minute, hang tight' ), duration: 15000 },
+		{ title: __( 'Applying your store configuration' ), duration: 12000 },
+		{ title: __( 'Almost there' ), duration: null as number | null },
+	];
+	const [ messageIndex, setMessageIndex ] = useState( 0 );
+	const [ fakeProgress, setFakeProgress ] = useState( 0 );
+
+	useInterval(
+		() => setMessageIndex( ( i ) => i + 1 ),
+		messageIndex < importMessages.length - 1 ? importMessages[ messageIndex ].duration : null
+	);
+	useInterval( () => setFakeProgress( ( p ) => Math.min( p + 1, 95 ) ), 1000 );
 
 	useEffect( () => {
 		// If blueprint exists, import it and then submit
@@ -122,7 +140,7 @@ export const PlaygroundSetupStep: Step< {
 
 		return (
 			<>
-				<Loading title={ __( 'Preparing your site for import' ) } />
+				<Loading title={ importMessages[ messageIndex ].title } progress={ fakeProgress } />
 				{ ! hasBlueprint && (
 					<PlaygroundIframe
 						className="playground__onboarding-iframe"


### PR DESCRIPTION
Part of WCCOM-2741.

## Proposed Changes

* Replaces the static "Preparing your site for import" title on the Playground import screen with six rotating messages that cycle on a time-based schedule.
* Adds a fake progress bar that increments +1 %/s (capped at 95 %) so the screen no longer looks frozen during the 35–60 s Atomic restore wait.

## Why are these changes being made?

CFT feedback identified that the import screen appeared completely frozen for 35+ seconds with no copy explaining what was happening. A real merchant would likely bail and reload. The rotating messages and moving progress bar make it clear that work is ongoing.

The remaining two issues from WCCOM-2741 (site name carry-over and checklist pre-checking) are both suspected to require wpcom/Atomic-side fixes and are tracked separately.

## Testing Instructions

* Trigger the Playground → WordPress.com launch flow (entrepreneur flow with `?from=playground-publish`).
* On the import screen, verify that the title cycles through the six messages and that the progress bar advances smoothly rather than sitting at 0.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1641" height="818" alt="Screenshot 2026-09-18 at 15 22 00" src="https://github.com/user-attachments/assets/433ce4e2-efc8-4ca0-bcd2-35ac55de423f" />

<img width="1642" height="749" alt="Screenshot 2026-09-18 at 15 22 07" src="https://github.com/user-attachments/assets/51615283-3102-424c-942e-8d5e872f0d76" />

<img width="1646" height="821" alt="Screenshot 2026-09-18 at 15 22 19" src="https://github.com/user-attachments/assets/ab243dea-e21d-413b-96e2-5f6450965b92" />