### PR TITLE
Agents Manager: add block settings toggle to selected block pill

### DIFF
--- a/packages/agents-manager/src/components/selected-block/index.tsx
+++ b/packages/agents-manager/src/components/selected-block/index.tsx
@@ -43,11 +43,42 @@ export default function SelectedBlock() {
 		};
 	}, [] );
 
-	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+	// The unified post/site editor normalizes the legacy `core/edit-post` and
+	// `core/edit-site` scopes to `core`, and exposes the block inspector under
+	// the `edit-post/block` identifier.
+	const isBlockSettingsOpen = useSelect(
+		( select ) =>
+			(
+				select( 'core/interface' ) as {
+					getActiveComplementaryArea?: ( scope: string ) => string | null;
+				}
+			 ).getActiveComplementaryArea?.( 'core' ) === 'edit-post/block',
+		[]
+	);
+
+	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );
+	// The block settings sidebar is a complementary area of the interface store,
+	// registered at runtime by the host post/site editor.
+	const { enableComplementaryArea, disableComplementaryArea } = useDispatch( 'core/interface' ) as {
+		enableComplementaryArea?: ( scope: string, area: string ) => void;
+		disableComplementaryArea?: ( scope: string ) => void;
+	};
 
 	const handleClearSelectedBlock = () => {
 		clearSelectedBlock();
 		window.dispatchEvent( new Event( SELECTED_BLOCK_CLEAR_EVENT ) );
+	};
+
+	const handleToggleBlockSettings = () => {
+		if ( ! block ) {
+			return;
+		}
+		if ( isBlockSettingsOpen ) {
+			disableComplementaryArea?.( 'core' );
+			return;
+		}
+		selectBlock( block.clientId );
+		enableComplementaryArea?.( 'core', 'edit-post/block' );
 	};
 
 	if ( ! block ) {
@@ -62,8 +93,19 @@ export default function SelectedBlock() {
 			animate={ animations.visible }
 			exit={ animations.hidden }
 		>
-			<BlockIcon icon={ icon } />
-			<span className="agents-manager-selected-block__name">{ name }</span>
+			<Button
+				className="agents-manager-selected-block__info"
+				onClick={ handleToggleBlockSettings }
+				label={
+					isBlockSettingsOpen
+						? __( 'Close block settings', __i18n_text_domain__ )
+						: __( 'Open block settings', __i18n_text_domain__ )
+				}
+				showTooltip
+			>
+				<BlockIcon icon={ icon } />
+				<span className="agents-manager-selected-block__name">{ name }</span>
+			</Button>
 			<hr className="agents-manager-selected-block__divider" />
 			<Button
 				className="agents-manager-selected-block__remove"

--- a/packages/agents-manager/src/components/selected-block/style.scss
+++ b/packages/agents-manager/src/components/selected-block/style.scss
@@ -26,6 +26,27 @@
 		}
 	}
 
+	&__info {
+		&.components-button {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			min-width: 0;
+			height: auto;
+			padding: 0;
+			color: var( --color-foreground );
+
+			&:hover,
+			&:focus,
+			&:active,
+			&:focus:not( :disabled ) {
+				color: currentColor;
+				box-shadow: none;
+				outline: none;
+			}
+		}
+	}
+
 	&__name {
 		font-size: $font-size-x-small;
 		overflow: hidden;


### PR DESCRIPTION
## Proposed Changes

* Make the selected-block "pill" icon and name clickable. Clicking it toggles the block settings sidebar in the host post/site editor.
* When opening, the block is (re)selected in the block editor and the interface store's `edit-post/block` complementary area is enabled; clicking again closes it.
* The button reflects state via its accessible label ("Open block settings" / "Close block settings") and shows a tooltip.
* Add styling so the icon + name render as an unstyled inline button (no default button chrome, focus ring, or hover box-shadow).


https://github.com/user-attachments/assets/e2b04f91-adac-47ea-9efa-be538597007a



## Why are these changes being made?

The selected-block pill previously only displayed the current block's icon and name with no way to jump to its settings. Wiring it to the interface store's block inspector lets users open/close block settings directly from the pill. The unified post/site editor normalizes the legacy `core/edit-post`/`core/edit-site` scopes to `core` and exposes the inspector under the `edit-post/block` identifier, which is what this toggle targets.

## Testing Instructions

* Run Calypso (`yarn start`) or the sandbox build (`cd apps/agents-manager && yarn dev --sync`) and open a page/post in the editor with the Agents Manager active.
* Select a block so the selected-block pill appears.
* Click the block icon/name in the pill — the block settings sidebar should open and the block should be selected. The tooltip/label should read "Close block settings".
* Click it again — the sidebar should close and the label should return to "Open block settings".
* Verify keyboard focus works on the button and there's no stray focus outline/box-shadow.
* Check dark mode rendering of the pill.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
