### PR TITLE
MSD: Refine Simple-to-Atomic transfer modal

### DIFF
--- a/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
@@ -34,7 +34,7 @@ export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
 			<Text>
 				{ createInterpolateElement(
 					__(
-						'Your site will be placed in the optimal data center, but you can <button>change it</button>.'
+						'We’ll place your site in the best data center for performance, but you can <button>choose a different location</button>.'
 					),
 					{
 						button: (
@@ -63,7 +63,7 @@ export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
 					label={ __( 'Pick your primary data center' ) }
 					help={ createInterpolateElement(
 						__(
-							'Your site is automatically backed up in real-time to another region.<br /><learnMoreLink />'
+							'For redundancy, your site will be replicated in real-time to another region.<br /><learnMoreLink />'
 						),
 						{
 							br: <br />,

--- a/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
@@ -7,7 +7,6 @@ import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import { ButtonStack } from '../../components/button-stack';
 import ComponentViewTracker from '../../components/component-view-tracker';
-import { Notice } from '../../components/notice';
 import { DataCenterForm } from './data-center-form';
 import {
 	hasAnyBlockingError as getHasAnyBlockingError,
@@ -38,13 +37,15 @@ export default function HostingFeatureActivationModal( {
 	const isEligible = data.is_eligible;
 	const needsPlanUpgrade = getHasHoldingError( errors, EligibilityErrors.NO_BUSINESS_PLAN );
 	const hasAnyBlockingError = getHasAnyBlockingError( errors );
+	const cannotActivate = ! isEligible && ! needsPlanUpgrade;
+
+	function handleGetHelp() {
+		setShowHelpCenter( true );
+		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_modal_help_center_click' );
+	}
 
 	function getContent() {
 		const flattenedWarnings = Object.values( warnings ).flat();
-		if ( isEligible && errors.length === 0 && flattenedWarnings.length === 0 ) {
-			return <Notice variant="success">{ __( 'This site is eligible to continue.' ) }</Notice>;
-		}
-
 		return (
 			<>
 				{ errors.length > 0 && <ErrorContentInfo errors={ errors } /> }
@@ -70,26 +71,18 @@ export default function HostingFeatureActivationModal( {
 						onChange={ ( value ) => setSelectedGeoAffinity( value ) }
 					/>
 				) }
-				<ButtonStack justify="space-between">
-					<Button
-						variant="link"
-						onClick={ () => {
-							setShowHelpCenter( true );
-							recordTracksEvent(
-								'calypso_dashboard_hosting_feature_activation_modal_help_center_click'
-							);
-						} }
-					>
-						{ __( 'Need help?' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						disabled={ ! isEligible && ! needsPlanUpgrade }
-						onClick={ handleClick }
-					>
-						{ needsPlanUpgrade ? __( 'Upgrade and continue' ) : __( 'Activate hosting features' ) }
-					</Button>
+				<ButtonStack justify="flex-end">
+					{ cannotActivate ? (
+						<Button __next40pxDefaultSize variant="primary" onClick={ handleGetHelp }>
+							{ __( 'Get help' ) }
+						</Button>
+					) : (
+						<Button __next40pxDefaultSize variant="primary" onClick={ handleClick }>
+							{ needsPlanUpgrade
+								? __( 'Upgrade and continue' )
+								: __( 'Activate hosting features' ) }
+						</Button>
+					) }
 				</ButtonStack>
 			</VStack>
 		</>

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
@@ -1,3 +1,5 @@
+import { siteAutomatedTransfersEligibilityQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { __experimentalText as Text, Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -27,20 +29,31 @@ export default function ActivationCallout( {
 }: ActivationCalloutProps ) {
 	const { recordTracksEvent } = useAnalytics();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const isBackport = isDashboardBackport();
+
+	// Resolve eligibility up front so a click can skip the modal when there is
+	// nothing to surface. The modal reuses this cached query, so it also opens
+	// instantly when it is shown.
+	const { data: eligibility } = useQuery( siteAutomatedTransfersEligibilityQuery( site.ID ) );
+
+	const hasErrors = ( eligibility?.errors.length ?? 0 ) > 0;
+
+	// The modal only has something to show when there are blocking errors or
+	// warnings to surface. A cleanly eligible site can start the transfer
+	// directly, using the optimal (default) data center. The backport modal
+	// keeps its existing behavior.
+	const canStartTransferDirectly =
+		! isBackport &&
+		!! eligibility &&
+		eligibility.is_eligible &&
+		eligibility.errors.length === 0 &&
+		Object.values( eligibility.warnings ).flat().length === 0;
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_impression', {
 			feature_id: tracksFeatureId,
 		} );
 	}, [ recordTracksEvent, tracksFeatureId ] );
-
-	const handleClick = () => {
-		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_click', {
-			feature_id: tracksFeatureId,
-		} );
-
-		setIsModalOpen( true );
-	};
 
 	const handleConfirm = ( options: { geo_affinity?: string } ) => {
 		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_confirm', {
@@ -57,8 +70,21 @@ export default function ActivationCallout( {
 		} );
 	};
 
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_click', {
+			feature_id: tracksFeatureId,
+			show_modal: ! canStartTransferDirectly,
+		} );
+
+		if ( canStartTransferDirectly ) {
+			handleConfirm( {} );
+			return;
+		}
+
+		setIsModalOpen( true );
+	};
+
 	const renderActivationModal = () => {
-		const isBackport = isDashboardBackport();
 		if ( ! isModalOpen ) {
 			return null;
 		}
@@ -86,7 +112,9 @@ export default function ActivationCallout( {
 		return (
 			<Suspense fallback={ null }>
 				<Modal
-					title={ __( 'Before you continue' ) }
+					title={
+						hasErrors ? __( 'Hosting features cannot be activated' ) : __( 'Before you continue' )
+					}
 					onRequestClose={ () => setIsModalOpen( false ) }
 					size="medium"
 				>


### PR DESCRIPTION
Part of DOTCOM-17667

## Proposed Changes

Aligns the MSD Simple-to-Atomic activation modal with the equivalent wp-admin entry point.

* **Start the transfer directly when there's nothing to surface.** Eligibility is resolved up front in the activation callout; when the site is cleanly eligible (eligible, no errors, no warnings), clicking **Activate** starts the transfer immediately (using the optimal/default data center) instead of opening a modal that would only show a redundant "eligible to continue" confirmation. In other words, this version of the modal is no longer displayed:

<img width="400" alt="Screenshot 2026-07-03 at 10 32 14" src="https://github.com/user-attachments/assets/b2271248-39bf-4f71-830b-300632529685" />


* **Data center copy refresh:**
  * "Your site will be placed in the optimal data center, but you can change it." → "We'll place your site in the best data center for performance, but you can choose a different location."
  * "Your site is automatically backed up in real-time to another region." → "For redundancy, your site will be replicated in real-time to another region."
* **Error state:** the modal title becomes "Hosting features cannot be activated", the "Need help?" link is removed, and the primary CTA becomes "Get help" (opens the Help Center) when the site cannot be activated.

Before | After
--- | ---
<img width="581" height="428" alt="Screenshot 2026-07-02 at 17 22 04" src="https://github.com/user-attachments/assets/326a44ab-6910-4d19-9c77-28e26c03b622" /> | <img width="572" height="443" alt="Screenshot 2026-07-03 at 12 45 55" src="https://github.com/user-attachments/assets/bd0482ec-8f65-4a3a-b70d-3f74b68455f0" />
<img width="569" height="231" alt="Screenshot 2026-07-03 at 12 46 47" src="https://github.com/user-attachments/assets/dec3863e-07c7-41f5-a230-55f2eeabfc14" /> | <img width="574" height="241" alt="Screenshot 2026-07-03 at 12 47 09" src="https://github.com/user-attachments/assets/9de7f029-c295-444d-a23e-1eac2d303a60" />



## Why are these changes being made?

To reduce user friction and to align the UI with recent changes in wp-admin.

## Testing Instructions

* Open the MSD using the Calypso live link below.
* Select a site with a Business plan and a custom domain
* Activate the hosting features
* Make sure the Atomic transfer initiates directly, without showing any modal
* Select now a site with a Business plan and without a custom domain
* Activate the hosting features
* Make sure the eligibility modal shows up now
* Check that the copy is correct.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)