### PR TITLE
Reword remaining lodash references in js-utils and docs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -314,7 +314,7 @@ jobs:
             **4. Injection / XSS.** Flag untrusted input flowing into HTML, template, `eval`, `Function`, shell calls (in scripts), or fetch URLs concatenated from input.
             Message: `Untrusted input from <source> flows into <sink>. Validate after decode/canonicalize.`
 
-            **5. Type safety / prototype pollution.** Flag prototype pollution via `Object.assign`, recursive merge, or lodash `_.merge` on attacker-controlled JSON; `as` casts on `JSON.parse` or fetched JSON; loose `==` on user data; unjustified `any` (see `client/AGENTS.md`).
+            **5. Type safety / prototype pollution.** Flag prototype pollution via `Object.assign` or a recursive merge on attacker-controlled JSON; `as` casts on `JSON.parse` or fetched JSON; loose `==` on user data; unjustified `any` (see `client/AGENTS.md`).
             Message: `<Specific risk> at <location>. <Specific fix>.`
 
             **6. Resource and DoS.** Flag ReDoS via unanchored regex on user input; unbounded loops over API responses; client-side state growth from streams/polling without bounds; missing `useMemo`/`useCallback` causing re-renders or network waterfalls.

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -9,9 +9,9 @@ not intended to be used outside of Calypso. Functions currently in here may be r
 without further notice.
 
 Most functions mirror the API of their Lodash equivalent so they can replace existing call sites
-directly, but they are intentionally narrower. Each function's doc comment describes only where its
+directly, but they are intentionally narrower — each function's doc comment describes only where its
 behavior diverges (for example: no iteratee shorthands, ASCII-only, dense arrays). Assume anything
-not called out matches the corresponding Lodash function for the inputs Calypso actually passes.
+not called out behaves as the original did for the inputs Calypso actually passes.
 
 Second, we want to think very carefully about what functions to add and which not. A lot of Lodash
 functionality these days can be replaced by native JavaScript code and that should be the premise.

--- a/packages/js-utils/src/base-extremum.ts
+++ b/packages/js-utils/src/base-extremum.ts
@@ -1,8 +1,8 @@
 /**
  * Shared core for `maxBy`/`minBy`. Returns the element of `array` whose
  * `iteratee` value is "best" per `isBetter`. Iteratee values are compared
- * **numerically** only (narrower than lodash's type-aware comparison, but how
- * every usage here ranks); nullish and `NaN` values are skipped, and `undefined`
+ * **numerically** only (which is how every usage here ranks); nullish and `NaN`
+ * values are skipped, and `undefined`
  * is returned for a nullish/empty array. Internal helper; not part of the public API.
  * @param array    The array to iterate over.
  * @param iteratee Invoked per element to produce the value to compare.

--- a/packages/js-utils/src/capitalize.ts
+++ b/packages/js-utils/src/capitalize.ts
@@ -3,9 +3,9 @@
  * input becomes an empty string. Works on full Unicode code points, so a leading
  * astral character is not split.
  *
- * Intentionally typed for strings only: it does not replicate lodash's coercion of
- * arbitrary values (arrays, symbols, boxed primitives, `-0`), whose `baseToString`
- * edge cases have no use here.
+ * Intentionally typed for strings only: it does not coerce non-string values
+ * (arrays, symbols, boxed primitives, `-0`), whose stringification edge cases
+ * have no use here.
  * @param value The string to capitalize.
  * @returns The capitalized string.
  */

--- a/packages/js-utils/src/escape-reg-exp.ts
+++ b/packages/js-utils/src/escape-reg-exp.ts
@@ -2,8 +2,7 @@
  * Escapes the RegExp special characters in a string so it can be safely embedded
  * as a literal inside a regular expression.
  *
- * Intentionally typed for strings only: it does not replicate lodash's coercion
- * of arbitrary values to strings.
+ * Intentionally typed for strings only: it does not coerce non-string values.
  * @param value The string to escape.
  * @returns The string with RegExp special characters escaped.
  */

