### PR TITLE
Filter merge queue PR triggers

### DIFF
--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -4,12 +4,26 @@ const val MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS = """
 -:gh-readonly-queue/*
 -:refs/heads/gh-readonly-queue/*
 """
+const val MERGE_QUEUE_PULL_REQUEST_FILTER_EXCLUSIONS = """
+-pr:source=gh-readonly-queue/*
+"""
 
 fun String.excludeMergeQueueBranches(): String {
 	return """
 		${this.trimIndent()}
 		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
 	""".trimIndent()
+}
+
+fun String.excludeMergeQueuePullRequests(): String {
+	return """
+		${this.trimIndent()}
+		${MERGE_QUEUE_PULL_REQUEST_FILTER_EXCLUSIONS.trim()}
+	""".trimIndent()
+}
+
+fun String.excludeMergeQueueBranchesAndPullRequests(): String {
+	return this.excludeMergeQueueBranches().excludeMergeQueuePullRequests()
 }
 
 fun allBranchesExceptMergeQueue(): String {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -4,7 +4,7 @@ import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
 import _self.lib.utils.allBranchesExceptMergeQueue
-import _self.lib.utils.excludeMergeQueueBranches
+import _self.lib.utils.excludeMergeQueueBranchesAndPullRequests
 import _self.lib.utils.mergeTrunk
 import _self.CalypsoE2ETestsBuildTemplate
 
@@ -908,7 +908,7 @@ object Translate : BuildType({
 			branchFilter = """
 				+:*
 				-:pull*
-			""".excludeMergeQueueBranches()
+			""".excludeMergeQueueBranchesAndPullRequests()
 		}
 	}
 
@@ -976,7 +976,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 					+:*
 					-:pull*
 					-:trunk
-				""".excludeMergeQueueBranches()
+				""".excludeMergeQueueBranchesAndPullRequests()
 				triggerRules = """
 					-:**.md
 				""".trimIndent()
@@ -1027,7 +1027,7 @@ object PlaywrightTestPRMatrix : BuildType({
 				+:*
 				-:pull*
 				-:trunk
-			""".excludeMergeQueueBranches()
+			""".excludeMergeQueueBranchesAndPullRequests()
 			triggerRules = """
 				-:**.md
 			""".trimIndent()
@@ -1115,7 +1115,7 @@ object PlaywrightTestDashboardPRMatrix : BuildType({
 				+:*
 				-:pull*
 				-:trunk
-			""".excludeMergeQueueBranches()
+			""".excludeMergeQueueBranchesAndPullRequests()
 			triggerRules = """
 				-:**.md
 				+:client/dashboard/**
@@ -1169,7 +1169,7 @@ object PlaywrightTestA4APRMatrix : BuildType({
 				+:*
 				-:pull*
 				-:trunk
-			""".excludeMergeQueueBranches()
+			""".excludeMergeQueueBranchesAndPullRequests()
 			triggerRules = """
 				-:**.md
 				+:client/a8c-for-agencies/**


### PR DESCRIPTION
## Proposed Changes

* Add a TeamCity merge queue pull request trigger exclusion helper using `-pr:source=gh-readonly-queue/*`.
* Apply it to WebApp VCS trigger filters that already exclude merge queue branches.

## Why are these changes being made?

* The existing branch filters exclude `gh-readonly-queue/*` as normal branch names, but TeamCity pull request trigger filters use `-pr:` expressions. Adding the PR-source exclusion gives these VCS triggers a matching rule for PR-style merge queue branches without reintroducing runtime skip steps.

## Testing Instructions

* `git diff --check -- .teamcity`
* Attempted `mvn org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate` from `.teamcity`; it could not resolve the TeamCity DSL parent POM because `teamcity.a8c.com/app/dsl-plugins-repository` timed out from this environment.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
