### PR TITLE
Exclude merge queue branches from non-required TeamCity jobs - Take II

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,8 +1,7 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
+import _self.lib.utils.excludeMergeQueueBranches
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -16,6 +15,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = "+:*".excludeMergeQueueBranches()
 		cleanCheckout = true
 	}
 
@@ -56,8 +56,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 	}
 
   	steps {
-		passMergeQueueBranchesEarly()
-		mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
+		mergeTrunk( skipIfConflict = true )
 
     	bashNodeScript {
 			name = "Prepare environment"
@@ -73,7 +72,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Determine Calypso URL"
@@ -112,7 +111,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "##teamcity[setParameter name='CALYPSO_BASE_URL' value='${'$'}FINAL_URL']"
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Determine Dashboard URL"
@@ -154,7 +153,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				echo "##teamcity[setParameter name='DASHBOARD_BASE_URL' value='${'$'}FINAL_URL']"
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Determine test group"
@@ -177,7 +176,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 				"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Set extra environment variables"
@@ -194,7 +193,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				fi
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Run e2e tests"
@@ -223,7 +222,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				yarn test:pw:%PROJECT% ${'$'}GREP_FLAG
 				"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Check for E2E teardown leaks"
@@ -244,9 +243,9 @@ object CalypsoE2ETestsBuildTemplate : Template({
 					# (nonZeroExitCode = false). Do NOT add 'exit 1': this ALWAYS step must leave green runs green.
 					echo "##teamcity[buildProblem description='E2E teardown leak: ${'$'}COUNT test user(s) not closed - see %PROJECT%/output' identity='e2e_teardown_leak']"
 				fi
-				""".trimIndent()
+			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Upload CTRF report"
@@ -269,7 +268,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
   }
 
   	artifactRules = """

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,7 +1,7 @@
 package _self
 
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.excludeMergeQueueBranches
+import _self.lib.utils.allBranchesExceptMergeQueue
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
@@ -15,7 +15,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
 	vcs {
 		root(Settings.WpCalypso)
-		branchFilter = "+:*".excludeMergeQueueBranches()
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -3,8 +3,6 @@ package _self.lib.customBuildType
 import Settings
 import _self.bashNodeScript
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -61,6 +59,7 @@ open class E2EBuildType(
 	var buildTriggers: Triggers.() -> Unit = {},
 	var buildDependencies: Dependencies.() -> Unit = {},
 	var addWpcomVcsRoot: Boolean = false,
+	var vcsBranchFilter: String? = null,
 	var buildSteps: BuildSteps.() -> Unit = {}
 
 ): BuildType() {
@@ -73,6 +72,7 @@ open class E2EBuildType(
 		val enableCommitStatusPublisher = enableCommitStatusPublisher
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
+		val vcsBranchFilter = vcsBranchFilter
 		val params = params
 		val buildSteps = buildSteps
 
@@ -91,6 +91,7 @@ open class E2EBuildType(
 
 		vcs {
 			root(Settings.WpCalypso)
+			vcsBranchFilter?.let { branchFilter = it }
 			cleanCheckout = true
 		}
 
@@ -104,12 +105,11 @@ open class E2EBuildType(
 		}
 
 		steps {
-			passMergeQueueBranchesEarly()
 			// IMPORTANT! This step MUST match what the docker image does. If trunk
 			// is merged when building the docker image, it must also be merged
 			// to run the tests, or they may not be compatible. See the "mergeTrunk"
 			// step in BuildDockerImage in WebApp.kt.
-			mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
+			mergeTrunk( skipIfConflict = true )
 
 			bashNodeScript {
 				name = "Prepare environment"
@@ -125,7 +125,7 @@ open class E2EBuildType(
 					yarn workspace @automattic/calypso-e2e build
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-			}.skipOnMergeQueueBranch()
+			}
 
 			bashNodeScript {
 				name = "Run tests"
@@ -165,7 +165,7 @@ open class E2EBuildType(
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"
-			}.skipOnMergeQueueBranch()
+			}
 
 			bashNodeScript {
 				name = "Collect results"
@@ -183,7 +183,7 @@ open class E2EBuildType(
 					find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-			}.skipOnMergeQueueBranch()
+			}
 			buildSteps()
 		}
 

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -6,7 +6,10 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 const val MERGE_QUEUE_BRANCH_SKIP_PARAM = "mergeQueueBranch.skipBuild"
-const val MERGE_QUEUE_BRANCH_TRIGGER_EXCLUSION = "-:gh-readonly-queue/*"
+const val MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS = """
+-:gh-readonly-queue/*
+-:refs/heads/gh-readonly-queue/*
+"""
 const val MERGE_QUEUE_BRANCH_SKIP_MESSAGE =
 	"This check was skipped because this is a merge queue and the check has already been run " +
 		"in the pull request. See: p4TIVU-b5I-p2#comment-12211"
@@ -46,6 +49,6 @@ fun <T : BuildStep> T.skipOnMergeQueueBranch(): T {
 fun String.excludeMergeQueueBranches(): String {
 	return """
 		${this.trimIndent()}
-		$MERGE_QUEUE_BRANCH_TRIGGER_EXCLUSION
+		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
 	""".trimIndent()
 }

--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -52,3 +52,10 @@ fun String.excludeMergeQueueBranches(): String {
 		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
 	""".trimIndent()
 }
+
+fun allBranchesExceptMergeQueue(): String {
+	return """
+		+:<default>
+		+:*
+	""".excludeMergeQueueBranches()
+}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -792,11 +792,11 @@ object Translate : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = "+:*".excludeMergeQueueBranches()
 		cleanCheckout = true
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -804,7 +804,7 @@ object Translate : BuildType({
 				${_self.yarn_install_cmd}
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Extract strings"
 			scriptContent = """
@@ -819,7 +819,7 @@ object Translate : BuildType({
 				echo "##teamcity[publishArtifacts './translate/calypso-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Build New Strings .pot"
 			scriptContent = """
@@ -840,7 +840,7 @@ object Translate : BuildType({
 				echo "##teamcity[publishArtifacts './translate/localci-new-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Notify GlotPress Translate build is ready"
 			scriptContent = """
@@ -861,7 +861,7 @@ object Translate : BuildType({
 							}
 						}'
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {
@@ -929,6 +929,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 				}
 			}
 		},
+		vcsBranchFilter = "+:*".excludeMergeQueueBranches(),
 		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,6 +3,7 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
+import _self.lib.utils.allBranchesExceptMergeQueue
 import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.passMergeQueueBranchesEarly
@@ -792,7 +793,7 @@ object Translate : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
-		branchFilter = "+:*".excludeMergeQueueBranches()
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -929,7 +930,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 				}
 			}
 		},
-		vcsBranchFilter = "+:*".excludeMergeQueueBranches(),
+		vcsBranchFilter = allBranchesExceptMergeQueue(),
 		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {


### PR DESCRIPTION
Take II of https://github.com/Automattic/wp-calypso/pull/112186.

### Changes
Currently, some checks are run in the PR, 3 of them are required. Most of these checks are rerun on the trunk after the merge. When I enabled the merge group queue, they started running in the queue as well. 

The nice thing is that we don't wait for them and skip them. But this PR attempts at avoiding running them at all in the merge queue. 