### PR TITLE
Legacy contact: add claim info to printable copy

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -55,12 +55,14 @@ export default function SecurityLegacyContact() {
 									<div className="legacy-contact-card__avatar">
 										<Icon icon={ people } size={ 28 } />
 									</div>
-									<VStack spacing={ 0 } alignment="flex-start">
-										<Text upperCase variant="muted" size={ 11 }>
+									<dl className="legacy-contact-card__details">
+										<Text as="dt" upperCase variant="muted" size={ 11 }>
 											{ __( 'Legacy contact email' ) }
 										</Text>
-										<Text size={ 15 }>{ contact.contact_email }</Text>
-									</VStack>
+										<Text as="dd" size={ 15 }>
+											{ contact.contact_email }
+										</Text>
+									</dl>
 								</HStack>
 								<Text>
 									{ __(

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -66,11 +66,7 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 							'To request access, your legacy contact should visit <link>wordpress.com/digital-legacy</link> and follow the instructions there. They’ll need the access key above.'
 						),
 						{
-							link: (
-								<a href={ localizeUrl( 'https://wordpress.com/digital-legacy' ) }>
-									wordpress.com/digital-legacy
-								</a>
-							),
+							link: <a href={ localizeUrl( 'https://wordpress.com/digital-legacy' ) } />,
 						}
 					) }
 				</Text>

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -1,5 +1,4 @@
 import { legacyContactQuery, legacyContactsQuery } from '@automattic/api-queries';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -66,7 +65,7 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 							'To request access, your legacy contact should visit <link>wordpress.com/digital-legacy</link> and follow the instructions there. They’ll need the access key above.'
 						),
 						{
-							link: <a href={ localizeUrl( 'https://wordpress.com/digital-legacy' ) } />,
+							link: <a href="https://wordpress.com/digital-legacy" />,
 						}
 					) }
 				</Text>

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -51,7 +51,13 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 			</dl>
 
 			<VStack spacing={ 1 } alignment="flex-start">
