### PR TITLE
Onboarding: set the Sell intent for commerce plans at site creation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -1,3 +1,4 @@
+import { isEcommerce } from '@automattic/calypso-products';
 import { Site, Onboard } from '@automattic/data-stores';
 import {
 	AI_SITE_BUILDER_FLOW,
@@ -236,13 +237,20 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		// eslint-disable-next-line no-nested-ternary
-		const siteIntent = isNewSiteMigrationFlow( flow )
-			? 'migration'
-			: isSimplifiedOnboarding
-			? // For the simplified onboarding flow, we'll use the build intent since user can't choose the intent.
-			  Onboard.SiteIntent.Build
-			: '';
+		const isCommercePlan = !! planCartItem && isEcommerce( planCartItem );
+
+		let siteIntent = '';
+		if ( isNewSiteMigrationFlow( flow ) ) {
+			siteIntent = 'migration';
+		} else if ( isCommercePlan ) {
+			// Create commerce sites with the Sell intent so My Home shows the selling
+			// launchpad. Setting it at creation (rather than post-checkout) is what
+			// makes it stick: the Atomic transfer restores the creation-time intent.
+			siteIntent = Onboard.SiteIntent.Sell;
+		} else if ( isSimplifiedOnboarding ) {
+			// For the simplified onboarding flow, we'll use the build intent since user can't choose the intent.
+			siteIntent = Onboard.SiteIntent.Build;
+		}
 
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const isPlaygroundPublish =


### PR DESCRIPTION
Part of DOTPROD-62
Fixes: DOTCOM-17794

## Proposed Changes

* In the `create-site` step, set the site intent to `Sell` for eCommerce plans (`isEcommerce( planCartItem )`), so commerce sites are created with the `sell` intent.

<img width="1844" height="783" alt="Screenshot 2026-07-07 at 16 09 37" src="https://github.com/user-attachments/assets/b6b22d9d-247f-4827-884d-fd51fae0f7ca" />

## Why are these changes being made?

After buying a Commerce plan, the "My Home" next-steps panel showed the default (build) launchpad — plan/theme done, install the mobile app, launch your site — instead of the selling tasks.

The My Home launchpad card is chosen by the backend home layout based on the site's persisted `site_intent`. The Commerce purchase goes through the `onboarding` flow, which has **no goals/intent step**, so the site is created with an empty / `build` intent.

Writing the intent *after* checkout does not work: a Commerce plan triggers an Atomic transfer, and the transfer restores the creation-time intent, reverting any post-checkout `sell` write. (Confirmed in testing: a `POST /site-intent` with `sell` returns 200, but a cold reload of `.../launchpad` reports `site_intent: "build"`.)

Setting the intent at **site creation** instead bakes `sell` into the site before provisioning, so the value survives the Atomic transfer and the backend serves the selling launchpad. Non-commerce plans are unaffected — migration and simplified-onboarding intents keep their existing behavior.

## Testing Instructions

* Go through onboarding and purchase a Commerce plan on a **fresh** site (an existing site already has its `site_intent` persisted and will not change).
* After checkout completes and the site finishes provisioning, open My Home and refresh.
* Confirm the next-steps panel shows selling tasks rather than the build tasks, and that the `.../launchpad` response reports `site_intent: "sell"`.
* Regression: purchase a non-commerce plan (e.g. Personal/Premium/Business) and confirm its launchpad is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
