### PR TITLE
A4A: Add scan card and detailed view to the agency site detail

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -2,9 +2,14 @@ import { agencySiteQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { category, backup } from '@wordpress/icons';
+import { category, backup, shield } from '@wordpress/icons';
 import { agencySiteRoute } from '../../../app/router/agency';
-import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../../components/sidebar';
+import {
+	SidebarBackButton,
+	SidebarExpandableMenuItem,
+	SidebarMenu,
+	SidebarMenuItem,
+} from '../../../components/sidebar';
 import AgencySiteSwitcherItem from './site-switcher-item';
 
 export default function AgencySiteSidebar() {
@@ -31,6 +36,20 @@ export default function AgencySiteSidebar() {
 							<SidebarMenuItem icon={ backup } to={ `/sites/${ siteSlug }/backups` }>
 								{ __( 'Backups' ) }
 							</SidebarMenuItem>
+						) }
+						{ site.has_scan && (
+							<SidebarExpandableMenuItem
+								label={ __( 'Scan' ) }
+								icon={ shield }
+								to={ `/sites/${ siteSlug }/scan` }
+							>
+								<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
+									{ __( 'Active threats' ) }
+								</SidebarMenuItem>
+								<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/history` }>
+									{ __( 'History' ) }
+								</SidebarMenuItem>
+							</SidebarExpandableMenuItem>
 						) }
 					</SidebarMenu>
 				</VStack>

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -1,17 +1,25 @@
+import { __experimentalGrid as Grid } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { agencySiteRoute } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
 import BackupCard from './backup-card';
+import ScanCard from './scan-card';
 
 export default function AgencySiteOverview() {
+	const { siteSlug } = agencySiteRoute.useParams();
 	const site = agencySiteRoute.useLoaderData();
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
 
 	return (
 		<PageLayout
 			header={ <PageHeader title={ getSiteName( site ) } description={ getDisplayUrl( site ) } /> }
 		>
-			<BackupCard site={ site } />
+			<Grid columns={ isSmallViewport ? 1 : 2 } gap={ isSmallViewport ? 4 : 6 }>
+				<BackupCard site={ site } />
+				<ScanCard site={ site } siteSlug={ siteSlug } />
+			</Grid>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/agency/sites/site/scan-card.tsx
+++ b/client/dashboard/agency/sites/site/scan-card.tsx
@@ -1,0 +1,20 @@
+import { __ } from '@wordpress/i18n';
+import { shield } from '@wordpress/icons';
+import OverviewCard from '../../../components/overview-card';
+import { ScanCardContent } from '../../../sites/overview-scan-card';
+import type { AgencySite } from '@automattic/api-core';
+
+export default function ScanCard( { site, siteSlug }: { site: AgencySite; siteSlug: string } ) {
+	if ( ! site.has_scan ) {
+		return (
+			<OverviewCard
+				icon={ shield }
+				title={ __( 'Last scan' ) }
+				heading={ __( 'Not active' ) }
+				description={ __( 'Scan isn’t enabled for this site.' ) }
+			/>
+		);
+	}
+
+	return <ScanCardContent siteId={ site.blog_id } scanUrl={ `/sites/${ siteSlug }/scan` } />;
+}

--- a/client/dashboard/agency/sites/site/scan-page.tsx
+++ b/client/dashboard/agency/sites/site/scan-page.tsx
@@ -1,0 +1,20 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSiteTimezone } from '../../../app/hooks/use-site-timezone';
+import { agencySiteRoute } from '../../../app/router/agency';
+import { ScanContent } from '../../../sites/scan/scan-content';
+
+export default function AgencySiteScanPage( { scanTab }: { scanTab: 'active' | 'history' } ) {
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { gmtOffset, timezoneString } = useSiteTimezone( site.ID );
+
+	return (
+		<ScanContent
+			site={ site }
+			scanTab={ scanTab }
+			timezoneString={ timezoneString }
+			gmtOffset={ gmtOffset }
+		/>
+	);
+}

--- a/client/dashboard/agency/sites/site/scan.tsx
+++ b/client/dashboard/agency/sites/site/scan.tsx
@@ -1,0 +1,33 @@
+import { agencySiteQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, shield } from '@wordpress/icons';
+import { agencySiteRoute } from '../../../app/router/agency';
+import { Card, CardBody } from '../../../components/card';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { Text } from '../../../components/text';
+
+export default function AgencySiteScan() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( agencySiteQuery( siteSlug ) );
+
+	if ( ! site?.has_scan ) {
+		return (
+			<PageLayout header={ <PageHeader title={ __( 'Scan' ) } /> }>
+				<Card>
+					<CardBody>
+						<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+							<Icon icon={ shield } />
+							<Text variant="muted">{ __( 'Scan isn’t enabled for this site.' ) }</Text>
+						</HStack>
+					</CardBody>
+				</Card>
+			</PageLayout>
+		);
+	}
+
+	return <Outlet />;
+}

--- a/client/dashboard/app/hooks/use-site-timezone.ts
+++ b/client/dashboard/app/hooks/use-site-timezone.ts
@@ -1,0 +1,12 @@
+import { siteSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export function useSiteTimezone( siteId: number ) {
+	return useSuspenseQuery( {
+		...siteSettingsQuery( siteId ),
+		select: ( s ) => ( {
+			gmtOffset: Number( s?.gmt_offset ) || 0,
+			timezoneString: s?.timezone_string || undefined,
+		} ),
+	} ).data;
+}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -8,11 +8,12 @@ import {
 	rawUserPreferencesQuery,
 	siteBackupsQuery,
 	siteBySlugQuery,
+	siteScanQuery,
 	siteSettingsQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute, notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { redirectAsNotAllowed } from './redirect';
+import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 
 // Pathless layout route that guards every agency route (blocks client users).
@@ -356,6 +357,60 @@ export const agencySiteBackupDownloadRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteSlug/scan` – layout that gates on the agency site's has_scan flag
+const agencySiteScanRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Scan' ) } ] } ),
+	getParentRoute: () => agencySiteRoute,
+	path: 'scan',
+	loader: async ( { params: { siteSlug } } ) => {
+		const agencySite = await queryClient.ensureQueryData( agencySiteQuery( siteSlug ) );
+		if ( ! agencySite?.has_scan ) {
+			return;
+		}
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../agency/sites/site/scan' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-scan' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteScanIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteScanRoute,
+	path: '/',
+	beforeLoad: ( { params: { siteSlug } } ) => {
+		throw dashboardRedirect( { to: `/sites/${ siteSlug }/scan/active` } );
+	},
+} );
+
+export const agencySiteScanActiveRoute = createRoute( {
+	getParentRoute: () => agencySiteScanRoute,
+	path: 'active',
+} ).lazy( () =>
+	import( '../../agency/sites/site/scan-page' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-scan-active' )( {
+			component: () => <d.default scanTab="active" />,
+		} )
+	)
+);
+
+export const agencySiteScanHistoryRoute = createRoute( {
+	getParentRoute: () => agencySiteScanRoute,
+	path: 'history',
+} ).lazy( () =>
+	import( '../../agency/sites/site/scan-page' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-scan-history' )( {
+			component: () => <d.default scanTab="history" />,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -378,6 +433,11 @@ export const createAgencyRoutes = () => [
 					agencySiteBackupRestoreRoute,
 					agencySiteBackupDownloadRoute,
 				] ),
+			] ),
+			agencySiteScanRoute.addChildren( [
+				agencySiteScanIndexRoute,
+				agencySiteScanActiveRoute,
+				agencySiteScanHistoryRoute,
 			] ),
 		] ),
 	] ),

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -28,7 +28,7 @@ function getScanURL( site: Site ) {
 		: `/sites/${ site.slug }/scan/active`;
 }
 
