### PR TITLE
A4A: Add Latest activity card and Logs > Activity view to agency site detail

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -2,7 +2,7 @@ import { agencySiteQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { category, backup, shield } from '@wordpress/icons';
+import { backup, category, formatListBullets, shield } from '@wordpress/icons';
 import { agencySiteRoute } from '../../../app/router/agency';
 import {
 	SidebarBackButton,
@@ -51,6 +51,15 @@ export default function AgencySiteSidebar() {
 								</SidebarMenuItem>
 							</SidebarExpandableMenuItem>
 						) }
+						<SidebarExpandableMenuItem
+							label={ __( 'Logs' ) }
+							icon={ formatListBullets }
+							to={ `/sites/${ siteSlug }/logs/activity` }
+						>
+							<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
+								{ __( 'Activity' ) }
+							</SidebarMenuItem>
+						</SidebarExpandableMenuItem>
 					</SidebarMenu>
 				</VStack>
 			) }

--- a/client/dashboard/agency/sites/site/activity-card.tsx
+++ b/client/dashboard/agency/sites/site/activity-card.tsx
@@ -1,0 +1,17 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { agencySiteRoute } from '../../../app/router/agency';
+import LatestActivityCard from '../../../sites/overview-latest-activity-card';
+
+export default function ActivityCard() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return (
+		<LatestActivityCard site={ site } activityLogUrl={ `/sites/${ siteSlug }/logs/activity` } />
+	);
+}

--- a/client/dashboard/agency/sites/site/activity.tsx
+++ b/client/dashboard/agency/sites/site/activity.tsx
@@ -1,0 +1,91 @@
+import { HostingFeatures, LogType } from '@automattic/api-core';
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { DateRangePicker } from '@automattic/date-range-picker';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useDateRange } from '../../../app/hooks/use-date-range';
+import { useSiteTimezoneWithJetpackFallback } from '../../../app/hooks/use-site-timezone';
+import { useLocale } from '../../../app/locale';
+import { agencySiteActivityRoute, agencySiteRoute } from '../../../app/router/agency';
+import { Card, CardBody } from '../../../components/card';
+import InlineSupportLink from '../../../components/inline-support-link';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import SiteActivityLogsDataViews from '../../../sites/logs-activity/dataviews';
+import { hasHostingFeature, hasPlanFeature } from '../../../utils/site-features';
+
+export default function AgencySiteActivity() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { gmtOffset, timezoneString } = useSiteTimezoneWithJetpackFallback( site );
+
+	const locale = useLocale();
+	const searchParams = agencySiteActivityRoute.useSearch();
+
+	// Activity has no auto-refresh, but the shared DataViews props require this state.
+	const [ autoRefresh, setAutoRefresh ] = useState( false );
+	const { dateRange, handleDateRangeChange } = useDateRange( {
+		timezoneString,
+		gmtOffset,
+		autoRefresh,
+	} );
+	const [ dateRangeVersion, setDateRangeVersion ] = useState( 0 );
+
+	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
+		handleDateRangeChange( next );
+		setDateRangeVersion( ( v ) => v + 1 );
+	};
+
+	const hasActivityLogAccess =
+		hasHostingFeature( site, HostingFeatures.ACTIVITY_LOG ) ||
+		hasPlanFeature( site, HostingFeatures.ACTIVITY_LOG );
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Activity' ) }
+					description={ createInterpolateElement(
+						__( 'View your site’s activity log. <learnMoreLink />' ),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="site-monitoring-logs" />,
+						}
+					) }
+					actions={
+						<DateRangePicker
+							start={ dateRange.start }
+							end={ dateRange.end }
+							gmtOffset={ gmtOffset }
+							timezoneString={ timezoneString }
+							locale={ locale }
+							onChange={ handleDateRangeChangeWrapper }
+						/>
+					}
+				/>
+			}
+		>
+			<Card className="site-logs-card site-logs-card--activity">
+				<CardBody>
+					{ /* TODO(A4A-2917): the reused activity DataViews shows a primary "Manage backup"
+					     row action on rewindable entries that navigates to the dotcom
+					     siteBackupDetailRoute, which A4A doesn't register — it dead-ends until
+					     agency backups routes exist. Hide or re-point it once backups land. */ }
+					<SiteActivityLogsDataViews
+						logType={ LogType.ACTIVITY }
+						dateRange={ dateRange }
+						dateRangeVersion={ dateRangeVersion }
+						autoRefresh={ autoRefresh }
+						setAutoRefresh={ setAutoRefresh }
+						gmtOffset={ gmtOffset }
+						timezoneString={ timezoneString }
+						site={ site }
+						hasActivityLogsAccess={ hasActivityLogAccess }
+						searchParams={ searchParams }
+					/>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -4,6 +4,7 @@ import { agencySiteRoute } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
+import ActivityCard from './activity-card';
 import BackupCard from './backup-card';
 import ScanCard from './scan-card';
 
