### PR TITLE
Agents Manager: hide chat under Big Sky onboarding overlay

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -737,6 +737,14 @@ body.post-new-php.agents-manager-sidebar-container {
 	}
 }
 
+// Hide the chat while Big Sky's full-screen onboarding overlay is open.
+body:has( .big-sky-onboarding.components-popover ) {
+	.agents-manager-chat,
+	.agents-manager-sidebar-fab {
+		display: none !important;
+	}
+}
+
 // Docked split-screen: flip --am-sidebar-width to 50vw. `$sidebar-width`
 // resolves through this variable so every consumer picks it up.
 body.agents-manager-sidebar-container.is-split-screen {


### PR DESCRIPTION
Related to AI-1045

## Proposed Changes

* Hide the Agents Manager chat (and its sidebar FAB) while Big Sky's full-screen onboarding/building overlay ("Please wait, your site is brewing") is mounted, via a `body:has( .big-sky-onboarding.components-popover )` rule scoped to the overlay's presence in the DOM.

## Why are these changes being made?

* The Big Sky onboarding overlay renders at `z-index: 99999`, while the Agents Manager chat sits in the shared overlay-panel band (`999990`/`999995`, mirrored with Help Center). Both are `position: fixed` elements in the root stacking context, so the chat always paints on top of the blocking "please wait" screen.
* Rather than bumping the overlay's z-index (a cross-repo magic number that would also break Big Sky's own dialogs, which rely on stacking above the overlay), the chat is hidden for the duration of the overlay. `display: none` keeps the chat mounted, so any active session/streaming continues and the chat reappears as soon as the overlay unmounts.

## Testing Instructions

**Sandbox (Simple/Atomic/CIAB):**

1. Sandbox `widgets.wp.com` and run `cd apps/agents-manager && yarn dev --sync`.
2. Start a Big Sky site build (create a new site through the Big Sky onboarding flow).
3. While the full-screen "Please wait, your site is brewing" overlay is shown, verify the Agents Manager chat and FAB are hidden instead of floating above the overlay.
4. Once the build finishes and the overlay closes, verify the chat reappears and works normally.

**Calypso (regression check):**

1. Run `yarn start` and open a site dashboard.
2. Open the Agents Manager chat and verify it renders and behaves as before (the new rule only matches while the Big Sky onboarding overlay is in the DOM).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)