### PR TITLE
E2E: wait on domain upsell suggestion text instead of illustration SVG

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -3,8 +3,6 @@ import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
 	visitSiteButton: '.button >> text=Visit site',
-	domainUpsellCard: '.domain-upsell__card',
-	domainUpsellSuggestedDomain: '.domain-upsell__card .domain-upsell-illustration',
 	domainUpsellBuyDomain: ( message: string ) =>
 		`.domain-upsell-actions button:text("${ message }")`,
 };
@@ -16,6 +14,7 @@ export class MyHomePage {
 	private page: Page;
 	private anchor: Locator;
 	readonly heading: Locator;
+	readonly suggestedUpsellDomainName: Locator;
 
 	/**
 	 * Constructs an instance of the component.
@@ -26,6 +25,8 @@ export class MyHomePage {
 		this.page = page;
 		this.anchor = page.getByRole( 'main' );
 		this.heading = this.page.getByRole( 'heading', { name: 'My Home' } );
+		// The <strong> renders empty until the domain suggestion query resolves.
+		this.suggestedUpsellDomainName = this.anchor.getByTestId( 'domain-upsell-domain-name' );
 	}
 
 	/**
@@ -73,28 +74,6 @@ export class MyHomePage {
 			return true;
 		} catch {
 			return false;
-		}
-	}
-
-	/**
-	 * Get the suggested domain in the upsell card.
-	 *
-	 * @returns {string} Suggested domain. Empty string if not found.
-	 */
-	async getSuggestedUpsellDomain(): Promise< string > {
-		// It's important to wait for an actual svg element to be present.
-		// The handling here is a little funky. We take a blank palceholder img, then we
-		// draw an SVG with just the text on top of it.
-		// There's a race condition where the placeholder img can render before the the text svg does.
-		const svgLocator = this.anchor.locator( '.domain-upsell-illustration svg' );
-
-		// But, innerText doesn't work on SVG nodes, so we need this locator to actually fetch the text.
-		const parentDivLocator = this.anchor.locator( '.domain-upsell-illustration' );
-		try {
-			await svgLocator.waitFor( { timeout: 20_000 } );
-			return await parentDivLocator.innerText();
-		} catch {
-			return '';
 		}
 	}
 

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -15,8 +15,6 @@ test.describe(
 			pagePlans,
 			sitePublic,
 		} ) => {
-			let suggestedDomain: string;
-
 			await test.step( 'When I navigate to the Home dashboard on a new Free public site', async function () {
 				await page.goto(
 					helperData.getCalypsoURL( `/home/${ sitePublic.blog_details.site_slug }` )
@@ -24,8 +22,10 @@ test.describe(
 			} );
 
 			await test.step( 'And domain upsell card has a suggested domain', async function () {
-				suggestedDomain = await pageMyHome.getSuggestedUpsellDomain();
-				expect( suggestedDomain ).not.toBe( '' );
+				// The suggestion API can be slow on CI, hence the raised timeout.
+				await expect( pageMyHome.suggestedUpsellDomainName ).toHaveText( /\S+\.\S+/, {
+					timeout: 60_000,
+				} );
 			} );
 
 			await test.step( 'When I click to begin searching for a domain', async function () {


### PR DESCRIPTION
Based on #111011.

## Proposed Changes

- `packages/calypso-e2e/src/lib/pages/my-home-page.ts`: drop `getSuggestedUpsellDomain()`, which waited 20s on `.domain-upsell-illustration svg` and swallowed the timeout into an empty string. The page object now exposes a `suggestedUpsellDomainName` locator on the existing `data-testid="domain-upsell-domain-name"` element, following the same pattern as the `heading` field. The unused `domainUpsellSuggestedDomain` and `domainUpsellCard` selectors are gone too.
- `test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts`: the suggestion check is now a web-first assertion, `await expect( pageMyHome.suggestedUpsellDomainName ).toHaveText( /\S+\.\S+/, { timeout: 60_000 } )`. The `suggestedDomain` variable was assigned and never read after the assertion, so it's deleted.

No product-code changes; the test ID already exists in `client/my-sites/customer-home/cards/features/domain-upsell/index.jsx`.

## Why are these changes being made?

#111011 diagnosed the flake correctly: the SVG illustration is a late, brittle readiness signal, and 20s isn't enough for the suggestion API on slow CI runs. It kept the try/catch though, so a timeout still surfaced as `expect( suggestedDomain ).not.toBe( '' )` with no hint of what timed out.

This version keeps the good parts (the test-id locator, the 60s ceiling) and changes the failure mode:

- a slow or failing suggestion API now fails the assertion directly, with the locator and timeout in the error, instead of a bare empty-string mismatch;
- `toHaveText( /\S+\.\S+/ )` waits on the actual contract (a domain-shaped string is rendered) rather than element visibility, so an empty-but-visible `<strong>` or placeholder junk can't produce a false pass;
- the empty-string sentinel API is gone; the spec was its only caller.

## Testing Instructions

Run the spec repeatedly against staging (`CALYPSO_BASE_URL` set to the Calypso staging URL):

```
yarn workspace @automattic/calypso-e2e build
yarn workspace wp-e2e-tests test:pw -- specs/domain-upsell/domain-upsell__my-home.spec.ts --repeat-each=5
```

10/10 passing on staging (5 repeats on each of pixel and chrome), 33-41s per run.
