### PR TITLE
Odyssey Stats: externalize react-dom/client to the host React

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -132,8 +132,26 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			injectPolyfill: true,
 			useDefaults: false,
-			requestToHandle: defaultRequestToHandle,
+			requestToHandle: ( request ) => {
+				// Map the `react-dom/client` subpath to WordPress's `react-dom` script
+				// handle (its `ReactDOM` global carries `createRoot`/`hydrateRoot`). The
+				// installed plugin version does not yet map this subpath itself.
+				if ( request === 'react-dom/client' ) {
+					return 'react-dom';
+				}
+				return defaultRequestToHandle( request );
+			},
 			requestToExternal: ( request ) => {
+				// Externalize `react-dom/client` to the same `ReactDOM` global as
+				// `react-dom` so `createRoot`/`hydrateRoot` come from the React that
+				// WordPress provides. Otherwise this subpath is bundled from
+				// node_modules and its `createRoot` reaches into the externalized
+				// react-dom internals of a different React major, returning a root
+				// whose `.render` is missing ("createRoot(...).render is not a
+				// function") against React 19.
+				if ( request === 'react-dom/client' ) {
+					return 'ReactDOM';
+				}
 				if (
 					! [
 						'lodash',


### PR DESCRIPTION
Part of [STATS-378](https://linear.app/a8c/issue/STATS-378/jetpack-stats-and-forms-blank-on-some-wpcloud-on-wordpresscom-sites)

## Proposed Changes

* Externalize the `react-dom/client` subpath in the Odyssey Stats webpack config, mapping it to WordPress's `ReactDOM` global and `react-dom` script handle — the same canonical mapping newer versions of `@wordpress/dependency-extraction-webpack-plugin` apply.

## Why are these changes being made?

Odyssey Stats externalizes `react` and `react-dom` to the React that the host WordPress provides, but `react-dom/client` was neither in the extraction allow-list nor mapped by the installed plugin version (`6.24.0`). As a result `react-dom/client` was bundled from `node_modules` (React 18.3.1) while the rest of react-dom resolved to the host global. On hosts now serving React 19, the bundled `createRoot` reached into the externalized react-dom internals of a different React major and returned a root object without a working `render`, producing the production error:

```
Uncaught (in promise) TypeError: pM(...).render is not a function
```

This matches the [STATS-378](https://linear.app/a8c/issue/STATS-378/jetpack-stats-and-forms-blank-on-some-wpcloud-on-wordpresscom-sites) console notes (`createRoot is not a function`, `Cannot read properties of undefined (reading 'unstable_scheduleCallback')`) and the staged/region-specific nature of the React 19 rollout that made it reproduce only on some sites.

With this change all React modules resolve to the single host-provided React, so there is no second copy to mismatch — the app now uses whatever React the host ships.

## Testing Instructions

* `cd apps/odyssey-stats && NODE_ENV=production yarn build`
* Confirm `dist/build.min.asset.php` lists `react-dom` in its dependencies and the bundle no longer contains a second React (`grep -c unstable_scheduleCallback dist/build.min.js` returns `0`).
* `yarn test:size` passes (`build.min.js` drops to \~485 kB gzipped since the react-dom reconciler is no longer bundled).
* Load Jetpack Stats in wp-admin on an Atomic site and confirm the content area renders without the `.render is not a function` console error.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](<https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md>) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](<https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md>)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "\[Status\] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "\[Status\] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?