### PR TITLE
Run Code style fully in merge queue

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -617,7 +617,6 @@ object CheckCodeStyleBranch : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -626,7 +625,7 @@ object CheckCodeStyleBranch : BuildType({
 				# Install modules
 				${_self.yarn_install_cmd}
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Run eslint"
 			scriptContent = """
@@ -717,14 +716,14 @@ object CheckCodeStyleBranch : BuildType({
 						' yarn-batch # Arbitrary name to be used as each batch's progname
 				fi
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Run code quality linters"
 			scriptContent = """
 				yarn run lint:unused-state-action-types
 				yarn run lint:config-defaults
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Run stylelint"
 			scriptContent = """
@@ -732,7 +731,7 @@ object CheckCodeStyleBranch : BuildType({
 				yarn run lint:css
 				yarn run lint:mixedindent
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Let `Code style (Web app)` run all of its TeamCity steps on merge queue branches.
* Keep the existing VCS trigger filter, so Code style still runs on PR/source branches and merge queue branches, but not on `trunk`.

## Why are these changes being made?

* We want merge queue branches to exercise Code style fully instead of short-circuiting through the shared merge queue skip helper.

## Testing Instructions

* Confirmed `git diff --check -- .teamcity/_self/projects/WebApp.kt` passes.
* Confirmed `mvn` is not available locally, so TeamCity DSL generation was not run.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
