### PR TITLE
Reader Spaces: add regular/wide column width choice

### DIFF
--- a/client/reader/spaces/AGENTS.md
+++ b/client/reader/spaces/AGENTS.md
@@ -41,8 +41,8 @@ without an action hash.
 
 - **Save/Create batches the editable fields.** "Save changes" and "Create" send
   the same draft model: `name`, `tags`, `feeds`, and
-  `layout: { color, icon, view }`. Source add/remove in the modal updates local
-  draft state only; the endpoint receives the final `feeds` list on submit.
+  `layout: { color, iconColor, icon, view, width }`. Source add/remove in the modal
+  updates local draft state only; the endpoint receives the final `feeds` list on submit.
 - **Draft state is seeded once** (a `isSeeded` flag), not on every `space` change,
   so a source add/remove (which rewrites the detail cache) can't clobber unsaved
   identity/layout edits.
@@ -55,8 +55,13 @@ without an action hash.
   When adding a color/icon, update `colors.ts` (`SPACE_COLORS` + labels) /
   `icons.ts` and the `icon-picker.tsx` label map (typed `Record< SpaceIcon, … >`,
   so a missing label is a type error).
-- **Not yet built (no backend):** description, AI tag auto-fill, text size, and
-  column layout shown in the design mockups are intentionally omitted.
+- **Column width** (`layout.width`, `'regular' | 'wide'`) is chosen in the Layout
+  tab and consumed by `view.tsx` as `wideLayout={ width === 'wide' }` on
+  `ReaderMain`. Unset falls back to `'wide'` (`DEFAULT_SPACE_WIDTH` in
+  `customize-modal/layout-tab.tsx`) so existing spaces keep their current width;
+  `wide` → `.main.is-wide-layout` (1040px), `regular` → the Reader default (768px).
+- **Not yet built (no backend):** description, AI tag auto-fill, and text size
+  shown in the design mockups are intentionally omitted.
 
 ## Conventions
 

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -205,7 +205,7 @@ describe( 'CreateSpaceModal', () => {
 				title: 'Reading',
 				feeds: [ 456 ],
 				tags: [],
-				layout: { color: 'green', iconColor: 'blue', icon: 'star', view: 'legacy' },
+				layout: { color: 'green', iconColor: 'blue', icon: 'star', view: 'legacy', width: 'wide' },
 			} )
 		);
 		const spaces = queryClient.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey );

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -6,6 +6,7 @@ import {
 	type SpaceColor,
 	type SpaceFeedLayout,
 	type SpaceIcon,
+	type SpaceLayoutWidth,
 	type SpaceSource,
 	type SpaceTextColor,
 } from '@automattic/api-core';
@@ -43,7 +44,7 @@ import { DEFAULT_SPACE_FEED_LAYOUT } from '../feed/layouts/registry';
 import { ConfirmDeleteDialog } from './confirm-delete';
 import { DeleteTab } from './delete-tab';
 import { IdentityTab } from './identity-tab';
-import { getLayoutPresetTitle, LayoutTab } from './layout-tab';
+import { DEFAULT_SPACE_WIDTH, getLayoutPresetTitle, LayoutTab } from './layout-tab';
 import { SourcesTab } from './sources-tab';
 
 import './style.scss';
@@ -176,6 +177,7 @@ function SpaceUpsertModalContent( {
 	} );
 	const [ icon, setIcon ] = useState< SpaceIcon >( 'inbox' );
 	const [ view, setView ] = useState< SpaceFeedLayout >( DEFAULT_SPACE_FEED_LAYOUT );
+	const [ width, setWidth ] = useState< SpaceLayoutWidth >( DEFAULT_SPACE_WIDTH );
 	const [ selectedSources, setSelectedSources ] = useState< SourceDraftItem[] >( [] );
 	const [ isConfirmingDelete, setIsConfirmingDelete ] = useState( false );
 
