### PR TITLE
Sidebar: link Purchases to Dashboard behind feature flag

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -23,6 +23,7 @@ import globalSidebarMenu from './static-data/global-sidebar-menu';
 import jetpackMenu from './static-data/jetpack-fallback-menu';
 import { applyLayoutDelta } from './utils/apply-layout-delta';
 import { normalizeWpcomAdminSidebarHostLinks } from './utils/normalize-wpcom-admin-sidebar-host-links';
+import { redirectSidebarPurchasesToDashboard } from './utils/redirect-purchases-to-dashboard';
 
 const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
@@ -130,11 +131,14 @@ const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const transformedBaseMenu =
 		typeof transformBaseMenu === 'function' ? transformBaseMenu( baseMenu ) : baseMenu;
 	const normalizedBaseMenu = normalizeWpcomAdminSidebarHostLinks( transformedBaseMenu );
+	const menuWithPurchasesLink = isEnabled( 'sidebar/purchases-dashboard-link' )
+		? redirectSidebarPurchasesToDashboard( normalizedBaseMenu, selectedSiteId )
+		: normalizedBaseMenu;
 	// Apply the user's saved layout-delta (Phase 2 task 2.5). When no delta
 	// is stored, `applyLayoutDelta` returns a copy of `baseMenu` unmodified.
 	// The cost on the no-delta path is one shallow array clone per render;
 	// memoisation lives upstream where the menu is read.
-	return applyLayoutDelta( normalizedBaseMenu, layoutDelta );
+	return applyLayoutDelta( menuWithPurchasesLink, layoutDelta );
 };
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar/utils/normalize-wpcom-admin-sidebar-host-links.ts
+++ b/client/my-sites/sidebar/utils/normalize-wpcom-admin-sidebar-host-links.ts
@@ -11,7 +11,7 @@ const WPCOM_HOST_ROUTE_PREFIXES = [
 	'/purchases/subscriptions/',
 ];
 
-function getPathname( url: unknown ): string | null {
+export function getPathname( url: unknown ): string | null {
 	if ( typeof url !== 'string' || url.trim() === '' ) {
 		return null;
 	}

--- a/client/my-sites/sidebar/utils/redirect-purchases-to-dashboard.ts
+++ b/client/my-sites/sidebar/utils/redirect-purchases-to-dashboard.ts
@@ -1,0 +1,48 @@
+import config from '@automattic/calypso-config';
+import { getPathname } from './normalize-wpcom-admin-sidebar-host-links';
+import type { AdminMenuItem } from 'calypso/state/admin-menu/types';
+
+const PURCHASES_SUBSCRIPTIONS_PREFIX = '/purchases/subscriptions/';
+
+function getDashboardPurchasesUrl( siteId: number ): string {
+	const path = `/me/billing/purchases?site=${ siteId }`;
+
+	if ( config( 'env' ) === 'development' ) {
+		const port = config( 'port' ) ?? 3000;
+		return new URL( path, `http://my.localhost:${ port }` ).href;
+	}
+
+	return new URL( path, 'https://my.wordpress.com' ).href;
+}
+
+function rewriteItem( item: AdminMenuItem, dashboardUrl: string ): AdminMenuItem {
+	const rewritten: AdminMenuItem = { ...item };
+
+	if ( getPathname( item.url )?.startsWith( PURCHASES_SUBSCRIPTIONS_PREFIX ) ) {
+		rewritten.url = dashboardUrl;
+	}
+
+	if ( Array.isArray( item.children ) ) {
+		rewritten.children = item.children.map( ( child ) => rewriteItem( child, dashboardUrl ) );
+	}
+
+	return rewritten;
+}
+
+/**
+ * Point the site sidebar's "Purchases" link at the Dashboard purchases page
+ * (pre-filtered to the current site) instead of the classic
+ * `/purchases/subscriptions/:site` screen. Gated by the
+ * `sidebar/purchases-dashboard-link` feature flag by the caller.
+ */
+export function redirectSidebarPurchasesToDashboard(
+	menuItems: AdminMenuItem[],
+	siteId: number | null
+): AdminMenuItem[] {
+	if ( ! siteId ) {
+		return menuItems;
+	}
+
+	const dashboardUrl = getDashboardPurchasesUrl( siteId );
+	return menuItems.map( ( item ) => rewriteItem( item, dashboardUrl ) );
+}

--- a/config/development.json
+++ b/config/development.json
@@ -204,6 +204,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"sidebar/purchases-dashboard-link": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"sign-in-with-paypal": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,6 +125,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"sidebar/purchases-dashboard-link": false,
 		"sign-in-with-apple": true,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/config/production.json
+++ b/config/production.json
@@ -156,6 +156,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"sidebar/purchases-dashboard-link": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,6 +154,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"sidebar/purchases-dashboard-link": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"sidebar/purchases-dashboard-link": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/social": true,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-505/point-site-sidebar-purchases-link-to-the-multi-site-dashboard

## Proposed Changes

Behind a new feature flag, this repoints the per-site Calypso sidebar's **Purchases** link (under Upgrades) from the classic `/purchases/subscriptions/:site` screen to the multi-site Dashboard purchases page, deep-linked to that site via the Dashboard's `?site=<blogId>` filter param.

* Add `redirectSidebarPurchasesToDashboard` util that rewrites any sidebar menu item whose path starts with `/purchases/subscriptions/` to the Dashboard purchases URL for the current site.
* Wire it into `use-site-menu-items` after menu normalization, gated by the new `sidebar/purchases-dashboard-link` flag and passing the current `selectedSiteId`. This covers both the live Admin Menu API menu and the static fallback menu.
* Build the target URL environment-aware: `http://my.localhost:<port>` in development, `https://my.wordpress.com` otherwise.
* Export the existing `getPathname` helper from the host-links normalizer for reuse.
* Add the `sidebar/purchases-dashboard-link` flag: `true` in development and wpcalypso; `false` in horizon, stage, and production.

## Why are these changes being made?

As the multi-site Dashboard rolls out to all users, the classic per-site sidebar still sends people to the old per-site Purchases UI. For users who have moved to the Dashboard, that's an inconsistent, outdated destination. We need a way to instead route the Purchases link to the Dashboard's purchases page, pre-filtered to the site they were viewing.

The Dashboard purchases page already supports a `?site=<blogId>` query param that pre-populates and marks primary the Site filter in its DataViews table, so a single site's purchases can be linked directly. The rewrite is applied at the `use-site-menu-items` choke point so it works whether the menu came from the Admin Menu API or the static fallback, and it matches on the `/purchases/subscriptions/` path so only the Purchases item is affected (not the parent Upgrades link). Everything is gated behind a feature flag that is off in production, so it can be validated in development/wpcalypso and rolled out in step with the Dashboard launch.

## Testing Instructions

TC:
```
yarn test-client client/my-sites/sidebar
```

Manual testing:
* Run Calypso locally (`yarn start`) with the local Dashboard dev server available, or use wpcalypso where the flag is enabled.
* Open a site-specific view and expand **Upgrades** in the sidebar.
* Click **Purchases** and confirm it now navigates to the Dashboard purchases page (`.../me/billing/purchases?site=<blogId>`) with the Site filter pre-applied to that site.
* Disable the flag (e.g. in `config/development.json`) and confirm the link falls back to the classic `/purchases/subscriptions/:site` screen.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
