### PR TITLE
Match nested merge queue branches in TeamCity

### DIFF
--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -2,7 +2,9 @@ package _self.lib.utils
 
 const val MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS = """
 -:gh-readonly-queue/*
+-:gh-readonly-queue/trunk/*
 -:refs/heads/gh-readonly-queue/*
+-:refs/heads/gh-readonly-queue/trunk/*
 """
 
 fun String.excludeMergeQueueBranches(): String {


### PR DESCRIPTION
## Proposed Changes

* Add nested merge queue branch exclusions for `gh-readonly-queue/trunk/*`.
* Add the matching fully-qualified ref exclusion for `refs/heads/gh-readonly-queue/trunk/*`.

## Why are these changes being made?

* TeamCity triggered `E2E Tests (mobile)` from VCS trigger `TRIGGER_1` for branch `gh-readonly-queue/trunk/pr-112265-caeed0c2206130fb7520a3649669711fb76c3a9e`.
* The existing `gh-readonly-queue/*` exclusions did not catch that nested branch shape, so non-required TeamCity jobs still ran for merge queue branches.

## Testing Instructions

* `git diff --check -- .teamcity/_self/lib/utils/MergeQueue.kt`
* Confirmed no old runtime skip helpers or PR-trigger filter helpers are present with `rg`.
* Attempted `mvn org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate` from `.teamcity`; it could not resolve the TeamCity DSL parent POM because `teamcity.a8c.com/app/dsl-plugins-repository` timed out from this environment.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
