### PR TITLE
Fix merge queue branch filter exclusions broken by trimIndent

### DIFF
--- a/.teamcity/_self/lib/utils/MergeQueue.kt
+++ b/.teamcity/_self/lib/utils/MergeQueue.kt
@@ -47,10 +47,11 @@ fun <T : BuildStep> T.skipOnMergeQueueBranch(): T {
 }
 
 fun String.excludeMergeQueueBranches(): String {
-	return """
-		${this.trimIndent()}
-		${MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()}
-	""".trimIndent()
+	// Concatenate instead of using a raw-string template: interpolating a
+	// multi-line value into an indented template leaves all but its first line
+	// unindented, so the final trimIndent() strips nothing and TeamCity receives
+	// tab-indented filter lines, which it silently ignores.
+	return this.trimIndent().trim() + "\n" + MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.trim()
 }
 
 fun allBranchesExceptMergeQueue(): String {


### PR DESCRIPTION
Part of the merge queue rollout (follow-up to #112221 / #112186).

## Proposed Changes

* Rebuild `excludeMergeQueueBranches()` in `.teamcity/_self/lib/utils/MergeQueue.kt` with plain string concatenation instead of an indented raw-string template.

## Why are these changes being made?

Merge queue branches (`gh-readonly-queue/*`) were still triggering VCS builds despite the branch filter exclusions added in #112221. The exclusions were generated, but corrupted by a Kotlin `trimIndent()` gotcha:

When a multi-line value is interpolated into an indented raw-string template, only its first line inherits the template's indentation — the remaining lines land at column 0. The trailing `trimIndent()` then computes a common indent of **zero** and strips nothing. The filter actually delivered to TeamCity was (tabs shown as `→`):

```
→→+:<default>
+:*
→→-:gh-readonly-queue/*
-:refs/heads/gh-readonly-queue/*
```

TeamCity does not trim leading whitespace in branch filter lines, so:

- `→→+:<default>` — dead rule
- `+:*` — works, includes everything
- `→→-:gh-readonly-queue/*` — dead rule, and the only one that could have matched
- `-:refs/heads/gh-readonly-queue/*` — clean, but never matches: branch filters operate on *logical* branch names (`gh-readonly-queue/trunk/pr-…`), not refs

The effective filter collapsed to `+:*`, so merge queue branches kept triggering.

This same bug explains the earlier incident: in #112186 the call site was `"+:*".excludeMergeQueueBranches()`, which put `+:*` on the tab-indented (dead) first line, leaving no include rules at all — that's what stopped the trunk E2E/Translate builds and led to the revert (#112216). The `+:<default>` addition in #112221 only reshuffled which lines happened to land at column 0.

With this fix, every call site (`allBranchesExceptMergeQueue()` and the inline `""" … """.excludeMergeQueueBranches()` filters) emits clean, unindented rules:

```
+:<default>
+:*
-:gh-readonly-queue/*
-:refs/heads/gh-readonly-queue/*
```

## Testing Instructions

* Simulated the Kotlin string semantics for all call-site shapes and verified every generated line is unindented and starts with `+:`/`-:`.
* After merge, in TeamCity check a build config that uses the helper (e.g. the E2E template or Translate): the trigger/VCS branch filter should show no indented lines.
* Enqueue a PR in the merge queue and confirm the non-required builds no longer start for the `gh-readonly-queue/…` branch, while trunk and PR branches still trigger normally.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)