### PR TITLE
Dashboard DataViews: don't enable 'reset view' when user only changes search term

### DIFF
--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -239,7 +239,7 @@ describe( 'usePersistentView', () => {
 			} );
 		} );
 
-		it( 'should sync transient properties to the current URL query params', async () => {
+		it( 'should sync transient properties to the current URL query params without persisting the view', async () => {
 			mockGetCalypsoPreferences( {} );
 			mockUpdateCalypsoPreferences();
 
@@ -263,6 +263,7 @@ describe( 'usePersistentView', () => {
 					layout: { previewSize: 120 },
 					sort: { field: 'name', direction: 'asc' },
 					page: 2,
+					startPosition: undefined,
 					search: 'test',
 				} );
 			} );
@@ -275,6 +276,8 @@ describe( 'usePersistentView', () => {
 					search: 'test',
 				} );
 			} );
+
+			expect( result.current.resetView ).toBeFalsy();
 		} );
 
 		it( 'should remove transient filters from the current URL query params if no longer in the view', async () => {

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -228,6 +228,7 @@ function removeTransientPropertiesFromView( view: View ): View {
 	const viewToPersist = { ...view };
 
 	delete viewToPersist.page;
+	delete viewToPersist.startPosition;
 	delete viewToPersist.search;
 
 	return viewToPersist;


### PR DESCRIPTION
## Proposed Changes

Spotted this while reading this: https://github.com/Automattic/wp-calypso/pull/112247#discussion_r3517027256

Since DataViews 14, when a user modifies the search term, we [modify](https://github.com/WordPress/gutenberg/blob/8a73de54ed3d9ee67ee203c63f43194c8674578c/packages/dataviews/src/components/dataviews-search/index.tsx#L39) the `view` object with a new `startPosition` field:

<img width="547" height="203" alt="image" src="https://github.com/user-attachments/assets/31da3b46-613f-4bc1-b14d-bf3fd28b9c87" />


Since we [upgraded Calypso to DataViews 14](https://github.com/Automattic/wp-calypso/pull/110933), this caused an issue where when we search in the search box, the persisted view is considered dirty and the reset indicator is shown. This PR fixes that.

## Why are these changes being made?

Fixes a regression as described above.

## Testing Instructions

1. Go to MSD /sites
2. Reset your view first if dirty
3. Type anything in the search box
4. Verify there's no dirty/reset indicator in the gear icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
