### PR TITLE
Wrap dashboard Classic Calypso links

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -11,6 +11,7 @@ import {
 	type MutationCacheNotifyEvent,
 } from '@tanstack/react-query';
 import { createContext, useContext, useMemo, useEffect, useRef, useCallback } from 'react';
+import { wpcomLink } from '../../utils/link';
 import { useAppContext } from '../context';
 import { OAUTH_CALLBACK_PATH } from './oauth-callback';
 import type { WPError } from '@automattic/api-core';
@@ -134,7 +135,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		}
 
 		const currentPath = window.location.href;
-		const path = config( 'wpcom_login_url' ) || '/log-in';
+		const path = config( 'wpcom_login_url' ) || wpcomLink( '/log-in' );
 		const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
 		window.location.href = loginUrl;
 	}, [ supports.startStoreRoute ] );

--- a/client/dashboard/components/logs-activity-formatted-block/api-core-parser.ts
+++ b/client/dashboard/components/logs-activity-formatted-block/api-core-parser.ts
@@ -15,7 +15,7 @@
  * // 	' updated',
  * // ]
  * // Rendered by FormattedBlock as:
- * // Site <a href="/sites/987">Example</a> updated
+ * // Site <a href="https://wordpress.com/sites/987">Example</a> updated
  */
 import type { ActivityBlockContent, ActivityBlockNode } from './types';
 import type { ActivityNotificationRange, ActivityLogEntry } from '@automattic/api-core';

--- a/client/dashboard/components/logs-activity-formatted-block/api-core-parser.ts
+++ b/client/dashboard/components/logs-activity-formatted-block/api-core-parser.ts
@@ -15,7 +15,7 @@
  * // 	' updated',
  * // ]
  * // Rendered by FormattedBlock as:
- * // Site <a href="https://wordpress.com/sites/987">Example</a> updated
+ * // Site <a href="/sites/987">Example</a> updated
  */
 import type { ActivityBlockContent, ActivityBlockNode } from './types';
 import type { ActivityNotificationRange, ActivityLogEntry } from '@automattic/api-core';

--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -11,7 +11,7 @@
  * 	],
  * 	meta: { activity: 'activity-log', intent: 'view' },
  * });
- * // Renders: Updated <a href="/reader/blogs/123/posts/456">Hello World</a>
+ * // Renders: Updated <a href="https://wordpress.com/reader/blogs/123/posts/456">Hello World</a>
  */
 import { ExternalLink } from '@wordpress/components';
 import { Fragment, type MouseEvent, type ReactNode } from 'react';
