### PR TITLE
A4A: Add combined Earn > Payout settings screen (shared with A4A app)

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
@@ -16,7 +16,7 @@ const useMigrationsMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
 	const { data } = useGetTipaltiPayee();
-	const accountStatus = getAccountStatus( data, translate );
+	const accountStatus = getAccountStatus( data );
 
 	const showIndicator = accountStatus?.actionRequired;
 

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
-import { getAccountStatus } from 'calypso/a8c-for-agencies/sections/referrals/lib/get-account-status';
+import { getAccountStatus } from 'calypso/dashboard/agency/earn/payout-settings/get-account-status';
 import {
 	A4A_MIGRATIONS_LINK,
 	A4A_MIGRATIONS_OVERVIEW_LINK,

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
@@ -16,7 +16,7 @@ const useReferralsMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
 	const { data } = useGetTipaltiPayee();
-	const accountStatus = getAccountStatus( data, translate );
+	const accountStatus = getAccountStatus( data );
 
 	const showIndicator = accountStatus?.actionRequired;
 

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
-import { getAccountStatus } from 'calypso/a8c-for-agencies/sections/referrals/lib/get-account-status';
+import { getAccountStatus } from 'calypso/dashboard/agency/earn/payout-settings/get-account-status';
 import {
 	A4A_REFERRALS_LINK,
 	A4A_REFERRALS_DASHBOARD,

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
@@ -16,7 +16,7 @@ const useWooPaymentsMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
 	const { data } = useGetTipaltiPayee();
-	const accountStatus = getAccountStatus( data, translate );
+	const accountStatus = getAccountStatus( data );
 
 	const showIndicator = accountStatus?.actionRequired;
 

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
-import { getAccountStatus } from 'calypso/a8c-for-agencies/sections/referrals/lib/get-account-status';
+import { getAccountStatus } from 'calypso/dashboard/agency/earn/payout-settings/get-account-status';
 import {
 	A4A_WOOPAYMENTS_LINK,
 	A4A_WOOPAYMENTS_DASHBOARD_LINK,

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -1,7 +1,5 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useLayoutEffect, useState } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -11,7 +9,8 @@ import {
 	A4A_WOOPAYMENTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { getAccountStatus } from 'calypso/dashboard/agency/earn/payout-settings/get-account-status';
+import { TipaltiPayoutSettings } from 'calypso/dashboard/agency/earn/payout-settings/tipalti-payout-settings';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
@@ -19,7 +18,6 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import useGetTipaltiIFrameURL from '../../hooks/use-get-tipalti-iframe-url';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
-import { getAccountStatus } from '../../lib/get-account-status';
 
 import './style.scss';
 
@@ -67,28 +65,12 @@ export default function ReferralsBankDetails( { type }: { type?: 'migrations' | 
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
 
-	const [ iFrameHeight, setIFrameHeight ] = useState( '100%' );
-
 	const { data, isFetching } = useGetTipaltiIFrameURL();
 	const { data: tipaltiData } = useGetTipaltiPayee();
 
 	const accountStatus = getAccountStatus( tipaltiData, translate );
 
 	const iFrameSrc = data?.iframe_url || '';
-
-	const tipaltiHandler = ( event: MessageEvent ) => {
-		if ( event.data && event.data.TipaltiIframeInfo ) {
-			const height = event.data.TipaltiIframeInfo?.height || '100%';
-			setIFrameHeight( height );
-		}
-	};
-
-	useLayoutEffect( () => {
-		window.addEventListener( 'message', tipaltiHandler, false );
-		return () => {
-			window.removeEventListener( 'message', tipaltiHandler, false );
-		};
-	}, [] );
 
 	const { title, mainPageBreadCrumb } = getPageInfo( translate, type, isDesktop );
 
@@ -137,30 +119,11 @@ export default function ReferralsBankDetails( { type }: { type?: 'migrations' | 
 					<div className="bank-details__heading">
 						{ translate( 'Connect your bank to receive payments' ) }
 					</div>
-					<div className="bank-details__subheading">
-						{ translate(
-							'Enter your bank details to start receiving payments through {{a}}Tipalti{{/a}}, our secure payments platform.',
-							{
-								components: {
-									a: (
-										<ExternalLink
-											className="referrals-overview__link"
-											href="https://tipalti.com/"
-											children={ null }
-										/>
-									),
-								},
-							}
-						) }
-					</div>
-
-					<div className="bank-details__iframe-container">
-						{ isFetching ? (
-							<TextPlaceholder />
-						) : (
-							<iframe width="100%" height={ iFrameHeight } src={ iFrameSrc } title={ title } />
-						) }
-					</div>
+					<TipaltiPayoutSettings
+						iframeUrl={ iFrameSrc }
+						isLoading={ isFetching }
+						iframeTitle={ title }
+					/>
 				</>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -68,7 +68,7 @@ export default function ReferralsBankDetails( { type }: { type?: 'migrations' | 
 	const { data, isFetching } = useGetTipaltiIFrameURL();
 	const { data: tipaltiData } = useGetTipaltiPayee();
 
-	const accountStatus = getAccountStatus( tipaltiData, translate );
+	const accountStatus = getAccountStatus( tipaltiData );
 
 	const iFrameSrc = data?.iframe_url || '';
 

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -6,18 +6,6 @@
 
 $iframe-background-color: #f7f7f7;
 
-.bank-details__iframe-container {
-	margin-block-start: 24px;
-	min-height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
-	height: 100%; // Setting the height to 100% to make sure the iFrame is always visible
-
-	.a4a-text-placeholder {
-		display: block;
-		min-height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
-		height: 100%;
-	}
-}
-
 .bank-details__layout.main.hosting-dashboard-layout {
 	height: 100%; // Setting the height to 100% to make sure the iFrame is always visible
 
@@ -33,11 +21,6 @@ $iframe-background-color: #f7f7f7;
 .bank-details__heading {
 	padding-block: 8px;
 	@include heading-x-large;
-}
-
-.bank-details__subheading {
-	@include body-large;
-	color: var(--color-neutral-60);
 }
 
 .bank-details__status {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -60,7 +60,7 @@ export default function LayoutBodyContent( {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_get_started_button_click' ) );
 	}, [ dispatch ] );
 
-	const accountStatus = getAccountStatus( tipaltiData, translate );
+	const accountStatus = getAccountStatus( tipaltiData );
 
 	const hasPayeeAccount = !! accountStatus?.status;
 	const bankAccountCTAText = hasPayeeAccount

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -21,12 +21,12 @@ import {
 import WooLogoColor from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { getAccountStatus } from 'calypso/dashboard/agency/earn/payout-settings/get-account-status';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import ConsolidatedViews from '../../consolidated-view';
-import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
 import ReferralList from '../../referrals-list';
 import type { Referral, ReferralCommissionPayoutResponse } from '../../types';

--- a/client/dashboard/agency/earn/payout-settings/get-account-status.ts
+++ b/client/dashboard/agency/earn/payout-settings/get-account-status.ts
@@ -1,18 +1,17 @@
-interface StatusMeta {
+import { __ } from '@wordpress/i18n';
+import type { TipaltiPayee } from '@automattic/api-core';
+
+interface AccountStatus {
 	statusType: 'success' | 'warning' | 'error';
 	status: string;
 	statusReason?: string;
 	actionRequired: boolean;
 }
 
-export const getAccountStatus = (
-	data: {
-		Status: string;
-		IsPayable: boolean;
-		PayableReason: string[];
-	} | null,
-	translate: ( key: string ) => string
-): StatusMeta | null => {
+export function getAccountStatus(
+	data: TipaltiPayee | null | undefined,
+	translate: ( key: string ) => string = __
+): AccountStatus | null {
 	if ( ! data ) {
 		return null;
 	}
@@ -71,6 +70,6 @@ export const getAccountStatus = (
 
 	return {
 		...statusMeta,
-		actionRequired: [ 'warning', 'error' ].includes( statusMeta?.statusType ),
-	} as StatusMeta;
-};
+		actionRequired: [ 'warning', 'error' ].includes( statusMeta.statusType ),
+	} as AccountStatus;
+}

--- a/client/dashboard/agency/earn/payout-settings/get-account-status.ts
+++ b/client/dashboard/agency/earn/payout-settings/get-account-status.ts
@@ -8,10 +8,7 @@ interface AccountStatus {
 	actionRequired: boolean;
 }
 
-export function getAccountStatus(
-	data: TipaltiPayee | null | undefined,
-	translate: ( key: string ) => string = __
-): AccountStatus | null {
+export function getAccountStatus( data: TipaltiPayee | null | undefined ): AccountStatus | null {
 	if ( ! data ) {
 		return null;
 	}
@@ -22,13 +19,13 @@ export function getAccountStatus(
 			if ( ! IsPayable ) {
 				statusMeta = {
 					statusType: 'warning',
-					status: translate( 'Not Payable' ),
+					status: __( 'Not Payable' ),
 					statusReason: PayableReason?.map( ( reason ) => {
 						if ( reason === 'No PM' ) {
-							return translate( 'Bank details are missing' );
+							return __( 'Bank details are missing' );
 						}
 						if ( reason === 'Tax' ) {
-							return translate( 'Tax form is missing' );
+							return __( 'Tax form is missing' );
 						}
 						return reason;
 					} ).join( ', ' ),
@@ -37,27 +34,27 @@ export function getAccountStatus(
 			}
 			statusMeta = {
 				statusType: 'success',
-				status: translate( 'Confirmed' ),
+				status: __( 'Confirmed' ),
 			};
 			break;
 		case 'Suspended':
 			statusMeta = {
 				statusType: 'error',
-				status: translate( 'Suspended' ),
+				status: __( 'Suspended' ),
 			};
 			break;
 		case 'Blocked':
 			statusMeta = {
 				statusType: 'error',
-				status: translate( 'Blocked' ),
-				statusReason: translate( 'Your account is blocked' ),
+				status: __( 'Blocked' ),
+				statusReason: __( 'Your account is blocked' ),
 			};
 			break;
 		case 'Closed':
 			statusMeta = {
 				statusType: 'error',
-				status: translate( 'Closed' ),
-				statusReason: translate( 'Your account is closed' ),
+				status: __( 'Closed' ),
+				statusReason: __( 'Your account is closed' ),
 			};
 			break;
 		default:

--- a/client/dashboard/agency/earn/payout-settings/index.tsx
+++ b/client/dashboard/agency/earn/payout-settings/index.tsx
@@ -39,7 +39,10 @@ export default function EarnPayoutSettings() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id ?? 0;
 
-	const { data: iframeData, isLoading } = useQuery( tipaltiIFrameUrlQuery( agencyId ) );
+	const { data: iframeData, isLoading } = useQuery( {
+		...tipaltiIFrameUrlQuery( agencyId ),
+		refetchOnWindowFocus: false,
+	} );
 
 	return (
 		<PageLayout

--- a/client/dashboard/agency/earn/payout-settings/index.tsx
+++ b/client/dashboard/agency/earn/payout-settings/index.tsx
@@ -1,18 +1,57 @@
+import {
+	activeAgencyQuery,
+	tipaltiIFrameUrlQuery,
+	tipaltiPayeeQuery,
+} from '@automattic/api-queries';
+import { Badge } from '@automattic/ui';
+import { useQuery } from '@tanstack/react-query';
+import { __experimentalHStack as HStack, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { Text } from '../../../components/text';
+import { getAccountStatus } from './get-account-status';
+import { TipaltiPayoutSettings } from './tipalti-payout-settings';
+
+function PaymentStatusBadge( { agencyId }: { agencyId: number } ) {
+	const { data: payee } = useQuery( tipaltiPayeeQuery( agencyId ) );
+	const accountStatus = getAccountStatus( payee );
+
+	if ( ! accountStatus ) {
+		return null;
+	}
+
+	const badge = <Badge intent={ accountStatus.statusType }>{ accountStatus.status }</Badge>;
+
+	return (
+		<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
+			<Text>{ __( 'Payment status:' ) }</Text>
+			{ accountStatus.statusReason ? (
+				<Tooltip text={ accountStatus.statusReason }>{ badge }</Tooltip>
+			) : (
+				badge
+			) }
+		</HStack>
+	);
+}
 
 export default function EarnPayoutSettings() {
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const agencyId = agency?.id ?? 0;
+
+	const { data: iframeData, isLoading } = useQuery( tipaltiIFrameUrlQuery( agencyId ) );
+
 	return (
 		<PageLayout
 			header={
 				<PageHeader
 					title={ __( 'Payout settings' ) }
 					description={ __( 'Manage where and how your agency gets paid.' ) }
+					actions={ agencyId ? <PaymentStatusBadge agencyId={ agencyId } /> : undefined }
 				/>
 			}
 		>
-			{ /* TODO: Build the Earn payout settings screen. */ }
+			<TipaltiPayoutSettings iframeUrl={ iframeData?.iframe_url } isLoading={ isLoading } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/agency/earn/payout-settings/style.scss
+++ b/client/dashboard/agency/earn/payout-settings/style.scss
@@ -1,0 +1,9 @@
+.earn-payout-settings-iframe-container {
+	display: flex;
+	justify-content: center;
+	min-height: 60vh;
+
+	iframe {
+		border: none;
+	}
+}

--- a/client/dashboard/agency/earn/payout-settings/tipalti-payout-settings.tsx
+++ b/client/dashboard/agency/earn/payout-settings/tipalti-payout-settings.tsx
@@ -20,7 +20,21 @@ export function TipaltiPayoutSettings( {
 	const [ iframeHeight, setIframeHeight ] = useState( '100%' );
 
 	useEffect( () => {
+		if ( ! iframeUrl ) {
+			return;
+		}
+
+		let allowedOrigin: string;
+		try {
+			allowedOrigin = new URL( iframeUrl ).origin;
+		} catch {
+			return;
+		}
+
 		const handleMessage = ( event: MessageEvent ) => {
+			if ( event.origin !== allowedOrigin ) {
+				return;
+			}
 			if ( event.data?.TipaltiIframeInfo ) {
 				setIframeHeight( event.data.TipaltiIframeInfo.height || '100%' );
 			}
@@ -28,7 +42,7 @@ export function TipaltiPayoutSettings( {
 
 		window.addEventListener( 'message', handleMessage, false );
 		return () => window.removeEventListener( 'message', handleMessage, false );
-	}, [] );
+	}, [ iframeUrl ] );
 
 	return (
 		<VStack spacing={ 4 }>

--- a/client/dashboard/agency/earn/payout-settings/tipalti-payout-settings.tsx
+++ b/client/dashboard/agency/earn/payout-settings/tipalti-payout-settings.tsx
@@ -1,0 +1,55 @@
+import { __experimentalVStack as VStack, ExternalLink, Spinner } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+import { Text } from '../../../components/text';
+
+import './style.scss';
+
+interface TipaltiPayoutSettingsProps {
+	iframeUrl?: string;
+	isLoading?: boolean;
+	iframeTitle?: string;
+}
+
+export function TipaltiPayoutSettings( {
+	iframeUrl = '',
+	isLoading = false,
+	iframeTitle = __( 'Payout settings' ),
+}: TipaltiPayoutSettingsProps ) {
+	const [ iframeHeight, setIframeHeight ] = useState( '100%' );
+
+	useEffect( () => {
+		const handleMessage = ( event: MessageEvent ) => {
+			if ( event.data?.TipaltiIframeInfo ) {
+				setIframeHeight( event.data.TipaltiIframeInfo.height || '100%' );
+			}
+		};
+
+		window.addEventListener( 'message', handleMessage, false );
+		return () => window.removeEventListener( 'message', handleMessage, false );
+	}, [] );
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text>
+				{ createInterpolateElement(
+					__(
+						'Enter your bank details to start receiving payments through <a>Tipalti</a>, our secure payments platform.'
+					),
+					{
+						a: <ExternalLink href="https://tipalti.com/" children={ null } />,
+					}
+				) }
+			</Text>
+
+			<div className="earn-payout-settings-iframe-container">
+				{ isLoading || ! iframeUrl ? (
+					<Spinner />
+				) : (
+					<iframe title={ iframeTitle } src={ iframeUrl } width="100%" height={ iframeHeight } />
+				) }
+			</div>
+		</VStack>
+	);
+}

--- a/packages/api-core/src/agency/fetchers.ts
+++ b/packages/api-core/src/agency/fetchers.ts
@@ -5,6 +5,8 @@ import type {
 	AgencyResourcesResponse,
 	McpSettings,
 	McpSettingsUpdate,
+	TipaltiIFrameUrl,
+	TipaltiPayee,
 } from './types';
 
 export async function fetchAgency(): Promise< AgencyApiResponse > {
@@ -57,4 +59,21 @@ export async function updateAgencyMcpSettings(
 		},
 		input
 	);
+}
+
+export async function fetchTipaltiIFrameUrl( agencyId: number ): Promise< TipaltiIFrameUrl > {
+	return wpcom.req.get(
+		{
+			path: '/agency/embeds/tipalti',
+			apiNamespace: 'wpcom/v2',
+		},
+		{ agency_id: agencyId }
+	);
+}
+
+export async function fetchTipaltiPayee( agencyId: number ): Promise< TipaltiPayee > {
+	return wpcom.req.get( {
+		path: `/agency/${ agencyId }/tipalti`,
+		apiNamespace: 'wpcom/v2',
+	} );
 }

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -95,3 +95,13 @@ export interface AgencyResourcesResponse {
 	results: AgencyResource[];
 	total: number;
 }
+
+export interface TipaltiIFrameUrl {
+	iframe_url: string;
+}
+
+export interface TipaltiPayee {
+	Status: string;
+	IsPayable: boolean;
+	PayableReason: string[];
+}

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -97,7 +97,6 @@ export const tipaltiIFrameUrlQuery = ( agencyId: number ) =>
 		queryKey: [ 'agency', agencyId, 'tipalti-iframe-url' ] as const,
 		queryFn: () => fetchTipaltiIFrameUrl( agencyId ),
 		enabled: !! agencyId,
-		refetchOnWindowFocus: false,
 	} );
 
 export const tipaltiPayeeQuery = ( agencyId: number ) =>
@@ -105,7 +104,6 @@ export const tipaltiPayeeQuery = ( agencyId: number ) =>
 		queryKey: [ 'agency', agencyId, 'tipalti-payee' ] as const,
 		queryFn: () => fetchTipaltiPayee( agencyId ),
 		enabled: !! agencyId,
-		refetchOnWindowFocus: false,
 	} );
 
 export const mcpSettingsQuery = ( agencyId: number ) =>

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -4,6 +4,8 @@ import {
 	fetchAgencyScheduleCallLink,
 	fetchAgencyMcpSettings,
 	updateAgencyMcpSettings,
+	fetchTipaltiIFrameUrl,
+	fetchTipaltiPayee,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -88,6 +90,22 @@ export const agencyResourcesQuery = () =>
 		queryKey: [ 'agency', 'resources' ] as const,
 		queryFn: fetchAgencyResources,
 		staleTime: 5 * 60 * 1000,
+	} );
+
+export const tipaltiIFrameUrlQuery = ( agencyId: number ) =>
+	queryOptions( {
+		queryKey: [ 'agency', agencyId, 'tipalti-iframe-url' ] as const,
+		queryFn: () => fetchTipaltiIFrameUrl( agencyId ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+
+export const tipaltiPayeeQuery = ( agencyId: number ) =>
+	queryOptions( {
+		queryKey: [ 'agency', agencyId, 'tipalti-payee' ] as const,
+		queryFn: () => fetchTipaltiPayee( agencyId ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
 	} );
 
 export const mcpSettingsQuery = ( agencyId: number ) =>


### PR DESCRIPTION
Resolves A4A-2846, A4A-2850, A4A-2858.

## Proposed Changes

* Build the MSD **Earn → Payout settings** screen (`/earn/payout-settings`), combining what were three separate A4A payout/payment settings screens (Referrals, Migrations, WooPayments) into a single Tipalti "set up secure payments" screen.
* Extract the Tipalti iframe body into a shared presentational component `TipaltiPayoutSettings` (lives in `client/dashboard`, consumed by both the dashboard and the A4A app).
* Consolidate `getAccountStatus` into a single shared source (removing the A4A copy); it now serves the A4A bank-details screen, A4A sidebar menu items, and the dashboard status badge.
* Add Tipalti iframe-URL and payee fetchers/types (`@automattic/api-core`) and query options (`@automattic/api-queries`) for the dashboard to consume. The A4A app keeps its own `useGetTipaltiIFrameURL`/`useGetTipaltiPayee` hooks (they resolve `agencyId` from Redux), so the two surfaces fetch the same endpoints via their own query layer rather than a single shared one.
* Refactor the A4A `ReferralsBankDetails` screen to render the shared component and drop its now-duplicated iframe markup, message listener, and dead CSS.

## Why are these changes being made?

* The three A4A payout-settings screens were the same component rendered with a `type` prop; the MSD design merges them into one Payout settings screen under Earn.
* Both the A4A app and the MSD dashboard will be maintained side by side for a while, so the shared iframe component and `getAccountStatus` keep the two surfaces in sync instead of drifting as duplicated copies. The data-fetching layer is not consolidated (A4A stays on its Redux-based hooks); only the presentational component and status logic are shared.

## Testing Instructions

* Open the Dashboard (A4A) live link > Manually change the URL to `/overview`, then go to **Earn → Payout settings** (`/earn/payout-settings`).
    * Confirm the Tipalti "connect your bank" content and iframe load, and that the **Payment status** badge appears (aligned with its label) when the agency has a Tipalti payee record.
* Open the A4A live link > visit the Referrals, Migrations, and WooPayments payment settings screens.
    * Confirm they still render the Tipalti iframe correctly (now via the shared component) and that the sidebar "action required" indicators still behave as before.

<img width="1916" height="927" alt="Screenshot 2026-07-03 at 3 14 34 PM" src="https://github.com/user-attachments/assets/4eaa9bd9-cbf9-430a-87f0-fb005755a41f" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

