### PR TITLE
Reuse Docker image by commit SHA

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -50,6 +50,7 @@ object BuildDockerImage : BuildType({
     )
 
     val imageBase = "registry.a8c.com/calypso/app"
+	val commitImageExistsParam = "dockerImage.commitImageExists"
 	val baseUrl = "https://calypso.live"
 
     val environments = listOf(
@@ -174,6 +175,36 @@ object BuildDockerImage : BuildType({
 		}
 
 		script {
+			name = "Reuse existing commit image"
+			conditions {
+				equals("teamcity.build.branch.is_default", "true")
+			}
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				commit_image="$imageBase:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}"
+				build_image="$imageBase:build-%build.number%"
+				latest_image="$imageBase:latest"
+
+				if ! docker manifest inspect "${'$'}commit_image" > /dev/null 2>&1; then
+					echo "No existing Docker image found for ${'$'}commit_image."
+					exit 0
+				fi
+
+				echo "Reusing existing Docker image for ${Settings.WpCalypso.paramRefs.buildVcsNumber}: ${'$'}commit_image"
+
+				docker pull "${'$'}commit_image"
+				docker tag "${'$'}commit_image" "${'$'}build_image"
+				docker tag "${'$'}commit_image" "${'$'}latest_image"
+				docker push "${'$'}build_image"
+
+				echo "##teamcity[setParameter name='$commitImageExistsParam' value='true']"
+				echo "##teamcity[buildStatus status='SUCCESS' text='Reused existing Docker image for this commit']"
+			"""
+		}
+
+		script {
 			name = "Post PR comment"
 			conditions {
 				doesNotEqual("teamcity.build.branch.is_default", "true")
@@ -198,6 +229,9 @@ object BuildDockerImage : BuildType({
 
 		script {
 			name = "Check Docker workspace COPY globs"
+			conditions {
+				doesNotEqual(commitImageExistsParam, "true")
+			}
 			scriptContent = """
 				#!/usr/bin/env bash
 				node ./bin/check-docker-workspace-copy-globs.mjs
@@ -225,6 +259,9 @@ object BuildDockerImage : BuildType({
 
 		dockerCommand {
 			name = "Build docker image"
+			conditions {
+				doesNotEqual(commitImageExistsParam, "true")
+			}
 			commandType = build {
 				source = file {
 					path = "Dockerfile"
@@ -240,6 +277,9 @@ object BuildDockerImage : BuildType({
 		}
 
 		dockerCommand {
+			conditions {
+				doesNotEqual(commitImageExistsParam, "true")
+			}
 			commandType = push {
 				namesAndTags = """
 					registry.a8c.com/calypso/app:build-%build.number%
@@ -321,6 +361,7 @@ object BuildDockerImage : BuildType({
 		dockerCommand {
 			name = "Rebuild cache image"
 			conditions {
+				doesNotEqual(commitImageExistsParam, "true")
 				equals("cache_mode", "base")
 				equals("UPDATE_BASE_IMAGE_CACHE", "true")
 				equals("teamcity.build.branch.is_default", "true")
@@ -342,6 +383,7 @@ object BuildDockerImage : BuildType({
 		dockerCommand {
 			name = "Push cache image"
 			conditions {
+				doesNotEqual(commitImageExistsParam, "true")
 				equals("cache_mode", "base")
 				equals("UPDATE_BASE_IMAGE_CACHE", "true")
 				equals("teamcity.build.branch.is_default", "true")


### PR DESCRIPTION
Part of #112227

## Proposed Changes

* Add a default-branch-only cache check for `Docker image (Web app)`.
* If `registry.a8c.com/calypso/app:commit-<sha>` already exists, retag it as the current `build-%build.number%` image and local `latest`.
* Skip the expensive Docker build, image push, and cache-image rebuild steps after a commit-image cache hit.

## Why are these changes being made?

* Merge queue branches can now build the Docker image for real. When the successful merge queue commit becomes the `trunk` commit, the `trunk` Docker image job can reuse the image that was already built for the same SHA.
* The reuse path is limited to the default branch to avoid reusing a stale PR image after `trunk` has moved.

## Testing Instructions

* Confirmed `git diff --check -- .teamcity/_self/projects/WebApp.kt` passes.
* Confirmed `mvn` is not available locally, so TeamCity DSL generation was not run.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
