### PR TITLE
A4A: Add backups to the agency site detail view

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -2,7 +2,7 @@ import { agencySiteQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { category } from '@wordpress/icons';
+import { category, backup } from '@wordpress/icons';
 import { agencySiteRoute } from '../../../app/router/agency';
 import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../../components/sidebar';
 import AgencySiteSwitcherItem from './site-switcher-item';
@@ -27,6 +27,11 @@ export default function AgencySiteSidebar() {
 						>
 							{ __( 'Overview' ) }
 						</SidebarMenuItem>
+						{ site.has_backup && (
+							<SidebarMenuItem icon={ backup } to={ `/sites/${ siteSlug }/backups` }>
+								{ __( 'Backups' ) }
+							</SidebarMenuItem>
+						) }
 					</SidebarMenu>
 				</VStack>
 			) }

--- a/client/dashboard/agency/sites/site/backup-card.tsx
+++ b/client/dashboard/agency/sites/site/backup-card.tsx
@@ -1,0 +1,20 @@
+import { __ } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
+import OverviewCard from '../../../components/overview-card';
+import { BackupCardContent } from '../../../sites/overview-backup-card';
+import type { AgencySite } from '@automattic/api-core';
+
+export default function BackupCard( { site }: { site: AgencySite } ) {
+	if ( ! site.has_backup ) {
+		return (
+			<OverviewCard
+				icon={ backup }
+				title={ __( 'Last backup' ) }
+				heading={ __( 'Not active' ) }
+				description={ __( 'Backups aren’t enabled for this site.' ) }
+			/>
+		);
+	}
+
+	return <BackupCardContent siteId={ site.blog_id } backupUrl={ `/sites/${ site.url }/backups` } />;
+}

--- a/client/dashboard/agency/sites/site/backup-download.tsx
+++ b/client/dashboard/agency/sites/site/backup-download.tsx
@@ -1,13 +1,9 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import Breadcrumbs from '../../../app/breadcrumbs';
 import { agencySiteBackupDownloadRoute } from '../../../app/router/agency';
