### PR TITLE
Feat(difm): exclude staging sites from Onboarding flow and unlock pre-submit content browsing

### DIFF
--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -168,7 +168,7 @@ function ResponsiveMenu( {
 				{ React.Children.map( children, ( child ) => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
 						const item = child as React.ReactElement< ResponsiveMenuItemProps >;
-						if ( item.props.target === '_blank' ) {
+						if ( item.props.href ) {
 							return (
 								<Button
 									className="dashboard-menu__item"
@@ -183,7 +183,9 @@ function ResponsiveMenu( {
 								>
 									<HStack justify="flex-start" spacing={ 1 }>
 										<span>{ item.props.children }</span>
-										<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+										{ item.props.target === '_blank' && (
+											<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+										) }
 									</HStack>
 								</Button>
 							);
@@ -268,11 +270,15 @@ function ResponsiveMenu( {
 					{ React.Children.map( children, ( child ) => {
 						if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
 							const item = child as React.ReactElement< ResponsiveMenuItemProps >;
-							if ( item.props.target === '_blank' ) {
+							if ( item.props.href ) {
+								const opensInNewTab = item.props.target === '_blank';
 								return (
 									<Menu.ItemLink
 										{ ...item.props }
 										onClick={ ( event ) => {
+											if ( ! opensInNewTab ) {
+												onClose();
+											}
 											item.props.onClick?.( event );
 											recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 												to: item.props.href ?? '',
@@ -281,7 +287,9 @@ function ResponsiveMenu( {
 									>
 										<HStack justify="flex-start" spacing={ 1 }>
 											<span>{ item.props.children }</span>
-											<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+											{ opensInNewTab && (
+												<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+											) }
 										</HStack>
 									</Menu.ItemLink>
 								);

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -44,17 +44,19 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 					{ __( 'Site building' ) }
 				</ResponsiveMenu.Item>
 				{ shouldShowContentCollectionLinks && (
-					<>
-						<ResponsiveMenu.Item href={ wpcomLink( `/posts/${ siteSlug }` ) }>
-							{ __( 'Posts' ) }
-						</ResponsiveMenu.Item>
-						<ResponsiveMenu.Item href={ wpcomLink( `/media/${ siteSlug }` ) }>
-							{ __( 'Media' ) }
-						</ResponsiveMenu.Item>
-						<ResponsiveMenu.Item href={ wpcomLink( `/pages/${ siteSlug }` ) }>
-							{ __( 'Pages' ) }
-						</ResponsiveMenu.Item>
-					</>
+					<ResponsiveMenu.Item href={ wpcomLink( `/posts/${ siteSlug }` ) }>
+						{ __( 'Posts' ) }
+					</ResponsiveMenu.Item>
+				) }
+				{ shouldShowContentCollectionLinks && (
+					<ResponsiveMenu.Item href={ wpcomLink( `/media/${ siteSlug }` ) }>
+						{ __( 'Media' ) }
+					</ResponsiveMenu.Item>
+				) }
+				{ shouldShowContentCollectionLinks && (
+					<ResponsiveMenu.Item href={ wpcomLink( `/pages/${ siteSlug }` ) }>
+						{ __( 'Pages' ) }
+					</ResponsiveMenu.Item>
 				) }
 				{ siteTypeSupports.domains && (
 					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -34,11 +34,27 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 	}
 
 	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
+		const shouldShowContentCollectionLinks =
+			site.options?.difm_lite_site_options?.is_website_content_submitted === false;
+
 		return (
 			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-building-in-progress` }>
 					{ __( 'Site building' ) }
 				</ResponsiveMenu.Item>
+				{ shouldShowContentCollectionLinks && (
+					<>
+						<ResponsiveMenu.Item to={ `/posts/${ siteSlug }` }>
+							{ __( 'Posts' ) }
+						</ResponsiveMenu.Item>
+						<ResponsiveMenu.Item to={ `/media/${ siteSlug }` }>
+							{ __( 'Media' ) }
+						</ResponsiveMenu.Item>
+						<ResponsiveMenu.Item to={ `/pages/${ siteSlug }` }>
+							{ __( 'Pages' ) }
+						</ResponsiveMenu.Item>
+					</>
+				) }
 				{ siteTypeSupports.domains && (
 					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
 						{ __( 'Domains' ) }

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../app/router/sites';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
+import { wpcomLink } from '../../utils/link';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -44,13 +45,13 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 				</ResponsiveMenu.Item>
 				{ shouldShowContentCollectionLinks && (
 					<>
-						<ResponsiveMenu.Item to={ `/posts/${ siteSlug }` }>
+						<ResponsiveMenu.Item href={ wpcomLink( `/posts/${ siteSlug }` ) }>
 							{ __( 'Posts' ) }
 						</ResponsiveMenu.Item>
-						<ResponsiveMenu.Item to={ `/media/${ siteSlug }` }>
+						<ResponsiveMenu.Item href={ wpcomLink( `/media/${ siteSlug }` ) }>
 							{ __( 'Media' ) }
 						</ResponsiveMenu.Item>
-						<ResponsiveMenu.Item to={ `/pages/${ siteSlug }` }>
+						<ResponsiveMenu.Item href={ wpcomLink( `/pages/${ siteSlug }` ) }>
 							{ __( 'Pages' ) }
 						</ResponsiveMenu.Item>
 					</>

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -34,6 +34,7 @@ import {
 	SidebarMenu,
 	SidebarMenuItem,
 } from '../../components/sidebar';
+import { wpcomLink } from '../../utils/link';
 import { hasHostingFeature } from '../../utils/site-features';
 import { isSiteMigrationInProgress } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
@@ -97,9 +98,15 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 				</SidebarMenuItem>
 				{ shouldShowContentCollectionLinks && (
 					<>
-						<SidebarMenuItem to={ `/posts/${ siteSlug }` }>{ __( 'Posts' ) }</SidebarMenuItem>
-						<SidebarMenuItem to={ `/media/${ siteSlug }` }>{ __( 'Media' ) }</SidebarMenuItem>
-						<SidebarMenuItem to={ `/pages/${ siteSlug }` }>{ __( 'Pages' ) }</SidebarMenuItem>
+						<SidebarMenuItem href={ wpcomLink( `/posts/${ siteSlug }` ) }>
+							{ __( 'Posts' ) }
+						</SidebarMenuItem>
+						<SidebarMenuItem href={ wpcomLink( `/media/${ siteSlug }` ) }>
+							{ __( 'Media' ) }
+						</SidebarMenuItem>
+						<SidebarMenuItem href={ wpcomLink( `/pages/${ siteSlug }` ) }>
+							{ __( 'Pages' ) }
+						</SidebarMenuItem>
 					</>
 				) }
 				{ siteTypeSupports.domains && (

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -87,11 +87,21 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 	}
 
 	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
+		const shouldShowContentCollectionLinks =
+			site.options?.difm_lite_site_options?.is_website_content_submitted === false;
+
 		return (
 			<SidebarMenu>
 				<SidebarMenuItem to={ `/sites/${ siteSlug }/site-building-in-progress` }>
 					{ __( 'Site building' ) }
 				</SidebarMenuItem>
+				{ shouldShowContentCollectionLinks && (
+					<>
+						<SidebarMenuItem to={ `/posts/${ siteSlug }` }>{ __( 'Posts' ) }</SidebarMenuItem>
+						<SidebarMenuItem to={ `/media/${ siteSlug }` }>{ __( 'Media' ) }</SidebarMenuItem>
+						<SidebarMenuItem to={ `/pages/${ siteSlug }` }>{ __( 'Pages' ) }</SidebarMenuItem>
+					</>
+				) }
 				{ siteTypeSupports.domains && (
 					<SidebarMenuItem to={ `/sites/${ siteSlug }/domains` }>
 						{ __( 'Domains' ) }

--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -22,6 +22,7 @@ import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { addQueryArgs, getSiteFragment, sectionify, trailingslashit } from 'calypso/lib/route';
 import { withoutHttp } from 'calypso/lib/url';
+import { isPathAllowedForDIFMPreSubmitContentCollection } from 'calypso/my-sites/difm-route-utils';
 import {
 	domainManagementDns,
 	domainManagementEdit,
@@ -313,13 +314,23 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 /**
  * The paths allowed for domain-only sites and DIFM in-progress sites are the same
  * with one exception - /domains/add should be allowed for DIFM in-progress sites.
+ * Before the customer submits DIFM content, the content-gathering sections are
+ * also allowed so customers can reference existing site content while filling
+ * out the form.
  * @param {string} path The path to be checked
  * @param {string} slug The site slug
  * @param {Array} domains The list of site domains
  * @param {Object} contextParams Context parameters
+ * @param {boolean} isWebsiteContentSubmitted Whether the DIFM content form has been submitted
  * @returns {boolean} true if the path is allowed, false otherwise
  */
-function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams ) {
+function isPathAllowedForDIFMInProgressSite(
+	path,
+	slug,
+	domains,
+	contextParams,
+	isWebsiteContentSubmitted = true
+) {
 	const DIFMLiteInProgressAllowedPaths = [ domainAddNew(), getEmailManagementPath( slug ) ];
 
 	const isAllowedForDomainOnlySites = domains.some( ( domain ) =>
@@ -328,6 +339,7 @@ function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams 
 
 	return (
 		isAllowedForDomainOnlySites ||
+		isPathAllowedForDIFMPreSubmitContentCollection( path, isWebsiteContentSubmitted ) ||
 		DIFMLiteInProgressAllowedPaths.some( ( DIFMLiteInProgressAllowedPath ) =>
 			path.startsWith( DIFMLiteInProgressAllowedPath )
 		)
@@ -405,6 +417,8 @@ function onSelectedSiteAvailable( context ) {
 	 * Ignore this check if we are inside a support session.
 	 */
 	const domains = getDomainsBySiteId( state, selectedSite.ID );
+	const isDIFMWebsiteContentSubmitted =
+		selectedSite.options?.difm_lite_site_options?.is_website_content_submitted !== false;
 	if (
 		isDIFMLiteInProgress( state, selectedSite.ID ) &&
 		! isSupportSession( state ) &&
@@ -412,7 +426,8 @@ function onSelectedSiteAvailable( context ) {
 			context.pathname,
 			selectedSite.slug,
 			domains,
-			context.params
+			context.params,
+			isDIFMWebsiteContentSubmitted
 		)
 	) {
 		renderSelectedSiteIsDIFMLiteInProgress( context, selectedSite );

--- a/client/my-sites/difm-route-utils.js
+++ b/client/my-sites/difm-route-utils.js
@@ -1,19 +1,19 @@
+/**
+ * Checks whether a path stays accessible during the DIFM Lite lockout while the
+ * website content form is still open (content not yet submitted).
+ *
+ * Fail safe: only an explicit boolean `false` (exposed by the API while the content
+ * form is open) unlocks these paths. A missing/undefined flag keeps the lockout.
+ * @param {string} path The Calypso route being visited.
+ * @param {boolean|undefined} isWebsiteContentSubmitted The `is_website_content_submitted` flag from `difm_lite_site_options`.
+ * @returns {boolean} Whether the path is allowed for content collection.
+ */
 export function isPathAllowedForDIFMPreSubmitContentCollection( path, isWebsiteContentSubmitted ) {
-	// Fail safe: only an explicit boolean `false` (exposed by the API while the content
-	// form is open) unlocks these paths. A missing/undefined flag keeps the lockout.
 	if ( isWebsiteContentSubmitted !== false ) {
 		return false;
 	}
 
-	const allowedPaths = [
-		'/media',
-		'/posts',
-		'/post',
-		'/pages',
-		'/page',
-		'/settings/taxonomies/category',
-		'/settings/taxonomies/post_tag',
-	];
+	const allowedPaths = [ '/media', '/posts', '/post', '/pages', '/page' ];
 
 	return allowedPaths.some(
 		( allowedPath ) => path === allowedPath || path.startsWith( `${ allowedPath }/` )

--- a/client/my-sites/difm-route-utils.js
+++ b/client/my-sites/difm-route-utils.js
@@ -1,0 +1,11 @@
+export function isPathAllowedForDIFMPreSubmitContentCollection( path, isWebsiteContentSubmitted ) {
+	if ( isWebsiteContentSubmitted ) {
+		return false;
+	}
+
+	const allowedPaths = [ '/media', '/posts', '/post', '/pages', '/page', '/settings/taxonomies' ];
+
+	return allowedPaths.some(
+		( allowedPath ) => path === allowedPath || path.startsWith( `${ allowedPath }/` )
+	);
+}

--- a/client/my-sites/difm-route-utils.js
+++ b/client/my-sites/difm-route-utils.js
@@ -1,9 +1,19 @@
 export function isPathAllowedForDIFMPreSubmitContentCollection( path, isWebsiteContentSubmitted ) {
-	if ( isWebsiteContentSubmitted ) {
+	// Fail safe: only an explicit boolean `false` (exposed by the API while the content
+	// form is open) unlocks these paths. A missing/undefined flag keeps the lockout.
+	if ( isWebsiteContentSubmitted !== false ) {
 		return false;
 	}
 
-	const allowedPaths = [ '/media', '/posts', '/post', '/pages', '/page', '/settings/taxonomies' ];
+	const allowedPaths = [
+		'/media',
+		'/posts',
+		'/post',
+		'/pages',
+		'/page',
+		'/settings/taxonomies/category',
+		'/settings/taxonomies/post_tag',
+	];
 
 	return allowedPaths.some(
 		( allowedPath ) => path === allowedPath || path.startsWith( `${ allowedPath }/` )

--- a/client/my-sites/test/difm-route-utils.test.js
+++ b/client/my-sites/test/difm-route-utils.test.js
@@ -9,8 +9,6 @@ describe( 'isPathAllowedForDIFMPreSubmitContentCollection', () => {
 		[ '/post/example.wordpress.com' ],
 		[ '/pages/example.wordpress.com' ],
 		[ '/page/example.wordpress.com' ],
-		[ '/settings/taxonomies/category/example.wordpress.com' ],
-		[ '/settings/taxonomies/post_tag/example.wordpress.com' ],
 	] )( 'allows %s before website content submission', ( path ) => {
 		expect( isPathAllowedForDIFMPreSubmitContentCollection( path, false ) ).toBe( true );
 	} );
@@ -42,13 +40,5 @@ describe( 'isPathAllowedForDIFMPreSubmitContentCollection', () => {
 		expect( isPathAllowedForDIFMPreSubmitContentCollection( '/media/example.wordpress.com' ) ).toBe(
 			false
 		);
-	} );
-
-	test.each( [
-		[ '/settings/taxonomies/some_custom_taxonomy/example.wordpress.com' ],
-		[ '/settings/taxonomies' ],
-		[ '/settings/taxonomies/example.wordpress.com' ],
-	] )( 'does not allow unrelated taxonomy path %s', ( path ) => {
-		expect( isPathAllowedForDIFMPreSubmitContentCollection( path, false ) ).toBe( false );
 	} );
 } );

--- a/client/my-sites/test/difm-route-utils.test.js
+++ b/client/my-sites/test/difm-route-utils.test.js
@@ -28,4 +28,27 @@ describe( 'isPathAllowedForDIFMPreSubmitContentCollection', () => {
 			isPathAllowedForDIFMPreSubmitContentCollection( '/stats/day/example.wordpress.com', false )
 		).toBe( false );
 	} );
+
+	test.each( [ [ undefined ], [ null ], [ true ], [ 0 ], [ 'false' ] ] )(
+		'fails safe and keeps paths locked when the submitted flag is %p (only explicit false unlocks)',
+		( flagValue ) => {
+			expect(
+				isPathAllowedForDIFMPreSubmitContentCollection( '/media/example.wordpress.com', flagValue )
+			).toBe( false );
+		}
+	);
+
+	it( 'fails safe when the submitted flag argument is missing', () => {
+		expect( isPathAllowedForDIFMPreSubmitContentCollection( '/media/example.wordpress.com' ) ).toBe(
+			false
+		);
+	} );
+
+	test.each( [
+		[ '/settings/taxonomies/some_custom_taxonomy/example.wordpress.com' ],
+		[ '/settings/taxonomies' ],
+		[ '/settings/taxonomies/example.wordpress.com' ],
+	] )( 'does not allow unrelated taxonomy path %s', ( path ) => {
+		expect( isPathAllowedForDIFMPreSubmitContentCollection( path, false ) ).toBe( false );
+	} );
 } );

--- a/client/my-sites/test/difm-route-utils.test.js
+++ b/client/my-sites/test/difm-route-utils.test.js
@@ -1,0 +1,31 @@
+import { isPathAllowedForDIFMPreSubmitContentCollection } from '../difm-route-utils';
+
+describe( 'isPathAllowedForDIFMPreSubmitContentCollection', () => {
+	test.each( [
+		[ '/media/example.wordpress.com' ],
+		[ '/media/images/example.wordpress.com' ],
+		[ '/posts/example.wordpress.com' ],
+		[ '/posts/my/example.wordpress.com' ],
+		[ '/post/example.wordpress.com' ],
+		[ '/pages/example.wordpress.com' ],
+		[ '/page/example.wordpress.com' ],
+		[ '/settings/taxonomies/category/example.wordpress.com' ],
+		[ '/settings/taxonomies/post_tag/example.wordpress.com' ],
+	] )( 'allows %s before website content submission', ( path ) => {
+		expect( isPathAllowedForDIFMPreSubmitContentCollection( path, false ) ).toBe( true );
+	} );
+
+	test.each( [
+		[ '/media/example.wordpress.com' ],
+		[ '/posts/example.wordpress.com' ],
+		[ '/pages/example.wordpress.com' ],
+	] )( 'does not allow %s after website content submission', ( path ) => {
+		expect( isPathAllowedForDIFMPreSubmitContentCollection( path, true ) ).toBe( false );
+	} );
+
+	it( 'keeps non-content paths locked before website content submission', () => {
+		expect(
+			isPathAllowedForDIFMPreSubmitContentCollection( '/stats/day/example.wordpress.com', false )
+		).toBe( false );
+	} );
+} );

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -9,6 +9,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch, useStore } from 'calypso/state';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { isSiteEligibleForDIFMPurchase } from './utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import './styles.scss';
 
@@ -16,7 +17,7 @@ interface Props {
 	stepSectionName: string | null;
 	stepName: string;
 	flowName: string;
-	signupDependencies: any;
+	signupDependencies: { back_to?: string };
 	goToStep: () => void;
 	goToNextStep: () => void;
 }
@@ -97,22 +98,18 @@ export default function DIFMSitePickerStep( props: Props ) {
 		return true;
 	};
 
-	const filterSites = ( site: SiteDetails ) => {
-		return !! (
-			site.capabilities?.manage_options &&
-			( site.is_wpcom_atomic || ! site.jetpack ) &&
-			! site.options?.is_wpforteams_site &&
-			! site.options?.is_difm_lite_in_progress
-		);
-	};
-
 	return (
 		<StepWrapper
 			headerText={ headerText }
 			fallbackHeaderText={ headerText }
 			subHeaderText={ subHeaderText }
 			fallbackSubHeaderText={ subHeaderText }
-			stepContent={ <DIFMSitePicker filter={ filterSites } onSiteSelect={ handleSiteSelect } /> }
+			stepContent={
+				<DIFMSitePicker
+					filter={ isSiteEligibleForDIFMPurchase }
+					onSiteSelect={ handleSiteSelect }
+				/>
+			}
 			hideSkip
 			backUrl={ backUrl }
 			allowBackFirstStep={ !! backUrl }

--- a/client/signup/steps/difm-site-picker/test/utils.test.ts
+++ b/client/signup/steps/difm-site-picker/test/utils.test.ts
@@ -1,0 +1,30 @@
+import { isSiteEligibleForDIFMPurchase } from '../utils';
+import type { SiteDetails } from '@automattic/data-stores';
+
+describe( 'isSiteEligibleForDIFMPurchase', () => {
+	const site = {
+		capabilities: { manage_options: true },
+		is_wpcom_atomic: true,
+		jetpack: false,
+		options: {},
+	} as SiteDetails;
+
+	it( 'allows eligible production sites', () => {
+		expect( isSiteEligibleForDIFMPurchase( site ) ).toBe( true );
+	} );
+
+	it( 'does not allow staging sites', () => {
+		expect( isSiteEligibleForDIFMPurchase( { ...site, is_wpcom_staging_site: true } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'does not allow sites with an active DIFM build', () => {
+		expect(
+			isSiteEligibleForDIFMPurchase( {
+				...site,
+				options: { is_difm_lite_in_progress: true },
+			} )
+		).toBe( false );
+	} );
+} );

--- a/client/signup/steps/difm-site-picker/utils.ts
+++ b/client/signup/steps/difm-site-picker/utils.ts
@@ -1,0 +1,11 @@
+import type { SiteDetails } from '@automattic/data-stores';
+
+export function isSiteEligibleForDIFMPurchase( site: SiteDetails ) {
+	return !! (
+		site.capabilities?.manage_options &&
+		( site.is_wpcom_atomic || ! site.jetpack ) &&
+		! site.is_wpcom_staging_site &&
+		! site.options?.is_wpforteams_site &&
+		! site.options?.is_difm_lite_in_progress
+	);
+}

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -170,20 +170,36 @@ export function requestSite( siteFragment, atomicCapabilitiesRetriesLeft = 3 ) {
 	return ( dispatch, getState ) => {
 		dispatch( { type: SITE_REQUEST, siteId: siteFragment } );
 
-		const result = doRequest( false ).catch( ( error ) => {
-			// Missing Jetpack JSON API methods may arrive as ApiNotFoundError, or as
-			// JetpackNotFoundError when WPCOM detects that Jetpack core is not installed.
-			if (
-				( error?.status === 403 &&
-					error?.message === 'API calls to this blog have been disabled.' ) ||
-				( error?.status === 400 &&
-					( error?.name === 'ApiNotFoundError' || error?.name === 'JetpackNotFoundError' ) )
-			) {
-				return doRequest( true );
-			}
+		const result = doRequest( false )
+			.then( ( site ) => {
+				// Requests for Atomic sites are proxied to the site's own Jetpack by
+				// default, and proxied responses never contain difm_lite_site_options
+				// (the SAL getter is WPCOM-only). Refetch from wpcom so a single-site
+				// refresh does not overwrite the flag delivered by /me/sites.
+				if (
+					site?.jetpack &&
+					site.options?.is_difm_lite_in_progress &&
+					site.options.difm_lite_site_options === undefined
+				) {
+					return doRequest( true );
+				}
 
-			return Promise.reject( error );
-		} );
+				return site;
+			} )
+			.catch( ( error ) => {
+				// Missing Jetpack JSON API methods may arrive as ApiNotFoundError, or as
+				// JetpackNotFoundError when WPCOM detects that Jetpack core is not installed.
+				if (
+					( error?.status === 403 &&
+						error?.message === 'API calls to this blog have been disabled.' ) ||
+					( error?.status === 400 &&
+						( error?.name === 'ApiNotFoundError' || error?.name === 'JetpackNotFoundError' ) )
+				) {
+					return doRequest( true );
+				}
+
+				return Promise.reject( error );
+			} );
 
 		result
 			.then( ( site ) => {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -181,7 +181,7 @@ export function requestSite( siteFragment, atomicCapabilitiesRetriesLeft = 3 ) {
 					site.options?.is_difm_lite_in_progress &&
 					site.options.difm_lite_site_options === undefined
 				) {
-					return doRequest( true );
+					return doRequest( true ).catch( () => site );
 				}
 
 				return site;

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -86,6 +86,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'site_creation_flow',
 	'site_source_slug',
 	'is_difm_lite_in_progress',
+	'difm_lite_site_options',
 	'is_gating_business_q1',
 	'site_intent',
 	'site_partner_bundle',

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -375,6 +375,21 @@ describe( 'actions', () => {
 					jetpack: true,
 					capabilities: {},
 					options: { is_difm_lite_in_progress: true },
+				} )
+				// Jetpack DIFM site whose optional wpcom refetch fails: preserve
+				// the usable proxied response and keep the pre-submit routes locked.
+				.get( '/rest/v1.2/sites/90005' )
+				.reply( 200, {
+					ID: 90005,
+					jetpack: true,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} )
+				.get( '/rest/v1.2/sites/90005' )
+				.query( { force: 'wpcom' } )
+				.reply( 500, {
+					error: 'server_error',
+					message: 'Something went wrong.',
 				} );
 		} );
 
@@ -431,6 +446,22 @@ describe( 'actions', () => {
 			expect( spy ).toHaveBeenCalledWith( {
 				type: SITE_REQUEST_SUCCESS,
 				siteId: 90004,
+			} );
+		} );
+
+		test( 'preserves the proxied response when the forced refetch fails', async () => {
+			const site = await requestSite( 90005 )( spy, () => {} );
+
+			expect( site ).toEqual( {
+				ID: 90005,
+				jetpack: true,
+				capabilities: {},
+				options: { is_difm_lite_in_progress: true },
+			} );
+			expect( spy ).toHaveBeenCalledWith( receiveSite( site ) );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: SITE_REQUEST_SUCCESS,
+				siteId: 90005,
 			} );
 		} );
 	} );

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -317,6 +317,124 @@ describe( 'actions', () => {
 		} );
 	} );
 
+	describe( 'requestSite() DIFM pre-submit flag refetch', () => {
+		const forcedOptions = {
+			is_difm_lite_in_progress: true,
+			difm_lite_site_options: { is_website_content_submitted: false },
+		};
+
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				// Jetpack (Atomic) DIFM site: proxied response is missing the flag,
+				// wpcom-forced response carries it.
+				.get( '/rest/v1.2/sites/90001' )
+				.reply( 200, {
+					ID: 90001,
+					jetpack: true,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} )
+				.get( '/rest/v1.2/sites/90001' )
+				.query( { force: 'wpcom' } )
+				.reply( 200, {
+					ID: 90001,
+					jetpack: true,
+					capabilities: {},
+					options: forcedOptions,
+				} )
+				// Jetpack DIFM site where the flag is already present: no refetch
+				// (a refetch would fail the test — no forced route is mocked).
+				.get( '/rest/v1.2/sites/90002' )
+				.reply( 200, {
+					ID: 90002,
+					jetpack: true,
+					capabilities: {},
+					options: forcedOptions,
+				} )
+				// Simple DIFM site: never proxied, must not be refetched.
+				.get( '/rest/v1.2/sites/90003' )
+				.reply( 200, {
+					ID: 90003,
+					jetpack: false,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} )
+				// Jetpack DIFM site whose forced response still lacks the flag
+				// (backend not deployed yet): settles after exactly one refetch.
+				.get( '/rest/v1.2/sites/90004' )
+				.reply( 200, {
+					ID: 90004,
+					jetpack: true,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} )
+				.get( '/rest/v1.2/sites/90004' )
+				.query( { force: 'wpcom' } )
+				.reply( 200, {
+					ID: 90004,
+					jetpack: true,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} );
+		} );
+
+		test( 'refetches with force=wpcom and dispatches the wpcom-served record', async () => {
+			await requestSite( 90001 )( spy, () => {} );
+			expect( spy ).toHaveBeenCalledWith(
+				receiveSite( {
+					ID: 90001,
+					jetpack: true,
+					capabilities: {},
+					options: forcedOptions,
+				} )
+			);
+		} );
+
+		test( 'does not refetch when the flag is already present', async () => {
+			await requestSite( 90002 )( spy, () => {} );
+			expect( spy ).toHaveBeenCalledWith(
+				receiveSite( {
+					ID: 90002,
+					jetpack: true,
+					capabilities: {},
+					options: forcedOptions,
+				} )
+			);
+			expect( spy ).toHaveBeenCalledWith( {
+				type: SITE_REQUEST_SUCCESS,
+				siteId: 90002,
+			} );
+		} );
+
+		test( 'does not refetch for non-Jetpack (Simple) DIFM sites', async () => {
+			await requestSite( 90003 )( spy, () => {} );
+			expect( spy ).toHaveBeenCalledWith(
+				receiveSite( {
+					ID: 90003,
+					jetpack: false,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} )
+			);
+		} );
+
+		test( 'settles after exactly one refetch when the forced response still lacks the flag', async () => {
+			await requestSite( 90004 )( spy, () => {} );
+			expect( spy ).toHaveBeenCalledWith(
+				receiveSite( {
+					ID: 90004,
+					jetpack: true,
+					capabilities: {},
+					options: { is_difm_lite_in_progress: true },
+				} )
+			);
+			expect( spy ).toHaveBeenCalledWith( {
+				type: SITE_REQUEST_SUCCESS,
+				siteId: 90004,
+			} );
+		} );
+	} );
+
 	describe( 'deleteSite()', () => {
 		const getState = () => ( {
 			sites: {

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -53,6 +53,7 @@ export const SITE_OPTIONS = [
 	'created_at',
 	'unmapped_url',
 	'is_difm_lite_in_progress',
+	'difm_lite_site_options',
 	'is_gating_business_q1',
 	'is_domain_only',
 	'is_redirect',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -29,10 +29,15 @@ export interface SiteCapabilities {
 	view_stats: boolean;
 }
 
+interface DifmLiteSiteOptions {
+	is_website_content_submitted?: boolean;
+}
+
 export interface SiteOptions {
 	admin_url: string;
 	apm_enabled?: boolean;
 	created_at?: string;
+	difm_lite_site_options?: DifmLiteSiteOptions;
 	is_domain_only?: boolean;
 	is_redirect?: boolean;
 	is_difm_lite_in_progress?: boolean;

--- a/packages/api-queries/src/__tests__/site-difm-refetch.test.ts
+++ b/packages/api-queries/src/__tests__/site-difm-refetch.test.ts
@@ -130,4 +130,23 @@ describe( 'siteByIdQuery DIFM pre-submit flag refetch', () => {
 		expect( proxied.isDone() ).toBe( true );
 		expect( forced.isDone() ).toBe( true );
 	} );
+
+	test( 'preserves the proxied response when the forced refetch fails', async () => {
+		const proxiedSite = makeSite( {
+			ID: 90005,
+			jetpack: true,
+			options: { is_difm_lite_in_progress: true },
+		} );
+		const proxied = mockGetSite( 90005, proxiedSite );
+		const forced = nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/sites/90005' )
+			.query( ( query ) => query.force === 'wpcom' )
+			.reply( 500, { error: 'server_error' } );
+
+		const site = ( await queryClient.fetchQuery( siteByIdQuery( 90005 ) ) ) as Site;
+
+		expect( site ).toEqual( proxiedSite );
+		expect( proxied.isDone() ).toBe( true );
+		expect( forced.isDone() ).toBe( true );
+	} );
 } );

--- a/packages/api-queries/src/__tests__/site-difm-refetch.test.ts
+++ b/packages/api-queries/src/__tests__/site-difm-refetch.test.ts
@@ -1,0 +1,133 @@
+import nock from 'nock';
+import { queryClient } from '../query-client';
+import { siteByIdQuery } from '../site';
+import type { Site } from '@automattic/api-core';
+
+// Same-instance query client so site.ts and the test share state.
+jest.mock( '../query-client', () => {
+	const { QueryClient: QC } = jest.requireActual( '@tanstack/react-query' );
+	const qc = new QC( { defaultOptions: { queries: { retry: false } } } );
+	return { queryClient: qc };
+} );
+
+// notFound used in queryFn error handling — won't fire in success-path tests.
+jest.mock( '@tanstack/react-router', () => ( {
+	notFound: () => new Error( 'Not found' ),
+} ) );
+
+function makeSite( overrides: Partial< Site > ): Site {
+	return {
+		ID: 1,
+		slug: 'example.com',
+		name: 'Test',
+		URL: 'https://example.com',
+		jetpack: false,
+		options: {},
+		...overrides,
+	} as Site;
+}
+
+function mockGetSite( siteId: number, site: Site, { force = false }: { force?: boolean } = {} ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/sites/${ siteId }` )
+		.query( ( q ) => ( force ? q.force === 'wpcom' : q.force === undefined ) )
+		.reply( 200, site );
+}
+
+describe( 'siteByIdQuery DIFM pre-submit flag refetch', () => {
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'refetches with force=wpcom when the flag is missing on a Jetpack DIFM site', async () => {
+		const proxied = mockGetSite(
+			90001,
+			makeSite( {
+				ID: 90001,
+				jetpack: true,
+				options: { is_difm_lite_in_progress: true },
+			} )
+		);
+		const forced = mockGetSite(
+			90001,
+			makeSite( {
+				ID: 90001,
+				jetpack: true,
+				options: {
+					is_difm_lite_in_progress: true,
+					difm_lite_site_options: { is_website_content_submitted: false },
+				},
+			} ),
+			{ force: true }
+		);
+
+		const site = ( await queryClient.fetchQuery( siteByIdQuery( 90001 ) ) ) as Site;
+
+		expect( site.options?.difm_lite_site_options?.is_website_content_submitted ).toBe( false );
+		expect( proxied.isDone() ).toBe( true );
+		expect( forced.isDone() ).toBe( true );
+	} );
+
+	test( 'does not refetch when the flag is already present', async () => {
+		// No forced route is mocked: a refetch would fail this test.
+		const proxied = mockGetSite(
+			90002,
+			makeSite( {
+				ID: 90002,
+				jetpack: true,
+				options: {
+					is_difm_lite_in_progress: true,
+					difm_lite_site_options: { is_website_content_submitted: true },
+				},
+			} )
+		);
+
+		const site = ( await queryClient.fetchQuery( siteByIdQuery( 90002 ) ) ) as Site;
+
+		expect( site.options?.difm_lite_site_options?.is_website_content_submitted ).toBe( true );
+		expect( proxied.isDone() ).toBe( true );
+	} );
+
+	test( 'does not refetch for non-Jetpack (Simple) DIFM sites', async () => {
+		const proxied = mockGetSite(
+			90003,
+			makeSite( {
+				ID: 90003,
+				jetpack: false,
+				options: { is_difm_lite_in_progress: true },
+			} )
+		);
+
+		const site = ( await queryClient.fetchQuery( siteByIdQuery( 90003 ) ) ) as Site;
+
+		expect( site.options?.difm_lite_site_options ).toBeUndefined();
+		expect( proxied.isDone() ).toBe( true );
+	} );
+
+	test( 'settles after exactly one refetch when the forced response still lacks the flag', async () => {
+		const proxied = mockGetSite(
+			90004,
+			makeSite( {
+				ID: 90004,
+				jetpack: true,
+				options: { is_difm_lite_in_progress: true },
+			} )
+		);
+		const forced = mockGetSite(
+			90004,
+			makeSite( {
+				ID: 90004,
+				jetpack: true,
+				options: { is_difm_lite_in_progress: true },
+			} ),
+			{ force: true }
+		);
+
+		const site = ( await queryClient.fetchQuery( siteByIdQuery( 90004 ) ) ) as Site;
+
+		// Fail-safe: the flag is still missing, consumers keep the lockout.
+		expect( site.options?.difm_lite_site_options ).toBeUndefined();
+		expect( proxied.isDone() ).toBe( true );
+		expect( forced.isDone() ).toBe( true );
+	} );
+} );

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -22,7 +22,22 @@ function isSiteNotFoundError( error: unknown ) {
 
 async function getSite( siteIdOrSlug: number | string ) {
 	try {
-		return await fetchSite( siteIdOrSlug );
+		const site = await fetchSite( siteIdOrSlug );
+
+		// Requests for Atomic sites are proxied to the site's own Jetpack by
+		// default, and proxied responses never contain difm_lite_site_options
+		// (the SAL getter is WPCOM-only). While a DIFM build is in progress the
+		// flag gates content browsing, so re-fetch the site from wpcom directly.
+		// At most one extra request, and only for sites with an active build.
+		if (
+			site.jetpack &&
+			site.options?.is_difm_lite_in_progress &&
+			site.options.difm_lite_site_options === undefined
+		) {
+			return await fetchSite( siteIdOrSlug, { force: 'wpcom' } );
+		}
+
+		return site;
 	} catch ( e ) {
 		// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
 		if ( isInaccessibleJetpackError( e ) ) {

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -34,7 +34,7 @@ async function getSite( siteIdOrSlug: number | string ) {
 			site.options?.is_difm_lite_in_progress &&
 			site.options.difm_lite_site_options === undefined
 		) {
-			return await fetchSite( siteIdOrSlug, { force: 'wpcom' } );
+			return await fetchSite( siteIdOrSlug, { force: 'wpcom' } ).catch( () => site );
 		}
 
 		return site;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -259,6 +259,7 @@ export interface SiteDetailsOptions {
 	image_thumbnail_height?: number;
 	image_thumbnail_width?: number;
 	import_engine?: string | null;
+	difm_lite_site_options?: DifmLiteSiteOptions;
 	is_automated_transfer?: boolean;
 	is_cloud_eligible?: boolean;
 	is_difm_lite_in_progress?: boolean;


### PR DESCRIPTION
Prevent staging sites from being selected for DIFM Express purchases, and let customers browse Posts, Media, and Pages while a DIFM build is in progress but website content has not yet been submitted.

Fixes [Enable DIFM Express builds on staging sites](https://linear.app/a8c/project/enable-difm-express-builds-on-staging-sites-bd3330678a98/overview)

Proposed Changes

- Exclude staging sites (is_wpcom_staging_site) from the DIFM Express existing-site picker via a shared isSiteEligibleForDIFMPurchase() helper.
- Request difm_lite_site_options on site records (Redux site options, api-core, data-stores types).
- Allow Posts, Media, Pages, and related editor routes for DIFM in-progress sites only when difm_lite_site_options.is_website_content_submitted === false.
- Show Posts, Media, and Pages in the Dashboard DIFM site menu/sidebar under the same pre-submit condition.
- Add unit tests for site eligibility filtering and pre-submit route allowlisting.

Why are these changes being made?

DIFM Express builds are moving toward a model where customers purchase on production and builds may target a linked staging site. Two Calypso gaps block that direction today:

1. Staging sites can appear in the DIFM site picker, but checkout fails on staging because billing/plan validation expects the production parent. Customers should not be able to select staging in the self-serve flow.
2. During content collection, customers need to reference existing posts, media, and pages while filling out the DIFM form. Today, the DIFM in-progress lockout blocks those sections even before content is submitted.

This PR implements the Calypso-side guardrails and pre-submit access rules. It intentionally fails safe: if difm_lite_site_options.is_website_content_submitted is missing from the site API, existing lockout behavior is preserved until WPCOM exposes that flag.

Follow-up WPCOM work (internal build-target override, staging fulfillment) is out of scope for this PR.

Testing Instructions

Automated

`yarn test-client client/signup/steps/difm-site-picker/test/utils.test.ts client/my-sites/test/difm-route-utils.test.js
`

Manual

- Staging hidden from DIFM purchase flow

  - Use an account with a Business-plan production site and a linked staging site.
  - Open /start/do-it-for-me and reach the existing-site picker.
  - Confirm the production site appears (if otherwise eligible).
  - Confirm the linked staging site does not appear.

- Production purchase flow unchanged
  - Select an eligible production site and continue through DIFM options/page selection.
  - Confirm checkout still uses the production site context.

- Pre-submit dashboard access (requires WPCOM to return is_website_content_submitted: false)

  On a DIFM in-progress site with options.is_difm_lite_in_progress: true and options.difm_lite_site_options.is_website_content_submitted: false, confirm these routes load without the DIFM lockout screen:
  
  > /media/<siteSlug>
  > /posts/<siteSlug>
  > /pages/<siteSlug>
  > /post/<siteSlug>
  > /page/<siteSlug>
  
  - Also confirm the Dashboard DIFM menu shows Posts, Media, and Pages.

- Post-submit lockout preserved (requires is_website_content_submitted: true)

  - Confirm Media/Posts/Pages routes show the DIFM in-progress lockout screen and the Dashboard menu does not show those links.

- Missing submitted flag stays locked

  - On a DIFM in-progress site where difm_lite_site_options is absent from the site response, confirm Media/Posts/Pages remain locked.

Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2)?
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector, Using memoizing selectors, and Our Approach to Data.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For UI changes, have we tested the change in various languages (e.g., ES, PT, FR, DE)? Text length and word order vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


## Update: Atomic DIFM builds — wpcom refetch

Single-site API requests for Atomic sites are proxied to the site's own Jetpack by default, and proxied responses never include `difm_lite_site_options` (the flag is rendered on the WordPress.com side only). Without a fix, the pre-submit unlock would silently never activate on Atomic DIFM builds: the dashboard's single-site query loads a record without the flag, and in legacy Redux a `requestSite()` refresh overwrites the complete record delivered by `/me/sites`.

Commit 44129049366 adds a self-healing refetch in both data layers (`getSite()` in `packages/api-queries/src/site.ts` and `requestSite()` in `client/state/sites/actions.js`): when a response is Jetpack-marked, reports an active DIFM build, and lacks the key, the site is refetched once with `force=wpcom`. At most one extra request, and only for sites with an active build. If the forced response still lacks the key or the refetch fails, the existing fail-safe lockout applies. Unit tests cover both layers: one-refetch, flag-already-present, Simple-site, forced-response-still-missing-key, and failed-refetch fallback cases.

### Additional testing — Atomic (requires the WPCOM flag to be live)

Until the backend exposes `difm_lite_site_options`, the fail-safe keeps today's lockout; what can be verified beforehand is the refetch behavior itself:

- On an Atomic site with an active DIFM build: load the site in Calypso and confirm in the network tab that the initial `/sites/{id}` response has `is_difm_lite_in_progress: true` without `difm_lite_site_options`, followed by exactly one `/sites/{id}?force=wpcom` request. No repeated forced requests.
- On a Simple DIFM site: no `force=wpcom` request is made.
- Once the backend flag is live: the forced response carries `difm_lite_site_options.is_website_content_submitted`, and with `false` the Posts/Media/Pages menu entries and routes unlock as described above.
