### PR TITLE
Reader Spaces: enable reader/spaces in all environments except production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -114,7 +114,7 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
 		"reader/social": true,
-		"reader/spaces": false,
+		"reader/spaces": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -142,7 +142,7 @@
 		"purchases/split-cancel-remove": false,
 		"push-notifications": true,
 		"reader/social": true,
-		"reader/spaces": false,
+		"reader/spaces": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/test.json
+++ b/config/test.json
@@ -99,7 +99,7 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": true,
 		"reader/social": true,
-		"reader/spaces": false,
+		"reader/spaces": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -147,7 +147,7 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
 		"reader/social": true,
-		"reader/spaces": false,
+		"reader/spaces": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Enable the `reader/spaces` feature flag in the `wpcalypso`, `horizon`, `stage`, and `test` config environments (development was already enabled).
* Keep `reader/spaces` disabled in `production` so the feature stays hidden for end users.

## Why are these changes being made?

Reader Spaces was only enabled locally in `development`. Turning it on across all non-production environments lets the feature be validated and dogfooded in pre-production (wpcalypso, horizon, stage) and exercised by unit tests, while remaining gated off in production until it's ready to ship.

## Testing Instructions

### Scenario 1 - Reader Spaces visible in non-production:
- On a wpcalypso/horizon/stage build, go to `/reader`
- Check if you can see the Spaces section in the Reader sidebar, and that `/reader/spaces` routes load

### Scenario 2 - Reader Spaces hidden in production:
- On a production build, go to `/reader`
- Check that the Spaces section is not shown in the sidebar and `/reader/spaces` is not accessible

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
