### PR TITLE
Run Docker image fully in merge queue

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -153,7 +153,6 @@ object BuildDockerImage : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		script {
 			name = "Webhook Start"
 			conditions {
@@ -172,7 +171,7 @@ object BuildDockerImage : BuildType({
 
 				curl -s -X POST -d "${'$'}payload" -H "TEAMCITY-SIGNATURE: ${'$'}signature" "%mc_teamcity_webhook%calypso/?build_id=%teamcity.build.id%"
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 
 		script {
 			name = "Post PR comment"
@@ -189,13 +188,13 @@ object BuildDockerImage : BuildType({
 				Please wait a few minutes and refresh this page.
 				EOF
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 
 		// We want calypso.live and Calypso e2e tests to run even if there's a merge conflict,
 		// just to keep things going. However, if we can merge, the webpack cache
 		// can be better utilized, since it's kept up-to-date for trunk commits.
 		// Note that this only happens on non-trunk
-		mergeTrunk( skipIfConflict = true ).skipOnMergeQueueBranch()
+		mergeTrunk( skipIfConflict = true )
 
 		script {
 			name = "Check Docker workspace COPY globs"
@@ -206,7 +205,7 @@ object BuildDockerImage : BuildType({
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID%"
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
-		}.skipOnMergeQueueBranch()
+		}
 
 		val commonArgs = """
 			--label com.a8c.image-builder=teamcity
@@ -238,7 +237,7 @@ object BuildDockerImage : BuildType({
 				commandArgs = "--pull --label com.a8c.target=calypso-live $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 
 		dockerCommand {
 			commandType = push {
@@ -247,7 +246,7 @@ object BuildDockerImage : BuildType({
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()
 			}
-		}.skipOnMergeQueueBranch()
+		}
 
 		script {
 			name = "Webhook fail OR webhook done and push trunk tag for deploy"
@@ -275,7 +274,7 @@ object BuildDockerImage : BuildType({
 
 				curl -s -X POST -d "${'$'}payload" -H "TEAMCITY-SIGNATURE: ${'$'}signature" "%mc_teamcity_webhook%calypso/?build_id=%teamcity.build.id%"
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 
 		script {
 			name = "Post PR comment with link"
@@ -291,7 +290,7 @@ object BuildDockerImage : BuildType({
 				$htmlBlock
 				EOF
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 
 		// TODO: Cache rebuilding is currently disabled. It takes a long time and
 		// causes timeouts on trunk. It needs to run more quickly to be worth it.
@@ -338,7 +337,7 @@ object BuildDockerImage : BuildType({
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 
 		dockerCommand {
 			name = "Push cache image"
@@ -350,7 +349,7 @@ object BuildDockerImage : BuildType({
 			commandType = push {
 				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
 			}
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	failureConditions {


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Let `Docker image (Web app)` run its normal TeamCity steps on merge queue branches.
* Remove the merge queue early-pass step and merge-queue skip guards from the Docker image build.

## Why are these changes being made?

* We want merge queue branches to build the Docker image for real instead of reporting success through the shared merge queue skip helper.

## Testing Instructions

* Confirmed `git diff --check -- .teamcity/_self/projects/WebApp.kt` passes.
* Confirmed `mvn` is not available locally, so TeamCity DSL generation was not run.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
