### PR TITLE
Reader Spaces: customize modal polish and default new spaces to Classic

### DIFF
--- a/client/reader/sidebar/spaces/style.scss
+++ b/client/reader/sidebar/spaces/style.scss
@@ -47,23 +47,11 @@
 // Active row: tint the whole row with the space's own accent so the current
 // space is unmistakable. The shared sidebar only paints a selected background in
 // dark mode, so in light mode this is the only active-state cue — without it the
-// current space reads no differently from the rest until hovered. A leading
-// accent bar reinforces it; the name takes on the space's foreground colour.
+// current space reads no differently from the rest until hovered. The name takes
+// on the space's foreground colour.
 .sidebar-spaces__item.selected {
 	.sidebar-spaces__link {
-		position: relative;
 		background-color: var( --space-color-bg );
-	}
-
-	.sidebar-spaces__link::before {
-		content: '';
-		position: absolute;
-		inset-inline-start: 0;
-		inset-block: 6px;
-		inline-size: 3px;
-		border-start-end-radius: 2px;
-		border-end-end-radius: 2px;
-		background: var( --space-color );
 	}
 
 	.sidebar-spaces__name {

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -141,7 +141,7 @@ describe( 'CreateSpaceModal', () => {
 		expect( within( dialog ).queryByRole( 'tab', { name: 'Delete' } ) ).not.toBeInTheDocument();
 
 		await user.click( within( dialog ).getByRole( 'tab', { name: 'Layout' } ) );
-		expect( within( dialog ).getByRole( 'radio', { name: /Compact list/ } ) ).toBeChecked();
+		expect( within( dialog ).getByRole( 'radio', { name: /Classic/ } ) ).toBeChecked();
 
 		await user.click( within( dialog ).getByRole( 'tab', { name: 'Sources' } ) );
 		expect(

--- a/client/reader/spaces/customize-modal/identity-tab.tsx
+++ b/client/reader/spaces/customize-modal/identity-tab.tsx
@@ -111,12 +111,10 @@ export function IdentityTab( {
 				/>
 			</VStack>
 
-			<VStack spacing={ 2 }>
+			<VStack spacing={ 2 } className="customize-space-modal__color-selection">
 				<span className="customize-space-modal__field-label">{ translate( 'Accent color' ) }</span>
 				<p className="customize-space-modal__field-help">
-					{ translate(
-						'Changes the color of post titles and actions in this space. Choose None to keep the feed neutral.'
-					) }
+					{ translate( 'Changes the color of post titles and actions in this space.' ) }
 				</p>
 				<SpaceColorPicker
 					value={ color }

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -176,7 +176,11 @@ function SpaceUpsertModalContent( {
 		return isKnownLanguageCode( base ) ? [ base ] : [];
 	} );
 	const [ icon, setIcon ] = useState< SpaceIcon >( 'inbox' );
-	const [ view, setView ] = useState< SpaceFeedLayout >( DEFAULT_SPACE_FEED_LAYOUT );
+	// New spaces default to the classic Reader stream layout; edit mode seeds the
+	// space's saved layout below.
+	const [ view, setView ] = useState< SpaceFeedLayout >(
+		isCreate ? 'legacy' : DEFAULT_SPACE_FEED_LAYOUT
+	);
 	const [ width, setWidth ] = useState< SpaceLayoutWidth >( DEFAULT_SPACE_WIDTH );
 	const [ selectedSources, setSelectedSources ] = useState< SourceDraftItem[] >( [] );
 	const [ isConfirmingDelete, setIsConfirmingDelete ] = useState( false );

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -30,6 +30,9 @@
 		font-weight: 600;
 	}
 }
+.customize-space-modal__color-selection {
+	padding-block-end: 24px;
+}
 
 .customize-space-modal__subtitle {
 	color: var( --color-text-subtle );
@@ -53,7 +56,6 @@
 		flex: 1;
 		flex-direction: column;
 		min-block-size: 0;
-		padding-block-end: 24px;
 	}
 }
 
@@ -63,7 +65,7 @@
 	flex-direction: column;
 	min-block-size: 0;
 	overflow-y: auto;
-	padding-block: 16px 8px;
+	padding-block: 16px 0;
 	padding-inline: 8px;
 }
 

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -42,7 +42,7 @@
 	flex: 1;
 	flex-direction: column;
 	min-block-size: 0;
-	padding-block-end: 12px;
+	padding-block-end: 0;
 	.components-tab-panel__tabs {
 		border-block-end: 1px solid var( --color-neutral-5 );
 		border-block-start: 1px solid var( --color-neutral-5 );

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -5,6 +5,7 @@
 .customize-space-modal {
 	&.components-modal__frame {
 		block-size: min( 760px, calc( 100% - 96px ) );
+		max-inline-size: 660px;
 	}
 
 	.components-modal__content {

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -53,6 +53,7 @@
 		flex: 1;
 		flex-direction: column;
 		min-block-size: 0;
+		padding-block-end: 24px;
 	}
 }
 

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -159,9 +159,7 @@ describe( 'CustomizeModal', () => {
 			} )
 		).toBeChecked();
 		expect(
-			screen.getByText(
-				'Changes the color of post titles and actions in this space. Choose None to keep the feed neutral.'
-			)
+			screen.getByText( 'Changes the color of post titles and actions in this space.' )
 		).toBeVisible();
 		expect( screen.getByRole( 'radio', { name: 'Inbox' } ) ).toBeChecked();
 	} );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of the Reader Spaces work (feature flag `reader/spaces`, a8c-only).

## Proposed Changes

* Cap the create/customize space modal width at 660px and refine its internal spacing (tab strip, tab content, and the accent-color block).
* Remove the leading accent bar on the active space in the sidebar, keeping the background tint and accent-colored name as the active-state cues.
* Shorten the Accent color help text in the Identity tab.
* Default new spaces to the classic Reader stream layout; edit mode still seeds the space's saved layout.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These are UX refinements to the dark-shipped Reader Spaces feature. The sidebar accent bar was not a standard pattern in the app, the classic stream is the most familiar layout to default new spaces to, and the modal sizing/spacing/copy tweaks tighten the create/customize experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With the `reader/spaces` feature flag enabled on an a8c account:

### Scenario 1 - Customize modal sizing and spacing:
- Go to `/reader/spaces/:id` and click Customize
- Check the modal is at most 660px wide, the tab strip sits flush with no extra gap beneath it, and there is breathing room below the tab content

### Scenario 2 - Active space in the sidebar:
- Go to `/reader` and open a space from the sidebar
- Check the selected space no longer shows a leading accent bar, while its background tint and accent-colored name still mark it as active

### Scenario 3 - Accent color help copy:
- Open Customize on a space and go to the Identity tab
- Check the Accent color help text reads "Changes the color of post titles and actions in this space."

### Scenario 4 - New space defaults to Classic:
- Go to `/reader`, click "Add a space" in the sidebar, and open the Layout tab
- Check the "Classic" layout is selected by default

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
