### PR TITLE
Reader Spaces: add analytics tracking for creation, editing, reading, and layout

### DIFF
--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -57,6 +57,14 @@ jest.mock( 'calypso/reader/hooks/use-infinite-list', () => ( {
 	} ),
 } ) );
 
+const mockRecordReaderTracksEvent: jest.Mock = jest.fn( () => ( {
+	type: 'TEST_TRACKS_EVENT',
+} ) );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
 const WORK: ReadSpace = {
 	id: '2f5d8f28-04b7-4f6a-a908-6c4d2b4b8f21',
 	name: 'Work',
@@ -94,6 +102,7 @@ function setup( { existing = [] as ReadSpace[], onCreated = jest.fn() } = {} ) {
 describe( 'CreateSpaceModal', () => {
 	beforeEach( () => {
 		mockSubscriptions = [];
+		mockRecordReaderTracksEvent.mockClear();
 	} );
 
 	afterEach( () => nock.cleanAll() );
@@ -206,6 +215,17 @@ describe( 'CreateSpaceModal', () => {
 		const detail = queryClient.getQueryData< ReadSpaceDetails >( readSpaceQuery( '7' ).queryKey );
 		expect( detail?.layout.view ).toBe( 'legacy' );
 		expect( onClose ).toHaveBeenCalled();
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_spaces_space_created',
+			{
+				tag_count: 0,
+				source_count: 1,
+				layout: 'legacy',
+				icon: 'star',
+				color: 'green',
+				icon_color: 'blue',
+			}
+		);
 	} );
 
 	it( 'notifies the parent with the created space', async () => {

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -219,6 +219,11 @@ function SpaceUpsertModalContent( {
 						dispatch(
 							recordReaderTracksEvent( 'calypso_reader_spaces_space_created', {
 								tag_count: createdSpace.tags.length,
+								source_count: selectedFeeds.length,
+								layout: view,
+								icon,
+								color,
+								icon_color: iconColor,
 							} )
 						);
 						dispatch(
@@ -260,6 +265,8 @@ function SpaceUpsertModalContent( {
 					dispatch(
 						recordReaderTracksEvent( 'calypso_reader_spaces_space_updated', {
 							tag_count: tags.length,
+							source_count: selectedFeeds.length,
+							layout: view,
 						} )
 					);
 					dispatch( successNotice( translate( 'Changes saved.' ), { duration: 5000 } ) );

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -16,6 +16,14 @@ jest.mock( '@automattic/calypso-router', () => ( {
 	default: Object.assign( jest.fn(), { replace: jest.fn() } ),
 } ) );
 
+const mockRecordReaderTracksEvent: jest.Mock = jest.fn( () => ( {
+	type: 'TEST_TRACKS_EVENT',
+} ) );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
 const existingSubscription: SiteSubscriptionItem = {
 	ID: 1,
 	URL: 'https://existing.example',
@@ -132,6 +140,7 @@ function render( {
 describe( 'CustomizeModal', () => {
 	beforeEach( () => {
 		mockSubscriptions = [];
+		mockRecordReaderTracksEvent.mockClear();
 	} );
 
 	afterEach( () => nock.cleanAll() );
@@ -223,6 +232,14 @@ describe( 'CustomizeModal', () => {
 		expect( cached?.name ).toBe( 'Reading' );
 		expect( cached?.layout.color ).toBe( 'green' );
 		expect( cached?.layout.view ).toBe( 'legacy' );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_spaces_space_updated',
+			{ tag_count: 1, source_count: 0, layout: 'legacy' }
+		);
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_spaces_layout_changed',
+			{ layout: 'legacy' }
+		);
 	} );
 
 	it( 'saves source changes with the rest of the edit draft', async () => {

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -8,6 +8,8 @@ import { useInfiniteStream } from 'calypso/reader/data/stream';
 import { ScrollDebugOverlay } from 'calypso/reader/hooks/use-infinite-list';
 import { keyForPost, keysAreEqual } from 'calypso/reader/post-key';
 import { useStreamPostKeySelection } from 'calypso/reader/stream/use-stream-post-key-selection';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { SpaceFeedSourceNotice } from './components/source-notice';
 import {
@@ -77,6 +79,7 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 	const isDiscover = variant === 'discover';
 	const streamKey = isDiscover ? `space_discover:${ spaceId }` : `space:${ spaceId }`;
 	const isLegacy = layout === 'legacy';
+	const dispatch = useDispatch();
 	const rawLocale = useSelector( getCurrentLocaleSlug );
 	const localeSlug = rawLocale && ! isDefaultLocale( rawLocale ) ? rawLocale : null;
 	const stream = useInfiniteStream( {
@@ -102,8 +105,15 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 				);
 				selectPostKey( streamItem ?? postKey );
 			}
+			dispatch(
+				recordReaderTracksEvent(
+					'calypso_reader_spaces_post_opened',
+					{ space_id: spaceId, layout, variant },
+					{ post }
+				)
+			);
 		},
-		[ selectPostKey, stream.items ]
+		[ dispatch, selectPostKey, stream.items, spaceId, layout, variant ]
 	);
 
 	// Scroll on the Reader's main bounded container (`.layout__primary > div`, which

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -48,6 +48,14 @@ jest.mock( 'calypso/state/reader/site-blocks/selectors', () => {
 	return { getBlockedSites };
 } );
 
+const mockRecordReaderTracksEvent: jest.Mock = jest.fn( () => ( {
+	type: 'TEST_TRACKS_EVENT',
+} ) );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
 const mockUseInfiniteStream = useInfiniteStream as jest.Mock;
 
 function streamResult( overrides: Partial< ReturnType< typeof useInfiniteStream > > = {} ) {
@@ -114,6 +122,7 @@ describe( 'SpaceFeed', () => {
 	beforeEach( () => {
 		window.history.replaceState( {}, '', '/reader/spaces/work-id' );
 		mockCurrentLocaleSlug = null;
+		mockRecordReaderTracksEvent.mockClear();
 		mockUseInfiniteStream.mockReturnValue( streamResult() );
 	} );
 
@@ -252,6 +261,31 @@ describe( 'SpaceFeed', () => {
 		expect(
 			queryClient.getQueryData( [ 'read', 'stream', 'selected', `space:${ WORK.id }`, null ] )
 		).toEqual( streamItem );
+	} );
+
+	it( 'records a tracks event when a post is opened', async () => {
+		const user = userEvent.setup();
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
+		const post = makePost();
+		mockUseInfiniteStream.mockReturnValue(
+			streamResult( { pages: [ { posts: [ post ] } as unknown as ReadStreamResponse ] } )
+		);
+
+		renderWithProvider( <SpaceFeed spaceId={ WORK.id } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		const link = screen.getByRole( 'link', { name: 'A layout-sensitive post' } );
+		link.addEventListener( 'click', ( event ) => event.preventDefault() );
+		await user.click( link );
+
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_spaces_post_opened',
+			{ space_id: WORK.id, layout: 'standard-list', variant: 'feed' },
+			{ post }
+		);
 	} );
 
 	it( 'requests the discover stream keyed by the space id for the discover variant', () => {

--- a/client/reader/spaces/test/view.test.tsx
+++ b/client/reader/spaces/test/view.test.tsx
@@ -3,13 +3,16 @@
  */
 import { readSpaceQuery, readSpacesQuery } from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SpacesView } from '../view';
 import type { ReadSpaceDetails } from '@automattic/api-core';
 
 const mockSpaceFeed = jest.fn< null, [ unknown ] >( () => null );
+const mockRecordReaderTracksEvent: jest.Mock = jest.fn( () => ( {
+	type: 'TEST_TRACKS_EVENT',
+} ) );
 
 jest.mock( 'calypso/components/data/document-head', () => ( {
 	__esModule: true,
@@ -20,6 +23,10 @@ jest.mock( 'calypso/components/data/document-head', () => ( {
 // the unified Customize modal, so stub it out to keep the test off the network.
 jest.mock( 'calypso/reader/spaces/feed', () => ( {
 	SpaceFeed: ( props: unknown ) => mockSpaceFeed( props ),
+} ) );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
 } ) );
 
 // Keep the rest of the module real (ReaderMain's global handlers use `useFollowSite`);
@@ -66,6 +73,7 @@ describe( 'SpacesView', () => {
 	beforeEach( () => {
 		window.history.replaceState( {}, '', '/reader/spaces' );
 		mockSpaceFeed.mockClear();
+		mockRecordReaderTracksEvent.mockClear();
 	} );
 
 	it( 'shows the Customize button on a space detail page', () => {
@@ -110,6 +118,23 @@ describe( 'SpacesView', () => {
 				spaceId: WORK.id,
 				layoutView: 'gallery',
 			} )
+		);
+	} );
+
+	it( 'records a page view event with the selected space appearance', async () => {
+		render( <SpacesView id={ WORK.id } /> );
+
+		await waitFor( () =>
+			expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+				'calypso_reader_spaces_page_viewed',
+				{
+					space_id: WORK.id,
+					layout: 'gallery',
+					icon: 'inbox',
+					color: 'blue',
+					tab: 'feed',
+				}
+			)
 		);
 	} );
 

--- a/client/reader/spaces/view.tsx
+++ b/client/reader/spaces/view.tsx
@@ -1,14 +1,17 @@
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { useSpaces } from 'calypso/reader/data/spaces';
 import { CustomizeModal, type CustomizeTab } from 'calypso/reader/spaces/customize-modal';
 import { SpaceFeed } from 'calypso/reader/spaces/feed';
+import { DEFAULT_SPACE_FEED_LAYOUT } from 'calypso/reader/spaces/feed/layouts/registry';
 import { SpaceNavigation } from 'calypso/reader/spaces/space-navigation';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import type { SpaceFeedLayout } from '@automattic/api-core';
 import type { SpaceTab } from 'calypso/reader/spaces/routes';
 
@@ -21,9 +24,12 @@ interface Props {
 
 export function SpacesView( { id, tab = 'feed' }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const spaces = useSpaces();
 	const space = id ? spaces.find( ( item ) => item.id === id ) : undefined;
-	const layoutView: SpaceFeedLayout | undefined = space?.layout.view;
+	const layoutView: SpaceFeedLayout = space?.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT;
+	const icon = space?.layout.icon;
+	const color = space?.layout.color;
 	const title = space ? space.name : translate( 'Spaces' );
 	// The generic "Spaces" heading belongs to the landing page only — while a
 	// specific space is still loading, render no heading rather than flashing it.
@@ -39,6 +45,22 @@ export function SpacesView( { id, tab = 'feed' }: Props ) {
 	const handleClose = () => {
 		setCustomizeTab( null );
 	};
+
+	useEffect( () => {
+		if ( ! id || ! icon || ! color ) {
+			return;
+		}
+
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_spaces_page_viewed', {
+				space_id: id,
+				layout: layoutView,
+				icon,
+				color,
+				tab,
+			} )
+		);
+	}, [ color, dispatch, icon, id, layoutView, tab ] );
 
 	let activePanel: ReactNode = null;
 	if ( id && space ) {


### PR DESCRIPTION
Part of RSM-4617

## Proposed Changes

* Enrich `calypso_reader_spaces_space_created` with `source_count`, `layout`, `icon`, `color` and `icon_color` (keeping `tag_count`).
* Enrich `calypso_reader_spaces_space_updated` with `source_count` and `layout` (the existing `calypso_reader_spaces_layout_changed` on edit is unchanged).
* Add `calypso_reader_spaces_post_opened` (`space_id`, `layout`, `variant` + post properties) fired from the feed shell's single post-open chokepoint.
* Add `calypso_reader_spaces_page_viewed` (`space_id`, `layout`, `icon`, `color`, `tab`) fired when a space page loads.
* Added/updated unit tests covering each event and its properties.

## Why are these changes being made?

The Spaces project bets that adapting the Reader to how you read makes people "read more, and come back more often." Reading articles from within a space was not tracked at all, and the create/edit events were too property-poor to reason about adoption or which layout users prefer. These events feed the engagement and preferred-layout metrics.

## Testing Instructions

_Spaces is behind the `reader/spaces` feature flag (a8c only). Observe events in the Tracks live view / browser console._

### Scenario 1 - Create a space:
- Go to `/reader/spaces` and create a space, choosing an icon, accent color, layout and some sources.
- Check that `calypso_reader_spaces_space_created` is recorded with `tag_count`, `source_count`, `layout`, `icon`, `color` and `icon_color`.

### Scenario 2 - Edit a space:
- Go to `/reader/spaces/:id`, open **Customize**, change the layout and add/remove a source, then save.
- Check that `calypso_reader_spaces_space_updated` is recorded with `tag_count`, `source_count` and `layout`, and that `calypso_reader_spaces_layout_changed` is recorded when the layout changed.

### Scenario 3 - View a space page:
- Go to `/reader/spaces/:id`.
- Check that `calypso_reader_spaces_page_viewed` is recorded with `space_id`, `layout`, `icon`, `color` and `tab`.

### Scenario 4 - Open a post from a space:
- Go to `/reader/spaces/:id` on a non-legacy layout and open a post from the feed.
- Check that `calypso_reader_spaces_post_opened` is recorded with `space_id`, `layout`, `variant` and the post properties.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
