### PR TITLE
Dashboard: fix launch celebration modal Get domain link 500 in standalone dashboard

### DIFF
--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import ConfettiAnimation from '../../components/confetti';
+import { getAddSiteDomainUrl } from '../../utils/domain-url';
 import type { Site } from '@automattic/api-core';
 import './styles.scss';
 
@@ -97,7 +98,7 @@ export default function SiteLaunchCelebrationModal( {
 				</Text>
 			);
 			buttonText = __( 'Get your domain' );
-			buttonHref = `/domains/add/${ site.slug }`;
+			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else if ( isPaidPlan && isBilledMonthly && ! hasCustomDomain ) {
 			contentElement = (
 				<Text as="p" className="flex-shrink-safe">
@@ -107,7 +108,7 @@ export default function SiteLaunchCelebrationModal( {
 				</Text>
 			);
 			buttonText = __( 'Get your domain' );
-			buttonHref = `/domains/add/${ site.slug }`;
+			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
 				<Text as="p" className="flex-shrink-safe">
@@ -120,7 +121,7 @@ export default function SiteLaunchCelebrationModal( {
 				</Text>
 			);
 			buttonText = __( 'Get your free domain' );
-			buttonHref = `/domains/add/${ site.slug }`;
+			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else {
 			return null;
 		}

--- a/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
@@ -6,6 +6,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
+import { getAddSiteDomainUrl } from '../../../utils/domain-url';
 import SiteLaunchCelebrationModal from '../index';
 import type { DomainSummary, Site } from '@automattic/api-core';
 
@@ -229,11 +230,12 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			// Wait for modal to render first
 			await screen.findByRole( 'dialog' );
 
-			// Upsell button should appear for free plan without custom domain
+			// Upsell button should appear for free plan without custom domain, pointing at the
+			// environment-aware add-domain URL rather than a bare relative path.
 			await screen.findByRole( 'link', { name: 'Get your domain' } );
 			expect( screen.getByRole( 'link', { name: 'Get your domain' } ) ).toHaveAttribute(
 				'href',
-				expect.stringContaining( '/domains/add/' )
+				getAddSiteDomainUrl( mockSite.slug )
 			);
 		} );
 

--- a/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
@@ -230,8 +230,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			// Wait for modal to render first
 			await screen.findByRole( 'dialog' );
 
-			// Upsell button should appear for free plan without custom domain, pointing at the
-			// environment-aware add-domain URL rather than a bare relative path.
+			// Upsell button should appear for free plan without custom domain
 			await screen.findByRole( 'link', { name: 'Get your domain' } );
 			expect( screen.getByRole( 'link', { name: 'Get your domain' } ) ).toHaveAttribute(
 				'href',


### PR DESCRIPTION
Fixes DOTMSD-1378

## Proposed Changes

* Build the "Get your domain" link in the site launch celebration modal via the shared `getAddSiteDomainUrl()` helper instead of a hardcoded relative `/domains/add/<slug>` path.
* Strengthen the modal's upsell test to assert the link points at the environment-aware add-domain URL.

## Why are these changes being made?

* In the standalone Multi-site Dashboard, a relative `/domains/add/<slug>` resolves against the current site host (e.g. `<slug>.wpcomstaging.com`), which has no add-domain flow — so the link 500s.
* The shared helper already handles both environments correctly: an absolute wordpress.com URL when standalone, and a relative path in the Calypso backport. Three other components already use it; this brings the modal in line.

## Testing Instructions

* In the multi-site dashboard, open a site's Performance page for a site without a custom domain.
* Launch the site so the celebration modal appears.
* Click "Get your domain" and confirm it lands on the wordpress.com add-domain flow rather than a 500.
* `yarn test-client client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
