### PR TITLE
Fix mobile spacing and CTA wrap on the Purchase Settings expiring notice

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -418,10 +418,25 @@
 
 .manage-purchase__expiring-credit-card-notice.calypso-notice,
 .manage-purchase__purchase-expiring-notice.calypso-notice {
+	// Inset the notice to match its neighbors. width:auto is required: the base
+	// .calypso-notice is width:100% border-box, so margin-inline alone overflows.
+	width: auto;
 	margin-bottom: 10px;
+	margin-inline: 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 16px;
+		margin-inline: 24px;
+	}
+
+	// On mobile, drop the action onto its own full-width row instead of cramming
+	// it inline beside the notice text (same idiom as step-wrapper's header).
+	@include breakpoint-deprecated( '<660px' ) {
+		flex-wrap: wrap;
+
+		.calypso-notice__action {
+			flex-basis: 100%;
+		}
 	}
 }
 


### PR DESCRIPTION
Resolves CHE-498

## Proposed Changes

* Give the expiring/credits notice on Purchase Settings a side gutter on mobile (16px, stepping to 24px above 660px) so it no longer sits flush to the screen edges.
* Drop the notice's action button ("Add Payment Method") onto its own full-width line below the text on mobile instead of cramming it inline beside the copy.

## Why are these changes being made?

On mobile the "purchased with credits" notice ran edge to edge and its "Add Payment Method" CTA was crammed inline beside the text. The base `.calypso-notice` is `width: 100%` with no side margin and a non-wrapping flex row, and this page's container has no side padding on mobile - so the notice sat flush and the CTA had nowhere to go.

Fix is page-scoped to `.manage-purchase__purchase-expiring-notice`, matching the 16/24px inset the sibling content already uses. `width: auto` goes with `margin-inline` since the base notice is `box-sizing: border-box; width: 100%` (margin alone overflows). CTA stacking reuses the `flex-wrap: wrap` + `flex-basis: 100%` idiom from the signup step header.

| Scenario | Before | After |
|----------|--------|-------|
| Mobile (<=480px) | Notice flush to edges, CTA crammed inline | 16px side gutters, CTA on its own line |
| 480-660px | Flush, CTA inline | 16px side gutters, CTA stacked |
| Desktop (>660px) | CTA inline, right-aligned | Unchanged |

## Testing Instructions

**Steps:**
1. Open Purchase Settings for a plan bought with credits and no payment method on file (`isPaidWithCredits` + `manualRenew`): `/purchases/subscriptions/{siteSlug}/{purchaseId}`
2. Set the browser to a mobile viewport (DevTools device mode, ~375px).
3. Verify the notice has visible left/right gutters (not flush to the edges) and there is no horizontal page scroll.
4. Verify "Add Payment Method" sits on its own full-width line below the notice text, not wrapping mid-button beside it.
5. Switch to desktop width (>=768px) and verify the CTA is inline and right-aligned with the notice at its normal width - unchanged from trunk.

If you don't have a credits purchase handy, the notice can be force-rendered by temporarily returning it at the top of `renderPurchaseExpiringNotice()` in `client/me/purchases/manage-purchase/notices.tsx`.

## Screenshots

_Mobile (with fix)_ - notice has side gutters and "Add Payment Method" drops to its own line:
<img width="566" height="292" alt="Mobile - credits notice with fix" src="https://github.com/user-attachments/assets/dc433172-aaee-418e-971a-be1471363012" />

_Desktop (unchanged)_ - CTA stays inline, right-aligned:
<img width="850" height="70" alt="Desktop - credits notice unchanged" src="https://github.com/user-attachments/assets/83c4d94e-95bc-4761-baec-ebd3f55a6dc4" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
