### PR TITLE
E2E: fix start-writing-tailored failure and phantom teardown leak

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-writing-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-writing-flow.ts
@@ -14,7 +14,6 @@ export class StartWritingFlow {
 	readonly completedChooseAPlanItem: Locator;
 	readonly completedNameYourBlogItem: Locator;
 	readonly completedWriteFirstPostItem: Locator;
-	readonly connectAccountsButton: Locator;
 	readonly connectToSocialButton: Locator;
 	/** Domain search component within the start writing flow */
 	readonly domainSearchComponent: DomainSearchComponent;
@@ -52,11 +51,14 @@ export class StartWritingFlow {
 		this.completedChooseAPlanItem = this.getCompletedItemLocator( 'Choose a plan' );
 		this.completedNameYourBlogItem = this.getCompletedItemLocator( 'Name your blog' );
 		this.completedWriteFirstPostItem = this.getCompletedItemLocator( 'Write your first post' );
-		this.connectAccountsButton = this.page.getByRole( 'button', { name: 'Connect accounts' } );
 		this.connectToSocialButton = this.page.getByRole( 'button', { name: 'Connect to social' } );
 		this.domainSearchComponent = new DomainSearchComponent( page );
 		this.editorPage = new EditorPage( page );
-		this.jetpackSocialPageHeading = this.page.getByText( 'Write once, post everywhere' );
+		this.jetpackSocialPageHeading = this.page.getByRole( 'heading', {
+			name: 'Social',
+			level: 1,
+			exact: true,
+		} );
 		this.keepUpMomentumText = this.page.getByText( 'Keep up the momentum with these final steps.' );
 		this.launchYourBlogButton = this.page.getByRole( 'button', { name: 'Launch your blog' } );
 		this.nowItsTimeToConnectYourSocialAccountsText = this.page.getByText(

--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -88,7 +88,12 @@ function errorMessage( error: unknown ): string {
  */
 export function isAccountClosedError( error: unknown ): boolean {
 	const message = error instanceof Error ? error.message : String( error ?? '' );
-	return /invalid_token|authorization_required|unauthorized|user_not_found/i.test( message );
+	// `invalid_username` is included because it means the account never existed
+	// (a rejected/throttled signup, surfaced via the bearer-token login fallback),
+	// so like the auth codes above it is a "nothing to leak" signal, not a bug.
+	return /invalid_token|authorization_required|unauthorized|user_not_found|invalid_username/i.test(
+		message
+	);
 }
 
 /**

--- a/packages/calypso-e2e/src/test/teardown-markers.test.ts
+++ b/packages/calypso-e2e/src/test/teardown-markers.test.ts
@@ -105,6 +105,7 @@ describe( 'teardown-markers: isAccountClosedError', () => {
 		'authorization_required: An active access token must be used.',
 		'Request was unauthorized',
 		'user_not_found: account is gone',
+		'invalid_username: no such account (rejected signup)',
 	] )( 'returns true for a dead-token / auth error (%s)', ( message ) => {
 		expect( isAccountClosedError( new Error( message ) ) ).toBe( true );
 	} );

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
@@ -19,6 +19,7 @@ test.describe(
 		test( 'One: As a new WordPress.com blogger I can sign up for a new free site and start writing straight away', async ( {
 			flowStartWriting,
 			helperData,
+			page,
 		} ) => {
 			testUserStartWriting = helperData.getNewTestUser( {
 				usernamePrefix: 'start_writing',
@@ -139,8 +140,15 @@ test.describe(
 			} );
 
 			await test.step( 'Then I see I am taken to the Jetpack Social page', async function () {
-				await expect( flowStartWriting.jetpackSocialPageHeading ).toBeVisible();
-				await expect( flowStartWriting.connectAccountsButton ).toBeVisible();
+				// This is a cross-app load into Jetpack Social wp-admin, which renders
+				// in two variants (a "Write once, post everywhere" splash and an
+				// accounts dashboard). Assert on the URL and h1, the only signals
+				// common to both, with the raised timeout the other cross-navigation
+				// steps in this flow use.
+				await expect( page ).toHaveURL( /jetpack-social/, { timeout: 20000 } );
+				await expect( flowStartWriting.jetpackSocialPageHeading ).toBeVisible( {
+					timeout: 20000,
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
Two fixes for the `signup__start-writing-tailored` Pre-Release E2E failure reported in p1783057519065979-slack-C0E1C5NCR (Pre-Release E2E Tests, build #4587).

## Proposed Changes

* **Jetpack Social assertion.** The page renders in two variants (a "Write once, post everywhere" splash and an accounts dashboard). The final step asserted a heading and a button that exist in only one variant, so it failed whenever the other rendered. It now asserts the two signals common to both, the URL (`/jetpack-social/`) and the `h1` "Social", with the raised timeout the other cross-navigation steps in this flow use. Removed the now-dead `connectAccountsButton` locator.
* **Phantom teardown leak.** A rejected or throttled signup never creates an account, so the teardown close probe fails with `invalid_username` from the bearer-token fallback. `isAccountClosedError` now recognizes it, so the leak check no longer records a marker for an account that never existed.

## Why are these changes being made?

The Jetpack Social page copy/layout changed and now serves two variants; the old locators matched neither reliably, so the test failed across recent Pre-Release runs. Separately, the teardown-leak detector ([TESTOPS-124](https://linear.app/a8c/issue/TESTOPS-124)) flagged a false positive on the same run: a signup rejected by WordPress.com security ([DOTCOM-13534](https://linear.app/a8c/issue/DOTCOM-13534)) has no account to leak, but the probe could not confirm that, so a marker was written and failed the build.

## Testing Instructions

Ran against staging on both `chrome` and `pixel` projects:

```
CALYPSO_BASE_URL=<CALYPSO_BASE_URL> yarn workspace wp-e2e-tests playwright test specs/onboarding/signup__start-writing-tailored.spec.ts --project=chrome --project=pixel --repeat-each=5 --reporter=list
```

* 5x-each: all passing after the fix; the URL + `h1` assertions hold across both page variants.
* `teardown-markers` unit tests pass, including a new `invalid_username` case.
* No leak markers written across ~30 signups, including one confirmed rejected-signup teardown.
