### PR TITLE
Sidebar: relabel WooCommerce to Store setup for eCommerce plans

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { isEcommercePlan } from '@automattic/calypso-products';
 import { useSelector } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
 import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
@@ -15,7 +16,7 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteDomain, getSitePlanSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import allSitesMenu from './static-data/all-sites-menu';
 import buildFallbackResponse from './static-data/fallback-menu';
@@ -23,6 +24,7 @@ import globalSidebarMenu from './static-data/global-sidebar-menu';
 import jetpackMenu from './static-data/jetpack-fallback-menu';
 import { applyLayoutDelta } from './utils/apply-layout-delta';
 import { normalizeWpcomAdminSidebarHostLinks } from './utils/normalize-wpcom-admin-sidebar-host-links';
+import { relabelWooCommerceAsStoreSetup } from './utils/relabel-woocommerce-store-setup';
 
 const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
@@ -67,6 +69,9 @@ const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const shouldShowThemes = useSelector( ( state ) =>
 		canCurrentUser( state, selectedSiteId, 'edit_theme_options' )
 	);
+
+	const planSlug = useSelector( ( state ) => getSitePlanSlug( state, selectedSiteId ) );
+	const isEcommercePlanSite = !! planSlug && isEcommercePlan( planSlug );
 
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, selectedSiteId ) );
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, selectedSiteId ) );
@@ -130,11 +135,17 @@ const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const transformedBaseMenu =
 		typeof transformBaseMenu === 'function' ? transformBaseMenu( baseMenu ) : baseMenu;
 	const normalizedBaseMenu = normalizeWpcomAdminSidebarHostLinks( transformedBaseMenu );
+	// On eCommerce-plan sites (WordPress.com context only, since only wpcom
+	// plans carry the eCommerce slug), the WooCommerce entry is the store-setup
+	// destination, so relabel it accordingly.
+	const relabeledBaseMenu = isEcommercePlanSite
+		? relabelWooCommerceAsStoreSetup( normalizedBaseMenu )
+		: normalizedBaseMenu;
 	// Apply the user's saved layout-delta (Phase 2 task 2.5). When no delta
 	// is stored, `applyLayoutDelta` returns a copy of `baseMenu` unmodified.
 	// The cost on the no-delta path is one shallow array clone per render;
 	// memoisation lives upstream where the menu is read.
-	return applyLayoutDelta( normalizedBaseMenu, layoutDelta );
+	return applyLayoutDelta( relabeledBaseMenu, layoutDelta );
 };
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar/utils/relabel-woocommerce-store-setup.ts
+++ b/client/my-sites/sidebar/utils/relabel-woocommerce-store-setup.ts
@@ -1,0 +1,25 @@
+import { translate } from 'i18n-calypso';
+import type { AdminMenuItem } from 'calypso/state/admin-menu/types';
+
+// The WooCommerce menu item arrives as `woocommerce` from the admin-menu API
+// and as `woo-php` from the static fallback data; both point at wc-admin.
+const WOOCOMMERCE_ITEM_SLUGS = [ 'woocommerce', 'woo-php' ];
+
+/**
+ * Relabel the WooCommerce sidebar item to "Store setup". Intended for
+ * eCommerce-plan sites in the WordPress.com context, where the WooCommerce
+ * entry is really the store-setup destination.
+ */
+export function relabelWooCommerceAsStoreSetup(
+	menuItems: readonly AdminMenuItem[] | null | undefined
+): AdminMenuItem[] {
+	if ( ! Array.isArray( menuItems ) ) {
+		return [];
+	}
+
+	return menuItems.map( ( item ) =>
+		WOOCOMMERCE_ITEM_SLUGS.includes( item.slug )
+			? { ...item, title: translate( 'Store setup' ) }
+			: item
+	);
+}

--- a/client/my-sites/sidebar/utils/test/relabel-woocommerce-store-setup.ts
+++ b/client/my-sites/sidebar/utils/test/relabel-woocommerce-store-setup.ts
@@ -1,0 +1,40 @@
+import { relabelWooCommerceAsStoreSetup } from '../relabel-woocommerce-store-setup';
+import type { AdminMenuItem } from 'calypso/state/admin-menu/types';
+
+const item = ( overrides: Partial< AdminMenuItem > ): AdminMenuItem => ( {
+	slug: 'example',
+	title: 'Example',
+	type: 'menu-item',
+	...overrides,
+} );
+
+describe( 'relabelWooCommerceAsStoreSetup()', () => {
+	it( 'relabels the WooCommerce API item to "Store setup"', () => {
+		const [ relabeled ] = relabelWooCommerceAsStoreSetup( [
+			item( { slug: 'woocommerce', title: 'WooCommerce' } ),
+		] );
+
+		expect( relabeled.title ).toBe( 'Store setup' );
+	} );
+
+	it( 'relabels the WooCommerce fallback item (woo-php) to "Store setup"', () => {
+		const [ relabeled ] = relabelWooCommerceAsStoreSetup( [
+			item( { slug: 'woo-php', title: 'WooCommerce' } ),
+		] );
+
+		expect( relabeled.title ).toBe( 'Store setup' );
+	} );
+
+	it( 'preserves other menu items', () => {
+		const stats = item( { slug: 'stats', title: 'Stats' } );
+		const [ relabeled ] = relabelWooCommerceAsStoreSetup( [ stats ] );
+
+		expect( relabeled ).toBe( stats );
+		expect( relabeled.title ).toBe( 'Stats' );
+	} );
+
+	it( 'returns an empty array for non-array input', () => {
+		expect( relabelWooCommerceAsStoreSetup( null ) ).toEqual( [] );
+		expect( relabelWooCommerceAsStoreSetup( undefined ) ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
Part of DOTCOM-17755

## Proposed Changes

* Relabel the WooCommerce sidebar entry to "Store setup" for eCommerce-plan sites in the WordPress.com (dotcom) context.
* Add `relabelWooCommerceAsStoreSetup` util that rewrites the item title, matching both the admin-menu API slug (`woocommerce`) and the static fallback slug (`woo-php`).
* Wire the util into `useSiteMenuItems`, gated on `isEcommercePlan(planSlug)`.
* Add unit tests for the util.

<img width="1844" height="592" alt="Screenshot 2026-07-03 at 12 09 49" src="https://github.com/user-attachments/assets/8271707b-8fc1-49c5-9288-998e6c952e09" />

## Why are these changes being made?

On eCommerce-plan sites the WooCommerce entry is really the store-setup destination, so "Store setup" is clearer than "WooCommerce". The change is scoped to the dotcom context because only WordPress.com plans carry the eCommerce plan slug, and Jetpack self-hosted sites resolve their menu through an earlier branch.

## Testing Instructions

* On an eCommerce-plan WordPress.com site, open the site sidebar and confirm the WooCommerce entry reads "Store setup".
* On a non-eCommerce plan (e.g. Business), confirm the entry still reads "WooCommerce".
* Run `yarn test-client client/my-sites/sidebar/utils/test/relabel-woocommerce-store-setup.ts`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)