-				<Text as="h4" size={ 15 } weight={ 600 } className="legacy-contact-print__heading">
+				<Text
+					as="h4"
+					upperCase
+					variant="muted"
+					size={ 11 }
+					className="legacy-contact-print__heading"
+				>
 					{ __( 'How to claim access' ) }
 				</Text>
 				<Text as="p" size={ 15 } lineHeight={ 1.5 }>

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -24,7 +24,7 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 	};
 
 	return (
-		<VStack spacing={ 8 }>
+		<VStack spacing={ 6 }>
 			<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
 			<Text as="p" size={ 15 } lineHeight={ 1.5 }>
 				{ __(

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -1,6 +1,8 @@
 import { legacyContactQuery, legacyContactsQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
@@ -44,6 +46,26 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 					{ __( 'Access key' ) }
 				</Text>
 				<div className="legacy-contact-print__key">{ contact.access_key }</div>
+			</VStack>
+
+			<VStack spacing={ 1 } alignment="flex-start">
+				<Text upperCase variant="muted" size={ 11 }>
+					{ __( 'How to claim access' ) }
+				</Text>
+				<Text size={ 15 }>
+					{ createInterpolateElement(
+						__(
+							'To request access, your legacy contact should visit <link>wordpress.com/digital-legacy</link> and follow the instructions there. They’ll need the access key above.'
+						),
+						{
+							link: (
+								<a href={ localizeUrl( 'https://wordpress.com/digital-legacy' ) }>
+									wordpress.com/digital-legacy
+								</a>
+							),
+						}
+					) }
+				</Text>
 			</VStack>
 
 			<ButtonStack justify="flex-start" className="legacy-contact-print__actions">

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -26,7 +26,7 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 	return (
 		<VStack spacing={ 6 }>
 			<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
-			<Text as="p">
+			<Text as="p" size={ 15 }>
 				{ __(
 					'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
 				) }

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -26,33 +26,35 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 	return (
 		<VStack spacing={ 6 }>
 			<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
-			<VStack spacing={ 2 }>
-				<Text>
-					{ __(
-						'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
-					) }
-				</Text>
-			</VStack>
+			<Text as="p">
+				{ __(
+					'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
+				) }
+			</Text>
+
+			<dl className="legacy-contact-print__fields">
+				<VStack spacing={ 1 } alignment="flex-start">
+					<Text as="dt" upperCase variant="muted" size={ 11 }>
+						{ __( 'Legacy contact email' ) }
+					</Text>
+					<Text as="dd" size={ 15 }>
+						{ contact.contact_email }
+					</Text>
+				</VStack>
+
+				<VStack spacing={ 1 } alignment="flex-start">
+					<Text as="dt" upperCase variant="muted" size={ 11 }>
+						{ __( 'Access key' ) }
+					</Text>
+					<dd className="legacy-contact-print__key">{ contact.access_key }</dd>
+				</VStack>
+			</dl>
 
 			<VStack spacing={ 1 } alignment="flex-start">
-				<Text upperCase variant="muted" size={ 11 }>
-					{ __( 'Legacy contact email' ) }
-				</Text>
-				<Text size={ 15 }>{ contact.contact_email }</Text>
-			</VStack>
-
-			<VStack spacing={ 1 } alignment="flex-start">
-				<Text upperCase variant="muted" size={ 11 }>
-					{ __( 'Access key' ) }
-				</Text>
-				<div className="legacy-contact-print__key">{ contact.access_key }</div>
-			</VStack>
-
-			<VStack spacing={ 1 } alignment="flex-start">
-				<Text upperCase variant="muted" size={ 11 }>
+				<Text as="h4" upperCase variant="muted" size={ 11 }>
 					{ __( 'How to claim access' ) }
 				</Text>
-				<Text size={ 15 }>
+				<Text as="p" size={ 15 }>
 					{ createInterpolateElement(
 						__(
 							'To request access, your legacy contact should visit <link>wordpress.com/digital-legacy</link> and follow the instructions there. They’ll need the access key above.'

--- a/client/dashboard/me/security-legacy-contact/print.tsx
+++ b/client/dashboard/me/security-legacy-contact/print.tsx
@@ -24,9 +24,9 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 	};
 
 	return (
-		<VStack spacing={ 6 }>
+		<VStack spacing={ 8 }>
 			<SectionHeader title={ __( 'Your legacy contact' ) } level={ 3 } />
-			<Text as="p" size={ 15 }>
+			<Text as="p" size={ 15 } lineHeight={ 1.5 }>
 				{ __(
 					'Keep this information somewhere safe. After your death, your legacy contact can give this key to WordPress.com to request access to your account.'
 				) }
@@ -51,10 +51,10 @@ function LegacyContactDetails( { legacyContactId }: { legacyContactId: number } 
 			</dl>
 
 			<VStack spacing={ 1 } alignment="flex-start">
-				<Text as="h4" upperCase variant="muted" size={ 11 }>
+				<Text as="h4" size={ 15 } weight={ 600 } className="legacy-contact-print__heading">
 					{ __( 'How to claim access' ) }
 				</Text>
-				<Text as="p" size={ 15 }>
+				<Text as="p" size={ 15 } lineHeight={ 1.5 }>
 					{ createInterpolateElement(
 						__(
 							'To request access, your legacy contact should visit <link>wordpress.com/digital-legacy</link> and follow the instructions there. They’ll need the access key above.'

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -19,6 +19,17 @@
 	}
 }
 
+.legacy-contact-print__fields {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	margin: 0;
+
+	dd {
+		margin: 0;
+	}
+}
+
 .legacy-contact-print__key {
 	font-family: monospace;
 	font-size: 1.5rem;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -4,6 +4,16 @@
 	border-radius: 8px;
 }
 
+.legacy-contact-card__details {
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+
+	dd {
+		margin: 0;
+	}
+}
+
 .legacy-contact-card__avatar {
 	display: flex;
 	flex-shrink: 0;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -19,6 +19,10 @@
 	}
 }
 
+.legacy-contact-print__heading {
+	margin-block: 0;
+}
+
 .legacy-contact-print__fields {
 	display: flex;
 	flex-direction: column;

--- a/client/dashboard/me/security-legacy-contact/test/print.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/print.test.tsx
@@ -32,28 +32,18 @@ describe( '<SecurityLegacyContactPrint />', () => {
 		queryClient.clear();
 	} );
 
-	test( 'shows the "How to claim access" section with the digital-legacy link', async () => {
-		interceptContacts( [ CONTACT ] );
-		interceptContact( CONTACT_WITH_KEY );
-
-		renderScreen();
-
-		expect( await screen.findByText( 'How to claim access' ) ).toBeVisible();
-
-		const link = await screen.findByRole( 'link', {
-			name: 'wordpress.com/digital-legacy',
-		} );
-		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/digital-legacy' );
-	} );
-
-	test( 'shows the contact email and access key', async () => {
+	test( 'shows the contact details and how to claim access', async () => {
 		interceptContacts( [ CONTACT ] );
 		interceptContact( CONTACT_WITH_KEY );
 
 		renderScreen();
 
 		expect( await screen.findByText( CONTACT.contact_email ) ).toBeVisible();
-		expect( await screen.findByText( CONTACT_WITH_KEY.access_key ) ).toBeVisible();
+		expect( screen.getByText( CONTACT_WITH_KEY.access_key ) ).toBeVisible();
+		expect( screen.getByText( 'How to claim access' ) ).toBeVisible();
+
+		const link = screen.getByRole( 'link', { name: 'wordpress.com/digital-legacy' } );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/digital-legacy' );
 	} );
 
 	test( 'shows the empty state when no contact is set up', async () => {
@@ -62,10 +52,8 @@ describe( '<SecurityLegacyContactPrint />', () => {
 		renderScreen();
 
 		expect(
-			await screen.findByText( 'You don\u2019t have a legacy contact set up yet.' )
+			await screen.findByText( 'You don’t have a legacy contact set up yet.' )
 		).toBeVisible();
-		expect(
-			await screen.findByRole( 'link', { name: 'Back to legacy contact' } )
-		).toBeVisible();
+		expect( await screen.findByRole( 'link', { name: 'Back to legacy contact' } ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/me/security-legacy-contact/test/print.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/print.test.tsx
@@ -1,0 +1,71 @@
+/** @jest-environment jsdom */
+import { queryClient } from '@automattic/api-queries';
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import SecurityLegacyContactPrint from '../print';
+
+const API = 'https://public-api.wordpress.com';
+const CONTACT = {
+	legacy_contact_id: 123,
+	contact_email: 'trusted@example.com',
+	created_at: '2026-01-01T00:00:00+00:00',
+};
+const CONTACT_WITH_KEY = {
+	...CONTACT,
+	access_key: 'abc-123-key',
+};
+
+const interceptContacts = ( contacts: Array< typeof CONTACT > ) =>
+	nock( API ).get( '/wpcom/v2/me/legacy-contacts' ).query( true ).reply( 200, contacts );
+
+const interceptContact = ( contact: typeof CONTACT_WITH_KEY ) =>
+	nock( API )
+		.get( `/wpcom/v2/me/legacy-contacts/${ contact.legacy_contact_id }` )
+		.query( true )
+		.reply( 200, contact );
+
+const renderScreen = () => render( <SecurityLegacyContactPrint />, { queryClient } );
+
+describe( '<SecurityLegacyContactPrint />', () => {
+	beforeEach( () => {
+		queryClient.clear();
+	} );
+
+	test( 'shows the "How to claim access" section with the digital-legacy link', async () => {
+		interceptContacts( [ CONTACT ] );
+		interceptContact( CONTACT_WITH_KEY );
+
+		renderScreen();
+
+		expect( await screen.findByText( 'How to claim access' ) ).toBeVisible();
+
+		const link = await screen.findByRole( 'link', {
+			name: 'wordpress.com/digital-legacy',
+		} );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/digital-legacy' );
+	} );
+
+	test( 'shows the contact email and access key', async () => {
+		interceptContacts( [ CONTACT ] );
+		interceptContact( CONTACT_WITH_KEY );
+
+		renderScreen();
+
+		expect( await screen.findByText( CONTACT.contact_email ) ).toBeVisible();
+		expect( await screen.findByText( CONTACT_WITH_KEY.access_key ) ).toBeVisible();
+	} );
+
+	test( 'shows the empty state when no contact is set up', async () => {
+		interceptContacts( [] );
+
+		renderScreen();
+
+		expect(
+			await screen.findByText( 'You don\u2019t have a legacy contact set up yet.' )
+		).toBeVisible();
+		expect(
+			await screen.findByRole( 'link', { name: 'Back to legacy contact' } )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Fixes RSM-4571

## Proposed Changes

* Add a "How to claim access" section to the legacy contact printable copy (`/me/security/legacy-contact/print`), with instructions and a link to `wordpress.com/digital-legacy`.

## Why are these changes being made?

* The printable copy gives the legacy contact the access key, but didn't tell them where or how to actually use it. Including the claim URL on the printed page means the person holding this document has everything they need to request access, without having to hunt for the right page.

## Testing Instructions

* Go to `/me/security/legacy-contact` with a legacy contact set up.
* Click "View printable copy".
* Confirm the "How to claim access" section appears with a link to `wordpress.com/digital-legacy`.
* Print (or print-preview) the page and confirm the section and link are present in the output.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

