### PR TITLE
Fix GitHub capitalization in Gutenberg issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
+++ b/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
@@ -9,12 +9,12 @@ assignees: ''
 
 <!--
 IMPORTANT: When updating this template, please make sure both copies are kept the same! This ensures our upgrade helper bot is in sync with our manual template.
-Github template: https://github.com/Automattic/wp-calypso/blob/trunk/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
+GitHub template: https://github.com/Automattic/wp-calypso/blob/trunk/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
 Gutenberg Upgrade Helper Bot™ template: trunk/bin/gutenberg-plugin-upgrade-tracking-issue-template.md
 
 Thanks for updating Gutenberg! Please be sure to update the title above with the version number you're upgrading. This post will cover all potential RCs and point releases (Example, "Gutenberg: v11.2.x plugin upgrade" would cover everything from 11.2.0-rc.1 to 11.2.1, should those all become available)
 
-- Previous Upgrade issue should be linked using Github issue numbers (for example, #53725)
+- Previous Upgrade issue should be linked using GitHub issue numbers (for example, #53725)
 - Release notes for the version(s) you're implementing should be linked directly to the WordPress/gutenberg repo tag
 (for example, linking the text 'v11.0.0-rc.1' to https://github.com/WordPress/gutenberg/releases/tag/v11.0.0-rc.1)
 -->


### PR DESCRIPTION
## Proposed Changes

* Fix `GitHub` capitalization in the Gutenberg plugin upgrade issue template.

## Why are these changes being made?

* This is a tiny docs-only typo fix for a pipeline smoke-test PR.

## Testing Instructions

* Review the one-line capitalization updates in `.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md`.
* Confirm `git diff --check -- .github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md` passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
