### PR TITLE
Keep payment method warning icon inline with its message on mobile

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -375,6 +375,11 @@
 		align-items: center;
 		gap: 4px;
 
+		@include breakpoint-deprecated( '<660px' ) {
+			clear: left;
+			text-align: left;
+		}
+
 		svg {
 			flex-shrink: 0;
 			fill: var( --color-warning-30 );


### PR DESCRIPTION
Resolves CHE-499

## Proposed Changes

* On mobile (`<=660px`), drop the "no payment method" warning row below the "Payment method" label and keep the warning icon glued to its message, in `client/me/purchases/manage-purchase/style.scss`.

## Why are these changes being made?

On mobile Purchase Settings, the yellow warning icon in the Payment method row dropped onto its own line, separated from its message, so the row looked broken.

At `<=660px` the sibling `.manage-purchase__detail-label` ("Payment method") is `float: left`. The warning row is a flex box (its own formatting context), so it got squeezed into the space beside that float, its long message wrapped, and the icon orphaned onto its own line.

* `clear: left` drops the warning row below the floated label so it takes the full content width, directly under the "Payment method" heading.
* `text-align: left` keeps the message next to the icon. Without it, the detail column's `text-align: right` shoves the wrapped message to the far edge and splits it from the icon.

Both are gated to `<660px`, so desktop is unchanged. The rule is scoped to `.manage-purchase__no-payment-method`, so the credit-card row and the "Included with plan" / "None" states are untouched. No component/copy change.

| Scenario | Before | After |
|----------|--------|-------|
| Payment method warning, mobile (`<=660px`) | Icon orphaned on its own line, message wrapped away from it | Icon inline, immediately left of its message, as one block under the heading |
| Payment method row, desktop (`>=660px`) | inline | unchanged |

## Screenshots

Before
<img width="670" height="130" alt="Purchase-Settings-WordPresscom-1782943232" src="https://github.com/user-attachments/assets/8dc9cc73-99d3-4cf2-a2e9-4bc71cf11ecb" />

After
<img width="880" height="134" alt="Purchase-Settings-WordPresscom-1782944296" src="https://github.com/user-attachments/assets/c261ec19-68b4-4be1-bf36-5f15f26130ca" />


## Testing Instructions

**Steps:**
1. Open a purchase whose Payment method row shows the warning (auto-renew ON with no stored payment method, or a plan bought with credits) at `/purchases/subscriptions/{siteSlug}/{purchaseId}`.
2. Set the browser to a mobile width, e.g. 375px (DevTools device mode).
3. Verify that the yellow warning icon sits immediately left of "You don't have a payment method to renew this subscription", as one intact block below the "Payment method" heading - not on its own separate line.
4. Resize to `>=660px` and verify the Payment method row is unchanged.
5. On another purchase that has a stored card, verify the credit-card Payment method row is unchanged at both widths.

**Before this change:**
- At 375px, the warning icon drops below the "Payment method" label onto its own line, message wrapped separately.

**After this change:**
- At 375px, the icon is inline with its message as one block under the heading.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
