### PR TITLE
Jetpack AI Sidebar: Bundle apply-block-edits fallback

### DIFF
--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -41,6 +41,17 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 | `jetpack_ai__show_component` | `handleShowComponent`       | via `getChatComponent` | Renders Jetpack AI chat components                       |
 | `big_sky__show_component`    | `handleLegacyShowComponent` | Jetpack or Big Sky     | Temporary migration support; delegates non-Jetpack types |
 | `wpcom/update-block-content` | `handleUpdateBlockContent`  | _(chat text)_          | Updates block content with shimmer effect                |
+| `big-sky/apply-block-edits`  | `handleApplyBlockEdits`     | _(chat text)_          | Batch block updates/inserts/deletes; bundled fallback    |
+
+### `big-sky/apply-block-edits` fallback
+
+The wpcom block-editing agent emits a client-executed call by the fixed name `big_sky__apply_block_edits`. When the Big Sky provider is loaded it registers and handles this ability; on surfaces without Big Sky, this package bundles a fallback so the call still resolves.
+
+- Same name is deliberate — see `src/utils/apply-block-edits/`. The engine is a trimmed port of Big Sky's Easy Site Editor implementation (block content editing only: no custom-CSS / global-styles staging, no contentOnly-section unlocking).
+- **Add-if-absent** (not filter-then-replace): `getAbilities()` bundles the fallback only when the host abilities list does not already contain `big_sky__apply_block_edits`. Big Sky registers into `window.wp.abilities`, so when it is loaded its ability is left in place and this fallback is skipped.
+- Returns `returnToAgent: true` (unlike `update-block-content`) because the backend agent needs the result to continue its workflow.
+- Custom CSS is refused with an explicit failure rather than silently dropped.
+- Eventual fix: abilities move into Agents Manager, removing the need for this duplicate.
 
 ### Show-component pattern
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -23,6 +23,12 @@ import TitlePicker from './components/title-picker';
 import './components/title-picker.scss';
 import './auto-scroll-fix.scss';
 import {
+	APPLY_BLOCK_EDITS_ABILITY,
+	APPLY_BLOCK_EDITS_NORMALIZED_ID,
+	isApplyBlockEditsTool,
+} from './utils/apply-block-edits/ability';
+import { handleApplyBlockEdits } from './utils/apply-block-edits/handle-apply-block-edits';
+import {
 	type CheckpointApi,
 	applyReviewEdit,
 	findBlockElement,
@@ -449,12 +455,29 @@ export const toolProvider = {
 		for ( const toolId of SHOW_COMPONENT_TOOL_IDS ) {
 			abilities = filterAbility( abilities, toolId );
 		}
+
+		// Add-if-absent (the opposite of the filter-then-replace above): only
+		// bundle the `big-sky/apply-block-edits` fallback when the Big Sky
+		// provider has not already registered it. When Big Sky is loaded it owns
+		// block editing, so its registered ability is left untouched here.
+		const hasApplyBlockEdits = abilities.some(
+			( a: any ) => normalizeAbilityName( a.name ?? '' ) === APPLY_BLOCK_EDITS_NORMALIZED_ID
+		);
+
 		const jetpackAbilities = [
 			...( isBlockTransformationsEnabled()
 				? [
 						{
 							...UPDATE_BLOCK_CONTENT_ABILITY,
 							callback: handleUpdateBlockContent,
+						},
+				  ]
+				: [] ),
+			...( ! hasApplyBlockEdits
+				? [
+						{
+							...APPLY_BLOCK_EDITS_ABILITY,
+							callback: handleApplyBlockEdits,
 						},
 				  ]
 				: [] ),
@@ -481,6 +504,10 @@ export const toolProvider = {
 		if ( isUpdateBlockContentTool( name ) ) {
 			const result = await handleUpdateBlockContent( args );
 			return { result, returnToAgent: false };
+		}
+
+		if ( isApplyBlockEditsTool( name ) ) {
+			return handleApplyBlockEdits( args );
 		}
 
 		if ( name === LEGACY_SHOW_COMPONENT_TOOL_ID && shouldDelegateLegacyShowComponent( args ) ) {

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/ability.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/ability.ts
@@ -1,0 +1,57 @@
+/**
+ * Descriptor + matcher for the bundled `big-sky/apply-block-edits` fallback.
+ *
+ * The name and schema mirror Big Sky's canonical `big-sky/apply-block-edits`
+ * ability — the backend wpcom block-editing agent emits this call by the fixed
+ * (Agents-Manager-normalized) id `big_sky__apply_block_edits`. Keeping the same
+ * name is what lets this fallback stand in on surfaces where the Big Sky
+ * provider is not loaded. The eventual fix is moving abilities into Agents
+ * Manager itself, which will remove the need for this duplicate.
+ */
+
+import type { Tool } from '@automattic/agenttic-client';
+
+export const APPLY_BLOCK_EDITS_TOOL_ID = 'big-sky/apply-block-edits';
+export const APPLY_BLOCK_EDITS_NORMALIZED_ID = 'big_sky__apply_block_edits';
+
+export const APPLY_BLOCK_EDITS_ABILITY: Tool = {
+	id: APPLY_BLOCK_EDITS_TOOL_ID,
+	name: APPLY_BLOCK_EDITS_TOOL_ID,
+	...( { label: 'Apply Block Edits', category: 'big-sky' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
+	description:
+		'Applies a collection of block edits (updates, insertions, deletions) to the editor.',
+	input_schema: {
+		type: 'object',
+		properties: {
+			updates: {
+				type: 'array',
+				description: 'Array of block updates to apply.',
+			},
+			inserts: {
+				type: 'array',
+				description: 'Array of block insertions to apply.',
+			},
+			deletes: {
+				type: 'array',
+				description: 'Array of block deletions (clientIds) to apply.',
+			},
+			summary: {
+				type: 'string',
+				description: 'Summary message to show to the user.',
+			},
+			reverseMap: {
+				type: 'object',
+				description: 'Optional reverse mapping for client IDs.',
+			},
+			customCSS: {
+				type: 'string',
+				description:
+					'Not supported on this surface; custom CSS / global styles editing is unavailable here.',
+			},
+		},
+	},
+};
+
+export function isApplyBlockEditsTool( toolId: string ): boolean {
+	return toolId === APPLY_BLOCK_EDITS_TOOL_ID || toolId === APPLY_BLOCK_EDITS_NORMALIZED_ID;
+}

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/block-edits.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/block-edits.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the pure block-edit engine ported from Big Sky's
+ * `big-sky/apply-block-edits` ability. These functions are dependency-injected
+ * (createBlock / available block types are passed in) so they carry no
+ * `@wordpress/*` or `window.wp` coupling and can be tested in isolation.
+ */
+import {
+	createBlockRecursively,
+	mergeBlockAttributes,
+	mergeBlocksRecursively,
+	normalizeBlockEdits,
+	resolveClientId,
+	validateBlockData,
+	validateBlockEdits,
+} from './block-edits';
+
+describe( 'resolveClientId', () => {
+	it( 'returns undefined for an empty or missing clientId', () => {
+		expect( resolveClientId( undefined, {} ) ).toBeUndefined();
+		expect( resolveClientId( null, {} ) ).toBeUndefined();
+		expect( resolveClientId( '', {} ) ).toBeUndefined();
+	} );
+
+	it( 'maps a compressed clientId through the reverse map', () => {
+		expect( resolveClientId( 'b1', { b1: 'real-1' } ) ).toBe( 'real-1' );
+	} );
+
+	it( 'falls back to the raw clientId when it is not in the map (real clientIds)', () => {
+		expect( resolveClientId( 'real-1', {} ) ).toBe( 'real-1' );
+	} );
+} );
+
+describe( 'normalizeBlockEdits', () => {
+	it( 'drops falsy update and insert entries', () => {
+		const edits = normalizeBlockEdits( {
+			updates: [ null as any, { clientId: 'a', name: 'core/paragraph' } ],
+			inserts: [ undefined as any, { block: { name: 'core/heading' } } ],
+			summary: 'x',
+		} );
+		expect( edits.updates ).toHaveLength( 1 );
+		expect( edits.inserts ).toHaveLength( 1 );
+	} );
+
+	it( 'coerces object-shaped deletes to clientId strings and drops the rest', () => {
+		const edits = normalizeBlockEdits( {
+			deletes: [ 'a', { clientId: 'b' }, {} as any, null as any ],
+			summary: 'x',
+		} );
+		expect( edits.deletes ).toEqual( [ 'a', 'b' ] );
+	} );
+
+	it( 'throws when there is nothing to do', () => {
+		expect( () => normalizeBlockEdits( {} ) ).toThrow();
+	} );
+
+	it( 'does not throw when only a summary is present', () => {
+		expect( () => normalizeBlockEdits( { summary: 'done' } ) ).not.toThrow();
+	} );
+
+	it( 'passes a string customCSS through', () => {
+		expect( normalizeBlockEdits( { customCSS: 'body{}' } ).customCSS ).toBe( 'body{}' );
+	} );
+} );
+
+describe( 'mergeBlockAttributes', () => {
+	it( 'deep-merges nested objects', () => {
+		expect(
+			mergeBlockAttributes( { style: { color: 'red', size: 1 } }, { style: { color: 'blue' } } )
+		).toEqual( { style: { color: 'blue', size: 1 } } );
+	} );
+
+	it( 'unsets a key when the source value is null', () => {
+		expect( mergeBlockAttributes( { a: 1, b: 2 }, { b: null } ) ).toEqual( { a: 1, b: undefined } );
+	} );
+
+	it( 'replaces (does not merge) arrays', () => {
+		expect( mergeBlockAttributes( { list: [ 1, 2, 3 ] }, { list: [ 9 ] } ) ).toEqual( {
+			list: [ 9 ],
+		} );
+	} );
+} );
+
+describe( 'mergeBlocksRecursively', () => {
+	it( 'returns the new block data when there is no original block', () => {
+		const data = { name: 'core/paragraph', attributes: { content: 'hi' } };
+		expect( mergeBlocksRecursively( null, data, {} ) ).toBe( data );
+	} );
+
+	it( 'preserves original attributes when the new attributes are an empty object', () => {
+		const original = {
+			clientId: 'a',
+			name: 'core/paragraph',
+			attributes: { content: 'keep me' },
+		};
+		const merged = mergeBlocksRecursively( original, { clientId: 'a', attributes: {} }, {} );
+		expect( merged.attributes ).toEqual( { content: 'keep me' } );
+	} );
+
+	it( 'deep-merges attributes when new attributes are provided', () => {
+		const original = {
+			clientId: 'a',
+			name: 'core/paragraph',
+			attributes: { content: 'old', level: 2 },
+		};
+		const merged = mergeBlocksRecursively(
+			original,
+			{ clientId: 'a', attributes: { content: 'new' } },
+			{}
+		);
+		expect( merged.attributes ).toEqual( { content: 'new', level: 2 } );
+	} );
+
+	it( 'throws when a bare { clientId } inner reference cannot be resolved', () => {
+		const original = {
+			clientId: 'a',
+			name: 'core/group',
+			attributes: {},
+			innerBlocks: [],
+		};
+		expect( () =>
+			mergeBlocksRecursively(
+				original,
+				{ clientId: 'a', innerBlocks: [ { clientId: 'missing' } ] },
+				{}
+			)
+		).toThrow();
+	} );
+} );
+
+describe( 'validateBlockData', () => {
+	const available = new Set( [ 'core/paragraph', 'core/heading' ] );
+
+	it( 'accepts a bare clientId reference when allowClientIdOnly is set', () => {
+		expect( () =>
+			validateBlockData( { clientId: 'a' }, available, { allowClientIdOnly: true } )
+		).not.toThrow();
+	} );
+
+	it( 'throws when a block has no name', () => {
+		expect( () => validateBlockData( {}, available ) ).toThrow();
+	} );
+
+	it( 'throws when the block type is not registered', () => {
+		expect( () => validateBlockData( { name: 'core/nonexistent' }, available ) ).toThrow();
+	} );
+
+	it( 'recurses into inner blocks', () => {
+		expect( () =>
+			validateBlockData(
+				{ name: 'core/paragraph', innerBlocks: [ { name: 'core/nonexistent' } ] },
+				available
+			)
+		).toThrow();
+	} );
+} );
+
+describe( 'validateBlockEdits', () => {
+	const available = new Set( [ 'core/paragraph' ] );
+
+	it( 'throws when an update is missing a clientId', () => {
+		expect( () =>
+			validateBlockEdits(
+				{ updates: [ { name: 'core/paragraph' } as any ], inserts: [], deletes: [] },
+				available
+			)
+		).toThrow();
+	} );
+
+	it( 'throws when an insert has no block name', () => {
+		expect( () =>
+			validateBlockEdits(
+				{ updates: [], inserts: [ { block: {} } as any ], deletes: [] },
+				available
+			)
+		).toThrow();
+	} );
+
+	it( 'accepts valid edits', () => {
+		expect( () =>
+			validateBlockEdits(
+				{
+					updates: [ { clientId: 'a', name: 'core/paragraph' } ],
+					inserts: [ { block: { name: 'core/paragraph' } } ],
+					deletes: [ 'b' ],
+				},
+				available
+			)
+		).not.toThrow();
+	} );
+} );
+
+describe( 'createBlockRecursively', () => {
+	// Fake createBlock mirroring @wordpress/blocks' signature.
+	const fakeCreateBlock = ( name: string, attributes: any, innerBlocks: any[] ) => ( {
+		clientId: `client-${ name }`,
+		name,
+		attributes,
+		innerBlocks,
+	} );
+
+	it( 'throws when the block data has no name', async () => {
+		await expect( createBlockRecursively( {}, fakeCreateBlock as any ) ).rejects.toThrow();
+	} );
+
+	it( 'creates a block with its attributes', async () => {
+		const block = await createBlockRecursively(
+			{ name: 'core/paragraph', attributes: { content: 'hi' } },
+			fakeCreateBlock as any
+		);
+		expect( block.name ).toBe( 'core/paragraph' );
+		expect( block.attributes ).toEqual( { content: 'hi' } );
+	} );
+
+	it( 'builds inner blocks recursively', async () => {
+		const block = await createBlockRecursively(
+			{
+				name: 'core/group',
+				innerBlocks: [ { name: 'core/paragraph', attributes: { content: 'child' } } ],
+			},
+			fakeCreateBlock as any
+		);
+		expect( block.innerBlocks ).toHaveLength( 1 );
+		expect( block.innerBlocks![ 0 ].name ).toBe( 'core/paragraph' );
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/block-edits.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/block-edits.ts
@@ -1,0 +1,258 @@
+/**
+ * Pure block-edit engine for the bundled `big-sky/apply-block-edits` fallback.
+ *
+ * Ported from Big Sky's Easy Site Editor implementation
+ * (`packages/easy-site-editor/src/lib/content-editor/block-edits.ts`), trimmed to
+ * the block-content-editing subset this surface needs: no custom-CSS / global
+ * styles staging and no contentOnly-section unlocking. `createBlock` and the set
+ * of registered block types are injected rather than imported so these functions
+ * stay free of `@wordpress/*` / `window.wp` coupling and remain unit-testable.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import type { ApplyBlockEditsArgs, BlockData, BlockInsert, BlockUpdate } from './types';
+
+export interface EditorBlock {
+	clientId: string;
+	name: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: EditorBlock[];
+}
+
+export interface CreatedBlock extends EditorBlock {
+	innerBlocks?: CreatedBlock[];
+}
+
+export interface NormalizedBlockEdits {
+	updates: BlockUpdate[];
+	inserts: BlockInsert[];
+	deletes: string[];
+	customCSS?: string;
+	summary?: string;
+	followUpTasks?: boolean;
+}
+
+export type CreateBlock = (
+	name: string,
+	attributes?: Record< string, unknown >,
+	innerBlocks?: CreatedBlock[]
+) => CreatedBlock;
+
+export function resolveClientId(
+	clientId: string | undefined | null,
+	reverseMap: Record< string, string >
+): string | undefined {
+	if ( ! clientId ) {
+		return undefined;
+	}
+
+	return reverseMap[ clientId ] || clientId;
+}
+
+export function normalizeBlockEdits( args: ApplyBlockEditsArgs ): NormalizedBlockEdits {
+	const updates = ( args.updates || [] ).filter( Boolean );
+	const inserts = ( args.inserts || [] ).filter( Boolean );
+	const deletes = ( args.deletes || [] )
+		.map( ( item ) => ( typeof item === 'string' ? item : item?.clientId ) )
+		.filter( ( clientId ): clientId is string => typeof clientId === 'string' && !! clientId );
+	const customCSS = typeof args.customCSS === 'string' ? args.customCSS : undefined;
+
+	if (
+		! updates.length &&
+		! inserts.length &&
+		! deletes.length &&
+		typeof customCSS === 'undefined' &&
+		! args.summary
+	) {
+		throw new Error(
+			__( 'Apply block edits needs at least one update, insert, delete, or summary.', 'jetpack' )
+		);
+	}
+
+	return {
+		updates,
+		inserts,
+		deletes,
+		customCSS,
+		summary: args.summary,
+		followUpTasks: args.followUpTasks,
+	};
+}
+
+// Deep-merges target and source objects. Setting a source key to `null` emits
+// `undefined` for that key so shallow-merge consumers like WordPress'
+// `updateBlockAttributes` actually overwrite the existing value with an unset
+// one (a bare `delete` would leave the old value intact after a spread).
+export function mergeBlockAttributes(
+	target: unknown,
+	source: unknown
+): Record< string, unknown > {
+	return deepMerge( target, source ) as Record< string, unknown >;
+}
+
+function deepMerge( target: unknown, source: unknown ): unknown {
+	if ( typeof source === 'undefined' ) {
+		return target;
+	}
+
+	if ( source === null ) {
+		return null;
+	}
+
+	if ( target === null || typeof target === 'undefined' ) {
+		return source;
+	}
+
+	if ( typeof source !== 'object' || Array.isArray( source ) ) {
+		return source;
+	}
+
+	if ( typeof target !== 'object' || Array.isArray( target ) ) {
+		return source;
+	}
+
+	const result = { ...( target as Record< string, unknown > ) };
+	const sourceRecord = source as Record< string, unknown >;
+
+	for ( const key of Object.keys( sourceRecord ) ) {
+		const mergedValue = deepMerge( result[ key ], sourceRecord[ key ] );
+		result[ key ] = mergedValue === null ? undefined : mergedValue;
+	}
+
+	return result;
+}
+
+// Recursively merges new block data onto an existing block, preserving
+// properties the new data does not override. `getBlock` is an optional live
+// lookup used to resolve inner blocks that a controlled parent (e.g.
+// `core/post-content`) reports with an empty local children list.
+export function mergeBlocksRecursively(
+	originalBlock: EditorBlock | null,
+	newBlockData: BlockData,
+	reverseMap: Record< string, string >,
+	getBlock?: ( clientId: string ) => EditorBlock | null
+): BlockData {
+	if ( ! originalBlock ) {
+		return newBlockData;
+	}
+
+	const shouldPreserveAttributes =
+		Array.isArray( newBlockData.attributes ) ||
+		( typeof newBlockData.attributes === 'object' &&
+			newBlockData.attributes !== null &&
+			Object.keys( newBlockData.attributes ).length === 0 );
+
+	const mergedBlock: BlockData = {
+		...originalBlock,
+		...newBlockData,
+		name: newBlockData.name || originalBlock.name,
+		attributes: shouldPreserveAttributes
+			? originalBlock.attributes || {}
+			: mergeBlockAttributes( originalBlock.attributes || {}, newBlockData.attributes || {} ),
+	};
+
+	if ( Array.isArray( newBlockData.innerBlocks ) ) {
+		mergedBlock.innerBlocks = newBlockData.innerBlocks.map( ( newInnerBlock ) => {
+			const originalClientId = resolveClientId( newInnerBlock.clientId, reverseMap );
+			const originalInnerBlock =
+				originalBlock.innerBlocks?.find( ( block ) => block.clientId === originalClientId ) ||
+				( originalClientId ? getBlock?.( originalClientId ) ?? null : null );
+
+			// A bare `{ clientId }` reference carries no block data of its own, so
+			// it only makes sense as a pointer to an existing block. Fail loudly
+			// rather than building a nameless block that later trips the opaque
+			// "Cannot create a block without a name." error.
+			if ( ! originalInnerBlock && ! newInnerBlock.name ) {
+				throw new Error(
+					sprintf(
+						/* translators: %s is a block client ID. */
+						__(
+							'Could not resolve existing block "%s" referenced while merging inner blocks.',
+							'jetpack'
+						),
+						String( newInnerBlock.clientId )
+					)
+				);
+			}
+
+			return mergeBlocksRecursively(
+				originalInnerBlock || null,
+				newInnerBlock,
+				reverseMap,
+				getBlock
+			);
+		} );
+	} else {
+		mergedBlock.innerBlocks = originalBlock.innerBlocks || [];
+	}
+
+	return mergedBlock;
+}
+
+export function validateBlockData(
+	block: BlockData,
+	availableBlocks: Set< string >,
+	options: { allowClientIdOnly?: boolean } = {}
+): void {
+	if ( options.allowClientIdOnly && block.clientId && ! block.name ) {
+		return;
+	}
+
+	if ( ! block.name ) {
+		throw new Error( __( 'Block data must include a block name.', 'jetpack' ) );
+	}
+
+	if ( ! availableBlocks.has( block.name ) ) {
+		throw new Error(
+			sprintf(
+				/* translators: %s is a block type name, such as core/paragraph. */
+				__( 'Block type "%s" is not available.', 'jetpack' ),
+				block.name
+			)
+		);
+	}
+
+	if ( block.innerBlocks?.length ) {
+		for ( const innerBlock of block.innerBlocks ) {
+			validateBlockData( innerBlock, availableBlocks, { allowClientIdOnly: true } );
+		}
+	}
+}
+
+export function validateBlockEdits(
+	edits: NormalizedBlockEdits,
+	availableBlocks: Set< string >
+): void {
+	for ( const update of edits.updates ) {
+		if ( ! update.clientId ) {
+			throw new Error(
+				__( 'Updates must include the clientId of the block to update.', 'jetpack' )
+			);
+		}
+		validateBlockData( update, availableBlocks, { allowClientIdOnly: true } );
+	}
+
+	for ( const insert of edits.inserts ) {
+		if ( ! insert.block?.name ) {
+			throw new Error( __( 'Insertions must include block data with a block name.', 'jetpack' ) );
+		}
+		validateBlockData( insert.block, availableBlocks );
+	}
+}
+
+export async function createBlockRecursively(
+	blockData: BlockData,
+	createBlock: CreateBlock
+): Promise< CreatedBlock > {
+	if ( ! blockData.name ) {
+		throw new Error( __( 'Cannot create a block without a name.', 'jetpack' ) );
+	}
+
+	const innerBlocks: CreatedBlock[] = Array.isArray( blockData.innerBlocks )
+		? await Promise.all(
+				blockData.innerBlocks.map( ( inner ) => createBlockRecursively( inner, createBlock ) )
+		  )
+		: [];
+
+	return createBlock( blockData.name, blockData.attributes || {}, innerBlocks );
+}

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/handle-apply-block-edits.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/handle-apply-block-edits.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Behavioural tests for the `handleApplyBlockEdits` client handler. A minimal
+ * in-memory block editor stands in for `window.wp.data` / `window.wp.blocks` so
+ * the insert / update / delete flow, the "no changes" honest-failure guard, and
+ * the custom-CSS refusal can be exercised without a real Gutenberg editor.
+ */
+import { handleApplyBlockEdits } from './handle-apply-block-edits';
+
+interface FakeBlock {
+	clientId: string;
+	name: string;
+	attributes: Record< string, unknown >;
+	innerBlocks: FakeBlock[];
+}
+
+function makeBlock(
+	partial: Partial< FakeBlock > & { clientId: string; name: string }
+): FakeBlock {
+	return { attributes: {}, innerBlocks: [], ...partial };
+}
+
+/**
+ * Install a fake `window.wp` backed by a mutable block tree and return helpers
+ * to inspect it. Registered block types default to a small allow-list.
+ */
+function installFakeEditor(
+	initial: FakeBlock[],
+	blockTypes = [ 'core/paragraph', 'core/heading', 'core/group' ]
+) {
+	const blocks = initial;
+	let counter = 0;
+
+	function findWithParent(
+		clientId: string,
+		list: FakeBlock[] = blocks
+	): { list: FakeBlock[]; index: number } | null {
+		for ( let i = 0; i < list.length; i++ ) {
+			if ( list[ i ].clientId === clientId ) {
+				return { list, index: i };
+			}
+			const nested = findWithParent( clientId, list[ i ].innerBlocks );
+			if ( nested ) {
+				return nested;
+			}
+		}
+		return null;
+	}
+
+	function getBlock( clientId: string ): FakeBlock | null {
+		const found = findWithParent( clientId );
+		return found ? found.list[ found.index ] : null;
+	}
+
+	function getBlockParents(
+		clientId: string,
+		list: FakeBlock[] = blocks,
+		trail: string[] = []
+	): string[] {
+		for ( const block of list ) {
+			if ( block.clientId === clientId ) {
+				return trail;
+			}
+			const nested = getBlockParents( clientId, block.innerBlocks, [ ...trail, block.clientId ] );
+			if ( nested.length || block.innerBlocks.some( ( b ) => b.clientId === clientId ) ) {
+				return nested;
+			}
+		}
+		return [];
+	}
+
+	( window as any ).wp = {
+		data: {
+			select: ( store: string ) =>
+				store === 'core/block-editor' ? { getBlock, getBlockParents, getBlocks: () => blocks } : {},
+			dispatch: ( store: string ) =>
+				store === 'core/block-editor'
+					? {
+							updateBlockAttributes: (
+								clientId: string,
+								attributes: Record< string, unknown >
+							) => {
+								const block = getBlock( clientId );
+								if ( block ) {
+									block.attributes = { ...block.attributes, ...attributes };
+								}
+							},
+							insertBlock: ( block: FakeBlock, index = 0, rootClientId?: string ) => {
+								const target = rootClientId ? getBlock( rootClientId )?.innerBlocks : blocks;
+								target?.splice( index, 0, block );
+							},
+							removeBlock: ( clientId: string ) => {
+								const found = findWithParent( clientId );
+								found?.list.splice( found.index, 1 );
+							},
+							replaceBlock: ( clientId: string, block: FakeBlock ) => {
+								const found = findWithParent( clientId );
+								if ( found ) {
+									found.list[ found.index ] = block;
+								}
+							},
+							replaceInnerBlocks: ( rootClientId: string, inner: FakeBlock[] ) => {
+								const block = getBlock( rootClientId );
+								if ( block ) {
+									block.innerBlocks = inner;
+								}
+							},
+					  }
+					: {},
+		},
+		blocks: {
+			createBlock: (
+				name: string,
+				attributes: Record< string, unknown > = {},
+				innerBlocks: FakeBlock[] = []
+			): FakeBlock =>
+				makeBlock( { clientId: `new-${ counter++ }`, name, attributes, innerBlocks } ),
+			getBlockTypes: () => blockTypes.map( ( name ) => ( { name } ) ),
+		},
+	};
+
+	return { getBlock, getBlocks: () => blocks };
+}
+
+afterEach( () => {
+	delete ( window as any ).wp;
+} );
+
+describe( 'handleApplyBlockEdits', () => {
+	it( 'applies an attribute update and reports success', async () => {
+		const editor = installFakeEditor( [
+			makeBlock( { clientId: 'a', name: 'core/paragraph', attributes: { content: 'old' } } ),
+		] );
+
+		const res = await handleApplyBlockEdits( {
+			updates: [ { clientId: 'a', name: 'core/paragraph', attributes: { content: 'new' } } ],
+			summary: 'Updated the paragraph.',
+		} );
+
+		expect( res.result.success ).toBe( true );
+		expect( res.returnToAgent ).toBe( true );
+		expect( editor.getBlock( 'a' )?.attributes.content ).toBe( 'new' );
+	} );
+
+	it( 'inserts a new block', async () => {
+		const editor = installFakeEditor( [ makeBlock( { clientId: 'a', name: 'core/paragraph' } ) ] );
+
+		const res = await handleApplyBlockEdits( {
+			inserts: [ { block: { name: 'core/heading', attributes: { content: 'Title' } } } ],
+		} );
+
+		expect( res.result.success ).toBe( true );
+		expect( editor.getBlocks() ).toHaveLength( 2 );
+	} );
+
+	it( 'deletes a block', async () => {
+		const editor = installFakeEditor( [
+			makeBlock( { clientId: 'a', name: 'core/paragraph' } ),
+			makeBlock( { clientId: 'b', name: 'core/heading' } ),
+		] );
+
+		const res = await handleApplyBlockEdits( { deletes: [ 'a' ] } );
+
+		expect( res.result.success ).toBe( true );
+		expect( editor.getBlock( 'a' ) ).toBeNull();
+		expect( editor.getBlocks() ).toHaveLength( 1 );
+	} );
+
+	it( 'returns an honest failure when the edits change nothing', async () => {
+		installFakeEditor( [
+			makeBlock( { clientId: 'a', name: 'core/paragraph', attributes: { content: 'same' } } ),
+		] );
+
+		const res = await handleApplyBlockEdits( {
+			updates: [ { clientId: 'a', name: 'core/paragraph', attributes: { content: 'same' } } ],
+		} );
+
+		expect( res.result.success ).toBe( false );
+		expect( res.returnToAgent ).toBe( true );
+	} );
+
+	it( 'refuses custom CSS instead of silently dropping it', async () => {
+		const editor = installFakeEditor( [ makeBlock( { clientId: 'a', name: 'core/paragraph' } ) ] );
+
+		const res = await handleApplyBlockEdits( { customCSS: 'body { color: red; }' } );
+
+		expect( res.result.success ).toBe( false );
+		expect( res.result.message.toLowerCase() ).toContain( 'css' );
+		// Blocks are untouched by a CSS-only request.
+		expect( editor.getBlocks() ).toHaveLength( 1 );
+	} );
+
+	it( 'reports an error result when a block type is not registered', async () => {
+		installFakeEditor( [ makeBlock( { clientId: 'a', name: 'core/paragraph' } ) ] );
+
+		const res = await handleApplyBlockEdits( {
+			inserts: [ { block: { name: 'core/does-not-exist' } } ],
+		} );
+
+		expect( res.result.success ).toBe( false );
+		expect( res.result.error ).toBeTruthy();
+		expect( res.returnToAgent ).toBe( true );
+	} );
+
+	it( 'fails gracefully when the editor is unavailable', async () => {
+		// No window.wp installed.
+		const res = await handleApplyBlockEdits( {
+			updates: [ { clientId: 'a', name: 'core/paragraph', attributes: { content: 'x' } } ],
+		} );
+
+		expect( res.result.success ).toBe( false );
+		expect( res.returnToAgent ).toBe( true );
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/handle-apply-block-edits.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/handle-apply-block-edits.ts
@@ -1,0 +1,216 @@
+/**
+ * Client handler for the bundled `big-sky/apply-block-edits` fallback ability.
+ *
+ * Applies a batch of block updates / insertions / deletions to the Gutenberg
+ * editor. Mirrors the behaviour of Big Sky's canonical apply-block-edits tool
+ * for the block-content-editing subset: no custom-CSS / global-styles staging
+ * and no contentOnly-section unlocking.
+ *
+ * Editor access goes through the `window.wp.data` / `window.wp.blocks` runtime
+ * globals (matching this package's `block-actions.ts` convention) rather than
+ * static `@wordpress/*` imports, so the handler targets the host editor's
+ * singleton stores and adds no bundled dependency.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { __ } from '@wordpress/i18n';
+import {
+	createBlockRecursively,
+	mergeBlocksRecursively,
+	normalizeBlockEdits,
+	resolveClientId,
+	validateBlockEdits,
+	type CreateBlock,
+	type EditorBlock,
+	type NormalizedBlockEdits,
+} from './block-edits';
+import type { ApplyBlockEditsArgs, ApplyBlockEditsResult } from './types';
+
+// `core/post-content` and `core/template-part` are controlled blocks: their
+// children are entity-backed and `replaceBlock` is silently a no-op on them, so
+// inner-block changes must go through `replaceInnerBlocks` instead.
+const CONTROLLED_INNER_BLOCK_PARENTS = new Set( [ 'core/post-content', 'core/template-part' ] );
+
+interface BlockEditorSelect {
+	getBlock: ( clientId: string ) => EditorBlock | null;
+	getBlockParents: ( clientId: string ) => string[];
+	getBlocks: () => EditorBlock[];
+}
+
+interface BlockEditorDispatch {
+	insertBlock: ( block: any, index?: number, rootClientId?: string ) => void;
+	removeBlock: ( clientId: string ) => void;
+	replaceBlock: ( clientId: string, block: any ) => void;
+	replaceInnerBlocks: ( rootClientId: string, blocks: any[] ) => void;
+	updateBlockAttributes: ( clientId: string, attributes: Record< string, unknown > ) => void;
+}
+
+function failure( message: string, error?: string ): ApplyBlockEditsResult {
+	return { result: { success: false, message, error }, returnToAgent: true };
+}
+
+async function applyEdits(
+	edits: NormalizedBlockEdits,
+	reverseMap: Record< string, string >,
+	select: BlockEditorSelect,
+	dispatch: BlockEditorDispatch,
+	createBlock: CreateBlock
+): Promise< void > {
+	const { getBlock, getBlockParents } = select;
+
+	// Inserts first: doing updates first would churn clientIds and break inserts.
+	for ( const insert of edits.inserts ) {
+		const originalParentClientId = resolveClientId( insert.parentClientId, reverseMap );
+
+		if ( insert.parentClientId && ! originalParentClientId ) {
+			throw new Error( __( 'Could not resolve the parent block for an insertion.', 'jetpack' ) );
+		}
+
+		if ( originalParentClientId && ! getBlock( originalParentClientId ) ) {
+			throw new Error( __( 'The parent block for an insertion was not found.', 'jetpack' ) );
+		}
+
+		const validBlock = await createBlockRecursively( insert.block, createBlock );
+		dispatch.insertBlock(
+			validBlock,
+			typeof insert.index === 'number' ? insert.index : 0,
+			originalParentClientId
+		);
+	}
+
+	// Updates deepest-first, so replacing an outer block does not invalidate the
+	// clientIds of inner blocks still queued for update.
+	const clientIdDepth = new Map< string, number >();
+	for ( const update of edits.updates ) {
+		const originalClientId = resolveClientId( update.clientId, reverseMap );
+		clientIdDepth.set(
+			update.clientId,
+			originalClientId ? getBlockParents( originalClientId )?.length ?? 0 : 0
+		);
+	}
+	const updates = [ ...edits.updates ].sort(
+		( a, b ) => ( clientIdDepth.get( b.clientId ) ?? 0 ) - ( clientIdDepth.get( a.clientId ) ?? 0 )
+	);
+
+	for ( const update of updates ) {
+		const { clientId, ...blockData } = update;
+		const originalClientId = resolveClientId( clientId, reverseMap );
+
+		if ( ! originalClientId ) {
+			throw new Error( __( 'Could not resolve a block to update.', 'jetpack' ) );
+		}
+
+		const targetBlock = getBlock( originalClientId );
+		if ( ! targetBlock ) {
+			throw new Error( __( 'A block to update was not found.', 'jetpack' ) );
+		}
+
+		const mergedBlockData = mergeBlocksRecursively( targetBlock, blockData, reverseMap, getBlock );
+		const hasInnerBlockChanges =
+			Array.isArray( blockData.innerBlocks ) && blockData.innerBlocks.length > 0;
+
+		if ( hasInnerBlockChanges ) {
+			const validBlock = await createBlockRecursively( mergedBlockData, createBlock );
+
+			if ( CONTROLLED_INNER_BLOCK_PARENTS.has( targetBlock.name ) ) {
+				dispatch.updateBlockAttributes( originalClientId, validBlock.attributes || {} );
+				dispatch.replaceInnerBlocks( originalClientId, validBlock.innerBlocks || [] );
+			} else {
+				dispatch.replaceBlock( originalClientId, validBlock );
+				reverseMap[ clientId ] = validBlock.clientId;
+			}
+		} else {
+			dispatch.updateBlockAttributes( originalClientId, mergedBlockData.attributes || {} );
+		}
+	}
+
+	// Deletes deepest-first for the same reason as updates.
+	const deletes = [ ...edits.deletes ].sort( ( a, b ) => {
+		const originalA = resolveClientId( a, reverseMap );
+		const originalB = resolveClientId( b, reverseMap );
+		return (
+			( originalB ? getBlockParents( originalB )?.length ?? 0 : 0 ) -
+			( originalA ? getBlockParents( originalA )?.length ?? 0 : 0 )
+		);
+	} );
+
+	for ( const clientId of deletes ) {
+		const originalClientId = resolveClientId( clientId, reverseMap );
+
+		if ( ! originalClientId ) {
+			throw new Error( __( 'Could not resolve a block to delete.', 'jetpack' ) );
+		}
+
+		if ( ! getBlock( originalClientId ) ) {
+			throw new Error( __( 'A block to delete was not found.', 'jetpack' ) );
+		}
+
+		dispatch.removeBlock( originalClientId );
+	}
+}
+
+export async function handleApplyBlockEdits(
+	input: ApplyBlockEditsArgs
+): Promise< ApplyBlockEditsResult > {
+	const wpData = ( window as any ).wp?.data;
+	const wpBlocks = ( window as any ).wp?.blocks;
+
+	if ( ! wpData || ! wpBlocks ) {
+		return failure(
+			__( 'The editor is not ready yet. Try the block edit again in a moment.', 'jetpack' ),
+			'Block editor stores are unavailable.'
+		);
+	}
+
+	// Custom CSS / global-styles editing is intentionally out of scope for this
+	// surface. Refuse it explicitly rather than silently dropping the request so
+	// the agent can report back to the user instead of claiming success.
+	if ( typeof input.customCSS === 'string' && input.customCSS.trim() ) {
+		return failure(
+			__( 'Editing custom CSS or global styles is not supported in this editor.', 'jetpack' ),
+			'customCSS is not supported.'
+		);
+	}
+
+	try {
+		const select: BlockEditorSelect = wpData.select( 'core/block-editor' );
+		const dispatch: BlockEditorDispatch = wpData.dispatch( 'core/block-editor' );
+		const createBlock: CreateBlock = wpBlocks.createBlock;
+
+		const edits = normalizeBlockEdits( input );
+		const availableBlocks = new Set< string >(
+			( wpBlocks.getBlockTypes() || [] ).map( ( blockType: any ) => blockType.name )
+		);
+		validateBlockEdits( edits, availableBlocks );
+
+		const reverseMap = input.reverseMap || {};
+		const before = JSON.stringify( select.getBlocks() );
+
+		await applyEdits( edits, reverseMap, select, dispatch, createBlock );
+
+		const after = JSON.stringify( select.getBlocks() );
+		if ( before === after ) {
+			return failure(
+				__(
+					'I was not able to make the requested changes. You can ask me to try again or to do something else.',
+					'jetpack'
+				),
+				'No block changes were detected after applying edits.'
+			);
+		}
+
+		return {
+			result: {
+				success: true,
+				message: edits.summary || __( 'I have applied the requested block edits.', 'jetpack' ),
+			},
+			returnToAgent: true,
+		};
+	} catch ( error ) {
+		return failure(
+			__( 'Something went wrong while applying the block edits. Please try again.', 'jetpack' ),
+			error instanceof Error ? error.message : String( error )
+		);
+	}
+}

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/types.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared types for the bundled `big-sky/apply-block-edits` fallback ability.
+ *
+ * These mirror the schema of Big Sky's canonical `big-sky/apply-block-edits`
+ * ability (backend-owned contract, emitted by the wpcom block-editing agent as
+ * `big_sky__apply_block_edits`). Kept dependency-free so the pure block-edit
+ * engine can import them without pulling in `@automattic/agenttic-client`.
+ */
+
+export interface BlockData {
+	name?: string;
+	clientId?: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: BlockData[] | null;
+}
+
+export interface BlockUpdate extends BlockData {
+	clientId: string;
+}
+
+export interface BlockInsert {
+	parentClientId?: string | null;
+	index?: number;
+	block: BlockData;
+}
+
+export type BlockDelete = string | { clientId?: string };
+
+export interface ApplyBlockEditsArgs {
+	updates?: BlockUpdate[];
+	inserts?: BlockInsert[];
+	deletes?: BlockDelete[];
+	customCSS?: string;
+	summary?: string;
+	followUpTasks?: boolean;
+	reverseMap?: Record< string, string >;
+}
+
+export interface ApplyBlockEditsResultData {
+	success: boolean;
+	message: string;
+	error?: string;
+	details?: unknown;
+}
+
+export interface ApplyBlockEditsResult {
+	result: ApplyBlockEditsResultData;
+	returnToAgent: boolean;
+	agentMessage?: string;
+}

--- a/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/wiring.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/apply-block-edits/wiring.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests that the provider surfaces the bundled `big-sky/apply-block-edits`
+ * fallback through `toolProvider`, but only when the Big Sky provider has not
+ * already registered it (add-if-absent), and routes `executeAbility` for the
+ * name to the local handler.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock( '../../extensions', () => ( {
+	registerBlockEditorFilters: jest.fn(),
+} ) );
+
+import { toolProvider } from '../../index';
+import { APPLY_BLOCK_EDITS_NORMALIZED_ID } from './ability';
+
+function normalize( name: string ): string {
+	return name.replace( /\//g, '__' ).replace( /-/g, '_' );
+}
+
+function setHostAbilities( list: any[] ): void {
+	( window as any ).wp = {
+		abilities: {
+			getAbilities: async () => list,
+			executeAbility: jest.fn(),
+		},
+	};
+}
+
+afterEach( () => {
+	delete ( window as any ).wp;
+	jest.restoreAllMocks();
+} );
+
+describe( 'apply-block-edits fallback wiring', () => {
+	it( 'adds the fallback ability when Big Sky has not registered it', async () => {
+		setHostAbilities( [] );
+
+		const abilities = await toolProvider.getAbilities();
+		const matches = abilities.filter(
+			( a: any ) => normalize( a.name ?? '' ) === APPLY_BLOCK_EDITS_NORMALIZED_ID
+		);
+
+		expect( matches ).toHaveLength( 1 );
+		expect( typeof matches[ 0 ].callback ).toBe( 'function' );
+	} );
+
+	it( 'does not add a duplicate when Big Sky already registered it', async () => {
+		const bigSkyAbility = { name: 'big-sky/apply-block-edits', callback: () => 'big-sky' };
+		setHostAbilities( [ bigSkyAbility ] );
+
+		const abilities = await toolProvider.getAbilities();
+		const matches = abilities.filter(
+			( a: any ) => normalize( a.name ?? '' ) === APPLY_BLOCK_EDITS_NORMALIZED_ID
+		);
+
+		expect( matches ).toHaveLength( 1 );
+		// Big Sky's registered ability is left in place, not replaced by the fallback.
+		expect( matches[ 0 ] ).toBe( bigSkyAbility );
+	} );
+
+	it( 'routes executeAbility for the normalized name to the local handler', async () => {
+		setHostAbilities( [] );
+
+		const res = await toolProvider.executeAbility( APPLY_BLOCK_EDITS_NORMALIZED_ID, {
+			updates: [],
+		} );
+
+		expect( res.result ).toBeDefined();
+		expect( res.returnToAgent ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Relates to FORNO-343

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
