### PR TITLE
A4A Amplify: gate section behind per-agency flag

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -238,7 +238,7 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isSectionNameEnabled( 'a8c-for-agencies-amplify' )
+			...( agency?.amplify?.allowed
 				? [
 						{
 							icon: megaphone,

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -105,3 +105,13 @@ export const requireMcpBetaAccessContext: Callback = ( context, next ) => {
 	}
 	next();
 };
+
+export const requireAmplifyAccessContext: Callback = ( context, next ) => {
+	const agency = getActiveAgency( context.store.getState() );
+
+	if ( ! agency?.amplify?.allowed ) {
+		page.redirect( A4A_OVERVIEW_LINK );
+		return;
+	}
+	next();
+};

--- a/client/a8c-for-agencies/sections/amplify/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/index.tsx
@@ -3,15 +3,26 @@ import {
 	A4A_AMPLIFY_LINK,
 	A4A_AMPLIFY_REPORTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import {
+	requireAccessContext,
+	requireAmplifyAccessContext,
+} from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { amplifyOverviewContext, amplifyReportsContext } from './controller';
 
 export default function () {
-	page( A4A_AMPLIFY_LINK, requireAccessContext, amplifyOverviewContext, makeLayout, clientRender );
+	page(
+		A4A_AMPLIFY_LINK,
+		requireAccessContext,
+		requireAmplifyAccessContext,
+		amplifyOverviewContext,
+		makeLayout,
+		clientRender
+	);
 	page(
 		A4A_AMPLIFY_REPORTS_LINK,
 		requireAccessContext,
+		requireAmplifyAccessContext,
 		amplifyReportsContext,
 		makeLayout,
 		clientRender

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -122,6 +122,9 @@ export interface Agency {
 	mcp?: {
 		allowed: boolean;
 	};
+	amplify?: {
+		allowed: boolean;
+	};
 	lead_matching?: {
 		allowed?: boolean;
 		draft?: LeadMatchingDetails | null;

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -72,7 +72,7 @@
 		"a8c-for-agencies-learn": true,
 		"a8c-for-agencies-dev-tools": true,
 		"a8c-for-agencies-exclusive-offers": true,
-		"a8c-for-agencies-amplify": false
+		"a8c-for-agencies-amplify": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
## Proposed Changes

Gate the A4A Amplify section behind a per-agency `amplify.allowed` flag instead of the global `a8c-for-agencies-amplify` section flag.

* Add an optional `amplify?: { allowed: boolean }` field to the `Agency` type, mirroring the existing `mcp` flag.
* Show the Amplify sidebar menu item only when `agency.amplify.allowed` is set.
* Add a `requireAmplifyAccessContext` route guard that redirects to the A4A overview when the active agency lacks access, and wire it into both the Amplify overview and reports routes.
* Flip the `a8c-for-agencies-amplify` section flag to `true` in production so the Amplify routes register there and the per-agency `amplify.allowed` flag becomes the sole access control, matching the `learn`/MCP rollout pattern.

Companion PR: `226450-ghe-Automattic/wpcom` (adds the `amplify.allowed` flag to the agency payload).

## Why are these changes being made?

Amplify access should be controlled per agency rather than being all-or-nothing via a global section flag, so the backend can grant it selectively.

## Testing Instructions

* Ensure the companion PR `226450-ghe-Automattic/wpcom` is applied to your sandbox (it must be merged or applied to the sandbox for the flag to be returned).
* As an agency **with** `amplify.allowed`: confirm the Amplify item appears in the sidebar and that both the Amplify overview and reports pages load.
* As an agency **without** `amplify.allowed`: confirm the Amplify sidebar item is hidden and that visiting the Amplify overview/reports URLs directly redirects to the A4A overview.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
