### PR TITLE
Replace lodash merge in the i18n babel plugin with a local POT assembly

### DIFF
--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -6,8 +6,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"dependencies": {
-		"gettext-parser": "^4.0.3",
-		"lodash": "^4.17.21"
+		"gettext-parser": "^4.0.3"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^"

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -35,7 +35,6 @@
 const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
 const { relative, sep } = require( 'path' );
 const { po } = require( 'gettext-parser' );
-const { merge } = require( 'lodash' );
 
 /**
  * Default output headers if none specified in plugin options.
@@ -201,6 +200,24 @@ function mergeStrings( source, target ) {
 	}
 }
 
+/**
+ * Builds the POT data for output by combining the extracted `strings` into a
+ * copy of `baseData`. Translations are merged per context so the base header
+ * entry (the empty context / empty msgid that carries the PO headers) is
+ * preserved rather than replaced by same-context extracted strings. `baseData`
+ * is not mutated.
+ * @param   {Object} baseData the base POT data (headers plus the header translation entry)
+ * @param   {Object} strings  extracted translations keyed by context, then by msgid
+ * @returns {Object} a new POT data object ready for `po.compile`
+ */
+function buildPotData( baseData, strings ) {
+	const translations = { ...baseData.translations };
+	for ( const context of Object.keys( strings ) ) {
+		translations[ context ] = { ...translations[ context ], ...strings[ context ] };
+	}
+	return { ...baseData, translations };
+}
+
 module.exports = function () {
 	let strings = {};
 	let nplurals = 2;
@@ -343,7 +360,7 @@ module.exports = function () {
 						return;
 					}
 
-					const data = merge( {}, baseData, { translations: strings } );
+					const data = buildPotData( baseData, strings );
 
 					const compiled = po.compile( data );
 
@@ -362,3 +379,5 @@ module.exports = function () {
 
 // Exported for unit testing of the translator-comment extraction logic.
 module.exports.getExtractedComment = getExtractedComment;
+// Exported for unit testing of the POT-data assembly.
+module.exports.buildPotData = buildPotData;

--- a/packages/babel-plugin-i18n-calypso/test/build-pot-data.js
+++ b/packages/babel-plugin-i18n-calypso/test/build-pot-data.js
@@ -1,0 +1,54 @@
+const { buildPotData } = require( '../src' );
+
+// The base POT data seeds the header block in the empty context / empty msgid
+// entry; extracted strings are keyed by context, then by msgid.
+const makeBaseData = () => ( {
+	charset: 'utf-8',
+	headers: { 'content-type': 'text/plain' },
+	translations: { '': { '': { msgid: '', msgstr: [ 'content-type: text/plain;\n' ] } } },
+} );
+
+describe( 'buildPotData', () => {
+	test( 'preserves the base header entry while adding extracted strings', () => {
+		const strings = { '': { hello: { msgid: 'hello', msgstr: [ '' ] } } };
+
+		expect( buildPotData( makeBaseData(), strings ) ).toEqual( {
+			charset: 'utf-8',
+			headers: { 'content-type': 'text/plain' },
+			translations: {
+				'': {
+					'': { msgid: '', msgstr: [ 'content-type: text/plain;\n' ] },
+					hello: { msgid: 'hello', msgstr: [ '' ] },
+				},
+			},
+		} );
+	} );
+
+	test( 'keeps translations from distinct contexts', () => {
+		const strings = {
+			'': { hello: { msgid: 'hello', msgstr: [ '' ] } },
+			verb: { book: { msgid: 'book', msgctxt: 'verb', msgstr: [ '' ] } },
+		};
+
+		const { translations } = buildPotData( makeBaseData(), strings );
+
+		expect( Object.keys( translations ) ).toEqual( [ '', 'verb' ] );
+		expect( translations[ '' ] ).toHaveProperty( 'hello' );
+		expect( translations[ '' ] ).toHaveProperty( '' ); // header survives
+		expect( translations.verb ).toHaveProperty( 'book' );
+	} );
+
+	test( 'does not mutate the reused baseData', () => {
+		const baseData = makeBaseData();
+		const strings = { ctx: { greet: { msgid: 'greet', msgstr: [ '' ] } } };
+
+		buildPotData( baseData, strings );
+
+		expect( baseData ).toEqual( makeBaseData() );
+		expect( baseData.translations ).not.toHaveProperty( 'ctx' );
+	} );
+
+	test( 'handles empty extracted strings', () => {
+		expect( buildPotData( makeBaseData(), {} ) ).toEqual( makeBaseData() );
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -274,7 +274,6 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     gettext-parser: "npm:^4.0.3"
-    lodash: "npm:^4.17.21"
   peerDependencies:
     "@babel/core": ^7.27.1
   languageName: unknown


### PR DESCRIPTION
## Proposed Changes

* Replace the lodash `merge` call in the i18n babel plugin with a small local helper that combines the extracted translation strings into the base POT data, and remove the plugin's lodash dependency.
* Add unit tests for the assembly, which previously had no coverage.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase. This plugin ships as un-transpiled source and deliberately avoids depending on built packages, so it uses a small local helper rather than a shared built utility. The POT data is only two levels deep (context, then msgid), so the helper merges translations per context rather than doing a general deep merge — that keeps the base header entry (the empty-context/empty-msgid entry carrying the PO headers) while adding the extracted strings, and produces output identical to the previous merge for real inputs. This removes lodash from the package entirely.

## Testing Instructions

* `yarn jest --config=test/packages/jest.config.js packages/babel-plugin-i18n-calypso/test/`
* Confirm generated `.pot` output still includes the header block and all extracted strings across contexts.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
