### PR TITLE
Replace lodash in build-app-languages with native code

### DIFF
--- a/packages/calypso-build/bin/build-app-languages.js
+++ b/packages/calypso-build/bin/build-app-languages.js
@@ -94,6 +94,10 @@ const DECIMAL_POINT_TRANSLATION = 'number_format_decimal_point';
 const THOUSANDS_SEPARATOR_KEY = 'number_format_thousands_sep';
 const THOUSANDS_SEPARATOR_TRANSLATION = 'number_format_thousands_sep';
 
+// Keys lodash `pick` refuses to set (its prototype-pollution guard), so a
+// translated string named exactly one of these is dropped rather than emitted.
+const PICK_BLOCKED_KEYS = new Set( [ '__proto__', 'constructor', 'prototype' ] );
+
 // Get module reference
 function getModuleReference( ref ) {
 	// References need to be relative to the root of the project
@@ -250,9 +254,10 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 		successfullyDownloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
 			const cmdPaletteTranslations = {};
 			for ( const key of allModulesStrings ) {
-				// Skip `__proto__` so it can never mutate the prototype here or in the
+				// Match lodash `pick`, which drops these protected keys — and skipping
+				// `__proto__` also avoids mutating the prototype here or in the
 				// generated output that embeds this object as a literal.
-				if ( key !== '__proto__' && Object.hasOwn( languageTranslations, key ) ) {
+				if ( ! PICK_BLOCKED_KEYS.has( key ) && Object.hasOwn( languageTranslations, key ) ) {
 					cmdPaletteTranslations[ key ] = languageTranslations[ key ];
 				}
 			}

--- a/packages/calypso-build/bin/build-app-languages.js
+++ b/packages/calypso-build/bin/build-app-languages.js
@@ -194,6 +194,12 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 					mappedKey = context + String.fromCharCode( 4 ) + mappedKey;
 				}
 
+				// Skip `__proto__`: assigning it would mutate the prototype instead of
+				// adding a key, and lodash's merge dropped it too.
+				if ( mappedKey === '__proto__' ) {
+					continue;
+				}
+
 				translationsFlatten[ mappedKey ] = value;
 			}
 		}
@@ -244,7 +250,9 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 		successfullyDownloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
 			const cmdPaletteTranslations = {};
 			for ( const key of allModulesStrings ) {
-				if ( Object.hasOwn( languageTranslations, key ) ) {
+				// Skip `__proto__` so it can never mutate the prototype here or in the
+				// generated output that embeds this object as a literal.
+				if ( key !== '__proto__' && Object.hasOwn( languageTranslations, key ) ) {
 					cmdPaletteTranslations[ key ] = languageTranslations[ key ];
 				}
 			}

--- a/packages/calypso-build/bin/build-app-languages.js
+++ b/packages/calypso-build/bin/build-app-languages.js
@@ -12,7 +12,6 @@ const fs = require( 'fs' );
 const resolve = require( 'path' ).resolve;
 const languages = require( '@automattic/languages' );
 const parse = require( 'gettext-parser' ).po.parse;
-const _ = require( 'lodash' );
 const { hideBin } = require( 'yargs/helpers' );
 const yargs = require( 'yargs/yargs' );
 
@@ -181,24 +180,23 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 
 	if ( fs.existsSync( stringsFilePath ) ) {
 		const { translations } = parse( fs.readFileSync( stringsFilePath ) );
-		const translationsFlatten = Object.entries( translations ).reduce(
-			( result, [ context, contextTranslations ] ) => {
-				const mappedTranslations = _.mapKeys( contextTranslations, ( value, key ) => {
-					let mappedKey = key.replace( /\\u([0-9a-fA-F]{4})/g, ( match, matchedGroup ) =>
-						String.fromCharCode( parseInt( matchedGroup, 16 ) )
-					);
+		// Flatten every context's translations into one object, keyed by an
+		// unescaped, context-prefixed key. Those keys are unique per context, so a
+		// plain assignment accumulates them the same way the previous deep merge did.
+		const translationsFlatten = {};
+		for ( const [ context, contextTranslations ] of Object.entries( translations ) ) {
+			for ( const [ key, value ] of Object.entries( contextTranslations ) ) {
+				let mappedKey = key.replace( /\\u([0-9a-fA-F]{4})/g, ( match, matchedGroup ) =>
+					String.fromCharCode( parseInt( matchedGroup, 16 ) )
+				);
 
-					if ( context ) {
-						mappedKey = context + String.fromCharCode( 4 ) + mappedKey;
-					}
+				if ( context ) {
+					mappedKey = context + String.fromCharCode( 4 ) + mappedKey;
+				}
 
-					return mappedKey;
-				} );
-
-				return _.merge( result, mappedTranslations );
-			},
-			{}
-		);
+				translationsFlatten[ mappedKey ] = value;
+			}
+		}
 
 		const translationsByRef = Object.keys( translationsFlatten ).reduce( ( acc, key ) => {
 			const originalRef = translationsFlatten[ key ].comments?.reference;
@@ -244,7 +242,12 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 
 		const languageRevisionsHashes = {};
 		successfullyDownloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
-			const cmdPaletteTranslations = _.pick( languageTranslations, allModulesStrings );
+			const cmdPaletteTranslations = {};
+			for ( const key of allModulesStrings ) {
+				if ( Object.hasOwn( languageTranslations, key ) ) {
+					cmdPaletteTranslations[ key ] = languageTranslations[ key ];
+				}
+			}
 			cmdPaletteTranslations[ DECIMAL_POINT_KEY ] =
 				languageTranslations[ DECIMAL_POINT_TRANSLATION ];
 			cmdPaletteTranslations[ THOUSANDS_SEPARATOR_KEY ] =

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -49,7 +49,6 @@
 		"css-loader": "^6.11.0",
 		"css-minimizer-webpack-plugin": "^3.4.1",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
-		"lodash": "^4.18.1",
 		"mini-css-extract-plugin": "^2.10.2",
 		"postcss-custom-properties": "^12.1.11",
 		"postcss-loader": "^6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,7 +482,6 @@ __metadata:
     css-minimizer-webpack-plugin: "npm:^3.4.1"
     duplicate-package-checker-webpack-plugin: "npm:^3.0.0"
     gettext-parser: "npm:^6.0.0"
-    lodash: "npm:^4.18.1"
     mini-css-extract-plugin: "npm:^2.10.2"
     postcss-custom-properties: "npm:^12.1.11"
     postcss-loader: "npm:^6.2.1"


### PR DESCRIPTION
## Proposed Changes

* Remove lodash from the `build-app-languages` build script: flatten the per-context translations with a plain nested loop in place of `mapKeys` + `merge`, and select the command-palette strings with a native key-selection loop in place of `pick`.
* Drop the now-unused `lodash` dependency from `@automattic/calypso-build` and update the lockfile.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase. This is an un-transpiled CommonJS build script, so it uses small native replacements rather than a shared built utility. The mapped keys are context-prefixed and therefore unique, so the previous deep merge only ever accumulated keys — a plain assignment is equivalent. The native selection keeps only keys actually present, matching the previous behavior. This was the last lodash consumer in the package, so the dependency is removed too.

## Testing Instructions

* This script builds per-language translation files from downloaded language data; exercise the language build and confirm the generated command-palette and chunk translation files are unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
