### PR TITLE
E2E: reuse a verified account for Calypso import site setup

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -359,6 +359,11 @@ export const test = base.extend<
 		 * Creates a new site with public visibility for testing.
 		 */
 		sitePublic: NewSiteResponse;
+		/**
+		 * Like `sitePublic`, but reuses a persistent, already-verified account and
+		 * only creates an ephemeral site: no signup or email-verification round trip.
+		 */
+		sitePublicShared: NewSiteResponse;
 	}
 >( {
 	viewportName: [ 'desktop', { option: true } ],
@@ -683,6 +688,24 @@ export const test = base.extend<
 			} );
 		}
 	},
+	sitePublicShared: async ( { page, helperData }, use ) => {
+		// getAccount persists auth cookies on first login so parallel tests reuse
+		// them instead of each re-logging-in; authenticate then loads them onto
+		// this test's page (needed by the import navigation).
+		const account = await getAccount( page, 'defaultUser' );
+		await account.authenticate( page );
+
+		// createSite is the first line that creates a real resource. From here on
+		// everything is wrapped so the site is deleted no matter what happens next:
+		// the test failing, timing out, or a later line throwing.
+		const siteName = helperData.getBlogName();
+		const site = await account.restAPI.createSite( { name: siteName, title: siteName } );
+		try {
+			await use( site );
+		} finally {
+			await deleteSiteBestEffort( account.restAPI, site );
+		}
+	},
 } );
 
 export const tags = {
@@ -720,6 +743,46 @@ export function skipIfMailosaurLimitReached(): void {
 		envVariables.MAILOSAUR_LIMIT_REACHED,
 		'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
 	);
+}
+
+/**
+ * Deletes an ephemeral test site. Retries transient failures and never throws:
+ * it runs from fixture teardown, which Playwright executes even when the test
+ * fails or times out, so a cleanup hiccup must not redden a passing test. On
+ * unrecoverable failure it logs a greppable `LEAKED` line and leaves the site
+ * for the external prune rather than masking the test result.
+ *
+ * @param {RestAPIClient} client Client authenticated as the site owner.
+ * @param {NewSiteResponse} site The site to delete.
+ */
+async function deleteSiteBestEffort(
+	client: RestAPIClient,
+	site: NewSiteResponse
+): Promise< void > {
+	const target = { id: site.blog_details.blogid, domain: site.blog_details.url };
+	for ( let attempt = 1; attempt <= 3; attempt++ ) {
+		let reason: string;
+		try {
+			// `deleteSite` returns null (without throwing) when it declines to act,
+			// e.g. the just-created site is not yet visible in `/all-domains/` so its
+			// ownership guard cannot confirm it. Treat that as a retryable failure so
+			// the site is not leaked silently.
+			if ( await client.deleteSite( target ) ) {
+				return;
+			}
+			reason = 'deletion declined (site ownership not yet confirmable)';
+		} catch ( error ) {
+			reason = String( error );
+		}
+		if ( attempt === 3 ) {
+			console.warn(
+				`LEAKED test site ${ target.domain } (id ${ target.id }): ` +
+					`not deleted after ${ attempt } attempts: ${ reason }`
+			);
+			return;
+		}
+		await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+	}
 }
 
 export { expect };

--- a/test/e2e/specs/tools/import__sites-medium.spec.ts
+++ b/test/e2e/specs/tools/import__sites-medium.spec.ts
@@ -100,7 +100,7 @@ test.describe(
 		} );
 
 		test( 'Three: As a New WordPress.com free plan user with a simple site, I can use the Calypso "Import Content" page to import my content from my Medium account', async ( {
-			sitePublic,
+			sitePublicShared: sitePublic,
 			pageImportContent,
 		} ) => {
 			await test.step( 'When I visit the "Import Content" page for my new site', async function () {

--- a/test/e2e/specs/tools/import__sites-squarespace.spec.ts
+++ b/test/e2e/specs/tools/import__sites-squarespace.spec.ts
@@ -100,7 +100,7 @@ test.describe(
 		} );
 
 		test( 'Three: As a New WordPress.com free plan user with a simple site, I can use the Calypso "Import Content" page to import my content from my Squarespace site', async ( {
-			sitePublic,
+			sitePublicShared: sitePublic,
 			pageImportContent,
 		} ) => {
 			await test.step( 'When I visit the "Import Content" page for my new site', async function () {

--- a/test/e2e/specs/tools/import__sites-substack.spec.ts
+++ b/test/e2e/specs/tools/import__sites-substack.spec.ts
@@ -145,7 +145,7 @@ test.describe(
 		} );
 
 		test( 'Three: As a New WordPress.com free plan user with a simple site, I can use the Calypso "Import Content" page to import my content from my Substack account', async ( {
-			sitePublic,
+			sitePublicShared: sitePublic,
 			pageImportContent,
 			pageImportContentFromSubstack,
 		} ) => {

--- a/test/e2e/specs/tools/import__sites-wordpress.spec.ts
+++ b/test/e2e/specs/tools/import__sites-wordpress.spec.ts
@@ -112,7 +112,7 @@ test.describe(
 			pageImportContent,
 			pageImportLetsFindYourSite,
 			pageImportContentWordpressQuestion,
-			sitePublic,
+			sitePublicShared: sitePublic,
 		} ) => {
 			const wordpressSiteURL = 'https://test.wordpress.com/';
 
@@ -170,7 +170,7 @@ test.describe(
 			pageImportContentWordpressQuestion,
 			pageImportContentFromAnotherPlatformOrFile,
 			pageImportPlans,
-			sitePublic,
+			sitePublicShared: sitePublic,
 		} ) => {
 			await test.step( 'When I visit the "Import Content" page for my new site', async function () {
 				await pageImportContent.visit( sitePublic.blog_details.site_slug );


### PR DESCRIPTION
Part of [TESTOPS-202](https://linear.app/a8c/issue/TESTOPS-202)

## Proposed Changes

- Add a `sitePublicShared` Playwright fixture: authenticates a persistent, already-verified account and creates an ephemeral site per test, deleting it on teardown (retries, never throws, logs leaked sites).
- Switch the 5 Calypso "Import Content" tests to it: `Three` in each of `import__sites-{wordpress,substack,squarespace,medium}`, plus `wordpress` `Four`.
- The wp-admin deep-link tests (`One`/`Two`) stay on `sitePublic`.

## Why are these changes being made?

`sitePublic` creates a fresh account and activates it by email for every test. Under cumulative signup load a per-IP activation throttle intermittently leaves the account unverified; the importer UI is gated on email verification, so the affected tests fail in setup, not in the import flow. That is why `import__sites-wordpress` `Four` and `import__sites-substack` `Three` were muted for months.

`sitePublicShared` drops the signup/activation dependency for tests that only need a fresh site, not a brand-new user. The deep-link tests keep `sitePublic` because they rely on fresh-signup onboarding state (the stepper hangs otherwise).

## Testing Instructions

Run the converted tests against staging (all pass, both formerly-muted tests included):

```
CALYPSO_BASE_URL=$CALYPSO_STAGING_URL yarn workspace wp-e2e-tests exec playwright test \
  specs/tools/import__sites-wordpress.spec.ts specs/tools/import__sites-substack.spec.ts \
  specs/tools/import__sites-squarespace.spec.ts specs/tools/import__sites-medium.spec.ts \
  --project=chrome --grep "Three:|Four:" --reporter=list
```

The two muted tests can be unmuted once this lands.
