### PR TITLE
Dashboard: gate plan purchases on plan ownership, not site ownership

### DIFF
--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -17,7 +17,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { check, chevronLeft, lineSolid } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import React, { Fragment, useState } from 'react';
-import { useAuth } from '../../app/auth';
 import { useHelpCenter } from '../../app/help-center';
 import { siteRoute, sitePlansRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
@@ -392,7 +391,7 @@ function PlanCardCTA( {
 	tierRank,
 	currentTierRank,
 	redirectAfterPurchase,
-	isSiteOwner,
+	canPurchasePlan,
 }: {
 	site: Site;
 	sitePlan: SiteContextualPlan;
@@ -400,7 +399,7 @@ function PlanCardCTA( {
 	tierRank: number;
 	currentTierRank: number;
 	redirectAfterPurchase: string;
-	isSiteOwner: boolean;
+	canPurchasePlan: boolean;
 } ) {
 	const { setNewMessagingChat } = useHelpCenter();
 	const isCurrentPlan =
@@ -414,7 +413,7 @@ function PlanCardCTA( {
 		);
 	}
 
-	if ( ! isSiteOwner ) {
+	if ( ! canPurchasePlan ) {
 		return null;
 	}
 
@@ -466,7 +465,7 @@ function PlanCard( {
 	currentTierRank,
 	redirectAfterPurchase,
 	totalPlanCount,
-	isSiteOwner,
+	canPurchasePlan,
 }: {
 	site: Site;
 	sitePlan: SiteContextualPlan;
@@ -476,7 +475,7 @@ function PlanCard( {
 	currentTierRank: number;
 	redirectAfterPurchase: string;
 	totalPlanCount: number;
-	isSiteOwner: boolean;
+	canPurchasePlan: boolean;
 } ) {
 	const isCurrentPlan =
 		sitePlan.current_plan === true || ( currentTierRank >= 0 && tierRank === currentTierRank );
@@ -541,7 +540,7 @@ function PlanCard( {
 						tierRank={ tierRank }
 						currentTierRank={ currentTierRank }
 						redirectAfterPurchase={ redirectAfterPurchase }
-						isSiteOwner={ isSiteOwner }
+						canPurchasePlan={ canPurchasePlan }
 					/>
 
 					{ sitePlan.plan_card_features && sitePlan.plan_card_features.length > 0 && (
@@ -715,8 +714,6 @@ export default function SitePlans() {
 	const { siteSlug } = siteRoute.useParams();
 	const { redirect_to } = useSearch( { from: sitePlansRoute.fullPath } );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { user } = useAuth();
-	const isSiteOwner = user.ID === site.site_owner;
 
 	const [ billingInterval, setBillingInterval ] = useState< SubscriptionBillPeriodValue >(
 		SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
@@ -730,6 +727,12 @@ export default function SitePlans() {
 		enabled: !! site.ID,
 	} );
 	const sitePlans = sitePlansData?.plans;
+
+	// A paid plan can only be changed by the account that owns it; a free or plan-less
+	// site can be upgraded by anyone with access.
+	const currentPlan = sitePlans?.find( ( p ) => p.current_plan );
+	const isPaidPlan = !! site.plan && ! site.plan.is_free;
+	const canPurchasePlan = ! isPaidPlan || !! currentPlan?.user_is_owner;
 	const pageContext = sitePlansData?.pageContext;
 	// Index sitePlans by product_id for O(1) sibling lookups
 	const plansByProductId = new Map< number, SiteContextualPlan >(
@@ -849,7 +852,7 @@ export default function SitePlans() {
 						currentTierRank={ currentTierRank }
 						redirectAfterPurchase={ redirectAfterPurchase }
 						totalPlanCount={ shownPlans.length }
-						isSiteOwner={ isSiteOwner }
+						canPurchasePlan={ canPurchasePlan }
 					/>
 				) ) }
 			</div>

--- a/client/dashboard/sites/site-plans/test/index.test.tsx
+++ b/client/dashboard/sites/site-plans/test/index.test.tsx
@@ -23,19 +23,29 @@ const SITE_ID = 1;
 const OWNER_USER_ID = 10;
 const NON_OWNER_USER_ID = 99;
 
-const site = {
-	ID: SITE_ID,
-	name: 'Test Site',
-	slug: 'test-site.wordpress.com',
-	URL: 'https://test-site.wordpress.com',
-	site_owner: OWNER_USER_ID,
-	plan: {
-		product_slug: 'free_plan',
-		product_name_short: 'Free',
-		is_free: true,
-		features: { active: [] },
-	},
-} as unknown as Site;
+const makeSite = ( plan: Record< string, unknown > ) =>
+	( {
+		ID: SITE_ID,
+		name: 'Test Site',
+		slug: 'test-site.wordpress.com',
+		URL: 'https://test-site.wordpress.com',
+		site_owner: OWNER_USER_ID,
+		plan,
+	} ) as unknown as Site;
+
+const freeSitePlan = {
+	product_slug: 'free_plan',
+	product_name_short: 'Free',
+	is_free: true,
+	features: { active: [] },
+};
+
+const paidSitePlan = {
+	product_slug: 'personal-bundle',
+	product_name_short: 'Personal',
+	is_free: false,
+	features: { active: [] },
+};
 
 const ownerUser = {
 	ID: OWNER_USER_ID,
@@ -60,7 +70,7 @@ const freePlan = {
 	product_tier_id: 1,
 	product_tier_product_ids: [ 1 ],
 	interval: 365,
-	current_plan: true,
+	current_plan: false,
 	raw_price: 0,
 	raw_price_integer: 0,
 	raw_discount: 0,
@@ -99,33 +109,72 @@ const personalPlan = {
 	is_domain_upgrade: false,
 };
 
-function mockApis() {
+const businessPlan = {
+	product_id: 3,
+	product_slug: 'business-bundle',
+	product_name: 'Business',
+	plan_card_name: 'Business',
+	plan_card_order: 2,
+	product_tier_id: 3,
+	product_tier_product_ids: [ 3 ],
+	interval: 365,
+	current_plan: false,
+	raw_price: 8,
+	raw_price_integer: 800,
+	raw_discount: 0,
+	raw_discount_integer: 0,
+	formatted_price: '$8',
+	formatted_original_price: '$8',
+	formatted_discount: '$0',
+	currency_code: 'USD',
+	original_price: { amount: 8, currency: 'USD' },
+	discount_reason: null,
+	cost_overrides: [],
+	is_domain_upgrade: false,
+};
+
+function mockApis( {
+	sitePlan,
+	plans,
+}: {
+	sitePlan: Record< string, unknown >;
+	plans: Record< number, Record< string, unknown > >;
+} ) {
 	nock( 'https://public-api.wordpress.com' )
-		.get( `/rest/v1.1/sites/${ site.slug }` )
+		.get( '/rest/v1.1/sites/test-site.wordpress.com' )
 		.query( true )
-		.reply( 200, site );
+		.reply( 200, makeSite( sitePlan ) );
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.4/sites/${ SITE_ID }/plans` )
 		.query( true )
-		.reply( 200, {
-			plans: {
-				1: freePlan,
-				2: personalPlan,
-			},
-		} );
+		.reply( 200, { plans } );
+}
+
+function mockFreeSite() {
+	mockApis( {
+		sitePlan: freeSitePlan,
+		plans: { 1: { ...freePlan, current_plan: true }, 2: personalPlan },
+	} );
+}
+
+function mockPaidSite( { userIsOwner }: { userIsOwner: boolean } ) {
+	mockApis( {
+		sitePlan: paidSitePlan,
+		plans: {
+			2: { ...personalPlan, current_plan: true, user_is_owner: userIsOwner },
+			3: businessPlan,
+		},
+	} );
 }
 
 describe( '<SitePlans>', () => {
-	beforeEach( () => {
-		mockApis();
-	} );
-
 	afterEach( () => {
 		nock.cleanAll();
 	} );
 
-	test( 'shows upgrade button for site owner', async () => {
+	test( 'shows upgrade CTAs on a free site for the site owner', async () => {
+		mockFreeSite();
 		render( <SitePlans />, { user: ownerUser } );
 
 		await screen.findByText( 'Personal' );
@@ -133,15 +182,35 @@ describe( '<SitePlans>', () => {
 		expect( screen.getByRole( 'link', { name: 'Get Personal' } ) ).toBeVisible();
 	} );
 
-	test( 'hides upgrade button for non-owner', async () => {
+	test( 'shows upgrade CTAs on a free site for a non-owner', async () => {
+		mockFreeSite();
 		render( <SitePlans />, { user: nonOwnerUser } );
 
 		await screen.findByText( 'Personal' );
 
-		expect( screen.queryByRole( 'link', { name: 'Get Personal' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Get Personal' } ) ).toBeVisible();
+	} );
+
+	test( 'shows upgrade CTAs when the user owns the current paid plan', async () => {
+		mockPaidSite( { userIsOwner: true } );
+		render( <SitePlans />, { user: ownerUser } );
+
+		await screen.findByText( 'Business' );
+
+		expect( screen.getByRole( 'link', { name: 'Get Business' } ) ).toBeVisible();
+	} );
+
+	test( 'hides upgrade CTAs when the current paid plan is owned by someone else', async () => {
+		mockPaidSite( { userIsOwner: false } );
+		render( <SitePlans />, { user: nonOwnerUser } );
+
+		await screen.findByText( 'Business' );
+
+		expect( screen.queryByRole( 'link', { name: 'Get Business' } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows "Your plan" indicator for current plan regardless of ownership', async () => {
+		mockPaidSite( { userIsOwner: false } );
 		render( <SitePlans />, { user: nonOwnerUser } );
 
 		await screen.findByText( 'Personal' );


### PR DESCRIPTION
Part of DOTMSD-1361

## Proposed Changes

Update the multi-site dashboard site plans to not gate on site owner but instead on purchase owner.


> [!NOTE]
>  Worth noting that this page is an experimental page and not live yet.

## Why are these changes being made?

#112101, erroneous gated the UI based on site ownership it should be gated on plan ownership.


## Testing Instructions

* `yarn test-client client/dashboard/sites/site-plans/test`
* As a **non-owner admin** on a **free** site: open Site Plans → upgrade CTAs (e.g. "Get Personal") are visible.
* On a site whose **paid** plan was purchased by a **different** account: upgrade CTAs are hidden, but the "Your plan" indicator still shows.
* As the **plan owner** on a paid plan: upgrade CTAs are visible.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?