### PR TITLE
Replace lodash assignWith in config parser with a native assign

### DIFF
--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -5,7 +5,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const debug = require( 'debug' )( 'config' );
-const { assignWith } = require( 'lodash' );
 
 function getDataFromFile( file ) {
 	let fileData = {};
@@ -40,10 +39,15 @@ module.exports = function ( configPath, defaultOpts ) {
 	const disabledFeatures = opts.disabledFeatures ? opts.disabledFeatures.split( ',' ) : [];
 
 	configFiles.forEach( function ( file ) {
-		// merge the objects in `features` field, and do a simple assignment for other fields
-		assignWith( data, getDataFromFile( file ), ( objValue, srcValue, key ) =>
-			key === 'features' ? { ...objValue, ...srcValue } : undefined
-		);
+		for ( const [ key, value ] of Object.entries( getDataFromFile( file ) ) ) {
+			// Never assign through `__proto__`; a direct write would invoke the
+			// prototype setter instead of setting an own property.
+			if ( key === '__proto__' ) {
+				continue;
+			}
+			// merge the objects in `features` field, and do a simple assignment for other fields
+			data[ key ] = key === 'features' ? { ...data[ key ], ...value } : value;
+		}
 	} );
 
 	if ( data.hasOwnProperty( 'features' ) ) {

--- a/client/server/config/test/parser.js
+++ b/client/server/config/test/parser.js
@@ -46,6 +46,10 @@ function setValidEnvFiles() {
 			myenv_only: 'myenv',
 			myenv_override: 'myenv',
 			myenvlocal_override: 'myenv',
+			features: {
+				enabledFeature2: false,
+				myenvFeature: true,
+			},
 		} ),
 		'/valid-path/myenv.local.json': JSON.stringify( {
 			myenvlocal_only: 'myenvlocal',
@@ -105,12 +109,34 @@ describe( 'parser', () => {
 		expect( data ).toHaveProperty( 'myenvlocal_only', 'myenvlocal' );
 		expect( data ).toHaveProperty( 'myenv_override', 'myenv' );
 		expect( data ).toHaveProperty( 'myenvlocal_override', 'myenvlocal' );
+		// `features` from later config files merges into (rather than replaces)
+		// earlier ones: `enabledFeature1` from `_shared` survives, `enabledFeature2`
+		// is overridden by `myenv`, and `myenvFeature` is added.
 		expect( data ).toHaveProperty( 'features', {
 			enabledFeature1: true,
-			enabledFeature2: true,
+			enabledFeature2: false,
 			disabledFeature1: false,
 			disabledFeature2: false,
+			myenvFeature: true,
 		} );
+	} );
+
+	test( 'should ignore a __proto__ config key without polluting or crashing', () => {
+		// JSON.parse (unlike an object literal) yields a real own `__proto__` key;
+		// a naive `data[ key ] = value` would set the prototype and then crash on
+		// `data.hasOwnProperty`. The parser must skip it instead.
+		mockFs( {
+			'/valid-path/_shared.json': '{ "__proto__": null, "safe": "ok", "features": { "a": true } }',
+		} );
+
+		let data;
+		expect( () => {
+			data = parser( '/valid-path' ).serverData;
+		} ).not.toThrow();
+		expect( Object.getPrototypeOf( data ) ).toBe( Object.prototype );
+		expect( data ).toHaveProperty( 'safe', 'ok' );
+		expect( data ).toHaveProperty( 'features', { a: true } );
+		expect( {}.polluted ).toBeUndefined();
 	} );
 
 	test( 'should override enabled feature when disabledFeatures set', () => {

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -165,6 +165,9 @@ const UPDATE_MESSAGE =
 	'Please write an explicit path update (walk/create the path, then apply the updater) instead of lodash `update`.';
 const CLONEDEEPWITH_MESSAGE =
 	'Please use `structuredClone` plus a targeted override, or a small recursive clone, instead of lodash `cloneDeepWith`.';
+const ASSIGNWITH_MESSAGE =
+	'Please assign natively — `Object.keys( source ).forEach( ( key ) => { object[ key ] = … } )` with the ' +
+	'per-key logic your customizer expressed — instead of lodash `assignWith`.';
 
 const paths = [
 	{ name: 'lodash', importNames: JS_UTILS_NAMES, message: JS_UTILS_MESSAGE },
@@ -208,6 +211,7 @@ const paths = [
 	{ name: 'lodash', importNames: [ 'matchesProperty' ], message: MATCHESPROPERTY_MESSAGE },
 	{ name: 'lodash', importNames: [ 'update' ], message: UPDATE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'cloneDeepWith' ], message: CLONEDEEPWITH_MESSAGE },
+	{ name: 'lodash', importNames: [ 'assignWith' ], message: ASSIGNWITH_MESSAGE },
 ];
 
 // Deep `lodash/<fn>` imports bypass the named-import paths above.
@@ -253,6 +257,7 @@ const patterns = [
 	{ group: [ 'lodash/matchesProperty' ], message: MATCHESPROPERTY_MESSAGE },
 	{ group: [ 'lodash/update' ], message: UPDATE_MESSAGE },
 	{ group: [ 'lodash/cloneDeepWith' ], message: CLONEDEEPWITH_MESSAGE },
+	{ group: [ 'lodash/assignWith' ], message: ASSIGNWITH_MESSAGE },
 ];
 
 // Functions whose namespace-member (`_.fn( … )` / `lodash.fn( … )`) and CommonJS
@@ -273,6 +278,7 @@ const NAMESPACE_GUARDED = [
 	{ name: 'matchesProperty', message: MATCHESPROPERTY_MESSAGE },
 	{ name: 'update', message: UPDATE_MESSAGE },
 	{ name: 'cloneDeepWith', message: CLONEDEEPWITH_MESSAGE },
+	{ name: 'assignWith', message: ASSIGNWITH_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).


### PR DESCRIPTION
## Proposed Changes

* Replace the lodash `assignWith` call in the server config parser with a plain per-key assignment loop that shallow-merges the `features` object and overwrites other keys, and skips `__proto__`.
* Restrict lodash `assignWith` via the shared lint guard, covering named imports, deep imports, and namespace/CommonJS access.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase. The parser is an un-transpiled CommonJS bootstrap module that cannot consume the shared ESM helpers, so the customizer is expressed directly as a small native loop. This removes the last lodash usage from application/server source; only build tooling remains. Skipping `__proto__` keeps a config key from reaching the prototype chain, matching the assignment behavior lodash provided here.

## Testing Instructions

* `yarn jest --config=test/server/jest.config.js client/server/config/test/parser.js`
* Confirm config cascade still merges `features` across files (rather than replacing), and that a config containing a `__proto__` key neither pollutes the prototype nor crashes parsing.
* Confirm `import { assignWith } from 'lodash'` (and `lodash/assignWith`, `_.assignWith`) now trip the lint guard.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