@@ -45,6 +45,8 @@ const Preformatted = ( { children }: { children: ReactNode } ) => <pre>{ childre
 const isWordPressDotComUrl = ( url?: string | null ) =>
 	!! url && url.startsWith( 'https://wordpress.com/' ); // we want the extra slash at the end because other subdomains could be used to trick this check (e.g. wordpress.com.malicious-site.com)
 
+const getWpcomHref = ( url: string ) => ( url.startsWith( '/' ) ? wpcomLink( url ) : url );
+
 const Link: BlockRenderer = ( { content, children, onClick, meta } ) => {
 	const { url, activity, section, intent } = content;
 
@@ -58,7 +60,7 @@ const Link: BlockRenderer = ( { content, children, onClick, meta } ) => {
 
 	return (
 		<ExternalLink
-			href={ url }
+			href={ getWpcomHref( url ) }
 			onClick={ onClick }
 			data-activity={ activity ?? meta.activity }
 			data-section={ section ?? meta.section }
@@ -91,7 +93,7 @@ const Post: BlockRenderer = ( { content, children, onClick } ) => {
 		: `/reader/blogs/${ siteId }/posts/${ postId }`;
 
 	return (
-		<a href={ href } onClick={ onClick }>
+		<a href={ wpcomLink( href ) } onClick={ onClick }>
 			{ children }
 		</a>
 	);
@@ -110,7 +112,7 @@ const Comment: BlockRenderer = ( { content, children, onClick } ) => {
 
 	return (
 		<a
-			href={ `/reader/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` }
+			href={ wpcomLink( `/reader/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` ) }
 			onClick={ onClick }
 		>
 			{ children }
@@ -189,7 +191,7 @@ const Theme: BlockRenderer = ( { content, children, onClick, meta } ) => {
 
 		return (
 			<a
-				href={ `/theme/${ themeSlug }/${ siteSlug }` }
+				href={ wpcomLink( `/theme/${ themeSlug }/${ siteSlug }` ) }
 				onClick={ onClick }
 				data-activity={ activity ?? meta.activity }
 				data-section={ section ?? meta.section ?? 'themes' }
@@ -226,7 +228,7 @@ const Backup: BlockRenderer = ( { content, children, onClick, meta } ) => {
 
 	return (
 		<a
-			href={ href }
+			href={ getWpcomHref( href ) }
 			onClick={ onClick }
 			data-activity={ activity ?? meta.activity }
 			data-section={ section ?? meta.section ?? 'backups' }

--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -11,7 +11,7 @@
  * 	],
  * 	meta: { activity: 'activity-log', intent: 'view' },
  * });
- * // Renders: Updated <a href="https://wordpress.com/reader/blogs/123/posts/456">Hello World</a>
+ * // Renders: Updated <a href="/reader/blogs/123/posts/456">Hello World</a>
  */
 import { ExternalLink } from '@wordpress/components';
 import { Fragment, type MouseEvent, type ReactNode } from 'react';

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -157,7 +157,7 @@ describe( 'Post blocks', () => {
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/posts/1/trash' );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/posts/1/trash' );
 		expect( link ).toHaveTextContent( 'Trashed post' );
 	} );
 
@@ -171,7 +171,7 @@ describe( 'Post blocks', () => {
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/reader/blogs/1/posts/10' );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/reader/blogs/1/posts/10' );
 	} );
 
 	test.each( [
@@ -209,7 +209,10 @@ describe( 'Comment blocks', () => {
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/reader/blogs/site/posts/post#comment-comment' );
+		expect( link ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/reader/blogs/site/posts/post#comment-comment'
+		);
 	} );
 
 	test.each( [
@@ -344,7 +347,7 @@ describe( 'Theme blocks', () => {
 		mockedIsA8CForAgencies.mockReturnValue( false );
 	} );
 
-	test( 'renders relative link for wordpress.com themes', () => {
+	test( 'renders wrapped Calypso link for wordpress.com themes', () => {
 		renderFormatted( {
 			type: 'theme',
 			themeUri: 'https://wordpress.com/themes/example',
@@ -354,7 +357,7 @@ describe( 'Theme blocks', () => {
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/theme/example/site-slug' );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/theme/example/site-slug' );
 	} );
 
 	test.each( [

--- a/client/dashboard/components/logs-activity/test/activity-event.test.tsx
+++ b/client/dashboard/components/logs-activity/test/activity-event.test.tsx
@@ -7,7 +7,9 @@ import isJetpackCloud from '../../../../lib/jetpack/is-jetpack-cloud';
 import { ActivityEvent } from '../activity-event';
 import type { Activity, ActivityDescription } from '../types';
 
-jest.mock( '@automattic/calypso-config', () => jest.fn( () => '' ) );
+jest.mock( '@automattic/calypso-config', () =>
+	jest.fn( ( key ) => ( key === 'wpcom_url' ? 'https://wordpress.com' : '' ) )
+);
 jest.mock( '../../../../lib/jetpack/is-jetpack-cloud', () => jest.fn( () => false ) );
 jest.mock( '../../../../lib/a8c-for-agencies/is-a8c-for-agencies', () => jest.fn( () => false ) );
 
@@ -191,7 +193,7 @@ describe( 'ActivityEvent', () => {
 		render( <ActivityEvent activity={ activity } /> );
 
 		const link = screen.getByRole( 'link', { name: 'Example' } );
-		expect( link.getAttribute( 'href' ) ).toBe( '/reader/blogs/123/posts/77' );
+		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/reader/blogs/123/posts/77' );
 	} );
 
 	it( 'renders comment links with anchors', () => {
@@ -259,7 +261,7 @@ describe( 'ActivityEvent', () => {
 		render( <ActivityEvent activity={ activity } /> );
 
 		const link = screen.getByRole( 'link', { name: 'Example' } );
-		expect( link.getAttribute( 'href' ) ).toBe( '/theme/example/example.com' );
+		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/theme/example/example.com' );
 	} );
 
 	it( 'renders external theme links with target and rel attributes', () => {
@@ -306,6 +308,6 @@ describe( 'ActivityEvent', () => {
 		render( <ActivityEvent activity={ activity } /> );
 
 		const link = screen.getByRole( 'link', { name: 'backup' } );
-		expect( link.getAttribute( 'href' ) ).toBe( '/backup/site-slug' );
+		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/backup/site-slug' );
 	} );
 } );

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -5,7 +5,6 @@ import {
 	domainQuery,
 	userMailboxesQuery,
 } from '@automattic/api-queries';
-import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -32,6 +31,7 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
+import { wpcomLink } from '../../utils/link';
 import AddNewDomain from '../components/add-new-domain';
 import { DnsRequirementsNotice } from './dns-requirements-notice';
 import { DEFAULT_MAX_DOMAIN_FORWARDS, useDomainMaxForwards } from './hooks/use-domain-max-forwards';
@@ -39,6 +39,8 @@ import { useForwardingAddresses } from './hooks/use-forwarding-addresses';
 import type { Field } from '@wordpress/dataviews';
 
 import '../style.scss';
+
+const SUPPORT_CONTACT_URL = wpcomLink( '/support/contact' );
 
 export interface FormData {
 	localPart: string;
@@ -228,7 +230,10 @@ function AddEmailForwarder() {
 									message,
 								}
 							),
-							{ actions: [ { label: __( 'Support' ), url: CALYPSO_CONTACT } ], type: 'snackbar' }
+							{
+								actions: [ { label: __( 'Support' ), url: SUPPORT_CONTACT_URL } ],
+								type: 'snackbar',
+							}
 						);
 					} else {
 						createErrorNotice(
@@ -241,7 +246,10 @@ function AddEmailForwarder() {
 									emailAddress: variables.mailbox,
 								}
 							),
-							{ actions: [ { label: __( 'Support' ), url: CALYPSO_CONTACT } ], type: 'snackbar' }
+							{
+								actions: [ { label: __( 'Support' ), url: SUPPORT_CONTACT_URL } ],
+								type: 'snackbar',
+							}
 						);
 					}
 				},

--- a/client/dashboard/emails/components/email-non-domain-owner-notice.tsx
+++ b/client/dashboard/emails/components/email-non-domain-owner-notice.tsx
@@ -1,10 +1,11 @@
 import { Domain } from '@automattic/api-core';
-import { Notice } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { wpcomLink } from '../../utils/link';
 
-const CALYPSO_CONTACT = '/help/contact';
+const SUPPORT_CONTACT_URL = wpcomLink( '/support/contact' );
 
 type EmailNonDomainOwnerMessageProps = {
 	domain?: Domain;
@@ -21,13 +22,13 @@ export const EmailNonDomainOwnerNotice = ( props: EmailNonDomainOwnerMessageProp
 		s: domain?.domain || '',
 	} );
 
-	const loginUrl = addQueryArgs( '/log-in/', {
+	const loginUrl = addQueryArgs( wpcomLink( '/log-in/' ), {
 		redirect_to: window.location.pathname,
 	} );
 
 	const selectedDomainName = domain?.domain ?? '';
 	const elements = {
-		contactSupportLink: <a href={ CALYPSO_CONTACT } rel="noopener noreferrer" target="_blank" />,
+		contactSupportLink: <ExternalLink href={ SUPPORT_CONTACT_URL } children={ null } />,
 		loginLink: <a href={ loginUrl } rel="external" />,
 		reachOutLink: isPrivacyAvailable ? (
 			<a href={ contactOwnerUrl } rel="noopener noreferrer" target="_blank" />

--- a/client/dashboard/emails/mailboxes-ready/index.tsx
+++ b/client/dashboard/emails/mailboxes-ready/index.tsx
@@ -1,11 +1,11 @@
 import { EmailBox } from '@automattic/api-core';
-import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalItem as Item,
 	__experimentalItemGroup as ItemGroup,
 	Button,
+	ExternalLink,
 	FlexBlock,
 	Notice,
 } from '@wordpress/components';
@@ -22,8 +22,11 @@ import {
 	buildGoogleMailboxLink,
 	buildTitanMailboxLink,
 } from '../../utils/email-utils';
+import { wpcomLink } from '../../utils/link';
 
 import './styles.scss';
+
+const SUPPORT_CONTACT_URL = wpcomLink( '/support/contact' );
 
 const MailboxesReadyNotice = () => {
 	const { mailboxAccount, status } = mailboxesReadyRoute.useLoaderData();
@@ -53,7 +56,7 @@ const MailboxesReadyNotice = () => {
 						}
 					),
 					{
-						link: <a href={ CALYPSO_CONTACT } rel="noopener noreferrer" target="_blank" />,
+						link: <ExternalLink href={ SUPPORT_CONTACT_URL } children={ null } />,
 						strong: <strong />,
 					}
 				) }

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/api-queries';
 import { useLocale } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
-import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -31,8 +30,11 @@ import OverviewCard from '../../components/overview-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
+import { wpcomLink } from '../../utils/link';
 
 import './style.scss';
+
+const SUPPORT_CONTACT_URL = wpcomLink( '/support/contact' );
 
 function AutoRenewButton( {
 	disableAutoRenew,
@@ -56,7 +58,7 @@ function AutoRenewButton( {
 			createErrorNotice( __( 'Failed to remove your product.' ), {
 				actions: [
 					{
-						url: CALYPSO_CONTACT,
+						url: SUPPORT_CONTACT_URL,
 						label: __( 'Please contact support' ),
 					},
 				],
@@ -66,7 +68,7 @@ function AutoRenewButton( {
 			createErrorNotice( __( 'Failed to update your subscription.' ), {
 				actions: [
 					{
-						url: CALYPSO_CONTACT,
+						url: SUPPORT_CONTACT_URL,
 						label: __( 'Please contact support' ),
 					},
 				],
@@ -82,7 +84,7 @@ function AutoRenewButton( {
 				const locale = useLocale();
 				const helpText = ( () => {
 					if ( isAutoRenewing ) {
-						// translators: date is a formatted date string
+						/* translators: %(date)s is a formatted date string. */
 						return sprintf( __( 'You will be billed on %(date)s' ), {
 							date: formatDate( new Date( Date.parse( data?.end_date ?? '' ) ), locale, {
 								dateStyle: 'long',
@@ -129,9 +131,11 @@ function AutoRenewButton( {
 					data={ subscription }
 					form={ form }
 					onChange={ () => {
-						isAutoRenewing
-							? disableAutoRenew( null, { onError: onError } )
-							: enableAutoRenew( null, { onError: onError } );
+						if ( isAutoRenewing ) {
+							disableAutoRenew( null, { onError: onError } );
+							return;
+						}
+						enableAutoRenew( null, { onError: onError } );
 					} }
 				/>
 			</CardBody>
@@ -175,7 +179,7 @@ function StopSubscriptionButton( {
 									createErrorNotice( __( 'There was a problem while removing your product.' ), {
 										actions: [
 											{
-												url: CALYPSO_CONTACT,
+												url: SUPPORT_CONTACT_URL,
 												label: __( 'Please contact support' ),
 											},
 										],
@@ -187,7 +191,7 @@ function StopSubscriptionButton( {
 										{
 											actions: [
 												{
-													url: CALYPSO_CONTACT,
+													url: SUPPORT_CONTACT_URL,
 													label: __( 'Please contact support' ),
 												},
 											],

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/atomic-revert-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/atomic-revert-step.tsx
@@ -9,6 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
 import { SectionHeader } from '../../../../../components/section-header';
 import { Text } from '../../../../../components/text';
+import { wpcomLink } from '../../../../../utils/link';
 import { BillingPurchaseInfoPopover } from '../../../dataviews';
 import type { AtomicTransfer, Purchase } from '@automattic/api-core';
 
@@ -177,7 +178,7 @@ export function AtomicRevertStep( props: Props ) {
 							),
 							{
 								backupLink: (
-									<Button variant="link" href={ `/backup/${ siteSlug }` }>
+									<Button variant="link" href={ wpcomLink( `/backup/${ siteSlug }` ) }>
 										{ __( 'download a backup' ) }
 									</Button>
 								),

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -168,7 +168,7 @@ function BackupPaymentMethodNotice() {
 	const noticeText = createInterpolateElement(
 		__( 'If the renewal fails, a <link>backup payment method</link> may be used.' ),
 		{
-			link: <a href="/me/purchases/payment-methods" />,
+			link: <Link to="/me/billing/payment-methods" />,
 		}
 	);
 	return <BillingPurchaseInfoPopover>{ noticeText }</BillingPurchaseInfoPopover>;

--- a/client/dashboard/me/billing-tax-details/user-tax-form.tsx
+++ b/client/dashboard/me/billing-tax-details/user-tax-form.tsx
@@ -6,10 +6,10 @@ import {
 	userTaxDetailsMutation,
 } from '@automattic/api-queries';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,
+	ExternalLink,
 	__experimentalHStack as HStack,
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
@@ -26,8 +26,11 @@ import { createContext, useContext, useState, useCallback, useMemo } from 'react
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import InlineSupportLink from '../../components/inline-support-link';
+import { wpcomLink } from '../../utils/link';
 import { getTaxName, getDataFormCountryCodes, stripCountryCodeFromVatId } from '../../utils/tax';
 import type { UserTaxDetails, UserTaxFormData } from '@automattic/api-core';
+
+const SUPPORT_CONTACT_URL = wpcomLink( '/support/contact' );
 
 export type UserTaxFormControlProps = DataFormControlProps< UserTaxFormData >;
 
@@ -97,10 +100,9 @@ function VatIdControl( { data, field, onChange }: UserTaxFormControlProps ) {
 			),
 			{
 				contactSupportLink: (
-					<a
-						target="_blank"
-						href={ CALYPSO_CONTACT }
-						rel="noreferrer"
+					<ExternalLink
+						href={ SUPPORT_CONTACT_URL }
+						children={ null }
 						onClick={ () => {
 							recordTracksEvent( 'calypso_dashboard_vat_details_support_click' );
 						} }
@@ -312,7 +314,7 @@ export default function UserTaxForm() {
 						{
 							contactSupportLink: (
 								<a
-									href="/help"
+									href={ wpcomLink( '/help' ) }
 									title={ contactSupportLinkTitle }
 									onClick={ handleOpenCenterChat }
 								/>

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -25,6 +25,7 @@ import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { wpcomLink } from '../../utils/link';
 import {
 	getProductionSiteId,
 	hasStagingSite,
@@ -212,7 +213,9 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 							'Before deleting your site, consider <link>exporting your content as a backup</link>.'
 						),
 						{
-							link: <ExternalLink href={ `/export/${ site.slug }` } children={ null } />,
+							link: (
+								<ExternalLink href={ wpcomLink( `/export/${ site.slug }` ) } children={ null } />
+							),
 						}
 					) }
 				</Text>

--- a/client/dashboard/sites/site-reset-modal/content-info.tsx
+++ b/client/dashboard/sites/site-reset-modal/content-info.tsx
@@ -1,6 +1,7 @@
 import { SiteResetContentSummary } from '@automattic/api-core';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { wpcomLink } from '../../utils/link';
 
 interface ContentItem {
 	text: string;
@@ -17,9 +18,9 @@ export default function ContentInfo( {
 	siteDomain: string;
 } ) {
 	const types: ContentType[] = [
-		[ 'post_count', 'post', `/posts/${ siteDomain }` ],
-		[ 'page_count', 'page', `/pages/${ siteDomain }` ],
-		[ 'media_count', 'media item', `/media/${ siteDomain }` ],
+		[ 'post_count', 'post', wpcomLink( `/posts/${ siteDomain }` ) ],
+		[ 'page_count', 'page', wpcomLink( `/pages/${ siteDomain }` ) ],
+		[ 'media_count', 'media item', wpcomLink( `/media/${ siteDomain }` ) ],
 		[ 'plugin_count', 'plugin', `https://${ siteDomain }/wp-admin/plugins.php` ],
 	];
 

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -21,6 +21,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useState, useCallback } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
+import { wpcomLink } from '../../utils/link';
 import ContentInfo from './content-info';
 import type { Site, SiteResetContentSummary, SiteResetStatus } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -99,7 +100,7 @@ function SiteResetContent( {
 						),
 						{
 							// @ts-expect-error children prop is injected by createInterpolateElement
-							link: <ExternalLink href={ `/export/${ siteDomain }` } />,
+							link: <ExternalLink href={ wpcomLink( `/export/${ siteDomain }` ) } />,
 						}
 					) }
 				</Text>

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -4,6 +4,7 @@ import {
 	pullFromStagingMutation,
 } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import {
 	Button,
 	ExternalLink,
@@ -517,10 +518,12 @@ function StagingSiteSyncModalInner( {
 														date: <span>{ displayBackupDate }</span>,
 													}
 												) }{ ' ' }
-												<ExternalLink
-													href={ wpcomLink( `/backup/${ querySiteSlug as string }` ) }
-													children={ __( 'Create new backup' ) }
-												/>
+												<Link
+													to="/sites/$siteSlug/backups"
+													params={ { siteSlug: querySiteSlug as string } }
+												>
+													{ __( 'Create new backup' ) }
+												</Link>
 											</Text>
 										</HStack>
 									) }

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -36,6 +36,7 @@ import { CardDivider } from '../../components/card';
 import Environment, { EnvironmentType } from '../../components/environment';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
+import { wpcomLink } from '../../utils/link';
 import type { FileBrowserConfig } from '../../../my-sites/backup/backup-contents-page/file-browser';
 import type { Field } from '@wordpress/dataviews';
 
@@ -403,7 +404,12 @@ function StagingSiteSyncModalInner( {
 			<VStack spacing={ 5 }>
 				<Text>
 					{ createInterpolateElement( syncConfig[ environment ].description, {
-						a: <ExternalLink href={ `/activity-log/${ targetSiteSlug }` } children={ null } />,
+						a: (
+							<ExternalLink
+								href={ wpcomLink( `/activity-log/${ targetSiteSlug }` ) }
+								children={ null }
+							/>
+						),
 					} ) }
 				</Text>
 				<HStack
@@ -512,7 +518,7 @@ function StagingSiteSyncModalInner( {
 													}
 												) }{ ' ' }
 												<ExternalLink
-													href={ `/backup/${ querySiteSlug as string }` }
+													href={ wpcomLink( `/backup/${ querySiteSlug as string }` ) }
 													children={ __( 'Create new backup' ) }
 												/>
 											</Text>

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -122,7 +122,7 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 				</Card>
 				<HStack spacing={ 3 } justify="flex-start">
 					<Text variant="muted">{ __( 'Not ready to upgrade?' ) }</Text>
-					<ExternalLink href={ `/export/${ site.slug }` }>
+					<ExternalLink href={ wpcomLink( `/export/${ site.slug }` ) }>
 						{ __( 'Export your content' ) }
 					</ExternalLink>
 					<Button variant="link" isDestructive onClick={ () => setIsSiteDeleteModalOpen( true ) }>


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Wrap dashboard links to Classic Calypso routes with `wpcomLink()`.
* Cover direct links, backport-only branches, support/login URLs, and activity-log formatted block URLs.
* Update activity-log tests to expect wrapped Calypso URLs.

## Why are these changes being made?

* Dashboard relative URLs that leave the dashboard need to resolve against the configured WordPress.com/Calypso host for the current environment.
* This keeps Classic Calypso destinations consistent with `client/dashboard/docs/links.md`.

## Testing Instructions

* `yarn test-client client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx client/dashboard/components/logs-activity/test/activity-event.test.tsx`
* `yarn test-client client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx`
* `yarn test-client client/dashboard/sites/jetpack-site-disconnect/test/index.test.tsx client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx`
* `yarn typecheck-client` currently fails on missing module declarations for `@automattic/omnibar` and `@automattic/date-range-picker` in existing dashboard files unrelated to this change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
