### PR TITLE
Use VCS filters for merge queue exclusions

### DIFF
--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -1,50 +1,9 @@
 package _self.lib.utils
 
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
-
-const val MERGE_QUEUE_BRANCH_SKIP_PARAM = "mergeQueueBranch.skipBuild"
 const val MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS = """
 -:gh-readonly-queue/*
 -:refs/heads/gh-readonly-queue/*
 """
-const val MERGE_QUEUE_BRANCH_SKIP_MESSAGE =
-	"This check was skipped because this is a merge queue and the check has already been run " +
-		"in the pull request. See: p4TIVU-b5I-p2#comment-12211"
-
-fun BuildSteps.passMergeQueueBranchesEarly(): ScriptBuildStep {
-	return script {
-		name = "Pass merge queue branch early"
-		scriptContent = """
-			#!/usr/bin/env bash
-			set -euo pipefail
-
-			branch="%teamcity.build.branch%"
-
-			case "${'$'}branch" in
-				gh-readonly-queue/*|refs/heads/gh-readonly-queue/*)
-					;;
-				*)
-					exit 0
-					;;
-			esac
-
-			echo "Merge queue branch detected: ${'$'}branch"
-			echo "$MERGE_QUEUE_BRANCH_SKIP_MESSAGE"
-			echo "##teamcity[setParameter name='$MERGE_QUEUE_BRANCH_SKIP_PARAM' value='true']"
-			echo "##teamcity[buildStatus status='SUCCESS' text='$MERGE_QUEUE_BRANCH_SKIP_MESSAGE']"
-		""".trimIndent()
-	}
-}
-
-fun <T : BuildStep> T.skipOnMergeQueueBranch(): T {
-	conditions {
-		doesNotEqual(MERGE_QUEUE_BRANCH_SKIP_PARAM, "true")
-	}
-	return this
-}
 
 fun String.excludeMergeQueueBranches(): String {
 	return """

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -2,8 +2,7 @@ package _self.projects
 
 import Settings
 import _self.bashNodeScript
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
+import _self.lib.utils.allBranchesExceptMergeQueue
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
@@ -38,6 +37,7 @@ object ToSAcceptanceTracking: BuildType ({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -50,7 +50,6 @@ object ToSAcceptanceTracking: BuildType ({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -65,7 +64,7 @@ object ToSAcceptanceTracking: BuildType ({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Capture screenshots"
@@ -82,7 +81,7 @@ object ToSAcceptanceTracking: BuildType ({
 				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=legal
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Collect results"
@@ -102,7 +101,7 @@ object ToSAcceptanceTracking: BuildType ({
 				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	features {

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -1,9 +1,8 @@
 package _self.projects
 
 import _self.bashNodeScript
+import _self.lib.utils.allBranchesExceptMergeQueue
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -102,6 +101,7 @@ object CalypsoApps: BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -120,15 +120,14 @@ object CalypsoApps: BuildType({
 	""".trimIndent()
 
 	steps {
-		passMergeQueueBranchesEarly()
-		mergeTrunk().skipOnMergeQueueBranch()
+		mergeTrunk()
 		bashNodeScript {
 			name = "Install dependencies"
 			scriptContent = """
 				composer install
 				yarn install
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 
 		// Automatically generate a list of apps to build by scanning the directories,
 		// then build every app in parallel using xargs for proper error handling.
@@ -157,7 +156,7 @@ object CalypsoApps: BuildType({
 					yarn workspace "{}" run teamcity:build-app || exit 1
 				'
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 
 		// After the artifacts are built, we process them. This includes comparing
 		// with each previous release (to determine if a new release is needed),
@@ -179,7 +178,7 @@ object CalypsoApps: BuildType({
 
 				node ./bin/process-calypso-app-artifacts.mjs
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	failureConditions {
@@ -197,6 +196,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 		// Only needed so that we can test the job in different branches.
 		vcs {
 			root(Settings.WpCalypso)
+			branchFilter = allBranchesExceptMergeQueue()
 			cleanCheckout = true
 		}
 
@@ -221,7 +221,6 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 		}
 
 		steps {
-			passMergeQueueBranchesEarly()
 			bashNodeScript {
 				name = "Upload Gutenberg source maps to Sentry"
 				scriptContent = """
@@ -238,17 +237,17 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 							--project wpcom-gutenberg-wp-admin \
 							--url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
 				"""
-			}.skipOnMergeQueueBranch()
+			}
 
 			uploadPluginSourceMaps(
 				slug = "wpcom-block-editor",
 				wpcomURL = "~/wpcom-block-editor"
-			).skipOnMergeQueueBranch()
+			)
 
 			uploadPluginSourceMaps(
 				slug = "notifications",
 				wpcomURL = "~/notifications"
-			).skipOnMergeQueueBranch()
+			)
 		}
 	}
 }

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -155,14 +155,14 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 				path = "./bin/post-threaded-slack-message.sh"
 				arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The $buildName passed successfully! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-			}.skipOnMergeQueueBranch()
+			}
 
 			exec {
 				name = "Post Failure Message to Slack"
 				executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 				path = "./bin/post-threaded-slack-message.sh"
 				arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The $buildName failed! Could you have a look?! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-			}.skipOnMergeQueueBranch()
+			}
 		},
 		buildFeatures = {
 			notifyAllFailuresAndFirstSuccess("#gutenberg-e2e")
@@ -178,7 +178,8 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				triggerBuild = always()
 				withPendingChangesOnly = false
 			}
-		}
+		},
+		vcsBranchFilter = allBranchesExceptMergeQueue()
 	)
 }
 
@@ -193,6 +194,7 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 
 		vcs {
 			root(Settings.WpCalypso)
+			branchFilter = allBranchesExceptMergeQueue()
 			cleanCheckout = true
 		}
 
@@ -204,12 +206,11 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		}
 
 		steps {
-			passMergeQueueBranchesEarly()
-			prepareE2eEnvironment().skipOnMergeQueueBranch()
+			prepareE2eEnvironment()
 
-			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration").skipOnMergeQueueBranch()
+			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration")
 
-			collectE2eResults().skipOnMergeQueueBranch()
+			collectE2eResults()
 		}
 
 		features {
@@ -250,6 +251,7 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 
 		vcs {
 			root(Settings.WpCalypso)
+			branchFilter = allBranchesExceptMergeQueue()
 			cleanCheckout = true
 		}
 
@@ -267,8 +269,7 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		}
 
 		steps {
-			passMergeQueueBranchesEarly()
-			prepareE2eEnvironment().skipOnMergeQueueBranch()
+			prepareE2eEnvironment()
 
 			atomicVariations.forEach { variation ->
 				runE2eTestsWithRetry(
@@ -278,10 +279,10 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 						"RUN_ID" to "Atomic: $variation"
 					),
 					stepName = "Run Atomic Jetpack E2E Tests: $variation",
-				).skipOnMergeQueueBranch()
+				)
 			}
 
-			collectE2eResults().skipOnMergeQueueBranch()
+			collectE2eResults()
 		}
 
 		features {
@@ -324,6 +325,7 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 
 		vcs {
 			root(Settings.WpCalypso)
+			branchFilter = allBranchesExceptMergeQueue()
 			cleanCheckout = true
 		}
 
@@ -341,12 +343,11 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 		}
 
 		steps {
-			passMergeQueueBranchesEarly()
-			prepareE2eEnvironment().skipOnMergeQueueBranch()
+			prepareE2eEnvironment()
 
-			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration").skipOnMergeQueueBranch()
+			runE2eTestsWithRetry(testGroup = "jetpack-wpcom-integration")
 
-			collectE2eResults().skipOnMergeQueueBranch()
+			collectE2eResults()
 		}
 
 		features {
@@ -490,20 +491,19 @@ private object GutenbergPlaywrightTests : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		exec {
 			name = "Post Successful Message to Slack"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 			path = "./bin/post-threaded-slack-message.sh"
 			arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The Gutenberg E2E Tests matrix leg passed successfully: %PROJECT%, %EXTRA_ENV_VARS%. <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-		}.skipOnMergeQueueBranch()
+		}
 
 		exec {
 			name = "Post Failure Message to Slack"
 			executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 			path = "./bin/post-threaded-slack-message.sh"
 			arguments = "\"%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID%\" \"%GB_E2E_ANNOUNCEMENT_THREAD_TS%\" \"The Gutenberg E2E Tests failed: %PROJECT%, %EXTRA_ENV_VARS%. Could you have a look?! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" \"%GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%\""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	features {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -6,8 +6,6 @@ import _self.lib.customBuildType.E2EBuildType
 import _self.lib.utils.allBranchesExceptMergeQueue
 import _self.lib.utils.excludeMergeQueueBranches
 import _self.lib.utils.mergeTrunk
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
 import _self.CalypsoE2ETestsBuildTemplate
 
 import jetbrains.buildServer.configs.kotlin.*
@@ -1202,6 +1200,7 @@ object JestPreReleaseE2ETests : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -1250,7 +1249,6 @@ object JestPreReleaseE2ETests : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
@@ -1265,7 +1263,7 @@ object JestPreReleaseE2ETests : BuildType({
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Run tests"
@@ -1291,7 +1289,7 @@ object JestPreReleaseE2ETests : BuildType({
 				RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=calypso-release --onlyFailures --json --outputFile=pre-release-test-results.json
 			"""
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 
 		bashNodeScript {
 			name = "Collect results"
@@ -1312,7 +1310,7 @@ object JestPreReleaseE2ETests : BuildType({
 				find test/e2e/allure-results -name '*.json' -print0 | xargs -r -0 mv -t allure-results
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	failureConditions {
@@ -1344,6 +1342,7 @@ object PreReleaseE2ETests : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,9 +2,7 @@
 import _self.bashNodeScript
 import _self.yarn_install_cmd
 import _self.CalypsoE2ETestsBuildTemplate
-import _self.lib.utils.MERGE_QUEUE_BRANCH_SKIP_PARAM
-import _self.lib.utils.passMergeQueueBranchesEarly
-import _self.lib.utils.skipOnMergeQueueBranch
+import _self.lib.utils.allBranchesExceptMergeQueue
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
@@ -69,7 +67,6 @@ project {
 
 	params {
 		param("env.CI", "true")
-		param(MERGE_QUEUE_BRANCH_SKIP_PARAM, "false")
 		// Force color support in chalk. For some reason it doesn't detect TeamCity
 		// as supported (even though both TeamCity and chalk support that.)
 		param("env.FORCE_COLOR", "1")
@@ -130,17 +127,17 @@ object YarnInstall : BuildType({
 	description = "Installs dependencies, e.g. yarn install"
 	vcs {
 		root(WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Yarn Install"
 			scriptContent = """
 				# Install modules
 				${_self.yarn_install_cmd}
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 	}
 	features {
 		perfmon {
@@ -169,11 +166,11 @@ object BuildBaseImages : BuildType({
 
 	vcs {
 		root(WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		dockerCommand {
 			name = "Build base image"
 			commandType = build {
@@ -184,7 +181,7 @@ object BuildBaseImages : BuildType({
 				commandArgs = "--no-cache --target base --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Build CI e2e image"
 			commandType = build {
@@ -195,7 +192,7 @@ object BuildBaseImages : BuildType({
 				commandArgs = "--target ci-e2e --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Build CI wpcom image"
 			commandType = build {
@@ -206,7 +203,7 @@ object BuildBaseImages : BuildType({
 				commandArgs = "--target ci-wpcom --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Retag images for publish"
 			scriptContent = """
@@ -238,7 +235,7 @@ object BuildBaseImages : BuildType({
 				retag_image registry.a8c.com/calypso/ci-e2e
 				retag_image registry.a8c.com/calypso/ci-wpcom
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Push images"
 			commandType = push {
@@ -247,7 +244,7 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/base:%build.number%
 				""".trimIndent()
 			}
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {
@@ -308,11 +305,11 @@ object BuildToolchainPreviewImages : BuildType({
 
 	vcs {
 		root(WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		val commonArgs = "--pull --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 
 		dockerCommand {
@@ -325,7 +322,7 @@ object BuildToolchainPreviewImages : BuildType({
 				commandArgs = "--target toolchain $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Build CI e2e image"
 			commandType = build {
@@ -336,7 +333,7 @@ object BuildToolchainPreviewImages : BuildType({
 				commandArgs = "--target ci-e2e $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Build CI wpcom image"
 			commandType = build {
@@ -347,7 +344,7 @@ object BuildToolchainPreviewImages : BuildType({
 				commandArgs = "--target ci-wpcom $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Smoke test toolchain image"
 			scriptContent = """
@@ -357,7 +354,7 @@ object BuildToolchainPreviewImages : BuildType({
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/toolchain:%build.number% -lc \
 					'node --version && yarn --version && git --version && jq --version'
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Smoke test CI e2e image"
 			scriptContent = """
@@ -370,7 +367,7 @@ object BuildToolchainPreviewImages : BuildType({
 					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null
 				'
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Smoke test CI wpcom image"
 			scriptContent = """
@@ -380,7 +377,7 @@ object BuildToolchainPreviewImages : BuildType({
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-wpcom:%build.number% -lc \
 					'php -v && composer --version && docker-compose version && sentry-cli --version'
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Retag images for publish"
 			scriptContent = """
@@ -412,7 +409,7 @@ object BuildToolchainPreviewImages : BuildType({
 				retag_image registry.a8c.com/calypso/ci-e2e
 				retag_image registry.a8c.com/calypso/ci-wpcom
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Push images"
 			commandType = push {
@@ -425,7 +422,7 @@ object BuildToolchainPreviewImages : BuildType({
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 			}
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {
@@ -489,11 +486,11 @@ object BuildCacheSeedImages : BuildType({
 
 	vcs {
 		root(WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 
 		dockerCommand {
@@ -506,7 +503,7 @@ object BuildCacheSeedImages : BuildType({
 				commandArgs = "--target cache-seed $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Build cache-seed debug smoke image"
 			commandType = build {
@@ -517,7 +514,7 @@ object BuildCacheSeedImages : BuildType({
 				commandArgs = "--target cache-seed-debug $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Smoke test cache-seed debug image"
 			scriptContent = """
@@ -529,7 +526,7 @@ object BuildCacheSeedImages : BuildType({
 				docker run --rm --entrypoint /bin/bash calypso/cache-seed-smoke:%build.number% -lc \
 					'du -sh /calypso/.cache /calypso/.yarn'
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Retag image for publish"
 			scriptContent = """
@@ -549,7 +546,7 @@ object BuildCacheSeedImages : BuildType({
 					exit 1
 				fi
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Push images"
 			commandType = push {
@@ -558,7 +555,7 @@ object BuildCacheSeedImages : BuildType({
 					registry.a8c.com/calypso/cache-seed:%build.number%
 				""".trimIndent()
 			}
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {
@@ -618,11 +615,11 @@ object BuildCacheSeedPreviewImage : BuildType({
 
 	vcs {
 		root(WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 
 		dockerCommand {
@@ -635,7 +632,7 @@ object BuildCacheSeedPreviewImage : BuildType({
 				commandArgs = "--target cache-seed $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Build cache-seed debug smoke image"
 			commandType = build {
@@ -646,7 +643,7 @@ object BuildCacheSeedPreviewImage : BuildType({
 				commandArgs = "--target cache-seed-debug $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
-		}.skipOnMergeQueueBranch()
+		}
 		script {
 			name = "Smoke test cache-seed debug image"
 			scriptContent = """
@@ -658,13 +655,13 @@ object BuildCacheSeedPreviewImage : BuildType({
 				docker run --rm --entrypoint /bin/bash calypso/cache-seed-smoke:%build.number% -lc \
 					'du -sh /calypso/.cache /calypso/.yarn'
 			""".trimIndent()
-		}.skipOnMergeQueueBranch()
+		}
 		dockerCommand {
 			name = "Push preview image"
 			commandType = push {
 				namesAndTags = "registry.a8c.com/calypso/cache-seed:%build.number%"
 			}
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	failureConditions {
@@ -695,18 +692,18 @@ object CheckCodeStyle : BuildType({
 
 	vcs {
 		root(WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
 				# Install modules
 				${_self.yarn_install_cmd}
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Run linters"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
@@ -714,7 +711,7 @@ object CheckCodeStyle : BuildType({
 				# Lint files
 				yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" .
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 
 	triggers {
@@ -786,6 +783,7 @@ object SmartBuildLauncher : BuildType({
 
 	vcs {
 		root(Settings.WpCalypso)
+		branchFilter = allBranchesExceptMergeQueue()
 		cleanCheckout = true
 	}
 
@@ -812,20 +810,19 @@ object SmartBuildLauncher : BuildType({
 	}
 
 	steps {
-		passMergeQueueBranchesEarly()
 		bashNodeScript {
 			name = "Install and build dependencies"
 			scriptContent = """
 				$yarn_install_cmd
 				yarn workspace @automattic/dependency-finder build
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 		bashNodeScript {
 			name = "Launch relevant builds"
 			scriptContent = """
 				node ./packages/dependency-finder/dist/esm/index.js
 			"""
-		}.skipOnMergeQueueBranch()
+		}
 	}
 })
 


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

* Remove the TeamCity merge-queue early-pass step helper and its step-level skip condition wrapper.
* Move non-required TeamCity builds that previously used the skip helper to VCS branch filters that exclude merge queue branches.
* Keep required WebApp merge-queue checks eligible to run in the merge queue.

## Why are these changes being made?
<!--
It is easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Non-required TeamCity builds should avoid merge queue work through branch selection instead of starting and then succeeding via skipped steps.
* This removes the redundant build-step parameter plumbing and makes merge queue behavior easier to reason about from the VCS filters.

## Testing Instructions

* Run `git diff --check origin/trunk...HEAD -- .teamcity`.
* Run `rg -n "MERGE_QUEUE_BRANCH_SKIP_PARAM|passMergeQueueBranchesEarly|skipOnMergeQueueBranch|mergeQueueBranch\\.skipBuild|Pass merge queue branch early" .teamcity` and verify there are no matches.
* Attempted `mvn -f .teamcity/pom.xml teamcity-configs:generate`, but Maven could not resolve the TeamCity DSL parent POM because `https://teamcity.a8c.com/app/dsl-plugins-repository` timed out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?