### PR TITLE
Plugins: keep the Get started CTA reachable on mobile

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -24,6 +24,7 @@ const PluginDetailsHeader = ( {
 	isJetpackCloud,
 	onReviewsClick = () => {},
 	isMarketplaceProduct,
+	cta = null,
 } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
@@ -138,6 +139,7 @@ const PluginDetailsHeader = ( {
 					</div>
 				</div>
 			</div>
+			{ cta }
 			<div className="plugin-details-header__description">
 				{ preventWidows( plugin.short_description || plugin.description ) }
 			</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -376,6 +376,11 @@ function PluginDetails( props ) {
 		/>
 	);
 
+	// On mobile the actions column (CTA, sidebar details, download) renders
+	// inside the header, above the description; on desktop (and while loading)
+	// it stays in the right rail. Exactly one placement renders at a time.
+	const showActionsInHeader = ! isWide && ! showPlaceholder;
+
 	const pluginDownload = ! showPlaceholder &&
 		! requestingPluginsForSites &&
 		isWporgPluginFetched && (
@@ -397,6 +402,22 @@ function PluginDetails( props ) {
 				<script type="application/ld+json">{ structuredData }</script>
 			</div>
 		);
+
+	const pluginActions = (
+		<div className="plugin-details__actions">
+			<div className="plugin-details__sidebar">
+				<PluginDetailsCTA plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
+
+				{ ! showPlaceholder && ! requestingPluginsForSites && (
+					<PluginDetailsSidebar plugin={ fullPlugin } />
+				) }
+
+				{ isMarketplaceRedesignEnabled && pluginDownload }
+			</div>
+
+			{ ! isMarketplaceRedesignEnabled && pluginDownload }
+		</div>
+	);
 
 	return (
 		<MainComponent
@@ -486,6 +507,7 @@ function PluginDetails( props ) {
 								isPlaceholder={ showPlaceholder }
 								onReviewsClick={ () => setIsReviewsModalVisible( true ) }
 								isMarketplaceProduct={ isMarketplaceProduct }
+								cta={ showActionsInHeader ? pluginActions : null }
 							/>
 						</div>
 						<div className="plugin-details__content">
@@ -549,19 +571,7 @@ function PluginDetails( props ) {
 							) }
 						</div>
 
-						<div className="plugin-details__actions">
-							<div className="plugin-details__sidebar">
-								<PluginDetailsCTA plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
-
-								{ ! showPlaceholder && ! requestingPluginsForSites && (
-									<PluginDetailsSidebar plugin={ fullPlugin } />
-								) }
-
-								{ isMarketplaceRedesignEnabled && pluginDownload }
-							</div>
-
-							{ ! isMarketplaceRedesignEnabled && pluginDownload }
-						</div>
+						{ ! showActionsInHeader && pluginActions }
 					</div>
 				</div>
 			</FullWidthSection>


### PR DESCRIPTION
Part of DSGCOM-596

## Proposed Changes

* On the plugin detail page, move the primary "Get started" CTA above the plugin description on mobile so it's reachable without scrolling. On desktop it stays in the right-rail sidebar as before.

## Why are these changes being made?

* On mobile the page led with the title, description, and metadata, pushing the main action far down the page where people had to scroll past everything before they could act on it. A sticky button was considered but would overlap the AI assistance button, so the CTA is surfaced above the description instead.

## Testing Instructions

* Open a plugin detail page (e.g. `/plugins/jetpack`) at a mobile viewport (≤ 960px), both logged out and logged in.
* Confirm the "Get started" CTA now appears directly below the title and above the description, and is visible without scrolling.
* Resize to desktop (> 960px) and confirm the CTA renders in the right-rail sidebar as before, with no duplicate CTA.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
