### PR TITLE
Replace lodash mergeWith with an @automattic/js-utils helper

### DIFF
--- a/client/state/action-watchers/utils.js
+++ b/client/state/action-watchers/utils.js
@@ -1,11 +1,10 @@
-import { mergeWith } from 'lodash';
+import { mergeWith } from '@automattic/js-utils';
 
 /**
- * Merge handler for lodash.mergeWith
+ * Merge customizer for `mergeWith`.
  *
  * Note that a return value of `undefined`
- * indicates to lodash that it should use
- * its normal merge algorithm.
+ * defers to the default merge algorithm.
  *
  * In this case, we want to merge keys if
  * they don't exists but when they do, we

--- a/client/state/posts/utils/apply-post-edits.js
+++ b/client/state/posts/utils/apply-post-edits.js
@@ -1,4 +1,4 @@
-import { mergeWith } from 'lodash';
+import { mergeWith } from '@automattic/js-utils';
 
 /*
  * Applies a metadata edit operation (either update or delete) to an existing array of

--- a/client/state/posts/utils/merge-post-edits.js
+++ b/client/state/posts/utils/merge-post-edits.js
@@ -1,4 +1,4 @@
-import { mergeWith } from 'lodash';
+import { mergeWith } from '@automattic/js-utils';
 
 function mergeMetadataEdits( edits, nextEdits ) {
 	// remove existing edits that get updated in `nextEdits`

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -63,6 +63,12 @@ const MERGE_MESSAGE =
 	'Please use `merge` from `@automattic/js-utils` instead of lodash `merge`. It deep-merges ' +
 	'plain JSON-like data (own enumerable properties, dense arrays) and does not merge inherited ' +
 	'properties, materialize sparse-array holes, or handle circular references.';
+// The js-utils mergeWith shares merge's narrower-than-lodash scope (own
+// enumerable properties, dense arrays); its customizer contract matches lodash.
+const MERGEWITH_MESSAGE =
+	'Please use `mergeWith` from `@automattic/js-utils` instead of lodash `mergeWith`. It takes the ' +
+	'same trailing customizer but deep-merges only plain JSON-like data (own enumerable properties, ' +
+	'dense arrays) and does not merge inherited properties or materialize sparse-array holes.';
 const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash `compact`.';
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
 const DEFER_MESSAGE = 'Please use native `setTimeout( fn, 0 )` instead of lodash `defer`.';
@@ -180,6 +186,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'clone' ], message: CLONE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'cloneDeep' ], message: CLONE_DEEP_MESSAGE },
 	{ name: 'lodash', importNames: [ 'merge' ], message: MERGE_MESSAGE },
+	{ name: 'lodash', importNames: [ 'mergeWith' ], message: MERGEWITH_MESSAGE },
 	{ name: 'lodash', importNames: [ 'property' ], message: PROPERTY_MESSAGE },
 	{ name: 'lodash', importNames: [ 'maxBy', 'minBy' ], message: EXTREMUM_MESSAGE },
 	{ name: 'lodash', importNames: [ 'partition' ], message: PARTITION_MESSAGE },
@@ -224,6 +231,7 @@ const patterns = [
 	{ group: [ 'lodash/clone' ], message: CLONE_MESSAGE },
 	{ group: [ 'lodash/cloneDeep' ], message: CLONE_DEEP_MESSAGE },
 	{ group: [ 'lodash/merge' ], message: MERGE_MESSAGE },
+	{ group: [ 'lodash/mergeWith' ], message: MERGEWITH_MESSAGE },
 	{ group: [ 'lodash/property' ], message: PROPERTY_MESSAGE },
 	{ group: [ 'lodash/maxBy', 'lodash/minBy' ], message: EXTREMUM_MESSAGE },
 	{ group: [ 'lodash/partition' ], message: PARTITION_MESSAGE },
@@ -258,6 +266,7 @@ const patterns = [
 const NAMESPACE_GUARDED = [
 	{ name: 'isEmpty', message: JS_UTILS_MESSAGE },
 	{ name: 'memoize', message: JS_UTILS_MESSAGE },
+	{ name: 'mergeWith', message: MERGEWITH_MESSAGE },
 	{ name: 'unescape', message: UNESCAPE_MESSAGE },
 	{ name: 'sampleSize', message: SAMPLESIZE_MESSAGE },
 	{ name: 'matches', message: MATCHES_MESSAGE },

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -15,6 +15,7 @@ export { default as mapValues } from './map-values';
 export { default as maxBy } from './max-by';
 export { default as memoize } from './memoize';
 export { default as merge } from './merge';
+export { default as mergeWith } from './mergeWith';
 export { default as minBy } from './min-by';
 export { default as omit } from './omit';
 export { default as omitBy } from './omit-by';

--- a/packages/js-utils/src/merge-internal.ts
+++ b/packages/js-utils/src/merge-internal.ts
@@ -1,0 +1,52 @@
+export type PlainObject = Record< string, unknown >;
+
+export const isPlainObject = ( value: unknown ): value is PlainObject => {
+	if ( value === null || typeof value !== 'object' ) {
+		return false;
+	}
+	const proto = Object.getPrototypeOf( value );
+	return proto === null || proto === Object.prototype;
+};
+
+// Values the merge recurses into rather than assigning by reference: arrays and
+// plain objects. Everything else (Dates, class instances, functions, typed
+// arrays, …) is copied by reference.
+export const isMergeable = ( value: unknown ): boolean =>
+	Array.isArray( value ) || isPlainObject( value );
+
+// Reads `constructor` as absent when it holds the built-in function, so a source
+// `constructor` merges into a fresh own property instead of the real constructor
+// (matching lodash). `__proto__` is skipped by callers before this is reached.
+export const safeGet = ( object: PlainObject, key: string ): unknown => {
+	if ( key === 'constructor' && typeof object[ key ] === 'function' ) {
+		return undefined;
+	}
+	return object[ key ];
+};
+
+// Picks the destination container to deep-merge a mergeable `srcValue` into:
+// reuse a type-compatible existing `objValue` so nested values merge in place,
+// otherwise start a fresh container to copy into.
+export const pickMergeContainer = (
+	objValue: unknown,
+	srcValue: unknown
+): PlainObject | unknown[] => {
+	if ( Array.isArray( srcValue ) ) {
+		return Array.isArray( objValue ) ? objValue : [];
+	}
+	if ( objValue !== null && typeof objValue === 'object' ) {
+		return objValue as PlainObject;
+	}
+	return {};
+};
+
+// Assigns like a sloppy-mode write. `Reflect.set` reports a rejected data-
+// property write — a frozen or sealed object, a non-extensible object gaining a
+// new key, or a non-writable property — as a `false` return rather than
+// throwing, so the merge keeps going, matching lodash (which runs non-strict).
+// Exceptions thrown by a userland setter still propagate, as they do in lodash.
+// A plain strict-mode assignment would instead throw on the rejected write and
+// abort the whole merge.
+export const assign = ( target: PlainObject, key: string, value: unknown ): void => {
+	Reflect.set( target, key, value );
+};

--- a/packages/js-utils/src/merge.ts
+++ b/packages/js-utils/src/merge.ts
@@ -1,39 +1,15 @@
-type PlainObject = Record< string, unknown >;
+import {
+	assign,
+	isMergeable,
+	pickMergeContainer,
+	safeGet,
+	type PlainObject,
+} from './merge-internal';
 
-const isPlainObject = ( value: unknown ): value is PlainObject => {
-	if ( value === null || typeof value !== 'object' ) {
-		return false;
-	}
-	const proto = Object.getPrototypeOf( value );
-	return proto === null || proto === Object.prototype;
-};
-
-// Values lodash recurses into rather than assigning by reference: arrays and
-// plain objects. Everything else (Dates, class instances, functions, typed
-// arrays, …) is copied by reference.
-const isMergeable = ( value: unknown ): boolean => Array.isArray( value ) || isPlainObject( value );
-
-// Reads `constructor` as absent when it holds the built-in function, so a source
-// `constructor` merges into a fresh own property instead of the real constructor
-// (matching lodash). `__proto__` is skipped entirely in `baseMerge`.
-const safeGet = ( object: PlainObject, key: string ): unknown => {
-	if ( key === 'constructor' && typeof object[ key ] === 'function' ) {
-		return undefined;
-	}
-	return object[ key ];
-};
-
-// Assigns like a sloppy-mode write. `Reflect.set` reports a rejected data-
-// property write — a frozen or sealed object, a non-extensible object gaining a
-// new key, or a non-writable property — as a `false` return rather than
-// throwing, so the merge keeps going, matching lodash (which runs non-strict).
-// Exceptions thrown by a userland setter still propagate, as they do in lodash.
-// A plain strict-mode assignment would instead throw on the rejected write and
-// abort the whole merge.
-const assign = ( target: PlainObject, key: string, value: unknown ): void => {
-	Reflect.set( target, key, value );
-};
-
+// This is kept as its own traversal rather than sharing one engine with
+// `mergeWith`: `merge` intentionally does not track a stack, so a circular
+// source stack-overflows (its documented, tested contract) while `mergeWith`
+// terminates on cycles. Unifying them would silently give `merge` that support.
 function baseMerge( target: PlainObject, source: PlainObject ): void {
 	if ( target === source ) {
 		return;
@@ -49,16 +25,7 @@ function baseMerge( target: PlainObject, source: PlainObject ): void {
 		const objValue = safeGet( target, key );
 
 		if ( isMergeable( srcValue ) ) {
-			// Reuse a compatible destination container so nested objects merge in
-			// place; otherwise start a fresh container to deep-copy into.
-			let newValue: PlainObject | unknown[];
-			if ( Array.isArray( srcValue ) ) {
-				newValue = Array.isArray( objValue ) ? objValue : [];
-			} else if ( objValue !== null && typeof objValue === 'object' ) {
-				newValue = objValue as PlainObject;
-			} else {
-				newValue = {};
-			}
+			const newValue = pickMergeContainer( objValue, srcValue );
 			baseMerge( newValue as PlainObject, srcValue as PlainObject );
 			// Skip the write when the container was reused (already in place).
 			if ( newValue !== objValue ) {

--- a/packages/js-utils/src/mergeWith.ts
+++ b/packages/js-utils/src/mergeWith.ts
@@ -116,21 +116,25 @@ function baseMergeWith(
  * properties, treats arrays as dense, and does not special-case typed arrays or
  * buffers. Unlike merge, circular references are supported (each in-progress
  * source is tracked so it is merged once).
- * @param object The destination object (mutated in place).
+ * @param object The destination (mutated in place; a nullish value becomes a fresh object).
  * @param args Source objects, optionally followed by a customizer function.
- * @returns The mutated destination object.
+ * @returns The mutated (or freshly created) destination object.
  */
 function mergeWith( object: object, ...args: unknown[] ): object {
 	const last = args[ args.length - 1 ];
 	const hasCustomizer = typeof last === 'function';
 	const customizer = hasCustomizer ? ( last as MergeWithCustomizer ) : defaultCustomizer;
 	const sources = hasCustomizer ? args.slice( 0, -1 ) : args;
+	// Coerce like lodash's assigner so a nullish destination becomes a fresh
+	// object rather than being read through — callers that merge into a
+	// possibly-absent value get the merged result back.
+	const target = Object( object ) as PlainObject;
 	for ( const source of sources ) {
 		if ( source != null ) {
-			baseMergeWith( object as PlainObject, source as PlainObject, customizer, new Map() );
+			baseMergeWith( target, source as PlainObject, customizer, new Map() );
 		}
 	}
-	return object;
+	return target;
 }
 
 export default mergeWith;

