### PR TITLE
Write On: handle email_unverified launch error in the launch-site flow

### DIFF
--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -1,17 +1,83 @@
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { useDispatch, useSelector } from 'calypso/state';
+import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 
-class LaunchSiteComponent extends Component {
-	componentDidMount() {
-		const { flowName, stepName } = this.props;
-		this.props.submitSignupStep( { stepName } );
-		this.props.goToNextStep( flowName );
-	}
+import './style.scss';
 
-	render() {
-		return null;
-	}
+// The launch endpoint returns this code only for Write On sites whose owner has
+// an unverified email, so reacting to it here is inherently scoped to that flow.
+const EMAIL_UNVERIFIED = 'email_unverified';
+
+function getErrorCode( errors ) {
+	return errors?.error ?? errors?.code;
 }
 
-export default connect( null, { submitSignupStep } )( LaunchSiteComponent );
+function LaunchSiteComponent( { flowName, stepName, positionInFlow } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const step = useSelector( ( state ) => getSignupProgress( state )?.[ stepName ] );
+	const status = step?.status;
+	const isEmailUnverified =
+		status === 'invalid' && getErrorCode( step?.errors ) === EMAIL_UNVERIFIED;
+
+	// Kick off the launch, but only when the step hasn't been submitted yet. The
+	// flow's processing screen unmounts this step while the request runs, so an
+	// unguarded submit would resubmit on every remount and loop endlessly. On
+	// success the flow controller advances the flow; a failure lands back here.
+	useEffect( () => {
+		if ( ! status ) {
+			dispatch( submitSignupStep( { stepName } ) );
+		}
+	}, [ dispatch, stepName, status ] );
+
+	// While pending/processing the flow shows its own launch screen, and success
+	// navigates away — so this step only renders when the launch is blocked on
+	// email verification.
+	if ( ! isEmailUnverified ) {
+		return null;
+	}
+
+	return (
+		<StepWrapper
+			flowName={ flowName }
+			stepName={ stepName }
+			positionInFlow={ positionInFlow }
+			hideFormattedHeader
+			hideSkip
+			hideBack
+			stepContent={
+				<div className="launch-site__verify-email">
+					<h2 className="launch-site__verify-email-title">
+						{ translate( 'Verify your email to launch' ) }
+					</h2>
+					<p className="launch-site__verify-email-description">
+						{ translate(
+							'Please verify your email address before launching your site, then try again.'
+						) }
+					</p>
+					<div className="launch-site__verify-email-actions">
+						<Button
+							variant="primary"
+							onClick={ () => dispatch( submitSignupStep( { stepName } ) ) }
+						>
+							{ translate( 'Try again' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={ () => dispatch( verifyEmail( { showGlobalNotices: true } ) ) }
+						>
+							{ translate( 'Resend verification email' ) }
+						</Button>
+					</div>
+				</div>
+			}
+		/>
+	);
+}
+
+export default LaunchSiteComponent;

--- a/client/signup/steps/launch-site/style.scss
+++ b/client/signup/steps/launch-site/style.scss
@@ -1,0 +1,29 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.launch-site__verify-email {
+	max-width: 480px;
+	margin-block: 0;
+	margin-inline: auto;
+	text-align: center;
+}
+
+.launch-site__verify-email-title {
+	font-size: 1.5rem;
+	margin-block-end: 8px;
+}
+
+.launch-site__verify-email-description {
+	color: var( --color-text-subtle );
+	margin-block-end: 24px;
+}
+
+.launch-site__verify-email-actions {
+	display: flex;
+	justify-content: center;
+	gap: 12px;
+
+	@include break-mobile {
+		flex-direction: column-reverse;
+	}
+}

--- a/client/signup/steps/launch-site/test/index.jsx
+++ b/client/signup/steps/launch-site/test/index.jsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import LaunchSiteComponent from '../';
+
+jest.mock( 'calypso/signup/step-wrapper', () => ( props ) => props.stepContent );
+
+jest.mock( 'calypso/state/signup/progress/selectors', () => ( {
+	getSignupProgress: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/signup/progress/actions', () => ( {
+	submitSignupStep: jest.fn( () => ( { type: 'TEST_SUBMIT' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/current-user/email-verification/actions', () => ( {
+	verifyEmail: jest.fn( () => ( { type: 'TEST_VERIFY' } ) ),
+} ) );
+
+const STEP_NAME = 'launch';
+const FLOW_NAME = 'launch-site';
+
+function setProgress( step ) {
+	getSignupProgress.mockReturnValue( step ? { [ STEP_NAME ]: step } : {} );
+}
+
+function renderStep() {
+	return renderWithProvider(
+		<LaunchSiteComponent flowName={ FLOW_NAME } stepName={ STEP_NAME } positionInFlow={ 2 } />
+	);
+}
+
+describe( 'LaunchSiteComponent', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'submits the step on mount to kick off the launch', () => {
+		setProgress( undefined );
+		renderStep();
+		expect( submitSignupStep ).toHaveBeenCalledWith( { stepName: STEP_NAME } );
+	} );
+
+	it( 'does not resubmit when the step is already in progress (avoids the remount loop)', () => {
+		setProgress( { stepName: STEP_NAME, status: 'pending' } );
+		renderStep();
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders nothing while the launch is pending', () => {
+		setProgress( { stepName: STEP_NAME, status: 'pending' } );
+		const { container } = renderStep();
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing on success (the flow controller handles navigation)', () => {
+		setProgress( { stepName: STEP_NAME, status: 'completed' } );
+		const { container } = renderStep();
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing on a non-email launch failure', () => {
+		setProgress( { stepName: STEP_NAME, status: 'invalid', errors: { error: 'internal_error' } } );
+		const { container } = renderStep();
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	describe( 'when the launch is blocked by an unverified email', () => {
+		beforeEach( () => {
+			setProgress( {
+				stepName: STEP_NAME,
+				status: 'invalid',
+				errors: { error: 'email_unverified' },
+			} );
+		} );
+
+		it( 'shows the verify-email panel', () => {
+			renderStep();
+			expect(
+				screen.getByRole( 'heading', { name: 'Verify your email to launch' } )
+			).toBeVisible();
+		} );
+
+		it( 'does not resubmit the step (the launch already resolved as invalid)', () => {
+			renderStep();
+			expect( submitSignupStep ).not.toHaveBeenCalled();
+		} );
+
+		it( 'resends the verification email when the user clicks Resend', async () => {
+			renderStep();
+			await userEvent.click( screen.getByRole( 'button', { name: 'Resend verification email' } ) );
+			expect( verifyEmail ).toHaveBeenCalledWith( { showGlobalNotices: true } );
+		} );
+
+		it( 'retries the launch when the user clicks Try again', async () => {
+			renderStep();
+			await userEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+			expect( submitSignupStep ).toHaveBeenCalledWith( { stepName: STEP_NAME } );
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of READ-569

## Proposed Changes

* Handle the `email_unverified` launch error in the `/start/launch-site` flow's `launch` step (`client/signup/steps/launch-site`). When the launch endpoint returns `403 email_unverified`, the step now renders an inline **"Verify your email to launch"** panel with **Resend verification email** and **Try again** actions, instead of leaving the user on a blank, silently-failed step.
* Reworked the step to submit the launch **once** (guarded on step status) and only render for the email-verification case — the flow's own processing screen covers the pending state and success still advances via the flow controller. The guard prevents a resubmit loop caused by the processing screen unmounting/remounting the step.
* Reuses the existing `verifyEmail()` action for the resend; uses `@wordpress/components` primitives and design-system color tokens.
* Added unit tests covering: single submit on mount, no resubmit while in progress, renders nothing while pending / on success / on non-email failure, the panel on `email_unverified`, and the resend + retry actions.

## Why are these changes being made?

The wpcom launch endpoints now return `403 email_unverified` for Write On sites (`site_creation_flow = 'write-on'`) whose owner has an unverified email — companion back-end change 225485-ghe-Automattic/wpcom. Previously the `launch` step navigated away on mount and swallowed any error, so an unverified author who reached launch (e.g. from the post-publish checklist's Launch CTA) got no feedback and a site that silently stayed private. This gives them an honest, actionable next step. The `email_unverified` code is only ever returned for Write On sites, so the handling is inherently scoped to that flow and every other launch path is unchanged.

## Testing Instructions

1. With a logged-in account whose **email is unverified**, on a Write On site (`site_creation_flow = 'write-on'`, Coming Soon), go through `/start/launch-site` → `domains-launch` → `plans-launch` (Free) → the `launch` step.
2. The launch API returns `403 email_unverified`; confirm the **"Verify your email to launch"** panel appears (heading + description + **Resend verification email** + **Try again**).
3. Click **Resend verification email** → confirm the "confirmation email sent" global notice.
4. Click **Try again** while still unverified → briefly shows the launch screen, then returns to the panel (no loop).
5. With a **verified** email, the same path launches normally (no panel).
6. On a **non-Write On** site, launch is not gated (panel never appears).

Unit tests: `yarn test-client client/signup/steps/launch-site/test/index.jsx`

> Known pre-existing behavior (not introduced here): refreshing the browser directly on the transient `launch` step renders a blank page — the signup app short-circuits to `null` for a non-first step with empty progress (`client/signup/main.jsx`), above this component. The normal user path does not hit this.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
