### PR TITLE
Refactor account-recovery interstitial to a 5-way SecurityLevel

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/copy.ts
+++ b/client/dashboard/app/account-recovery-interstitial/copy.ts
@@ -1,19 +1,19 @@
 /**
- * Copy for the account-recovery interstitial, keyed by `InterstitialVariant`.
+ * Copy for the account-recovery interstitial, keyed by `SecurityLevel`.
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { securityAccountRecoveryRoute, securityTwoStepAuthRoute } from '../router/me';
 
 /**
- * Which message to show in the interstitial, depending on account recovery settings.
- * Each of these variants map to a correspondent `SecurityLevel` ("none", "partial", "strong").
+ * How secure the user's account already is. Single source of truth for the tiers,
+ * used to key both the copy map here and the snooze windows in the interstitial.
  */
-export type InterstitialVariant =
-	| 'none' // none
-	| 'add-two-factor' // partial
-	| 'add-recovery-method' // partial
-	| 'add-backup-codes' // strong
-	| 'strong'; // strong
+export type SecurityLevel =
+	| 'none' // no recovery method and no 2FA
+	| 'partial-has-recovery' // a recovery method but no 2FA
+	| 'partial-has-2fa' // 2FA but no recovery method
+	| 'strong-no-backup-codes' // recovery method and 2FA, but no backup codes
+	| 'strong'; // recovery method, 2FA, and backup codes
 
 export interface InterstitialCta {
 	/** Tracks `cta_id` dimension. */
@@ -28,30 +28,6 @@ interface InterstitialCopy {
 	description: string;
 	primaryCta: InterstitialCta;
 	secondaryCta?: InterstitialCta;
-}
-
-/** Picks the copy variant depending on the user's account recovery settings. */
-export function getInterstitialVariant(
-	hasRecoveryMethod: boolean,
-	hasTwoFactor: boolean,
-	hasBackupCodes: boolean
-): InterstitialVariant {
-	if ( ! hasRecoveryMethod && ! hasTwoFactor ) {
-		return 'none';
-	}
-	// Exactly one of recovery-method / 2FA is missing: nudge toward the missing one. A missing
-	// recovery method outranks missing backup codes, so this is checked before backup codes.
-	if ( ! hasTwoFactor ) {
-		return 'add-two-factor';
-	}
-	if ( ! hasRecoveryMethod ) {
-		return 'add-recovery-method';
-	}
-	// Has a recovery method and 2FA; the only remaining gap is downloading backup codes.
-	if ( ! hasBackupCodes ) {
-		return 'add-backup-codes';
-	}
-	return 'strong';
 }
 
 /** `joe@gmail.com` → `j••••@gmail.com`. */
@@ -114,7 +90,7 @@ function getStrongDescription( {
 /** `recoveryMethods` carries the user's validated recovery details, to personalize the `strong` copy. */
 export function getInterstitialCopy(
 	recoveryMethods: { recoveryEmail?: string; recoveryPhoneNumber?: string } = {}
-): Record< InterstitialVariant, InterstitialCopy > {
+): Record< SecurityLevel, InterstitialCopy > {
 	return {
 		// Nothing set up: lead with a recovery method, offer 2FA as the secondary.
 		none: {
@@ -134,7 +110,7 @@ export function getInterstitialCopy(
 			},
 		},
 		// Has a recovery method, missing 2FA: push two-factor.
-		'add-two-factor': {
+		'partial-has-recovery': {
 			title: __( 'Take your security further' ),
 			description: __(
 				'Add an extra layer of security. Enable two-step authentication to go beyond email or phone recovery.'
@@ -151,7 +127,7 @@ export function getInterstitialCopy(
 			},
 		},
 		// Has 2FA, missing a recovery method: push a recovery email/phone safety net.
-		'add-recovery-method': {
+		'partial-has-2fa': {
 			title: __( 'Don’t get locked out of your account' ),
 			description: __(
 				'Two-step authentication is great—but if you lose access to your authenticator, you’ll need another way in. Add a recovery email or phone as a safety net.'
@@ -169,7 +145,7 @@ export function getInterstitialCopy(
 		},
 		// Has a recovery method and 2FA but hasn't downloaded backup codes: nudge that last step.
 		// Both CTAs "review" rather than "set up" — everything else is already in place.
-		'add-backup-codes': {
+		'strong-no-backup-codes': {
 			title: __( 'Don’t get locked out of your account' ),
 			description: __(
 				'If you ever lose access to your authenticator, backup codes are your way back in. Download them now and keep them somewhere safe.'

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -12,45 +12,48 @@ import { useId, useState } from 'react';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Text } from '../../components/text';
 import { useAnalytics } from '../analytics';
-import { getInterstitialCopy, getInterstitialVariant } from './copy';
+import { getInterstitialCopy } from './copy';
 import heroIllustration from './hero-illustration.png';
-import type { InterstitialCta } from './copy';
+import type { InterstitialCta, SecurityLevel } from './copy';
 import './style.scss';
 
 const DAY_IN_SECONDS = 86400;
 
 /**
- * How secure the user's account already is. Single source of truth for the tiers;
- * SNOOZE_DAYS and the copy map are both keyed by it.
- */
-type SecurityLevel = 'none' | 'partial' | 'strong';
-
-/**
  * Snooze windows (in days) by security level
  */
 const SNOOZE_DAYS: Record< SecurityLevel, number > = {
-	none: 14, // no recovery method or 2FA set up
-	partial: 30, // a recovery method but no 2FA or vice-versa
-	strong: 365, // recovery method and 2FA in place (the only nudge left is backup codes)
+	none: 14, // no recovery method and no 2FA
+	'partial-has-recovery': 30, // a recovery method but no 2FA
+	'partial-has-2fa': 30, // 2FA but no recovery method
+	'strong-no-backup-codes': 365, // recovery method and 2FA in place (the only nudge left is backup codes)
+	strong: 365, // recovery method, 2FA, and backup codes all in place
 };
 
 /** Maps the user's account-recovery setup to a SecurityLevel. */
 function getSecurityLevel(
 	hasRecoveryEmail: boolean,
 	hasRecoveryPhone: boolean,
-	hasTwoFactor: boolean
+	hasTwoFactor: boolean,
+	hasBackupCodes: boolean
 ): SecurityLevel {
 	const hasRecoveryMethod = hasRecoveryEmail || hasRecoveryPhone;
 
 	if ( ! hasRecoveryMethod && ! hasTwoFactor ) {
 		return 'none';
 	}
-
-	if ( hasRecoveryMethod && hasTwoFactor ) {
-		return 'strong';
+	// Exactly one of recovery-method / 2FA is missing: the level names which one is present.
+	if ( ! hasTwoFactor ) {
+		return 'partial-has-recovery';
 	}
-
-	return 'partial';
+	if ( ! hasRecoveryMethod ) {
+		return 'partial-has-2fa';
+	}
+	// Has a recovery method and 2FA; the only remaining gap is downloading backup codes.
+	if ( ! hasBackupCodes ) {
+		return 'strong-no-backup-codes';
+	}
+	return 'strong';
 }
 
 /**
@@ -85,32 +88,32 @@ export default function AccountRecoveryInterstitial() {
 	const hasRecoveryPhone = !! accountRecovery?.phone_validated;
 	const hasTwoFactor = !! userSettings?.two_step_enabled;
 	const hasBackupCodes = !! userSettings?.two_step_backup_codes_printed;
-	const hasRecoveryMethod = hasRecoveryEmail || hasRecoveryPhone;
 
-	const securityLevel = getSecurityLevel( hasRecoveryEmail, hasRecoveryPhone, hasTwoFactor );
+	const securityLevel = getSecurityLevel(
+		hasRecoveryEmail,
+		hasRecoveryPhone,
+		hasTwoFactor,
+		hasBackupCodes
+	);
 	const snoozeDays = SNOOZE_DAYS[ securityLevel ];
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
-
-	// Selects the copy variant depending on the user's account recovery settings.
-	const variant = getInterstitialVariant( hasRecoveryMethod, hasTwoFactor, hasBackupCodes );
 
 	// Eligible once the data has loaded and the snooze (if any) has elapsed.
 	const isEligible =
 		isAccountRecoveryLoaded && isUserSettingsLoaded && isSnoozeLoaded && ! isSnoozed;
 
-	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
-	// missing a recovery method, 2FA, or backup codes.
-	if ( isDismissed || ! isEligible || variant === 'strong' ) {
+	// Fully-secured users (securityLevel === 'strong') are left alone — we only nudge people who are
+	// still missing a recovery method, 2FA, or backup codes.
+	if ( isDismissed || ! isEligible || securityLevel === 'strong' ) {
 		return null;
 	}
 
-	// Shared Tracks properties for every interstitial event. The coarse `security_level` and 5-way
-	// `recovery_status` summarize the setup; the `has_*` booleans expose exactly which methods are
-	// in place for a finer-grained breakdown.
+	// Shared Tracks properties for every interstitial event. The 5-way `security_level` summarizes
+	// the setup; the `has_*` booleans expose exactly which methods are in place for a finer-grained
+	// breakdown.
 	const tracksProperties = {
 		security_level: securityLevel,
-		recovery_status: variant,
 		has_recovery_email: hasRecoveryEmail,
 		has_recovery_phone: hasRecoveryPhone,
 		has_two_factor: hasTwoFactor,
@@ -122,7 +125,7 @@ export default function AccountRecoveryInterstitial() {
 		recoveryPhoneNumber: accountRecovery?.phone_validated
 			? accountRecovery.phone?.number
 			: undefined,
-	} )[ variant ];
+	} )[ securityLevel ];
 	const { primaryCta, secondaryCta } = copy;
 
 	const snooze = () => {
@@ -154,7 +157,7 @@ export default function AccountRecoveryInterstitial() {
 	// Users who already have a recovery method and 2FA in place get a year-long snooze, so a
 	// "remind me in 365 days" nudge would read as a permanent dismissal — label it as such.
 	const remindLabel =
-		securityLevel === 'strong'
+		securityLevel === 'strong-no-backup-codes'
 			? __( 'Dismiss' )
 			: sprintf(
 					// translators: %d is the number of days until the reminder reappears.

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -131,7 +131,10 @@ export default function AccountRecoveryInterstitial() {
 	};
 
 	const handleSnooze = () => {
-		recordTracksEvent( 'calypso_account_recovery_nudge_interstitial_dismiss', tracksProperties );
+		recordTracksEvent( 'calypso_account_recovery_nudge_interstitial_dismiss', {
+			...tracksProperties,
+			snooze_period: snoozeDays,
+		} );
 		snooze();
 	};
 

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -75,7 +75,6 @@ describe( '<AccountRecoveryInterstitial>', () => {
 			'calypso_account_recovery_nudge_interstitial_impression',
 			{
 				security_level: 'none',
-				recovery_status: 'none',
 				has_recovery_email: false,
 				has_recovery_phone: false,
 				has_two_factor: false,
@@ -103,8 +102,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_account_recovery_nudge_interstitial_impression',
 			{
-				security_level: 'partial',
-				recovery_status: 'add-two-factor',
+				security_level: 'partial-has-recovery',
 				has_recovery_email: true,
 				has_recovery_phone: false,
 				has_two_factor: false,
@@ -147,12 +145,10 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Review recovery email or phone' } )
 		).toBeVisible();
-		// Coarse tier stays 'strong'; the fine-grained dimension captures the missing backup codes.
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_account_recovery_nudge_interstitial_impression',
 			{
-				security_level: 'strong',
-				recovery_status: 'add-backup-codes',
+				security_level: 'strong-no-backup-codes',
 				has_recovery_email: true,
 				has_recovery_phone: false,
 				has_two_factor: true,
@@ -218,7 +214,6 @@ describe( '<AccountRecoveryInterstitial>', () => {
 			'calypso_account_recovery_nudge_interstitial_dismiss',
 			{
 				security_level: 'none',
-				recovery_status: 'none',
 				has_recovery_email: false,
 				has_recovery_phone: false,
 				has_two_factor: false,

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -223,6 +223,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 				has_recovery_phone: false,
 				has_two_factor: false,
 				has_backup_codes: false,
+				snooze_period: 14,
 			}
 		);
 	} );


### PR DESCRIPTION
## Proposed Changes

Refactors the account-recovery interstitial's security tiers from a coarse 3-way value (`none` / `partial` / `strong`) to a 5-way `SecurityLevel` that names exactly which methods are in place:

- `none` — no recovery method and no 2FA
- `partial-has-recovery` — a recovery method but no 2FA
- `partial-has-2fa` — 2FA but no recovery method
- `strong-no-backup-codes` — recovery method and 2FA, but no backup codes
- `strong` — recovery method, 2FA, and backup codes

`SecurityLevel` becomes the single source of truth. The copy map is re-keyed on it, the duplicate `getInterstitialVariant` (which computed the same distinctions from the same inputs) is removed, and both the snooze windows and the copy lookup key off the one value.

The now-redundant `recovery_status` Tracks dimension is dropped; `security_level` carries the full 5-way detail. The `has_*` booleans are unchanged.

A separate first commit adds a `snooze_period` property to the interstitial `dismiss` Tracks event 

## Why are these changes being made?

The coarse tier and the copy variant had drifted into two parallel enums computing the same thing, and the `security_level` Tracks dimension collapsed distinct states (e.g. "has recovery, no 2FA" vs. "has 2FA, no recovery") into a single `partial` bucket. Unifying on one 5-way value removes the duplication and gives analytics the finer-grained breakdown directly on `security_level`.

## Testing Instructions

* Run `yarn test-client client/dashboard/app/account-recovery-interstitial`.
* In the dashboard, exercise each account-recovery state (no methods; recovery only; 2FA only; recovery + 2FA without backup codes) and confirm the interstitial shows the matching copy and reminder label, and that fully-secured users see no modal.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
