### PR TITLE
Replace lodash compact/groupBy/chunk in bin scripts with native code

### DIFF
--- a/bin/generate-style-variants.js
+++ b/bin/generate-style-variants.js
@@ -1,4 +1,3 @@
-const _ = require( 'lodash' );
 const argv = require( 'yargs' ).argv;
 
 const [ baseName, colorName ] = argv._;
@@ -22,10 +21,10 @@ const suffixes = [
 ];
 
 suffixes.forEach( ( suffix ) => {
-	const propertyName = _.compact( [ '--color', baseName, suffix ] ).join( '-' );
-	const variableName = _.compact( [ '--studio', colorName, determineShadeIndex( suffix ) ] ).join(
-		'-'
-	);
+	const propertyName = [ '--color', baseName, suffix ].filter( Boolean ).join( '-' );
+	const variableName = [ '--studio', colorName, determineShadeIndex( suffix ) ]
+		.filter( Boolean )
+		.join( '-' );
 
 	printEntry( propertyName, variableName );
 } );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -3,10 +3,18 @@ const spawnSync = require( 'child_process' ).spawnSync;
 const existsSync = require( 'fs' ).existsSync;
 const path = require( 'path' );
 const chalk = require( 'chalk' );
-const _ = require( 'lodash' );
 
 const phpcsPath = getPathForCommand( 'phpcs' );
 const phpcbfPath = getPathForCommand( 'phpcbf' );
+
+// Groups an array's items into an object keyed by the iteratee's return value.
+function groupBy( collection, iteratee ) {
+	return collection.reduce( ( groups, item ) => {
+		const key = iteratee( item );
+		( groups[ key ] = groups[ key ] || [] ).push( item );
+		return groups;
+	}, {} );
+}
 
 function quotedPath( pathToQuote ) {
 	if ( pathToQuote.includes( ' ' ) ) {
@@ -102,7 +110,7 @@ const {
 	toPrettify = [],
 	toStylelintfix = [],
 	toPHPCBF = [],
-} = _.groupBy( toFormat, ( file ) => {
+} = groupBy( toFormat, ( file ) => {
 	switch ( true ) {
 		case file.endsWith( '.scss' ):
 			return 'toStylelintfix';
@@ -117,12 +125,13 @@ const {
 toPrettify.forEach( ( file ) => console.log( `Prettier formatting staged file: ${ file }` ) );
 if ( toPrettify.length ) {
 	// chunk this up into multiple runs if we have a lot of files to avoid E2BIG
-	_.chunk( toPrettify, 500 ).forEach( ( chunk ) => {
+	for ( let i = 0; i < toPrettify.length; i += 500 ) {
+		const batch = toPrettify.slice( i, i + 500 );
 		execSync(
-			`./node_modules/.bin/prettier --ignore-path .eslintignore --write ${ chunk.join( ' ' ) }`
+			`./node_modules/.bin/prettier --ignore-path .eslintignore --write ${ batch.join( ' ' ) }`
 		);
-		execSync( `git add ${ chunk.join( ' ' ) }` );
-	} );
+		execSync( `git add ${ batch.join( ' ' ) }` );
+	}
 }
 
 // Format the sass files with stylelint and then re-stage them. Swallow the output.
@@ -156,7 +165,7 @@ const {
 	toEslint = [],
 	toStylelint = [],
 	toPHPCS = [],
-} = _.groupBy(
+} = groupBy(
 	files.filter( ( file ) => ! file.endsWith( '.json' ) ),
 	( file ) => {
 		switch ( true ) {

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -70,6 +70,9 @@ const MERGEWITH_MESSAGE =
 	'same trailing customizer but deep-merges only plain JSON-like data (own enumerable properties, ' +
 	'dense arrays) and does not merge inherited properties or materialize sparse-array holes.';
 const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash `compact`.';
+const CHUNK_MESSAGE =
+	'Please split with a small loop (`for ( let i = 0; i < array.length; i += size ) ' +
+	'chunks.push( array.slice( i, i + size ) )`) instead of lodash `chunk`.';
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
 const DEFER_MESSAGE = 'Please use native `setTimeout( fn, 0 )` instead of lodash `defer`.';
 const DELAY_MESSAGE = 'Please use native `setTimeout( fn, wait )` instead of lodash `delay`.';
@@ -174,6 +177,7 @@ const paths = [
 	{ name: 'lodash', importNames: CASE_NAMES, message: CASE_MESSAGE },
 	{ name: 'lodash', importNames: COMPOSE_NAMES, message: COMPOSE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'compact' ], message: COMPACT_MESSAGE },
+	{ name: 'lodash', importNames: [ 'chunk' ], message: CHUNK_MESSAGE },
 	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
 	{ name: 'lodash', importNames: [ 'defer' ], message: DEFER_MESSAGE },
 	{ name: 'lodash', importNames: [ 'delay' ], message: DELAY_MESSAGE },
@@ -220,6 +224,7 @@ const patterns = [
 	{ group: CASE_NAMES.map( ( name ) => `lodash/${ name }` ), message: CASE_MESSAGE },
 	{ group: COMPOSE_NAMES.map( ( name ) => `lodash/${ name }` ), message: COMPOSE_MESSAGE },
 	{ group: [ 'lodash/compact' ], message: COMPACT_MESSAGE },
+	{ group: [ 'lodash/chunk' ], message: CHUNK_MESSAGE },
 	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
 	{ group: [ 'lodash/defer' ], message: DEFER_MESSAGE },
 	{ group: [ 'lodash/delay' ], message: DELAY_MESSAGE },
@@ -279,6 +284,9 @@ const NAMESPACE_GUARDED = [
 	{ name: 'update', message: UPDATE_MESSAGE },
 	{ name: 'cloneDeepWith', message: CLONEDEEPWITH_MESSAGE },
 	{ name: 'assignWith', message: ASSIGNWITH_MESSAGE },
+	{ name: 'compact', message: COMPACT_MESSAGE },
+	{ name: 'groupBy', message: JS_UTILS_MESSAGE },
+	{ name: 'chunk', message: CHUNK_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).


### PR DESCRIPTION
## Proposed Changes

* Remove lodash from two build scripts: the style-variant generator now uses `array.filter( Boolean )` in place of `compact`, and the pre-commit hook uses a small local `groupBy` and an inline chunking loop in place of `groupBy`/`chunk`.
* Guard lodash `compact`, `groupBy`, and `chunk` at the namespace/CommonJS level (and add a full ES guard for `chunk`), now that their last namespace usages are gone.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase. These are un-transpiled CommonJS build scripts, so they use small native replacements rather than a shared built utility. The native swaps produce output identical to the lodash calls they replace. With the last `_.compact`/`_.groupBy`/`_.chunk` usages gone, these functions can be locked down against reintroduction.

## Testing Instructions

* Run `node bin/generate-style-variants.js gray gray` and confirm the emitted CSS variables are unchanged (empty suffixes are dropped from names).
* Make a commit touching a `.js`/`.scss`/`.php` file and confirm the pre-commit hook still formats and re-stages each type correctly.
* Confirm `import { compact } from 'lodash'` / `_.compact( … )` (and the same for `groupBy`/`chunk`) now trip the lint guard.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