--- a/packages/js-utils/src/mergeWith.ts
+++ b/packages/js-utils/src/mergeWith.ts
@@ -1,0 +1,136 @@
+import {
+	assign,
+	isMergeable,
+	pickMergeContainer,
+	safeGet,
+	type PlainObject,
+} from './merge-internal';
+
+/**
+ * Called for every source key to optionally produce the merged value. Returning
+ * `undefined` defers to the default merge for that key; any other return value
+ * is used as-is (no further recursion). `stack` maps each source value being
+ * merged to its destination container, so `stack.size` reflects the current
+ * recursion depth — `0` at the top level.
+ */
+export type MergeWithCustomizer = (
+	objValue: unknown,
+	srcValue: unknown,
+	key: string,
+	object: PlainObject,
+	source: PlainObject,
+	stack: Map< unknown, unknown >
+) => unknown;
+
+// The customizer used when the caller omits one: defers every key to the
+// default merge, so `mergeWith` degrades to a plain deep merge (like lodash).
+const defaultCustomizer: MergeWithCustomizer = () => undefined;
+
+// SameValueZero, matching lodash's `eq`: like `===` but treats two NaNs as
+// equal. Used to skip writes that would not change the destination.
+const eq = ( a: unknown, b: unknown ): boolean => a === b || ( a !== a && b !== b );
+
+// Mirrors lodash's `assignMergeValue`: assign only when the value actually
+// differs, and let a `undefined` value create an absent key without clobbering
+// an existing one.
+const assignMergeValue = ( target: PlainObject, key: string, value: unknown ): void => {
+	if (
+		( value !== undefined && ! eq( target[ key ], value ) ) ||
+		( value === undefined && ! ( key in target ) )
+	) {
+		assign( target, key, value );
+	}
+};
+
+function baseMergeDeep(
+	target: PlainObject,
+	source: PlainObject,
+	key: string,
+	srcValue: unknown,
+	customizer: MergeWithCustomizer,
+	stack: Map< unknown, unknown >
+): void {
+	const objValue = safeGet( target, key );
+
+	// A source value already being merged upstream: reuse its destination
+	// container instead of recursing again, so circular references terminate.
+	const stacked = stack.get( srcValue );
+	if ( stacked ) {
+		assignMergeValue( target, key, stacked );
+		return;
+	}
+
+	let newValue = customizer( objValue, srcValue, key, target, source, stack );
+
+	// A customizer result other than `undefined` is used as-is. Otherwise deep-
+	// merge into a compatible container. Every value reaching this branch is
+	// mergeable (array or plain object), so unlike lodash there is no buffer or
+	// typed-array case that would skip the recursion.
+	if ( newValue === undefined ) {
+		newValue = pickMergeContainer( objValue, srcValue );
+		stack.set( srcValue, newValue );
+		baseMergeWith( newValue as PlainObject, srcValue as PlainObject, customizer, stack );
+		stack.delete( srcValue );
+	}
+	assignMergeValue( target, key, newValue );
+}
+
+function baseMergeWith(
+	target: PlainObject,
+	source: PlainObject,
+	customizer: MergeWithCustomizer,
+	stack: Map< unknown, unknown >
+): void {
+	if ( target === source ) {
+		return;
+	}
+	for ( const key of Object.keys( source ) ) {
+		// Never read or write through `__proto__`; it can only reach a prototype.
+		if ( key === '__proto__' ) {
+			continue;
+		}
+		const srcValue = safeGet( source, key );
+		if ( isMergeable( srcValue ) ) {
+			baseMergeDeep( target, source, key, srcValue, customizer, stack );
+		} else {
+			const objValue = safeGet( target, key );
+			let newValue = customizer( objValue, srcValue, key, target, source, stack );
+			if ( newValue === undefined ) {
+				newValue = srcValue;
+			}
+			assignMergeValue( target, key, newValue );
+		}
+	}
+}
+
+/**
+ * Like {@link ./merge merge}, but a `customizer` invoked for every source key
+ * decides the merged value: it runs first and, when it returns anything other
+ * than `undefined`, that result is assigned directly instead of the default
+ * deep merge. As in lodash, the customizer is optional and identified by being
+ * the trailing argument when it is a function; otherwise every argument after
+ * the destination is treated as a source and the merge runs without one. Sources
+ * are merged left to right.
+ *
+ * This shares merge's narrower-than-lodash scope: it merges only own enumerable
+ * properties, treats arrays as dense, and does not special-case typed arrays or
+ * buffers. Unlike merge, circular references are supported (each in-progress
+ * source is tracked so it is merged once).
+ * @param object The destination object (mutated in place).
+ * @param args Source objects, optionally followed by a customizer function.
+ * @returns The mutated destination object.
+ */
+function mergeWith( object: object, ...args: unknown[] ): object {
+	const last = args[ args.length - 1 ];
+	const hasCustomizer = typeof last === 'function';
+	const customizer = hasCustomizer ? ( last as MergeWithCustomizer ) : defaultCustomizer;
+	const sources = hasCustomizer ? args.slice( 0, -1 ) : args;
+	for ( const source of sources ) {
+		if ( source != null ) {
+			baseMergeWith( object as PlainObject, source as PlainObject, customizer, new Map() );
+		}
+	}
+	return object;
+}
+
+export default mergeWith;

