### PR TITLE
Onboarding: route the diy-launchpad cohort to Site Setup after checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -82,6 +82,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		);
 		const coupon = useQuery().get( 'coupon' );
 		const refParameter = useQuery().get( 'ref' );
+		const diyLaunchpad = useQuery().get( 'diy-launchpad' );
 		const siteSlugParam = useQuery().get( 'siteSlug' );
 
 		const { setShouldShowNotification } = usePurchasePlanNotification();
@@ -95,6 +96,19 @@ const onboarding: FlowV2< typeof initialize > = {
 			providedDependencies: ProvidedDependencies,
 			planCartItem: MinimalRequestCartProduct | null
 		): Promise< [ string, string | null, string | null ] > => {
+			// Site Setup replaces My Home, so the diy-launchpad cohort must land there directly:
+			// any other destination (e.g. /home) would be the orphaned screen we just removed.
+			if ( diyLaunchpad && providedDependencies.siteSlug ) {
+				const siteSlug = providedDependencies.siteSlug as string;
+				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
+				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
+				return [
+					`${ adminUrl }admin.php?page=site-setup-wp-admin&enable-ai-launchpad=1`,
+					null,
+					null,
+				];
+			}
+
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
 				return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 			}
@@ -267,6 +281,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							addQueryArgs( withLocale( '/setup/onboarding/post-checkout-onboarding', locale ), {
 								siteSlug: siteSlugParam,
 								...( refParameter ? { ref: refParameter } : {} ),
+								...( diyLaunchpad ? { 'diy-launchpad': diyLaunchpad } : {} ),
 							} )
 						);
 						return;
@@ -300,6 +315,7 @@ const onboarding: FlowV2< typeof initialize > = {
 											{
 												siteSlug,
 												...( refParameter ? { ref: refParameter } : {} ),
+												...( diyLaunchpad ? { 'diy-launchpad': diyLaunchpad } : {} ),
 											}
 									  );
 
@@ -320,6 +336,9 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
+						} else if ( diyLaunchpad ) {
+							// The diy-launchpad cohort skips the AI/manual chooser and lands straight in Site Setup.
+							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )


### PR DESCRIPTION
<!-- part of DOTOBRD-497 -->

## Proposed Changes

* Add a `diy-launchpad` query param to the standard `onboarding` flow. When `?diy-launchpad=1` is present, after checkout the flow overrides the post-checkout destination to the Site Setup wp-admin page (`admin.php?page=site-setup-wp-admin&enable-ai-launchpad=1`) **and** skips the post-checkout "Set up your site" AI/manual chooser, landing the user directly in Site Setup.
* The override is the **first** branch in `getPostCheckoutDestination` and short-circuits ahead of the `postCheckoutBigSky` / Woo chooser in the `processing` step, so the flagged cohort takes precedence over the goal/plugin `/home` redirect, the Woo ref, and the AI chooser. The **Playground importer** `redirect_to` is intentionally left untouched — a signup carrying a `playground` id is mid-import and must keep its importer destination; `diy-launchpad` and `playground` are mutually exclusive entry points, so the cohort is unaffected.
* The param is threaded through checkout exactly like `ref` (into the checkout `redirect_to` and the NO_ACTION recovery redirect), so it survives the full-page checkout round trip. `useFlowNavigation` merges `window.location.search` on every `navigate()`, so it also survives the `post-checkout-onboarding → processing` hop.

## Why are these changes being made?

The AI Launchpad — now surfaced as **"Site Setup"** — is being prepared for a DIY paid-onboarding user-testing cohort. This lets that cohort be routed straight into Site Setup by appending `?diy-launchpad=1` to the onboarding URL, with **no backend change**: the destination's `enable-ai-launchpad=1` param is consumed by the existing mu-wpcom enable handler. Because Site Setup *replaces* My Home for eligible sites, any other destination (e.g. `/home`) would drop the cohort onto an orphaned screen — hence the flag takes precedence over the other post-checkout destinations. The companion mu-wpcom PR that renames the page and provides the landing screen is Automattic/jetpack#50206.

## Testing Instructions

* Run a standard paid `onboarding` signup with the flag: `/setup/onboarding/domains?diy-launchpad=1` (pick a paid plan — Personal is enough; a 100%-off coupon works via `&coupon=<CODE>`).
* After checkout, confirm you are redirected straight to `…/wp-admin/admin.php?page=site-setup-wp-admin&enable-ai-launchpad=1` (which self-enables and renders Site Setup) — with **no** "Set up your site" AI/manual chooser in between.
* Without the flag, confirm onboarding behaves exactly as before (lands on the usual My Home / post-checkout destination).

Note: the `site-setup-wp-admin` slug resolves once Automattic/jetpack#50206 is deployed. Before that, the existing enable handler still fires on the `enable-ai-launchpad` param and redirects to the current launchpad slug, so the onboarding → enable → land-in-launchpad chain still works.