-function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
+function ScanCardWithThreats( { scanUrl, scan }: { scanUrl: string; scan: SiteScan } ) {
 	const threatCount = scan.threats?.length ?? 0;
 	const heading = sprintf(
 		/* translators: %d: number of risks */
@@ -46,13 +46,13 @@ function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 			{ ...CARD_PROPS }
 			heading={ heading }
 			description={ description }
-			link={ getScanURL( site ) }
+			link={ scanUrl }
 			intent="error"
 		/>
 	);
 }
 
-function ScanCardNoThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
+function ScanCardNoThreats( { scanUrl, scan }: { scanUrl: string; scan: SiteScan } ) {
 	const lastScanDate = useTimeSince( scan.most_recent?.timestamp );
 	let description = '\u00A0';
 
@@ -69,14 +69,14 @@ function ScanCardNoThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 			{ ...CARD_PROPS }
 			heading={ __( 'No risks found' ) }
 			description={ description }
-			link={ getScanURL( site ) }
+			link={ scanUrl }
 			intent="success"
 		/>
 	);
 }
 
-function ScanCardContent( { site }: { site: Site } ) {
-	const { data: scan } = useQuery( siteScanQuery( site.ID ) );
+export function ScanCardContent( { siteId, scanUrl }: { siteId: number; scanUrl: string } ) {
+	const { data: scan } = useQuery( siteScanQuery( siteId ) );
 
 	if ( scan === undefined ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
@@ -87,10 +87,10 @@ function ScanCardContent( { site }: { site: Site } ) {
 	}
 
 	if ( scan.threats.length > 0 ) {
-		return <ScanCardWithThreats site={ site } scan={ scan } />;
+		return <ScanCardWithThreats scanUrl={ scanUrl } scan={ scan } />;
 	}
 
-	return <ScanCardNoThreats site={ site } scan={ scan } />;
+	return <ScanCardNoThreats scanUrl={ scanUrl } scan={ scan } />;
 }
 
 export default function ScanCard( { site }: { site: Site } ) {
@@ -119,7 +119,7 @@ export default function ScanCard( { site }: { site: Site } ) {
 			upsellDescription={ __( 'We guard your site. You run your business.' ) }
 			upsellLink={ getScanURL( site ) }
 		>
-			<ScanCardContent site={ site } />
+			<ScanCardContent siteId={ site.ID } scanUrl={ getScanURL( site ) } />
 		</HostingFeatureGatedWithOverviewCard>
 	);
 }

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -1,98 +1,33 @@
 import { HostingFeatures } from '@automattic/api-core';
-import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button, Modal } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { shield } from '@wordpress/icons';
-import { useState } from 'react';
-import { useAnalytics } from '../../app/analytics';
-import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { useSiteTimezone } from '../../app/hooks/use-site-timezone';
 import { siteRoute } from '../../app/router/sites';
-import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody } from '../../components/card';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
 import TimeMismatchNotice, {
 	useShouldShowTimeMismatchNotice,
 } from '../../components/time-mismatch-notice';
