### PR TITLE
Activity Logs: replace broken search with Activity Type column + wider default range

### DIFF
--- a/client/dashboard/sites/logs-activity/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/fields.tsx
@@ -141,6 +141,7 @@ export function useActivityFields( {
 				id: 'activity_type',
 				type: 'text',
 				label: __( 'Activity type' ),
+				enableSorting: false,
 				getValue: ( { item } ) => getActivityLogTypeSlugFromName( item.activityName ),
 				render: ( { item } ) => (
 					<span>
@@ -148,7 +149,6 @@ export function useActivityFields( {
 					</span>
 				),
 				elements: activityLogTypeElements,
-				isVisible: () => false,
 				filterBy: { operators: [ 'isAny' as Operator ] },
 			},
 		];

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -200,11 +200,11 @@ function SiteActivityLogsDataViews( {
 				config={
 					hasActivityLogsAccess ? undefined : { perPageSizes: [ ACTIVITY_LOGS_DEFAULT_PAGE_SIZE ] }
 				} // Disable changing perPage if no access
-				search
+				search={ false }
 				defaultLayouts={ { table: {} } }
 				onChangeView={ onChangeView }
 				onReset={ resetView }
-				empty={ <p>{ view.search ? __( 'No activity found' ) : __( 'No activities' ) }</p> }
+				empty={ <p>{ __( 'No activities' ) }</p> }
 				children={ hasActivityLogsAccess ? undefined : <DataViews.Layout /> } // showing only the layout when on the free plan.
 			/>
 

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -3,14 +3,16 @@ import { siteActivityLogQuery, siteActivityLogGroupCountsQuery } from '@automatt
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { View, Field, Filter } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import fastDeepEqual from 'fast-deep-equal/es6';
 import { useMemo, useEffect } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { usePersistentView } from '../../../app/hooks/use-persistent-view';
+import { useLocale } from '../../../app/locale';
 import { PerformanceTrackerStop } from '../../../app/performance-tracking';
 import { siteLogsActivityRoute } from '../../../app/router/sites';
-import { DataViews } from '../../../components/dataviews';
+import { DataViews, DataViewsEmptyStateLayout } from '../../../components/dataviews';
+import { formatDate } from '../../../utils/datetime';
 import { getActivityLogHiddenGroups } from '../../../utils/site-features';
 import { buildTimeRangeInSeconds } from '../../logs/utils';
 import { ActivityLogsCallout } from '../activity-logs-callout';
@@ -38,6 +40,7 @@ function SiteActivityLogsDataViews( {
 	hasActivityLogsAccess,
 }: SiteLogsDataViewsPropsActivity ) {
 	const { recordTracksEvent } = useAnalytics();
+	const locale = useLocale();
 
 	const { startSec, endSec } = useMemo(
 		() => buildTimeRangeInSeconds( dateRange.start, dateRange.end, timezoneString, gmtOffset ),
@@ -186,6 +189,20 @@ function SiteActivityLogsDataViews( {
 	}, [ dateRangeVersion ] );
 
 	const logData = activityLogData?.activityLogs || [];
+
+	const emptyState = (
+		<DataViewsEmptyStateLayout
+			isBorderless
+			title={ __( 'No results' ) }
+			description={ sprintf(
+				// translators: %1$s and %2$s are dates, e.g. "Jan 1, 2026".
+				__( 'No activity was logged between %1$s and %2$s.' ),
+				formatDate( dateRange.start, locale ),
+				formatDate( dateRange.end, locale )
+			) }
+		/>
+	);
+
 	return (
 		<>
 			{ ! isLoadingActivityLogQuery && <PerformanceTrackerStop /> }
@@ -204,7 +221,7 @@ function SiteActivityLogsDataViews( {
 				defaultLayouts={ { table: {} } }
 				onChangeView={ onChangeView }
 				onReset={ resetView }
-				empty={ <p>{ __( 'No activities' ) }</p> }
+				empty={ emptyState }
 				children={ hasActivityLogsAccess ? undefined : <DataViews.Layout /> } // showing only the layout when on the free plan.
 			/>
 

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -138,7 +138,11 @@ const mockActivityLogsData = {
 	totalPages: 1,
 };
 
-function renderActivityLogsDataViews() {
+function renderActivityLogsDataViews(
+	{ activityLogs }: { activityLogs: unknown[] } = {
+		activityLogs: mockActivityLogsData.activityLogs,
+	}
+) {
 	nock( API_BASE )
 		.get( '/rest/v1.1/me/preferences' )
 		.query( true )
@@ -148,10 +152,10 @@ function renderActivityLogsDataViews() {
 		.query( true )
 		.reply( 200, {
 			current: {
-				orderedItems: mockActivityLogsData.activityLogs,
+				orderedItems: activityLogs,
 			},
-			totalItems: mockActivityLogsData.totalItems,
-			totalPages: mockActivityLogsData.totalPages,
+			totalItems: activityLogs.length,
+			totalPages: activityLogs.length ? 1 : 0,
 		} );
 
 	return render(
@@ -189,6 +193,13 @@ test( 'clicking backup action navigates to backup detail page', async () => {
 			rewindId: 'rewind-123',
 		},
 	} );
+} );
+
+test( 'shows the empty state describing the date range when there are no activities', async () => {
+	renderActivityLogsDataViews( { activityLogs: [] } );
+
+	expect( await screen.findByText( 'No results' ) ).toBeInTheDocument();
+	expect( screen.getByText( /No activity was logged between/ ) ).toBeInTheDocument();
 } );
 
 test( 'shows the Activity type column by default and hides the search box', async () => {

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -191,6 +191,20 @@ test( 'clicking backup action navigates to backup detail page', async () => {
 	} );
 } );
 
+test( 'shows the Activity type column by default and hides the search box', async () => {
+	renderActivityLogsDataViews();
+
+	await waitFor(
+		() => {
+			expect( screen.getByText( 'Backup completed' ) ).toBeInTheDocument();
+		},
+		{ timeout: 5000 }
+	);
+
+	expect( screen.getByRole( 'columnheader', { name: 'Activity type' } ) ).toBeInTheDocument();
+	expect( screen.queryByRole( 'searchbox' ) ).not.toBeInTheDocument();
+} );
+
 test( 'data is properly displayed', async () => {
 	renderActivityLogsDataViews();
 

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -202,20 +202,6 @@ test( 'shows the empty state describing the date range when there are no activit
 	expect( screen.getByText( /No activity was logged between/ ) ).toBeInTheDocument();
 } );
 
-test( 'shows the Activity type column by default and hides the search box', async () => {
-	renderActivityLogsDataViews();
-
-	await waitFor(
-		() => {
-			expect( screen.getByText( 'Backup completed' ) ).toBeInTheDocument();
-		},
-		{ timeout: 5000 }
-	);
-
-	expect( screen.getByRole( 'columnheader', { name: 'Activity type' } ) ).toBeInTheDocument();
-	expect( screen.queryByRole( 'searchbox' ) ).not.toBeInTheDocument();
-} );
-
 test( 'data is properly displayed', async () => {
 	renderActivityLogsDataViews();
 

--- a/client/dashboard/sites/logs-activity/dataviews/views.ts
+++ b/client/dashboard/sites/logs-activity/dataviews/views.ts
@@ -7,7 +7,7 @@ export const DEFAULT_VIEW: View = {
 		field: 'published',
 		direction: 'desc',
 	},
-	fields: [ 'published', 'event', 'actor' ],
+	fields: [ 'published', 'event', 'actor', 'activity_type' ],
 	layout: {
 		density: 'balanced',
 		styles: {

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -126,6 +126,7 @@ function SiteLogsContent( {
 		timezoneString,
 		gmtOffset,
 		autoRefresh,
+		defaultDays: logType === LogType.ACTIVITY ? 90 : 7,
 	} );
 	// this is used to track changes across the dateRange to ensure the components can react to changes when they are triggered by a change in the DateRangePicker
 	const [ dateRangeVersion, setDateRangeVersion ] = useState( 0 );

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -126,7 +126,7 @@ function SiteLogsContent( {
 		timezoneString,
 		gmtOffset,
 		autoRefresh,
-		defaultDays: logType === LogType.ACTIVITY ? 90 : 7,
+		defaultDays: logType === LogType.ACTIVITY ? 30 : 7,
 	} );
 	// this is used to track changes across the dateRange to ensure the components can react to changes when they are triggered by a change in the DateRangePicker
 	const [ dateRangeVersion, setDateRangeVersion ] = useState( 0 );


### PR DESCRIPTION
Part of DOTMSD-1382

## Proposed Changes

Activity Logs search is misleading as the server only searches posts by title, ID, or author (tracked in BACKUP-126). 

Until the API can search event content, this leans on filtering instead of search:

* Hide the search box on the activity log.
* Show the **Activity Type** column by default so its filter is discoverable.
* Default the activity log date range to 1 month (web/PHP server logs stay at 7 days).


**Screenshot**

After looking at the data, it's possible that many sites don't have activities in the last 30 days. So in order to make sure the logs don't appear broken, I've updated the no results view to include the date range filter as an indication to users that they can broaden their search.

| Before | After |
|--------|--------|
| <img width="2604" height="2002" alt="my wordpress com_sites_abstracting blog_logs_activity_from=1782918000 to=1783090799" src="https://github.com/user-attachments/assets/5e8cb2bc-6426-4089-807d-93c92c81255f" /> | <img width="2604" height="2002" alt="my localhost_3000_sites_abstracting blog_logs_activity_from=1782918000 to=1783090799" src="https://github.com/user-attachments/assets/a7aaf858-39a1-4766-a97c-ca0bc017f4ea" /> | 


## Why are these changes being made?

* A search box that returns near-empty results for common terms reads as "no matching activity exists," which is wrong and erodes trust in the log.
* The Activity Type filter already works server-side and covers the real use case (find plugin/backup/theme/etc. events). Surfacing the column makes that filter obvious.
* A wider default range means more relevant history is visible without immediately reaching for the date picker.

## Testing Instructions

* Open a site's Activity Logs (`/sites/:siteSlug/logs`).
* Confirm there is no search box, the **Activity type** column shows by default, and the date range defaults to the last 3 months.
* Use the Activity type filter to narrow to e.g. Plugins / Backups and confirm results update.
* Confirm the Web server / PHP logs tabs still default to 7 days and are otherwise unchanged.
* `yarn test-client client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx`

## Notes

* The underlying content-search limitation is BACKUP-126; this PR is an interim UX fix, not a search fix.
* Users with a previously persisted activity-log view (saved columns or a lingering search term) may need a reset to pick up the new defaults.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
