### PR TITLE
Monetize: swap mobile section-nav dropdown for a horizontal scrollable tab bar

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -179,22 +179,11 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		return tabItem.path === currentPath;
 	};
 
-	// Mirror the visible tab selection so the mobile dropdown header always
-	// reflects the active tab (including ads sub-sections, which map to the
-	// "Ads" tab, and paths carrying a query string).
-	const getEarnSelectedText = () => {
-		const selected = getEarnTabs().find( isEarnTabSelected );
-		return selected ? selected.title : '';
-	};
-
 	const getEarnSectionNav = () => {
 		return (
 			<div className="earn-navigation">
-				<SectionNav
-					selectedText={ getEarnSelectedText() }
-					variation={ ! isJetpackPlatform ? 'minimal' : '' }
-				>
-					<NavTabs>
+				<SectionNav variation={ ! isJetpackPlatform ? 'minimal' : '' } enforceTabsView>
+					<NavTabs hasHorizontalScroll>
 						{ getEarnTabs().map( ( tabItem ) => {
 							return (
 								<NavItem

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -41,13 +41,28 @@ body.is-section-jetpack-monetize {
 		}
 	}
 
-	// Drop the overflow fade mask — the tabs fit, and the left fade otherwise
-	// dims the flush-aligned first tab label.
+	// Scroll the tab bar horizontally when the tabs overflow (mobile) so every
+	// section stays reachable instead of being clipped off the edge. The edge
+	// fade below signals the overflow, so hide the native scrollbar.
 	.section-nav-tabs:not( .is-dropdown ) .section-nav-tabs__list {
-		&.is-overflowing-first,
-		&.is-overflowing-last,
-		&.is-overflowing-first.is-overflowing-last {
-			mask-image: none;
+		overflow-x: auto;
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+
+	// From the mobile breakpoint up the tabs fit and the first tab sits flush, so
+	// drop the edge fade there (the left fade would otherwise dim that flush
+	// label). Below it the bar scrolls, so keep the fade as a "more tabs" cue.
+	@include break-mobile {
+		.section-nav-tabs:not( .is-dropdown ) .section-nav-tabs__list {
+			&.is-overflowing-first,
+			&.is-overflowing-last,
+			&.is-overflowing-first.is-overflowing-last {
+				mask-image: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes MON-75

## Proposed Changes

- Replace the Monetize section nav's mobile **dropdown** with a horizontal, **scrollable tab bar**, matching the pattern already used across the Reader navigations (`SectionNav enforceTabsView` + `NavTabs hasHorizontalScroll`).
- Add `overflow-x: auto` to the tab list so the bar actually scrolls when the tabs exceed the viewport, keeping every page (Monetization Options, Paid Subscribers, Payment Settings, Ads) reachable instead of clipped.
- Keep the edge-fade "more tabs" affordance below the mobile breakpoint, and hide the native scrollbar (matching `client/components/scrollable-horizontal-navigation`).
- Remove the now-unused `getEarnSelectedText` helper — it only fed the dropdown header, which no longer renders under `enforceTabsView`.

## Why are these changes being made?

On mobile, the Monetize section nav collapsed into a dropdown labeled with the current page name (e.g. "Payment Settings"). It didn't match any navigation pattern used elsewhere, so it didn't read as navigation, and the other Monetize pages were easy to miss entirely. A horizontal scrollable tab bar keeps all pages visible and reads clearly as navigation.

## Testing Instructions

1. Check out this branch and run Calypso locally.
2. Visit `/earn/{site}` and narrow the browser to a mobile width (< 480px) or use device emulation.
3. Confirm the section nav renders as a horizontal tab bar (Monetization Options, Paid Subscribers, Payment Settings, Ads) — **not** a dropdown.
4. Confirm the bar scrolls horizontally and "Ads" is reachable; the edge fade signals more tabs.
5. Confirm clicking a tab navigates and updates the active state.
6. Widen to desktop: all tabs fit, the first tab sits flush with the content, no scrollbar/fade.

Notes for reviewers:
- This also affects the Jetpack Cloud `/monetize` route (same component), which now gets horizontal tabs too.
- The native scrollbar is intentionally hidden; the edge fade + partially-visible next tab is the scroll affordance. This is a deliberate divergence from the Reader navs, which leave the scrollbar visible.
- `yarn typecheck-client` is clean for the changed files (unrelated `@automattic/omnibar` / `@automattic/date-range-picker` module-resolution errors are a local unbuilt-package artifact; CI builds packages first).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
