### PR TITLE
Trim redundant lodash references from js-utils comments

### DIFF
--- a/bin/codemods/src/unglobalize-selectors.js
+++ b/bin/codemods/src/unglobalize-selectors.js
@@ -1,7 +1,7 @@
 import config from './config';
 
 // Local, dependency-free kebab-case for selector identifiers (e.g. `getSitePlan`
-// → `get-site-plan`), matching lodash's tokenization for ASCII identifiers.
+// → `get-site-plan`). Tokenizes ASCII identifiers only.
 const WORD_PATTERN = /[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+/g;
 const kebabCase = ( input ) =>
 	( String( input ).match( WORD_PATTERN ) ?? [] ).map( ( word ) => word.toLowerCase() ).join( '-' );

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -76,7 +76,7 @@ class NavTabs extends Component {
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.setDropdownDebounced );
 		// cancel the debounced `setDropdown` calls that might be already scheduled.
-		// see https://lodash.com/docs/4.17.4#debounce to learn about the `cancel` method.
+		// `debounce` returns a function with a `cancel` method that drops pending calls.
 		this.setDropdownDebounced.cancel();
 		this.setDropdownAfterLayoutFlush.cancel();
 		this.unobserve();

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -475,7 +475,7 @@ describe( 'initial-state', () => {
 		const initialState = { currentUser: { id: 123456789 } };
 
 		beforeEach( async () => {
-			// we use fake timers from Sinon (aka Lolex) because `lodash.throttle` also uses `Date.now()`
+			// we use fake timers from Sinon (aka Lolex) because `throttle` also uses `Date.now()`
 			// and relies on it returning a mocked value. Jest fake timers don't mock `Date`, Lolex does.
 			jest.useFakeTimers();
 			setStoredItemSpy = jest

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -634,7 +634,9 @@ We encourage you to make use of these methods in favor of traditional `for` and 
 - [`Array#some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some)
 - [`Array#every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every)
 
-Calypso [includes polyfills](https://github.com/Automattic/wp-calypso/pull/25419) for many more Array prototype methods that were added in ES2015 and beyond. You can safely use them without fear of breaking older browsers, and you should always prefer them over their [Lodash](https://lodash.com/) equivalents, which in most cases offer little more.
+Calypso [includes polyfills](https://github.com/Automattic/wp-calypso/pull/25419) for many more Array prototype methods that were added in ES2015 and beyond. You can safely use them without fear of breaking older browsers.
+
+Avoid [Lodash](https://lodash.com/) entirely. It is being removed from Calypso and new imports are blocked by lint. Prefer native JavaScript; when a native equivalent is genuinely awkward, use a helper from [`@automattic/js-utils`](../../packages/js-utils).
 
 Introduced in ES2015, [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) provide a shorter syntax for function expressions while preserving the parent scope's `this` context. Arrow functions are especially well-suited for iteration method callbacks.
 

--- a/packages/api-queries/src/domain-whois.ts
+++ b/packages/api-queries/src/domain-whois.ts
@@ -45,8 +45,7 @@ function isRecord( value: unknown ): value is Record< string, unknown > {
 /**
  * Convert a camelCaseWord to a snake_case_word.
  *
- * This is designed to work nearly identically to the lodash `snakeCase`
- * function. Notably:
+ * Notably:
  *
  * - Leading and trailing spaces are removed.
  * - Leading and trailing underscores are removed.

--- a/packages/calypso-build/bin/build-app-languages.js
+++ b/packages/calypso-build/bin/build-app-languages.js
@@ -94,8 +94,9 @@ const DECIMAL_POINT_TRANSLATION = 'number_format_decimal_point';
 const THOUSANDS_SEPARATOR_KEY = 'number_format_thousands_sep';
 const THOUSANDS_SEPARATOR_TRANSLATION = 'number_format_thousands_sep';
 
-// Keys lodash `pick` refuses to set (its prototype-pollution guard), so a
-// translated string named exactly one of these is dropped rather than emitted.
+// Prototype-related keys a translated string must never introduce as data:
+// assigning `__proto__` would mutate the prototype rather than add a key, so all
+// three are skipped defensively.
 const PICK_BLOCKED_KEYS = new Set( [ '__proto__', 'constructor', 'prototype' ] );
 
 // Get module reference
@@ -199,7 +200,7 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 				}
 
 				// Skip `__proto__`: assigning it would mutate the prototype instead of
-				// adding a key, and lodash's merge dropped it too.
+				// adding an own key.
 				if ( mappedKey === '__proto__' ) {
 					continue;
 				}
@@ -254,9 +255,9 @@ function buildLanguages( downloadedLanguages, languageRevisions ) {
 		successfullyDownloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
 			const cmdPaletteTranslations = {};
 			for ( const key of allModulesStrings ) {
-				// Match lodash `pick`, which drops these protected keys — and skipping
-				// `__proto__` also avoids mutating the prototype here or in the
-				// generated output that embeds this object as a literal.
+				// Drop the prototype-related keys: skipping `__proto__` avoids mutating
+				// the prototype here or in the generated output that embeds this object
+				// as a literal.
 				if ( ! PICK_BLOCKED_KEYS.has( key ) && Object.hasOwn( languageTranslations, key ) ) {
 					cmdPaletteTranslations[ key ] = languageTranslations[ key ];
 				}

--- a/packages/components/src/suggestions/index.tsx
+++ b/packages/components/src/suggestions/index.tsx
@@ -149,8 +149,7 @@ class Suggestions extends Component< Props, State > {
 			( suggestion ) => !! suggestion.category
 		);
 
-		// For all intents and purposes `groupBy` keeps the order stable
-		// https://github.com/lodash/lodash/issues/2212
+		// `groupBy` preserves the input order within each group.
 		// `withCategory` is the truthy-category half of the partition above, so
 		// `category` is always present here.
 		const byCategory = groupBy( withCategory, ( suggestion ) => suggestion.category! );

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -8,6 +8,11 @@ This package was created to help with Lodash removal in Calypso in the first pla
 not intended to be used outside of Calypso. Functions currently in here may be removed in the future
 without further notice.
 
+Most functions mirror the API of their Lodash equivalent so they can replace existing call sites
+directly, but they are intentionally narrower. Each function's doc comment describes only where its
+behavior diverges (for example: no iteratee shorthands, ASCII-only, dense arrays). Assume anything
+not called out matches the corresponding Lodash function for the inputs Calypso actually passes.
+
 Second, we want to think very carefully about what functions to add and which not. A lot of Lodash
 functionality these days can be replaced by native JavaScript code and that should be the premise.
 In case you still want to add a function here please open a Pull Request which describes your use-case

--- a/packages/js-utils/src/base-extremum.ts
+++ b/packages/js-utils/src/base-extremum.ts
@@ -1,9 +1,9 @@
 /**
  * Shared core for `maxBy`/`minBy`. Returns the element of `array` whose
  * `iteratee` value is "best" per `isBetter`. Iteratee values are compared
- * **numerically** (the supported subset of lodash, which is how every call site
- * ranks); nullish and `NaN` values are skipped, and `undefined` is returned for
- * a nullish/empty array. Internal helper; not part of the public API.
+ * **numerically** only (narrower than lodash's type-aware comparison, but how
+ * every usage here ranks); nullish and `NaN` values are skipped, and `undefined`
+ * is returned for a nullish/empty array. Internal helper; not part of the public API.
  * @param array    The array to iterate over.
  * @param iteratee Invoked per element to produce the value to compare.
  * @param isBetter Whether `current` should replace the running `computed` best.

--- a/packages/js-utils/src/base-order-by.ts
+++ b/packages/js-utils/src/base-order-by.ts
@@ -14,11 +14,11 @@ interface Decorated< T > {
 	value: T;
 }
 
-// Port of lodash `compareAscending`: orders two values with `undefined` after
-// defined, `null` after non-null, `NaN` last, and symbols after comparable
-// values — so mixed/missing criteria sort like lodash. The `as number` casts
-// only satisfy the relational operators; at runtime the native comparison
-// handles strings, dates, etc. correctly.
+// Orders two values with `undefined` after defined, `null` after non-null,
+// `NaN` last, and symbols after comparable values, so mixed/missing criteria
+// sort deterministically. The `as number` casts only satisfy the relational
+// operators; at runtime the native comparison handles strings, dates, etc.
+// correctly.
 const compareAscending = ( value: unknown, other: unknown ): number => {
 	if ( value !== other ) {
 		const valIsDefined = value !== undefined;
@@ -77,13 +77,13 @@ const resolveIteratee = < T >(
 	iteratee: Iteratee< T > | null | undefined
 ): ( ( value: T ) => unknown ) => {
 	if ( iteratee == null ) {
-		// A nullish iteratee sorts by identity, like lodash.
+		// A nullish iteratee sorts by identity.
 		return identity;
 	}
 	if ( typeof iteratee === 'function' ) {
 		return iteratee;
 	}
-	// A property name, index, or path — resolved per value (lodash `castPath` is
+	// A property name, index, or path — resolved per value (`castPath` is
 	// object-dependent: a literal key present on the value is used whole).
 	return ( value ) => baseGet( value, iteratee );
 };
@@ -104,7 +104,7 @@ const compareMultiple = < T >(
 			return result * ( orders[ index ] === 'desc' ? -1 : 1 );
 		}
 	}
-	// Tie-break by original index to keep the sort stable, like lodash.
+	// Tie-break by original index to keep the sort stable.
 	return object.index - other.index;
 };
 
@@ -125,7 +125,7 @@ const baseOrderBy = < T >(
 		values = [];
 	} else if ( Array.isArray( collection ) ) {
 		// `Array.from` materializes holes in sparse arrays as `undefined`, so they
-		// are sorted (last) rather than skipped by `map`, matching lodash.
+		// are sorted (last) rather than skipped by `map`.
 		values = Array.from( collection );
 	} else {
 		values = Object.values( collection );

--- a/packages/js-utils/src/camel-case.ts
+++ b/packages/js-utils/src/camel-case.ts
@@ -1,9 +1,9 @@
 import words from './words';
 
 /**
- * Converts an ASCII identifier or key to camelCase, matching lodash's
- * `camelCase` for that input — not a Unicode/deburr replacement (see `words`).
- * Unlike the simpler `snakeToCamelCase`, it fully tokenizes any casing.
+ * Converts an ASCII identifier or key to camelCase — not a Unicode/deburr
+ * replacement (see `words`). Unlike the simpler `snakeToCamelCase`, it fully
+ * tokenizes any casing.
  */
 export default function camelCase( input: string | null | undefined ): string {
 	return words( String( input ?? '' ) ).reduce( ( result, word, index ) => {

--- a/packages/js-utils/src/camel-to-snake-case.ts
+++ b/packages/js-utils/src/camel-to-snake-case.ts
@@ -1,8 +1,7 @@
 /**
  * Convert a camelCaseWord to a snake_case_word.
  *
- * This is designed to work nearly identically to the lodash `snakeCase`
- * function. Notably:
+ * Notable behaviors:
  *
  * - Leading and trailing spaces are removed.
  * - Leading and trailing underscores are removed.

--- a/packages/js-utils/src/capitalize.ts
+++ b/packages/js-utils/src/capitalize.ts
@@ -1,7 +1,7 @@
 /**
- * Upper-cases the first character of a string and lower-cases the rest, matching
- * lodash's `capitalize` for string input. Nullish input becomes an empty string.
- * Works on full Unicode code points, so a leading astral character is not split.
+ * Upper-cases the first character of a string and lower-cases the rest. Nullish
+ * input becomes an empty string. Works on full Unicode code points, so a leading
+ * astral character is not split.
  *
  * Intentionally typed for strings only: it does not replicate lodash's coercion of
  * arbitrary values (arrays, symbols, boxed primitives, `-0`), whose `baseToString`

--- a/packages/js-utils/src/defaults.ts
+++ b/packages/js-utils/src/defaults.ts
@@ -11,9 +11,8 @@ function defaults< T extends object >(
 
 /**
  * Assigns own enumerable properties of the source objects to `object` for every
- * destination property that is `undefined`, matching lodash `defaults`. Earlier
- * sources take precedence, `object` always wins over sources, and `object` is
- * mutated and returned.
+ * destination property that is `undefined`. Earlier sources take precedence,
+ * `object` always wins over sources, and `object` is mutated and returned.
  * @param object  The destination object (mutated).
  * @param sources The source objects.
  * @returns `object`.
@@ -25,19 +24,19 @@ function defaults(
 	const objectProto = Object.prototype as Record< string, unknown >;
 	const hasOwn = Object.prototype.hasOwnProperty;
 
-	// `Object()` coerces a nullish destination to `{}`, like lodash.
+	// `Object()` coerces a nullish destination to `{}`.
 	const target = Object( object ) as Record< string, unknown >;
 	for ( const source of sources ) {
 		if ( source == null ) {
 			continue;
 		}
-		// Iterate own and inherited enumerable keys (lodash uses `keysIn`).
+		// Iterate own and inherited enumerable keys.
 		// eslint-disable-next-line guard-for-in
 		for ( const key in source ) {
 			const value = target[ key ];
 			// Assign when the destination resolves to `undefined`, or to an
 			// inherited `Object.prototype` value that isn't an own property (e.g.
-			// `constructor`, `toString`) — matching lodash `customDefaultsAssignIn`.
+			// `constructor`, `toString`).
 			if (
 				value === undefined ||
 				( value === objectProto[ key ] && ! hasOwn.call( target, key ) )

--- a/packages/js-utils/src/escape-reg-exp.ts
+++ b/packages/js-utils/src/escape-reg-exp.ts
@@ -1,7 +1,6 @@
 /**
  * Escapes the RegExp special characters in a string so it can be safely embedded
- * as a literal inside a regular expression, matching lodash's `escapeRegExp` for
- * string input.
+ * as a literal inside a regular expression.
  *
  * Intentionally typed for strings only: it does not replicate lodash's coercion
  * of arbitrary values to strings.

--- a/packages/js-utils/src/flow.ts
+++ b/packages/js-utils/src/flow.ts
@@ -1,11 +1,11 @@
-// Variadic function composition is inherently loosely typed; like lodash's own
-// types, the runtime is untyped and consumers rely on inference at the call.
+// Variadic function composition is inherently loosely typed; the runtime is
+// untyped and consumers rely on inference at the call.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFunction = ( ...args: any[] ) => any;
 
 /**
  * Creates a function that runs the given functions left-to-right, passing the
- * result of each to the next, matching lodash `flow`. Functions may be passed
+ * result of each to the next. Functions may be passed
  * variadically and/or in arrays (flattened one level); the first receives all
  * arguments, the rest a single value. `this` is forwarded.
  * @param funcs The functions to compose.
@@ -13,7 +13,7 @@ type AnyFunction = ( ...args: any[] ) => any;
  */
 const flow = ( ...funcs: Array< AnyFunction | readonly AnyFunction[] > ): AnyFunction => {
 	const fns = funcs.flat() as AnyFunction[];
-	// Validate up front, like lodash, rather than failing on first invocation.
+	// Validate up front rather than failing on first invocation.
 	for ( const fn of fns ) {
 		if ( typeof fn !== 'function' ) {
 			throw new TypeError( 'Expected a function' );

--- a/packages/js-utils/src/get-tag.ts
+++ b/packages/js-utils/src/get-tag.ts
@@ -4,8 +4,8 @@ const symToStringTag = Symbol.toStringTag;
 
 /**
  * Reads a value's internal tag while ignoring a spoofed `Symbol.toStringTag`, by
- * temporarily unsetting the symbol before calling `Object.prototype.toString`.
- * Mirrors lodash's `getRawTag` so a value can't masquerade as another type.
+ * temporarily unsetting the symbol before calling `Object.prototype.toString`,
+ * so a value can't masquerade as another type.
  */
 const getRawTag = ( value: Record< symbol, unknown > ): string => {
 	const isOwn = hasOwnProperty.call( value, symToStringTag );
@@ -34,8 +34,8 @@ const getRawTag = ( value: Record< symbol, unknown > ): string => {
 /**
  * Returns a value's `Object.prototype.toString` tag (e.g. `'[object Map]'`),
  * resisting a spoofed `Symbol.toStringTag` so an object can't masquerade as
- * another built-in type. Mirrors lodash's `getTag`/`baseGetTag`; `Object()`
- * boxing keeps the `in` check safe for primitives.
+ * another built-in type. `Object()` boxing keeps the `in` check safe for
+ * primitives.
  * @param value The value to read the tag of.
  * @returns The internal `[object …]` tag string.
  */

--- a/packages/js-utils/src/group-by.ts
+++ b/packages/js-utils/src/group-by.ts
@@ -32,12 +32,12 @@ function groupBy< T >(
 				);
 			}
 			// `?.` keeps the property shorthand null-safe and primitive-tolerant:
-			// nullish values yield `undefined` instead of throwing, matching lodash.
+			// nullish values yield `undefined` instead of throwing.
 			rawKey = ( value as any )?.[ iteratee ];
 		}
 
 		// Coerce to a string up front so keys that collide as object keys (e.g.
-		// `1` and `'1'`) accumulate into the same group, matching lodash.
+		// `1` and `'1'`) accumulate into the same group.
 		const key = String( rawKey );
 		const group = groups.get( key );
 		if ( group ) {

--- a/packages/js-utils/src/is-empty.ts
+++ b/packages/js-utils/src/is-empty.ts
@@ -3,10 +3,10 @@ import getTag from './get-tag';
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 const objectProto = Object.prototype;
 
-// The tags lodash's `isFunction` treats as callable. Matching against the tag
-// (rather than `typeof`) excludes a frozen object whose spoofed
-// `Symbol.toStringTag` can't be unmasked from the array-like branch, as lodash
-// does — its `isArrayLike` gate is `!isFunction`, and `isFunction` is tag-based.
+// The tags treated as callable. Matching against the tag (rather than
+// `typeof`) excludes a frozen object whose spoofed `Symbol.toStringTag` can't
+// be unmasked from the array-like branch — the array-like gate is
+// `!isFunction`, and the function check is tag-based.
 const FUNCTION_TAGS = new Set( [
 	'[object Function]',
 	'[object GeneratorFunction]',
@@ -14,13 +14,13 @@ const FUNCTION_TAGS = new Set( [
 	'[object Proxy]',
 ] );
 
-// Mirrors lodash's `isLength`: a valid array-like length is a non-negative
-// integer no greater than the maximum safe integer.
+// A valid array-like length is a non-negative integer no greater than the
+// maximum safe integer.
 const isLength = ( value: unknown ): value is number =>
 	typeof value === 'number' && value > -1 && value % 1 === 0 && value <= Number.MAX_SAFE_INTEGER;
 
-// Mirrors lodash's `isPrototype`: whether the value is the `prototype` object of
-// its own constructor (or `Object.prototype`).
+// Whether the value is the `prototype` object of its own constructor (or
+// `Object.prototype`).
 const isPrototype = ( value: unknown ): boolean => {
 	const Ctor = ( value as { constructor?: unknown } ).constructor;
 	const proto =
@@ -29,8 +29,7 @@ const isPrototype = ( value: unknown ): boolean => {
 };
 
 /**
- * Checks whether a value is an empty object, collection, map, or set, matching
- * lodash's `isEmpty`.
+ * Checks whether a value is an empty object, collection, map, or set.
  *
  * A value is empty when it is `null`/`undefined`; an array, string, typed array,
  * `arguments`, or jQuery-like array-like (`splice` + valid `length`) with a
@@ -51,16 +50,16 @@ const isEmpty = ( value: unknown ): boolean => {
 	// values created in another realm — e.g. a `Map` from an iframe or `vm`
 	// context, whose `instanceof Map` is `false` against this realm's `Map`.
 	// `getTag` reads the *raw* tag so a spoofed `Symbol.toStringTag` can't make a
-	// plain object masquerade as a `Map`/`Set` (matching lodash).
+	// plain object masquerade as a `Map`/`Set`.
 	const tag = getTag( value );
 
-	// Array-like values lodash measures by `length`: arrays, strings, typed
-	// arrays (and Node buffers, which subclass `Uint8Array`), `arguments`, and
-	// jQuery-like collections (an object with a `splice` method). Lodash gates
-	// this whole branch behind `isArrayLike` — a valid `length` on a non-function
-	// — so a bare object that merely owns a `length`, a function (whose `length`
-	// is its arity), or an `arguments`/spoofed value whose `length` has been
-	// removed, falls through to the own-key check below.
+	// Array-like values measured by `length`: arrays, strings, typed arrays (and
+	// Node buffers, which subclass `Uint8Array`), `arguments`, and jQuery-like
+	// collections (an object with a `splice` method). This whole branch is gated
+	// behind an array-like check — a valid `length` on a non-function — so a bare
+	// object that merely owns a `length`, a function (whose `length` is its
+	// arity), or an `arguments`/spoofed value whose `length` has been removed,
+	// falls through to the own-key check below.
 	const length = ( value as { length?: unknown } ).length;
 	if (
 		isLength( length ) &&
@@ -68,7 +67,7 @@ const isEmpty = ( value: unknown ): boolean => {
 		( Array.isArray( value ) ||
 			typeof value === 'string' ||
 			( ArrayBuffer.isView( value ) && tag !== '[object DataView]' ) ||
-			// Lodash's `isArguments` is gated by `isObjectLike`, so a function
+			// The `arguments` check is gated by an object-like test, so a function
 			// spoofing an `Arguments` tag is not measured by its arity.
 			( typeof value === 'object' && tag === '[object Arguments]' ) ||
 			( typeof value === 'object' &&
@@ -78,15 +77,15 @@ const isEmpty = ( value: unknown ): boolean => {
 	}
 
 	if ( tag === '[object Map]' || tag === '[object Set]' ) {
-		// `! size` (not `size === 0`) matches lodash for a frozen object whose
-		// spoofed `Symbol.toStringTag` can't be unmasked and so has no `size`.
+		// `! size` (not `size === 0`) handles a frozen object whose spoofed
+		// `Symbol.toStringTag` can't be unmasked and so has no `size`.
 		return ! ( value as Map< unknown, unknown > | Set< unknown > ).size;
 	}
 
 	// Everything else (plain objects, class instances, and primitives) is empty
 	// when it has no own enumerable string-keyed properties. `for…in` skips
-	// symbol keys, matching lodash. For a prototype object lodash ignores the
-	// own `constructor` key, so `Foo.prototype = { constructor: Foo }` is empty.
+	// symbol keys. For a prototype object the own `constructor` key is
+	// ignored, so `Foo.prototype = { constructor: Foo }` is empty.
 	const skipConstructor = isPrototype( value );
 	for ( const key in value as object ) {
 		if ( hasOwnProperty.call( value, key ) && ! ( skipConstructor && key === 'constructor' ) ) {

--- a/packages/js-utils/src/is-error.ts
+++ b/packages/js-utils/src/is-error.ts
@@ -4,7 +4,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
 const funcToString = Function.prototype.toString;
 const objectCtorString = funcToString.call( Object );
 
-// Mirrors lodash's `isPlainObject`, including its constructor-string check so
+// Whether a value is a plain object, using a constructor-string check so
 // cross-realm plain objects (e.g. from another iframe) are still recognized as
 // plain rather than mistaken for `Error`-like objects.
 const isPlainObject = ( value: object ): boolean => {
@@ -24,8 +24,8 @@ const isPlainObject = ( value: object ): boolean => {
 };
 
 /**
- * Checks whether a value is an `Error` (or `Error`-like) object, matching
- * lodash's `isError`. Unlike a bare `value instanceof Error`, this also detects
+ * Checks whether a value is an `Error` (or `Error`-like) object. Unlike a bare
+ * `value instanceof Error`, this also detects
  * `DOMException`s and cross-realm errors (e.g. an `Error` from another iframe),
  * resists a spoofed `Symbol.toStringTag`, and still returns `false` for plain
  * objects.

--- a/packages/js-utils/src/is-symbol.ts
+++ b/packages/js-utils/src/is-symbol.ts
@@ -1,6 +1,6 @@
 /**
  * Whether a value is a symbol, including boxed symbols (`Object( Symbol() )`).
- * Uses the object tag so the check is realm-safe, matching lodash `isSymbol`.
+ * Uses the object tag so the check is realm-safe.
  * Internal helper; not part of the public API.
  */
 const isSymbol = ( value: unknown ): boolean =>

--- a/packages/js-utils/src/kebab-case.ts
+++ b/packages/js-utils/src/kebab-case.ts
@@ -1,8 +1,8 @@
 import words from './words';
 
 /**
- * Converts an ASCII identifier or key to kebab-case, matching lodash's
- * `kebabCase` for that input — not a Unicode/deburr replacement (see `words`).
+ * Converts an ASCII identifier or key to kebab-case. Not a Unicode/deburr
+ * replacement (see `words`).
  */
 export default function kebabCase( input: string | null | undefined ): string {
 	return words( String( input ?? '' ) )

--- a/packages/js-utils/src/max-by.ts
+++ b/packages/js-utils/src/max-by.ts
@@ -2,9 +2,9 @@ import baseExtremum from './base-extremum';
 
 /**
  * Returns the element of `array` with the maximum `iteratee` value. Iteratee
- * values are compared numerically (the supported subset of lodash `maxBy`);
- * nullish/`NaN` values are skipped, and `undefined` is returned for a nullish or
- * empty array.
+ * values are compared numerically (narrower than lodash `maxBy`, which supports
+ * more comparison modes); nullish/`NaN` values are skipped, and `undefined` is
+ * returned for a nullish or empty array.
  * @param array    The array to iterate over.
  * @param iteratee Invoked per element to produce the value to rank by.
  * @returns The element with the maximum value, or `undefined`.

--- a/packages/js-utils/src/memoize.ts
+++ b/packages/js-utils/src/memoize.ts
@@ -7,8 +7,8 @@ export interface MemoizedFunction< Args extends unknown[], Return > {
  * Wraps a function so results are cached by a key derived from its arguments.
  * By default the key is the first argument; pass `resolver` to compute a custom
  * key. The cache is exposed as `.cache` (a `Map`) so callers can clear or
- * inspect it. Mirrors lodash's `memoize` for these uses, but does not support
- * its pluggable `memoize.Cache` or argument-type `TypeError` checks.
+ * inspect it. Unlike lodash's `memoize`, this does not support a pluggable
+ * `memoize.Cache` or argument-type `TypeError` checks.
  * @param func The function to have its output memoized.
  * @param resolver Optional function that resolves the cache key from the arguments.
  * @returns The memoized function, with its cache exposed as `.cache`.
@@ -18,7 +18,7 @@ const memoize = < Args extends unknown[], Return >(
 	resolver?: ( ...args: Args ) => unknown
 ): MemoizedFunction< Args, Return > => {
 	// Use a regular function (not an arrow) so the caller's `this` is forwarded
-	// to `func`/`resolver`, matching lodash's `func.apply( this, arguments )`.
+	// to `func`/`resolver` via `func.apply( this, args )`.
 	const memoized = function ( this: unknown, ...args: Args ): Return {
 		const key = resolver ? resolver.apply( this, args ) : args[ 0 ];
 		const { cache } = memoized;

--- a/packages/js-utils/src/merge-internal.ts
+++ b/packages/js-utils/src/merge-internal.ts
@@ -15,8 +15,8 @@ export const isMergeable = ( value: unknown ): boolean =>
 	Array.isArray( value ) || isPlainObject( value );
 
 // Reads `constructor` as absent when it holds the built-in function, so a source
-// `constructor` merges into a fresh own property instead of the real constructor
-// (matching lodash). `__proto__` is skipped by callers before this is reached.
+// `constructor` merges into a fresh own property instead of the real
+// constructor. `__proto__` is skipped by callers before this is reached.
 export const safeGet = ( object: PlainObject, key: string ): unknown => {
 	if ( key === 'constructor' && typeof object[ key ] === 'function' ) {
 		return undefined;
@@ -43,8 +43,8 @@ export const pickMergeContainer = (
 // Assigns like a sloppy-mode write. `Reflect.set` reports a rejected data-
 // property write — a frozen or sealed object, a non-extensible object gaining a
 // new key, or a non-writable property — as a `false` return rather than
-// throwing, so the merge keeps going, matching lodash (which runs non-strict).
-// Exceptions thrown by a userland setter still propagate, as they do in lodash.
+// throwing, so the merge keeps going.
+// Exceptions thrown by a userland setter still propagate.
 // A plain strict-mode assignment would instead throw on the rejected write and
 // abort the whole merge.
 export const assign = ( target: PlainObject, key: string, value: unknown ): void => {

--- a/packages/js-utils/src/mergeWith.ts
+++ b/packages/js-utils/src/mergeWith.ts
@@ -23,16 +23,15 @@ export type MergeWithCustomizer = (
 ) => unknown;
 
 // The customizer used when the caller omits one: defers every key to the
-// default merge, so `mergeWith` degrades to a plain deep merge (like lodash).
+// default merge, so `mergeWith` degrades to a plain deep merge.
 const defaultCustomizer: MergeWithCustomizer = () => undefined;
 
-// SameValueZero, matching lodash's `eq`: like `===` but treats two NaNs as
-// equal. Used to skip writes that would not change the destination.
+// SameValueZero: like `===` but treats two NaNs as equal. Used to skip writes
+// that would not change the destination.
 const eq = ( a: unknown, b: unknown ): boolean => a === b || ( a !== a && b !== b );
 
-// Mirrors lodash's `assignMergeValue`: assign only when the value actually
-// differs, and let a `undefined` value create an absent key without clobbering
-// an existing one.
+// Assign only when the value actually differs, and let a `undefined` value
+// create an absent key without clobbering an existing one.
 const assignMergeValue = ( target: PlainObject, key: string, value: unknown ): void => {
 	if (
 		( value !== undefined && ! eq( target[ key ], value ) ) ||
@@ -107,8 +106,8 @@ function baseMergeWith(
  * Like {@link ./merge merge}, but a `customizer` invoked for every source key
  * decides the merged value: it runs first and, when it returns anything other
  * than `undefined`, that result is assigned directly instead of the default
- * deep merge. As in lodash, the customizer is optional and identified as the
- * trailing argument only when it is a function AND at least one source precedes
+ * deep merge. The customizer is optional and identified as the trailing
+ * argument only when it is a function AND at least one source precedes
  * it; otherwise every argument after the destination is treated as a source
  * (so a lone trailing function is merged as a source) and the merge runs without
  * a customizer. Sources are merged left to right.
@@ -126,9 +125,9 @@ function mergeWith( object: object | null | undefined, ...args: unknown[] ): obj
 	const hasCustomizer = args.length > 1 && typeof last === 'function';
 	const customizer = hasCustomizer ? ( last as MergeWithCustomizer ) : defaultCustomizer;
 	const sources = hasCustomizer ? args.slice( 0, -1 ) : args;
-	// Coerce like lodash's assigner so a nullish destination becomes a fresh
-	// object rather than being read through — callers that merge into a
-	// possibly-absent value get the merged result back.
+	// Coerce a nullish destination into a fresh object rather than reading
+	// through it — callers that merge into a possibly-absent value get the
+	// merged result back.
 	const target = Object( object ) as PlainObject;
 	for ( const source of sources ) {
 		if ( source != null ) {

--- a/packages/js-utils/src/min-by.ts
+++ b/packages/js-utils/src/min-by.ts
@@ -2,9 +2,8 @@ import baseExtremum from './base-extremum';
 
 /**
  * Returns the element of `array` with the minimum `iteratee` value. Iteratee
- * values are compared numerically (the supported subset of lodash `minBy`);
- * nullish/`NaN` values are skipped, and `undefined` is returned for a nullish or
- * empty array.
+ * values are compared numerically; nullish/`NaN` values are skipped, and
+ * `undefined` is returned for a nullish or empty array.
  * @param array    The array to iterate over.
  * @param iteratee Invoked per element to produce the value to rank by.
  * @returns The element with the minimum value, or `undefined`.

--- a/packages/js-utils/src/once.ts
+++ b/packages/js-utils/src/once.ts
@@ -1,7 +1,7 @@
 /**
  * Wraps a function so it runs at most once. The first invocation calls `fn` and
  * caches its result; every later invocation returns that cached result without
- * calling `fn` again (ignoring any later arguments). Matches lodash's `once`.
+ * calling `fn` again (ignoring any later arguments).
  * @param fn The function to restrict to a single invocation.
  * @returns The restricted function.
  */
@@ -11,7 +11,7 @@ const once = < Args extends unknown[], Return >(
 	let called = false;
 	let result: Return;
 	// Use a regular function (not an arrow) so the caller's `this` is forwarded
-	// to `fn`, matching lodash's `func.apply( this, arguments )`.
+	// to `fn`.
 	return function ( this: unknown, ...args: Args ): Return {
 		if ( ! called ) {
 			called = true;

--- a/packages/js-utils/src/order-by.ts
+++ b/packages/js-utils/src/order-by.ts
@@ -3,7 +3,7 @@ import type { Iteratee, Order } from './base-order-by';
 
 /**
  * Like `sortBy`, but allows specifying a sort order (`'asc'` or `'desc'`) per
- * iteratee, matching lodash `orderBy`. Iteratees may be functions or property
+ * iteratee. Iteratees may be functions or property
  * names/indices (including dotted/bracket paths and path arrays); a nullish
  * iteratee (or none) sorts by the values themselves. Orders shorter than the
  * iteratee list default to ascending. The sort is stable, works on arrays and
@@ -18,7 +18,7 @@ const orderBy = < T >(
 	iteratees?: Iteratee< T > | ReadonlyArray< Iteratee< T > > | null,
 	orders?: Order | ReadonlyArray< Order > | null
 ): T[] => {
-	// A nullish (single or array) argument normalizes to an empty list, like lodash.
+	// A nullish (single or array) argument normalizes to an empty list.
 	let normalizedIteratees: ReadonlyArray< Iteratee< T > >;
 	if ( iteratees == null ) {
 		normalizedIteratees = [];

--- a/packages/js-utils/src/partition.ts
+++ b/packages/js-utils/src/partition.ts
@@ -1,8 +1,8 @@
 /**
  * Splits the values of `collection` into two groups: the first contains values
- * for which `predicate` returns truthy, the second the rest. Mirrors lodash
- * `partition`: works on arrays and plain objects (iterating values) and treats
- * a nullish collection as empty.
+ * for which `predicate` returns truthy, the second the rest. Works on arrays
+ * and plain objects (iterating values) and treats a nullish collection as
+ * empty.
  * @param collection The array or object to iterate over.
  * @param predicate  Invoked per value.
  * @returns A tuple of `[ truthy, falsy ]` value arrays.

--- a/packages/js-utils/src/random.ts
+++ b/packages/js-utils/src/random.ts
@@ -7,7 +7,7 @@ function random( lower: number, upper: number, floating?: boolean ): number;
 /**
  * Produces a random number between `lower` and `upper` (inclusive). An integer
  * is returned unless either bound is fractional or `floating` is `true`, in
- * which case a floating-point number is returned — mirroring lodash `random`.
+ * which case a floating-point number is returned.
  *
  * If only one numeric argument is provided it is treated as the upper bound
  * (with `0` as the lower bound); with no numeric arguments a number between `0`

--- a/packages/js-utils/src/range.ts
+++ b/packages/js-utils/src/range.ts
@@ -4,8 +4,7 @@ import toFinite from './to-finite';
  * Creates an array of numbers progressing from `start` up to, but not
  * including, `end`. A `step` of `-1` is used if a negative `start` is specified
  * without an `end` or `step`. If `end` is not specified, it's set to `start`
- * with `start` then set to `0`. Bounds are coerced to finite numbers, matching
- * lodash.
+ * with `start` then set to `0`. Bounds are coerced to finite numbers.
  * @param start The start of the range (or the end, if `end` is omitted).
  * @param end   The end of the range (exclusive).
  * @param step  The value to increment or decrement by.

--- a/packages/js-utils/src/set.ts
+++ b/packages/js-utils/src/set.ts
@@ -13,7 +13,7 @@ const eq = ( value: unknown, other: unknown ): boolean =>
 	value === other || ( Number.isNaN( value as number ) && Number.isNaN( other as number ) );
 
 // Assigns only when the value actually changes, so setters/proxy traps aren't
-// triggered for same-value writes, matching lodash `assignValue`.
+// triggered for same-value writes.
 const assignValue = (
 	object: Record< PropertyKey, unknown >,
 	key: PropertyKey,
@@ -29,7 +29,7 @@ const assignValue = (
 };
 
 // Whether a path segment is a valid array index (so the intermediate container
-// created for it should be an array rather than a plain object), like lodash.
+// created for it should be an array rather than a plain object).
 const isIndex = ( value: PropertyKey ): boolean => {
 	const type = typeof value;
 	if ( type !== 'number' && ( type === 'symbol' || ! reIsUint.test( value as string ) ) ) {
@@ -40,7 +40,7 @@ const isIndex = ( value: PropertyKey ): boolean => {
 };
 
 // Converts a path segment to a property key, preserving symbols and mapping
-// negative zero to `'-0'`, like lodash `toKey`.
+// negative zero to `'-0'`.
 const toKey = ( value: PropertyKey ): PropertyKey => {
 	if ( typeof value === 'string' || typeof value === 'symbol' ) {
 		return value;
@@ -50,8 +50,8 @@ const toKey = ( value: PropertyKey ): PropertyKey => {
 
 /**
  * Sets the value at `path` of `object`, creating missing intermediate
- * containers (arrays for index-like segments, objects otherwise), matching
- * lodash `set`. `object` is mutated and returned; a non-object `object` is
+ * containers (arrays for index-like segments, objects otherwise).
+ * `object` is mutated and returned; a non-object `object` is
  * returned unchanged. Assignments to `__proto__`/`constructor`/`prototype` keys
  * are skipped to avoid prototype pollution.
  * @param object The object to modify.

--- a/packages/js-utils/src/snake-case.ts
+++ b/packages/js-utils/src/snake-case.ts
@@ -1,8 +1,8 @@
 import words from './words';
 
 /**
- * Converts an ASCII identifier or key to snake_case, matching lodash's
- * `snakeCase` for that input — not a Unicode/deburr replacement (see `words`).
+ * Converts an ASCII identifier or key to snake_case — not a Unicode/deburr
+ * replacement (see `words`).
  * Unlike the simpler `camelToSnakeCase`, it also splits kebab-case input.
  */
 export default function snakeCase( input: string | null | undefined ): string {

--- a/packages/js-utils/src/snake-to-camel-case.ts
+++ b/packages/js-utils/src/snake-to-camel-case.ts
@@ -1,7 +1,5 @@
 /**
  * Convert a snake_case_word to a camelCaseWord.
- *
- * This is designed to work nearly identically to the lodash `camelCase` function.
  */
 export default function snakeToCamelCase( snakeCaseString: string | undefined ): string {
 	if ( ! snakeCaseString ) {

--- a/packages/js-utils/src/sort-by.ts
+++ b/packages/js-utils/src/sort-by.ts
@@ -4,8 +4,8 @@ import type { Iteratee } from './base-order-by';
 type SortIteratee< T > = Iteratee< T > | ReadonlyArray< Iteratee< T > > | null | undefined;
 
 /**
- * Sorts the values of `collection` in ascending order by each iteratee,
- * matching lodash `sortBy`. Iteratees may be functions or property
+ * Sorts the values of `collection` in ascending order by each iteratee.
+ * Iteratees may be functions or property
  * names/indices (including dotted/bracket paths and path arrays), passed
  * variadically and/or as arrays (flattened one level); a nullish iteratee (or
  * none) sorts by the values themselves. The sort is stable, works on arrays and
@@ -18,8 +18,8 @@ const sortBy = < T >(
 	collection: readonly T[] | Record< PropertyKey, T > | null | undefined,
 	...iteratees: Array< SortIteratee< T > >
 ): T[] => {
-	// Flatten the iteratee arguments one level, like lodash `baseFlatten`, so
-	// variadic args and array args combine into a single iteratee list.
+	// Flatten the iteratee arguments one level so variadic args and array args
+	// combine into a single iteratee list.
 	const normalized: Array< Iteratee< T > | null | undefined > = [];
 	for ( const iteratee of iteratees ) {
 		if ( Array.isArray( iteratee ) ) {

--- a/packages/js-utils/src/to-finite.ts
+++ b/packages/js-utils/src/to-finite.ts
@@ -1,10 +1,10 @@
 import isSymbol from './is-symbol';
 
-// lodash's largest finite number; ±Infinity coerce to this in `toFinite`.
+// The largest finite number; ±Infinity coerce to this in `toFinite`.
 const MAX_INTEGER = 1.7976931348623157e308;
 
 /**
- * Coerces a value to a number, matching lodash `toNumber`. Notably, the
+ * Coerces a value to a number. Notably, the
  * primitive of an object is derived from `valueOf` only — if `valueOf` returns
  * another object, that result is stringified (rather than falling back to the
  * original object's `toString`, as native `Number` would). Symbols become `NaN`.
@@ -28,7 +28,7 @@ const toNumber = ( value: unknown ): number => {
 };
 
 /**
- * Coerces a value to a finite number, matching lodash `toFinite`: numeric
+ * Coerces a value to a finite number: numeric
  * strings (including binary/octal/hex) are parsed, `±Infinity` clamp to
  * `±MAX_INTEGER`, and everything non-numeric (symbols, objects, `NaN`, etc.)
  * becomes `0` — never throwing. Internal helper; not part of the public API.

--- a/packages/js-utils/src/to-path.ts
+++ b/packages/js-utils/src/to-path.ts
@@ -3,7 +3,7 @@ import isSymbol from './is-symbol';
 // Property-path parsing, ported from lodash. A string is tokenized into path
 // segments (dot, bracket, and quoted-bracket notation), except a string that is
 // a literal key of the object is used whole rather than split — `castPath` is
-// object-dependent, like lodash. Internal helper; not part of the public API.
+// object-dependent. Internal helper; not part of the public API.
 const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
 const reIsPlainProp = /^\w*$/;
 const rePropName =
@@ -39,7 +39,7 @@ const stringToPath = ( string: string ): string[] => {
 
 /**
  * Casts `value` to a property-path array, resolving a string against `object`
- * (an existing literal key is used whole), matching lodash `castPath`.
+ * (an existing literal key is used whole).
  */
 const castPath = (
 	value: PropertyKey | readonly PropertyKey[],

--- a/packages/js-utils/src/truncate.ts
+++ b/packages/js-utils/src/truncate.ts
@@ -13,12 +13,12 @@ import toFinite from './to-finite';
 const DEFAULT_LENGTH = 30;
 const DEFAULT_OMISSION = '...';
 
-// lodash coerces `length` via `toInteger` (toward-zero integer of `toFinite`).
+// Coerces `length` via `toInteger` (toward-zero integer of `toFinite`).
 const toInteger = ( value: unknown ): number => Math.trunc( toFinite( value ) );
 
-// lodash coerces strings via `baseToString`, which differs from native `String`
-// in two ways: symbols (primitive or boxed) stringify to their description
-// rather than throwing, and negative zero becomes `'-0'`.
+// `baseToString` differs from native `String` in two ways: symbols (primitive
+// or boxed) stringify to their description rather than throwing, and negative
+// zero becomes `'-0'`.
 const baseToString = ( value: unknown ): string => {
 	if ( typeof value === 'string' ) {
 		return value;
@@ -33,11 +33,10 @@ const baseToString = ( value: unknown ): string => {
 	return result === '0' && Object.is( value, -0 ) ? '-0' : result;
 };
 
-// Unicode-aware string segmentation, ported from lodash so that grapheme
-// clusters (ZWJ emoji sequences, regional-indicator flags, combining marks,
-// variation selectors, Fitzpatrick modifiers) are counted and sliced as single
-// units — matching lodash `truncate` exactly rather than splitting per code
-// point.
+// Unicode-aware string segmentation so that grapheme clusters (ZWJ emoji
+// sequences, regional-indicator flags, combining marks, variation selectors,
+// Fitzpatrick modifiers) are counted and sliced as single units rather than
+// split per code point.
 const rsAstralRange = '\\ud800-\\udfff';
 const rsComboMarksRange = '\\u0300-\\u036f';
 const reComboHalfMarksRange = '\\ufe20-\\ufe2f';
@@ -80,7 +79,7 @@ const stringToArray = ( string: string ): string[] =>
 
 /**
  * Truncates `string` if it is longer than the given maximum length, replacing
- * the excess with `omission`. Mirrors lodash `truncate`, including the
+ * the excess with `omission`. Supports the
  * `separator` option (truncate to a word/pattern boundary), lenient option
  * coercion (non-object options and oddly-typed `length`/`omission` fall back or
  * coerce rather than throw), and Unicode-aware length/slicing so grapheme
@@ -90,10 +89,9 @@ const stringToArray = ( string: string ): string[] =>
  * @returns The truncated string.
  */
 const truncate = ( string: string, options?: TruncateOptions ): string => {
-	// Mirror lodash's option handling: only plain objects/arrays contribute
-	// options; `length` is coerced with `toInteger` and `omission` with `String`,
-	// so non-object or oddly-typed inputs fall back to defaults instead of
-	// throwing.
+	// Only plain objects/arrays contribute options; `length` is coerced with
+	// `toInteger` and `omission` with `String`, so non-object or oddly-typed
+	// inputs fall back to defaults instead of throwing.
 	let length = DEFAULT_LENGTH;
 	let omission = DEFAULT_OMISSION;
 	let separator: string | RegExp | undefined;

--- a/packages/js-utils/src/words.ts
+++ b/packages/js-utils/src/words.ts
@@ -1,5 +1,5 @@
 /**
- * Splits an ASCII identifier or phrase into words like lodash: on
+ * Splits an ASCII identifier or phrase into words: on
  * camelCase/PascalCase boundaries, acronym runs (`XMLHttp` → `XML`, `Http`),
  * digit groups, and separators. Unlike lodash it does not deburr accents or
  * strip apostrophes — callers pass identifiers/keys, not free-form text.


### PR DESCRIPTION
## Proposed Changes

* State once, in the `@automattic/js-utils` README, that its helpers mirror the API of their Lodash equivalents but are intentionally narrower.
* Remove the repeated per-function "matches/mirrors lodash" parity assertions from the helper comments, keeping the divergence notes that flag where a helper is narrower than its Lodash counterpart (no iteratee shorthands, ASCII-only, dense arrays, etc.).
* Reword a few build-tooling comments to describe their behavior on their own terms rather than by reference to lodash.

## Why are these changes being made?

* The per-function comments repeated that each helper "matches lodash," which restates what the package already exists to do. A single note in the README is enough; the per-function comments now only carry the caveats a reader actually needs — where the behavior is *not* a 1:1 match. Comments-only; no behavior changes.
* Load-bearing references are deliberately kept: the lodash→lodash-es webpack replacement plugin, links to lodash issues/docs that explain a workaround, extracted-code provenance, and the eslint guard's own messages.

## Testing Instructions

* `yarn typecheck-packages` and `yarn test-packages` — comments-only, so behavior and types are unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
