### PR TITLE
Replace lodash memoize with an @automattic/js-utils helper

### DIFF
--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -1,5 +1,4 @@
-import { pick, shuffle } from '@automattic/js-utils';
-import { memoize } from 'lodash';
+import { memoize, pick, shuffle } from '@automattic/js-utils';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';

--- a/client/lib/checklist/index.js
+++ b/client/lib/checklist/index.js
@@ -1,5 +1,4 @@
-import { pick } from '@automattic/js-utils';
-import { memoize } from 'lodash';
+import { memoize, pick } from '@automattic/js-utils';
 
 class WpcomTaskList {
 	constructor( tasks = [] ) {

--- a/client/lib/shortcode/index.js
+++ b/client/lib/shortcode/index.js
@@ -1,5 +1,5 @@
+import { memoize } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
-import { memoize } from 'lodash';
 
 /**
  * Module variables

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -1,9 +1,9 @@
 /* eslint-disable prettier/prettier */
 import { Card, Spinner } from '@automattic/components';
+import { memoize } from '@automattic/js-utils';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import clsx from 'clsx';
 import { translate, useRtl } from 'i18n-calypso';
-import { memoize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -1,8 +1,8 @@
 import config from '@automattic/calypso-config';
+import { memoize } from '@automattic/js-utils';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
-import { memoize } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component, useRef } from 'react';

--- a/client/post-editor/media-modal/preload-image.js
+++ b/client/post-editor/media-modal/preload-image.js
@@ -1,7 +1,7 @@
-import { memoize } from 'lodash';
+import { memoize } from '@automattic/js-utils';
 
 export default memoize( function ( src ) {
-	// This is a non-standard use of the Lodash memoize helper, used here to
+	// This is a non-standard use of the memoize helper, used here to
 	// prevent multiple preloads for the same image.
 	new window.Image().src = src;
 } );

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -28,6 +28,7 @@ const JS_UTILS_NAMES = [
 	'pick',
 	'omit',
 	'mapValues',
+	'memoize',
 	'pickBy',
 	'omitBy',
 	'groupBy',
@@ -244,6 +245,7 @@ const patterns = [
 // own namespace/CommonJS guards below.
 const NAMESPACE_GUARDED = [
 	{ name: 'isEmpty', message: JS_UTILS_MESSAGE },
+	{ name: 'memoize', message: JS_UTILS_MESSAGE },
 	{ name: 'unescape', message: UNESCAPE_MESSAGE },
 	{ name: 'sampleSize', message: SAMPLESIZE_MESSAGE },
 	{ name: 'matches', message: MATCHES_MESSAGE },

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -13,6 +13,7 @@ export { default as mapKeys } from './map-keys';
 export { default as mapRecordKeysRecursively } from './map-record-keys-recursively';
 export { default as mapValues } from './map-values';
 export { default as maxBy } from './max-by';
+export { default as memoize } from './memoize';
 export { default as minBy } from './min-by';
 export { default as omit } from './omit';
 export { default as omitBy } from './omit-by';

--- a/packages/js-utils/src/memoize.ts
+++ b/packages/js-utils/src/memoize.ts
@@ -7,7 +7,8 @@ export interface MemoizedFunction< Args extends unknown[], Return > {
  * Wraps a function so results are cached by a key derived from its arguments.
  * By default the key is the first argument; pass `resolver` to compute a custom
  * key. The cache is exposed as `.cache` (a `Map`) so callers can clear or
- * inspect it. Matches lodash's `memoize`.
+ * inspect it. Mirrors lodash's `memoize` for these uses, but does not support
+ * its pluggable `memoize.Cache` or argument-type `TypeError` checks.
  * @param func The function to have its output memoized.
  * @param resolver Optional function that resolves the cache key from the arguments.
  * @returns The memoized function, with its cache exposed as `.cache`.

--- a/packages/js-utils/src/memoize.ts
+++ b/packages/js-utils/src/memoize.ts
@@ -1,0 +1,35 @@
+export interface MemoizedFunction< Args extends unknown[], Return > {
+	( ...args: Args ): Return;
+	cache: Map< unknown, Return >;
+}
+
+/**
+ * Wraps a function so results are cached by a key derived from its arguments.
+ * By default the key is the first argument; pass `resolver` to compute a custom
+ * key. The cache is exposed as `.cache` (a `Map`) so callers can clear or
+ * inspect it. Matches lodash's `memoize`.
+ * @param func The function to have its output memoized.
+ * @param resolver Optional function that resolves the cache key from the arguments.
+ * @returns The memoized function, with its cache exposed as `.cache`.
+ */
+const memoize = < Args extends unknown[], Return >(
+	func: ( ...args: Args ) => Return,
+	resolver?: ( ...args: Args ) => unknown
+): MemoizedFunction< Args, Return > => {
+	// Use a regular function (not an arrow) so the caller's `this` is forwarded
+	// to `func`/`resolver`, matching lodash's `func.apply( this, arguments )`.
+	const memoized = function ( this: unknown, ...args: Args ): Return {
+		const key = resolver ? resolver.apply( this, args ) : args[ 0 ];
+		const { cache } = memoized;
+		if ( cache.has( key ) ) {
+			return cache.get( key ) as Return;
+		}
+		const result = func.apply( this, args );
+		cache.set( key, result );
+		return result;
+	} as MemoizedFunction< Args, Return >;
+	memoized.cache = new Map< unknown, Return >();
+	return memoized;
+};
+
+export default memoize;

--- a/packages/js-utils/src/test/memoize.ts
+++ b/packages/js-utils/src/test/memoize.ts
@@ -1,0 +1,53 @@
+import memoize from '../memoize';
+
+describe( 'memoize', () => {
+	it( 'caches by the first argument by default', () => {
+		const fn = jest.fn( ( a: number, b: number ) => a + b );
+		const memoized = memoize( fn );
+
+		expect( memoized( 1, 2 ) ).toBe( 3 );
+		// Same first argument returns the cached result, ignoring later arguments.
+		expect( memoized( 1, 9 ) ).toBe( 3 );
+		expect( memoized( 2, 2 ) ).toBe( 4 );
+		expect( fn ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'uses the resolver to compute the cache key', () => {
+		const fn = jest.fn( ( a: number, b: number ) => a + b );
+		const memoized = memoize( fn, ( a, b ) => `${ a }-${ b }` );
+
+		expect( memoized( 1, 2 ) ).toBe( 3 );
+		expect( memoized( 1, 2 ) ).toBe( 3 );
+		expect( memoized( 1, 9 ) ).toBe( 10 );
+		expect( fn ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'caches falsy and undefined results', () => {
+		const fn = jest.fn( () => undefined );
+		const memoized = memoize( fn );
+
+		expect( memoized( 'x' ) ).toBeUndefined();
+		expect( memoized( 'x' ) ).toBeUndefined();
+		expect( fn ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'exposes a clearable cache', () => {
+		const fn = jest.fn( ( a: number ) => a * 2 );
+		const memoized = memoize( fn );
+
+		memoized( 2 );
+		expect( memoized.cache.has( 2 ) ).toBe( true );
+
+		memoized.cache.clear();
+		memoized( 2 );
+		expect( fn ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'forwards the caller’s `this` binding', () => {
+		const memoized = memoize( function ( this: { value: number } ) {
+			return this.value;
+		} );
+
+		expect( memoized.call( { value: 7 } ) ).toBe( 7 );
+	} );
+} );

--- a/packages/state-utils/package.json
+++ b/packages/state-utils/package.json
@@ -38,6 +38,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/js-utils": "workspace:^",
 		"@wordpress/is-shallow-equal": "^5.48.0",
 		"@wordpress/warning": "^3.48.0",
 		"lodash": "^4.17.21",

--- a/packages/state-utils/src/create-selector/README.md
+++ b/packages/state-utils/src/create-selector/README.md
@@ -66,4 +66,4 @@ createSelector( ( state ) => foo( state ) && bar( state ), [ foo, bar, baz ] );
 
 ### How can I access the internal cache?
 
-While you should rarely need to do so, you can manage the internal Lodash `memoize.Cache` instance on the `memoizedSelector` property of the returned function.
+While you should rarely need to do so, you can manage the internal cache — a `Map` exposed as `.cache` — on the `memoizedSelector` property of the returned function.

--- a/packages/state-utils/src/create-selector/index.ts
+++ b/packages/state-utils/src/create-selector/index.ts
@@ -1,6 +1,6 @@
+import { memoize } from '@automattic/js-utils';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import warn from '@wordpress/warning';
-import { memoize } from 'lodash';
 
 /**
  * Constants
@@ -101,7 +101,7 @@ export default function createSelector<
 			}
 
 			if ( lastDependants && ! isShallowEqual( currentDependants, lastDependants ) ) {
-				memoizedSelector.cache.clear?.();
+				memoizedSelector.cache.clear();
 			}
 
 			lastDependants = currentDependants;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,6 +2254,7 @@ __metadata:
   resolution: "@automattic/state-utils@workspace:packages/state-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/js-utils": "workspace:^"
     "@wordpress/is-shallow-equal": "npm:^5.48.0"
     "@wordpress/warning": "npm:^3.48.0"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
## Proposed Changes

* Add a faithful `memoize` helper to `@automattic/js-utils` (default first-argument cache key, optional resolver, cache exposed as a `Map`) and migrate the remaining lodash `memoize` consumers to it.
* Guard the `lodash` ES import, deep import, namespace member, and CommonJS shapes against reintroduction, consistent with the other migrated functions.

## Why are these changes being made?

* Continues the incremental removal of lodash in favor of small, faithful shared helpers. `memoize` had no `you-dont-need-lodash-underscore` backstop, so it needed both a shared replacement and a full guard. A shared js-utils export is the only home reachable by both the client consumers and `state-utils`.

## Testing Instructions

* `yarn jest --config packages/js-utils/jest.config.js packages/js-utils/src/test/memoize.ts` — new helper unit tests.
* `yarn jest --config packages/state-utils/jest.config.js` — exercises the memoized `create-selector`.
* `yarn typecheck-packages` and `yarn typecheck-client` pass.
* Behavior is unchanged for all consumers; the helper matches lodash's default-first-arg keying, resolver, and `.cache` semantics.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
