### PR TITLE
Product Icon: render plan icon for 3-year plan terms

### DIFF
--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -59,16 +59,20 @@ export type SupportedSlugs =
 	| 'personal-bundle'
 	| 'personal-bundle-2y'
 	| 'personal-bundle-monthly'
+	| 'personal-bundle-3y'
 	| 'value_bundle'
 	| 'value_bundle-2y'
 	| 'value_bundle-monthly'
 	| 'value_bundle_monthly'
+	| 'value_bundle-3y'
 	| 'ecommerce-bundle'
 	| 'ecommerce-bundle-2y'
 	| 'ecommerce-bundle-monthly'
+	| 'ecommerce-bundle-3y'
 	| 'business-bundle'
 	| 'business-bundle-2y'
 	| 'business-bundle-monthly'
+	| 'business-bundle-3y'
 	| 'pro-plan'
 	| 'starter-plan'
 	| 'wp_com_hundred_year_bundle_centennially'
@@ -167,18 +171,34 @@ export type SupportedSlugs =
 export const iconToProductSlugMap: Record< keyof typeof paths, readonly SupportedSlugs[] > = {
 	'wpcom-free': [ 'free_plan' ],
 	'wpcom-blogger': [ 'blogger-bundle', 'blogger-bundle-2y' ],
-	'wpcom-personal': [ 'personal-bundle', 'personal-bundle-2y', 'personal-bundle-monthly' ],
+	'wpcom-personal': [
+		'personal-bundle',
+		'personal-bundle-2y',
+		'personal-bundle-monthly',
+		'personal-bundle-3y',
+	],
 	'wpcom-premium': [
 		'value_bundle',
 		'value_bundle-2y',
 		'value_bundle-monthly',
 		'value_bundle_monthly',
+		'value_bundle-3y',
 		'pro-plan',
 		'starter-plan',
 	],
 	'wpcom-100-year': [ 'wp_com_hundred_year_bundle_centennially' ],
-	'wpcom-ecommerce': [ 'ecommerce-bundle', 'ecommerce-bundle-2y', 'ecommerce-bundle-monthly' ],
-	'wpcom-business': [ 'business-bundle', 'business-bundle-2y', 'business-bundle-monthly' ],
+	'wpcom-ecommerce': [
+		'ecommerce-bundle',
+		'ecommerce-bundle-2y',
+		'ecommerce-bundle-monthly',
+		'ecommerce-bundle-3y',
+	],
+	'wpcom-business': [
+		'business-bundle',
+		'business-bundle-2y',
+		'business-bundle-monthly',
+		'business-bundle-3y',
+	],
 	'jetpack-ai': [ 'jetpack_ai_monthly', 'jetpack_ai_yearly' ],
 	'jetpack-free': [ 'jetpack_free' ],
 	'jetpack-personal': [ 'jetpack_personal', 'jetpack_personal_monthly' ],

--- a/packages/components/src/product-icon/test/index.tsx
+++ b/packages/components/src/product-icon/test/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+import ProductIcon from '../index';
+import type { SupportedSlugs } from '../config';
+
+describe( 'ProductIcon', () => {
+	// The four 3-year WPCOM term slugs and the icon each should resolve to.
+	const threeYearSlugs: [ SupportedSlugs, string ][] = [
+		[ 'personal-bundle-3y', 'wpcom-personal' ],
+		[ 'value_bundle-3y', 'wpcom-premium' ],
+		[ 'business-bundle-3y', 'wpcom-business' ],
+		[ 'ecommerce-bundle-3y', 'wpcom-ecommerce' ],
+	];
+
+	it.each( threeYearSlugs )( 'renders the %s icon as is-%s', ( slug, iconKey ) => {
+		const { container } = render( <ProductIcon slug={ slug } /> );
+		expect( container.querySelector( `img.product-icon.is-${ iconKey }` ) ).toBeInTheDocument();
+	} );
+
+	// Regression guard: every term variant of the four mapped WPCOM families resolves to an icon.
+	const familyTerms: SupportedSlugs[] = [
+		'personal-bundle',
+		'personal-bundle-monthly',
+		'personal-bundle-2y',
+		'personal-bundle-3y',
+		'value_bundle',
+		'value_bundle-monthly',
+		'value_bundle-2y',
+		'value_bundle-3y',
+		'business-bundle',
+		'business-bundle-monthly',
+		'business-bundle-2y',
+		'business-bundle-3y',
+		'ecommerce-bundle',
+		'ecommerce-bundle-monthly',
+		'ecommerce-bundle-2y',
+		'ecommerce-bundle-3y',
+	];
+
+	it.each( familyTerms )( 'renders an icon for %s', ( slug ) => {
+		const { container } = render( <ProductIcon slug={ slug } /> );
+		expect( container.querySelector( 'img.product-icon' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Resolves CHE-501

## Proposed Changes

* Add the four WPCOM 3-year (triennial) plan term slugs - `personal-bundle-3y`, `value_bundle-3y`, `business-bundle-3y`, `ecommerce-bundle-3y` - to `iconToProductSlugMap` and the `SupportedSlugs` type in `packages/components/src/product-icon/config.ts`. Each is added to its existing plan bucket (`wpcom-personal`, `wpcom-premium`, `wpcom-business`, `wpcom-ecommerce`), reusing the SVG already used by the 1y/2y/monthly terms. No new assets.
* Add `packages/components/src/product-icon/test/index.tsx` - the first test for `ProductIcon`. It asserts the four 3-year slugs render an `<img>` with the right icon class, plus a regression guard over every term variant (monthly/1y/2y/3y) of the four families.

## Why are these changes being made?

`ProductIcon` resolves an icon by looking the plan slug up in `iconToProductSlugMap`. If a slug is in no bucket, the lookup returns `undefined` and the component renders `null` - silently, with no fallback. The My Plan card always renders the icon wrapper `div` and only renders `<ProductIcon>` inside it, so a `null` icon leaves a visible empty bordered box.

The four 3-year term slugs live in `calypso-products` constants but were never added to `product-icon/config.ts`. Their monthly/1y/2y siblings are present, so those terms render fine - only 3-year plans showed the empty box.

| Scenario | Before | After |
|----------|--------|-------|
| My Plan card, 3-year plan (Personal / Premium / Business / eCommerce) | empty bordered box | plan icon renders |
| My Plan card, monthly / 1y / 2y plan | icon renders | icon renders (unchanged) |

## Testing Instructions

**Automated:**
```
yarn test-packages packages/components/src/product-icon
yarn typecheck-packages
```
The test fails on trunk (the four 3-year slugs resolve to `null`) and passes with this change.

**Manual:**
1. Get a site onto a 3-year plan. Fastest: navigate to `/checkout/{site}/personal-bundle-3y` ($99 Personal) and complete checkout, or on `/plans/{site}` open the billing interval dropdown and pick "Pay every 3 years". (Slugs: `personal-bundle-3y`, `value_bundle-3y`, `business-bundle-3y`, `ecommerce-bundle-3y`.)
2. Navigate to `/plans/my-plan/{site}`.
3. Verify that the My Plan card shows the plan icon (e.g. `img.product-icon.is-wpcom-personal`) to the left of the plan name - not an empty bordered box.

**Before this change:** the icon area is an empty bordered box for any 3-year plan.
**After this change:** the icon renders (reuses the existing 1y/2y SVG).

### Screenshot - My Plan card, 3-year Personal plan (after)

My Plan card on a 3-year Personal plan, showing the plan icon renders instead of an empty box.
<img width="1568" height="191" alt="dsgcom-705-my-plan-3y-icon" src="https://github.com/user-attachments/assets/8865e53b-7e8e-47bf-8026-3f0b955d5de7" />



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