-import { useTimeSince } from '../../components/time-since';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { SitesNoticeArbiter } from '../notice-arbiter';
-import { ActiveThreatsDataViews } from '../scan-active';
-import { ScanHistoryDataViews } from '../scan-history';
-import { BulkFixThreatsModal } from './components/bulk-fix-threats-modal';
 import illustrationUrl from './scan-callout-illustration.svg';
-import { ScanNotices } from './scan-notices';
-import { ScanNowButton } from './scan-now-button';
-import { ScanStatus } from './status';
-import { useScanState } from './use-scan-state';
-
-import './style.scss';
+import { ScanContent } from './scan-content';
 
 function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	const { siteSlug } = siteRoute.useParams();
 
-	const { recordTracksEvent } = useAnalytics();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const [ showBulkFixModal, setShowBulkFixModal ] = useState( false );
 
 	const settingsUrl = site.options?.admin_url
 		? `${ site.options.admin_url }options-general.php`
 		: '';
 
-	const { data: siteSettings } = useSuspenseQuery( {
-		...siteSettingsQuery( site.ID ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
+	const { gmtOffset, timezoneString } = useSiteTimezone( site.ID );
 
-	const { gmtOffset, timezoneString } = siteSettings;
-
-	const scanState = useScanState( site.ID );
-	const { scan, status } = scanState;
-	const isScanInProgress = status === 'enqueued' || status === 'running';
-	const fixableThreatsCount = scan?.threats?.filter( ( threat ) => threat.fixable ).length || 0;
-	const lastScanTime = scan?.most_recent?.timestamp;
-	const lastScanRelativeTime = useTimeSince( lastScanTime || '' );
-	const threatCount = scan?.threats?.length || 0;
-
-	const showScanNotices = status === 'error' || status === 'success';
 	const showTimeMismatchNotice = useShouldShowTimeMismatchNotice( {
 		siteTime: gmtOffset,
 		siteId: site.ID,
 	} );
-
-	const getPageDescription = () => {
-		if ( lastScanTime && lastScanRelativeTime ) {
-			return sprintf(
-				/* translators: %s: relative time since last scan */
-				__( 'Latest scan ran %s.' ),
-				lastScanRelativeTime
-			);
-		}
-
-		return null;
-	};
-
-	const renderActiveTab = () => {
-		if ( isScanInProgress ) {
-			return (
-				<>
-					<PerformanceTrackerStop />
-					<ScanStatus scanState={ scanState } />
-				</>
-			);
-		}
-		return (
-			<ActiveThreatsDataViews
-				site={ site }
-				timezoneString={ timezoneString }
-				gmtOffset={ gmtOffset }
-			/>
-		);
-	};
 
 	return (
 		<HostingFeatureGatedWithCallout
@@ -108,83 +43,23 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 				'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
 			) }
 		>
-			<PageLayout
-				header={
-					<PageHeader
-						description={ getPageDescription() }
-						actions={
-							<ButtonStack>
-								<ScanNowButton site={ site } scanState={ scanState } />
-								{ fixableThreatsCount > 0 && (
-									<Button
-										variant="primary"
-										disabled={ isScanInProgress }
-										onClick={ () => {
-											recordTracksEvent( 'calypso_dashboard_scan_fix_threats_cta_click', {
-												threat_count: fixableThreatsCount,
-											} );
-											setShowBulkFixModal( true );
-										} }
-									>
-										{ sprintf(
-											/* translators: %(threatsCount)d: number of threats */
-											_n(
-												'Auto-fix %(threatsCount)d threat',
-												'Auto-fix %(threatsCount)d threats',
-												fixableThreatsCount
-											),
-											{
-												threatsCount: fixableThreatsCount,
-											}
-										) }
-									</Button>
-								) }
-							</ButtonStack>
-						}
-					/>
-				}
+			<ScanContent
+				site={ site }
+				scanTab={ scanTab }
+				timezoneString={ timezoneString }
+				gmtOffset={ gmtOffset }
 				notices={
-					<>
-						{ /* Action feedback, not an on-load banner: rendered outside the arbiter. */ }
-						{ showScanNotices && <ScanNotices status={ status } threatCount={ threatCount } /> }
-						<SitesNoticeArbiter>
-							{ showTimeMismatchNotice && (
-								<TimeMismatchNotice
-									settingsUrl={ settingsUrl }
-									siteTime={ gmtOffset }
-									siteId={ site.ID }
-								/>
-							) }
-						</SitesNoticeArbiter>
-					</>
-				}
-			>
-				<Card>
-					<CardBody>
-						{ scanTab === 'active' && renderActiveTab() }
-						{ scanTab === 'history' && (
-							<ScanHistoryDataViews
-								site={ site }
-								timezoneString={ timezoneString }
-								gmtOffset={ gmtOffset }
+					<SitesNoticeArbiter>
+						{ showTimeMismatchNotice && (
+							<TimeMismatchNotice
+								settingsUrl={ settingsUrl }
+								siteTime={ gmtOffset }
+								siteId={ site.ID }
 							/>
 						) }
-					</CardBody>
-				</Card>
-			</PageLayout>
-			{ showBulkFixModal && (
-				<Modal
-					title={ __( 'Auto-fix threats' ) }
-					onRequestClose={ () => setShowBulkFixModal( false ) }
-					size="medium"
-				>
-					<BulkFixThreatsModal
-						items={ scan?.threats?.filter( ( threat ) => threat.fixable ) || [] }
-						closeModal={ () => setShowBulkFixModal( false ) }
-						site={ site }
-					/>
-				</Modal>
-			) }
+					</SitesNoticeArbiter>
+				}
+			/>
 		</HostingFeatureGatedWithCallout>
 	);
 }

--- a/client/dashboard/sites/scan/scan-content.tsx
+++ b/client/dashboard/sites/scan/scan-content.tsx
@@ -1,0 +1,151 @@
+import { Button, Modal } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { useTimeSince } from '../../components/time-since';
+import { ActiveThreatsDataViews } from '../scan-active';
+import { ScanHistoryDataViews } from '../scan-history';
+import { BulkFixThreatsModal } from './components/bulk-fix-threats-modal';
+import { ScanNotices } from './scan-notices';
+import { ScanNowButton } from './scan-now-button';
+import { ScanStatus } from './status';
+import { useScanState } from './use-scan-state';
+import type { Site } from '@automattic/api-core';
+
+import './style.scss';
+
+export function ScanContent( {
+	site,
+	scanTab,
+	timezoneString,
+	gmtOffset,
+	notices,
+}: {
+	site: Site;
+	scanTab: 'active' | 'history';
+	timezoneString?: string;
+	gmtOffset?: number;
+	notices?: React.ReactNode;
+} ) {
+	const { recordTracksEvent } = useAnalytics();
+	const [ showBulkFixModal, setShowBulkFixModal ] = useState( false );
+
+	const scanState = useScanState( site.ID );
+	const { scan, status } = scanState;
+	const isScanInProgress = status === 'enqueued' || status === 'running';
+	const fixableThreatsCount = scan?.threats?.filter( ( threat ) => threat.fixable ).length || 0;
+	const lastScanTime = scan?.most_recent?.timestamp;
+	const lastScanRelativeTime = useTimeSince( lastScanTime || '' );
+	const threatCount = scan?.threats?.length || 0;
+
+	const showScanNotices = status === 'error' || status === 'success';
+
+	const getPageDescription = () => {
+		if ( lastScanTime && lastScanRelativeTime ) {
+			return sprintf(
+				/* translators: %s: relative time since last scan */
+				__( 'Latest scan ran %s.' ),
+				lastScanRelativeTime
+			);
+		}
+
+		return null;
+	};
+
+	const renderActiveTab = () => {
+		if ( isScanInProgress ) {
+			return (
+				<>
+					<PerformanceTrackerStop />
+					<ScanStatus scanState={ scanState } />
+				</>
+			);
+		}
+		return (
+			<ActiveThreatsDataViews
+				site={ site }
+				timezoneString={ timezoneString }
+				gmtOffset={ gmtOffset }
+			/>
+		);
+	};
+
+	return (
+		<>
+			<PageLayout
+				header={
+					<PageHeader
+						description={ getPageDescription() }
+						actions={
+							<ButtonStack>
+								<ScanNowButton site={ site } scanState={ scanState } />
+								{ fixableThreatsCount > 0 && (
+									<Button
+										variant="primary"
+										disabled={ isScanInProgress }
+										onClick={ () => {
+											recordTracksEvent( 'calypso_dashboard_scan_fix_threats_cta_click', {
+												threat_count: fixableThreatsCount,
+											} );
+											setShowBulkFixModal( true );
+										} }
+									>
+										{ sprintf(
+											/* translators: %(threatsCount)d: number of threats */
+											_n(
+												'Auto-fix %(threatsCount)d threat',
+												'Auto-fix %(threatsCount)d threats',
+												fixableThreatsCount
+											),
+											{
+												threatsCount: fixableThreatsCount,
+											}
+										) }
+									</Button>
+								) }
+							</ButtonStack>
+						}
+					/>
+				}
+				notices={
+					<>
+						{ /* Action feedback, not an on-load banner: rendered outside the arbiter. */ }
+						{ showScanNotices && <ScanNotices status={ status } threatCount={ threatCount } /> }
+						{ notices }
+					</>
+				}
+			>
+				<Card>
+					<CardBody>
+						{ scanTab === 'active' && renderActiveTab() }
+						{ scanTab === 'history' && (
+							<ScanHistoryDataViews
+								site={ site }
+								timezoneString={ timezoneString }
+								gmtOffset={ gmtOffset }
+							/>
+						) }
+					</CardBody>
+				</Card>
+			</PageLayout>
+			{ showBulkFixModal && (
+				<Modal
+					title={ __( 'Auto-fix threats' ) }
+					onRequestClose={ () => setShowBulkFixModal( false ) }
+					size="medium"
+				>
+					<BulkFixThreatsModal
+						items={ scan?.threats?.filter( ( threat ) => threat.fixable ) || [] }
+						closeModal={ () => setShowBulkFixModal( false ) }
+						site={ site }
+					/>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/api-core/src/jetpack-agency-sites/types.ts
+++ b/packages/api-core/src/jetpack-agency-sites/types.ts
@@ -4,6 +4,7 @@ export interface AgencySite {
 	blogname?: string;
 	url_with_scheme?: string;
 	has_backup?: boolean;
+	has_scan?: boolean;
 	jetpack_boost_scores?: {
 		overall: number;
 	};


### PR DESCRIPTION
Resolves A4A-2916

## Proposed Changes

Adds Scan to a site's page in the Automattic for Agencies dashboard:

* A **Scan card** on the site Overview showing the latest scan result (risks found, or all clear) — shown side by side with the Backup card.
* A **Scan** section in the sidebar with **Active threats** and **History**.
* A full **Scan** page to review threats, run a scan, and fix or ignore issues.
* Sites that don't have Scan show a simple "Not active" state.

## Why are these changes being made?

Agencies could see a site's overview but had no way to review or act on security scans from the new site page. This brings Scan to agency-managed sites, reusing the same Scan experience the main dashboard already has.

## Testing Instructions

1. Open the Automattic for Agencies dashboard as an agency user.
2. Open a site that has Scan enabled.
3. On the Overview, confirm the **Scan card** shows next to the Backup card with the latest scan result.
4. In the sidebar, open **Scan** and confirm **Active threats** and **History**.
5. On the Scan page, try **Scan now**; if there are threats, try **Fix**, **Ignore**, and **Auto-fix**.
6. Open **History** and confirm past scans are listed.
7. Open a site without Scan and confirm it shows "Not active" and has no Scan sidebar item.
8. Confirm nothing changed on the main (dotcom) dashboard.

<img width="1905" height="865" alt="Screenshot 2026-07-03 at 11 14 19 AM" src="https://github.com/user-attachments/assets/e3ef78fc-75c8-454d-bcc8-7081f5c1cc12" />

<img width="1916" height="582" alt="Screenshot 2026-07-03 at 11 14 29 AM" src="https://github.com/user-attachments/assets/8e4efa1e-d767-4ed7-a3cd-d672ac8213fc" />

<img width="1916" height="582" alt="Screenshot 2026-07-03 at 11 14 42 AM" src="https://github.com/user-attachments/assets/b3c6e88e-1941-4d02-b9e4-fec1115359ae" />

<img width="1916" height="962" alt="Screenshot 2026-07-03 at 11 19 16 AM" src="https://github.com/user-attachments/assets/17c6d9ea-c181-4cb6-afdb-9b1087cdb409" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
