### PR TITLE
E2E: add flake probes for signup and importer flows

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -1,5 +1,6 @@
 import { Locator, Page, Response } from 'playwright';
 import { reloadAndRetry, waitForElementEnabled } from '../../element-helper';
+import { flakeProbe, capturePageState } from '../flake-probe';
 
 type CartResponseDiagnostic = {
 	method: string;
@@ -253,7 +254,15 @@ export class DomainSearchComponent {
 		row: Locator,
 		waitForContinueButton: boolean = true
 	): Promise< string | null > {
-		await row.waitFor();
+		try {
+			await row.waitFor();
+		} catch ( error ) {
+			flakeProbe( 'domainSearch.suggestionRowTimeout', {
+				...( await capturePageState( this.page ) ),
+				error: ( error as Error ).message,
+			} );
+			throw error;
+		}
 
 		// List freshness is guaranteed by search(), which waits for the
 		// suggestions response and for the DOM to reflect it before returning,

--- a/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
@@ -32,7 +32,14 @@ export class EditorWelcomeGuideComponent {
 		const editorParent = await this.editor.parent();
 
 		const welcomGuideWrapper = editorParent.locator( selectors.welcomeGuideWrapper );
-		await welcomGuideWrapper.waitFor( { state: 'visible' } );
+		// The guide only shows on some editor loads. Keep the framework's default
+		// wait window so a slow-rendering guide is still caught, but return instead
+		// of throwing when it never appears.
+		try {
+			await welcomGuideWrapper.waitFor( { state: 'visible', timeout: 10000 } );
+		} catch {
+			return;
+		}
 
 		const closeBtn = editorParent.locator( selectors.welcomeGuideCloseButton );
 		await closeBtn.click();

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -1,6 +1,7 @@
 import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 import envVariables from '../../env-variables';
+import { flakeProbe, capturePageState } from '../flake-probe';
 import { NavbarComponent } from './navbar-component';
 
 type FocusType = 'Sites' | 'Sidebar';
@@ -39,10 +40,18 @@ export class SidebarComponent {
 	async waitForSidebarInitialization(): Promise< void > {
 		const sidebarLocator = this.page.locator( `${ selectors.sidebar }, .global-sidebar` ).first();
 
-		await Promise.all( [
-			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
-			sidebarLocator.waitFor( { timeout: 20 * 1000 } ),
-		] );
+		try {
+			await Promise.all( [
+				this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
+				sidebarLocator.waitFor( { timeout: 20 * 1000 } ),
+			] );
+		} catch ( error ) {
+			flakeProbe( 'sidebar.initializationTimeout', {
+				...( await capturePageState( this.page ) ),
+				error: ( error as Error ).message,
+			} );
+			throw error;
+		}
 
 		// If the sidebar is collapsed (via the Collapse Menu toggle),
 		// re-expand the sidebar.

--- a/packages/calypso-e2e/src/lib/flake-probe.ts
+++ b/packages/calypso-e2e/src/lib/flake-probe.ts
@@ -1,0 +1,41 @@
+import type { Page } from 'playwright';
+
+// Throwaway diagnostics for the signup/importer flakes tracked in
+// fix/e2e-signup-importer-flake-probes. Emits greppable [FLAKE-PROBE] lines to
+// the CI build log. Remove this file and its call sites once the timing/failure
+// data has been collected.
+
+const PREFIX = '[FLAKE-PROBE]';
+
+/**
+ * Emits a single greppable diagnostic line to stdout (captured in the CI log).
+ *
+ * Writes via `process.stdout.write` rather than `console.log`: CI runs the Jest
+ * package tests with `--silent`, which mutes `console.*`, and a single write
+ * keeps the line intact when workers run concurrently.
+ */
+export function flakeProbe( label: string, data: Record< string, unknown > ): void {
+	process.stdout.write( `${ PREFIX } ${ label } ${ JSON.stringify( data ) }\n` );
+}
+
+/**
+ * Captures cheap page state at a failure point. Never throws and never waits on
+ * elements, so it cannot itself hang or mask the original failure.
+ */
+export async function capturePageState( page: Page ): Promise< Record< string, unknown > > {
+	const safe = async < T >( fn: () => Promise< T >, fallback: T ): Promise< T > => {
+		try {
+			return await fn();
+		} catch {
+			return fallback;
+		}
+	};
+
+	return {
+		url: page.url(),
+		headings: ( await safe( () => page.locator( 'h1, h2' ).allInnerTexts(), [] ) ).slice( 0, 8 ),
+		errors: (
+			await safe( () => page.locator( '[class*="error"], [role="alert"]' ).allInnerTexts(), [] )
+		).slice( 0, 8 ),
+	};
+}

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -1,5 +1,6 @@
 import { Page } from 'playwright';
 import { DataHelper } from '../..';
+import { flakeProbe, capturePageState } from '../flake-probe';
 
 const selectors = {
 	// Generic
@@ -159,7 +160,16 @@ export class StartImportFlow {
 	 * Validates that we've landed on the importer drag page.
 	 */
 	async validateImporterDragPage( importer: string ): Promise< void > {
-		await this.page.locator( selectors.importerDrag( importer ) ).waitFor( { timeout: 60_000 } );
+		try {
+			await this.page.locator( selectors.importerDrag( importer ) ).waitFor( { timeout: 60_000 } );
+		} catch ( error ) {
+			flakeProbe( 'importer.dragPageTimeout', {
+				importer,
+				...( await capturePageState( this.page ) ),
+				error: ( error as Error ).message,
+			} );
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/index.ts
+++ b/packages/calypso-e2e/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { TestAccount } from './test-account';
+export { flakeProbe, capturePageState } from './flake-probe';
 
 export * from './pages';
 export * from './flows';

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -27,6 +27,8 @@ import {
 	CookieBannerComponent,
 	EditorToolbarSettingsButton,
 } from '../components';
+import { flakeProbe } from '../flake-probe';
+import { armResponseCapture } from '../response-capture';
 import { BlockInserter, OpenInlineInserter } from './shared-types';
 import type {
 	EditorPreviewOptions,
@@ -1129,32 +1131,67 @@ export class EditorPage {
 		);
 
 		// Resolve the promises.
-		let publishedAtMs: number | undefined;
-		const [ response ] = await Promise.all( [
-			// First URL matches Atomic requests while the second matches Simple requests.
-			Promise.race( [
-				this.page.waitForResponse(
-					async ( response ) =>
-						/v2\/(posts|pages)\/[\d]+/.test( response.url() ) &&
-						response.request().method() === 'POST',
-					{ timeout: timeout }
-				),
-				this.page.waitForResponse(
-					async ( response ) =>
-						/.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/.test( response.url() ) &&
-						response.request().method() === 'PUT',
-					{ timeout: timeout }
-				),
-			] ).then( ( publishResponse ) => {
-				// Captured the moment the publish response arrives, before the remaining
-				// publish-panel actions settle, so the probe measures the full window.
-				publishedAtMs = Date.now();
-				return publishResponse;
-			} ),
-			...actionsArray,
-		] );
+		// Capture the publish response body via request interception. Playwright reads
+		// bodies lazily over CDP; in publish-then-navigate flows (start-writing redirects
+		// to the launchpad on publish) a deferred response.json() races the navigation,
+		// which evicts the resource and fails with "No resource with given identifier
+		// found". route.fetch() buffers the body in the driver, immune to that eviction.
+		// Arm it before the publish actions trigger the request.
+		const bodyCapture = await armResponseCapture(
+			this.page,
+			/v2\/(posts|pages)\/\d+|v2\/sites\/\d+\/(posts|pages)\/\d+/,
+			( request ) => {
+				const url = request.url();
+				const method = request.method();
+				return (
+					( /v2\/(posts|pages)\/[\d]+/.test( url ) && method === 'POST' ) ||
+					( /v2\/sites\/[\d]+\/(posts|pages)\/[\d]+/.test( url ) && method === 'PUT' )
+				);
+			},
+			{ timeout: timeout }
+		);
 
-		const json = ( await response.json() ) as PublishResponseBody;
+		let publishedAtMs: number | undefined;
+		let response!: Response;
+		let json!: PublishResponseBody;
+		try {
+			// First URL matches Atomic requests while the second matches Simple requests.
+			[ response ] = await Promise.all( [
+				Promise.race( [
+					this.page.waitForResponse(
+						async ( response ) =>
+							/v2\/(posts|pages)\/[\d]+/.test( response.url() ) &&
+							response.request().method() === 'POST',
+						{ timeout: timeout }
+					),
+					this.page.waitForResponse(
+						async ( response ) =>
+							/.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/.test( response.url() ) &&
+							response.request().method() === 'PUT',
+						{ timeout: timeout }
+					),
+				] ).then( ( publishResponse ) => {
+					publishedAtMs = Date.now();
+					return publishResponse;
+				} ),
+				...actionsArray,
+			] );
+
+			try {
+				json = JSON.parse( await bodyCapture.body ) as PublishResponseBody;
+			} catch ( error ) {
+				flakeProbe( 'publish.responseBodyUnavailable', {
+					status: response.status(),
+					method: response.request().method(),
+					url: sanitizeURLForDiagnostics( response.url() ),
+					msSincePublishResponse: publishedAtMs !== undefined ? Date.now() - publishedAtMs : null,
+					error: ( error as Error ).message,
+				} );
+				throw error;
+			}
+		} finally {
+			await bodyCapture.dispose();
+		}
 		// AT and Simple sites have slightly differing response from the API.
 		const publishedURL = json.link || json.body?.link;
 		if ( ! publishedURL ) {

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -1,5 +1,6 @@
 import { Locator, Page, Response } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
+import { flakeProbe, capturePageState } from '../flake-probe';
 
 const selectors = {
 	continue: 'button:text("Continue"),a:text("Continue")',
@@ -47,10 +48,18 @@ export class LoginPage {
 		await this.fillUsername( username );
 		await this.clickSubmit();
 		await this.fillPassword( password );
-		await Promise.all( [
-			this.page.waitForNavigation( { timeout: 20 * 1000 } ),
-			this.clickSubmit(),
-		] );
+		try {
+			await Promise.all( [
+				this.page.waitForNavigation( { timeout: 20 * 1000 } ),
+				this.clickSubmit(),
+			] );
+		} catch ( error ) {
+			flakeProbe( 'login.submitNavigationTimeout', {
+				...( await capturePageState( this.page ) ),
+				error: ( error as Error ).message,
+			} );
+			throw error;
+		}
 	}
 
 	/**
@@ -66,7 +75,32 @@ export class LoginPage {
 	 */
 	async fillUsername( value: string ): Promise< Locator > {
 		const locator = await this.page.locator( 'input[name="usernameOrEmail"]' );
-		await locator.fill( value );
+		const startedAtMs = Date.now();
+		const probeFillFailure = async ( label: string, err: unknown ): Promise< void > =>
+			flakeProbe( label, {
+				elapsedMs: Date.now() - startedAtMs,
+				visible: await locator.isVisible().catch( () => null ),
+				enabled: await locator.isEnabled().catch( () => null ),
+				count: await locator.count().catch( () => null ),
+				...( await capturePageState( this.page ) ),
+				error: ( err as Error ).message,
+			} );
+		try {
+			await locator.fill( value );
+		} catch ( firstError ) {
+			// The login input can stay disabled if the page fails to hydrate; a
+			// reload recovers it. Probe the stall, then reload and retry once before
+			// failing, so reload-recoveries are counted separately from hard failures.
+			await probeFillFailure( 'login.fillUsernameDisabledReloading', firstError );
+			await this.page.reload();
+			try {
+				await locator.fill( value );
+			} catch ( error ) {
+				await probeFillFailure( 'login.fillUsernameTimeout', error );
+				throw error;
+			}
+		}
+		flakeProbe( 'login.fillUsername', { elapsedMs: Date.now() - startedAtMs } );
 
 		return locator;
 	}

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -1,5 +1,6 @@
 import { Page, Locator, Frame } from 'playwright';
 import { getCalypsoURL } from '../../../data-helper';
+import { armResponseCapture } from '../../response-capture';
 import type { NewSiteResponse, NewUserResponse } from '../../../types/rest-api-client.types';
 
 /**
@@ -460,18 +461,19 @@ export class UserSignupPage {
 			this.page.on( 'framenavigated', handler );
 		} );
 
-		// Ensure response is captured correctly
-		const responsePromise = this.page.waitForResponse( /\/users\/new\?[^?]*$/ );
-		await this.submitButton.click();
-
-		const [ response ] = await Promise.all( [ responsePromise, redirectDetected ] );
-
-		if ( ! response ) {
-			throw new Error( 'Failed to create new user at WooCommerce using WPCC.' );
+		// Capture the /users/new body via interception: the redirect to
+		// woocommerce.com evicts the page response before response.json() can read it,
+		// so read it from route.fetch() (buffered in the driver) instead.
+		const bodyCapture = await armResponseCapture( this.page, /\/users\/new\?/, ( request ) =>
+			/\/users\/new\?[^?]*$/.test( request.url() )
+		);
+		try {
+			await this.submitButton.click();
+			const [ text ] = await Promise.all( [ bodyCapture.body, redirectDetected ] );
+			return JSON.parse( text ) as NewUserResponse;
+		} finally {
+			await bodyCapture.dispose();
 		}
-
-		const responseBody: NewUserResponse = await response.json();
-		return responseBody;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/response-capture.ts
+++ b/packages/calypso-e2e/src/lib/response-capture.ts
@@ -1,0 +1,93 @@
+import { Page, Route, Request as PlaywrightRequest } from 'playwright';
+
+interface ArmedCapture {
+	/**
+	 * Resolves with the matched response's body text, captured immune to a page
+	 * navigation that would otherwise evict it. Rejects if no matching response
+	 * arrives within the timeout.
+	 */
+	body: Promise< string >;
+	/** Removes the route and clears the timeout. Safe to call more than once. */
+	dispose: () => Promise< void >;
+}
+
+/**
+ * Arms interception for the first request satisfying `isTarget` and returns a
+ * promise for its response body text.
+ *
+ * Playwright reads response bodies lazily over CDP (`Network.getResponseBody`).
+ * When the page navigates right after a request — publish redirecting to the
+ * launchpad, WooCommerce signup redirecting to woocommerce.com — a later
+ * `response.json()` races the navigation, which evicts the network resource and
+ * throws "No resource with given identifier found". `route.fetch()` returns an
+ * APIResponse buffered in the driver process, not the page, so reading its body
+ * is immune to that eviction.
+ *
+ * Arm this before the action that triggers the request, run the action, then
+ * await `body`. Always `dispose()` afterwards to remove the route.
+ *
+ * @param page       The page to intercept on.
+ * @param urlPattern Route pattern; keep it narrow so unrelated requests are not
+ *                   intercepted. Non-matching-method requests to the same URL
+ *                   are passed through untouched.
+ * @param isTarget   Predicate selecting the exact request to capture.
+ * @param options         Optional settings.
+ * @param options.timeout Milliseconds to wait for a matching response (default 30s).
+ */
+export async function armResponseCapture(
+	page: Page,
+	urlPattern: RegExp,
+	isTarget: ( request: PlaywrightRequest ) => boolean,
+	options: { timeout?: number } = {}
+): Promise< ArmedCapture > {
+	const timeout = options.timeout ?? 30_000;
+
+	let settle!: ( text: string ) => void;
+	let fail!: ( error: Error ) => void;
+	const body = new Promise< string >( ( resolve, reject ) => {
+		settle = resolve;
+		fail = reject;
+	} );
+
+	let matched = false;
+	const handler = async ( route: Route ) => {
+		if ( matched || ! isTarget( route.request() ) ) {
+			await route.continue();
+			return;
+		}
+		matched = true;
+		try {
+			const apiResponse = await route.fetch();
+			const text = await apiResponse.text();
+			// Fulfill from the decoded text, dropping the encoding/length headers so
+			// the browser does not try to gunzip an already-decoded body.
+			const headers = { ...apiResponse.headers() };
+			delete headers[ 'content-encoding' ];
+			delete headers[ 'content-length' ];
+			await route.fulfill( { status: apiResponse.status(), headers, body: text } );
+			settle( text );
+		} catch ( error ) {
+			fail( error as Error );
+			await route.continue().catch( () => undefined );
+		}
+	};
+
+	await page.route( urlPattern, handler );
+
+	const timer = setTimeout(
+		() => fail( new Error( `armResponseCapture: no matching response within ${ timeout }ms` ) ),
+		timeout
+	);
+
+	let disposed = false;
+	const dispose = async (): Promise< void > => {
+		if ( disposed ) {
+			return;
+		}
+		disposed = true;
+		clearTimeout( timer );
+		await page.unroute( urlPattern, handler ).catch( () => undefined );
+	};
+
+	return { body, dispose };
+}

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
@@ -1,4 +1,10 @@
-import { NewTestUserDetails, NewUserResponse, RestAPIClient } from '@automattic/calypso-e2e';
+import {
+	NewTestUserDetails,
+	NewUserResponse,
+	RestAPIClient,
+	flakeProbe,
+	capturePageState,
+} from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 
@@ -113,10 +119,18 @@ test.describe(
 				// The plans grid renders after the step transition, so the
 				// free-plan button can appear later than the 10s action timeout.
 				// Wait explicitly before clicking.
-				await flowStartWriting.startWithFreePlanButton.waitFor( {
-					state: 'visible',
-					timeout: 30 * 1000,
-				} );
+				try {
+					await flowStartWriting.startWithFreePlanButton.waitFor( {
+						state: 'visible',
+						timeout: 30 * 1000,
+					} );
+				} catch ( error ) {
+					flakeProbe( 'startWriting.freePlanButtonTimeout', {
+						...( await capturePageState( page ) ),
+						error: ( error as Error ).message,
+					} );
+					throw error;
+				}
 				await flowStartWriting.startWithFreePlanButton.click();
 			} );
 

--- a/test/e2e/specs/shared/api-wait-for-account-propagation.ts
+++ b/test/e2e/specs/shared/api-wait-for-account-propagation.ts
@@ -1,4 +1,8 @@
-import type { MyAccountInformationResponse, RestAPIClient } from '@automattic/calypso-e2e';
+import {
+	flakeProbe,
+	type MyAccountInformationResponse,
+	type RestAPIClient,
+} from '@automattic/calypso-e2e';
 
 const POLL_INTERVAL = 1000;
 const POLL_TIMEOUT = 30 * 1000;
@@ -63,6 +67,11 @@ async function pollMyAccountInformation(
 		}
 		await new Promise( ( resolve ) => setTimeout( resolve, POLL_INTERVAL ) );
 	}
+	flakeProbe( 'apiPropagation.timeout', {
+		message: timeoutMessage,
+		lastError: String( lastError ),
+		pollTimeoutMs: POLL_TIMEOUT,
+	} );
 	throw new Error( lastError ? `${ timeoutMessage } Last error: ${ lastError }` : timeoutMessage );
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR both **fixes** confirmed E2E flakes and adds **temporary** `[FLAKE-PROBE]` diagnostics (log-only, original error rethrown, no behavior change) for failure clusters still under investigation.

### Fixes

* **Publish / signup response-body CDP race** (`editor-page.publish()`, WPCC signup `/users/new`) — Playwright reads response bodies lazily over CDP; a post-publish → launchpad (and post-signup → woocommerce.com) navigation evicted the body before `response.json()` could read it (`No resource with given identifier found`). New `armResponseCapture` helper reads the body from `route.fetch()`, buffered in the driver and immune to the navigation. The `publish.responseBodyUnavailable` probe dropped from **2 on every healthy CI run to 0** across repeated healthy runs.
* **Login username input stuck disabled** (`login-page.ts` `fillUsername`) — the input can stay `disabled` past the 10s action timeout when the page fails to hydrate. Reload once and retry (validated ~10/10 recoveries in CI).
* **Editor welcome guide hard-wait** (`editor-welcome-guide-component.ts` `closeWelcomeGuideIfNeeded`) — the guide only shows on some editor loads; tolerate its absence instead of throwing after a 10s wait.

### Probes (temporary, removed once data is collected)

Emitted via `process.stdout.write` so CI's `--silent` Jest runs don't mute them; each is a try/catch that logs one line and rethrows.

* `login-page.ts` — submit-navigation timeout
* `sidebar-component.ts` — sidebar initialization timeout
* `start-import-flow.ts` — importer drag-page timeout
* `domain-search-component.ts` — `selectSuggestion` row timeout
* `signup__start-writing-tailored.spec.ts` — free-plan button timeout
* `api-wait-for-account-propagation.ts` — account-propagation poll timeout (logs `lastError` to separate an `invalid_token` rejection from `email_verified` never flipping)
* `editor-page.ts` `publish()` — `responseBodyUnavailable` guard, kept to confirm the CDP-race fix stays at 0

Helpers: `packages/calypso-e2e/src/lib/response-capture.ts` (the fix), `packages/calypso-e2e/src/lib/flake-probe.ts` (throwaway diagnostics).

## Why these changes are being made?

Recurring flakes on the Calypso E2E / pre-release Playwright matrix retried into *different* errors each attempt (flaky, not broken). Existing traces showed the final assertion but not the timing or intermediate page state needed to isolate root cause. The probes captured that state in CI, which pinned three root causes (above) and surfaced further clusters still being characterized.

## Testing Instructions

Not usefully runnable locally (needs live WordPress.com env). Verified via CI: grep the E2E build logs for `[FLAKE-PROBE]`. The publish fix was confirmed by repeated healthy-container reruns showing `publish.responseBodyUnavailable` at 0 (was 2/run pre-fix).
