### PR TITLE
A4A MCP: Starter prompts on the MCP overview

### DIFF
--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -11,6 +11,7 @@ import { check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { Card, CardBody } from '../../../components/card';
 import SummaryButton from '../../../components/summary-button';
+import McpStarterPrompts from './starter-prompts-content';
 import type { RecordTracksEvent } from './types';
 import type { McpSettings, McpSettingsUpdate } from '@automattic/api-core';
 import type { MouseEvent } from 'react';
@@ -148,6 +149,10 @@ export default function McpOverview( {
 					onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
 				/>
 			</VStack>
+
+			<Spacer marginTop={ 8 } marginBottom={ 0 }>
+				<McpStarterPrompts recordTracksEvent={ recordTracksEvent } disabled={ ! mainEnabled } />
+			</Spacer>
 		</>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -1,0 +1,142 @@
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check, copy } from '@wordpress/icons';
+import { useCallback, useEffect, useState } from 'react';
+import { CollapsibleCard } from '../../../components/collapsible-card';
+import type { RecordTracksEvent } from './types';
+
+import './style.scss';
+
+export interface StarterPrompt {
+	id: string;
+	title: string;
+	description: string;
+	prompt: string;
+}
+
+export const STARTER_PROMPTS: StarterPrompt[] = [
+	{
+		id: 'program-health-snapshot',
+		title: __( 'Program health snapshot' ),
+		description: __(
+			'Get a high-level read on your account, covering your tier and what it takes to level up, earnings and eligibility across all streams, and billing status, with the top action items surfaced first.'
+		),
+		prompt: __(
+			'Give me a high-level health check of my Automattic for Agencies account. Cover three areas: (1) **Agency & tier** — my current tier, influenced revenue, and the gap to the next tier plus what’s required to get there; (2) **Earnings & eligibility** — lifetime earnings across referrals, WooPayments, and migrations, upcoming payouts, and flag any unresolved or unattributed referrals I could be leaving on the table; (3) **Billing** — current and previous month charges, payment method, and any upcoming renewals at risk of lapsing. Summarize with the most important action items up top.'
+		),
+	},
+	{
+		id: 'portfolio-health-summary',
+		title: __( 'Portfolio health summary' ),
+		description: __(
+			'Scan every site you manage and get a grouped list of issues, including active threats, disconnected sites, vulnerable plugins, monitors down, and pending updates, so you know what to fix first.'
+		),
+		prompt: __(
+			'Scan all the sites I manage in Automattic for Agencies and give me a succinct list of issues across the portfolio. Group by issue type — active threats, disconnected sites, vulnerable plugins, monitors down, and pending plugin updates — and list the affected sites under each. Start with a one-line count of healthy vs. unhealthy sites, and tell me which issues to fix first.'
+		),
+	},
+	{
+		id: 'recurring-weekly-report',
+		title: __( 'Recurring weekly report' ),
+		description: __(
+			'Schedule an automatic weekly rundown of your entire account, including priorities, earnings, tier progress, site health, and billing, delivered where you want it every Monday morning.'
+		),
+		prompt: __(
+			'Every Monday at 9:00 AM, generate a full weekly report on my Automattic for Agencies account and deliver it to me. Include an executive summary with top priorities, then sections for: earnings & eligibility (lifetime paid, upcoming payouts, unresolved referrals, migration incentive status), agency tier and progress, portfolio health (healthy vs. unhealthy site counts with issues grouped by type), and renewals & billing. Lead with anything urgent — active security threats or anything at risk of lapsing. Keep it skimmable with clear sections. Ask me where I’d like it delivered — Slack, email, or a saved document — before scheduling.'
+		),
+	},
+];
+
+function StarterPromptItem( {
+	prompt,
+	onCopy,
+}: {
+	prompt: StarterPrompt;
+	onCopy: ( prompt: StarterPrompt ) => void;
+} ) {
+	const [ copied, setCopied ] = useState( false );
+
+	const handleCopy = useCallback( async () => {
+		try {
+			await navigator.clipboard.writeText( prompt.prompt );
+			onCopy( prompt );
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 2000 );
+		} catch {
+			// If the clipboard write fails, stay silent — the user can select the
+			// prompt manually from the text below.
+		}
+	}, [ prompt, onCopy ] );
+
+	return (
+		<VStack spacing={ 2 }>
+			<Text weight={ 600 } size={ 15 }>
+				{ prompt.title }
+			</Text>
+			<Text variant="muted">{ prompt.description }</Text>
+			<div className="mcp-starter-prompt">
+				<Button
+					className="mcp-starter-prompt__copy"
+					variant="tertiary"
+					icon={ copied ? check : copy }
+					label={ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
+					showTooltip
+					onClick={ handleCopy }
+				/>
+				<Text className="mcp-starter-prompt__text">{ prompt.prompt }</Text>
+			</div>
+		</VStack>
+	);
+}
+
+export default function McpStarterPrompts( {
+	recordTracksEvent = () => {},
+	disabled = false,
+}: {
+	recordTracksEvent?: RecordTracksEvent;
+	disabled?: boolean;
+} ) {
+	// Default to expanded once MCP is enabled, collapsed while it's disabled.
+	// Resync whenever the enabled state flips (initial load or live toggle),
+	// while still letting the user collapse/expand manually in between.
+	const [ expanded, setExpanded ] = useState( ! disabled );
+	useEffect( () => {
+		setExpanded( ! disabled );
+	}, [ disabled ] );
+
+	const onCopy = useCallback(
+		( prompt: StarterPrompt ) => {
+			recordTracksEvent( 'calypso_a4a_ai_mcp_starter_prompt_copied', { prompt_id: prompt.id } );
+		},
+		[ recordTracksEvent ]
+	);
+
+	return (
+		<CollapsibleCard
+			expanded={ expanded }
+			onToggle={ setExpanded }
+			disabled={ disabled }
+			toggleLabel={ __( 'Toggle starter prompts' ) }
+			header={
+				<Text weight={ 600 } size={ 15 }>
+					{ __( 'Starter prompts' ) }
+				</Text>
+			}
+		>
+			<VStack spacing={ 5 }>
+				<Text variant="muted">
+					{ __(
+						'The sky’s the limit with AI agents. To help you get the most out of our MCP, we’ve created a set of starter prompts you can hand straight to the AI agent of your choice once connected. Feel free to modify them as you see fit for the best experience, tailored to your agency.'
+					) }
+				</Text>
+				{ STARTER_PROMPTS.map( ( prompt ) => (
+					<StarterPromptItem key={ prompt.id } prompt={ prompt } onCopy={ onCopy } />
+				) ) }
+			</VStack>
+		</CollapsibleCard>
+	);
+}

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -88,14 +88,15 @@ function StarterPromptItem( {
 			<VStack spacing={ 3 }>
 				<Text variant="muted">{ prompt.description }</Text>
 				<div className="mcp-starter-prompt">
-					<Button
-						className="mcp-starter-prompt__copy"
-						variant="tertiary"
-						icon={ copied ? check : copy }
-						label={ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
-						showTooltip
-						onClick={ handleCopy }
-					/>
+					<div className="mcp-starter-prompt__copy">
+						<Button
+							variant="tertiary"
+							icon={ copied ? check : copy }
+							label={ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
+							showTooltip
+							onClick={ handleCopy }
+						/>
+					</div>
 					<Text className="mcp-starter-prompt__text">{ prompt.prompt }</Text>
 				</div>
 			</VStack>

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -140,7 +140,7 @@ export default function McpStarterPrompts( {
 			</CardBody>
 			{ STARTER_PROMPTS.map( ( prompt ) => (
 				<Fragment key={ prompt.id }>
-					<CardDivider className="mcp-starter-prompts__divider" />
+					<CardDivider style={ { borderColor: 'var(--color-border-subtle)' } } />
 					<StarterPromptItem prompt={ prompt } disabled={ disabled } onCopy={ onCopy } />
 				</Fragment>
 			) ) }

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -140,7 +140,7 @@ export default function McpStarterPrompts( {
 			</CardBody>
 			{ STARTER_PROMPTS.map( ( prompt ) => (
 				<Fragment key={ prompt.id }>
-					<CardDivider />
+					<CardDivider className="mcp-starter-prompts__divider" />
 					<StarterPromptItem prompt={ prompt } disabled={ disabled } onCopy={ onCopy } />
 				</Fragment>
 			) ) }

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -5,7 +5,8 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
-import { useCallback, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { useCallback, useState } from 'react';
 import { CollapsibleCard } from '../../../components/collapsible-card';
 import type { RecordTracksEvent } from './types';
 
@@ -53,9 +54,11 @@ export const STARTER_PROMPTS: StarterPrompt[] = [
 
 function StarterPromptItem( {
 	prompt,
+	disabled,
 	onCopy,
 }: {
 	prompt: StarterPrompt;
+	disabled?: boolean;
 	onCopy: ( prompt: StarterPrompt ) => void;
 } ) {
 	const [ copied, setCopied ] = useState( false );
@@ -73,23 +76,30 @@ function StarterPromptItem( {
 	}, [ prompt, onCopy ] );
 
 	return (
-		<VStack spacing={ 2 }>
-			<Text weight={ 600 } size={ 15 }>
-				{ prompt.title }
-			</Text>
-			<Text variant="muted">{ prompt.description }</Text>
-			<div className="mcp-starter-prompt">
-				<Button
-					className="mcp-starter-prompt__copy"
-					variant="tertiary"
-					icon={ copied ? check : copy }
-					label={ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
-					showTooltip
-					onClick={ handleCopy }
-				/>
-				<Text className="mcp-starter-prompt__text">{ prompt.prompt }</Text>
-			</div>
-		</VStack>
+		<CollapsibleCard
+			disabled={ disabled }
+			toggleLabel={ prompt.title }
+			header={
+				<Text weight={ 600 } size={ 15 }>
+					{ prompt.title }
+				</Text>
+			}
+		>
+			<VStack spacing={ 3 }>
+				<Text variant="muted">{ prompt.description }</Text>
+				<div className="mcp-starter-prompt">
+					<Button
+						className="mcp-starter-prompt__copy"
+						variant="tertiary"
+						icon={ copied ? check : copy }
+						label={ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
+						showTooltip
+						onClick={ handleCopy }
+					/>
+					<Text className="mcp-starter-prompt__text">{ prompt.prompt }</Text>
+				</div>
+			</VStack>
+		</CollapsibleCard>
 	);
 }
 
@@ -100,14 +110,6 @@ export default function McpStarterPrompts( {
 	recordTracksEvent?: RecordTracksEvent;
 	disabled?: boolean;
 } ) {
-	// Default to expanded once MCP is enabled, collapsed while it's disabled.
-	// Resync whenever the enabled state flips (initial load or live toggle),
-	// while still letting the user collapse/expand manually in between.
-	const [ expanded, setExpanded ] = useState( ! disabled );
-	useEffect( () => {
-		setExpanded( ! disabled );
-	}, [ disabled ] );
-
 	const onCopy = useCallback(
 		( prompt: StarterPrompt ) => {
 			recordTracksEvent( 'calypso_a4a_ai_mcp_starter_prompt_copied', { prompt_id: prompt.id } );
@@ -116,27 +118,30 @@ export default function McpStarterPrompts( {
 	);
 
 	return (
-		<CollapsibleCard
-			expanded={ expanded }
-			onToggle={ setExpanded }
-			disabled={ disabled }
-			toggleLabel={ __( 'Toggle starter prompts' ) }
-			header={
+		<VStack spacing={ 4 }>
+			<VStack
+				spacing={ 2 }
+				className={ clsx( 'mcp-starter-prompts__intro', { 'is-disabled': disabled } ) }
+			>
 				<Text weight={ 600 } size={ 15 }>
 					{ __( 'Starter prompts' ) }
 				</Text>
-			}
-		>
-			<VStack spacing={ 5 }>
 				<Text variant="muted">
 					{ __(
 						'The sky’s the limit with AI agents. To help you get the most out of our MCP, we’ve created a set of starter prompts you can hand straight to the AI agent of your choice once connected. Feel free to modify them as you see fit for the best experience, tailored to your agency.'
 					) }
 				</Text>
+			</VStack>
+			<VStack spacing={ 3 }>
 				{ STARTER_PROMPTS.map( ( prompt ) => (
-					<StarterPromptItem key={ prompt.id } prompt={ prompt } onCopy={ onCopy } />
+					<StarterPromptItem
+						key={ prompt.id }
+						prompt={ prompt }
+						disabled={ disabled }
+						onCopy={ onCopy }
+					/>
 				) ) }
 			</VStack>
-		</CollapsibleCard>
+		</VStack>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -1,12 +1,14 @@
 import {
 	Button,
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useCallback, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
+import { Card, CardBody, CardDivider } from '../../../components/card';
 import { CollapsibleCard } from '../../../components/collapsible-card';
 import type { RecordTracksEvent } from './types';
 
@@ -77,6 +79,7 @@ function StarterPromptItem( {
 
 	return (
 		<CollapsibleCard
+			isBorderless
 			disabled={ disabled }
 			toggleLabel={ prompt.title }
 			header={
@@ -88,7 +91,7 @@ function StarterPromptItem( {
 			<VStack spacing={ 3 }>
 				<Text variant="muted">{ prompt.description }</Text>
 				<div className="mcp-starter-prompt">
-					<div className="mcp-starter-prompt__copy">
+					<HStack justify="flex-end" className="mcp-starter-prompt__toolbar">
 						<Button
 							variant="tertiary"
 							icon={ copied ? check : copy }
@@ -96,7 +99,7 @@ function StarterPromptItem( {
 							showTooltip
 							onClick={ handleCopy }
 						/>
-					</div>
+					</HStack>
 					<Text className="mcp-starter-prompt__text">{ prompt.prompt }</Text>
 				</div>
 			</VStack>
@@ -119,30 +122,28 @@ export default function McpStarterPrompts( {
 	);
 
 	return (
-		<VStack spacing={ 4 }>
-			<VStack
-				spacing={ 2 }
-				className={ clsx( 'mcp-starter-prompts__intro', { 'is-disabled': disabled } ) }
-			>
-				<Text weight={ 600 } size={ 15 }>
-					{ __( 'Starter prompts' ) }
-				</Text>
-				<Text variant="muted">
-					{ __(
-						'The sky’s the limit with AI agents. To help you get the most out of our MCP, we’ve created a set of starter prompts you can hand straight to the AI agent of your choice once connected. Feel free to modify them as you see fit for the best experience, tailored to your agency.'
-					) }
-				</Text>
-			</VStack>
-			<VStack spacing={ 3 }>
-				{ STARTER_PROMPTS.map( ( prompt ) => (
-					<StarterPromptItem
-						key={ prompt.id }
-						prompt={ prompt }
-						disabled={ disabled }
-						onCopy={ onCopy }
-					/>
-				) ) }
-			</VStack>
-		</VStack>
+		<Card>
+			<CardBody>
+				<VStack
+					spacing={ 2 }
+					className={ clsx( 'mcp-starter-prompts__intro', { 'is-disabled': disabled } ) }
+				>
+					<Text weight={ 600 } size={ 15 }>
+						{ __( 'Starter prompts' ) }
+					</Text>
+					<Text variant="muted">
+						{ __(
+							'The sky’s the limit with AI agents. To help you get the most out of our MCP, we’ve created a set of starter prompts you can hand straight to the AI agent of your choice once connected. Feel free to modify them as you see fit for the best experience, tailored to your agency.'
+						) }
+					</Text>
+				</VStack>
+			</CardBody>
+			{ STARTER_PROMPTS.map( ( prompt ) => (
+				<Fragment key={ prompt.id }>
+					<CardDivider />
+					<StarterPromptItem prompt={ prompt } disabled={ disabled } onCopy={ onCopy } />
+				</Fragment>
+			) ) }
+		</Card>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -48,6 +48,10 @@
 	max-height: 400px;
 }
 
+.mcp-starter-prompts__intro.is-disabled {
+	opacity: 0.5;
+}
+
 .mcp-starter-prompt {
 	position: relative;
 	padding: 12px 16px;

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -53,23 +53,18 @@
 }
 
 .mcp-starter-prompt {
-	position: relative;
 	padding: 12px 16px;
 	border: 1px solid var( --color-border-subtle );
 	border-radius: 4px;
 	background: var( --color-neutral-0 );
 }
 
-.mcp-starter-prompt__copy {
-	position: absolute;
-	inset-block-start: 4px;
-	inset-inline-end: 4px;
+.mcp-starter-prompt__toolbar {
+	margin-block-end: 4px;
 }
 
 .mcp-starter-prompt__text {
 	display: block;
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
-	// Reserve room so the text never runs under the copy button.
-	padding-inline-end: 32px;
 }

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -60,7 +60,7 @@
 	background: var( --color-neutral-0 );
 }
 
-.mcp-starter-prompt__copy.components-button {
+.mcp-starter-prompt__copy {
 	position: absolute;
 	inset-block-start: 4px;
 	inset-inline-end: 4px;

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -47,3 +47,25 @@
 	min-height: 80px;
 	max-height: 400px;
 }
+
+.mcp-starter-prompt {
+	position: relative;
+	padding: 12px 16px;
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 4px;
+	background: var( --color-neutral-0 );
+}
+
+.mcp-starter-prompt__copy.components-button {
+	position: absolute;
+	inset-block-start: 4px;
+	inset-inline-end: 4px;
+}
+
+.mcp-starter-prompt__text {
+	display: block;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	// Reserve room so the text never runs under the copy button.
+	padding-inline-end: 32px;
+}

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -52,16 +52,6 @@
 	opacity: 0.5;
 }
 
-// The default CardDivider renders at the card's border color, which is heavier
-// than the subtle separators an FAQ list wants. Redraw it as a light hairline.
-hr.mcp-starter-prompts__divider {
-	background: transparent;
-	border: 0;
-	border-top: 1px solid var( --color-border-subtle );
-	height: 0;
-	margin: 0;
-}
-
 .mcp-starter-prompt {
 	padding: 12px 16px;
 	border: 1px solid var( --color-border-subtle );

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -52,6 +52,16 @@
 	opacity: 0.5;
 }
 
+// The default CardDivider renders at the card's border color, which is heavier
+// than the subtle separators an FAQ list wants. Redraw it as a light hairline.
+hr.mcp-starter-prompts__divider {
+	background: transparent;
+	border: 0;
+	border-top: 1px solid var( --color-border-subtle );
+	height: 0;
+	margin: 0;
+}
+
 .mcp-starter-prompt {
 	padding: 12px 16px;
 	border: 1px solid var( --color-border-subtle );

--- a/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
@@ -3,6 +3,7 @@
  */
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../../../test-utils';
 import McpOverview from '../overview-content';
 import type { McpSettings } from '@automattic/api-core';
@@ -11,18 +12,30 @@ const enabledSettings = { enabled: true, available_abilities: [] } as unknown as
 const disabledSettings = { enabled: false, available_abilities: [] } as unknown as McpSettings;
 
 describe( '<McpOverview> starter prompts section', () => {
-	test( 'expands the starter prompts inline when MCP access is enabled', () => {
+	test( 'shows expandable starter prompts when MCP access is enabled', async () => {
 		render( <McpOverview settings={ enabledSettings } onSave={ jest.fn() } /> );
 
 		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
 		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
+
+		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
+		expect(
+			screen.getByText( /Give me a high-level health check of my Automattic for Agencies account/ )
+		).toBeVisible();
 	} );
 
-	test( 'collapses and disables the starter prompts section until MCP access is enabled', () => {
+	test( 'disables the starter prompts until MCP access is enabled', async () => {
 		render( <McpOverview settings={ disabledSettings } onSave={ jest.fn() } /> );
 
 		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
-		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Toggle starter prompts' } ) ).toBeDisabled();
+		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Program health snapshot' } ) ).toBeDisabled();
+
+		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
+		expect(
+			screen.queryByText(
+				/Give me a high-level health check of my Automattic for Agencies account/
+			)
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import McpOverview from '../overview-content';
+import type { McpSettings } from '@automattic/api-core';
+
+const enabledSettings = { enabled: true, available_abilities: [] } as unknown as McpSettings;
+const disabledSettings = { enabled: false, available_abilities: [] } as unknown as McpSettings;
+
+describe( '<McpOverview> starter prompts section', () => {
+	test( 'expands the starter prompts inline when MCP access is enabled', () => {
+		render( <McpOverview settings={ enabledSettings } onSave={ jest.fn() } /> );
+
+		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
+		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
+	} );
+
+	test( 'collapses and disables the starter prompts section until MCP access is enabled', () => {
+		render( <McpOverview settings={ disabledSettings } onSave={ jest.fn() } /> );
+
+		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
+		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Toggle starter prompts' } ) ).toBeDisabled();
+	} );
+} );

--- a/client/dashboard/agency/resources/mcp/test/starter-prompts-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/starter-prompts-content.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../../test-utils';
+import McpStarterPrompts, { STARTER_PROMPTS } from '../starter-prompts-content';
+
+let clipboardWriteText: jest.Mock;
+
+function mockClipboard() {
+	Object.defineProperty( window.navigator, 'clipboard', {
+		value: { writeText: clipboardWriteText },
+		configurable: true,
+	} );
+}
+
+beforeEach( () => {
+	clipboardWriteText = jest.fn().mockResolvedValue( undefined );
+	mockClipboard();
+} );
+
+describe( '<McpStarterPrompts>', () => {
+	test( 'is expanded by default and shows all three prompts when enabled', () => {
+		render( <McpStarterPrompts /> );
+
+		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
+		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
+		expect( screen.getByText( 'Portfolio health summary' ) ).toBeVisible();
+		expect( screen.getByText( 'Recurring weekly report' ) ).toBeVisible();
+	} );
+
+	test( 'can be collapsed by the user', async () => {
+		render( <McpStarterPrompts /> );
+
+		await userEvent.click(
+			screen.getAllByRole( 'button', { name: 'Toggle starter prompts' } )[ 0 ]
+		);
+
+		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'copies the raw prompt text and records a tracks event', async () => {
+		const recordTracksEvent = jest.fn();
+		render( <McpStarterPrompts recordTracksEvent={ recordTracksEvent } /> );
+
+		const firstPrompt = STARTER_PROMPTS[ 0 ];
+		await userEvent.click( screen.getAllByRole( 'button', { name: /copy prompt/i } )[ 0 ] );
+
+		expect( clipboardWriteText ).toHaveBeenCalledWith( firstPrompt.prompt );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_a4a_ai_mcp_starter_prompt_copied', {
+			prompt_id: firstPrompt.id,
+		} );
+	} );
+
+	test( 'is collapsed and cannot be expanded when disabled', async () => {
+		render( <McpStarterPrompts disabled /> );
+
+		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByText( 'Starter prompts' ) );
+
+		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/agency/resources/mcp/test/starter-prompts-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/starter-prompts-content.test.tsx
@@ -22,23 +22,24 @@ beforeEach( () => {
 } );
 
 describe( '<McpStarterPrompts>', () => {
-	test( 'is expanded by default and shows all three prompts when enabled', () => {
+	test( 'shows a collapsed FAQ item per prompt with the prompt text hidden', () => {
 		render( <McpStarterPrompts /> );
 
 		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
 		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
 		expect( screen.getByText( 'Portfolio health summary' ) ).toBeVisible();
 		expect( screen.getByText( 'Recurring weekly report' ) ).toBeVisible();
+
+		// The prompt text stays out of the way until the item is expanded.
+		expect( screen.queryByText( STARTER_PROMPTS[ 0 ].prompt ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'can be collapsed by the user', async () => {
+	test( 'expands an item to reveal its prompt', async () => {
 		render( <McpStarterPrompts /> );
 
-		await userEvent.click(
-			screen.getAllByRole( 'button', { name: 'Toggle starter prompts' } )[ 0 ]
-		);
+		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
 
-		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( STARTER_PROMPTS[ 0 ].prompt ) ).toBeVisible();
 	} );
 
 	test( 'copies the raw prompt text and records a tracks event', async () => {
@@ -46,7 +47,8 @@ describe( '<McpStarterPrompts>', () => {
 		render( <McpStarterPrompts recordTracksEvent={ recordTracksEvent } /> );
 
 		const firstPrompt = STARTER_PROMPTS[ 0 ];
-		await userEvent.click( screen.getAllByRole( 'button', { name: /copy prompt/i } )[ 0 ] );
+		await userEvent.click( screen.getByText( firstPrompt.title ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /copy prompt/i } ) );
 
 		expect( clipboardWriteText ).toHaveBeenCalledWith( firstPrompt.prompt );
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_a4a_ai_mcp_starter_prompt_copied', {
@@ -54,13 +56,11 @@ describe( '<McpStarterPrompts>', () => {
 		} );
 	} );
 
-	test( 'is collapsed and cannot be expanded when disabled', async () => {
+	test( 'items cannot be expanded when disabled', async () => {
 		render( <McpStarterPrompts disabled /> );
 
-		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
 
-		await userEvent.click( screen.getByText( 'Starter prompts' ) );
-
-		expect( screen.queryByText( 'Program health snapshot' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( STARTER_PROMPTS[ 0 ].prompt ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/components/collapsible-card/index.tsx
+++ b/client/dashboard/components/collapsible-card/index.tsx
@@ -15,6 +15,8 @@ interface CollapsibleCardProps {
 	toggleLabel?: string;
 	initialExpanded?: boolean;
 	className?: string;
+	// When disabled, the card is forced collapsed and can't be toggled.
+	disabled?: boolean;
 	// Controlled mode props
 	expanded?: boolean;
 	onToggle?: ( expanded: boolean ) => void;
@@ -27,6 +29,7 @@ export const CollapsibleCard = ( {
 	size = 'medium',
 	isBorderless = false,
 	initialExpanded = false,
+	disabled = false,
 	expanded: controlledExpanded,
 	className,
 	onToggle,
@@ -36,7 +39,7 @@ export const CollapsibleCard = ( {
 
 	// Determine if controlled
 	const isControlled = controlledExpanded !== undefined;
-	const isExpanded = isControlled ? controlledExpanded : internalExpanded;
+	const isExpanded = ! disabled && ( isControlled ? controlledExpanded : internalExpanded );
 
 	const id = useInstanceId( CollapsibleCard, 'collapsible-card' );
 	const label = toggleLabel ?? __( 'Toggle content' );
@@ -77,24 +80,33 @@ export const CollapsibleCard = ( {
 
 	return (
 		<Card
-			className={ clsx( 'collapsible-card', { collapsed: ! isExpanded }, className ) }
+			className={ clsx(
+				'collapsible-card',
+				{ collapsed: ! isExpanded, 'is-disabled': disabled },
+				className
+			) }
 			isBorderless={ isBorderless }
 			size={ size }
 		>
 			<CardBody>
 				<div
 					className="collapsible-card__header"
-					onClick={ handleHeaderClick }
-					role="button"
-					tabIndex={ 0 }
-					onKeyDown={ ( event: React.KeyboardEvent< HTMLDivElement > ) => {
-						// Allow keyboard activation with Enter or Space
-						if ( event.key === 'Enter' || event.key === ' ' ) {
-							event.preventDefault();
-							handleCollapsedChange();
-						}
-					} }
-					aria-expanded={ isExpanded }
+					onClick={ disabled ? undefined : handleHeaderClick }
+					role={ disabled ? undefined : 'button' }
+					tabIndex={ disabled ? undefined : 0 }
+					onKeyDown={
+						disabled
+							? undefined
+							: ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+									// Allow keyboard activation with Enter or Space
+									if ( event.key === 'Enter' || event.key === ' ' ) {
+										event.preventDefault();
+										handleCollapsedChange();
+									}
+							  }
+					}
+					aria-expanded={ disabled ? undefined : isExpanded }
+					aria-disabled={ disabled || undefined }
 					aria-label={ label }
 				>
 					<HStack justify="space-between">
@@ -102,6 +114,7 @@ export const CollapsibleCard = ( {
 						<Button
 							icon={ chevronUp }
 							className={ clsx( 'collapsible-card__toggle', { collapsed: ! isExpanded } ) }
+							disabled={ disabled }
 							onClick={ ( event: React.MouseEvent< HTMLButtonElement > ) => {
 								event.stopPropagation();
 								handleCollapsedChange();

--- a/client/dashboard/components/collapsible-card/style.scss
+++ b/client/dashboard/components/collapsible-card/style.scss
@@ -17,6 +17,14 @@
 		margin-inline-start: auto;
 	}
 
+	&.is-disabled {
+		opacity: 0.5;
+
+		.collapsible-card__header {
+			cursor: default;
+		}
+	}
+
 	// Make header clickable with visual feedback
 	.collapsible-card__header {
 		cursor: pointer;


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2920/a4a-mcp-starter-prompts-for-the-private-beta

## Proposed Changes

* Add a collapsible **Starter prompts** section below the setup steps on the A4A MCP overview page, listing three copy-paste starter prompts (program health snapshot, portfolio health summary, recurring weekly report).
* Each prompt has a title, a short description, and the full prompt in a read-only block with an icon-only copy-to-clipboard button pinned to the top-right.
* The section is **expanded by default once MCP access is enabled**, and **collapsed and greyed out** while MCP access is disabled.
* Add a backward-compatible `disabled` prop to the shared `CollapsibleCard` component (forces collapsed, disables the toggle, greys the card) to support the gating.
* Emit `calypso_a4a_ai_mcp_starter_prompt_copied` (with `prompt_id`) when a prompt is copied.

Because the MCP overview content lives in the Dashboard client and is reused by the Calypso A4A wrappers, this single change surfaces the section in both.

<img width="1571" height="1095" alt="Screenshot 2026-07-03 at 7 48 32 PM" src="https://github.com/user-attachments/assets/74605be4-0dad-42ed-85d3-5cf2e212070f" />


## Why are these changes being made?

To help agencies get value from the MCP quickly, regardless of technical background, by giving them ready-made prompts they can hand straight to their AI agent once connected. Keeping the section collapsible (and gated on MCP being enabled) keeps the overview tidy while surfacing the prompts at the moment they become usable.

## Testing Instructions

1. Open **Resources & tools → AI and MCP** in an account with MCP beta access.
2. With **Enable MCP access** off: confirm the **Starter prompts** section appears below the three setup steps, collapsed and greyed out, and cannot be expanded.
3. Toggle **Enable MCP access** on: confirm the section expands automatically and shows the three prompts.
4. Click a prompt's copy button: confirm the icon briefly switches to a checkmark and the clipboard contains the exact prompt text.
5. Collapse/expand the section via its header while enabled; toggle MCP access off again and confirm it collapses and greys out.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