@@ -190,6 +192,7 @@ function SpaceUpsertModalContent( {
 			setIconColor( resolveSpaceIconColor( space.layout ) );
 			setIcon( space.layout.icon );
 			setView( space.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT );
+			setWidth( space.layout.width ?? DEFAULT_SPACE_WIDTH );
 			setSelectedSources( space.sources.map( getSpaceSourceDraftItem ) );
 			setIsSeeded( true );
 		}
@@ -227,7 +230,7 @@ function SpaceUpsertModalContent( {
 					name: name.trim(),
 					tags,
 					languages,
-					layout: { color, iconColor, icon, view },
+					layout: { color, iconColor, icon, view, width },
 					feeds: selectedFeeds,
 				},
 				{
@@ -269,7 +272,7 @@ function SpaceUpsertModalContent( {
 					tags,
 					languages,
 					feeds: selectedFeeds,
-					layout: { color, iconColor, icon, view },
+					layout: { color, iconColor, icon, view, width },
 				},
 			},
 			{
@@ -333,7 +336,9 @@ function SpaceUpsertModalContent( {
 			);
 		}
 		if ( tabName === 'layout' ) {
-			return <LayoutTab value={ view } onChange={ setView } />;
+			return (
+				<LayoutTab value={ view } onChange={ setView } width={ width } onWidthChange={ setWidth } />
+			);
 		}
 		if ( tabName === 'sources' ) {
 			return (

--- a/client/reader/spaces/customize-modal/layout-tab.tsx
+++ b/client/reader/spaces/customize-modal/layout-tab.tsx
@@ -1,12 +1,20 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import type { SpaceFeedLayout } from '@automattic/api-core';
+import type { SpaceFeedLayout, SpaceLayoutWidth } from '@automattic/api-core';
 
 type TranslateFn = ReturnType< typeof useTranslate >;
+
+/**
+ * Column width a space's feed defaults to when none is stored — `wide` keeps the
+ * roomy layout that every space rendered with before the width choice shipped.
+ */
+export const DEFAULT_SPACE_WIDTH: SpaceLayoutWidth = 'wide';
 
 interface Props {
 	value: SpaceFeedLayout;
 	onChange: ( view: SpaceFeedLayout ) => void;
+	width: SpaceLayoutWidth;
+	onWidthChange: ( width: SpaceLayoutWidth ) => void;
 }
 
 /**
@@ -31,7 +39,7 @@ export function getLayoutPresetTitle( view: SpaceFeedLayout, translate: Translat
  * The feed-layout presets. `legacy` uses the existing classic Reader stream
  * layout and is offered alongside the newer curated layouts.
  */
-export function LayoutTab( { value, onChange }: Props ) {
+export function LayoutTab( { value, onChange, width, onWidthChange }: Props ) {
 	const translate = useTranslate();
 
 	const presets: { id: SpaceFeedLayout; description: string; beta?: boolean }[] = [
@@ -39,6 +47,19 @@ export function LayoutTab( { value, onChange }: Props ) {
 		{ id: 'standard-list', description: translate( 'Many items, fast scanning' ), beta: true },
 		{ id: 'gallery', description: translate( 'Grid of cards with thumbnails' ), beta: true },
 		{ id: 'board', description: translate( 'Big roomy cards, casual scroll' ), beta: true },
+	];
+
+	const widths: { id: SpaceLayoutWidth; title: string; description: string }[] = [
+		{
+			id: 'regular',
+			title: translate( 'Regular' ),
+			description: translate( 'Narrower, single reading column' ),
+		},
+		{
+			id: 'wide',
+			title: translate( 'Wide' ),
+			description: translate( 'Full-width, roomy layout' ),
+		},
 	];
 
 	return (
@@ -72,6 +93,33 @@ export function LayoutTab( { value, onChange }: Props ) {
 							) }
 						</span>
 						<span className="customize-space-modal__card-description">{ preset.description }</span>
+					</label>
+				) ) }
+			</div>
+			<p className="customize-space-modal__subtitle">
+				{ translate( 'Choose the column width for this space.' ) }
+			</p>
+			<div
+				className="customize-space-modal__grid"
+				role="radiogroup"
+				aria-label={ translate( 'Width' ) }
+			>
+				{ widths.map( ( option ) => (
+					<label
+						key={ option.id }
+						className="customize-space-modal__card"
+						data-selected={ option.id === width }
+					>
+						<input
+							type="radio"
+							className="customize-space-modal__radio"
+							name="space-layout-width"
+							value={ option.id }
+							checked={ option.id === width }
+							onChange={ () => onWidthChange( option.id ) }
+						/>
+						<span className="customize-space-modal__card-title">{ option.title }</span>
+						<span className="customize-space-modal__card-description">{ option.description }</span>
 					</label>
 				) ) }
 			</div>

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -229,7 +229,7 @@ describe( 'CustomizeModal', () => {
 				tags: [ 'tech' ],
 				// The seeded language is carried through unchanged on save.
 				languages: [ 'en' ],
-				layout: { color: 'green', iconColor: 'blue', icon: 'inbox', view: 'legacy' },
+				layout: { color: 'green', iconColor: 'blue', icon: 'inbox', view: 'legacy', width: 'wide' },
 			} )
 		);
 		const cached = queryClient.getQueryData< ReadSpaceDetails >(
@@ -246,6 +246,41 @@ describe( 'CustomizeModal', () => {
 			'calypso_reader_spaces_layout_changed',
 			{ layout: 'legacy' }
 		);
+	} );
+
+	it( 'defaults an unset width to Wide and lets the user switch to Regular', async () => {
+		const user = userEvent.setup();
+		const { onClose } = render();
+		const onBody = jest.fn();
+		mockUpdateEndpoint( onBody );
+
+		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
+
+		const widthGroup = screen.getByRole( 'radiogroup', { name: 'Width' } );
+		// The space has no stored width, so it seeds to the Wide default.
+		expect( within( widthGroup ).getByRole( 'radio', { name: /Wide/ } ) ).toBeChecked();
+		expect( within( widthGroup ).getByRole( 'radio', { name: /Regular/ } ) ).not.toBeChecked();
+
+		await user.click( within( widthGroup ).getByRole( 'radio', { name: /Regular/ } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Save changes' } ) );
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
+
+		expect( onBody ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				layout: expect.objectContaining( { width: 'regular' } ),
+			} )
+		);
+	} );
+
+	it( 'seeds the width control from the stored layout width', async () => {
+		const user = userEvent.setup();
+		render( { space: { ...SPACE, layout: { ...SPACE.layout, width: 'regular' } } } );
+
+		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
+
+		const widthGroup = screen.getByRole( 'radiogroup', { name: 'Width' } );
+		expect( within( widthGroup ).getByRole( 'radio', { name: /Regular/ } ) ).toBeChecked();
 	} );
 
 	it( 'saves source changes with the rest of the edit draft', async () => {

--- a/client/reader/spaces/test/view.test.tsx
+++ b/client/reader/spaces/test/view.test.tsx
@@ -122,6 +122,29 @@ describe( 'SpacesView', () => {
 		);
 	} );
 
+	it( 'renders the wide layout by default when the space has no stored width', () => {
+		render( <SpacesView id={ WORK.id } /> );
+
+		expect( screen.getByRole( 'main' ) ).toHaveClass( 'is-wide-layout' );
+	} );
+
+	it( 'renders the regular (non-wide) layout when the space width is regular', () => {
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const regularSpace: ReadSpaceDetails = {
+			...WORK,
+			layout: { ...WORK.layout, width: 'regular' },
+		};
+		queryClient.setQueryData( readSpacesQuery().queryKey, [ regularSpace ] );
+		queryClient.setQueryData( readSpaceQuery( regularSpace.id ).queryKey, regularSpace );
+
+		renderWithProvider( <SpacesView id={ regularSpace.id } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		expect( screen.getByRole( 'main' ) ).not.toHaveClass( 'is-wide-layout' );
+	} );
+
 	it( 'records a page view event with the selected space appearance', async () => {
 		render( <SpacesView id={ WORK.id } /> );
 

--- a/client/reader/spaces/view.tsx
+++ b/client/reader/spaces/view.tsx
@@ -7,6 +7,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { useSpaces } from 'calypso/reader/data/spaces';
 import { CustomizeModal, type CustomizeTab } from 'calypso/reader/spaces/customize-modal';
+import { DEFAULT_SPACE_WIDTH } from 'calypso/reader/spaces/customize-modal/layout-tab';
 import { SpaceFeed } from 'calypso/reader/spaces/feed';
 import { DEFAULT_SPACE_FEED_LAYOUT } from 'calypso/reader/spaces/feed/layouts/registry';
 import { SpaceNavigation } from 'calypso/reader/spaces/space-navigation';
@@ -28,6 +29,7 @@ export function SpacesView( { id, tab = 'feed' }: Props ) {
 	const spaces = useSpaces();
 	const space = id ? spaces.find( ( item ) => item.id === id ) : undefined;
 	const layoutView: SpaceFeedLayout = space?.layout.view ?? DEFAULT_SPACE_FEED_LAYOUT;
+	const isWide = ( space?.layout.width ?? DEFAULT_SPACE_WIDTH ) === 'wide';
 	const icon = space?.layout.icon;
 	const color = space?.layout.color;
 	const title = space ? space.name : translate( 'Spaces' );
@@ -73,7 +75,7 @@ export function SpacesView( { id, tab = 'feed' }: Props ) {
 	}
 
 	return (
-		<ReaderMain className="reader-spaces" wideLayout>
+		<ReaderMain className="reader-spaces" wideLayout={ isWide }>
 			<DocumentHead
 				title={ translate( '%s ‹ Reader', {
 					args: title,

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -46,6 +46,20 @@ describe( 'read spaces adapters', () => {
 			expect( layout ).toEqual( { color: 'celadon', icon: 'star', view: 'gallery' } );
 		} );
 
+		it( 'passes through the optional column width when present', () => {
+			const { layout } = adaptReadSpace(
+				wireSpace( { layout: { color: 'celadon', icon: 'star', width: 'regular' } } )
+			);
+
+			expect( layout ).toEqual( { color: 'celadon', icon: 'star', width: 'regular' } );
+		} );
+
+		it( 'omits the column width when absent', () => {
+			const { layout } = adaptReadSpace( wireSpace() );
+
+			expect( layout ).not.toHaveProperty( 'width' );
+		} );
+
 		it( 'carries neither sources nor tags on the summary shape', () => {
 			const summary = adaptReadSpace( wireSpace() );
 			expect( summary ).not.toHaveProperty( 'sources' );

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -40,6 +40,9 @@ export function adaptReadSpace( item: ReadSpaceApiItem ): ReadSpace {
 	if ( item.layout.view ) {
 		layout.view = item.layout.view;
 	}
+	if ( item.layout.width ) {
+		layout.width = item.layout.width;
+	}
 	return {
 		id: String( item.id ),
 		name: item.title,

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -53,6 +53,13 @@ export type SpaceIcon =
 export type SpaceFeedLayout = 'standard-list' | 'gallery' | 'board' | 'legacy';
 
 /**
+ * Column width of the space feed — `regular` is the narrow single reading column
+ * shared with the rest of the Reader; `wide` is the roomy layout. Unset falls
+ * back to `wide` so spaces created before this shipped keep their current width.
+ */
+export type SpaceLayoutWidth = 'regular' | 'wide';
+
+/**
  * Presentation settings for a space, grouped so they can grow beyond color and
  * icon (e.g. cover image, sort order) without widening `ReadSpace` itself.
  */
@@ -65,6 +72,8 @@ export interface SpaceLayout {
 	icon: SpaceIcon;
 	// Which feed layout to render.
 	view?: SpaceFeedLayout;
+	// Column width of the space feed. Unset falls back to `wide`.
+	width?: SpaceLayoutWidth;
 }
 
 /**


### PR DESCRIPTION
Closes RSM-4630

## Proposed Changes

* Add a per-space **column width** setting to Reader Spaces: `layout.width` with values `regular` and `wide`. Previously every Space always rendered in the wide layout.
* Customize → **Layout** tab now has a second control (two buttons: **Regular** / **Wide**) below the feed-layout presets, mirroring the existing preset picker.
* The chosen width is saved with the rest of the space `layout` on create/update and drives `wideLayout` on the Space view (`wide` → 1040px wide column, `regular` → the standard 768px Reader column). No new width CSS — reuses the existing `.is-wide-layout` class and Reader default.
* An unset width falls back to `wide`, so existing spaces keep their current appearance.
* Model/adapter support in `@automattic/api-core` (`SpaceLayoutWidth` type, `width` carried through `adaptReadSpace`). Added regression tests for the adapter, the width control, persistence, and the view rendering.

## Why are these changes being made?

The Spaces design always included a regular/wide column choice, but it was intentionally left out of the client because the backend didn't persist it yet (documented in `client/reader/spaces/AGENTS.md`). The backend now stores `layout.width`, so this wires up the reader-facing control and lets each Space remember whether it reads best in a narrow or a wide column.

Layout analytics are handled separately in RSM-4617 and intentionally not duplicated here.

## Testing Instructions

### Scenario 1 - Switch a space to the regular column:
- Go to `/reader/spaces/:id` for one of your spaces (a8c-only, behind the `reader/spaces` flag)
- Click **Customize**, open the **Layout** tab
- Check that the **Width** control shows **Regular** and **Wide**, with **Wide** selected for an existing space
- Select **Regular**, click **Save changes**
- Check that the feed re-renders in the narrower single reading column
- Reload the page and check the space still opens in the regular column

### Scenario 2 - Wide is the default and persists:
- Go to `/reader/spaces/:id` and open **Customize → Layout**
- Select **Wide**, click **Save changes**
- Check that the feed renders in the roomy full-width layout and survives a reload
- Check that a space you have never changed still opens wide by default

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