@@ -20,6 +21,7 @@ export default function AgencySiteOverview() {
 				<BackupCard site={ site } />
 				<ScanCard site={ site } siteSlug={ siteSlug } />
 			</Grid>
+			<ActivityCard />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/app/hooks/use-site-timezone.ts
+++ b/client/dashboard/app/hooks/use-site-timezone.ts
@@ -1,12 +1,29 @@
+import { type Site, type SiteSettings } from '@automattic/api-core';
 import { siteSettingsQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+
+const selectTimezone = ( s: SiteSettings | undefined ) => ( {
+	gmtOffset: Number( s?.gmt_offset ) || 0,
+	timezoneString: s?.timezone_string || undefined,
+} );
 
 export function useSiteTimezone( siteId: number ) {
 	return useSuspenseQuery( {
 		...siteSettingsQuery( siteId ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
+		select: selectTimezone,
 	} ).data;
+}
+
+// Sites with a Jetpack connection error can't reach the settings endpoint, so we
+// skip the fetch and fall back to UTC defaults to keep the page accessible. Uses a
+// non-suspense query because the fetch has to be conditional on reachability.
+export function useSiteTimezoneWithJetpackFallback( site: Site ) {
+	const isReachable = ! site.__inaccessible_jetpack_error;
+	const { data } = useQuery( {
+		...siteSettingsQuery( site.ID ),
+		enabled: isReachable,
+		select: selectTimezone,
+	} );
+
+	return isReachable && data ? data : { gmtOffset: 0, timezoneString: undefined };
 }

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -381,6 +381,40 @@ const agencySiteScanRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteSlug/logs` – logs parent, redirects to the activity log
+export const agencySiteLogsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Logs' ) } ] } ),
+	getParentRoute: () => agencySiteRoute,
+	path: 'logs',
+} );
+
+const agencySiteLogsIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteLogsRoute,
+	path: '/',
+	beforeLoad: ( { params: { siteSlug } } ) => {
+		throw dashboardRedirect( { to: `/sites/${ siteSlug }/logs/activity` } );
+	},
+} );
+
+// `/sites/$siteSlug/logs/activity` – activity log detailed view
+export const agencySiteActivityRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Activity' ) } ] } ),
+	getParentRoute: () => agencySiteLogsRoute,
+	path: 'activity',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! site.__inaccessible_jetpack_error ) {
+			await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../agency/sites/site/activity' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-activity' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const agencySiteScanIndexRoute = createRoute( {
 	getParentRoute: () => agencySiteScanRoute,
 	path: '/',
@@ -439,6 +473,7 @@ export const createAgencyRoutes = () => [
 				agencySiteScanActiveRoute,
 				agencySiteScanHistoryRoute,
 			] ),
+			agencySiteLogsRoute.addChildren( [ agencySiteLogsIndexRoute, agencySiteActivityRoute ] ),
 		] ),
 	] ),
 ];

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -404,7 +404,7 @@ export const agencySiteActivityRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! site.__inaccessible_jetpack_error ) {
-			await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+			await queryClient.prefetchQuery( siteSettingsQuery( site.ID ) );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -10,7 +10,6 @@ import { useAnalytics } from '../../../app/analytics';
 import { usePersistentView } from '../../../app/hooks/use-persistent-view';
 import { useLocale } from '../../../app/locale';
 import { PerformanceTrackerStop } from '../../../app/performance-tracking';
-import { siteLogsActivityRoute } from '../../../app/router/sites';
 import { DataViews, DataViewsEmptyStateLayout } from '../../../components/dataviews';
 import { formatDate } from '../../../utils/datetime';
 import { getActivityLogHiddenGroups } from '../../../utils/site-features';
@@ -28,6 +27,9 @@ import './style.scss';
 type SiteLogsDataViewsPropsActivity = SiteLogsDataViewsProps & {
 	logType: typeof LogType.ACTIVITY;
 	hasActivityLogsAccess: boolean;
+	// View state deep-linked via the URL, read from the active route's search.
+	// Passed in so this component isn't bound to a specific route.
+	searchParams?: Record< string, unknown >;
 };
 
 const ACTIVITY_LOGS_DEFAULT_PAGE_SIZE = 20;
@@ -38,6 +40,7 @@ function SiteActivityLogsDataViews( {
 	dateRange,
 	dateRangeVersion,
 	hasActivityLogsAccess,
+	searchParams,
 }: SiteLogsDataViewsPropsActivity ) {
 	const { recordTracksEvent } = useAnalytics();
 	const locale = useLocale();
@@ -46,8 +49,6 @@ function SiteActivityLogsDataViews( {
 		() => buildTimeRangeInSeconds( dateRange.start, dateRange.end, timezoneString, gmtOffset ),
 		[ dateRange.start, dateRange.end, gmtOffset, timezoneString ]
 	);
-
-	const searchParams = siteLogsActivityRoute.useSearch();
 
 	const { view, updateView, resetView } = usePersistentView( {
 		slug: 'site-logs-activity',

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -168,6 +168,7 @@ function renderActivityLogsDataViews(
 			setAutoRefresh={ jest.fn() }
 			logType="activity"
 			hasActivityLogsAccess
+			searchParams={ {} }
 		/>
 	);
 }

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -2,6 +2,7 @@ import { HostingFeatures, LogType, type Site, type SiteSettings } from '@automat
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { DateRangePicker, isLast7Days } from '@automattic/date-range-picker';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSearch } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
@@ -85,6 +86,7 @@ function SiteLogsContent( {
 	);
 
 	const siteId = site.ID;
+	const activitySearchParams = useSearch( { strict: false } );
 	const showTimeMismatchNotice = useShouldShowTimeMismatchNotice( {
 		siteTime: gmtOffset,
 		siteId,
@@ -240,6 +242,7 @@ function SiteLogsContent( {
 								timezoneString={ timezoneString }
 								site={ site }
 								hasActivityLogsAccess={ hasActivityLogAccess }
+								searchParams={ activitySearchParams }
 							/>
 						</>
 					) }

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -60,9 +60,11 @@ function getActivityLogUrl( site: Site ) {
 export default function LatestActivityCard( {
 	site,
 	isCompact = false,
+	activityLogUrl,
 }: {
 	site: Site;
 	isCompact?: boolean;
+	activityLogUrl?: string;
 } ) {
 	const notGroup = getActivityLogHiddenGroups( site );
 	const { data } = useQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
@@ -106,7 +108,7 @@ export default function LatestActivityCard( {
 			{ data && data.length > 0 && (
 				<SummaryButtonCardFooter
 					title={ __( 'See all activity' ) }
-					href={ getActivityLogUrl( site ) }
+					href={ activityLogUrl ?? getActivityLogUrl( site ) }
 					density="medium"
 					onClick={ handleClickSeeAll }
 				/>


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/112228

Part of [A4A-2917](https://linear.app/a8c/issue/A4A-2917)

## Proposed Changes

* Adds a **Latest activity** card to the agency site overview, reusing the multi-site dashboard's `LatestActivityCard`.
* Adds a **Logs › Activity** detailed view to the agency site detail (route, sidebar item, and page), reusing the dashboard's activity `DataViews`.
* Small, reusable refactors to shared dashboard components so both dotcom and agency can consume them:
  * `LatestActivityCard` gains an optional `activityLogUrl` so the "See all activity" link can target the agency route.
  * The activity `DataViews` now takes `searchParams` as a prop instead of reading a specific route's search, so it is no longer bound to the dotcom route.
* Known limitation (flagged with a `TODO(A4A-2917)` in `activity.tsx`): the reused activity `DataViews` shows a primary "Manage backup" row action on rewindable entries that navigates to the dotcom backup detail route, which the A4A variant doesn't register yet — it dead-ends until the agency backups routes land.

## Why are these changes being made?

* Agencies need visibility into a managed site's activity from the new dashboard-based site detail view. This adds the first "Logs" section and an at-a-glance overview card, reusing the existing dashboard components rather than duplicating them.

## Testing Instructions

1. Check out this branch and run the dashboard client for A4A (`yarn start-dashboard`), signed in as an agency
2. Or open Dashboard Live (A4A) link > Visit /overview manually to see the A4A view.
3. Open a managed site's detail view and confirm the **Latest activity** card appears on the Overview, listing recent events with a "See all activity" link.
4. In the sidebar, expand **Logs** and open **Activity**; confirm the activity log renders in a card with search, filters, date range, and pagination.
5. Change the date range and confirm the list updates.
6. Confirm the dotcom site Logs › Activity view (non-agency) still works unchanged.

<img width="1916" height="796" alt="Screenshot 2026-07-03 at 12 32 10 PM" src="https://github.com/user-attachments/assets/19009497-23a5-4720-aeca-351f6515b89c" />

<img width="1916" height="887" alt="Screenshot 2026-07-03 at 12 32 56 PM" src="https://github.com/user-attachments/assets/3d24de32-5e7f-464c-9c22-1b738b1c4104" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