-import { PageHeader } from '../../../components/page-header';
-import PageLayout from '../../../components/page-layout';
-import { BackupDownloadFlow } from '../../../sites/backup-download/flow';
+import { BackupDownloadPage } from '../../../sites/backup-download/download-page';
 
 export default function AgencySiteBackupDownload() {
 	const { siteSlug, rewindId } = agencySiteBackupDownloadRoute.useParams();
@@ -15,7 +11,7 @@ export default function AgencySiteBackupDownload() {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const router = useRouter();
 
-	const handleDownloadIdConsumed = useCallback( () => {
+	const onConsumeDownloadId = useCallback( () => {
 		router.navigate( {
 			to: agencySiteBackupDownloadRoute.fullPath,
 			params: { siteSlug, rewindId },
@@ -25,18 +21,11 @@ export default function AgencySiteBackupDownload() {
 	}, [ router, siteSlug, rewindId ] );
 
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
-			}
-		>
-			<BackupDownloadFlow
-				site={ site }
-				rewindId={ rewindId }
-				initialDownloadId={ downloadId }
-				onDownloadIdConsumed={ handleDownloadIdConsumed }
-			/>
-		</PageLayout>
+		<BackupDownloadPage
+			site={ site }
+			rewindId={ rewindId }
+			downloadId={ downloadId }
+			onConsumeDownloadId={ onConsumeDownloadId }
+		/>
 	);
 }

--- a/client/dashboard/agency/sites/site/backup-download.tsx
+++ b/client/dashboard/agency/sites/site/backup-download.tsx
@@ -1,0 +1,42 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { agencySiteBackupDownloadRoute } from '../../../app/router/agency';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { BackupDownloadFlow } from '../../../sites/backup-download/flow';
+
+export default function AgencySiteBackupDownload() {
+	const { siteSlug, rewindId } = agencySiteBackupDownloadRoute.useParams();
+	const { downloadId } = agencySiteBackupDownloadRoute.useSearch();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const router = useRouter();
+
+	const handleDownloadIdConsumed = useCallback( () => {
+		router.navigate( {
+			to: agencySiteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId },
+			search: {},
+			replace: true,
+		} );
+	}, [ router, siteSlug, rewindId ] );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
+			}
+		>
+			<BackupDownloadFlow
+				site={ site }
+				rewindId={ rewindId }
+				initialDownloadId={ downloadId }
+				onDownloadIdConsumed={ handleDownloadIdConsumed }
+			/>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/sites/site/backup-restore.tsx
+++ b/client/dashboard/agency/sites/site/backup-restore.tsx
@@ -1,0 +1,24 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { agencySiteBackupRestoreRoute } from '../../../app/router/agency';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { BackupRestoreFlow } from '../../../sites/backup-restore/flow';
+
+export default function AgencySiteBackupRestore() {
+	const { siteSlug, rewindId } = agencySiteBackupRestoreRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Site restore' ) } />
+			}
+		>
+			<BackupRestoreFlow site={ site } rewindId={ rewindId } />
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/sites/site/backups-list-page.tsx
+++ b/client/dashboard/agency/sites/site/backups-list-page.tsx
@@ -1,0 +1,135 @@
+import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { DateRangePicker } from '@automattic/date-range-picker';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useParams, useRouter } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { useDateRange } from '../../../app/hooks/use-date-range';
+import { useLocale } from '../../../app/locale';
+import {
+	agencySiteRoute,
+	agencySiteBackupsIndexRoute,
+	agencySiteBackupDetailRoute,
+	agencySiteBackupRestoreRoute,
+	agencySiteBackupDownloadRoute,
+} from '../../../app/router/agency';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { BackupsBrowser, useIsBackupsSmallViewport } from '../../../sites/backups/backups-browser';
+import type { ActivityLogEntry } from '@automattic/api-core';
+
+export default function AgencySiteBackupsListPage() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	const router = useRouter();
+	const locale = useLocale();
+
+	const routeParams = useParams( { strict: false, shouldThrow: false } ) as
+		| { rewindId?: string }
+		| undefined;
+	const rewindId = routeParams?.rewindId;
+
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	const { data: siteSettings } = useSuspenseQuery( {
+		...siteSettingsQuery( site.ID ),
+		select: ( s ) => ( {
+			gmtOffset: Number( s?.gmt_offset ) || 0,
+			timezoneString: s?.timezone_string || undefined,
+		} ),
+	} );
+	const { gmtOffset, timezoneString } = siteSettings;
+
+	const { dateRange, handleDateRangeChange } = useDateRange( {
+		timezoneString,
+		gmtOffset,
+		defaultDays: 30,
+	} );
+
+	const navigateToBackup = useCallback(
+		( selected: ActivityLogEntry | null ) => {
+			router.navigate(
+				selected
+					? {
+							to: agencySiteBackupDetailRoute.fullPath,
+							params: { siteSlug, rewindId: selected.rewind_id },
+							search: ( query: Record< string, string > ) => query,
+					  }
+					: {
+							to: agencySiteBackupsIndexRoute.fullPath,
+							params: { siteSlug },
+							search: ( query: Record< string, string > ) => query,
+					  }
+			);
+		},
+		[ router, siteSlug ]
+	);
+
+	const handleRequestRestore = ( selected: ActivityLogEntry ) => {
+		router.navigate( {
+			to: agencySiteBackupRestoreRoute.fullPath,
+			params: { siteSlug, rewindId: selected.rewind_id },
+		} );
+	};
+
+	const handleRequestDownload = ( selected: ActivityLogEntry ) => {
+		router.navigate( {
+			to: agencySiteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId: selected.rewind_id },
+		} );
+	};
+
+	const handleGranularDownloadReady = ( selected: ActivityLogEntry, downloadId: number ) => {
+		router.navigate( {
+			to: agencySiteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId: selected.rewind_id },
+			search: { downloadId },
+		} );
+	};
+
+	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
+		handleDateRangeChange( next );
+		navigateToBackup( null );
+	};
+
+	const isMobileDetailsView = useIsBackupsSmallViewport() && !! rewindId;
+
+	const actions = (
+		<DateRangePicker
+			start={ dateRange.start }
+			end={ dateRange.end }
+			gmtOffset={ gmtOffset }
+			timezoneString={ timezoneString }
+			locale={ locale }
+			defaultFallbackPreset="last-30-days"
+			onChange={ handleDateRangeChangeWrapper }
+		/>
+	);
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
+					description={ __(
+						'Access and restore your site backups, powered by Jetpack VaultPress Backup.'
+					) }
+					prefix={ isMobileDetailsView ? <Breadcrumbs length={ 2 } /> : undefined }
+					actions={ isMobileDetailsView ? undefined : actions }
+				/>
+			}
+		>
+			<BackupsBrowser
+				site={ site }
+				rewindId={ rewindId }
+				dateRange={ dateRange }
+				timezoneString={ timezoneString }
+				gmtOffset={ gmtOffset }
+				onSelectBackup={ navigateToBackup }
+				onRequestRestore={ handleRequestRestore }
+				onRequestDownload={ handleRequestDownload }
+				onGranularDownloadReady={ handleGranularDownloadReady }
+			/>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/sites/site/backups-list-page.tsx
+++ b/client/dashboard/agency/sites/site/backups-list-page.tsx
@@ -1,12 +1,7 @@
-import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { DateRangePicker } from '@automattic/date-range-picker';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams, useRouter } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
-import { useCallback } from 'react';
-import Breadcrumbs from '../../../app/breadcrumbs';
-import { useDateRange } from '../../../app/hooks/use-date-range';
-import { useLocale } from '../../../app/locale';
+import { useMemo } from 'react';
 import {
 	agencySiteRoute,
 	agencySiteBackupsRoute,
@@ -15,145 +10,59 @@ import {
 	agencySiteBackupRestoreRoute,
 	agencySiteBackupDownloadRoute,
 } from '../../../app/router/agency';
-import { PageHeader } from '../../../components/page-header';
-import PageLayout from '../../../components/page-layout';
-import { BackupNotices } from '../../../sites/backups/backup-notices';
-import { BackupNowButton } from '../../../sites/backups/backup-now-button';
-import { BackupsBrowser, useIsBackupsSmallViewport } from '../../../sites/backups/backups-browser';
-import { useBackupState } from '../../../sites/backups/use-backup-state';
-import type { ActivityLogEntry } from '@automattic/api-core';
+import { BackupsPage, type BackupsNavigation } from '../../../sites/backups/backups-page';
 
 export default function AgencySiteBackupsListPage() {
 	const { siteSlug } = agencySiteRoute.useParams();
 	const router = useRouter();
-	const locale = useLocale();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const searchParams = agencySiteBackupsRoute.useSearch();
 
 	const routeParams = useParams( { strict: false, shouldThrow: false } ) as
 		| { rewindId?: string }
 		| undefined;
 	const rewindId = routeParams?.rewindId;
-	const searchParams = agencySiteBackupsRoute.useSearch();
 
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-	const { gmtOffset, timezoneString } = siteSettings;
-
-	const backupState = useBackupState( site.ID );
-
-	const { dateRange, handleDateRangeChange } = useDateRange( {
-		timezoneString,
-		gmtOffset,
-		defaultDays: 30,
-	} );
-
-	const navigateToBackup = useCallback(
-		( selected: ActivityLogEntry | null ) => {
-			router.navigate(
-				selected
-					? {
+	const navigation = useMemo< BackupsNavigation >(
+		() => ( {
+			selectBackup: ( id ) =>
+				id
+					? router.navigate( {
 							to: agencySiteBackupDetailRoute.fullPath,
-							params: { siteSlug, rewindId: selected.rewind_id },
+							params: { siteSlug, rewindId: id },
 							search: ( query: Record< string, string > ) => query,
-					  }
-					: {
+					  } )
+					: router.navigate( {
 							to: agencySiteBackupsIndexRoute.fullPath,
 							params: { siteSlug },
 							search: ( query: Record< string, string > ) => query,
-					  }
-			);
-		},
+					  } ),
+			requestRestore: ( id ) =>
+				router.navigate( {
+					to: agencySiteBackupRestoreRoute.fullPath,
+					params: { siteSlug, rewindId: id },
+				} ),
+			requestDownload: ( id, downloadId ) =>
+				downloadId
+					? router.navigate( {
+							to: agencySiteBackupDownloadRoute.fullPath,
+							params: { siteSlug, rewindId: id },
+							search: { downloadId },
+					  } )
+					: router.navigate( {
+							to: agencySiteBackupDownloadRoute.fullPath,
+							params: { siteSlug, rewindId: id },
+					  } ),
+		} ),
 		[ router, siteSlug ]
 	);
 
-	const handleRequestRestore = ( selected: ActivityLogEntry ) => {
-		router.navigate( {
-			to: agencySiteBackupRestoreRoute.fullPath,
-			params: { siteSlug, rewindId: selected.rewind_id },
-		} );
-	};
-
-	const handleRequestDownload = ( selected: ActivityLogEntry ) => {
-		router.navigate( {
-			to: agencySiteBackupDownloadRoute.fullPath,
-			params: { siteSlug, rewindId: selected.rewind_id },
-		} );
-	};
-
-	const handleGranularDownloadReady = ( selected: ActivityLogEntry, downloadId: number ) => {
-		router.navigate( {
-			to: agencySiteBackupDownloadRoute.fullPath,
-			params: { siteSlug, rewindId: selected.rewind_id },
-			search: { downloadId },
-		} );
-	};
-
-	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
-		handleDateRangeChange( next );
-		navigateToBackup( null );
-	};
-
-	const isMobileDetailsView = useIsBackupsSmallViewport() && !! rewindId;
-
-	const actions = (
-		<>
-			{ /* This div is required to fix a layout width issue when the DateRangePicker is placed together with the BackupNowButton. */ }
-			<div>
-				<DateRangePicker
-					start={ dateRange.start }
-					end={ dateRange.end }
-					gmtOffset={ gmtOffset }
-					timezoneString={ timezoneString }
-					locale={ locale }
-					defaultFallbackPreset="last-30-days"
-					onChange={ handleDateRangeChangeWrapper }
-				/>
-			</div>
-			<BackupNowButton site={ site } backupState={ backupState } />
-		</>
-	);
-
 	return (
-		<PageLayout
-			header={
-				<PageHeader
-					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
-					description={ __(
-						'Access and restore your site backups, powered by Jetpack VaultPress Backup.'
-					) }
-					prefix={ isMobileDetailsView ? <Breadcrumbs length={ 2 } /> : undefined }
-					actions={ isMobileDetailsView ? undefined : actions }
-				/>
-			}
-			notices={
-				! isMobileDetailsView && backupState.status !== 'idle' ? (
-					<BackupNotices
-						backupState={ backupState }
-						site={ site }
-						timezoneString={ timezoneString }
-						gmtOffset={ gmtOffset }
-					/>
-				) : undefined
-			}
-		>
-			<BackupsBrowser
-				site={ site }
-				rewindId={ rewindId }
-				dateRange={ dateRange }
-				timezoneString={ timezoneString }
-				gmtOffset={ gmtOffset }
-				searchParams={ searchParams }
-				onSelectBackup={ navigateToBackup }
-				onRequestRestore={ handleRequestRestore }
-				onRequestDownload={ handleRequestDownload }
-				onGranularDownloadReady={ handleGranularDownloadReady }
-			/>
-		</PageLayout>
+		<BackupsPage
+			site={ site }
+			navigation={ navigation }
+			rewindId={ rewindId }
+			searchParams={ searchParams }
+		/>
 	);
 }

--- a/client/dashboard/agency/sites/site/backups-list-page.tsx
+++ b/client/dashboard/agency/sites/site/backups-list-page.tsx
@@ -9,6 +9,7 @@ import { useDateRange } from '../../../app/hooks/use-date-range';
 import { useLocale } from '../../../app/locale';
 import {
 	agencySiteRoute,
+	agencySiteBackupsRoute,
 	agencySiteBackupsIndexRoute,
 	agencySiteBackupDetailRoute,
 	agencySiteBackupRestoreRoute,
@@ -16,7 +17,10 @@ import {
 } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { BackupNotices } from '../../../sites/backups/backup-notices';
+import { BackupNowButton } from '../../../sites/backups/backup-now-button';
 import { BackupsBrowser, useIsBackupsSmallViewport } from '../../../sites/backups/backups-browser';
+import { useBackupState } from '../../../sites/backups/use-backup-state';
 import type { ActivityLogEntry } from '@automattic/api-core';
 
 export default function AgencySiteBackupsListPage() {
@@ -28,6 +32,7 @@ export default function AgencySiteBackupsListPage() {
 		| { rewindId?: string }
 		| undefined;
 	const rewindId = routeParams?.rewindId;
+	const searchParams = agencySiteBackupsRoute.useSearch();
 
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
@@ -39,6 +44,8 @@ export default function AgencySiteBackupsListPage() {
 		} ),
 	} );
 	const { gmtOffset, timezoneString } = siteSettings;
+
+	const backupState = useBackupState( site.ID );
 
 	const { dateRange, handleDateRangeChange } = useDateRange( {
 		timezoneString,
@@ -95,15 +102,21 @@ export default function AgencySiteBackupsListPage() {
 	const isMobileDetailsView = useIsBackupsSmallViewport() && !! rewindId;
 
 	const actions = (
-		<DateRangePicker
-			start={ dateRange.start }
-			end={ dateRange.end }
-			gmtOffset={ gmtOffset }
-			timezoneString={ timezoneString }
-			locale={ locale }
-			defaultFallbackPreset="last-30-days"
-			onChange={ handleDateRangeChangeWrapper }
-		/>
+		<>
+			{ /* This div is required to fix a layout width issue when the DateRangePicker is placed together with the BackupNowButton. */ }
+			<div>
+				<DateRangePicker
+					start={ dateRange.start }
+					end={ dateRange.end }
+					gmtOffset={ gmtOffset }
+					timezoneString={ timezoneString }
+					locale={ locale }
+					defaultFallbackPreset="last-30-days"
+					onChange={ handleDateRangeChangeWrapper }
+				/>
+			</div>
+			<BackupNowButton site={ site } backupState={ backupState } />
+		</>
 	);
 
 	return (
@@ -118,6 +131,16 @@ export default function AgencySiteBackupsListPage() {
 					actions={ isMobileDetailsView ? undefined : actions }
 				/>
 			}
+			notices={
+				! isMobileDetailsView && backupState.status !== 'idle' ? (
+					<BackupNotices
+						backupState={ backupState }
+						site={ site }
+						timezoneString={ timezoneString }
+						gmtOffset={ gmtOffset }
+					/>
+				) : undefined
+			}
 		>
 			<BackupsBrowser
 				site={ site }
@@ -125,6 +148,7 @@ export default function AgencySiteBackupsListPage() {
 				dateRange={ dateRange }
 				timezoneString={ timezoneString }
 				gmtOffset={ gmtOffset }
+				searchParams={ searchParams }
 				onSelectBackup={ navigateToBackup }
 				onRequestRestore={ handleRequestRestore }
 				onRequestDownload={ handleRequestDownload }

--- a/client/dashboard/agency/sites/site/backups.tsx
+++ b/client/dashboard/agency/sites/site/backups.tsx
@@ -2,23 +2,18 @@ import { agencySiteQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, backup as backupIcon } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
-import { FileBrowserProvider } from '../../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
-import { useLocale } from '../../../app/locale';
 import { agencySiteRoute } from '../../../app/router/agency';
 import { Card, CardBody } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { Text } from '../../../components/text';
+import { BackupFileBrowserProvider } from '../../../sites/backups/backup-file-browser-provider';
 
 export default function AgencySiteBackups() {
 	const { siteSlug } = agencySiteRoute.useParams();
 	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
-	const locale = useLocale();
-	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 
 	if ( ! site?.has_backup ) {
 		return (
@@ -35,14 +30,9 @@ export default function AgencySiteBackups() {
 		);
 	}
 
-	const notices = {
-		showError: ( message: string ) => createErrorNotice( message, { type: 'snackbar' } ),
-		showSuccess: ( message: string ) => createSuccessNotice( message, { type: 'snackbar' } ),
-	};
-
 	return (
-		<FileBrowserProvider locale={ locale } notices={ notices }>
+		<BackupFileBrowserProvider>
 			<Outlet />
-		</FileBrowserProvider>
+		</BackupFileBrowserProvider>
 	);
 }

--- a/client/dashboard/agency/sites/site/backups.tsx
+++ b/client/dashboard/agency/sites/site/backups.tsx
@@ -1,0 +1,48 @@
+import { agencySiteQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { Icon, backup as backupIcon } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { FileBrowserProvider } from '../../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
+import { useLocale } from '../../../app/locale';
+import { agencySiteRoute } from '../../../app/router/agency';
+import { Card, CardBody } from '../../../components/card';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { Text } from '../../../components/text';
+
+export default function AgencySiteBackups() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
+	const locale = useLocale();
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+
+	if ( ! site?.has_backup ) {
+		return (
+			<PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> }>
+				<Card>
+					<CardBody>
+						<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+							<Icon icon={ backupIcon } />
+							<Text variant="muted">{ __( 'Backups aren’t enabled for this site.' ) }</Text>
+						</HStack>
+					</CardBody>
+				</Card>
+			</PageLayout>
+		);
+	}
+
+	const notices = {
+		showError: ( message: string ) => createErrorNotice( message, { type: 'snackbar' } ),
+		showSuccess: ( message: string ) => createSuccessNotice( message, { type: 'snackbar' } ),
+	};
+
+	return (
+		<FileBrowserProvider locale={ locale } notices={ notices }>
+			<Outlet />
+		</FileBrowserProvider>
+	);
+}

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -2,6 +2,7 @@ import { agencySiteRoute } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
+import BackupCard from './backup-card';
 
 export default function AgencySiteOverview() {
 	const site = agencySiteRoute.useLoaderData();
@@ -9,6 +10,8 @@ export default function AgencySiteOverview() {
 	return (
 		<PageLayout
 			header={ <PageHeader title={ getSiteName( site ) } description={ getDisplayUrl( site ) } /> }
-		/>
+		>
+			<BackupCard site={ site } />
+		</PageLayout>
 	);
 }

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -6,6 +6,9 @@ import {
 	mcpSettingsQuery,
 	queryClient,
 	rawUserPreferencesQuery,
+	siteBackupsQuery,
+	siteBySlugQuery,
+	siteSettingsQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute, notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
@@ -266,11 +269,26 @@ const agencySiteOverviewRoute = createRoute( {
 	)
 );
 
-// `/sites/$siteId/backups` – layout that hosts the backups list/detail views
-const agencySiteBackupsRoute = createRoute( {
+// `/sites/$siteSlug/backups` – layout that hosts the backups list/detail views
+export const agencySiteBackupsRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Backups' ) } ] } ),
 	getParentRoute: () => agencySiteRoute,
 	path: 'backups',
+	loader: async ( { params: { siteSlug } } ) => {
+		const [ agencySite, site ] = await Promise.all( [
+			queryClient.ensureQueryData( agencySiteQuery( siteSlug ) ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
+
+		if ( ! agencySite?.has_backup ) {
+			return;
+		}
+
+		await Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			queryClient.ensureQueryData( siteBackupsQuery( site.ID ) ),
+		] );
+	},
 } ).lazy( () =>
 	import( '../../agency/sites/site/backups' ).then( ( d ) =>
 		createLazyRoute( 'agency-site-backups' )( {
@@ -290,7 +308,7 @@ export const agencySiteBackupsIndexRoute = createRoute( {
 	)
 );
 
-// `/sites/$siteId/backups/$rewindId` – layout hosting the detail view + restore/download flows
+// `/sites/$siteSlug/backups/$rewindId` – layout hosting the detail view + restore/download flows
 export const agencySiteBackupDetailRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Backups' ) } ] } ),
 	getParentRoute: () => agencySiteBackupsRoute,

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -266,6 +266,78 @@ const agencySiteOverviewRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteId/backups` – layout that hosts the backups list/detail views
+const agencySiteBackupsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Backups' ) } ] } ),
+	getParentRoute: () => agencySiteRoute,
+	path: 'backups',
+} ).lazy( () =>
+	import( '../../agency/sites/site/backups' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-backups' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const agencySiteBackupsIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteBackupsRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../agency/sites/site/backups-list-page' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-backups-index' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// `/sites/$siteId/backups/$rewindId` – layout hosting the detail view + restore/download flows
+export const agencySiteBackupDetailRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Backups' ) } ] } ),
+	getParentRoute: () => agencySiteBackupsRoute,
+	path: '$rewindId',
+} );
+
+const agencySiteBackupDetailIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteBackupDetailRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../agency/sites/site/backups-list-page' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-backup-detail' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const agencySiteBackupRestoreRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Site restore' ) } ] } ),
+	getParentRoute: () => agencySiteBackupDetailRoute,
+	path: 'restore',
+} ).lazy( () =>
+	import( '../../agency/sites/site/backup-restore' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-backup-restore' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const agencySiteBackupDownloadRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Download backup' ) } ] } ),
+	getParentRoute: () => agencySiteBackupDetailRoute,
+	path: 'download',
+	validateSearch: ( search ) => {
+		const downloadId = Number( search.downloadId );
+		return {
+			downloadId: downloadId > 0 ? downloadId : undefined,
+		};
+	},
+} ).lazy( () =>
+	import( '../../agency/sites/site/backup-download' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-backup-download' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -279,6 +351,16 @@ export const createAgencyRoutes = () => [
 		earnWooPaymentsRoute,
 		earnMigrationsRoute,
 		earnPayoutSettingsRoute,
-		agencySiteRoute.addChildren( [ agencySiteOverviewRoute ] ),
+		agencySiteRoute.addChildren( [
+			agencySiteOverviewRoute,
+			agencySiteBackupsRoute.addChildren( [
+				agencySiteBackupsIndexRoute,
+				agencySiteBackupDetailRoute.addChildren( [
+					agencySiteBackupDetailIndexRoute,
+					agencySiteBackupRestoreRoute,
+					agencySiteBackupDownloadRoute,
+				] ),
+			] ),
+		] ),
 	] ),
 ];


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/112208.

Part of A4A-2905 
Resolves A4A-2915

This is **PR 2 of 2**. The shared, route-agnostic backup components it consumes were extracted in PR 1 (#112208); this PR contains only the A4A wiring (`client/dashboard/agency/**` + the agency router).

## Proposed Changes

* Adds the full **Backups** experience to the A4A agency site detail view — the activity-log restore-point list, the detail pane with file browser, **Download**, and **Restore** — reusing the shared backup components extracted in #112208.
* Adds thin A4A shells + routes: `/sites/$siteSlug/backups`, `.../$rewindId`, `.../restore`, `.../download`, gated on the agency site's `has_backup` flag.
* Adds a **Backups** item in the site-scoped sidebar and a Last-backup card on the Overview.

## Why are these changes being made?

* Agencies could view a site's detail but had no backup management there. This brings the dashboard's backup functionality to A4A without duplicating it — the shared extraction in #112208 keeps a single implementation for the list/detail/restore/download logic across variants.

## Testing Instructions

1. Build and run the Dashboard client for A4A (`yarn start-dashboard`) as an agency (non-client) user.
2. Open a backup-enabled agency site → **Backups** in the site sidebar (and the Last-backup card on Overview).
3. Confirm the restore-point list, date-range filtering, and the detail pane (file browser) render.
4. Confirm **Download backup** and **Restore to this point** navigate to their flows and complete.
5. Confirm the Last-backup card on the Overview links to the site's backups page (using the site URL slug) and reflects backup state.
6. Confirm the dotcom backups experience (multi-site dashboard) is unchanged.

<img width="1905" height="600" alt="Screenshot 2026-07-02 at 3 38 25 PM" src="https://github.com/user-attachments/assets/2839a1fb-e154-4f1e-bbc6-b01c2e332591" />

<img width="1905" height="865" alt="Screenshot 2026-07-02 at 3 38 56 PM" src="https://github.com/user-attachments/assets/0555d6d6-1e1e-44b9-80e0-92f2fa735a94" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
