### PR TITLE
Blackbox: fit challenge to login form width and spacing

### DIFF
--- a/client/blocks/login/blackbox-challenge.jsx
+++ b/client/blocks/login/blackbox-challenge.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useBlackbox } from 'calypso/blocks/login/utils/use-blackbox';
 
@@ -25,5 +26,17 @@ export default function BlackboxChallenge( { enabled, onSubmitBlockedChange } ) 
 		return null;
 	}
 
-	return <div ref={ containerRef } className="login__form-blackbox-challenge" />;
+	// The container always renders while enabled so the challenge has a mount
+	// point, but it only takes up space once a challenge is actually showing.
+	// Flag that state so the stylesheet reserves spacing only then.
+	const isChallengeVisible = isChallengeActive || hasChallengeContent;
+
+	return (
+		<div
+			ref={ containerRef }
+			className={ clsx( 'login__form-blackbox-challenge', {
+				'has-visible-challenge': isChallengeVisible,
+			} ) }
+		/>
+	);
 }

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -127,3 +127,11 @@ form {
 		margin-top: 12px;
 	}
 }
+
+// The challenge container is always present while the bot check is enabled but
+// only occupies space once a challenge is actually visible, so scope the spacing
+// to `.has-visible-challenge` to avoid a gap when nothing renders. Kept small
+// since the form already separates the challenge from the Continue button.
+.login__form-blackbox-challenge.has-visible-challenge {
+	margin-block-end: 8px;
+}

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -86,6 +86,9 @@ export function useBlackbox( { containerRef, enabled } ) {
 				window.Blackbox.configure( {
 					apiKey: config( 'blackbox_api_key' ),
 					challengeContainer: containerRef.current,
+					// Fill the login form column so the challenge lines up with the
+					// input above and the full-width Continue button below.
+					challengeMaxWidth: '100%',
 					onChallengeStart: () => {
 						if ( ! cancelled ) {
 							hasStartedChallenge = true;


### PR DESCRIPTION
## Proposed Changes

- Set the challenge width to 100% to fill the login form column, so it lines up with the email input and the Continue button.
- Add a small amount of spacing above the button only while a challenge is visible so an inactive check doesn't leave a gap.

Before:

<img width="327" height="229" alt="Screenshot 2026-07-02 at 8 34 56 PM" src="https://github.com/user-attachments/assets/851fb0fa-dab7-42d9-a597-b1b5c2e42305" /> 
<img width="431" height="199" alt="Screenshot 2026-07-02 at 9 11 03 PM" src="https://github.com/user-attachments/assets/5d9d63bc-3d83-45d9-8028-3c22a0037c41" />

After:

<img width="329" height="229" alt="Screenshot 2026-07-02 at 9 02 08 PM" src="https://github.com/user-attachments/assets/3423a253-fe0a-44c8-81ed-156ae7a50d07" /> <img width="420" height="197" alt="Screenshot 2026-07-02 at 9 10 05 PM" src="https://github.com/user-attachments/assets/6c2cc75a-18f3-4e28-995d-0d5eefdc34db" />


## Why are these changes being made?

The challenge widget's spacing looked bad, and we added a new option to Blackbox to help this.

## Testing Instructions

- Go to `/log-in` and verify the spacing looks the same.
- Force a challenge
- Verify the widget width/margin looks acceptable
- Repeat on `/log-in/lostpassword`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
