### PR TITLE
Allow default branch in TeamCity merge queue filters

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,7 +1,6 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.allBranchesExceptMergeQueue
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -15,7 +14,6 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 	vcs {
 		root(Settings.WpCalypso)
-		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,7 +1,7 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.excludeMergeQueueBranches
+import _self.lib.utils.allBranchesExceptMergeQueue
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -15,7 +15,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 	vcs {
 		root(Settings.WpCalypso)
-		branchFilter = "+:*".excludeMergeQueueBranches()
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,6 +1,7 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
+import _self.lib.utils.allBranchesExceptMergeQueue
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -14,6 +15,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -59,6 +59,7 @@ open class E2EBuildType(
 	var buildTriggers: Triggers.() -> Unit = {},
 	var buildDependencies: Dependencies.() -> Unit = {},
 	var addWpcomVcsRoot: Boolean = false,
+	var vcsBranchFilter: String? = null,
 	var buildSteps: BuildSteps.() -> Unit = {}
 
 ): BuildType() {
@@ -71,6 +72,7 @@ open class E2EBuildType(
 		val enableCommitStatusPublisher = enableCommitStatusPublisher
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
+		val vcsBranchFilter = vcsBranchFilter
 		val params = params
 		val buildSteps = buildSteps
 
@@ -89,6 +91,7 @@ open class E2EBuildType(
 
 		vcs {
 			root(Settings.WpCalypso)
+			vcsBranchFilter?.let { branchFilter = it }
 			cleanCheckout = true
 		}
 

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -59,7 +59,6 @@ open class E2EBuildType(
 	var buildTriggers: Triggers.() -> Unit = {},
 	var buildDependencies: Dependencies.() -> Unit = {},
 	var addWpcomVcsRoot: Boolean = false,
-	var vcsBranchFilter: String? = null,
 	var buildSteps: BuildSteps.() -> Unit = {}
 
 ): BuildType() {
@@ -72,7 +71,6 @@ open class E2EBuildType(
 		val enableCommitStatusPublisher = enableCommitStatusPublisher
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
-		val vcsBranchFilter = vcsBranchFilter
 		val params = params
 		val buildSteps = buildSteps
 
@@ -91,7 +89,6 @@ open class E2EBuildType(
 
 		vcs {
 			root(Settings.WpCalypso)
-			vcsBranchFilter?.let { branchFilter = it }
 			cleanCheckout = true
 		}
 

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -52,3 +52,10 @@ fun String.excludeMergeQueueBranches(): String {
 		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
 	""".trimIndent()
 }
+
+fun allBranchesExceptMergeQueue(): String {
+	return """
+		+:<default>
+		+:*
+	""".excludeMergeQueueBranches()
+}

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -52,10 +52,3 @@ fun String.excludeMergeQueueBranches(): String {
 		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
 	""".trimIndent()
 }
-
-fun allBranchesExceptMergeQueue(): String {
-	return """
-		+:<default>
-		+:*
-	""".excludeMergeQueueBranches()
-}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,6 +3,7 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
+import _self.lib.utils.allBranchesExceptMergeQueue
 import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.passMergeQueueBranchesEarly
@@ -792,6 +793,7 @@ object Translate : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -928,6 +930,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 				}
 			}
 		},
+		vcsBranchFilter = allBranchesExceptMergeQueue(),
 		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,6 +3,7 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
+import _self.lib.utils.allBranchesExceptMergeQueue
 import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.passMergeQueueBranchesEarly
@@ -792,7 +793,7 @@ object Translate : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
-		branchFilter = "+:*".excludeMergeQueueBranches()
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -929,7 +930,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 				}
 			}
 		},
-		vcsBranchFilter = "+:*".excludeMergeQueueBranches(),
+		vcsBranchFilter = allBranchesExceptMergeQueue(),
 		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,7 +3,6 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
-import _self.lib.utils.allBranchesExceptMergeQueue
 import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.passMergeQueueBranchesEarly
@@ -793,7 +792,6 @@ object Translate : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
-		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -930,7 +928,6 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 				}
 			}
 		},
-		vcsBranchFilter = allBranchesExceptMergeQueue(),
 		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {


### PR DESCRIPTION
No issue.

## Proposed Changes

* Remove the build-configuration VCS branch filters that were added to the shared Playwright E2E template, Translate, and the legacy PR E2E build type.
* Keep the merge queue exclusions on the non-required jobs' VCS trigger filters.

## Why are these changes being made?

* The build-level branch filters prevented TeamCity from running expected default-branch and PR branch builds.
* This showed up as `Builds in default branch are disabled` for `Pre-Release E2E Tests (Playwright Test)`, and the PR validation also stopped reporting the non-required E2E checks.
* Trigger-level exclusions are the safer scope here: they avoid merge queue trigger noise without blocking default branch or pull request E2E builds.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
