### PR TITLE
Dashboard: Extract route-agnostic backup components for reuse

### DIFF
--- a/client/dashboard/sites/backup-download/download-page.tsx
+++ b/client/dashboard/sites/backup-download/download-page.tsx
@@ -1,0 +1,39 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { BackupDownloadFlow } from './flow';
+import type { Site } from '@automattic/api-core';
+
+interface BackupDownloadPageProps {
+	site: Site;
+	rewindId: string;
+	downloadId?: number;
+	// Clears the downloadId once it has seeded the flow; each variant navigates its own route.
+	onConsumeDownloadId: () => void;
+}
+
+export function BackupDownloadPage( {
+	site,
+	rewindId,
+	downloadId,
+	onConsumeDownloadId,
+}: BackupDownloadPageProps ) {
+	useEffect( () => {
+		if ( downloadId ) {
+			onConsumeDownloadId();
+		}
+	}, [ downloadId, onConsumeDownloadId ] );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
+			}
+		>
+			<BackupDownloadFlow site={ site } rewindId={ rewindId } initialDownloadId={ downloadId } />
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/backup-download/flow.tsx
+++ b/client/dashboard/sites/backup-download/flow.tsx
@@ -1,0 +1,138 @@
+import { siteSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState, useEffect } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { Card, CardBody } from '../../components/card';
+import { useFormattedTime } from '../../components/formatted-time';
+import SiteBackupDownloadError from './error';
+import SiteBackupDownloadForm from './form';
+import SiteBackupDownloadProgress from './progress';
+import SiteBackupDownloadSuccess from './success';
+import type { Site } from '@automattic/api-core';
+
+type DownloadStep = 'form' | 'progress' | 'success' | 'error';
+
+export function BackupDownloadFlow( {
+	site,
+	rewindId,
+	initialDownloadId,
+	onDownloadIdConsumed,
+}: {
+	site: Site;
+	rewindId: string;
+	initialDownloadId?: number;
+	onDownloadIdConsumed?: () => void;
+} ) {
+	const { data: siteSettings } = useSuspenseQuery( {
+		...siteSettingsQuery( site.ID ),
+		select: ( s ) => ( {
+			gmtOffset: Number( s?.gmt_offset ) || 0,
+			timezoneString: s?.timezone_string || undefined,
+		} ),
+	} );
+	const { gmtOffset, timezoneString } = siteSettings;
+
+	const initialStep: DownloadStep = initialDownloadId ? 'progress' : 'form';
+
+	const [ currentStep, setCurrentStep ] = useState< DownloadStep >( initialStep );
+	const [ downloadId, setDownloadId ] = useState< number | null >( initialDownloadId || null );
+	const [ downloadUrl, setDownloadUrl ] = useState< string | null >( null );
+	const [ fileSizeBytes, setFileSizeBytes ] = useState< string | undefined >();
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
+
+	// Clean up the downloadId query param once we've captured it.
+	useEffect( () => {
+		if ( initialDownloadId ) {
+			onDownloadIdConsumed?.();
+		}
+	}, [ initialDownloadId, onDownloadIdConsumed ] );
+
+	const handleDownloadInitiate = ( newDownloadId: number ) => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_started' );
+		setCurrentStep( 'progress' );
+		setDownloadId( newDownloadId );
+	};
+
+	const handleDownloadComplete = ( newDownloadUrl: string, newFileSizeBytes?: string ) => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_completed' );
+		setCurrentStep( 'success' );
+		setDownloadUrl( newDownloadUrl );
+		setFileSizeBytes( newFileSizeBytes );
+		createSuccessNotice( __( 'Backup download file is ready.' ), {
+			type: 'snackbar',
+		} );
+	};
+
+	const handleDownloadError = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_failed' );
+		setCurrentStep( 'error' );
+	};
+
+	const handleRetry = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_retry' );
+		setCurrentStep( 'form' );
+		setDownloadId( null );
+		setDownloadUrl( null );
+		setFileSizeBytes( undefined );
+	};
+
+	const downloadPointDate = useFormattedTime(
+		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
+		{
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
+
+	const renderStep = () => {
+		switch ( currentStep ) {
+			case 'form':
+				return (
+					<SiteBackupDownloadForm
+						siteId={ site.ID }
+						rewindId={ rewindId }
+						downloadPointDate={ downloadPointDate }
+						onDownloadInitiate={ handleDownloadInitiate }
+					/>
+				);
+			case 'progress':
+				return downloadId ? (
+					<SiteBackupDownloadProgress
+						site={ site }
+						downloadId={ downloadId }
+						onDownloadComplete={ handleDownloadComplete }
+						onDownloadError={ handleDownloadError }
+					/>
+				) : null;
+			case 'success':
+				return downloadUrl ? (
+					<SiteBackupDownloadSuccess
+						downloadPointDate={ downloadPointDate }
+						downloadUrl={ downloadUrl }
+						fileSizeBytes={ fileSizeBytes }
+					/>
+				) : null;
+			case 'error':
+				return <SiteBackupDownloadError onRetry={ handleRetry } />;
+		}
+	};
+
+	if ( currentStep === 'success' ) {
+		return <>{ renderStep() }</>;
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>{ renderStep() }</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/backup-download/flow.tsx
+++ b/client/dashboard/sites/backup-download/flow.tsx
@@ -4,7 +4,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -20,21 +20,14 @@ export function BackupDownloadFlow( {
 	site,
 	rewindId,
 	initialDownloadId,
-	onDownloadIdConsumed,
 }: {
 	site: Site;
 	rewindId: string;
 	initialDownloadId?: number;
-	onDownloadIdConsumed?: () => void;
 } ) {
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-	const { gmtOffset, timezoneString } = siteSettings;
+	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
+	const gmtOffset = siteSettings.gmt_offset;
+	const timezoneString = siteSettings.timezone_string;
 
 	const initialStep: DownloadStep = initialDownloadId ? 'progress' : 'form';
 
@@ -44,13 +37,6 @@ export function BackupDownloadFlow( {
 	const [ fileSizeBytes, setFileSizeBytes ] = useState< string | undefined >();
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
-
-	// Clean up the downloadId query param once we've captured it.
-	useEffect( () => {
-		if ( initialDownloadId ) {
-			onDownloadIdConsumed?.();
-		}
-	}, [ initialDownloadId, onDownloadIdConsumed ] );
 
 	const handleDownloadInitiate = ( newDownloadId: number ) => {
 		recordTracksEvent( 'calypso_dashboard_backups_download_started' );

--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -7,7 +7,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { siteBackupDownloadRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
 import type { DownloadConfig } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -51,14 +50,15 @@ const fields: Field< DownloadConfig >[] = [
 
 function SiteBackupDownloadForm( {
 	siteId,
+	rewindId,
 	downloadPointDate,
 	onDownloadInitiate,
 }: {
 	siteId: number;
+	rewindId: string;
 	downloadPointDate: string;
 	onDownloadInitiate: ( downloadId: number ) => void;
 } ) {
-	const { rewindId } = siteBackupDownloadRoute.useParams();
 	const { mutate: downloadMutation, isPending: isDownloadMutationPending } = useMutation(
 		siteBackupDownloadInitiateMutation( siteId )
 	);

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -2,7 +2,7 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from 'react';
+import { useEffect } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
@@ -15,14 +15,16 @@ function SiteBackupDownload() {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const router = useRouter();
 
-	const handleDownloadIdConsumed = useCallback( () => {
-		router.navigate( {
-			to: siteBackupDownloadRoute.fullPath,
-			params: { siteSlug, rewindId },
-			search: {},
-			replace: true,
-		} );
-	}, [ router, siteSlug, rewindId ] );
+	useEffect( () => {
+		if ( searchDownloadId ) {
+			router.navigate( {
+				to: siteBackupDownloadRoute.fullPath,
+				params: { siteSlug, rewindId },
+				search: {},
+				replace: true,
+			} );
+		}
+	}, [ router, siteSlug, rewindId, searchDownloadId ] );
 
 	return (
 		<PageLayout
@@ -35,7 +37,6 @@ function SiteBackupDownload() {
 				site={ site }
 				rewindId={ rewindId }
 				initialDownloadId={ searchDownloadId }
-				onDownloadIdConsumed={ handleDownloadIdConsumed }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,134 +1,28 @@
-import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-import { useState, useEffect } from 'react';
-import { useAnalytics } from '../../app/analytics';
+import { useCallback } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
-import { Card, CardBody } from '../../components/card';
-import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import SiteBackupDownloadError from './error';
-import SiteBackupDownloadForm from './form';
-import SiteBackupDownloadProgress from './progress';
-import SiteBackupDownloadSuccess from './success';
-
-type DownloadStep = 'form' | 'progress' | 'success' | 'error';
+import { BackupDownloadFlow } from './flow';
 
 function SiteBackupDownload() {
 	const { siteSlug, rewindId } = siteBackupDownloadRoute.useParams();
 	const { downloadId: searchDownloadId } = siteBackupDownloadRoute.useSearch();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-
-	const { gmtOffset, timezoneString } = siteSettings;
-
-	// Initialize step based on whether downloadId is provided in search params
-	const initialStep: DownloadStep = searchDownloadId ? 'progress' : 'form';
-
-	const [ currentStep, setCurrentStep ] = useState< DownloadStep >( initialStep );
-	const [ downloadId, setDownloadId ] = useState< number | null >( searchDownloadId || null );
-	const [ downloadUrl, setDownloadUrl ] = useState< string | null >( null );
-	const [ fileSizeBytes, setFileSizeBytes ] = useState< string | undefined >();
-	const { createSuccessNotice } = useDispatch( noticesStore );
-	const { recordTracksEvent } = useAnalytics();
-
 	const router = useRouter();
 
-	// Clean up the downloadId query param once we've captured it
-	useEffect( () => {
-		if ( searchDownloadId ) {
-			router.navigate( {
-				to: siteBackupDownloadRoute.fullPath,
-				params: { siteSlug, rewindId },
-				search: {},
-				replace: true,
-			} );
-		}
-	}, [ router, siteSlug, rewindId, searchDownloadId ] );
-
-	const handleDownloadInitiate = ( newDownloadId: number ) => {
-		recordTracksEvent( 'calypso_dashboard_backups_download_started' );
-		setCurrentStep( 'progress' );
-		setDownloadId( newDownloadId );
-	};
-
-	const handleDownloadComplete = ( newDownloadUrl: string, newFileSizeBytes?: string ) => {
-		recordTracksEvent( 'calypso_dashboard_backups_download_completed' );
-		setCurrentStep( 'success' );
-		setDownloadUrl( newDownloadUrl );
-		setFileSizeBytes( newFileSizeBytes );
-		createSuccessNotice( __( 'Backup download file is ready.' ), {
-			type: 'snackbar',
+	const handleDownloadIdConsumed = useCallback( () => {
+		router.navigate( {
+			to: siteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId },
+			search: {},
+			replace: true,
 		} );
-	};
-
-	const handleDownloadError = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_download_failed' );
-		setCurrentStep( 'error' );
-	};
-
-	const handleRetry = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_download_retry' );
-		setCurrentStep( 'form' );
-		setDownloadId( null );
-		setDownloadUrl( null );
-		setFileSizeBytes( undefined );
-	};
-
-	const downloadPointDate = useFormattedTime(
-		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
-		{
-			dateStyle: 'medium',
-			timeStyle: 'short',
-		},
-		timezoneString,
-		gmtOffset
-	);
-
-	const renderStep = () => {
-		switch ( currentStep ) {
-			case 'form':
-				return (
-					<SiteBackupDownloadForm
-						siteId={ site.ID }
-						downloadPointDate={ downloadPointDate }
-						onDownloadInitiate={ handleDownloadInitiate }
-					/>
-				);
-			case 'progress':
-				return downloadId ? (
-					<SiteBackupDownloadProgress
-						site={ site }
-						downloadId={ downloadId }
-						onDownloadComplete={ handleDownloadComplete }
-						onDownloadError={ handleDownloadError }
-					/>
-				) : null;
-			case 'success':
-				return downloadUrl ? (
-					<SiteBackupDownloadSuccess
-						downloadPointDate={ downloadPointDate }
-						downloadUrl={ downloadUrl }
-						fileSizeBytes={ fileSizeBytes }
-					/>
-				) : null;
-			case 'error':
-				return <SiteBackupDownloadError onRetry={ handleRetry } />;
-		}
-	};
+	}, [ router, siteSlug, rewindId ] );
 
 	return (
 		<PageLayout
@@ -137,15 +31,12 @@ function SiteBackupDownload() {
 				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
 			}
 		>
-			{ currentStep !== 'success' ? (
-				<Card>
-					<CardBody>
-						<VStack spacing={ 4 }>{ renderStep() }</VStack>
-					</CardBody>
-				</Card>
-			) : (
-				renderStep()
-			) }
+			<BackupDownloadFlow
+				site={ site }
+				rewindId={ rewindId }
+				initialDownloadId={ searchDownloadId }
+				onDownloadIdConsumed={ handleDownloadIdConsumed }
+			/>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,44 +1,32 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
-import { useEffect } from 'react';
-import Breadcrumbs from '../../app/breadcrumbs';
+import { useCallback } from 'react';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
-import { BackupDownloadFlow } from './flow';
+import { BackupDownloadPage } from './download-page';
 
 function SiteBackupDownload() {
 	const { siteSlug, rewindId } = siteBackupDownloadRoute.useParams();
-	const { downloadId: searchDownloadId } = siteBackupDownloadRoute.useSearch();
+	const { downloadId } = siteBackupDownloadRoute.useSearch();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const router = useRouter();
 
-	useEffect( () => {
-		if ( searchDownloadId ) {
-			router.navigate( {
-				to: siteBackupDownloadRoute.fullPath,
-				params: { siteSlug, rewindId },
-				search: {},
-				replace: true,
-			} );
-		}
-	}, [ router, siteSlug, rewindId, searchDownloadId ] );
+	const onConsumeDownloadId = useCallback( () => {
+		router.navigate( {
+			to: siteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId },
+			search: {},
+			replace: true,
+		} );
+	}, [ router, siteSlug, rewindId ] );
 
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
-			}
-		>
-			<BackupDownloadFlow
-				site={ site }
-				rewindId={ rewindId }
-				initialDownloadId={ searchDownloadId }
-			/>
-		</PageLayout>
+		<BackupDownloadPage
+			site={ site }
+			rewindId={ rewindId }
+			downloadId={ downloadId }
+			onConsumeDownloadId={ onConsumeDownloadId }
+		/>
 	);
 }
 

--- a/client/dashboard/sites/backup-restore/flow.tsx
+++ b/client/dashboard/sites/backup-restore/flow.tsx
@@ -1,0 +1,120 @@
+import { siteSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
+import { useAnalytics } from '../../app/analytics';
+import { Card, CardBody } from '../../components/card';
+import { useFormattedTime } from '../../components/formatted-time';
+import SiteBackupRestoreError from './error';
+import SiteBackupRestoreForm from './form';
+import SiteBackupGranularRestoreForm from './granular-form';
+import SiteBackupRestoreProgress from './progress';
+import SiteBackupRestoreSuccess from './success';
+import type { Site } from '@automattic/api-core';
+
+type RestoreStep = 'form' | 'progress' | 'success' | 'error';
+
+export function BackupRestoreFlow( { site, rewindId }: { site: Site; rewindId: string } ) {
+	const { data: siteSettings } = useSuspenseQuery( {
+		...siteSettingsQuery( site.ID ),
+		select: ( s ) => ( {
+			gmtOffset: Number( s?.gmt_offset ) || 0,
+			timezoneString: s?.timezone_string || undefined,
+		} ),
+	} );
+	const { gmtOffset, timezoneString } = siteSettings;
+
+	const [ currentStep, setCurrentStep ] = useState< RestoreStep >( 'form' );
+	const [ restoreId, setRestoreId ] = useState< number | null >( null );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
+	const { fileBrowserState } = useFileBrowserContext();
+	const browserSelectedList = fileBrowserState.getSelectedList( Number( rewindId ) );
+	const hasSelectedFiles = browserSelectedList.length > 0;
+	const hasSelectedAllFiles = browserSelectedList[ 0 ]?.path === '//';
+
+	const handleRestoreInitiate = ( newRestoreId: number ) => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_started' );
+		setCurrentStep( 'progress' );
+		setRestoreId( newRestoreId );
+	};
+
+	const handleRestoreComplete = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_completed' );
+		setCurrentStep( 'success' );
+		createSuccessNotice( __( 'Site restore completed.' ), {
+			type: 'snackbar',
+		} );
+	};
+
+	const handleRestoreError = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_failed' );
+		setCurrentStep( 'error' );
+	};
+
+	const handleRetry = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_retry' );
+		setCurrentStep( 'form' );
+		setRestoreId( null );
+	};
+
+	const restorePointDate = useFormattedTime(
+		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
+		{
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
+
+	const renderStep = () => {
+		switch ( currentStep ) {
+			case 'form':
+				return hasSelectedFiles && ! hasSelectedAllFiles ? (
+					<SiteBackupGranularRestoreForm
+						siteId={ site.ID }
+						rewindId={ rewindId }
+						restorePointDate={ restorePointDate }
+						onRestoreInitiate={ handleRestoreInitiate }
+					/>
+				) : (
+					<SiteBackupRestoreForm
+						siteId={ site.ID }
+						rewindId={ rewindId }
+						restorePointDate={ restorePointDate }
+						onRestoreInitiate={ handleRestoreInitiate }
+					/>
+				);
+			case 'progress':
+				return restoreId ? (
+					<SiteBackupRestoreProgress
+						site={ site }
+						restoreId={ restoreId }
+						onRestoreComplete={ handleRestoreComplete }
+						onRestoreError={ handleRestoreError }
+					/>
+				) : null;
+			case 'success':
+				return <SiteBackupRestoreSuccess site={ site } restorePointDate={ restorePointDate } />;
+			case 'error':
+				return <SiteBackupRestoreError onRetry={ handleRetry } />;
+		}
+	};
+
+	if ( currentStep === 'success' ) {
+		return <>{ renderStep() }</>;
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>{ renderStep() }</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/backup-restore/flow.tsx
+++ b/client/dashboard/sites/backup-restore/flow.tsx
@@ -19,14 +19,9 @@ import type { Site } from '@automattic/api-core';
 type RestoreStep = 'form' | 'progress' | 'success' | 'error';
 
 export function BackupRestoreFlow( { site, rewindId }: { site: Site; rewindId: string } ) {
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-	const { gmtOffset, timezoneString } = siteSettings;
+	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
+	const gmtOffset = siteSettings.gmt_offset;
+	const timezoneString = siteSettings.timezone_string;
 
 	const [ currentStep, setCurrentStep ] = useState< RestoreStep >( 'form' );
 	const [ restoreId, setRestoreId ] = useState< number | null >( null );

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -7,7 +7,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { siteBackupRestoreRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import type { RestoreConfig } from '@automattic/api-core';
@@ -52,14 +51,15 @@ const fields: Field< RestoreConfig >[] = [
 
 function SiteBackupRestoreForm( {
 	siteId,
+	rewindId,
 	restorePointDate,
 	onRestoreInitiate,
 }: {
 	siteId: number;
+	rewindId: string;
 	restorePointDate: string;
 	onRestoreInitiate: ( restoreId: number ) => void;
 } ) {
-	const { rewindId } = siteBackupRestoreRoute.useParams();
 	const { mutate: restoreMutation, isPending: isRestoreMutationPending } = useMutation(
 		siteBackupRestoreInitiateMutation( siteId )
 	);

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -6,7 +6,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
-import { siteBackupRestoreRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { Text } from '../../components/text';
@@ -14,14 +13,15 @@ import FileSectionPanelBody from './file-section-panel-body';
 
 function SiteBackupGranularRestoreForm( {
 	siteId,
+	rewindId,
 	restorePointDate,
 	onRestoreInitiate,
 }: {
 	siteId: number;
+	rewindId: string;
 	restorePointDate: string;
 	onRestoreInitiate: ( restoreId: number ) => void;
 } ) {
-	const { rewindId } = siteBackupRestoreRoute.useParams();
 	const { mutate: restoreMutation, isPending: isRestoreMutationPending } = useMutation(
 		siteBackupGranularRestoreMutation( siteId )
 	);

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -1,114 +1,15 @@
-import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
-import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
-import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
-import { Card, CardBody } from '../../components/card';
-import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import SiteBackupRestoreError from './error';
-import SiteBackupRestoreForm from './form';
-import SiteBackupGranularRestoreForm from './granular-form';
-import SiteBackupRestoreProgress from './progress';
-import SiteBackupRestoreSuccess from './success';
-
-type RestoreStep = 'form' | 'progress' | 'success' | 'error';
+import { BackupRestoreFlow } from './flow';
 
 function SiteBackupRestore() {
 	const { siteSlug, rewindId } = siteBackupRestoreRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-
-	const { gmtOffset, timezoneString } = siteSettings;
-	const [ currentStep, setCurrentStep ] = useState< RestoreStep >( 'form' );
-	const [ restoreId, setRestoreId ] = useState< number | null >( null );
-	const { createSuccessNotice } = useDispatch( noticesStore );
-	const { recordTracksEvent } = useAnalytics();
-	const { fileBrowserState } = useFileBrowserContext();
-	const browserSelectedList = fileBrowserState.getSelectedList( Number( rewindId ) );
-	const hasSelectedFiles = browserSelectedList.length > 0;
-	const hasSelectedAllFiles = browserSelectedList[ 0 ]?.path === '//';
-
-	const handleRestoreInitiate = ( newRestoreId: number ) => {
-		recordTracksEvent( 'calypso_dashboard_backups_restore_started' );
-		setCurrentStep( 'progress' );
-		setRestoreId( newRestoreId );
-	};
-
-	const handleRestoreComplete = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_restore_completed' );
-		setCurrentStep( 'success' );
-		createSuccessNotice( __( 'Site restore completed.' ), {
-			type: 'snackbar',
-		} );
-	};
-
-	const handleRestoreError = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_restore_failed' );
-		setCurrentStep( 'error' );
-	};
-
-	const handleRetry = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_restore_retry' );
-		setCurrentStep( 'form' );
-		setRestoreId( null );
-	};
-
-	const restorePointDate = useFormattedTime(
-		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
-		{
-			dateStyle: 'medium',
-			timeStyle: 'short',
-		},
-		timezoneString,
-		gmtOffset
-	);
-
-	const renderStep = () => {
-		switch ( currentStep ) {
-			case 'form':
-				return hasSelectedFiles && ! hasSelectedAllFiles ? (
-					<SiteBackupGranularRestoreForm
-						siteId={ site.ID }
-						restorePointDate={ restorePointDate }
-						onRestoreInitiate={ handleRestoreInitiate }
-					/>
-				) : (
-					<SiteBackupRestoreForm
-						siteId={ site.ID }
-						restorePointDate={ restorePointDate }
-						onRestoreInitiate={ handleRestoreInitiate }
-					/>
-				);
-			case 'progress':
-				return restoreId ? (
-					<SiteBackupRestoreProgress
-						site={ site }
-						restoreId={ restoreId }
-						onRestoreComplete={ handleRestoreComplete }
-						onRestoreError={ handleRestoreError }
-					/>
-				) : null;
-			case 'success':
-				return <SiteBackupRestoreSuccess site={ site } restorePointDate={ restorePointDate } />;
-			case 'error':
-				return <SiteBackupRestoreError onRetry={ handleRetry } />;
-		}
-	};
 
 	return (
 		<PageLayout
@@ -117,15 +18,7 @@ function SiteBackupRestore() {
 				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Site restore' ) } />
 			}
 		>
-			{ currentStep !== 'success' ? (
-				<Card>
-					<CardBody>
-						<VStack spacing={ 4 }>{ renderStep() }</VStack>
-					</CardBody>
-				</Card>
-			) : (
-				renderStep()
-			) }
+			<BackupRestoreFlow site={ site } rewindId={ rewindId } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -1,6 +1,5 @@
 import { siteGranularBackupDownloadInitiateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
@@ -13,7 +12,6 @@ import { useCallback } from 'react';
 import FileBrowser from '../../../my-sites/backup/backup-contents-page/file-browser';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import { useAnalytics } from '../../app/analytics';
-import { siteBackupRestoreRoute, siteBackupDownloadRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody, CardHeader } from '../../components/card';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -27,10 +25,20 @@ interface BackupDetailsProps {
 	site: Site;
 	timezoneString?: string;
 	gmtOffset?: number;
+	onRequestRestore?: () => void;
+	onRequestDownload?: () => void;
+	onGranularDownloadReady?: ( downloadId: number ) => void;
 }
 
-export function BackupDetails( { backup, site, timezoneString, gmtOffset }: BackupDetailsProps ) {
-	const router = useRouter();
+export function BackupDetails( {
+	backup,
+	site,
+	timezoneString,
+	gmtOffset,
+	onRequestRestore,
+	onRequestDownload,
+	onGranularDownloadReady,
+}: BackupDetailsProps ) {
 	const { recordTracksEvent } = useAnalytics();
 	const publishedTimestamp = backup.published || backup.last_published;
 	const formattedTime = useFormattedTime(
@@ -55,20 +63,6 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const direction = isSmallViewport ? 'column-reverse' : 'row';
 
-	const handleRestoreClick = () => {
-		router.navigate( {
-			to: siteBackupRestoreRoute.fullPath,
-			params: { siteSlug: site.slug, rewindId: backup.rewind_id },
-		} );
-	};
-
-	const handleDownloadClick = useCallback( () => {
-		router.navigate( {
-			to: siteBackupDownloadRoute.fullPath,
-			params: { siteSlug: site.slug, rewindId: backup.rewind_id },
-		} );
-	}, [ router, site.slug, backup.rewind_id ] );
-
 	const handleGranularDownloadClick = useCallback( () => {
 		const browserCheckList = fileBrowserState.getCheckList( Number( backup.rewind_id ) );
 		const includePaths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
@@ -84,12 +78,7 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 			},
 			{
 				onSuccess: ( downloadId ) => {
-					// Navigate to download page with the downloadId to skip the form
-					router.navigate( {
-						to: siteBackupDownloadRoute.fullPath,
-						params: { siteSlug: site.slug, rewindId: backup.rewind_id },
-						search: { downloadId },
-					} );
+					onGranularDownloadReady?.( downloadId );
 				},
 			}
 		);
@@ -98,37 +87,38 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 		recordTracksEvent,
 		granularDownloadMutate,
 		backup.rewind_id,
-		router,
-		site.slug,
+		onGranularDownloadReady,
 	] );
 
 	const hasSelectedFiles = selectedFilesCount > 0;
-	const actions = backup.rewind_id ? (
-		<ButtonStack alignment="stretch" justify="center" direction={ direction }>
-			<Button
-				variant="tertiary"
-				size={ isSmallViewport ? 'default' : 'compact' }
-				onClick={ hasSelectedFiles ? handleGranularDownloadClick : handleDownloadClick }
-				style={ { justifyContent: 'center' } }
-				disabled={ isGranularDownloadPending }
-				isBusy={ isGranularDownloadPending }
-			>
-				{ hasSelectedFiles
-					? _n( 'Download selected file', 'Download selected files', selectedFilesCount )
-					: __( 'Download backup' ) }
-			</Button>
-			<Button
-				variant="primary"
-				size={ isSmallViewport ? 'default' : 'compact' }
-				onClick={ handleRestoreClick }
-				style={ { justifyContent: 'center' } }
-			>
-				{ hasSelectedFiles
-					? _n( 'Restore selected file', 'Restore selected files', selectedFilesCount )
-					: __( 'Restore to this point' ) }
-			</Button>
-		</ButtonStack>
-	) : null;
+	const showActions = !! ( onRequestRestore || onRequestDownload );
+	const actions =
+		showActions && backup.rewind_id ? (
+			<ButtonStack alignment="stretch" justify="center" direction={ direction }>
+				<Button
+					variant="tertiary"
+					size={ isSmallViewport ? 'default' : 'compact' }
+					onClick={ hasSelectedFiles ? handleGranularDownloadClick : onRequestDownload }
+					style={ { justifyContent: 'center' } }
+					disabled={ isGranularDownloadPending }
+					isBusy={ isGranularDownloadPending }
+				>
+					{ hasSelectedFiles
+						? _n( 'Download selected file', 'Download selected files', selectedFilesCount )
+						: __( 'Download backup' ) }
+				</Button>
+				<Button
+					variant="primary"
+					size={ isSmallViewport ? 'default' : 'compact' }
+					onClick={ onRequestRestore }
+					style={ { justifyContent: 'center' } }
+				>
+					{ hasSelectedFiles
+						? _n( 'Restore selected file', 'Restore selected files', selectedFilesCount )
+						: __( 'Restore to this point' ) }
+				</Button>
+			</ButtonStack>
+		) : null;
 
 	return (
 		<Card>
@@ -168,10 +158,10 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 								rewindId={ Number( backup.rewind_id ) }
 								siteId={ site.ID }
 								siteSlug={ site.slug }
-								isRestoreEnabled
+								isRestoreEnabled={ !! onRequestRestore }
 								onTrackEvent={ recordTracksEvent }
 								source="dashboard"
-								onRequestGranularRestore={ handleRestoreClick }
+								onRequestGranularRestore={ onRequestRestore }
 							/>
 						</div>
 					) }

--- a/client/dashboard/sites/backups/backup-file-browser-provider.tsx
+++ b/client/dashboard/sites/backups/backup-file-browser-provider.tsx
@@ -1,0 +1,21 @@
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { FileBrowserProvider } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
+import { useLocale } from '../../app/locale';
+import type { ReactNode } from 'react';
+
+export function BackupFileBrowserProvider( { children }: { children: ReactNode } ) {
+	const locale = useLocale();
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+
+	const notices = {
+		showError: ( message: string ) => createErrorNotice( message, { type: 'snackbar' } ),
+		showSuccess: ( message: string ) => createSuccessNotice( message, { type: 'snackbar' } ),
+	};
+
+	return (
+		<FileBrowserProvider locale={ locale } notices={ notices }>
+			{ children }
+		</FileBrowserProvider>
+	);
+}

--- a/client/dashboard/sites/backups/backups-browser.tsx
+++ b/client/dashboard/sites/backups/backups-browser.tsx
@@ -1,0 +1,143 @@
+import { __experimentalGrid as Grid } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { useState, useEffect } from 'react';
+import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { Card, CardBody } from '../../components/card';
+import { BackupDetails } from './backup-details';
+import { BackupDetailsSkeleton } from './backup-details-skeleton';
+import { BackupsList } from './backups-list';
+import { useActivityLog } from './use-activity-log';
+import type { ActivityLogEntry, Site } from '@automattic/api-core';
+
+export function useIsBackupsSmallViewport() {
+	return useViewportMatch( 'xlarge', '<' );
+}
+
+interface BackupsBrowserProps {
+	site: Site;
+	rewindId?: string;
+	dateRange?: { start: Date; end: Date };
+	timezoneString?: string;
+	gmtOffset?: number;
+	searchParams?: Record< string, unknown >;
+	onSelectBackup: ( backup: ActivityLogEntry | null ) => void;
+	onRequestRestore?: ( backup: ActivityLogEntry ) => void;
+	onRequestDownload?: ( backup: ActivityLogEntry ) => void;
+	onGranularDownloadReady?: ( backup: ActivityLogEntry, downloadId: number ) => void;
+}
+
+export function BackupsBrowser( {
+	site,
+	rewindId,
+	dateRange,
+	timezoneString,
+	gmtOffset,
+	searchParams,
+	onSelectBackup,
+	onRequestRestore,
+	onRequestDownload,
+	onGranularDownloadReady,
+}: BackupsBrowserProps ) {
+	const isSmallViewport = useIsBackupsSmallViewport();
+	const [ selectedBackup, setSelectedBackupInState ] = useState< ActivityLogEntry | null >( null );
+
+	const { activityLog, isLoadingActivityLog } = useActivityLog( {
+		siteId: site.ID,
+		dateRange,
+		gmtOffset,
+		timezoneString,
+	} );
+
+	// Auto-select backup based on rewindId parameter.
+	useEffect( () => {
+		if ( rewindId && activityLog ) {
+			const targetBackup = activityLog.find( ( item ) => item.rewind_id === rewindId );
+			if ( targetBackup ) {
+				setSelectedBackupInState( targetBackup );
+			}
+			return;
+		}
+
+		// Select the first backup on the index route (desktop only) to keep the panel populated.
+		const backup = activityLog?.[ 0 ];
+		if ( ! rewindId && backup && ! isSmallViewport ) {
+			setSelectedBackupInState( backup );
+		}
+
+		if ( ! rewindId && ! backup ) {
+			setSelectedBackupInState( null );
+		}
+	}, [ rewindId, activityLog, isSmallViewport ] );
+
+	const renderDetails = ( backup: ActivityLogEntry ) => (
+		<BackupDetails
+			backup={ backup }
+			site={ site }
+			timezoneString={ timezoneString }
+			gmtOffset={ gmtOffset }
+			onRequestRestore={ onRequestRestore ? () => onRequestRestore( backup ) : undefined }
+			onRequestDownload={ onRequestDownload ? () => onRequestDownload( backup ) : undefined }
+			onGranularDownloadReady={
+				onGranularDownloadReady
+					? ( downloadId: number ) => onGranularDownloadReady( backup, downloadId )
+					: undefined
+			}
+		/>
+	);
+
+	const renderList = () => (
+		<BackupsList
+			siteId={ site.ID }
+			searchParams={ searchParams }
+			activityLog={ activityLog }
+			isLoadingActivityLog={ isLoadingActivityLog }
+			selectedBackup={ selectedBackup }
+			setSelectedBackup={ onSelectBackup }
+			dateRange={ dateRange }
+			timezoneString={ timezoneString }
+			gmtOffset={ gmtOffset }
+		/>
+	);
+
+	if ( isSmallViewport ) {
+		if ( selectedBackup ) {
+			return (
+				<>
+					<PerformanceTrackerStop />
+					{ renderDetails( selectedBackup ) }
+				</>
+			);
+		}
+
+		return (
+			<>
+				{ ! isLoadingActivityLog && <PerformanceTrackerStop /> }
+				{ renderList() }
+			</>
+		);
+	}
+
+	const renderDetailsPanel = () => {
+		if ( isLoadingActivityLog ) {
+			return <BackupDetailsSkeleton />;
+		}
+
+		if ( selectedBackup ) {
+			return renderDetails( selectedBackup );
+		}
+
+		return (
+			<Card>
+				<CardBody style={ { minHeight: '300px' } } children={ null } />
+			</Card>
+		);
+	};
+
+	return (
+		<Grid columns={ 2 } templateColumns="40% 1fr">
+			{ ! isLoadingActivityLog && <PerformanceTrackerStop /> }
+			{ renderList() }
+			{ renderDetailsPanel() }
+		</Grid>
+	);
+}

--- a/client/dashboard/sites/backups/backups-browser.tsx
+++ b/client/dashboard/sites/backups/backups-browser.tsx
@@ -1,6 +1,6 @@
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { Card, CardBody } from '../../components/card';
 import { BackupDetails } from './backup-details';
@@ -13,9 +13,51 @@ export function useIsBackupsSmallViewport() {
 	return useViewportMatch( 'xlarge', '<' );
 }
 
-interface BackupsBrowserProps {
+// Single owner of the resolved selection so the page header and browser body can't disagree.
+export function useBackupsBrowserState( {
+	site,
+	rewindId,
+	dateRange,
+	timezoneString,
+	gmtOffset,
+	enabled,
+}: {
 	site: Site;
 	rewindId?: string;
+	dateRange?: { start: Date; end: Date };
+	timezoneString?: string;
+	gmtOffset?: number;
+	enabled?: boolean;
+} ) {
+	const isSmallViewport = useIsBackupsSmallViewport();
+
+	const { activityLog, isLoadingActivityLog } = useActivityLog( {
+		siteId: site.ID,
+		dateRange,
+		gmtOffset,
+		timezoneString,
+		enabled,
+	} );
+
+	const selectedBackup = useMemo< ActivityLogEntry | null >( () => {
+		if ( rewindId ) {
+			return activityLog?.find( ( item ) => item.rewind_id === rewindId ) ?? null;
+		}
+		if ( ! isSmallViewport ) {
+			return activityLog?.[ 0 ] ?? null;
+		}
+		return null;
+	}, [ rewindId, activityLog, isSmallViewport ] );
+
+	return { activityLog, isLoadingActivityLog, selectedBackup, isSmallViewport };
+}
+
+interface BackupsBrowserProps {
+	site: Site;
+	activityLog: ActivityLogEntry[];
+	isLoadingActivityLog: boolean;
+	selectedBackup: ActivityLogEntry | null;
+	isSmallViewport: boolean;
 	dateRange?: { start: Date; end: Date };
 	timezoneString?: string;
 	gmtOffset?: number;
@@ -28,7 +70,10 @@ interface BackupsBrowserProps {
 
 export function BackupsBrowser( {
 	site,
-	rewindId,
+	activityLog,
+	isLoadingActivityLog,
+	selectedBackup,
+	isSmallViewport,
 	dateRange,
 	timezoneString,
 	gmtOffset,
@@ -38,37 +83,6 @@ export function BackupsBrowser( {
 	onRequestDownload,
 	onGranularDownloadReady,
 }: BackupsBrowserProps ) {
-	const isSmallViewport = useIsBackupsSmallViewport();
-	const [ selectedBackup, setSelectedBackupInState ] = useState< ActivityLogEntry | null >( null );
-
-	const { activityLog, isLoadingActivityLog } = useActivityLog( {
-		siteId: site.ID,
-		dateRange,
-		gmtOffset,
-		timezoneString,
-	} );
-
-	// Auto-select backup based on rewindId parameter.
-	useEffect( () => {
-		if ( rewindId && activityLog ) {
-			const targetBackup = activityLog.find( ( item ) => item.rewind_id === rewindId );
-			if ( targetBackup ) {
-				setSelectedBackupInState( targetBackup );
-			}
-			return;
-		}
-
-		// Select the first backup on the index route (desktop only) to keep the panel populated.
-		const backup = activityLog?.[ 0 ];
-		if ( ! rewindId && backup && ! isSmallViewport ) {
-			setSelectedBackupInState( backup );
-		}
-
-		if ( ! rewindId && ! backup ) {
-			setSelectedBackupInState( null );
-		}
-	}, [ rewindId, activityLog, isSmallViewport ] );
-
 	const renderDetails = ( backup: ActivityLogEntry ) => (
 		<BackupDetails
 			backup={ backup }

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -1,10 +1,9 @@
-import { siteBackupActivityLogGroupCountsQuery, siteBySlugQuery } from '@automattic/api-queries';
-import { useSuspenseQuery, useQuery } from '@tanstack/react-query';
+import { siteBackupActivityLogGroupCountsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo } from 'react';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
-import { siteRoute, siteBackupsRoute } from '../../app/router/sites';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { buildTimeRangeForActivityLog } from '../../utils/site-activity-log';
 import { getFields } from './dataviews/fields';
@@ -28,6 +27,8 @@ const defaultView: View = {
 };
 
 export function BackupsList( {
+	siteId,
+	searchParams,
 	selectedBackup,
 	setSelectedBackup,
 	dateRange,
@@ -36,6 +37,8 @@ export function BackupsList( {
 	activityLog,
 	isLoadingActivityLog,
 }: {
+	siteId: number;
+	searchParams?: Record< string, unknown >;
 	selectedBackup: ActivityLogEntry | null;
 	setSelectedBackup: ( backup: ActivityLogEntry | null ) => void;
 	dateRange?: { start: Date; end: Date };
@@ -44,10 +47,6 @@ export function BackupsList( {
 	activityLog: ActivityLogEntry[];
 	isLoadingActivityLog: boolean;
 } ) {
-	const { siteSlug } = siteRoute.useParams();
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-
-	const searchParams = siteBackupsRoute.useSearch();
 	const { view, updateView, resetView } = usePersistentView( {
 		slug: 'site-backups',
 		defaultView,
@@ -68,7 +67,7 @@ export function BackupsList( {
 	}, [ dateRange, timezoneString, gmtOffset ] );
 
 	const { data: groupCountsData } = useQuery(
-		siteBackupActivityLogGroupCountsQuery( site.ID, after, before )
+		siteBackupActivityLogGroupCountsQuery( siteId, after, before )
 	);
 
 	const fields = getFields( groupCountsData?.groups, timezoneString, gmtOffset );

--- a/client/dashboard/sites/backups/backups-page.tsx
+++ b/client/dashboard/sites/backups/backups-page.tsx
@@ -1,0 +1,141 @@
+import { siteSettingsQuery } from '@automattic/api-queries';
+import { DateRangePicker } from '@automattic/date-range-picker';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { useDateRange } from '../../app/hooks/use-date-range';
+import { useLocale } from '../../app/locale';
+import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { BackupNotices } from './backup-notices';
+import { BackupNowButton } from './backup-now-button';
+import { BackupsBrowser, useBackupsBrowserState } from './backups-browser';
+import { useBackupState } from './use-backup-state';
+import type { Site } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+// The route-specific navigation each variant (dotcom, A4A) wires to its own route tree,
+// so the page shell below stays route-agnostic. Passing `null` clears back to the index route.
+export interface BackupsNavigation {
+	selectBackup: ( rewindId: string | null ) => void;
+	requestRestore: ( rewindId: string ) => void;
+	requestDownload: ( rewindId: string, downloadId?: number ) => void;
+}
+
+interface BackupsPageProps {
+	site: Site;
+	navigation: BackupsNavigation;
+	rewindId?: string;
+	searchParams?: Record< string, unknown >;
+	hasBackups?: boolean;
+	extraNotices?: ReactNode;
+}
+
+export function BackupsPage( {
+	site,
+	navigation,
+	rewindId,
+	searchParams,
+	hasBackups = true,
+	extraNotices,
+}: BackupsPageProps ) {
+	const locale = useLocale();
+	const backupState = useBackupState( site.ID );
+
+	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
+	const gmtOffset = siteSettings.gmt_offset;
+	const timezoneString = siteSettings.timezone_string;
+
+	const { dateRange, handleDateRangeChange } = useDateRange( {
+		timezoneString,
+		gmtOffset,
+		defaultDays: 30,
+	} );
+
+	const { activityLog, isLoadingActivityLog, selectedBackup, isSmallViewport } =
+		useBackupsBrowserState( {
+			site,
+			rewindId,
+			dateRange,
+			timezoneString,
+			gmtOffset,
+			enabled: hasBackups,
+		} );
+	const isMobileDetailsView = isSmallViewport && !! selectedBackup;
+	const shouldShowActions = hasBackups && ! isMobileDetailsView;
+
+	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
+		handleDateRangeChange( next );
+		navigation.selectBackup( null );
+	};
+
+	const actions = (
+		<>
+			{ /* This div is required to fix a layout width issue when the DateRangePicker is placed together with the BackupNowButton. */ }
+			<div>
+				<DateRangePicker
+					start={ dateRange.start }
+					end={ dateRange.end }
+					gmtOffset={ gmtOffset }
+					timezoneString={ timezoneString }
+					locale={ locale }
+					defaultFallbackPreset="last-30-days"
+					onChange={ handleDateRangeChangeWrapper }
+				/>
+			</div>
+			<BackupNowButton site={ site } backupState={ backupState } />
+		</>
+	);
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
+					description={ __(
+						'Access and restore your site backups, powered by Jetpack VaultPress Backup.'
+					) }
+					prefix={ isMobileDetailsView ? <Breadcrumbs length={ 2 } /> : undefined }
+					actions={ shouldShowActions ? actions : undefined }
+				/>
+			}
+			notices={
+				<>
+					{ /* Action feedback, not an on-load banner: rendered outside the arbiter. */ }
+					{ ! isMobileDetailsView && backupState.status !== 'idle' && (
+						<BackupNotices
+							backupState={ backupState }
+							site={ site }
+							timezoneString={ timezoneString }
+							gmtOffset={ gmtOffset }
+						/>
+					) }
+					{ extraNotices }
+				</>
+			}
+		>
+			{ hasBackups ? (
+				<BackupsBrowser
+					site={ site }
+					activityLog={ activityLog }
+					isLoadingActivityLog={ isLoadingActivityLog }
+					selectedBackup={ selectedBackup }
+					isSmallViewport={ isSmallViewport }
+					dateRange={ dateRange }
+					timezoneString={ timezoneString }
+					gmtOffset={ gmtOffset }
+					searchParams={ searchParams }
+					onSelectBackup={ ( selected ) => navigation.selectBackup( selected?.rewind_id ?? null ) }
+					onRequestRestore={ ( selected ) => navigation.requestRestore( selected.rewind_id ) }
+					onRequestDownload={ ( selected ) => navigation.requestDownload( selected.rewind_id ) }
+					onGranularDownloadReady={ ( selected, downloadId ) =>
+						navigation.requestDownload( selected.rewind_id, downloadId )
+					}
+				/>
+			) : (
+				<PerformanceTrackerStop />
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -28,7 +28,7 @@ import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callou
 import { SitesNoticeArbiter } from '../notice-arbiter';
 import { BackupNotices } from './backup-notices';
 import { BackupNowButton } from './backup-now-button';
-import { BackupsBrowser, useIsBackupsSmallViewport } from './backups-browser';
+import { BackupsBrowser, useBackupsBrowserState } from './backups-browser';
 import illustrationUrl from './backups-callout-illustration.svg';
 import { useBackupState } from './use-backup-state';
 import './style.scss';
@@ -48,14 +48,9 @@ export function BackupsListPage() {
 	const searchParams = siteBackupsRoute.useSearch();
 	const backupState = useBackupState( site.ID );
 
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-	const { gmtOffset, timezoneString } = siteSettings;
+	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
+	const gmtOffset = siteSettings.gmt_offset;
+	const timezoneString = siteSettings.timezone_string;
 
 	const { dateRange, handleDateRangeChange } = useDateRange( {
 		timezoneString,
@@ -109,9 +104,17 @@ export function BackupsListPage() {
 		navigateToBackup( null );
 	};
 
-	const isSmallViewport = useIsBackupsSmallViewport();
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-	const isMobileDetailsView = isSmallViewport && !! rewindId;
+	const { activityLog, isLoadingActivityLog, selectedBackup, isSmallViewport } =
+		useBackupsBrowserState( {
+			site,
+			rewindId,
+			dateRange,
+			timezoneString,
+			gmtOffset,
+			enabled: hasBackups,
+		} );
+	const isMobileDetailsView = isSmallViewport && !! selectedBackup;
 	const shouldShowActions = hasBackups && ! isMobileDetailsView;
 
 	const actions = (
@@ -162,7 +165,10 @@ export function BackupsListPage() {
 			{ hasBackups ? (
 				<BackupsBrowser
 					site={ site }
-					rewindId={ rewindId }
+					activityLog={ activityLog }
+					isLoadingActivityLog={ isLoadingActivityLog }
+					selectedBackup={ selectedBackup }
+					isSmallViewport={ isSmallViewport }
 					dateRange={ dateRange }
 					timezoneString={ timezoneString }
 					gmtOffset={ gmtOffset }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -1,18 +1,10 @@
 import { HostingFeatures } from '@automattic/api-core';
-import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { DateRangePicker } from '@automattic/date-range-picker';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, useParams, useRouter } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { backup } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
-import { useCallback } from 'react';
-import { FileBrowserProvider } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
-import Breadcrumbs from '../../app/breadcrumbs';
-import { useDateRange } from '../../app/hooks/use-date-range';
-import { useLocale } from '../../app/locale';
-import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { useMemo } from 'react';
 import {
 	siteRoute,
 	siteBackupsRoute,
@@ -21,180 +13,74 @@ import {
 	siteBackupRestoreRoute,
 	siteBackupDownloadRoute,
 } from '../../app/router/sites';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { SitesNoticeArbiter } from '../notice-arbiter';
-import { BackupNotices } from './backup-notices';
-import { BackupNowButton } from './backup-now-button';
-import { BackupsBrowser, useBackupsBrowserState } from './backups-browser';
+import { BackupFileBrowserProvider } from './backup-file-browser-provider';
 import illustrationUrl from './backups-callout-illustration.svg';
-import { useBackupState } from './use-backup-state';
+import { BackupsPage, type BackupsNavigation } from './backups-page';
 import './style.scss';
-import type { ActivityLogEntry } from '@automattic/api-core';
 
 export function BackupsListPage() {
-	const locale = useLocale();
 	const { siteSlug } = siteRoute.useParams();
 	const router = useRouter();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const searchParams = siteBackupsRoute.useSearch();
 
 	const routeParams = useParams( { strict: false, shouldThrow: false } ) as
 		| { rewindId?: string }
 		| undefined;
 	const rewindId = routeParams?.rewindId;
 
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const searchParams = siteBackupsRoute.useSearch();
-	const backupState = useBackupState( site.ID );
-
-	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
-	const gmtOffset = siteSettings.gmt_offset;
-	const timezoneString = siteSettings.timezone_string;
-
-	const { dateRange, handleDateRangeChange } = useDateRange( {
-		timezoneString,
-		gmtOffset,
-		defaultDays: 30,
-	} );
-
-	const navigateToBackup = useCallback(
-		( selected: ActivityLogEntry | null ) => {
-			if ( selected ) {
+	const navigation = useMemo< BackupsNavigation >(
+		() => ( {
+			selectBackup: ( id ) =>
+				id
+					? router.navigate( {
+							to: siteBackupDetailRoute.fullPath,
+							params: { siteSlug, rewindId: id },
+							search: ( query: Record< string, string > ) => query,
+					  } )
+					: router.navigate( {
+							to: siteBackupsIndexRoute.fullPath,
+							params: { siteSlug },
+							search: ( query: Record< string, string > ) => query,
+					  } ),
+			requestRestore: ( id ) =>
 				router.navigate( {
-					to: siteBackupDetailRoute.fullPath,
-					params: { siteSlug, rewindId: selected.rewind_id },
-					search: ( query: Record< string, string > ) => query,
-				} );
-			} else {
-				router.navigate( {
-					to: siteBackupsIndexRoute.fullPath,
-					params: { siteSlug },
-					search: ( query: Record< string, string > ) => query,
-				} );
-			}
-		},
+					to: siteBackupRestoreRoute.fullPath,
+					params: { siteSlug, rewindId: id },
+				} ),
+			requestDownload: ( id, downloadId ) =>
+				downloadId
+					? router.navigate( {
+							to: siteBackupDownloadRoute.fullPath,
+							params: { siteSlug, rewindId: id },
+							search: { downloadId },
+					  } )
+					: router.navigate( {
+							to: siteBackupDownloadRoute.fullPath,
+							params: { siteSlug, rewindId: id },
+					  } ),
+		} ),
 		[ router, siteSlug ]
 	);
 
-	const handleRequestRestore = ( selected: ActivityLogEntry ) => {
-		router.navigate( {
-			to: siteBackupRestoreRoute.fullPath,
-			params: { siteSlug, rewindId: selected.rewind_id },
-		} );
-	};
-
-	const handleRequestDownload = ( selected: ActivityLogEntry ) => {
-		router.navigate( {
-			to: siteBackupDownloadRoute.fullPath,
-			params: { siteSlug, rewindId: selected.rewind_id },
-		} );
-	};
-
-	const handleGranularDownloadReady = ( selected: ActivityLogEntry, downloadId: number ) => {
-		router.navigate( {
-			to: siteBackupDownloadRoute.fullPath,
-			params: { siteSlug, rewindId: selected.rewind_id },
-			search: { downloadId },
-		} );
-	};
-
-	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
-		handleDateRangeChange( next );
-		navigateToBackup( null );
-	};
-
-	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-	const { activityLog, isLoadingActivityLog, selectedBackup, isSmallViewport } =
-		useBackupsBrowserState( {
-			site,
-			rewindId,
-			dateRange,
-			timezoneString,
-			gmtOffset,
-			enabled: hasBackups,
-		} );
-	const isMobileDetailsView = isSmallViewport && !! selectedBackup;
-	const shouldShowActions = hasBackups && ! isMobileDetailsView;
-
-	const actions = (
-		<>
-			{ /* This div is required to fix a layout width issue when the DateRangePicker is placed together with the BackupNowButton. */ }
-			<div>
-				<DateRangePicker
-					start={ dateRange.start }
-					end={ dateRange.end }
-					gmtOffset={ gmtOffset }
-					timezoneString={ timezoneString }
-					locale={ locale }
-					defaultFallbackPreset="last-30-days"
-					onChange={ handleDateRangeChangeWrapper }
-				/>
-			</div>
-			<BackupNowButton site={ site } backupState={ backupState } />
-		</>
-	);
-
 	return (
-		<PageLayout
-			header={
-				<PageHeader
-					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
-					description={ __(
-						'Access and restore your site backups, powered by Jetpack VaultPress Backup.'
-					) }
-					prefix={ isMobileDetailsView ? <Breadcrumbs length={ 2 } /> : undefined }
-					actions={ shouldShowActions ? actions : undefined }
-				/>
-			}
-			notices={
-				<>
-					{ /* Action feedback, not an on-load banner: rendered outside the arbiter. */ }
-					{ ! isMobileDetailsView && backupState.status !== 'idle' && (
-						<BackupNotices
-							backupState={ backupState }
-							site={ site }
-							timezoneString={ timezoneString }
-							gmtOffset={ gmtOffset }
-						/>
-					) }
-					<SitesNoticeArbiter />
-				</>
-			}
-		>
-			{ hasBackups ? (
-				<BackupsBrowser
-					site={ site }
-					activityLog={ activityLog }
-					isLoadingActivityLog={ isLoadingActivityLog }
-					selectedBackup={ selectedBackup }
-					isSmallViewport={ isSmallViewport }
-					dateRange={ dateRange }
-					timezoneString={ timezoneString }
-					gmtOffset={ gmtOffset }
-					searchParams={ searchParams }
-					onSelectBackup={ navigateToBackup }
-					onRequestRestore={ handleRequestRestore }
-					onRequestDownload={ handleRequestDownload }
-					onGranularDownloadReady={ handleGranularDownloadReady }
-				/>
-			) : (
-				<PerformanceTrackerStop />
-			) }
-		</PageLayout>
+		<BackupsPage
+			site={ site }
+			navigation={ navigation }
+			rewindId={ rewindId }
+			searchParams={ searchParams }
+			hasBackups={ hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) }
+			extraNotices={ <SitesNoticeArbiter /> }
+		/>
 	);
 }
 
 function SiteBackups() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
-	const locale = useLocale();
-
-	const hostingNotices = {
-		showError: ( message: string ) => createErrorNotice( message, { type: 'snackbar' } ),
-		showSuccess: ( message: string ) => createSuccessNotice( message, { type: 'snackbar' } ),
-	};
 
 	return (
 		<HostingFeatureGatedWithCallout
@@ -209,9 +95,9 @@ function SiteBackups() {
 				'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
 			) }
 		>
-			<FileBrowserProvider locale={ locale } notices={ hostingNotices }>
+			<BackupFileBrowserProvider>
 				<Outlet />
-			</FileBrowserProvider>
+			</BackupFileBrowserProvider>
 		</HostingFeatureGatedWithCallout>
 	);
 }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -3,32 +3,33 @@ import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { DateRangePicker } from '@automattic/date-range-picker';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, useParams, useRouter } from '@tanstack/react-router';
-import { __experimentalGrid as Grid } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { backup } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { FileBrowserProvider } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useDateRange } from '../../app/hooks/use-date-range';
 import { useLocale } from '../../app/locale';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
-import { siteRoute, siteBackupsIndexRoute, siteBackupDetailRoute } from '../../app/router/sites';
-import { Card, CardBody } from '../../components/card';
+import {
+	siteRoute,
+	siteBackupsRoute,
+	siteBackupsIndexRoute,
+	siteBackupDetailRoute,
+	siteBackupRestoreRoute,
+	siteBackupDownloadRoute,
+} from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { SitesNoticeArbiter } from '../notice-arbiter';
-import { BackupDetails } from './backup-details';
-import { BackupDetailsSkeleton } from './backup-details-skeleton';
 import { BackupNotices } from './backup-notices';
 import { BackupNowButton } from './backup-now-button';
+import { BackupsBrowser, useIsBackupsSmallViewport } from './backups-browser';
 import illustrationUrl from './backups-callout-illustration.svg';
-import { BackupsList } from './backups-list';
-import { useActivityLog } from './use-activity-log';
 import { useBackupState } from './use-backup-state';
 import './style.scss';
 import type { ActivityLogEntry } from '@automattic/api-core';
@@ -38,15 +39,13 @@ export function BackupsListPage() {
 	const { siteSlug } = siteRoute.useParams();
 	const router = useRouter();
 
-	const routeParams = useParams( {
-		strict: false,
-		shouldThrow: false,
-	} ) as { rewindId?: string } | undefined;
-
+	const routeParams = useParams( { strict: false, shouldThrow: false } ) as
+		| { rewindId?: string }
+		| undefined;
 	const rewindId = routeParams?.rewindId;
 
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-
+	const searchParams = siteBackupsRoute.useSearch();
 	const backupState = useBackupState( site.ID );
 
 	const { data: siteSettings } = useSuspenseQuery( {
@@ -56,7 +55,6 @@ export function BackupsListPage() {
 			timezoneString: s?.timezone_string || undefined,
 		} ),
 	} );
-
 	const { gmtOffset, timezoneString } = siteSettings;
 
 	const { dateRange, handleDateRangeChange } = useDateRange( {
@@ -64,137 +62,56 @@ export function BackupsListPage() {
 		gmtOffset,
 		defaultDays: 30,
 	} );
-	const [ selectedBackup, setSelectedBackupInState ] = useState< ActivityLogEntry | null >( null );
 
-	const { activityLog, isLoadingActivityLog } = useActivityLog( {
-		siteId: site.ID,
-		dateRange,
-		gmtOffset,
-		timezoneString,
-	} );
-
-	const setSelectedBackup = useCallback(
-		( backup?: ActivityLogEntry | null, replace = false ) => {
-			if ( backup ) {
+	const navigateToBackup = useCallback(
+		( selected: ActivityLogEntry | null ) => {
+			if ( selected ) {
 				router.navigate( {
 					to: siteBackupDetailRoute.fullPath,
-					params: {
-						siteSlug,
-						rewindId: backup.rewind_id,
-					},
-					// The following preserves the existing query string.
+					params: { siteSlug, rewindId: selected.rewind_id },
 					search: ( query: Record< string, string > ) => query,
-					replace,
 				} );
 			} else {
 				router.navigate( {
 					to: siteBackupsIndexRoute.fullPath,
-					params: {
-						siteSlug,
-					},
-					// The following preserves the existing query string.
+					params: { siteSlug },
 					search: ( query: Record< string, string > ) => query,
-					replace,
 				} );
 			}
 		},
 		[ router, siteSlug ]
 	);
 
-	const isSmallViewport = useViewportMatch( 'xlarge', '<' );
+	const handleRequestRestore = ( selected: ActivityLogEntry ) => {
+		router.navigate( {
+			to: siteBackupRestoreRoute.fullPath,
+			params: { siteSlug, rewindId: selected.rewind_id },
+		} );
+	};
 
-	// Auto-select backup based on rewindId parameter
-	useEffect( () => {
-		if ( rewindId && activityLog ) {
-			const targetBackup = activityLog.find( ( item ) => item.rewind_id === rewindId );
-			if ( targetBackup ) {
-				setSelectedBackupInState( targetBackup );
-			}
-			return;
-		}
+	const handleRequestDownload = ( selected: ActivityLogEntry ) => {
+		router.navigate( {
+			to: siteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId: selected.rewind_id },
+		} );
+	};
 
-		// if no rewindId, then it's hitting the index route
-		// we select the first found backup without changing the route in that case to make things look nice.
-		// no selection if it's mobile!
-		const backup = activityLog?.[ 0 ];
-		if ( ! rewindId && backup && ! isSmallViewport ) {
-			setSelectedBackupInState( backup );
-		}
-
-		// no rewind id in param, and no backup? We have an empty query
-		// don't set any backup
-		if ( ! rewindId && ! backup ) {
-			setSelectedBackupInState( null );
-		}
-	}, [ rewindId, activityLog, setSelectedBackupInState, isSmallViewport ] );
+	const handleGranularDownloadReady = ( selected: ActivityLogEntry, downloadId: number ) => {
+		router.navigate( {
+			to: siteBackupDownloadRoute.fullPath,
+			params: { siteSlug, rewindId: selected.rewind_id },
+			search: { downloadId },
+		} );
+	};
 
 	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
 		handleDateRangeChange( next );
-		setSelectedBackup( null, false );
+		navigateToBackup( null );
 	};
-	const columns = isSmallViewport ? 1 : 2;
 
+	const isSmallViewport = useIsBackupsSmallViewport();
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-
-	const handleBackupSelection = ( backup: ActivityLogEntry | null ) => {
-		setSelectedBackup( backup );
-	};
-
-	const renderMobileView = () => {
-		if ( selectedBackup ) {
-			return (
-				<>
-					<PerformanceTrackerStop />
-					<BackupDetails
-						backup={ selectedBackup }
-						site={ site }
-						timezoneString={ timezoneString }
-						gmtOffset={ gmtOffset }
-					/>
-				</>
-			);
-		}
-
-		return (
-			<>
-				{ ! isLoadingActivityLog && <PerformanceTrackerStop /> }
-				<BackupsList
-					activityLog={ activityLog }
-					isLoadingActivityLog={ isLoadingActivityLog }
-					selectedBackup={ selectedBackup }
-					setSelectedBackup={ handleBackupSelection }
-					dateRange={ dateRange }
-					timezoneString={ timezoneString }
-					gmtOffset={ gmtOffset }
-				/>
-			</>
-		);
-	};
-
-	const renderDetailsPanel = () => {
-		if ( isLoadingActivityLog ) {
-			return <BackupDetailsSkeleton />;
-		}
-
-		if ( selectedBackup ) {
-			return (
-				<BackupDetails
-					backup={ selectedBackup }
-					site={ site }
-					timezoneString={ timezoneString }
-					gmtOffset={ gmtOffset }
-				/>
-			);
-		}
-
-		return (
-			<Card>
-				<CardBody style={ { minHeight: '300px' } } children={ null } />
-			</Card>
-		);
-	};
-
-	const isMobileDetailsView = isSmallViewport && selectedBackup;
+	const isMobileDetailsView = isSmallViewport && !! rewindId;
 	const shouldShowActions = hasBackups && ! isMobileDetailsView;
 
 	const actions = (
@@ -242,28 +159,22 @@ export function BackupsListPage() {
 				</>
 			}
 		>
-			{ hasBackups && (
-				<>
-					{ isSmallViewport ? (
-						renderMobileView()
-					) : (
-						<Grid columns={ columns } templateColumns="40% 1fr">
-							{ ! isLoadingActivityLog && <PerformanceTrackerStop /> }
-							<BackupsList
-								activityLog={ activityLog }
-								isLoadingActivityLog={ isLoadingActivityLog }
-								selectedBackup={ selectedBackup }
-								setSelectedBackup={ handleBackupSelection }
-								dateRange={ dateRange }
-								timezoneString={ timezoneString }
-								gmtOffset={ gmtOffset }
-							/>
-							{ renderDetailsPanel() }
-						</Grid>
-					) }
-				</>
+			{ hasBackups ? (
+				<BackupsBrowser
+					site={ site }
+					rewindId={ rewindId }
+					dateRange={ dateRange }
+					timezoneString={ timezoneString }
+					gmtOffset={ gmtOffset }
+					searchParams={ searchParams }
+					onSelectBackup={ navigateToBackup }
+					onRequestRestore={ handleRequestRestore }
+					onRequestDownload={ handleRequestDownload }
+					onGranularDownloadReady={ handleGranularDownloadReady }
+				/>
+			) : (
+				<PerformanceTrackerStop />
 			) }
-			{ ! hasBackups && <PerformanceTrackerStop /> }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/backups/use-activity-log.ts
+++ b/client/dashboard/sites/backups/use-activity-log.ts
@@ -10,6 +10,7 @@ export interface UseActivityLogOptions {
 	dateRange?: { start: Date; end: Date };
 	timezoneString?: string;
 	gmtOffset?: number;
+	enabled?: boolean;
 }
 
 export interface UseActivityLogResult {
@@ -25,6 +26,7 @@ export function useActivityLog( {
 	timezoneString,
 	gmtOffset,
 	dateRange,
+	enabled = true,
 }: UseActivityLogOptions ): UseActivityLogResult {
 	const { backup, hasRecentlyCompleted } = useBackupState( siteId );
 
@@ -43,6 +45,7 @@ export function useActivityLog( {
 
 	const queryResult = useQuery( {
 		...siteBackupActivityLogEntriesQuery( siteId, undefined, true, after, before ),
+		enabled,
 		refetchInterval: ( query ) => {
 			if ( ! backup || ! hasRecentlyCompleted ) {
 				return false;

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -27,7 +27,13 @@ const SUCCESSFUL_BACKUP_ACTIVITIES = [
 
 const FAILED_BACKUP_ACTIVITIES = [ 'rewind__backup_error', 'rewind__backup_only_error' ];
 
-function BackupCardFailed( { site, backup }: { site: Site; backup?: SiteActivityLog } ) {
+function BackupCardFailed( {
+	backupUrl,
+	backup,
+}: {
+	backupUrl: string;
+	backup?: SiteActivityLog;
+} ) {
 	const timeSinceLastSuccessful = useTimeSince( backup?.published ?? new Date( 0 ).toISOString() );
 
 	const description = backup
@@ -43,13 +49,19 @@ function BackupCardFailed( { site, backup }: { site: Site; backup?: SiteActivity
 			{ ...CARD_PROPS }
 			heading={ __( 'Backup failed' ) }
 			description={ description }
-			link={ getBackupUrl( site ) }
+			link={ backupUrl }
 			intent="error"
 		/>
 	);
 }
 
-function BackupCardSuccess( { site, lastBackup }: { site: Site; lastBackup: SiteActivityLog } ) {
+function BackupCardSuccess( {
+	backupUrl,
+	lastBackup,
+}: {
+	backupUrl: string;
+	lastBackup: SiteActivityLog;
+} ) {
 	const timeSinceLastBackup = useTimeSince( lastBackup.published );
 	const formattedLastBackupTime = useFormattedTime( lastBackup.published, { timeStyle: 'short' } );
 
@@ -58,15 +70,15 @@ function BackupCardSuccess( { site, lastBackup }: { site: Site; lastBackup: Site
 			{ ...CARD_PROPS }
 			heading={ timeSinceLastBackup }
 			description={ formattedLastBackupTime }
-			link={ getBackupUrl( site ) }
+			link={ backupUrl }
 			intent="success"
 		/>
 	);
 }
 
-function BackupCardContent( { site }: { site: Site } ) {
+export function BackupCardContent( { siteId, backupUrl }: { siteId: number; backupUrl: string } ) {
 	const { data: lastBackup, isLoading } = useQuery( {
-		...siteActivityLogQuery( site.ID, {
+		...siteActivityLogQuery( siteId, {
 			name: [ ...SUCCESSFUL_BACKUP_ACTIVITIES, ...FAILED_BACKUP_ACTIVITIES ],
 			number: 1,
 		} ),
@@ -74,7 +86,7 @@ function BackupCardContent( { site }: { site: Site } ) {
 	} );
 
 	const { data: lastSuccessfulBackup } = useQuery( {
-		...siteActivityLogQuery( site.ID, { name: SUCCESSFUL_BACKUP_ACTIVITIES, number: 1 } ),
+		...siteActivityLogQuery( siteId, { name: SUCCESSFUL_BACKUP_ACTIVITIES, number: 1 } ),
 		select: ( data ) => data.activityLogs[ 0 ],
 		// Only fetch successful backups if there are any failed backups
 		enabled: !! lastBackup && FAILED_BACKUP_ACTIVITIES.includes( lastBackup.name ),
@@ -90,16 +102,16 @@ function BackupCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No backups yet' ) }
 				description={ __( 'Your first backup will be ready soon.' ) }
-				link={ getBackupUrl( site ) }
+				link={ backupUrl }
 			/>
 		);
 	}
 
 	if ( FAILED_BACKUP_ACTIVITIES.includes( lastBackup.name ) ) {
-		return <BackupCardFailed site={ site } backup={ lastSuccessfulBackup } />;
+		return <BackupCardFailed backupUrl={ backupUrl } backup={ lastSuccessfulBackup } />;
 	}
 
-	return <BackupCardSuccess site={ site } lastBackup={ lastBackup } />;
+	return <BackupCardSuccess backupUrl={ backupUrl } lastBackup={ lastBackup } />;
 }
 
 export default function BackupCard( { site }: { site: Site } ) {
@@ -128,7 +140,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 			upsellDescription={ __( 'Get back online quickly with one-click restores.' ) }
 			upsellLink={ getBackupUrl( site ) }
 		>
-			<BackupCardContent site={ site } />
+			<BackupCardContent siteId={ site.ID } backupUrl={ getBackupUrl( site ) } />
 		</HostingFeatureGatedWithOverviewCard>
 	);
 }

--- a/packages/api-core/src/site-settings/fetchers.ts
+++ b/packages/api-core/src/site-settings/fetchers.ts
@@ -6,5 +6,8 @@ export async function fetchSiteSettings( siteId: number ): Promise< SiteSettings
 		path: `/sites/${ siteId }/settings`,
 		apiVersion: '1.4',
 	} );
-	return settings;
+	return {
+		...settings,
+		gmt_offset: Number( settings.gmt_offset ) || 0,
+	};
 }

--- a/packages/api-core/src/site-settings/types.ts
+++ b/packages/api-core/src/site-settings/types.ts
@@ -1,7 +1,7 @@
 export interface SiteSettings {
 	blog_public?: number;
 	is_fully_managed_agency_site?: boolean;
-	gmt_offset?: number | string;
+	gmt_offset?: number;
 	timezone_string?: string;
 	/**
 	 * @deprecated Use `wpcom_public_coming_soon` instead.


### PR DESCRIPTION
Part of A4A-2905
Part of A4A-2915

This is **PR 1 of 2**. It is the dotcom-side, behavior-preserving refactor that extracts the multi-site dashboard's backup UI into shared, route-agnostic components. PR 2 (the A4A feature that consumes them) is stacked on top of this branch.

## Proposed Changes

Refactor the dashboard's backup UI into shared, route-agnostic pieces so the list/detail/restore/download logic can be reused across variants (dotcom and, in the follow-up PR, A4A). **No A4A code here** — changes are confined to `client/dashboard/sites/**`.

* **`BackupsBrowser`** — list + detail grid + selection + activity-log fetch, extracted from the dotcom backups page.
* **`BackupRestoreFlow` / `BackupDownloadFlow`** — the restore/download step machines, extracted into standalone components.
* **`BackupDetails`** — restore/download navigation is now injected via callbacks (`onRequestRestore` / `onRequestDownload` / `onGranularDownloadReady`) instead of calling the router directly, so the component is route-agnostic.
* **`BackupCardContent`** — the overview card body, parameterized by `siteId` + `backupUrl` instead of a full `site` object.
* Restore/download **forms** take `rewindId` as a prop instead of reading it from `useParams`, decoupling them from a specific route.
* dotcom's backup pages (`sites/backups`, `sites/backup-restore`, `sites/backup-download`) become thin shells over these shared components.

## Why are these changes being made?

The follow-up PR brings backup management to the A4A agency site detail view. Rather than duplicate the list/detail/restore/download logic, this PR extracts it into shared, route-agnostic components so there is a single implementation across variants. Splitting the extraction into its own PR keeps this change reviewable as a pure, behavior-preserving refactor (risk = dotcom regression) separate from the A4A feature wiring.

## Testing Instructions

1. Build and run the Dashboard client (`yarn start-dashboard`).
2. Open a backup-enabled site → **Backups**.
3. Confirm the restore-point list, date-range filtering, and the detail pane (file browser) render as before.
4. Confirm **Download backup** and **Restore to this point** navigate to their flows and complete.
5. Confirm the Last-backup card on the site Overview links to and reflects backup state as before.
6. Confirm behavior is unchanged from `trunk` across desktop and mobile viewports.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
