### PR TITLE
Dashboard: stop gating the Add domain button on site ownership

### DIFF
--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -72,16 +72,9 @@ function SiteDomains() {
 		actions.some( ( action ) => action.isEligible === undefined || action.isEligible( item ) )
 	);
 
-	const isSiteOwner = user.ID === site.site_owner;
-
 	return (
 		<PageLayout
-			header={
-				<PageHeader
-					title={ __( 'Domains' ) }
-					actions={ isSiteOwner ? <AddDomainButton /> : null }
-				/>
-			}
+			header={ <PageHeader title={ __( 'Domains' ) } actions={ <AddDomainButton /> } /> }
 			notices={
 				<>
 					{ /* Action feedback, not an on-load banner: rendered outside the arbiter. */ }

--- a/client/dashboard/sites/domains/test/index.test.tsx
+++ b/client/dashboard/sites/domains/test/index.test.tsx
@@ -103,11 +103,11 @@ describe( '<SiteDomains>', () => {
 		expect( screen.getByRole( 'button', { name: 'Add domain name' } ) ).toBeVisible();
 	} );
 
-	test( 'hides "Add domain name" button for non-owner', async () => {
+	test( 'shows "Add domain name" button for non-owner', async () => {
 		render( <SiteDomains />, { user: nonOwnerUser } );
 
 		await screen.findByRole( 'heading', { name: 'Domains' } );
 
-		expect( screen.queryByRole( 'button', { name: 'Add domain name' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Add domain name' } ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Part of DOTMSD-1361

## Proposed Changes

Restore ability to add domain to site as admin, even if not site owner.

## Why are these changes being made?

In #112101, we erroneously hid the ability to add a domain based on the incorrect idea that purchasing is gated by site owner. That is incorrect. We don't stop admins from purchasing products for sites they are not admins for. We do stop them from altering already purchased products by different admin accounts.

## Testing Instructions

* `yarn test-client client/dashboard/sites/domains/test`
* As a **non-owner admin**: open Site Domains → "Add domain name" is visible.
* As the **site owner**: unchanged — the button is still visible.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?