### PR TITLE
Dashboard: move chunk-load recovery out of the logger folder

### DIFF
--- a/client/dashboard/app/chunk-load-recovery.ts
+++ b/client/dashboard/app/chunk-load-recovery.ts
@@ -1,4 +1,4 @@
-import { bumpStat } from '../analytics';
+import { bumpStat } from './analytics';
 
 // Marks a page load as a chunk-load retry. Mirrors the classic Calypso
 // mechanism in client/layout/error.jsx: the flag lives in the URL for the whole

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -3,7 +3,7 @@ import calypsoConfig from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { maybeReloadForChunkError } from './chunk-reload';
+import { maybeReloadForChunkError } from '../chunk-load-recovery';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -4,7 +4,7 @@
 
 import { captureException } from '@automattic/calypso-sentry';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { maybeReloadForChunkError } from '../chunk-reload';
+import { maybeReloadForChunkError } from '../../chunk-load-recovery';
 import { handleOnCatch } from '../index';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
@@ -16,7 +16,7 @@ jest.mock( '@automattic/calypso-sentry', () => ( {
 jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn(),
 } ) );
-jest.mock( '../chunk-reload', () => ( {
+jest.mock( '../../chunk-load-recovery', () => ( {
 	maybeReloadForChunkError: jest.fn(),
 } ) );
 

--- a/client/dashboard/app/test/chunk-load-recovery.test.ts
+++ b/client/dashboard/app/test/chunk-load-recovery.test.ts
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 
-import { bumpStat } from '../../analytics';
-import { isChunkLoadError, maybeReloadForChunkError } from '../chunk-reload';
+import { bumpStat } from '../analytics';
+import { isChunkLoadError, maybeReloadForChunkError } from '../chunk-load-recovery';
 
-jest.mock( '../../analytics', () => ( {
+jest.mock( '../analytics', () => ( {
 	bumpStat: jest.fn(),
 } ) );
 


### PR DESCRIPTION
Part of DOTMSD-1344

Follow-up to #112111 addressing review feedback.

## Proposed Changes

* Move the Dashboard chunk-load recovery logic out of `app/logger/` up to `app/chunk-load-recovery.ts` (and its test to `app/test/chunk-load-recovery.test.ts`). No behavior change — this is a pure relocation plus import-path updates, done with `git mv` so history is preserved.

## Why are these changes being made?

* On #112111, the reviewer noted it's architecturally odd to keep runtime recovery logic in the logger folder, especially since it reads and resets `window.location`. The logger's job is to log; deciding to reload the page and mutate the URL belongs a level up, alongside the rest of the app wiring. This move makes that separation explicit.

## Testing Instructions

* `yarn test-client client/dashboard/app/test/chunk-load-recovery.test.ts` — 6/6 pass.
* Behavior is unchanged from #112111; see that PR's testing instructions to reproduce a stale-deploy chunk 404 and confirm the one-shot reload still recovers.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
