### PR TITLE
Reader: fix misaligned Add Tags form in Firefox

### DIFF
--- a/client/reader/sidebar/reader-sidebar-tags/add-tags-form/style.scss
+++ b/client/reader/sidebar/reader-sidebar-tags/add-tags-form/style.scss
@@ -1,5 +1,6 @@
 
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@import "@automattic/typography/styles/variables";
 @import "calypso/assets/stylesheets/shared/extends-forms";
 
 .add-tags-form {

--- a/client/reader/sidebar/reader-sidebar-tags/add-tags-form/style.scss
+++ b/client/reader/sidebar/reader-sidebar-tags/add-tags-form/style.scss
@@ -1,5 +1,6 @@
 
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@import "calypso/assets/stylesheets/shared/extends-forms";
 
 .add-tags-form {
 	display: flex;


### PR DESCRIPTION
Fixes READ-579

## Proposed Changes

* The Reader sidebar "Add a tag" `<input>` relies on `@extend %form-field !optional` for its sizing, but that placeholder — and the typography variables it depends on — used to be supplied by the SCSS prelude, so this file never imported them. Removing the prelude ([#111583](https://github.com/Automattic/wp-calypso/pull/111583)) dropped `%form-field` from this file's scope, and because the extend is `!optional` it silently compiled to nothing, leaving the input with browser-default sizing.
* Import `@automattic/typography/styles/variables` and `calypso/assets/stylesheets/shared/extends-forms` explicitly so `%form-field` resolves again, restoring `width: 100%` and `box-sizing: border-box` on the input.

<img width="286" height="174" alt="image" src="https://github.com/user-attachments/assets/d5242d79-344b-433a-abca-52a441c9be9a" />


## Why are these changes being made?

Without the `%form-field` styles the input fell back to UA-default sizing, which honors the input's intrinsic `min-width` inside the sidebar's flex row and overflows/misaligns the form — most visibly in Firefox (also seen in proxied Chrome), matching the report in READ-579. This restores the intended full-width, border-box input to match the "Add" button.

## Testing Instructions

* In **Firefox**, open the Reader, expand the **Tags** section in the sidebar, and check the "Add a tag" form at the bottom of the tag list. The input should fill the column width, sit on the border-box, and align with the "Add" button without overflowing. Compare against `trunk` to confirm the misalignment is gone.
* Spot-check other browsers (Chrome, Safari) and dark mode to confirm no regression.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
