### PR TITLE
A4A: Refresh intro sentence on MCP setup page

### DIFF
--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -88,7 +88,7 @@ export default function McpOverview( {
 			<Spacer marginBottom={ 8 } style={ { maxWidth: '650px' } }>
 				<Text size={ 15 }>
 					{ __(
-						'Set up AI agent access in three steps. Access won’t work until you complete all three.'
+						'Connect an AI agent to check site health, tier progress, payouts, and more across your agency, on demand. Set it up in three easy steps and put your agent to work.'
 					) }
 				</Text>
 			</Spacer>


### PR DESCRIPTION
Part of A4A-2919

## Proposed Changes

* Refresh the intro sentence on the AI & MCP setup page (agency resources) to better introduce the functionality.
  * **Before:** "Set up AI agent access in three steps. Access won’t work until you complete all three."
  * **After:** "Connect an AI agent to check site health, tier progress, payouts, and more across your agency, on demand. Set it up in three easy steps and put your agent to work."

## Why are these changes being made?

The previous copy was terse and only described the setup step count. The refreshed sentence introduces what an AI agent can actually do across the agency before prompting the user to set it up, giving better context ahead of the Private Beta launch.

## Testing Instructions

* Open the A4A live link
* Navigate to the AI & MCP page under agency resources.
* Confirm the intro paragraph above the three setup steps shows the new sentence.

<img width="856" height="543" alt="Screenshot 2026-07-03 at 9 52 56 AM" src="https://github.com/user-attachments/assets/a15c042d-3266-4005-9c78-7aea73fe56d9" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
