### PR TITLE
Calypso E2E: fix flaky Stripe checkout via frameLocator

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -21,10 +21,12 @@ export class MeSidebarComponent {
 	 */
 	async openMobileMenu() {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// Wait for the masterbar to finish re-rendering after page navigation
-			// before clicking, otherwise the element can be detached mid-click.
-			await this.page.waitForLoadState( 'networkidle' );
-			await this.page.getByTitle( 'Menu' ).click();
+			// networkidle hangs here: WordPress.com pages keep polling and may never
+			// go network-quiet. Wait for the Menu toggle itself instead; the locator
+			// click re-resolves if a masterbar re-render detaches it mid-click.
+			const menuToggle = this.page.getByTitle( 'Menu' );
+			await menuToggle.waitFor( { state: 'visible' } );
+			await menuToggle.click();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -2,7 +2,7 @@ import { getCalypsoURL } from '../../data-helper';
 import { waitForElementEnabled } from '../../element-helper';
 import envVariables from '../../env-variables';
 import type { PaymentDetails, RegistrarDetails } from '../../types/data-helper.types';
-import type { Frame, Page } from 'playwright';
+import type { Page } from 'playwright';
 
 const selectors = {
 	// Modal
@@ -333,21 +333,28 @@ export class CartCheckoutPage {
 		// top to bottom.
 		await this.page.fill( selectors.cardholderName, paymentDetails.cardHolder );
 
-		const cardNumberFrameHandle = await this.page.waitForSelector( selectors.cardNumberFrame );
-		const cardNumberFrame = ( await cardNumberFrameHandle.contentFrame() ) as Frame;
-		const cardNumberInput = await cardNumberFrame.waitForSelector( selectors.cardNumberInput );
-		await cardNumberInput.fill( paymentDetails.cardNumber );
+		// Stripe remounts its split-field iframes (__privateStripeFrame ids change),
+		// so resolve each lazily via frameLocator; a cached contentFrame handle goes
+		// stale. Explicit timeout because the 10s global actionTimeout is too short
+		// for a cold Stripe.js mount.
+		const fillTimeout = 30 * 1000;
 
-		const expiryFrameHandle = await this.page.waitForSelector( selectors.cardExpiryFrame );
-		const expiryFrame = ( await expiryFrameHandle.contentFrame() ) as Frame;
-		const expiryInput = await expiryFrame.waitForSelector( selectors.cardExpiryInput );
-		await expiryInput.fill( `${ paymentDetails.expiryMonth }${ paymentDetails.expiryYear }` );
+		const cardNumberInput = this.page
+			.frameLocator( selectors.cardNumberFrame )
+			.locator( selectors.cardNumberInput );
+		await cardNumberInput.fill( paymentDetails.cardNumber, { timeout: fillTimeout } );
 
-		const cvvFrame = ( await (
-			await this.page.waitForSelector( selectors.cardCVVFrame )
-		).contentFrame() ) as Frame;
-		const cvvInput = await cvvFrame.waitForSelector( selectors.cardCVVInput );
-		await cvvInput.fill( paymentDetails.cvv );
+		const expiryInput = this.page
+			.frameLocator( selectors.cardExpiryFrame )
+			.locator( selectors.cardExpiryInput );
+		await expiryInput.fill( `${ paymentDetails.expiryMonth }${ paymentDetails.expiryYear }`, {
+			timeout: fillTimeout,
+		} );
+
+		const cvvInput = this.page
+			.frameLocator( selectors.cardCVVFrame )
+			.locator( selectors.cardCVVInput );
+		await cvvInput.fill( paymentDetails.cvv, { timeout: fillTimeout } );
 	}
 
 	/**

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -355,6 +355,17 @@ test.describe(
 				);
 			} );
 
+			await test.step( 'And I skip the plan step if it appears', async function () {
+				// Adding a domain to a site that already has a paid plan normally lands
+				// straight on checkout, but a plan-eligibility propagation race can
+				// surface the "There's a plan for you" interstitial. When it does, take
+				// the free escape hatch to continue to checkout without adding a plan.
+				await page.waitForURL( /setup\/domain\/plans|\/checkout\// );
+				if ( /setup\/domain\/plans/.test( page.url() ) ) {
+					await pageSignupPickPlan.selectEscapeHatchWithoutSiteCreation( 'Free' );
+				}
+			} );
+
 			await test.step( 'Then I see the domain at checkout', async function () {
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );


### PR DESCRIPTION
Related: p1783036856064929-slack-C0E1C5NCR (pre-release E2E matrix flake report)

Three independent flakes in the same `setup-domain__flows.spec.ts` paid-site flow, each surfaced and fixed in turn:

## Proposed Changes

**1. Stripe checkout payment fill (`CartCheckoutPage.enterPaymentDetails`)**
* Resolves the three Stripe split-field iframes (card number, expiry, CVC) with `frameLocator().locator()` instead of an eager `waitForSelector()` + `contentFrame()` handle.
* Each `fill()` gets an explicit 30s timeout to override the 10s global `actionTimeout`.
* Removed the now-unused `Frame` import.

**2. Mobile menu open (`MeSidebarComponent.openMobileMenu`)**
* Waits for the masterbar Menu toggle to be visible, then clicks, instead of `waitForLoadState('networkidle')`.

**3. Plan interstitial in the add-domain step (`setup-domain__flows.spec.ts`)**
* After selecting the existing site, handles the "There's a plan for you" interstitial if it appears — takes the free escape hatch to continue to checkout without adding a plan. Happy path (auto-skip to checkout) is unchanged.

## Why these changes being made?

**Stripe checkout:**
* The pre-release E2E matrix intermittently failed with the Stripe `cardExpiry` frame/input "resolved to hidden" past the 10s timeout, on both the run and its retry.
* Stripe remounts its split-field iframes as they mount (the `__privateStripeFrame` ids change). A cached `contentFrame()` handle goes stale on remount, so the input inside never resolves. `frameLocator` re-resolves the frame lazily on each action and survives the remount.
* The 10s global `actionTimeout` is too short for a cold Stripe.js load on a slow CI agent; the explicit 30s covers it without loosening the global default.

**Mobile menu:**
* Surfaced on this branch's CI run: the same test hit a 240s test timeout at "navigate to Me > Purchases", in `openMobileMenu`'s `waitForLoadState('networkidle')`.
* `networkidle` requires 500ms of zero network activity; WordPress.com pages keep polling (analytics, notifications) and may never reach it, so the wait hangs to the test timeout. Waiting for the Menu toggle itself is deterministic, and the locator click re-resolves if a masterbar re-render detaches it mid-click (the original reason for the wait).

**Plan interstitial:**
* Surfaced while validating the mobile menu fix: 1 run in 5 failed earlier in the flow, at "I see the domain at checkout". The page snapshot showed the domain flow's "There's a plan for you" interstitial, not checkout.
* Adding a domain to a site that already has a paid plan normally skips the plan step, but a plan-eligibility propagation race (the plan was purchased seconds earlier in the same test) intermittently surfaces the interstitial. Unlike both sibling tests, this one had no handler, so `validateCartItem` waited on a cart that never rendered. The escape hatch is the same non-destructive path the sibling free-site test uses; it does not touch the site's existing paid plan.

## Testing Instructions

* Run the flow against the default staging base URL (`CALYPSO_BASE_URL`), repeated to expose flakiness:
  `yarn workspace wp-e2e-tests playwright test specs/flows/setup-domain__flows.spec.ts --project=pixel --repeat-each=10 -g "add a domain, then cancel the plan"`
* Stripe fix: passed 10/10 on `pixel`. Mobile menu fix exercised on every `pixel` run (the Me > Purchases step runs `openMobileMenu`). Original failures: TeamCity [18379538](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix/18379538) (Stripe expiry frame) and [18384090](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/18384090) (networkidle hang).

## Pre-merge Checklist

- [x] Have you followed the general commit checklist? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes? N/A — test-infrastructure fix to an existing page object; no behavior to unit-test. Covered by the repeated E2E run above.
- [ ] Have you tested the feature in Simple, Atomic, self-hosted Jetpack sites? N/A — E2E harness change.
- [x] Have you checked for TypeScript, React or other console errors? `@automattic/calypso-e2e` builds clean (tsc); pre-commit eslint + prettier pass.
- [ ] For UI changes, tested in dark mode? N/A.
- [ ] Have you tested accessibility changes? N/A.
- [ ] Have you used memoizing on expensive computations? N/A.
- [ ] For strings, followed the i18n guidelines? N/A — no strings.
- [ ] Added "[Status] Needs Privacy Updates" if tracking changed? N/A — no tracking change.
