### PR TITLE
Fix page view tracker README typos

### DIFF
--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -8,10 +8,10 @@ This component is aware of the selected site and, if the current URL contains a 
 
 ## Props
 
-- `delay`: time in millisecods to delay the recording of the page view event.
+- `delay`: time in milliseconds to delay the recording of the page view event.
 - `path`: required `String` that represents the path to report as the source of the page view event. It should follow Calypso's [Path Conventions](https://github.com/Automattic/wp-calypso/blob/HEAD/client/lib/analytics/docs/page-views.md#paths-conventions).
-- `title`: required `String` that represent the page's title. It should follow Calypso's [Title Conventions](https://github.com/Automattic/wp-calypso/blob/HEAD/client/lib/analytics/docs/page-views.md#titles-conventions).
-- `properties`: optional `Object` with aditional properties that correspond to IDs or variables present on the `path`.
+- `title`: required `String` that represents the page's title. It should follow Calypso's [Title Conventions](https://github.com/Automattic/wp-calypso/blob/HEAD/client/lib/analytics/docs/page-views.md#titles-conventions).
+- `properties`: optional `Object` with additional properties that correspond to IDs or variables present on the `path`.
 
 ## Examples
 


### PR DESCRIPTION
No issue.

## Proposed Changes

* Correct typos in the Page View Tracker README prop descriptions.

## Why are these changes being made?

* This keeps the documentation accurate and tidy while providing a tiny merge queue test change.

## Testing Instructions

* Ran `git diff --check -- client/lib/analytics/page-view-tracker/README.md`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?