### PR TITLE
Reader Spaces: Enable to move sites to spaces

### DIFF
--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import CommentButton from 'calypso/blocks/comment-button';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
-import ReaderFollowButton from 'calypso/reader/follow-button';
 import LikeButton from 'calypso/reader/like-button';
 import { isLikeable } from 'calypso/reader/post/capabilities';
+import { SubscribeWithSpaceButton } from 'calypso/reader/spaces/subscribe-with-space';
 import { recordAction, recordPermalinkClick } from 'calypso/reader/stats';
 import { userCan } from 'calypso/state/posts/utils';
 
@@ -88,7 +88,7 @@ const ReaderFullPostActionBar = ( {
 					<PostEditButton post={ post } site={ site } iconSize={ 24 } onClick={ onEditClick } />
 				) }
 				{ followUrl && (
-					<ReaderFollowButton
+					<SubscribeWithSpaceButton
 						feedId={ feedId }
 						siteId={ siteId }
 						siteUrl={ followUrl }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -168,6 +168,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.post-edit-button,
 	.reader-full-post__view-original-button,
 	.reader-full-post__seen-button,
+	.reader-subscribe-with-space__spaces,
 	.follow-button {
 		margin: 0;
 		padding: 8px 16px;

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -1,8 +1,12 @@
 import { readTeamsQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { category } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import CommentButton from 'calypso/blocks/comment-button';
 import ReaderSaveButton from 'calypso/blocks/reader-save-button';
 import ShareButton from 'calypso/blocks/reader-share';
@@ -15,7 +19,9 @@ import {
 	isRebloggable,
 	isLikeable,
 } from 'calypso/reader/post/capabilities';
-import { useSelector } from 'calypso/state';
+import { SpacePickerModal } from 'calypso/reader/spaces/subscribe-with-space/space-picker-modal';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { ReaderFreshlyPressedButton } from '../reader-freshly-pressed-button';
 import './style.scss';
@@ -34,6 +40,10 @@ const ReaderPostActions = ( {
 	variant = 'default',
 	split = false,
 } ) => {
+	const translate = useTranslate();
+	const [ isSpacePickerOpen, setIsSpacePickerOpen ] = useState( false );
+	const showSpaces = isEnabled( 'reader/spaces' );
+	const dispatch = useDispatch();
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showShare = isSharable( post );
 	const showReblog = isRebloggable( post, hasSites );
@@ -47,68 +57,100 @@ const ReaderPostActions = ( {
 	const isAutomattician = isAutomatticTeamMember( data?.teams ?? [] );
 	const shouldShowFreshlyPressed = fullPost && isAutomattician && showShare;
 
-	return (
-		<ul className={ listClassnames }>
-			{ showShare && (
-				<li className="reader-post-actions__item">
-					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
-				</li>
-			) }
+	const openSpacePicker = () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_subscribe_space_button_clicked', {
+				feed_id: post.feed_ID,
+				blog_id: post.site_ID,
+				source: 'post_actions',
+			} )
+		);
+		setIsSpacePickerOpen( true );
+	};
 
-			{ showReblog && (
-				<li className="reader-post-actions__item">
-					<ShareButton
-						post={ post }
-						position="bottom"
-						tagName="div"
-						iconSize={ iconSize }
-						isReblogSelection
-					/>
-				</li>
+	return (
+		<>
+			<ul className={ listClassnames }>
+				{ showSpaces && (
+					<li className="reader-post-actions__item">
+						<Button
+							className="reader-post-actions__space-button"
+							icon={ category }
+							iconSize={ iconSize }
+							label={ translate( 'Move site to a space' ) }
+							onClick={ openSpacePicker }
+						/>
+					</li>
+				) }
+				{ showShare && (
+					<li className="reader-post-actions__item">
+						<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
+					</li>
+				) }
+
+				{ showReblog && (
+					<li className="reader-post-actions__item">
+						<ShareButton
+							post={ post }
+							position="bottom"
+							tagName="div"
+							iconSize={ iconSize }
+							isReblogSelection
+						/>
+					</li>
+				) }
+				{ isEnabled( 'reader/saved-posts' ) && (
+					<li className="reader-post-actions__item">
+						<ReaderSaveButton post={ post } iconSize={ iconSize } />
+					</li>
+				) }
+				{ showComments && ! commentsApiDisabled && (
+					<li className="reader-post-actions__item">
+						<CommentButton
+							key="comment-button"
+							commentCount={ post.discussion.comment_count }
+							onClick={ onCommentClick }
+							tagName="button"
+							icon={ ReaderCommentIcon( {
+								iconSize,
+								viewBox: '0 -1 20 20',
+							} ) }
+							alwaysShowTooltip
+						/>
+					</li>
+				) }
+				{ showLikes && (
+					<li className="reader-post-actions__item">
+						<LikeButton
+							key="like-button"
+							siteId={ +post.site_ID }
+							postId={ +post.ID }
+							post={ post }
+							site={ site }
+							fullPost={ fullPost }
+							tagName="button"
+							forceCounter
+							iconSize={ iconSize }
+							showZeroCount={ false }
+							likeSource="reader"
+						/>
+					</li>
+				) }
+				{ shouldShowFreshlyPressed && (
+					<li className="reader-post-actions__item">
+						<ReaderFreshlyPressedButton blogId={ post.site_ID } postId={ post.ID } />
+					</li>
+				) }
+			</ul>
+			{ showSpaces && isSpacePickerOpen && (
+				<SpacePickerModal
+					feedId={ post.feed_ID }
+					blogId={ post.site_ID }
+					feedUrl={ post.feed_URL || post.site_URL }
+					onClose={ () => setIsSpacePickerOpen( false ) }
+				/>
 			) }
-			{ isEnabled( 'reader/saved-posts' ) && (
-				<li className="reader-post-actions__item">
-					<ReaderSaveButton post={ post } iconSize={ iconSize } />
-				</li>
-			) }
-			{ showComments && ! commentsApiDisabled && (
-				<li className="reader-post-actions__item">
-					<CommentButton
-						key="comment-button"
-						commentCount={ post.discussion.comment_count }
-						onClick={ onCommentClick }
-						tagName="button"
-						icon={ ReaderCommentIcon( {
-							iconSize,
-							viewBox: '0 -1 20 20',
-						} ) }
-						alwaysShowTooltip
-					/>
-				</li>
-			) }
-			{ showLikes && (
-				<li className="reader-post-actions__item">
-					<LikeButton
-						key="like-button"
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						post={ post }
-						site={ site }
-						fullPost={ fullPost }
-						tagName="button"
-						forceCounter
-						iconSize={ iconSize }
-						showZeroCount={ false }
-						likeSource="reader"
-					/>
-				</li>
-			) }
-			{ shouldShowFreshlyPressed && (
-				<li className="reader-post-actions__item">
-					<ReaderFreshlyPressedButton blogId={ post.site_ID } postId={ post.ID } />
-				</li>
-			) }
-		</ul>
+		</>
 	);
 };
 

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -6,7 +6,6 @@ import { category } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
 import CommentButton from 'calypso/blocks/comment-button';
 import ReaderSaveButton from 'calypso/blocks/reader-save-button';
 import ShareButton from 'calypso/blocks/reader-share';
@@ -19,9 +18,8 @@ import {
 	isRebloggable,
 	isLikeable,
 } from 'calypso/reader/post/capabilities';
-import { SpacePickerModal } from 'calypso/reader/spaces/subscribe-with-space/space-picker-modal';
-import { useDispatch, useSelector } from 'calypso/state';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { useSpacePicker } from 'calypso/reader/spaces/subscribe-with-space/use-space-picker';
+import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { ReaderFreshlyPressedButton } from '../reader-freshly-pressed-button';
 import './style.scss';
@@ -41,9 +39,13 @@ const ReaderPostActions = ( {
 	split = false,
 } ) => {
 	const translate = useTranslate();
-	const [ isSpacePickerOpen, setIsSpacePickerOpen ] = useState( false );
 	const showSpaces = isEnabled( 'reader/spaces' );
-	const dispatch = useDispatch();
+	const { openSpacePicker, spacePickerModal } = useSpacePicker( {
+		feedId: post.feed_ID,
+		blogId: post.site_ID,
+		feedUrl: post.feed_URL || post.site_URL,
+		source: 'post_actions',
+	} );
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showShare = isSharable( post );
 	const showReblog = isRebloggable( post, hasSites );
@@ -56,17 +58,6 @@ const ReaderPostActions = ( {
 	const { data } = useQuery( readTeamsQuery() );
 	const isAutomattician = isAutomatticTeamMember( data?.teams ?? [] );
 	const shouldShowFreshlyPressed = fullPost && isAutomattician && showShare;
-
-	const openSpacePicker = () => {
-		dispatch(
-			recordReaderTracksEvent( 'calypso_reader_subscribe_space_button_clicked', {
-				feed_id: post.feed_ID,
-				blog_id: post.site_ID,
-				source: 'post_actions',
-			} )
-		);
-		setIsSpacePickerOpen( true );
-	};
 
 	return (
 		<>
@@ -142,14 +133,7 @@ const ReaderPostActions = ( {
 					</li>
 				) }
 			</ul>
-			{ showSpaces && isSpacePickerOpen && (
-				<SpacePickerModal
-					feedId={ post.feed_ID }
-					blogId={ post.site_ID }
-					feedUrl={ post.feed_URL || post.site_URL }
-					onClose={ () => setIsSpacePickerOpen( false ) }
-				/>
-			) }
+			{ showSpaces && spacePickerModal }
 		</>
 	);
 };

--- a/client/blocks/reader-post-actions/test/index.jsx
+++ b/client/blocks/reader-post-actions/test/index.jsx
@@ -2,11 +2,22 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import ReaderPostActions from '../index';
+
+let mockReaderSpacesEnabled = false;
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: ( flag ) => ( flag === 'reader/spaces' ? mockReaderSpacesEnabled : false ),
+} ) );
+
+const mockRecordReaderTracksEvent = jest.fn( () => ( { type: 'MOCK_TRACKS_EVENT' } ) );
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
 
 // Mock the components that are complex to test
 jest.mock( 'calypso/blocks/comment-button', () => () => <div data-testid="comment-button" /> );
@@ -14,6 +25,9 @@ jest.mock( 'calypso/blocks/reader-share', () => () => <div data-testid="share-bu
 jest.mock( 'calypso/reader/like-button', () => () => <div data-testid="like-button" /> );
 jest.mock( 'calypso/blocks/reader-freshly-pressed-button', () => ( {
 	ReaderFreshlyPressedButton: () => <div data-testid="freshly-pressed-button" />,
+} ) );
+jest.mock( 'calypso/reader/spaces/subscribe-with-space/space-picker-modal', () => ( {
+	SpacePickerModal: () => null,
 } ) );
 
 // Simple mock store
@@ -45,6 +59,8 @@ describe( 'ReaderPostActions', () => {
 	} );
 
 	beforeEach( () => {
+		mockReaderSpacesEnabled = false;
+		mockRecordReaderTracksEvent.mockClear();
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/read/teams' )
@@ -102,5 +118,38 @@ describe( 'ReaderPostActions', () => {
 
 			expect( queryByTestId( 'comment-button' ) ).toBeInTheDocument();
 		} );
+	} );
+
+	it( 'tracks when the spaces button is clicked', async () => {
+		mockReaderSpacesEnabled = true;
+		const user = userEvent.setup();
+		const store = createMockStore();
+		const props = {
+			...defaultProps,
+			post: {
+				...defaultProps.post,
+				feed_ID: 789,
+				feed_URL: 'https://example.com/feed',
+			},
+		};
+
+		render(
+			<QueryClientProvider client={ createQueryClient() }>
+				<Provider store={ store }>
+					<ReaderPostActions { ...props } />
+				</Provider>
+			</QueryClientProvider>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Move site to a space' } ) );
+
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_subscribe_space_button_clicked',
+			{
+				blog_id: 456,
+				feed_id: 789,
+				source: 'post_actions',
+			}
+		);
 	} );
 } );

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -32,6 +32,16 @@ export const useIsSubscribed = ( args: IsFollowingArgs ) => {
 	return getIsSubscribedFromData( data, args );
 };
 
+export const useIsSubscribedStatus = ( args: IsFollowingArgs ) => {
+	const { data, isError, isLoading } = useSiteSubscriptions();
+
+	return {
+		isSubscribed: getIsSubscribedFromData( data, args ),
+		isError,
+		isLoading,
+	};
+};
+
 export const useAliasedSiteSubscriptionFeedUrl = ( feedUrl: string ) => {
 	const { data } = useSiteSubscriptions();
 

--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -35,8 +35,10 @@ export function useSpace(
 
 /**
  * Details (sources + tags) for several spaces at once, keyed by space id. Used by
- * the subscribe-with-space picker to know which spaces already contain the feed
- * without mounting a query per row. Backed by the same detail cache as `useSpace`.
+ * the subscribe-with-space picker to know which spaces already contain the feed.
+ * Batches the per-space detail queries in a single hook at the modal level (rather
+ * than each row mounting its own `useSpace`), sharing the same detail cache as
+ * `useSpace`. Note this still runs one query per space id.
  */
 export function useSpacesDetails( spaceIds: string[] ): {
 	byId: Record< string, ReadSpaceDetails | undefined >;

--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -5,8 +5,8 @@ import {
 	readSpacesQuery,
 	updateReadSpaceMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { ReadSpace } from '@automattic/api-core';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { ReadSpace, ReadSpaceDetails } from '@automattic/api-core';
 
 /**
  * The user's spaces for the sidebar and space views, from the live list
@@ -30,6 +30,28 @@ export function useSpace(
 	return useQuery( {
 		...readSpaceQuery( spaceId ?? '' ),
 		enabled: enabled && Boolean( spaceId ),
+	} );
+}
+
+/**
+ * Details (sources + tags) for several spaces at once, keyed by space id. Used by
+ * the subscribe-with-space picker to know which spaces already contain the feed
+ * without mounting a query per row. Backed by the same detail cache as `useSpace`.
+ */
+export function useSpacesDetails( spaceIds: string[] ): {
+	byId: Record< string, ReadSpaceDetails | undefined >;
+	isError: boolean;
+	isLoading: boolean;
+} {
+	return useQueries( {
+		queries: spaceIds.map( ( id ) => readSpaceQuery( id ) ),
+		combine: ( results ) => ( {
+			byId: Object.fromEntries(
+				results.map( ( result, index ) => [ spaceIds[ index ], result.data ] )
+			),
+			isError: results.some( ( result ) => result.isError ),
+			isLoading: results.some( ( result ) => result.isLoading ),
+		} ),
 	} );
 }
 

--- a/client/reader/follow-button/index.tsx
+++ b/client/reader/follow-button/index.tsx
@@ -13,6 +13,7 @@ import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 
 interface ReaderFollowButtonProps {
 	className?: string;
+	disabled?: boolean;
 	feedId?: number;
 	followApiSource?: string;
 	followSource?: string;

--- a/client/reader/spaces/subscribe-with-space/index.tsx
+++ b/client/reader/spaces/subscribe-with-space/index.tsx
@@ -2,11 +2,9 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { category } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, type ComponentProps } from 'react';
+import { type ComponentProps } from 'react';
 import ReaderFollowButton from 'calypso/reader/follow-button';
-import { useDispatch } from 'calypso/state';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { SpacePickerModal } from './space-picker-modal';
+import { useSpacePicker } from './use-space-picker';
 
 import './style.scss';
 
@@ -21,23 +19,17 @@ type Props = ComponentProps< typeof ReaderFollowButton >;
 export function SubscribeWithSpaceButton( props: Props ) {
 	const { siteUrl, feedId, siteId, followApiSource } = props;
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { openSpacePicker, spacePickerModal } = useSpacePicker( {
+		feedId,
+		blogId: siteId,
+		feedUrl: siteUrl,
+		followApiSource,
+		source: 'full_post_action_bar',
+	} );
 
 	if ( ! isEnabled( 'reader/spaces' ) ) {
 		return <ReaderFollowButton { ...props } />;
 	}
-
-	const openModal = () => {
-		dispatch(
-			recordReaderTracksEvent( 'calypso_reader_subscribe_space_button_clicked', {
-				feed_id: feedId,
-				blog_id: siteId,
-				source: 'full_post_action_bar',
-			} )
-		);
-		setIsModalOpen( true );
-	};
 
 	return (
 		<>
@@ -47,19 +39,11 @@ export function SubscribeWithSpaceButton( props: Props ) {
 					className="reader-subscribe-with-space__spaces"
 					icon={ category }
 					label={ translate( 'Move site to a space' ) }
-					onClick={ openModal }
+					onClick={ openSpacePicker }
 				/>
 				<ReaderFollowButton { ...props } />
 			</HStack>
-			{ isModalOpen && (
-				<SpacePickerModal
-					feedId={ feedId }
-					blogId={ siteId }
-					feedUrl={ siteUrl }
-					followApiSource={ followApiSource }
-					onClose={ () => setIsModalOpen( false ) }
-				/>
-			) }
+			{ spacePickerModal }
 		</>
 	);
 }

--- a/client/reader/spaces/subscribe-with-space/index.tsx
+++ b/client/reader/spaces/subscribe-with-space/index.tsx
@@ -1,0 +1,65 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { category } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState, type ComponentProps } from 'react';
+import ReaderFollowButton from 'calypso/reader/follow-button';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SpacePickerModal } from './space-picker-modal';
+
+import './style.scss';
+
+type Props = ComponentProps< typeof ReaderFollowButton >;
+
+/**
+ * Subscribe control for the full-post view. When the `reader/spaces` flag is off it
+ * renders the plain `ReaderFollowButton`. With the flag on it adds an icon-only
+ * button to the left of Subscribe that opens the Space picker (the picker itself
+ * subscribes the feed on open).
+ */
+export function SubscribeWithSpaceButton( props: Props ) {
+	const { siteUrl, feedId, siteId, followApiSource } = props;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	if ( ! isEnabled( 'reader/spaces' ) ) {
+		return <ReaderFollowButton { ...props } />;
+	}
+
+	const openModal = () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_subscribe_space_button_clicked', {
+				feed_id: feedId,
+				blog_id: siteId,
+				source: 'full_post_action_bar',
+			} )
+		);
+		setIsModalOpen( true );
+	};
+
+	return (
+		<>
+			<HStack spacing={ 2 } expanded={ false } className="reader-subscribe-with-space">
+				<Button
+					__next40pxDefaultSize
+					className="reader-subscribe-with-space__spaces"
+					icon={ category }
+					label={ translate( 'Move site to a space' ) }
+					onClick={ openModal }
+				/>
+				<ReaderFollowButton { ...props } />
+			</HStack>
+			{ isModalOpen && (
+				<SpacePickerModal
+					feedId={ feedId }
+					blogId={ siteId }
+					feedUrl={ siteUrl }
+					followApiSource={ followApiSource }
+					onClose={ () => setIsModalOpen( false ) }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/reader/spaces/subscribe-with-space/space-picker-modal.tsx
+++ b/client/reader/spaces/subscribe-with-space/space-picker-modal.tsx
@@ -217,7 +217,12 @@ export function SpacePickerModal( { feedUrl, feedId, blogId, followApiSource, on
 		return spaces.filter( ( space ) => space.name.toLowerCase().includes( q ) );
 	}, [ spaces, query ] );
 
-	const rowsDisabled = isSubscribing || isLoading || isError || isSaving;
+	// The picker subscribes the feed on open, so keep space edits disabled until the
+	// feed is actually subscribed. `! isSubscribed` covers the whole window: before
+	// the follow fires, while the subscription check or the follow is in flight, and
+	// after a follow that failed and rolled back the optimistic subscription.
+	const isSubscriptionNotReady = isSubscriptionLoading || isSubscribing || ! isSubscribed;
+	const rowsDisabled = isSubscriptionNotReady || isLoading || isError || isSaving;
 
 	let spacesContent;
 	if ( spaces.length === 0 ) {
@@ -328,7 +333,7 @@ export function SpacePickerModal( { feedUrl, feedId, blogId, followApiSource, on
 						variant="primary"
 						isBusy={ isSaving }
 						disabled={
-							isSubscribing ||
+							isSubscriptionNotReady ||
 							isLoading ||
 							isError ||
 							isSaving ||

--- a/client/reader/spaces/subscribe-with-space/space-picker-modal.tsx
+++ b/client/reader/spaces/subscribe-with-space/space-picker-modal.tsx
@@ -11,6 +11,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
+import Skeleton from 'calypso/reader/components/skeleton';
 import {
 	getFollowingSource,
 	useFollowSite,
@@ -43,7 +44,10 @@ interface Props {
 }
 
 /** Strip the scheme and a leading `www.` so the feed reads as a plain domain. */
-function feedHostLabel( feedUrl: string ): string {
+function feedHostLabel( feedUrl: string | undefined ): string {
+	if ( ! feedUrl ) {
+		return '';
+	}
 	try {
 		return new URL( feedUrl ).hostname.replace( /^www\./, '' );
 	} catch {
@@ -215,6 +219,54 @@ export function SpacePickerModal( { feedUrl, feedId, blogId, followApiSource, on
 
 	const rowsDisabled = isSubscribing || isLoading || isError || isSaving;
 
+	let spacesContent;
+	if ( spaces.length === 0 ) {
+		spacesContent = (
+			<p className="reader-space-picker__empty">
+				{ translate( 'You don’t have any spaces yet.' ) }
+			</p>
+		);
+	} else if ( isLoading ) {
+		spacesContent = (
+			<SpacePickerSkeleton
+				count={ Math.min( spaces.length, 6 ) }
+				label={ translate( 'Loading your spaces' ) as string }
+			/>
+		);
+	} else {
+		spacesContent = (
+			<>
+				{ showSearch && (
+					<SearchControl
+						__nextHasNoMarginBottom
+						className="reader-space-picker__search"
+						value={ query }
+						onChange={ setQuery }
+						placeholder={ translate( 'Search your spaces…' ) }
+					/>
+				) }
+				{ filteredSpaces.length === 0 ? (
+					<p className="reader-space-picker__empty">
+						{ translate( 'No spaces match “%(query)s”.', { args: { query } } ) }
+					</p>
+				) : (
+					<VStack spacing={ 1 } role="list" className="reader-space-picker__list">
+						{ filteredSpaces.map( ( space ) => (
+							<SpacePickerRow
+								key={ space.id }
+								space={ space }
+								detail={ byId[ space.id ] }
+								isSelected={ selected.has( space.id ) }
+								disabled={ rowsDisabled }
+								onToggle={ () => toggleSpace( space.id ) }
+							/>
+						) ) }
+					</VStack>
+				) }
+			</>
+		);
+	}
+
 	return (
 		// The Modal renders through a portal, but React events still bubble up the
 		// component tree. This picker can be opened from inside a clickable post card,
@@ -260,41 +312,7 @@ export function SpacePickerModal( { feedUrl, feedId, blogId, followApiSource, on
 					</span>
 				</HStack>
 
-				{ spaces.length === 0 ? (
-					<p className="reader-space-picker__empty">
-						{ translate( 'You don’t have any spaces yet.' ) }
-					</p>
-				) : (
-					<>
-						{ showSearch && (
-							<SearchControl
-								__nextHasNoMarginBottom
-								className="reader-space-picker__search"
-								value={ query }
-								onChange={ setQuery }
-								placeholder={ translate( 'Search your spaces…' ) }
-							/>
-						) }
-						{ filteredSpaces.length === 0 ? (
-							<p className="reader-space-picker__empty">
-								{ translate( 'No spaces match “%(query)s”.', { args: { query } } ) }
-							</p>
-						) : (
-							<VStack spacing={ 1 } role="list" className="reader-space-picker__list">
-								{ filteredSpaces.map( ( space ) => (
-									<SpacePickerRow
-										key={ space.id }
-										space={ space }
-										detail={ byId[ space.id ] }
-										isSelected={ selected.has( space.id ) }
-										disabled={ rowsDisabled }
-										onToggle={ () => toggleSpace( space.id ) }
-									/>
-								) ) }
-							</VStack>
-						) }
-					</>
-				) }
+				{ spacesContent }
 
 				<HStack className="reader-space-picker__footer" justify="flex-end" spacing={ 2 }>
 					<Button
@@ -391,5 +409,36 @@ function SpacePickerRow( { space, detail, isSelected, disabled, onToggle }: RowP
 				onClick={ onToggle }
 			/>
 		</HStack>
+	);
+}
+
+function SpacePickerSkeleton( { count, label }: { count: number; label: string } ) {
+	return (
+		<VStack
+			spacing={ 1 }
+			className="reader-space-picker__list"
+			role="status"
+			aria-label={ label }
+			aria-live="polite"
+		>
+			{ Array.from( { length: count }, ( _value, index ) => (
+				<HStack
+					key={ index }
+					spacing={ 3 }
+					alignment="center"
+					justify="space-between"
+					className="reader-space-picker__row"
+				>
+					<HStack spacing={ 3 } alignment="center" justify="flex-start">
+						<Skeleton shape="circle" width="40px" height="40px" />
+						<VStack spacing={ 2 }>
+							<Skeleton width="140px" height="16px" />
+							<Skeleton width="72px" height="12px" />
+						</VStack>
+					</HStack>
+					<Skeleton width="40px" height="40px" />
+				</HStack>
+			) ) }
+		</VStack>
 	);
 }

--- a/client/reader/spaces/subscribe-with-space/space-picker-modal.tsx
+++ b/client/reader/spaces/subscribe-with-space/space-picker-modal.tsx
@@ -1,0 +1,395 @@
+import { getReadSpaceSourceKey, type ReadSpace, type ReadSpaceDetails } from '@automattic/api-core';
+import {
+	Button,
+	Modal,
+	SearchControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Icon, check, close, plus, rss } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { SiteIcon } from 'calypso/blocks/site-icon';
+import {
+	getFollowingSource,
+	useFollowSite,
+	useIsSubscribedStatus,
+	useSiteSubscriptionForFeed,
+} from 'calypso/reader/data/site-subscriptions';
+import { useSpaces, useSpacesDetails, useUpdateSpace } from 'calypso/reader/data/spaces';
+import { resolveSpaceIconColor } from 'calypso/reader/spaces/colors';
+import { getSpaceErrorMessage } from 'calypso/reader/spaces/form-helpers';
+import { SPACE_ICONS } from 'calypso/reader/spaces/icons';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+
+import './style.scss';
+
+// Show the search field only once the list is long enough to be worth filtering.
+const SEARCH_THRESHOLD = 6;
+
+// Ties the hidden Modal header's accessible name to our custom visible heading.
+const SPACE_PICKER_HEADING_ID = 'reader-space-picker__heading';
+
+interface Props {
+	feedUrl: string;
+	feedId?: number;
+	blogId?: number;
+	/** Follow source recorded when the picker subscribes the feed on open. */
+	followApiSource?: string;
+	onClose: () => void;
+}
+
+/** Strip the scheme and a leading `www.` so the feed reads as a plain domain. */
+function feedHostLabel( feedUrl: string ): string {
+	try {
+		return new URL( feedUrl ).hostname.replace( /^www\./, '' );
+	} catch {
+		return feedUrl
+			.replace( /^https?:\/\//, '' )
+			.replace( /^www\./, '' )
+			.replace( /\/.*$/, '' );
+	}
+}
+
+/**
+ * Lets the user choose which of their Spaces this (just-subscribed) feed belongs
+ * to. Toggling a Space only edits a local draft; nothing is written until the user
+ * hits Save, which then persists each changed Space through its update endpoint
+ * (`useUpdateSpace`) with the full replacement feed list. Cancel discards the draft.
+ */
+export function SpacePickerModal( { feedUrl, feedId, blogId, followApiSource, onClose }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const spaces = useSpaces();
+	const [ query, setQuery ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	// Opening the picker subscribes the feed straight away (if it isn't already), so
+	// the user only has to pick the Space. Adds stay disabled until it resolves.
+	const {
+		isSubscribed,
+		isError: isSubscriptionError,
+		isLoading: isSubscriptionLoading,
+	} = useIsSubscribedStatus( { feedUrl, feedId, blogId } );
+	const { mutate: followSite, isPending: isSubscribing } = useFollowSite();
+	const openedRef = useRef( false );
+	useEffect( () => {
+		if ( openedRef.current ) {
+			return;
+		}
+		openedRef.current = true;
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_subscribe_space_modal_opened', {
+				feed_id: feedId,
+				blog_id: blogId,
+			} )
+		);
+		// Runs once when the picker opens.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+	const followAttemptedRef = useRef( false );
+	useEffect( () => {
+		if (
+			followAttemptedRef.current ||
+			isSubscriptionLoading ||
+			isSubscriptionError ||
+			isSubscribed
+		) {
+			return;
+		}
+		followAttemptedRef.current = true;
+		followSite( { feedUrl, source: followApiSource ?? getFollowingSource() } );
+	}, [
+		feedUrl,
+		followApiSource,
+		followSite,
+		isSubscribed,
+		isSubscriptionError,
+		isSubscriptionLoading,
+	] );
+
+	const feedSourceKey = getReadSpaceSourceKey( { feedId, blogId, feedUrl } );
+	// Feed identifier the update endpoint accepts (numeric id, falling back to url).
+	const feedIdentifier = feedId ?? feedUrl;
+	const feedHost = useMemo( () => feedHostLabel( feedUrl ), [ feedUrl ] );
+	// The just-subscribed feed's own site icon for the preview row.
+	const feedSubscription = useSiteSubscriptionForFeed( feedId );
+
+	const spaceIds = useMemo( () => spaces.map( ( space ) => space.id ), [ spaces ] );
+	const { byId, isError, isLoading } = useSpacesDetails( spaceIds );
+
+	// Which spaces already contain the feed, from the server.
+	const initialSelected = useMemo( () => {
+		const selected = new Set< string >();
+		for ( const space of spaces ) {
+			const detail = byId[ space.id ];
+			if (
+				detail?.sources.some( ( source ) => getReadSpaceSourceKey( source ) === feedSourceKey )
+			) {
+				selected.add( space.id );
+			}
+		}
+		return selected;
+	}, [ spaces, byId, feedSourceKey ] );
+
+	// Local draft of the desired membership. `null` until the user edits it, so the
+	// list keeps reflecting the server state while the details are still loading.
+	const [ draft, setDraft ] = useState< Set< string > | null >( null );
+	const selected = draft ?? initialSelected;
+
+	const toggleSpace = ( spaceId: string ) => {
+		setDraft( ( previous ) => {
+			const next = new Set( previous ?? initialSelected );
+			if ( next.has( spaceId ) ) {
+				next.delete( spaceId );
+			} else {
+				next.add( spaceId );
+			}
+			return next;
+		} );
+	};
+
+	const toAdd = [ ...selected ].filter( ( id ) => ! initialSelected.has( id ) );
+	const toRemove = [ ...initialSelected ].filter( ( id ) => ! selected.has( id ) );
+	const hasChanges = toAdd.length > 0 || toRemove.length > 0;
+	const changedSpaceIds = [ ...toAdd, ...toRemove ];
+	const hasMissingChangedDetails = changedSpaceIds.some( ( id ) => ! byId[ id ] );
+
+	const { mutateAsync: updateSpace } = useUpdateSpace();
+
+	// A space is edited through its update endpoint with the full replacement feed
+	// list, so build it from the space's current sources (minus this feed) and add
+	// the feed back only when it should be a member.
+	const buildFeeds = ( spaceId: string, shouldInclude: boolean ): ( number | string )[] => {
+		const others = ( byId[ spaceId ]?.sources ?? [] )
+			.filter( ( source ) => getReadSpaceSourceKey( source ) !== feedSourceKey )
+			.map( ( source ) => source.feedId ?? source.feedUrl );
+		return shouldInclude ? [ ...others, feedIdentifier ] : others;
+	};
+
+	const handleSave = async () => {
+		if ( ! hasChanges ) {
+			onClose();
+			return;
+		}
+		if ( isError || hasMissingChangedDetails ) {
+			return;
+		}
+
+		setIsSaving( true );
+		try {
+			await Promise.all( [
+				...toAdd.map( ( spaceId ) =>
+					updateSpace( { spaceId, params: { feeds: buildFeeds( spaceId, true ) } } )
+				),
+				...toRemove.map( ( spaceId ) =>
+					updateSpace( { spaceId, params: { feeds: buildFeeds( spaceId, false ) } } )
+				),
+			] );
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_subscribe_space_saved', {
+					feed_id: feedId,
+					added: toAdd.length,
+					removed: toRemove.length,
+				} )
+			);
+			dispatch( successNotice( translate( 'Spaces updated.' ), { duration: 5000 } ) );
+			onClose();
+		} catch ( error ) {
+			setIsSaving( false );
+			dispatch( errorNotice( getSpaceErrorMessage( error, translate ), { duration: 5000 } ) );
+		}
+	};
+
+	const showSearch = spaces.length > SEARCH_THRESHOLD;
+	const filteredSpaces = useMemo( () => {
+		const q = query.trim().toLowerCase();
+		if ( ! q ) {
+			return spaces;
+		}
+		return spaces.filter( ( space ) => space.name.toLowerCase().includes( q ) );
+	}, [ spaces, query ] );
+
+	const rowsDisabled = isSubscribing || isLoading || isError || isSaving;
+
+	return (
+		// The Modal renders through a portal, but React events still bubble up the
+		// component tree. This picker can be opened from inside a clickable post card,
+		// so stop clicks here to keep Cancel/close from also triggering the card's
+		// navigation to the feed.
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div onClick={ ( event ) => event.stopPropagation() }>
+			<Modal
+				onRequestClose={ onClose }
+				className="reader-space-picker"
+				__experimentalHideHeader
+				// No `title` (the built-in header is hidden); label the dialog from our
+				// own visible heading so the dialog still has an accessible name.
+				aria={ { labelledby: SPACE_PICKER_HEADING_ID } }
+			>
+				<VStack className="reader-space-picker__header" spacing={ 0 }>
+					<HStack>
+						<h1 id={ SPACE_PICKER_HEADING_ID } className="reader-space-picker__header-heading">
+							{ translate( 'Move site to a space' ) }
+						</h1>
+						<Button
+							icon={ <Icon icon={ close } /> }
+							label={ translate( 'Close' ) }
+							onClick={ onClose }
+						/>
+					</HStack>
+					<p className="reader-space-picker__subtitle">
+						{ translate( 'Adds the whole site to a space, not just this post.' ) }
+					</p>
+				</VStack>
+
+				{ /* What you're adding — the feed you just subscribed to. */ }
+				<HStack
+					spacing={ 3 }
+					alignment="center"
+					justify="flex-start"
+					className="reader-space-picker__feed"
+				>
+					<SiteIcon iconUrl={ feedSubscription?.site_icon } siteId={ blogId } size={ 24 } />
+					<span className="reader-space-picker__feed-text">
+						<span className="reader-space-picker__feed-label">{ translate( 'Site' ) }</span>
+						<span className="reader-space-picker__feed-host">{ feedHost }</span>
+					</span>
+				</HStack>
+
+				{ spaces.length === 0 ? (
+					<p className="reader-space-picker__empty">
+						{ translate( 'You don’t have any spaces yet.' ) }
+					</p>
+				) : (
+					<>
+						{ showSearch && (
+							<SearchControl
+								__nextHasNoMarginBottom
+								className="reader-space-picker__search"
+								value={ query }
+								onChange={ setQuery }
+								placeholder={ translate( 'Search your spaces…' ) }
+							/>
+						) }
+						{ filteredSpaces.length === 0 ? (
+							<p className="reader-space-picker__empty">
+								{ translate( 'No spaces match “%(query)s”.', { args: { query } } ) }
+							</p>
+						) : (
+							<VStack spacing={ 1 } role="list" className="reader-space-picker__list">
+								{ filteredSpaces.map( ( space ) => (
+									<SpacePickerRow
+										key={ space.id }
+										space={ space }
+										detail={ byId[ space.id ] }
+										isSelected={ selected.has( space.id ) }
+										disabled={ rowsDisabled }
+										onToggle={ () => toggleSpace( space.id ) }
+									/>
+								) ) }
+							</VStack>
+						) }
+					</>
+				) }
+
+				<HStack className="reader-space-picker__footer" justify="flex-end" spacing={ 2 }>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						disabled={ isSaving }
+						onClick={ onClose }
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isBusy={ isSaving }
+						disabled={
+							isSubscribing ||
+							isLoading ||
+							isError ||
+							isSaving ||
+							hasMissingChangedDetails ||
+							! hasChanges
+						}
+						onClick={ handleSave }
+					>
+						{ translate( 'Save' ) }
+					</Button>
+				</HStack>
+			</Modal>
+		</div>
+	);
+}
+
+interface RowProps {
+	space: ReadSpace;
+	detail: ReadSpaceDetails | undefined;
+	isSelected: boolean;
+	disabled: boolean;
+	onToggle: () => void;
+}
+
+function SpacePickerRow( { space, detail, isSelected, disabled, onToggle }: RowProps ) {
+	const translate = useTranslate();
+	const icon = SPACE_ICONS[ space.layout.icon ] ?? rss;
+	const accentColor = resolveSpaceIconColor( space.layout );
+
+	// `detail` already carries the source list, so the count is free.
+	const sourceCount = detail?.sources.length ?? 0;
+	let metaLabel = '';
+	if ( detail ) {
+		metaLabel =
+			sourceCount === 0
+				? translate( 'No feeds yet' )
+				: ( translate( '%(count)d feed', '%(count)d feeds', {
+						count: sourceCount,
+						args: { count: sourceCount },
+				  } ) as string );
+	}
+
+	return (
+		<HStack
+			spacing={ 3 }
+			alignment="center"
+			justify="space-between"
+			role="listitem"
+			aria-label={ space.name }
+			className={ clsx( 'reader-space-picker__row', `reader-space-picker__row--${ accentColor }`, {
+				'is-added': isSelected,
+			} ) }
+		>
+			<HStack
+				spacing={ 3 }
+				alignment="center"
+				justify="flex-start"
+				className="reader-space-picker__info"
+			>
+				<span className="reader-space-picker__icon" aria-hidden="true">
+					<Icon icon={ icon } size={ 22 } />
+				</span>
+				<span className="reader-space-picker__text">
+					<span className="reader-space-picker__name">{ space.name }</span>
+					{ metaLabel && <span className="reader-space-picker__meta">{ metaLabel }</span> }
+				</span>
+			</HStack>
+			<Button
+				__next40pxDefaultSize
+				variant={ isSelected ? 'secondary' : 'primary' }
+				icon={ isSelected ? check : plus }
+				disabled={ disabled }
+				aria-label={
+					isSelected
+						? ( translate( 'Remove from %(name)s', { args: { name: space.name } } ) as string )
+						: ( translate( 'Add to %(name)s', { args: { name: space.name } } ) as string )
+				}
+				onClick={ onToggle }
+			/>
+		</HStack>
+	);
+}

--- a/client/reader/spaces/subscribe-with-space/style.scss
+++ b/client/reader/spaces/subscribe-with-space/style.scss
@@ -6,7 +6,9 @@
 .reader-space-picker {
 	&.components-modal__frame {
 		min-inline-size: 480px;
-		block-size: min( 680px, calc( 100% - 96px ) );
+		// Size to content, but cap the height so a long list scrolls instead of
+		// growing the whole modal.
+		max-block-size: min( 680px, calc( 100% - 96px ) );
 	}
 
 	.components-modal__content {
@@ -99,8 +101,10 @@
 }
 
 // Only the list scrolls; the header, feed preview, search and footer stay put.
+// Rows stay top-aligned (VStack would otherwise distribute them).
 .reader-space-picker__list {
-	flex: 1;
+	flex: 0 1 auto;
+	justify-content: flex-start;
 	min-block-size: 0;
 	overflow-y: auto;
 }

--- a/client/reader/spaces/subscribe-with-space/style.scss
+++ b/client/reader/spaces/subscribe-with-space/style.scss
@@ -1,0 +1,130 @@
+@use 'calypso/reader/spaces/colors' as space-colors;
+
+.components-modal__frame.reader-space-picker {
+	min-inline-size: 480px;
+}
+
+.reader-space-picker__header {
+	padding-block-end: 12px;
+	&-heading {
+		font-size: 20px;
+		font-weight: 600;
+	}
+}
+
+.reader-space-picker__subtitle {
+	margin-block: 4px 0;
+	color: var( --color-text-subtle );
+	font-size: 0.875rem;
+	line-height: 1.4;
+}
+
+.reader-space-picker__footer {
+	margin-block-start: 16px;
+	padding-block-start: 16px;
+	border-block-start: 1px solid var( --color-neutral-5 );
+}
+
+// "What you're adding" — the feed the subscribe action just followed.
+.reader-space-picker__feed {
+	margin-bottom: 16px;
+	padding: 10px 12px;
+	border-radius: 8px;
+	background: var( --color-neutral-0 );
+}
+
+.reader-space-picker__feed .site-icon {
+	flex-shrink: 0;
+}
+
+.reader-space-picker__feed-text {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	min-inline-size: 0;
+}
+
+.reader-space-picker__feed-label {
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: var( --color-text-subtle );
+}
+
+.reader-space-picker__feed-host {
+	font-weight: 500;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.reader-space-picker__search {
+	margin-bottom: 12px;
+}
+
+.reader-space-picker__empty {
+	color: var( --color-text-subtle );
+	margin: 8px 0;
+}
+
+.reader-space-picker__row {
+	min-height: 56px;
+	padding: 6px 8px;
+	border-radius: 8px;
+	transition: background 0.12s ease;
+
+	&:hover {
+		background: var( --color-neutral-0 );
+	}
+}
+
+.reader-space-picker__info {
+	min-inline-size: 0;
+	flex: 1;
+}
+
+// Consumes `--space-color` / `--space-color-bg` set by the `--#{$color}` modifier
+// on the row (see the loop below), mirroring the sidebar space item.
+.reader-space-picker__icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	inline-size: 40px;
+	block-size: 40px;
+	border-radius: 8px;
+	background: var( --space-color-bg );
+	color: var( --space-color );
+}
+
+.reader-space-picker__text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-inline-size: 0;
+}
+
+.reader-space-picker__name {
+	font-weight: 500;
+	color: var( --color-text );
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.reader-space-picker__meta {
+	font-size: 0.75rem;
+	color: var( --color-text-subtle );
+	line-height: 1.2;
+}
+
+// Each space exposes its accent as `--space-color` / `--space-color-bg`; emit the
+// values on the row so both the icon tile and the added-row tint can read them.
+// Palette lives once in `colors.scss` (via the shared `space-accent-color` mixin).
+@each $color in space-colors.$space-colors {
+	.reader-space-picker__row--#{$color} {
+		@include space-colors.space-accent-color( $color );
+	}
+}

--- a/client/reader/spaces/subscribe-with-space/style.scss
+++ b/client/reader/spaces/subscribe-with-space/style.scss
@@ -1,10 +1,30 @@
 @use 'calypso/reader/spaces/colors' as space-colors;
 
-.components-modal__frame.reader-space-picker {
-	min-inline-size: 480px;
+// Fixed-height flex column: static header + feed preview + search, a scrolling
+// list, and a pinned footer — so only the list scrolls, not the whole modal.
+// Mirrors the customize-space modal layout.
+.reader-space-picker {
+	&.components-modal__frame {
+		min-inline-size: 480px;
+		block-size: min( 680px, calc( 100% - 96px ) );
+	}
+
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.components-modal__children-container {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		min-block-size: 0;
+	}
 }
 
 .reader-space-picker__header {
+	flex-shrink: 0;
 	padding-block-end: 12px;
 	&-heading {
 		font-size: 20px;
@@ -20,6 +40,7 @@
 }
 
 .reader-space-picker__footer {
+	flex-shrink: 0;
 	margin-block-start: 16px;
 	padding-block-start: 16px;
 	border-block-start: 1px solid var( --color-neutral-5 );
@@ -27,6 +48,7 @@
 
 // "What you're adding" — the feed the subscribe action just followed.
 .reader-space-picker__feed {
+	flex-shrink: 0;
 	margin-block-end: 16px;
 	padding-block: 10px;
 	padding-inline: 12px;
@@ -61,16 +83,30 @@
 }
 
 .reader-space-picker__search {
+	flex-shrink: 0;
 	margin-block-end: 12px;
 }
 
+// Fills the scroll area so the footer stays pinned even when the message is short.
 .reader-space-picker__empty {
+	display: flex;
+	flex: 1;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
 	color: var( --color-text-subtle );
-	margin-block: 8px;
-	margin-inline: 0;
+	margin: 0;
+}
+
+// Only the list scrolls; the header, feed preview, search and footer stay put.
+.reader-space-picker__list {
+	flex: 1;
+	min-block-size: 0;
+	overflow-y: auto;
 }
 
 .reader-space-picker__row {
+	flex-shrink: 0;
 	min-height: 56px;
 	padding-block: 6px;
 	padding-inline: 8px;

--- a/client/reader/spaces/subscribe-with-space/style.scss
+++ b/client/reader/spaces/subscribe-with-space/style.scss
@@ -27,8 +27,9 @@
 
 // "What you're adding" — the feed the subscribe action just followed.
 .reader-space-picker__feed {
-	margin-bottom: 16px;
-	padding: 10px 12px;
+	margin-block-end: 16px;
+	padding-block: 10px;
+	padding-inline: 12px;
 	border-radius: 8px;
 	background: var( --color-neutral-0 );
 }
@@ -60,17 +61,19 @@
 }
 
 .reader-space-picker__search {
-	margin-bottom: 12px;
+	margin-block-end: 12px;
 }
 
 .reader-space-picker__empty {
 	color: var( --color-text-subtle );
-	margin: 8px 0;
+	margin-block: 8px;
+	margin-inline: 0;
 }
 
 .reader-space-picker__row {
 	min-height: 56px;
-	padding: 6px 8px;
+	padding-block: 6px;
+	padding-inline: 8px;
 	border-radius: 8px;
 	transition: background 0.12s ease;
 

--- a/client/reader/spaces/subscribe-with-space/test/index.test.tsx
+++ b/client/reader/spaces/subscribe-with-space/test/index.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SubscribeWithSpaceButton } from '../index';
+import type { ReadSpace, ReadSpaceDetails } from '@automattic/api-core';
+
+const mockRecordReaderTracksEvent = jest.fn( () => ( { type: 'MOCK_TRACKS_EVENT' } ) );
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
+let mockFlagEnabled = true;
+jest.mock( '@automattic/calypso-config', () => {
+	const configFn = jest.fn();
+	const isEnabled = ( flag: string ) => ( flag === 'reader/spaces' ? mockFlagEnabled : false );
+	return {
+		__esModule: true,
+		default: Object.assign( configFn, { isEnabled } ),
+		isEnabled,
+	};
+} );
+
+// SiteIcon pulls in the sites Redux data-layer (QuerySites); stub it so the picker
+// tests don't fire a real site request.
+jest.mock( 'calypso/blocks/site-icon', () => ( {
+	SiteIcon: () => null,
+} ) );
+
+let mockIsSubscribed = false;
+let mockIsSubscribedLoading = false;
+const mockFollowSite = jest.fn();
+let mockFollowPending = false;
+jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
+	useIsSubscribed: () => mockIsSubscribed,
+	useIsSubscribedStatus: () => ( {
+		isSubscribed: mockIsSubscribed,
+		isLoading: mockIsSubscribedLoading,
+	} ),
+	useFollowSite: () => ( { mutate: mockFollowSite, isPending: mockFollowPending } ),
+	useUnfollowSite: () => ( { mutate: jest.fn(), isPending: false } ),
+	useSiteSubscriptionForFeed: () => undefined,
+	getFollowingSource: () => 'reader_full_post',
+} ) );
+
+const mockUpdateSpace = jest.fn().mockResolvedValue( undefined );
+let mockSpaces: ReadSpace[] = [];
+let mockDetailsById: Record< string, ReadSpaceDetails | undefined > = {};
+let mockDetailsLoading = false;
+let mockDetailsError = false;
+jest.mock( 'calypso/reader/data/spaces', () => ( {
+	useSpaces: () => mockSpaces,
+	useSpacesDetails: () => ( {
+		byId: mockDetailsById,
+		isLoading: mockDetailsLoading,
+		isError: mockDetailsError,
+	} ),
+	useUpdateSpace: () => ( { mutateAsync: mockUpdateSpace, isPending: false } ),
+} ) );
+
+const space: ReadSpace = {
+	id: '10',
+	name: 'Work',
+	layout: { color: 'none', icon: 'inbox' },
+};
+
+const props = {
+	siteUrl: 'https://blog.example/feed',
+	feedId: 456,
+	siteId: 123,
+};
+
+beforeEach( () => {
+	mockFlagEnabled = true;
+	mockIsSubscribed = false;
+	mockIsSubscribedLoading = false;
+	mockFollowPending = false;
+	mockSpaces = [ space ];
+	mockDetailsById = { [ space.id ]: { ...space, sources: [], tags: [] } };
+	mockDetailsLoading = false;
+	mockDetailsError = false;
+	mockFollowSite.mockClear();
+	mockUpdateSpace.mockClear();
+	mockRecordReaderTracksEvent.mockClear();
+} );
+
+const openPicker = async ( user: ReturnType< typeof userEvent.setup > ) => {
+	await user.click( screen.getByRole( 'button', { name: 'Move site to a space' } ) );
+	return screen.findByRole( 'dialog', { name: 'Move site to a space' } );
+};
+
+it( 'renders only the plain follow button when the flag is off', () => {
+	mockFlagEnabled = false;
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	expect( screen.getByRole( 'button', { name: 'Subscribe' } ) ).toBeVisible();
+	expect(
+		screen.queryByRole( 'button', { name: 'Move site to a space' } )
+	).not.toBeInTheDocument();
+} );
+
+it( 'renders the spaces button alongside subscribe when the flag is on', () => {
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	expect( screen.getByRole( 'button', { name: 'Subscribe' } ) ).toBeVisible();
+	expect( screen.getByRole( 'button', { name: 'Move site to a space' } ) ).toBeVisible();
+} );
+
+it( 'subscribes and opens the picker when the spaces button is clicked', async () => {
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( mockFollowSite ).toHaveBeenCalledWith( {
+		feedUrl: 'https://blog.example/feed',
+		source: 'reader_full_post',
+	} );
+	expect( screen.getByRole( 'listitem', { name: 'Work' } ) ).toBeVisible();
+} );
+
+it( 'tracks when the full post spaces button is clicked', async () => {
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+		'calypso_reader_subscribe_space_button_clicked',
+		{
+			blog_id: 123,
+			feed_id: 456,
+			source: 'full_post_action_bar',
+		}
+	);
+} );
+
+it( 'does not re-subscribe when the feed is already subscribed', async () => {
+	mockIsSubscribed = true;
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( mockFollowSite ).not.toHaveBeenCalled();
+} );
+
+it( 'waits for subscription state before subscribing from the picker', async () => {
+	mockIsSubscribedLoading = true;
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( mockFollowSite ).not.toHaveBeenCalled();
+} );
+
+it( 'only applies the added space on Save (not while toggling), via the update endpoint', async () => {
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+	await user.click( await screen.findByRole( 'button', { name: 'Add to Work' } ) );
+
+	// Toggling the row must not write anything yet.
+	expect( mockUpdateSpace ).not.toHaveBeenCalled();
+
+	await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+	expect( mockUpdateSpace ).toHaveBeenCalledWith( {
+		spaceId: '10',
+		params: { feeds: [ 456 ] },
+	} );
+} );
+
+it( 'removes the feed from a space on Save by replacing its feed list', async () => {
+	mockDetailsById = {
+		[ space.id ]: {
+			...space,
+			tags: [],
+			sources: [
+				{
+					feedId: 456,
+					feedUrl: 'https://blog.example/feed',
+					blogId: 123,
+					name: null,
+					siteIcon: null,
+				},
+			],
+		},
+	};
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+	await user.click( await screen.findByRole( 'button', { name: 'Remove from Work' } ) );
+	await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+	expect( mockUpdateSpace ).toHaveBeenCalledWith( {
+		spaceId: '10',
+		params: { feeds: [] },
+	} );
+} );
+
+it( 'discards the draft on Cancel without writing anything', async () => {
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+	await user.click( await screen.findByRole( 'button', { name: 'Add to Work' } ) );
+	await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+	expect( mockUpdateSpace ).not.toHaveBeenCalled();
+	expect(
+		screen.queryByRole( 'dialog', { name: 'Move site to a space' } )
+	).not.toBeInTheDocument();
+} );
+
+it( 'disables Save until a change is made', async () => {
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+
+	await user.click( await screen.findByRole( 'button', { name: 'Add to Work' } ) );
+
+	expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+} );
+
+it( 'does not allow editing when space details fail to load', async () => {
+	mockDetailsById = { [ space.id ]: undefined };
+	mockDetailsError = true;
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( await screen.findByRole( 'button', { name: 'Add to Work' } ) ).toBeDisabled();
+	expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+} );
+
+it( 'shows the empty state when the user has no spaces', async () => {
+	mockSpaces = [];
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( await screen.findByText( 'You don’t have any spaces yet.' ) ).toBeVisible();
+} );

--- a/client/reader/spaces/subscribe-with-space/test/index.test.tsx
+++ b/client/reader/spaces/subscribe-with-space/test/index.test.tsx
@@ -170,6 +170,7 @@ it( 'waits for subscription state before subscribing from the picker', async () 
 } );
 
 it( 'only applies the added space on Save (not while toggling), via the update endpoint', async () => {
+	mockIsSubscribed = true;
 	const user = userEvent.setup();
 	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
 
@@ -188,6 +189,7 @@ it( 'only applies the added space on Save (not while toggling), via the update e
 } );
 
 it( 'removes the feed from a space on Save by replacing its feed list', async () => {
+	mockIsSubscribed = true;
 	mockDetailsById = {
 		[ space.id ]: {
 			...space,
@@ -217,6 +219,7 @@ it( 'removes the feed from a space on Save by replacing its feed list', async ()
 } );
 
 it( 'discards the draft on Cancel without writing anything', async () => {
+	mockIsSubscribed = true;
 	const user = userEvent.setup();
 	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
 
@@ -231,6 +234,7 @@ it( 'discards the draft on Cancel without writing anything', async () => {
 } );
 
 it( 'disables Save until a change is made', async () => {
+	mockIsSubscribed = true;
 	const user = userEvent.setup();
 	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
 
@@ -243,7 +247,20 @@ it( 'disables Save until a change is made', async () => {
 	expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
 } );
 
+it( 'keeps the space rows and Save disabled until the feed is subscribed', async () => {
+	// The feed is not subscribed yet (the open-time follow hasn't resolved).
+	mockIsSubscribed = false;
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( await screen.findByRole( 'button', { name: 'Add to Work' } ) ).toBeDisabled();
+	expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+} );
+
 it( 'does not allow editing when space details fail to load', async () => {
+	mockIsSubscribed = true;
 	mockDetailsById = { [ space.id ]: undefined };
 	mockDetailsError = true;
 	const user = userEvent.setup();

--- a/client/reader/spaces/subscribe-with-space/test/index.test.tsx
+++ b/client/reader/spaces/subscribe-with-space/test/index.test.tsx
@@ -78,7 +78,7 @@ beforeEach( () => {
 	mockIsSubscribedLoading = false;
 	mockFollowPending = false;
 	mockSpaces = [ space ];
-	mockDetailsById = { [ space.id ]: { ...space, sources: [], tags: [] } };
+	mockDetailsById = { [ space.id ]: { ...space, sources: [], tags: [], languages: [] } };
 	mockDetailsLoading = false;
 	mockDetailsError = false;
 	mockFollowSite.mockClear();
@@ -194,6 +194,7 @@ it( 'removes the feed from a space on Save by replacing its feed list', async ()
 		[ space.id ]: {
 			...space,
 			tags: [],
+			languages: [],
 			sources: [
 				{
 					feedId: 456,

--- a/client/reader/spaces/subscribe-with-space/test/index.test.tsx
+++ b/client/reader/spaces/subscribe-with-space/test/index.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SubscribeWithSpaceButton } from '../index';
 import type { ReadSpace, ReadSpaceDetails } from '@automattic/api-core';
 
-const mockRecordReaderTracksEvent = jest.fn( () => ( { type: 'MOCK_TRACKS_EVENT' } ) );
+const mockRecordReaderTracksEvent = jest.fn().mockReturnValue( { type: 'MOCK_TRACKS_EVENT' } );
 jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
 	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
 } ) );
@@ -90,6 +90,18 @@ const openPicker = async ( user: ReturnType< typeof userEvent.setup > ) => {
 	await user.click( screen.getByRole( 'button', { name: 'Move site to a space' } ) );
 	return screen.findByRole( 'dialog', { name: 'Move site to a space' } );
 };
+
+it( 'shows a loading skeleton while the space details are loading', async () => {
+	mockDetailsLoading = true;
+	const user = userEvent.setup();
+	renderWithProvider( <SubscribeWithSpaceButton { ...props } /> );
+
+	await openPicker( user );
+
+	expect( screen.getByRole( 'status', { name: 'Loading your spaces' } ) ).toBeVisible();
+	// The interactive space rows are not rendered while loading.
+	expect( screen.queryByRole( 'button', { name: 'Add to Work' } ) ).not.toBeInTheDocument();
+} );
 
 it( 'renders only the plain follow button when the flag is off', () => {
 	mockFlagEnabled = false;

--- a/client/reader/spaces/subscribe-with-space/use-space-picker.tsx
+++ b/client/reader/spaces/subscribe-with-space/use-space-picker.tsx
@@ -1,0 +1,51 @@
+import { useState, type ReactNode } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SpacePickerModal } from './space-picker-modal';
+
+interface Options {
+	feedId?: number;
+	blogId?: number;
+	feedUrl: string;
+	/** Follow source recorded when the picker subscribes the feed on open. */
+	followApiSource?: string;
+	/** Where the picker was opened from, for the click Tracks event. */
+	source: string;
+}
+
+/**
+ * Shared open-state + Tracks event + rendered `SpacePickerModal` for the surfaces
+ * that let a user add a site to a Space (the full-post action bar and the post
+ * actions row). Returns the opener to wire to a button and the modal element to
+ * render; the modal is `null` until opened.
+ */
+export function useSpacePicker( { feedId, blogId, feedUrl, followApiSource, source }: Options ): {
+	openSpacePicker: () => void;
+	spacePickerModal: ReactNode;
+} {
+	const dispatch = useDispatch();
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const openSpacePicker = () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_subscribe_space_button_clicked', {
+				feed_id: feedId,
+				blog_id: blogId,
+				source,
+			} )
+		);
+		setIsOpen( true );
+	};
+
+	const spacePickerModal = isOpen ? (
+		<SpacePickerModal
+			feedId={ feedId }
+			blogId={ blogId }
+			feedUrl={ feedUrl }
+			followApiSource={ followApiSource }
+			onClose={ () => setIsOpen( false ) }
+		/>
+	) : null;
+
+	return { openSpacePicker, spacePickerModal };
+}


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes RSM-4541 

## Proposed Changes

* Adds a Reader Spaces picker entry point next to Subscribe in the full-post action bar.
* Adds a Reader Spaces action to post action controls behind the `reader/spaces` feature flag.
* Auto-subscribes the site before saving space membership, then persists selected space changes through the existing full-feed replacement update path.
* Tracks picker button clicks, modal opens, and saved add/remove counts, with regression coverage for loading/error states.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reader Spaces needs a direct way to put a newly subscribed site into one or more spaces from Reader post surfaces without sending users through the full customize flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Scenario 1 - Full post subscribe action:
- Go to `/reader`
- Open a post from a feed that can be subscribed to
- Check if the action bar shows a Spaces button next to Subscribe when the `reader/spaces` flag is enabled
- Click the Spaces button
- Check if the "Move site to a space" dialog opens and shows the site plus available spaces

### Scenario 2 - Post actions:
- Go to `/reader`
- Find a post card with action buttons
- Check if the Spaces button appears with the other post actions when the `reader/spaces` flag is enabled
- Click the Spaces button
- Check if the "Move site to a space" dialog opens without navigating away from the post list

### Scenario 3 - Save space membership:
- Open the "Move site to a space" dialog from either Reader post surface
- Add the site to a space and click Save
- Check if the dialog closes and a "Spaces updated." notice appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