--- a/packages/js-utils/src/mergeWith.ts
+++ b/packages/js-utils/src/mergeWith.ts
@@ -107,10 +107,11 @@ function baseMergeWith(
  * Like {@link ./merge merge}, but a `customizer` invoked for every source key
  * decides the merged value: it runs first and, when it returns anything other
  * than `undefined`, that result is assigned directly instead of the default
- * deep merge. As in lodash, the customizer is optional and identified by being
- * the trailing argument when it is a function; otherwise every argument after
- * the destination is treated as a source and the merge runs without one. Sources
- * are merged left to right.
+ * deep merge. As in lodash, the customizer is optional and identified as the
+ * trailing argument only when it is a function AND at least one source precedes
+ * it; otherwise every argument after the destination is treated as a source
+ * (so a lone trailing function is merged as a source) and the merge runs without
+ * a customizer. Sources are merged left to right.
  *
  * This shares merge's narrower-than-lodash scope: it merges only own enumerable
  * properties, treats arrays as dense, and does not special-case typed arrays or
@@ -120,9 +121,9 @@ function baseMergeWith(
  * @param args Source objects, optionally followed by a customizer function.
  * @returns The mutated (or freshly created) destination object.
  */
-function mergeWith( object: object, ...args: unknown[] ): object {
+function mergeWith( object: object | null | undefined, ...args: unknown[] ): object {
 	const last = args[ args.length - 1 ];
-	const hasCustomizer = typeof last === 'function';
+	const hasCustomizer = args.length > 1 && typeof last === 'function';
 	const customizer = hasCustomizer ? ( last as MergeWithCustomizer ) : defaultCustomizer;
 	const sources = hasCustomizer ? args.slice( 0, -1 ) : args;
 	// Coerce like lodash's assigner so a nullish destination becomes a fresh

--- a/packages/js-utils/src/test/mergeWith.ts
+++ b/packages/js-utils/src/test/mergeWith.ts
@@ -154,9 +154,23 @@ describe( 'mergeWith', () => {
 	it( 'returns a fresh object when the destination is nullish, like lodash', () => {
 		// A null destination (e.g. an unknown post merged with local edits) must
 		// yield the merged edits rather than throwing on the null read.
-		const mine = mergeWith( null as unknown as object, { a: 1, b: [ 2 ] }, overwriteArrays );
+		const mine = mergeWith( null, { a: 1, b: [ 2 ] }, overwriteArrays );
 		const theirs = lodashMergeWith( null, { a: 1, b: [ 2 ] }, overwriteArrays );
 		expect( mine ).toEqual( theirs );
 		expect( mine ).toEqual( { a: 1, b: [ 2 ] } );
+	} );
+
+	it( 'treats a lone trailing function as a source, not a customizer, like lodash', () => {
+		// With no source preceding it, a function argument is merged for its own
+		// enumerable properties rather than being called as a customizer.
+		const makeFn = () => {
+			const fn = () => undefined;
+			( fn as unknown as Record< string, unknown > ).a = 1;
+			return fn;
+		};
+		const mine = mergeWith( {}, makeFn() );
+		const theirs = lodashMergeWith( {}, makeFn() );
+		expect( mine ).toEqual( theirs );
+		expect( ( mine as Record< string, unknown > ).a ).toBe( 1 );
 	} );
 } );

--- a/packages/js-utils/src/test/mergeWith.ts
+++ b/packages/js-utils/src/test/mergeWith.ts
@@ -150,4 +150,13 @@ describe( 'mergeWith', () => {
 		const theirs = lodashMergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
 		expect( mine ).toEqual( theirs );
 	} );
+
+	it( 'returns a fresh object when the destination is nullish, like lodash', () => {
+		// A null destination (e.g. an unknown post merged with local edits) must
+		// yield the merged edits rather than throwing on the null read.
+		const mine = mergeWith( null as unknown as object, { a: 1, b: [ 2 ] }, overwriteArrays );
+		const theirs = lodashMergeWith( null, { a: 1, b: [ 2 ] }, overwriteArrays );
+		expect( mine ).toEqual( theirs );
+		expect( mine ).toEqual( { a: 1, b: [ 2 ] } );
+	} );
 } );

--- a/packages/js-utils/src/test/mergeWith.ts
+++ b/packages/js-utils/src/test/mergeWith.ts
@@ -1,0 +1,153 @@
+// eslint-disable-next-line no-restricted-imports -- parity test against the lodash function being replaced
+import lodashMergeWith from 'lodash/mergeWith';
+import mergeWith from '../mergeWith';
+
+type Customizer = (
+	objValue: unknown,
+	srcValue: unknown,
+	key: string,
+	object: object,
+	source: object,
+	stack: { size: number }
+) => unknown;
+
+// Only touches `.size`, which both a native Map and lodash's Stack expose, so
+// the same customizer can drive both implementations in a differential test.
+const overwriteArrays: Customizer = ( _objValue, srcValue ) =>
+	Array.isArray( srcValue ) ? srcValue : undefined;
+
+const concatArrays: Customizer = ( objValue, srcValue ) =>
+	Array.isArray( objValue ) ? objValue.concat( srcValue ) : undefined;
+
+const topLevelOnly: Customizer = ( _objValue, srcValue, key, _obj, _src, stack ) =>
+	key === 'special' && stack.size === 0 ? 'REPLACED' : undefined;
+
+const noop: Customizer = () => undefined;
+
+describe( 'mergeWith', () => {
+	// Each case is [ label, customizer, factory ]; the factory produces fresh
+	// inputs because both implementations mutate their destination.
+	const cases: Array< [ string, Customizer, () => unknown[] ] > = [
+		[
+			'noop customizer behaves like a deep merge',
+			noop,
+			() => [ { a: { b: 1 } }, { a: { c: 2 } } ],
+		],
+		[
+			'arrays overwrite instead of merging by index',
+			overwriteArrays,
+			() => [ { a: [ 1, 2, 3 ] }, { a: [ 9 ] } ],
+		],
+		[
+			'nested arrays overwrite',
+			overwriteArrays,
+			() => [ { a: { list: [ 1, 2 ], n: 1 } }, { a: { list: [ 3 ], m: 2 } } ],
+		],
+		[ 'arrays concatenate', concatArrays, () => [ { a: [ 1, 2 ] }, { a: [ 3, 4 ] } ] ],
+		[
+			'concat creates a fresh array when destination lacks the key',
+			concatArrays,
+			() => [ {}, { a: [ 1, 2 ] } ],
+		],
+		[
+			'top-level key replaced, nested key of same name untouched',
+			topLevelOnly,
+			() => [
+				{ special: 1, nested: { special: 2 } },
+				{ special: 9, nested: { special: 9 } },
+			],
+		],
+		[
+			'customizer undefined falls back to default for primitives',
+			overwriteArrays,
+			() => [ { a: 1 }, { a: 2 } ],
+		],
+		[
+			'multiple sources merge left to right',
+			overwriteArrays,
+			() => [ {}, { a: 1 }, { a: 2, b: 3 } ],
+		],
+		[ 'null source is ignored', overwriteArrays, () => [ { a: 1 }, null, { b: 2 } ] ],
+		[ 'undefined source is ignored', overwriteArrays, () => [ { a: 1 }, undefined, { b: 2 } ] ],
+		[ 'undefined src value skips existing key', noop, () => [ { a: 1 }, { a: undefined } ] ],
+		[ 'null overrides object', noop, () => [ { a: { b: 1 } }, { a: null } ] ],
+		[
+			'__proto__ payload is dropped',
+			noop,
+			() => [ {}, JSON.parse( '{ "__proto__": { "x": 1 }, "a": 1 }' ) ],
+		],
+	];
+
+	it.each( cases )( 'matches lodash: %s', ( _label, customizer, make ) => {
+		const mineArgs = [ ...make(), customizer ] as [ object, ...unknown[] ];
+		const theirsArgs = [ ...make(), customizer ] as [ object, ...unknown[] ];
+		const mine = ( mergeWith as ( ...a: unknown[] ) => unknown )( ...mineArgs );
+		const theirs = ( lodashMergeWith as ( ...a: unknown[] ) => unknown )( ...theirsArgs );
+		expect( mine ).toEqual( theirs );
+	} );
+
+	it( 'passes stack.size reflecting recursion depth to the customizer', () => {
+		const depths: number[] = [];
+		mergeWith(
+			{ a: { b: { c: 1 } } },
+			{ a: { b: { c: 2 } } },
+			( _o, _s, _k, _obj, _src, stack ) => {
+				depths.push( stack.size );
+				return undefined;
+			}
+		);
+		// a → depth 0, a.b → depth 1, a.b.c → depth 2.
+		expect( depths ).toEqual( [ 0, 1, 2 ] );
+	} );
+
+	it( 'supports circular sources without infinite recursion, like lodash', () => {
+		const make = () => {
+			const circular: Record< string, unknown > = { a: 1 };
+			circular.self = circular;
+			return circular;
+		};
+		const mine = mergeWith( {}, make(), noop ) as Record< string, unknown >;
+		const theirs = lodashMergeWith( {}, make(), noop ) as Record< string, unknown >;
+		expect( mine.a ).toBe( 1 );
+		// The nested `self` is merged once into its own container, then short-
+		// circuited on re-entry — matching lodash rather than looping forever.
+		expect( mine.self ).toEqual( theirs.self );
+		expect( ( mine.self as Record< string, unknown > ).self ).toBe( mine.self );
+	} );
+
+	it( 'does not pollute Object.prototype via __proto__', () => {
+		mergeWith( {}, JSON.parse( '{ "__proto__": { "polluted": 1 } }' ), noop );
+		expect( ( {} as Record< string, unknown > ).polluted ).toBeUndefined();
+	} );
+
+	it( 'merges into a null-prototype destination with a concat customizer', () => {
+		const result = mergeWith(
+			Object.create( null ),
+			{ handlers: [ 1 ] },
+			{ handlers: [ 2 ] },
+			concatArrays
+		) as Record< string, unknown >;
+		expect( result.handlers ).toEqual( [ 1, 2 ] );
+	} );
+
+	it( 'mutates and returns the destination', () => {
+		const target = { a: 1 };
+		const result = mergeWith( target, { b: 2 }, noop );
+		expect( result ).toBe( target );
+		expect( target ).toEqual( { a: 1, b: 2 } );
+	} );
+
+	it( 'treats a non-function trailing argument as a source, like lodash', () => {
+		// No customizer given — the last object is merged, not dropped or called.
+		const mine = mergeWith( { a: { x: 1 } }, { a: { y: 2 } }, { b: 3 } );
+		const theirs = lodashMergeWith( { a: { x: 1 } }, { a: { y: 2 } }, { b: 3 } );
+		expect( mine ).toEqual( theirs );
+		expect( mine ).toEqual( { a: { x: 1, y: 2 }, b: 3 } );
+	} );
+
+	it( 'merges a single source with no customizer, like lodash', () => {
+		const mine = mergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
+		const theirs = lodashMergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
+		expect( mine ).toEqual( theirs );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* Add a `mergeWith` helper to `@automattic/js-utils` and migrate the last lodash `mergeWith` call sites (post-edit merging and action-watcher handlers) to it, continuing the incremental removal of lodash.
* Factor the shared deep-merge primitives out of `merge` into an internal module so `merge` and `mergeWith` no longer duplicate them.
* Restrict lodash `mergeWith` via the shared lint guard, covering named imports, deep imports, and namespace/CommonJS access.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase in favor of small, purpose-built helpers. The helper is a faithful port for the plain JSON-like data these call sites merge, with differential tests pinning its behavior against lodash. This removes the last `mergeWith` usages from application source and lets the guard lock the function down at every import shape.

## Testing Instructions

* `yarn jest --config=test/packages/jest.config.js packages/js-utils/src/test/mergeWith.ts packages/js-utils/src/test/merge.ts`
* `yarn test-client client/state/posts/test/utils.js client/state/action-watchers/test/utils.js`
* Confirm `import { mergeWith } from 'lodash'` (and `lodash/mergeWith`, `_.mergeWith`) now trip the lint guard, and that the migrated flows (saving post edits, action watchers) behave unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