--- a/packages/js-utils/src/group-by.ts
+++ b/packages/js-utils/src/group-by.ts
@@ -5,8 +5,8 @@ type Iteratee< T, TResult > = TResult | ( ( value: T ) => TResult );
 /**
  * Groups the values of `collection` into arrays keyed by the result of running
  * each value through `iteratee`. A function iteratee receives the value; a
- * property-name iteratee reads that single property from each value (lodash's
- * deep dot-paths are not supported — pass a function for those); omitting the
+ * property-name iteratee reads that single property from each value (deep
+ * dot-paths are not supported — pass a function for those); omitting the
  * iteratee groups by the value itself. Insertion order is preserved.
  */
 function groupBy< T >(
@@ -23,8 +23,8 @@ function groupBy< T >(
 		} else if ( typeof iteratee === 'function' ) {
 			rawKey = iteratee( value );
 		} else {
-			// The string shorthand reads one property, not lodash's dot-separated
-			// deep paths. Reject those loudly so a `'a.b'` call fails fast instead
+			// The string shorthand reads one property, not a dot-separated deep
+			// path. Reject those loudly so a `'a.b'` call fails fast instead
 			// of silently grouping everything under `undefined`.
 			if ( typeof iteratee === 'string' && iteratee.includes( '.' ) ) {
 				throw new Error(

--- a/packages/js-utils/src/key-by.ts
+++ b/packages/js-utils/src/key-by.ts
@@ -1,5 +1,7 @@
 /**
- * See https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_keyBy
+ * Builds an object keyed by running each value of a collection through an
+ * iteratee (a function, or a property name read from each object value). On a
+ * key collision the later value wins.
  */
 type Collection< T > = T[] | { [ key in PropertyKey ]: T };
 

--- a/packages/js-utils/src/map-keys.ts
+++ b/packages/js-utils/src/map-keys.ts
@@ -1,8 +1,8 @@
 /**
  * Returns a new object with the same own enumerable string-keyed values as
  * `object`, each key replaced by `iteratee( value, key, object )`. A function
- * iteratee is required — unlike lodash there is no property-name shorthand or
- * identity default. When the iteratee maps two keys to the same value, the last
+ * iteratee is required — there is no property-name shorthand or identity
+ * default. When the iteratee maps two keys to the same value, the last
  * one wins.
  */
 function mapKeys< T >(

--- a/packages/js-utils/src/max-by.ts
+++ b/packages/js-utils/src/max-by.ts
@@ -2,8 +2,8 @@ import baseExtremum from './base-extremum';
 
 /**
  * Returns the element of `array` with the maximum `iteratee` value. Iteratee
- * values are compared numerically (narrower than lodash `maxBy`, which supports
- * more comparison modes); nullish/`NaN` values are skipped, and `undefined` is
+ * values are compared numerically (other comparison modes are not supported);
+ * nullish/`NaN` values are skipped, and `undefined` is
  * returned for a nullish or empty array.
  * @param array    The array to iterate over.
  * @param iteratee Invoked per element to produce the value to rank by.

--- a/packages/js-utils/src/memoize.ts
+++ b/packages/js-utils/src/memoize.ts
@@ -7,8 +7,8 @@ export interface MemoizedFunction< Args extends unknown[], Return > {
  * Wraps a function so results are cached by a key derived from its arguments.
  * By default the key is the first argument; pass `resolver` to compute a custom
  * key. The cache is exposed as `.cache` (a `Map`) so callers can clear or
- * inspect it. Unlike lodash's `memoize`, this does not support a pluggable
- * `memoize.Cache` or argument-type `TypeError` checks.
+ * inspect it. It does not support a pluggable `Cache` or argument-type
+ * `TypeError` checks.
  * @param func The function to have its output memoized.
  * @param resolver Optional function that resolves the cache key from the arguments.
  * @returns The memoized function, with its cache exposed as `.cache`.

--- a/packages/js-utils/src/merge.ts
+++ b/packages/js-utils/src/merge.ts
@@ -50,10 +50,10 @@ function baseMerge( target: PlainObject, source: PlainObject ): void {
  * key is ignored entirely and a `constructor` key is merged as a plain own
  * property, so neither can pollute a prototype.
  *
- * This targets plain JSON-like data and is intentionally narrower than lodash's
- * `merge`: it merges only own (not inherited) enumerable properties, treats
- * arrays as dense (sparse holes are not materialized), and does not special-case
- * typed arrays, buffers, or circular references.
+ * This targets plain JSON-like data and is intentionally narrow: it merges only
+ * own (not inherited) enumerable properties, treats arrays as dense (sparse
+ * holes are not materialized), and does not special-case typed arrays, buffers,
+ * or circular references.
  * @param object The destination object (mutated in place).
  * @param source The source object to merge in (additional sources are merged left to right).
  * @returns The mutated destination object.

--- a/packages/js-utils/src/mergeWith.ts
+++ b/packages/js-utils/src/mergeWith.ts
@@ -63,8 +63,8 @@ function baseMergeDeep(
 
 	// A customizer result other than `undefined` is used as-is. Otherwise deep-
 	// merge into a compatible container. Every value reaching this branch is
-	// mergeable (array or plain object), so unlike lodash there is no buffer or
-	// typed-array case that would skip the recursion.
+	// mergeable (array or plain object), so there is no buffer or typed-array
+	// case that would skip the recursion.
 	if ( newValue === undefined ) {
 		newValue = pickMergeContainer( objValue, srcValue );
 		stack.set( srcValue, newValue );
@@ -112,9 +112,9 @@ function baseMergeWith(
  * (so a lone trailing function is merged as a source) and the merge runs without
  * a customizer. Sources are merged left to right.
  *
- * This shares merge's narrower-than-lodash scope: it merges only own enumerable
- * properties, treats arrays as dense, and does not special-case typed arrays or
- * buffers. Unlike merge, circular references are supported (each in-progress
+ * This shares merge's narrow scope: it merges only own enumerable properties,
+ * treats arrays as dense, and does not special-case typed arrays or buffers.
+ * Unlike merge, circular references are supported (each in-progress
  * source is tracked so it is merged once).
  * @param object The destination (mutated in place; a nullish value becomes a fresh object).
  * @param args Source objects, optionally followed by a customizer function.

--- a/packages/js-utils/src/test/camel-case.ts
+++ b/packages/js-utils/src/test/camel-case.ts
@@ -14,14 +14,14 @@ describe( 'camelCase', () => {
 		expect( camelCase( 'firstName' ) ).toBe( 'firstName' );
 	} );
 
-	it( 'splits acronym and numeric boundaries like lodash', () => {
+	it( 'splits acronym and numeric boundaries', () => {
 		expect( camelCase( 'XMLHttpRequest' ) ).toBe( 'xmlHttpRequest' );
 		expect( camelCase( 'parseURL' ) ).toBe( 'parseUrl' );
 		expect( camelCase( 'version1Point2' ) ).toBe( 'version1Point2' );
 	} );
 
-	it( 'is scoped to ASCII — accents/apostrophes are not deburred like lodash', () => {
-		// lodash camelCase( 'déjà-vu' ) is 'dejaVu'; these helpers tokenize ASCII only.
+	it( 'is scoped to ASCII — accents/apostrophes are not deburred', () => {
+		// These helpers tokenize ASCII only, so accents are not deburred.
 		expect( camelCase( 'déjà-vu' ) ).toBe( 'dJVu' );
 		expect( camelCase( "it's-here" ) ).toBe( 'itSHere' );
 	} );

--- a/packages/js-utils/src/test/defaults.ts
+++ b/packages/js-utils/src/test/defaults.ts
@@ -24,20 +24,20 @@ describe( 'defaults', () => {
 		expect( target ).toEqual( { a: 1, b: 2 } );
 	} );
 
-	it( 'coerces a nullish destination to a new object, like lodash', () => {
+	it( 'coerces a nullish destination to a new object', () => {
 		// @ts-expect-error -- exercises runtime tolerance of a nullish destination.
 		expect( defaults( null, { a: 1 } ) ).toEqual( { a: 1 } );
 		// @ts-expect-error -- see above.
 		expect( defaults( undefined, { b: 2 } ) ).toEqual( { b: 2 } );
 	} );
 
-	it( 'copies inherited enumerable source properties, like lodash', () => {
+	it( 'copies inherited enumerable source properties', () => {
 		const source = Object.create( { inherited: 9 } );
 		source.own = 1;
 		expect( defaults( {}, source ) ).toEqual( { own: 1, inherited: 9 } );
 	} );
 
-	it( 'fills keys that resolve through Object.prototype, like lodash', () => {
+	it( 'fills keys that resolve through Object.prototype', () => {
 		const result = defaults( {}, { constructor: 'x', toString: 'y', own: 1 } );
 		expect( result.constructor ).toBe( 'x' );
 		expect( result.toString ).toBe( 'y' );

--- a/packages/js-utils/src/test/escape-reg-exp.ts
+++ b/packages/js-utils/src/test/escape-reg-exp.ts
@@ -2,8 +2,8 @@ import escapeRegExp from '../escape-reg-exp';
 
 describe( 'escapeRegExp', () => {
 	it( 'escapes RegExp special characters', () => {
-		expect( escapeRegExp( '[lodash](https://lodash.com/)' ) ).toBe(
-			'\\[lodash\\]\\(https://lodash\\.com/\\)'
+		expect( escapeRegExp( '[link](https://example.com/)' ) ).toBe(
+			'\\[link\\]\\(https://example\\.com/\\)'
 		);
 		expect( escapeRegExp( 'a.b*c+?' ) ).toBe( 'a\\.b\\*c\\+\\?' );
 		expect( escapeRegExp( '^start$' ) ).toBe( '\\^start\\$' );

--- a/packages/js-utils/src/test/flow.ts
+++ b/packages/js-utils/src/test/flow.ts
@@ -35,7 +35,7 @@ describe( 'flow', () => {
 		expect( flow()( 42 ) ).toBe( 42 );
 	} );
 
-	it( 'throws up front when a composed value is not a function, like lodash', () => {
+	it( 'throws up front when a composed value is not a function', () => {
 		// @ts-expect-error -- exercises runtime validation of non-function values.
 		expect( () => flow( [ ( x: number ) => x, undefined ] ) ).toThrow( 'Expected a function' );
 		// @ts-expect-error -- see above.

--- a/packages/js-utils/src/test/group-by.ts
+++ b/packages/js-utils/src/test/group-by.ts
@@ -15,7 +15,7 @@ describe( 'groupBy', () => {
 		expect( groupBy( [ a, b, c ], 'type' ) ).toStrictEqual( { x: [ a, c ], y: [ b ] } );
 	} );
 
-	it( 'rejects lodash-style deep paths rather than grouping under `undefined`', () => {
+	it( 'rejects deep property paths rather than grouping under `undefined`', () => {
 		expect( () => groupBy( [ { parent: { ID: 1 } } ], 'parent.ID' ) ).toThrow( /deep paths/ );
 	} );
 
@@ -42,13 +42,13 @@ describe( 'groupBy', () => {
 		expect( groupBy( undefined, ( v ) => v ) ).toStrictEqual( {} );
 	} );
 
-	it( 'reads existing properties of primitive values, like lodash', () => {
+	it( 'reads existing properties of primitive values', () => {
 		expect( groupBy( [ 'one', 'two', 'six' ], 'length' ) ).toStrictEqual( {
 			'3': [ 'one', 'two', 'six' ],
 		} );
 	} );
 
-	it( 'groups primitives under `undefined` for a missing property, like lodash', () => {
+	it( 'groups primitives under `undefined` for a missing property', () => {
 		expect( groupBy( [ 1, 2 ], 'type' ) ).toStrictEqual( { undefined: [ 1, 2 ] } );
 	} );
 

--- a/packages/js-utils/src/test/is-empty.ts
+++ b/packages/js-utils/src/test/is-empty.ts
@@ -91,9 +91,9 @@ describe( 'isEmpty', () => {
 		expect( isEmpty( { [ Symbol.toStringTag ]: 'Map' } ) ).toBe( true );
 	} );
 
-	it( 'matches lodash for a frozen object with an un-unmaskable spoofed tag', () => {
+	it( 'handles a frozen object with an un-unmaskable spoofed tag', () => {
 		// Frozen, so the spoofed tag can't be cleared: the Map branch sees no
-		// `size`, and `! undefined` is `true` (as lodash does), not `0 === …`.
+		// `size`, and `! undefined` is `true`, not `0 === …`.
 		expect( isEmpty( Object.freeze( { [ Symbol.toStringTag ]: 'Map' } ) ) ).toBe( true );
 	} );
 
@@ -121,7 +121,7 @@ describe( 'isEmpty', () => {
 		expect( isEmpty( filled ) ).toBe( false );
 	} );
 
-	describe( 'matches lodash isEmpty', () => {
+	describe( 'matches the reference implementation', () => {
 		function Bar() {}
 		Bar.prototype = { constructor: Bar };
 		function Baz() {}
@@ -140,7 +140,7 @@ describe( 'isEmpty', () => {
 		/* eslint-enable prefer-rest-params */
 		delete ( lengthlessArgs as { length?: unknown } ).length;
 
-		// A function is never array-like in lodash (its `length` is arity), so it
+		// A function is never treated as array-like (its `length` is arity), so it
 		// is measured by own keys. Only a function whose spoofed `Arguments` tag
 		// can't be unmasked (frozen) would otherwise reach the length branch.
 		const spliceFn = Object.assign( function () {}, { splice() {} } );
@@ -149,7 +149,7 @@ describe( 'isEmpty', () => {
 		( taggedFn as { key?: number } ).key = 1;
 		Object.freeze( taggedFn );
 
-		// A frozen object spoofing a function-family tag: lodash's `isArrayLike`
+		// A frozen object spoofing a function-family tag: the `isArrayLike` check
 		// excludes it (tag-based `isFunction`), so it is measured by own keys, not
 		// its `length`. Each is non-empty (owns `length`/`splice`).
 		const functionTagSpoofs = [ 'Function', 'AsyncFunction', 'GeneratorFunction', 'Proxy' ].map(

--- a/packages/js-utils/src/test/kebab-case.ts
+++ b/packages/js-utils/src/test/kebab-case.ts
@@ -12,14 +12,14 @@ describe( 'kebabCase', () => {
 		expect( kebabCase( 'primitive_value' ) ).toBe( 'primitive-value' );
 	} );
 
-	it( 'splits Pascal acronym and numeric boundaries like lodash', () => {
+	it( 'splits Pascal acronym and numeric boundaries', () => {
 		expect( kebabCase( 'QuotaExceededError' ) ).toBe( 'quota-exceeded-error' );
 		expect( kebabCase( 'postalCode' ) ).toBe( 'postal-code' );
 		expect( kebabCase( 'address1' ) ).toBe( 'address-1' );
 	} );
 
-	it( 'is scoped to ASCII — accents are not deburred like lodash', () => {
-		// lodash kebabCase( 'déjà-vu' ) is 'deja-vu'; these helpers tokenize ASCII only.
+	it( 'is scoped to ASCII — accents are not deburred', () => {
+		// These helpers tokenize ASCII only, so accents are not deburred.
 		expect( kebabCase( 'déjà-vu' ) ).toBe( 'd-j-vu' );
 	} );
 

--- a/packages/js-utils/src/test/merge.ts
+++ b/packages/js-utils/src/test/merge.ts
@@ -56,7 +56,7 @@ describe( 'merge', () => {
 		],
 	];
 
-	it.each( cases )( 'matches lodash: %s', ( _label, make ) => {
+	it.each( cases )( 'matches the reference implementation: %s', ( _label, make ) => {
 		const mineArgs = make() as [ Record< string, unknown >, ...unknown[] ];
 		const theirsArgs = make() as [ Record< string, unknown >, ...unknown[] ];
 		const mine = ( merge as ( ...a: unknown[] ) => unknown )( ...mineArgs );
@@ -83,16 +83,16 @@ describe( 'merge', () => {
 	} );
 
 	it( 'merges only own enumerable source properties, not inherited ones', () => {
-		// Intentionally narrower than lodash, which also copies inherited
-		// enumerable properties (it iterates with `for…in`).
+		// Intentionally narrower: inherited enumerable properties are not copied
+		// (a `for…in` traversal would include them).
 		const source = Object.create( { inherited: 1 } ) as Record< string, unknown >;
 		source.own = 2;
 		expect( merge( {}, source ) ).toEqual( { own: 2 } );
 	} );
 
 	it( 'treats arrays as dense — sparse holes are not materialized', () => {
-		// Intentionally narrower than lodash, which fills the hole (index 1 is
-		// present as `null` in its result).
+		// Intentionally narrower: the sparse hole is not filled (index 1 is
+		// not materialized as `null` in the result).
 		const sparse: number[] = [ 1 ];
 		sparse[ 2 ] = 3; // leaves a hole at index 1
 		const result = merge( {} as { a?: unknown[] }, { a: sparse } );
@@ -107,7 +107,7 @@ describe( 'merge', () => {
 		expect( () => merge( {}, circular ) ).toThrow();
 	} );
 
-	it( 'propagates exceptions from a throwing setter, like lodash', () => {
+	it( 'propagates exceptions from a throwing setter', () => {
 		const makeTarget = () =>
 			Object.defineProperty( {}, 'x', {
 				set() {
@@ -147,7 +147,7 @@ describe( 'merge', () => {
 		expect( source ).toEqual( { a: { b: 1 } } );
 	} );
 
-	it( 'silently ignores writes to a frozen target, like lodash', () => {
+	it( 'silently ignores writes to a frozen target', () => {
 		const frozen = Object.freeze( { a: { b: 1 } } );
 		// Computing this at all proves the write does not throw under strict mode.
 		const mine = merge( frozen, { meta: 1 } as Record< string, unknown > );

--- a/packages/js-utils/src/test/mergeWith.ts
+++ b/packages/js-utils/src/test/mergeWith.ts
@@ -11,7 +11,7 @@ type Customizer = (
 	stack: { size: number }
 ) => unknown;
 
-// Only touches `.size`, which both a native Map and lodash's Stack expose, so
+// Only touches `.size`, which both a native Map and the reference implementation's stack expose, so
 // the same customizer can drive both implementations in a differential test.
 const overwriteArrays: Customizer = ( _objValue, srcValue ) =>
 	Array.isArray( srcValue ) ? srcValue : undefined;
@@ -78,7 +78,7 @@ describe( 'mergeWith', () => {
 		],
 	];
 
-	it.each( cases )( 'matches lodash: %s', ( _label, customizer, make ) => {
+	it.each( cases )( 'matches the reference implementation: %s', ( _label, customizer, make ) => {
 		const mineArgs = [ ...make(), customizer ] as [ object, ...unknown[] ];
 		const theirsArgs = [ ...make(), customizer ] as [ object, ...unknown[] ];
 		const mine = ( mergeWith as ( ...a: unknown[] ) => unknown )( ...mineArgs );
@@ -100,7 +100,7 @@ describe( 'mergeWith', () => {
 		expect( depths ).toEqual( [ 0, 1, 2 ] );
 	} );
 
-	it( 'supports circular sources without infinite recursion, like lodash', () => {
+	it( 'supports circular sources without infinite recursion', () => {
 		const make = () => {
 			const circular: Record< string, unknown > = { a: 1 };
 			circular.self = circular;
@@ -110,7 +110,7 @@ describe( 'mergeWith', () => {
 		const theirs = lodashMergeWith( {}, make(), noop ) as Record< string, unknown >;
 		expect( mine.a ).toBe( 1 );
 		// The nested `self` is merged once into its own container, then short-
-		// circuited on re-entry — matching lodash rather than looping forever.
+		// circuited on re-entry rather than looping forever.
 		expect( mine.self ).toEqual( theirs.self );
 		expect( ( mine.self as Record< string, unknown > ).self ).toBe( mine.self );
 	} );
@@ -137,7 +137,7 @@ describe( 'mergeWith', () => {
 		expect( target ).toEqual( { a: 1, b: 2 } );
 	} );
 
-	it( 'treats a non-function trailing argument as a source, like lodash', () => {
+	it( 'treats a non-function trailing argument as a source', () => {
 		// No customizer given — the last object is merged, not dropped or called.
 		const mine = mergeWith( { a: { x: 1 } }, { a: { y: 2 } }, { b: 3 } );
 		const theirs = lodashMergeWith( { a: { x: 1 } }, { a: { y: 2 } }, { b: 3 } );
@@ -145,13 +145,13 @@ describe( 'mergeWith', () => {
 		expect( mine ).toEqual( { a: { x: 1, y: 2 }, b: 3 } );
 	} );
 
-	it( 'merges a single source with no customizer, like lodash', () => {
+	it( 'merges a single source with no customizer', () => {
 		const mine = mergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
 		const theirs = lodashMergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
 		expect( mine ).toEqual( theirs );
 	} );
 
-	it( 'returns a fresh object when the destination is nullish, like lodash', () => {
+	it( 'returns a fresh object when the destination is nullish', () => {
 		// A null destination (e.g. an unknown post merged with local edits) must
 		// yield the merged edits rather than throwing on the null read.
 		const mine = mergeWith( null, { a: 1, b: [ 2 ] }, overwriteArrays );
@@ -160,7 +160,7 @@ describe( 'mergeWith', () => {
 		expect( mine ).toEqual( { a: 1, b: [ 2 ] } );
 	} );
 
-	it( 'treats a lone trailing function as a source, not a customizer, like lodash', () => {
+	it( 'treats a lone trailing function as a source, not a customizer', () => {
 		// With no source preceding it, a function argument is merged for its own
 		// enumerable properties rather than being called as a customizer.
 		const makeFn = () => {

--- a/packages/js-utils/src/test/order-by.ts
+++ b/packages/js-utils/src/test/order-by.ts
@@ -60,7 +60,7 @@ describe( 'orderBy', () => {
 		] );
 	} );
 
-	it( 'treats a nullish iteratee as identity sorting, like lodash', () => {
+	it( 'treats a nullish iteratee as identity sorting', () => {
 		expect( orderBy( [ 1, 2, 3 ], null, 'desc' ) ).toEqual( [ 3, 2, 1 ] );
 	} );
 } );

--- a/packages/js-utils/src/test/partition.ts
+++ b/packages/js-utils/src/test/partition.ts
@@ -25,8 +25,8 @@ describe( 'partition', () => {
 		expect( partition( undefined, () => true ) ).toEqual( [ [], [] ] );
 	} );
 
-	it( 'invokes the predicate with only the value, matching lodash', () => {
-		// lodash `partition` passes a function predicate only the value (not the
+	it( 'invokes the predicate with only the value', () => {
+		// The predicate receives only the value (not the
 		// index/key), so this helper does the same.
 		const argCounts: number[] = [];
 		partition( [ 10, 20, 30 ], ( ...args ) => {

--- a/packages/js-utils/src/test/random.ts
+++ b/packages/js-utils/src/test/random.ts
@@ -71,7 +71,7 @@ describe( 'random', () => {
 
 	it( 'should treat a symbol bound as 0 instead of throwing', () => {
 		mockRandom( 0.999999 );
-		// @ts-expect-error -- lodash coerces non-numeric bounds rather than throwing.
+		// @ts-expect-error -- non-numeric bounds are coerced rather than throwing.
 		expect( random( Symbol( 'x' ) ) ).toBe( 0 );
 	} );
 

--- a/packages/js-utils/src/test/range.ts
+++ b/packages/js-utils/src/test/range.ts
@@ -23,7 +23,7 @@ describe( 'range', () => {
 		expect( range( 3, 3 ) ).toEqual( [] );
 	} );
 
-	it( 'should coerce numeric-string and non-finite bounds like lodash', () => {
+	it( 'should coerce numeric-string and non-finite bounds', () => {
 		// @ts-expect-error -- exercises lenient coercion for untyped callers.
 		expect( range( '1', '5' ) ).toEqual( [ 1, 2, 3, 4 ] );
 		expect( range( 0, NaN ) ).toEqual( [] );
@@ -31,8 +31,8 @@ describe( 'range', () => {
 		expect( range( 0, undefined ) ).toEqual( [] );
 	} );
 
-	it( 'should treat a symbol bound as 0, like lodash', () => {
-		// @ts-expect-error -- lodash coerces non-numeric bounds rather than throwing.
+	it( 'should treat a symbol bound as 0', () => {
+		// @ts-expect-error -- non-numeric bounds are coerced rather than throwing.
 		expect( range( Symbol( 'x' ) ) ).toEqual( [] );
 	} );
 
@@ -40,8 +40,8 @@ describe( 'range', () => {
 		expect( range( 0, 5, 0 ) ).toEqual( [ 0, 0, 0, 0, 0 ] );
 	} );
 
-	it( 'should throw on an Infinity bound, like lodash', () => {
-		// lodash coerces Infinity to MAX_INTEGER, so the resulting array length
+	it( 'should throw on an Infinity bound', () => {
+		// Infinity is coerced to MAX_INTEGER, so the resulting array length
 		// is invalid for both implementations.
 		expect( () => range( 0, Infinity ) ).toThrow( RangeError );
 	} );

--- a/packages/js-utils/src/test/set.ts
+++ b/packages/js-utils/src/test/set.ts
@@ -13,7 +13,7 @@ describe( 'set', () => {
 		expect( set( {}, 'a[0].b', 9 ) ).toEqual( { a: [ { b: 9 } ] } );
 	} );
 
-	it( 'treats numeric array-path segments as indices, like lodash', () => {
+	it( 'treats numeric array-path segments as indices', () => {
 		expect( set( {}, [ 'a', 2 ], 'x' ) ).toEqual( { a: [ undefined, undefined, 'x' ] } );
 	} );
 
@@ -42,7 +42,7 @@ describe( 'set', () => {
 		expect( ( {} as Record< string, unknown > ).polluted ).toBeUndefined();
 	} );
 
-	it( 'preserves symbol path segments, like lodash', () => {
+	it( 'preserves symbol path segments', () => {
 		const sym = Symbol( 's' );
 		const object: Record< PropertyKey, unknown > = {};
 		set( object, [ sym ], 1 );
@@ -51,11 +51,11 @@ describe( 'set', () => {
 		expect( ( object.x as Record< PropertyKey, unknown > )[ sym ] ).toBe( 2 );
 	} );
 
-	it( 'maps a negative-zero segment to "-0", like lodash', () => {
+	it( 'maps a negative-zero segment to "-0"', () => {
 		expect( set( {}, [ -0 ], 9 ) ).toEqual( { '-0': 9 } );
 	} );
 
-	it( 'skips the write for a same-value (SameValueZero) assignment, like lodash', () => {
+	it( 'skips the write for a same-value (SameValueZero) assignment', () => {
 		let writes = 0;
 		let stored: unknown = 5;
 		const object = {};

--- a/packages/js-utils/src/test/snake-case.ts
+++ b/packages/js-utils/src/test/snake-case.ts
@@ -9,7 +9,7 @@ describe( 'snakeCase', () => {
 		expect( snakeCase( 'country-code' ) ).toBe( 'country_code' );
 	} );
 
-	it( 'splits acronym and numeric boundaries like lodash', () => {
+	it( 'splits acronym and numeric boundaries', () => {
 		expect( snakeCase( 'XMLHttpRequest' ) ).toBe( 'xml_http_request' );
 		expect( snakeCase( 'address1' ) ).toBe( 'address_1' );
 	} );
@@ -19,8 +19,8 @@ describe( 'snakeCase', () => {
 		expect( snakeCase( 'first_name' ) ).toBe( 'first_name' );
 	} );
 
-	it( 'is scoped to ASCII — accents are not deburred like lodash', () => {
-		// lodash snakeCase( 'déjà-vu' ) is 'deja_vu'; these helpers tokenize ASCII only.
+	it( 'is scoped to ASCII — accents are not deburred', () => {
+		// These helpers tokenize ASCII only, so accents are not deburred.
 		expect( snakeCase( 'déjà-vu' ) ).toBe( 'd_j_vu' );
 	} );
 

--- a/packages/js-utils/src/test/sort-by.ts
+++ b/packages/js-utils/src/test/sort-by.ts
@@ -12,7 +12,7 @@ describe( 'sortBy', () => {
 	} );
 
 	it( 'sorts by a property name', () => {
-		// Capitalized "Bob" sorts before lowercase names, like lodash.
+		// Capitalized "Bob" sorts before lowercase names.
 		expect( sortBy( people, 'name' ).map( ( p ) => p.name ) ).toEqual( [
 			'Bob',
 			'alice',
@@ -112,7 +112,7 @@ describe( 'sortBy', () => {
 		] );
 	} );
 
-	it( 'treats a literal key containing dots as a whole key, like lodash', () => {
+	it( 'treats a literal key containing dots as a whole key', () => {
 		expect( sortBy( [ { 'key.with.dot': 2 }, { 'key.with.dot': 1 } ], 'key.with.dot' ) ).toEqual( [
 			{ 'key.with.dot': 1 },
 			{ 'key.with.dot': 2 },
@@ -123,18 +123,18 @@ describe( 'sortBy', () => {
 		expect( sortBy( [ { '': 2 }, { '': 1 } ], '' ) ).toEqual( [ { '': 1 }, { '': 2 } ] );
 	} );
 
-	it( 'treats a nullish iteratee as identity sorting, like lodash', () => {
-		// @ts-expect-error -- null iteratee sorts by identity (lodash parity).
+	it( 'treats a nullish iteratee as identity sorting', () => {
+		// @ts-expect-error -- null iteratee sorts by identity.
 		expect( sortBy( [ 2, 1, 3 ], null ) ).toEqual( [ 1, 2, 3 ] );
 		expect( sortBy( [ 2, 1, 3 ], undefined ) ).toEqual( [ 1, 2, 3 ] );
 	} );
 
-	it( 'materializes sparse-array holes as undefined, like lodash', () => {
+	it( 'materializes sparse-array holes as undefined', () => {
 		// eslint-disable-next-line no-sparse-arrays
 		expect( sortBy( [ , 1, , 0 ] ) ).toEqual( [ 0, 1, undefined, undefined ] );
 	} );
 
-	it( 'flattens iteratee arguments one level, like lodash', () => {
+	it( 'flattens iteratee arguments one level', () => {
 		const data = [
 			{ a: 1, b: 1, c: 3 },
 			{ a: 1, b: 1, c: 1 },

--- a/packages/js-utils/src/test/to-finite.ts
+++ b/packages/js-utils/src/test/to-finite.ts
@@ -1,7 +1,7 @@
 import toFinite from '../to-finite';
 
 describe( 'toFinite', () => {
-	// Expected values verified against lodash `toFinite`.
+	// Expected values verified against the reference implementation.
 	it.each( [
 		[ 'integer', 5, 5 ],
 		[ 'negative', -5, -5 ],
@@ -28,7 +28,7 @@ describe( 'toFinite', () => {
 		[ 'single-element array', [ 5 ], 5 ],
 		[ 'multi-element array', [ 5, 6 ], 0 ],
 		[ 'plain object', {}, 0 ],
-	] )( 'coerces %s to %p like lodash', ( _label, input, expected ) => {
+	] )( 'coerces %s to %p', ( _label, input, expected ) => {
 		expect( toFinite( input ) ).toBe( expected );
 	} );
 
@@ -36,16 +36,16 @@ describe( 'toFinite', () => {
 		expect( toFinite( Symbol( 'x' ) ) ).toBe( 0 );
 	} );
 
-	it( 'returns 0 for a boxed symbol, like lodash', () => {
+	it( 'returns 0 for a boxed symbol', () => {
 		expect( toFinite( Object( Symbol( 'x' ) ) ) ).toBe( 0 );
 	} );
 
-	it( 'derives object values from valueOf only, like lodash', () => {
+	it( 'derives object values from valueOf only', () => {
 		// `valueOf` returning a primitive is used directly.
 		expect( toFinite( { valueOf: () => 8 } ) ).toBe( 8 );
 		expect( toFinite( { valueOf: () => '8' } ) ).toBe( 8 );
-		// `valueOf` returning an object is stringified — lodash does NOT fall back
-		// to the original object's `toString`, so this is 0 (not 8) like lodash.
+		// `valueOf` returning an object is stringified — there is no fall back
+		// to the original object's `toString`, so this is 0 (not 8).
 		expect( toFinite( { valueOf: () => ( {} ), toString: () => '8' } ) ).toBe( 0 );
 		// With no custom `valueOf`, the default returns the object, so `toString`
 		// is consulted via stringification.

--- a/packages/js-utils/src/test/truncate.ts
+++ b/packages/js-utils/src/test/truncate.ts
@@ -39,7 +39,7 @@ describe( 'truncate', () => {
 		expect( truncate( 'tiny string here', { length: 2 } ) ).toBe( '...' );
 	} );
 
-	describe( 'lenient option coercion (matching lodash)', () => {
+	describe( 'lenient option coercion', () => {
 		it( 'falls back to defaults for non-object options', () => {
 			// @ts-expect-error -- exercises lenient handling for untyped callers.
 			expect( truncate( 'abcdef', null ) ).toBe( 'abcdef' );
@@ -48,7 +48,7 @@ describe( 'truncate', () => {
 		} );
 
 		it( 'coerces length via toInteger', () => {
-			// @ts-expect-error -- null length coerces to 0, like lodash.
+			// @ts-expect-error -- null length coerces to 0.
 			expect( truncate( 'abcdef', { length: null } ) ).toBe( '...' );
 			// @ts-expect-error -- string length coerces.
 			expect( truncate( 'abcdefghij', { length: '5' } ) ).toBe( 'ab...' );
@@ -60,7 +60,7 @@ describe( 'truncate', () => {
 			expect( truncate( 'abcdef', { length: 4, omission: 1 } ) ).toBe( 'abc1' );
 		} );
 
-		it( 'coerces negative zero to "-0" like lodash baseToString', () => {
+		it( 'coerces negative zero to "-0"', () => {
 			// @ts-expect-error -- exercises the -0 coercion edge.
 			expect( truncate( 'abcdef', { length: 4, omission: -0 } ) ).toBe( 'ab-0' );
 			// @ts-expect-error -- -0 input coerces to "-0".
@@ -70,12 +70,12 @@ describe( 'truncate', () => {
 		it( 'coerces symbols (primitive and boxed) without throwing', () => {
 			// @ts-expect-error -- symbol input stringifies to its description.
 			expect( truncate( Symbol( 'x' ) ) ).toBe( 'Symbol(x)' );
-			// @ts-expect-error -- boxed symbols are handled too, like lodash.
+			// @ts-expect-error -- boxed symbols are handled too.
 			expect( truncate( Object( Symbol( 'x' ) ) ) ).toBe( 'Symbol(x)' );
 		} );
 	} );
 
-	describe( 'Unicode grapheme clusters (matching lodash)', () => {
+	describe( 'Unicode grapheme clusters', () => {
 		const grin = String.fromCodePoint( 0x1f600 ); // 😀
 		const us = String.fromCodePoint( 0x1f1fa, 0x1f1f8 ); // 🇺🇸
 		const gb = String.fromCodePoint( 0x1f1ec, 0x1f1e7 ); // 🇬🇧

--- a/packages/js-utils/src/to-path.ts
+++ b/packages/js-utils/src/to-path.ts
@@ -1,8 +1,8 @@
 import isSymbol from './is-symbol';
 
-// Property-path parsing, ported from lodash. A string is tokenized into path
-// segments (dot, bracket, and quoted-bracket notation), except a string that is
-// a literal key of the object is used whole rather than split — `castPath` is
+// Property-path parsing. A string is tokenized into path segments (dot,
+// bracket, and quoted-bracket notation), except a string that is a literal key
+// of the object is used whole rather than split — path casting is
 // object-dependent. Internal helper; not part of the public API.
 const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
 const reIsPlainProp = /^\w*$/;

--- a/packages/js-utils/src/truncate.ts
+++ b/packages/js-utils/src/truncate.ts
@@ -68,9 +68,9 @@ const rsSymbol =
 	[ rsNonAstral + rsCombo + '?', rsCombo, rsRegional, rsSurrPair, rsAstral ].join( '|' ) +
 	')';
 const reUnicode = RegExp( rsFitz + '(?=' + rsFitz + ')|' + rsSymbol + rsSeq, 'g' );
-// Faithful port of lodash's Unicode-detection class: it intentionally combines
-// ZWJ, surrogate, combining-mark, and variation-selector ranges and matches on
-// UTF-16 code units (no `u` flag), which the rule misreads as a mistake.
+// Unicode-detection class: it intentionally combines ZWJ, surrogate,
+// combining-mark, and variation-selector ranges and matches on UTF-16 code
+// units (no `u` flag), which the rule misreads as a mistake.
 // eslint-disable-next-line no-misleading-character-class
 const reHasUnicode = RegExp( '[' + rsZWJ + rsAstralRange + rsComboRange + rsVarRange + ']' );
 

--- a/packages/js-utils/src/words.ts
+++ b/packages/js-utils/src/words.ts
@@ -1,8 +1,8 @@
 /**
  * Splits an ASCII identifier or phrase into words: on
  * camelCase/PascalCase boundaries, acronym runs (`XMLHttp` → `XML`, `Http`),
- * digit groups, and separators. Unlike lodash it does not deburr accents or
- * strip apostrophes — callers pass identifiers/keys, not free-form text.
+ * digit groups, and separators. It does not deburr accents or strip
+ * apostrophes — callers pass identifiers/keys, not free-form text.
  */
 const WORD_PATTERN = /[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+/g;
 


### PR DESCRIPTION
## Proposed Changes

* Reword the divergence notes in the `@automattic/js-utils` source comments so each helper describes its limits on its own terms rather than by reference to lodash (e.g. "unlike lodash there is no property-name shorthand" → "there is no property-name shorthand").
* Rename the parity test cases to drop "like lodash" / "matching lodash" from their descriptions.
* Trim lodash from the js-utils README (tightened to fewer mentions), a code-review workflow prompt, and a handful of test comments.

## Why are these changes being made?

* Continues reducing incidental lodash references now that the package README states once, globally, that these helpers mirror their lodash equivalents. The comments and test names no longer restate that per function. The differential tests still import lodash as their reference oracle — that import (and its `eslint-disable` justification) is the mechanism that proves parity, so it stays.

## Testing Instructions

* `yarn typecheck-packages` and `yarn test-packages` — comments/test-descriptions/docs only, so behavior and types are unchanged. (One test-data string in `escape-reg-exp.ts` was changed to a neutral example; its expectation was updated to match.)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
