### PR TITLE
Replace lodash in build-languages; guard mapKeys/pick/chain

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -4,7 +4,6 @@ const { writeFile } = require( 'fs' ).promises;
 const path = require( 'path' );
 const languages = require( '@automattic/languages' );
 const parse = require( 'gettext-parser' ).po.parse;
-const _ = require( 'lodash' );
 
 const LANGUAGES_BASE_URL = 'https://widgets.wp.com/languages/calypso';
 const LANGUAGES_REVISIONS_FILENAME = 'lang-revisions.json';
@@ -19,6 +18,22 @@ const DECIMAL_POINT_KEY = 'number_format_decimals';
 const DECIMAL_POINT_TRANSLATION = 'number_format_decimal_point';
 const THOUSANDS_SEPARATOR_KEY = 'number_format_thousands_sep';
 const THOUSANDS_SEPARATOR_TRANSLATION = 'number_format_thousands_sep';
+
+// Keys lodash `pick` refuses to set (its prototype-pollution guard), so a
+// translated string named exactly one of these is dropped rather than picked.
+const PICK_BLOCKED_KEYS = new Set( [ '__proto__', 'constructor', 'prototype' ] );
+
+// Selects the given keys from `object`, keeping only those present. Mirrors
+// lodash `pick`, including dropping the protected keys above.
+function pick( object, keys ) {
+	const result = {};
+	for ( const key of keys ) {
+		if ( ! PICK_BLOCKED_KEYS.has( key ) && Object.hasOwn( object, key ) ) {
+			result[ key ] = object[ key ];
+		}
+	}
+	return result;
+}
 
 // Create languages directory
 function createLanguagesDir() {
@@ -97,24 +112,29 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 
 	if ( fs.existsSync( CALYPSO_STRINGS ) ) {
 		const { translations } = parse( fs.readFileSync( CALYPSO_STRINGS ) );
-		const translationsFlatten = Object.entries( translations ).reduce(
-			( result, [ context, contextTranslations ] ) => {
-				const mappedTranslations = _.mapKeys( contextTranslations, ( value, key ) => {
-					let mappedKey = key.replace( /\\u([0-9a-fA-F]{4})/g, ( match, matchedGroup ) =>
-						String.fromCharCode( parseInt( matchedGroup, 16 ) )
-					);
+		// Flatten every context's translations into one object, keyed by an
+		// unescaped, context-prefixed key. Those keys are unique per context, so a
+		// plain assignment never overwrites across contexts.
+		const translationsFlatten = {};
+		for ( const [ context, contextTranslations ] of Object.entries( translations ) ) {
+			for ( const [ key, value ] of Object.entries( contextTranslations ) ) {
+				let mappedKey = key.replace( /\\u([0-9a-fA-F]{4})/g, ( match, matchedGroup ) =>
+					String.fromCharCode( parseInt( matchedGroup, 16 ) )
+				);
 
-					if ( context ) {
-						mappedKey = context + String.fromCharCode( 4 ) + mappedKey;
-					}
+				if ( context ) {
+					mappedKey = context + String.fromCharCode( 4 ) + mappedKey;
+				}
 
-					return mappedKey;
-				} );
+				// Skip `__proto__`: assigning it would mutate the prototype instead of
+				// adding an own key.
+				if ( mappedKey === '__proto__' ) {
+					continue;
+				}
 
-				return _.merge( result, mappedTranslations );
-			},
-			{}
-		);
+				translationsFlatten[ mappedKey ] = value;
+			}
+		}
 		const translationsByRef = Object.keys( translationsFlatten ).reduce( ( acc, key ) => {
 			const originalRef = translationsFlatten[ key ].comments.reference;
 
@@ -138,7 +158,8 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 		// CHUNKS_MAP_PATTERN is relative to the project root, while require is relative to current dir. Hence the `../`
 		const chunksMap = require( '../' + CHUNKS_MAP_PATTERN );
 
-		const chunks = _.mapValues( chunksMap, ( modules ) => {
+		const chunks = {};
+		for ( const [ chunkName, modules ] of Object.entries( chunksMap ) ) {
 			const strings = new Set();
 
 			modules.forEach( ( modulePath ) => {
@@ -157,21 +178,25 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 				stringsFromModule.forEach( ( string ) => strings.add( string ) );
 			} );
 
-			return [ ...strings ];
-		} );
+			chunks[ chunkName ] = [ ...strings ];
+		}
 
 		successfullyDownloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
-			const languageChunks = _.chain( chunks )
-				.mapValues( ( stringIds ) => _.pick( languageTranslations, stringIds ) )
-				.omitBy( ( chunk ) => Object.keys( chunk ).length === 0 )
-				.value();
+			const languageChunks = {};
+			for ( const [ chunkName, stringIds ] of Object.entries( chunks ) ) {
+				const chunkTranslations = pick( languageTranslations, stringIds );
+				// Omit chunks with no translated strings.
+				if ( Object.keys( chunkTranslations ).length > 0 ) {
+					languageChunks[ chunkName ] = chunkTranslations;
+				}
+			}
 
 			// Write language translated chunks map
 			const translatedChunksKeys = Object.keys( languageChunks ).map(
 				( chunk ) => path.parse( chunk ).name
 			);
 			const manifestJsonDataRaw = {
-				locale: _.pick( languageTranslations, [ CONFIG_BLOCK_KEY ] ),
+				locale: pick( languageTranslations, [ CONFIG_BLOCK_KEY ] ),
 				translatedChunks: translatedChunksKeys,
 			};
 			manifestJsonDataRaw.locale[ DECIMAL_POINT_KEY ] =

--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -19,12 +19,13 @@ const DECIMAL_POINT_TRANSLATION = 'number_format_decimal_point';
 const THOUSANDS_SEPARATOR_KEY = 'number_format_thousands_sep';
 const THOUSANDS_SEPARATOR_TRANSLATION = 'number_format_thousands_sep';
 
-// Keys lodash `pick` refuses to set (its prototype-pollution guard), so a
-// translated string named exactly one of these is dropped rather than picked.
+// Prototype-related keys a translated string must never introduce as data:
+// assigning `__proto__` would mutate the prototype rather than add a key, so all
+// three are skipped defensively.
 const PICK_BLOCKED_KEYS = new Set( [ '__proto__', 'constructor', 'prototype' ] );
 
-// Selects the given keys from `object`, keeping only those present. Mirrors
-// lodash `pick`, including dropping the protected keys above.
+// Selects the given keys from `object` that are present, excluding the
+// prototype-related keys above.
 function pick( object, keys ) {
 	const result = {};
 	for ( const key of keys ) {

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -275,9 +275,9 @@ const patterns = [
 // backstopped by the `eslint-plugin-you-dont-need-lodash-underscore` rules in
 // the root config, but that plugin ships no rule for these, so they get their
 // own namespace/CommonJS guards below. Only add a function here once its
-// namespace/CommonJS usages are also gone — e.g. `mapValues` is guarded for ES
-// imports above but still used as `_.mapValues` in build tooling, so it stays
-// out until that is migrated.
+// namespace/CommonJS usages are also gone — e.g. `merge` is guarded for ES
+// imports above but still destructured from `require( 'lodash' )` in the repo's
+// own `.eslintrc.js`, so it stays out until that is migrated.
 const NAMESPACE_GUARDED = [
 	{ name: 'isEmpty', message: JS_UTILS_MESSAGE },
 	{ name: 'memoize', message: JS_UTILS_MESSAGE },
@@ -292,7 +292,6 @@ const NAMESPACE_GUARDED = [
 	{ name: 'compact', message: COMPACT_MESSAGE },
 	{ name: 'groupBy', message: JS_UTILS_MESSAGE },
 	{ name: 'chunk', message: CHUNK_MESSAGE },
-	{ name: 'merge', message: MERGE_MESSAGE },
 	{ name: 'mapKeys', message: JS_UTILS_MESSAGE },
 	{ name: 'pick', message: JS_UTILS_MESSAGE },
 	{ name: 'chain', message: CHAIN_MESSAGE },

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -73,6 +73,9 @@ const COMPACT_MESSAGE = 'Please use `array.filter( Boolean )` instead of lodash 
 const CHUNK_MESSAGE =
 	'Please split with a small loop (`for ( let i = 0; i < array.length; i += size ) ' +
 	'chunks.push( array.slice( i, i + size ) )`) instead of lodash `chunk`.';
+const CHAIN_MESSAGE =
+	'Please call the operations in sequence (native array/object methods, or a small loop) ' +
+	'instead of a lodash `chain( … )` sequence ending in `.value()`.';
 const FLATTEN_MESSAGE = 'Please use native `array.flatMap()` / `array.flat()` instead.';
 const DEFER_MESSAGE = 'Please use native `setTimeout( fn, 0 )` instead of lodash `defer`.';
 const DELAY_MESSAGE = 'Please use native `setTimeout( fn, wait )` instead of lodash `delay`.';
@@ -178,6 +181,7 @@ const paths = [
 	{ name: 'lodash', importNames: COMPOSE_NAMES, message: COMPOSE_MESSAGE },
 	{ name: 'lodash', importNames: [ 'compact' ], message: COMPACT_MESSAGE },
 	{ name: 'lodash', importNames: [ 'chunk' ], message: CHUNK_MESSAGE },
+	{ name: 'lodash', importNames: [ 'chain' ], message: CHAIN_MESSAGE },
 	{ name: 'lodash', importNames: [ 'flatMap', 'flatten' ], message: FLATTEN_MESSAGE },
 	{ name: 'lodash', importNames: [ 'defer' ], message: DEFER_MESSAGE },
 	{ name: 'lodash', importNames: [ 'delay' ], message: DELAY_MESSAGE },
@@ -225,6 +229,7 @@ const patterns = [
 	{ group: COMPOSE_NAMES.map( ( name ) => `lodash/${ name }` ), message: COMPOSE_MESSAGE },
 	{ group: [ 'lodash/compact' ], message: COMPACT_MESSAGE },
 	{ group: [ 'lodash/chunk' ], message: CHUNK_MESSAGE },
+	{ group: [ 'lodash/chain' ], message: CHAIN_MESSAGE },
 	{ group: [ 'lodash/flatMap', 'lodash/flatten' ], message: FLATTEN_MESSAGE },
 	{ group: [ 'lodash/defer' ], message: DEFER_MESSAGE },
 	{ group: [ 'lodash/delay' ], message: DELAY_MESSAGE },
@@ -270,9 +275,9 @@ const patterns = [
 // backstopped by the `eslint-plugin-you-dont-need-lodash-underscore` rules in
 // the root config, but that plugin ships no rule for these, so they get their
 // own namespace/CommonJS guards below. Only add a function here once its
-// namespace/CommonJS usages are also gone — e.g. `merge` is guarded for ES
-// imports above but still used as `_.merge` in build tooling, so it stays out
-// until that is migrated.
+// namespace/CommonJS usages are also gone — e.g. `mapValues` is guarded for ES
+// imports above but still used as `_.mapValues` in build tooling, so it stays
+// out until that is migrated.
 const NAMESPACE_GUARDED = [
 	{ name: 'isEmpty', message: JS_UTILS_MESSAGE },
 	{ name: 'memoize', message: JS_UTILS_MESSAGE },
@@ -287,6 +292,10 @@ const NAMESPACE_GUARDED = [
 	{ name: 'compact', message: COMPACT_MESSAGE },
 	{ name: 'groupBy', message: JS_UTILS_MESSAGE },
 	{ name: 'chunk', message: CHUNK_MESSAGE },
+	{ name: 'merge', message: MERGE_MESSAGE },
+	{ name: 'mapKeys', message: JS_UTILS_MESSAGE },
+	{ name: 'pick', message: JS_UTILS_MESSAGE },
+	{ name: 'chain', message: CHAIN_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).


### PR DESCRIPTION
## Proposed Changes

* Remove lodash from the `build-languages` build script: flatten the per-context translations with a plain loop (in place of `mapKeys` + `merge`), build the chunk→strings map with a loop (in place of `mapValues`), unwind the `chain(...).mapValues().omitBy().value()` sequence into a single loop, and pick translations with a small local helper (in place of `pick`).
* With no `_.mapKeys`/`_.pick`/`_.chain` namespace usages left anywhere, add them to the namespace/CommonJS lint guard (and give `chain` a full guard). `merge` stays out of the namespace guard for now — the repo's own `.eslintrc.js` still destructures it from `require( 'lodash' )` for config composition — so that migration is left as a focused follow-up.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase. This is an un-transpiled CommonJS build script, so it uses small native replacements rather than a shared built utility. The mapped translation keys are context-prefixed and therefore unique, so the previous deep merge only ever accumulated keys — a plain assignment is equivalent; the native selection keeps only keys actually present, and drops the protected keys lodash `pick`/`merge` refused. Locking these functions at the namespace level prevents reintroduction now that the last build-tooling usages are gone.

## Testing Instructions

* This script builds per-language translation chunk manifests from downloaded language data; exercise the language build and confirm the generated `language-manifest.json` and chunk maps are unchanged.
* Confirm `_.mapKeys`/`_.pick`/`_.chain` (and `import { … } from 'lodash'`) now trip the lint guard, and that `yarn eslint .eslintrc.js` still passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
