### PR TITLE
Pin composite/declaration in client/tsconfig-reference.json

### DIFF
--- a/client/tsconfig-reference.json
+++ b/client/tsconfig-reference.json
@@ -1,6 +1,9 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"noEmit": false
+		"noEmit": false,
+		"composite": true,
+		"declaration": true,
+		"declarationMap": true
 	}
 }


### PR DESCRIPTION
Task-related: [DOTCOM-17552](https://linear.app/a8c/issue/DOTCOM-17552)
Addressing this feedback: https://github.com/Automattic/wp-calypso/pull/112095#issuecomment-4861873787


## Proposed Changes

* Explicitly declare `composite`, `declaration`, and `declarationMap` in `client/tsconfig-reference.json` instead of relying on them being inherited from `client/tsconfig.json`.

This is a **no-op on trunk today**: `client/tsconfig.json` extends the shared `@automattic/calypso-typescript-config` (via `mixed-package.json` → `ts-package.json`), which already sets all three to `true`, and the reference config inherits them. This PR just pins those values at the reference config itself.

## Why are these changes being made?

`client/tsconfig-reference.json` extends `client/tsconfig.json` and is consumed by `apps/odyssey-stats/tsconfig.json` as a composite project reference (`references: [ … { "path": "../../client/tsconfig-reference.json" } ]`). A referenced project must have `composite: true`, otherwise `tsc` aborts with `TS6306: Referenced project must have setting "composite": true`.

Today the reference config satisfies this only by inheritance. The upcoming React 19 upgrade (#112095) sets `composite: false` on the leaf `client/tsconfig.json` as a declaration-emit workaround, which the reference config would silently inherit — breaking odyssey-stats' type resolution with `TS6306`.

Decoupling the reference config from the leaf config's `composite` setting immunizes odyssey-stats against that regression while leaving the React 19 leaf-config workaround (and the real `typecheck-client` CI gate) untouched.

## Testing Instructions

* `tsc --noEmit --project apps/odyssey-stats/tsconfig.json` — no `TS6306`. (odyssey-stats has ~66 pre-existing, unrelated typecheck errors on trunk — untyped `.js` imports, SCSS side-effect imports, missing pre-built `.d.ts` — that are not gated by CI and are unchanged by this PR.)
* `yarn typecheck-client` still passes.
* The reference config is used for type resolution only; no `tsc --build` path emits from it (odyssey-stats builds via calypso-build/webpack), so no declaration-emit output changes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)