### PR TITLE
Domain-only flow: make checkout simplification the default

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -19,7 +19,6 @@ import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { useExperiment } from 'calypso/lib/explat';
 import {
 	domainMapping,
 	domainAddNew,
@@ -71,12 +70,6 @@ const DomainSearchUI = (
 
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
-
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_signup_domain_only_checkout_simplification_v1',
-		{ isEligible: isDomainOnlyFlow }
-	);
-	const isTreatment = experimentAssignment?.variationName === 'treatment';
 
 	const site = useSelector( getSelectedSite );
 
@@ -205,8 +198,8 @@ const DomainSearchUI = (
 						{ stepName: 'site-picker', wasSkipped: true },
 						{ themeSlugWithRepo: 'pub/twentysixteen' }
 					);
-				} else if ( isTreatment && isDomainOnlyFlow ) {
-					// Experiment: skip the 'Choose how to use your domain' step for domain-only purchases.
+				} else if ( isDomainOnlyFlow ) {
+					// Skip the 'Choose how to use your domain' step for domain-only purchases.
 					submitSignupStep(
 						{
 							stepName: 'site-or-domain',
@@ -266,7 +259,6 @@ const DomainSearchUI = (
 		goToNextStep,
 		locale,
 		isDomainOnlyFlow,
-		isTreatment,
 		baseSubmitStepProps,
 		baseSubmitProvidedDependencies,
 		dashboard,

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'calypso/lib/explat', () => ( { useExperiment: jest.fn() } ) );
 jest.mock(
 	'calypso/signup/step-wrapper',
 	() => ( props: { stepContent?: React.ReactNode } ) => props.stepContent ?? null
@@ -16,11 +15,9 @@ jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', (
 
 import React from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
-import { useExperiment } from 'calypso/lib/explat';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import DomainSearchStep from '../';
 
-const mockUseExperiment = useExperiment as jest.Mock;
 const mockWPCOMDomainSearch = WPCOMDomainSearch as jest.Mock;
 
 const domainItem = { meta: 'example.com', product_slug: 'domain_reg' };
@@ -43,15 +40,13 @@ function renderStep( props = baseProps ) {
 	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
 }
 
-describe( 'DomainSearchStep — calypso_signup_domain_only_checkout_simplification_v1 experiment', () => {
+describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockWPCOMDomainSearch.mockReturnValue( null );
 	} );
 
-	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected for treatment users in the domain flow', () => {
-		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment' } ] );
-
+	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected in the domain flow', () => {
 		const submitSignupStep = jest.fn();
 		const goToNextStep = jest.fn();
 		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
@@ -91,34 +86,7 @@ describe( 'DomainSearchStep — calypso_signup_domain_only_checkout_simplificati
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'submits the domain step with correct payload and does not skip steps for control users in the domain flow', () => {
-		mockUseExperiment.mockReturnValue( [ false, { variationName: 'control' } ] );
-
-		const submitSignupStep = jest.fn();
-		const goToNextStep = jest.fn();
-		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
-
-		events.onContinue( [ domainItem ] );
-
-		expect( submitSignupStep ).toHaveBeenCalledTimes( 1 );
-		expect( submitSignupStep ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				stepName: 'domain-only',
-				domainItem,
-				isPurchasingItem: true,
-				siteUrl: 'example.com',
-			} ),
-			expect.objectContaining( {
-				domainItem,
-				siteUrl: 'example.com',
-			} )
-		);
-		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'submits the domain step and does not skip steps for treatment users in a non-domain flow', () => {
-		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment' } ] );
-
+	it( 'submits the domain step and does not skip steps in a non-domain flow', () => {
 		const submitSignupStep = jest.fn();
 		const goToNextStep = jest.fn();
 		const events = renderStep( {


### PR DESCRIPTION
Part of DOTPROD-122

## Proposed Changes

* Removes the ExPlat experiment gate (`calypso_signup_domain_only_checkout_simplification_v1`) from the `/start/domain` signup flow and makes the treatment behavior the default.
* The `onContinue` handler in the `domain-only` step now auto-submits `site-or-domain`, `site-picker`, and `plans-site-selected` as complete for every domain-only-flow purchase, so the signup framework skips the "Choose how to use your domain" step for all users.
* Drops the now-unused `useExperiment` import and the `isTreatment` check.
* Updates the step's tests to assert the always-skip default and removes the control-variant / experiment-mock cases.

## Why are these changes being made?

The `calypso_signup_domain_only_checkout_simplification_v1` experiment has concluded in production in favor of the treatment variant. This makes that behavior the default and removes the experiment scaffolding.

## Testing Instructions

* Go to `/start/domain`, search for and select a domain.
* The "Choose how to use your domain" step should not appear — the flow proceeds directly to auth/checkout.
* `yarn test-client client/signup/steps/domains`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
