### PR TITLE
Legacy contact: show a live character counter on the notes field

### DIFF
--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -37,17 +37,19 @@ const fields: Field< LegacyContactFormData >[] = [
 			const { id, getValue } = field;
 			const value = getValue( { item: data } ) || '';
 			const remaining = LEGACY_CONTACT_NOTES_MAX_LENGTH - value.length;
-			const isNearLimit = remaining <= LEGACY_CONTACT_NOTES_WARNING_THRESHOLD;
+			const isAtLimit = remaining <= 0;
+			const isNearLimit = ! isAtLimit && remaining <= LEGACY_CONTACT_NOTES_WARNING_THRESHOLD;
 
 			return (
 				<div className="legacy-contact-notes-field">
 					<span
 						className={ clsx( 'legacy-contact-notes-field__count', {
 							'is-near-limit': isNearLimit,
+							'is-at-limit': isAtLimit,
 						} ) }
 						// Only announce once the user is near the limit, so screen
 						// readers aren't read the count on every keystroke.
-						aria-live={ isNearLimit ? 'polite' : 'off' }
+						aria-live={ isNearLimit || isAtLimit ? 'polite' : 'off' }
 					>
 						{ sprintf(
 							/* translators: %d is the number of characters remaining. */

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from '@wordpress/data';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import clsx from 'clsx';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
@@ -12,6 +13,7 @@ import { SectionHeader } from '../../components/section-header';
 import type { Field } from '@wordpress/dataviews';
 
 const LEGACY_CONTACT_NOTES_MAX_LENGTH = 500;
+const LEGACY_CONTACT_NOTES_WARNING_THRESHOLD = 50;
 
 interface LegacyContactFormData {
 	email: string;
@@ -35,10 +37,16 @@ const fields: Field< LegacyContactFormData >[] = [
 			const { id, getValue } = field;
 			const value = getValue( { item: data } ) || '';
 			const remaining = LEGACY_CONTACT_NOTES_MAX_LENGTH - value.length;
+			const isNearLimit = remaining <= LEGACY_CONTACT_NOTES_WARNING_THRESHOLD;
 
 			return (
 				<div className="legacy-contact-notes-field">
-					<span className="legacy-contact-notes-field__count" aria-hidden="true">
+					<span
+						className={ clsx( 'legacy-contact-notes-field__count', {
+							'is-near-limit': isNearLimit,
+						} ) }
+						aria-hidden="true"
+					>
 						{ sprintf(
 							/* translators: %d is the number of characters remaining. */
 							_n( '%d character remaining', '%d characters remaining', remaining ),

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -37,29 +37,26 @@ const fields: Field< LegacyContactFormData >[] = [
 			const remaining = LEGACY_CONTACT_NOTES_MAX_LENGTH - value.length;
 
 			return (
-				<TextareaControl
-					__nextHasNoMarginBottom
-					value={ value }
-					onChange={ ( nextValue ) => onChange( { [ id ]: nextValue } ) }
-					label={ hideLabelFromVision ? undefined : field.label }
-					help={
-						<>
-							{ __(
-								'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
-							) }
-							<br />
-							<span>
-								{ sprintf(
-									/* translators: %d is the number of characters remaining. */
-									_n( '%d character remaining.', '%d characters remaining.', remaining ),
-									remaining
-								) }
-							</span>
-						</>
-					}
-					maxLength={ LEGACY_CONTACT_NOTES_MAX_LENGTH }
-					rows={ 3 }
-				/>
+				<div className="legacy-contact-notes-field">
+					<span className="legacy-contact-notes-field__count">
+						{ sprintf(
+							/* translators: %d is the number of characters remaining. */
+							_n( '%d character remaining', '%d characters remaining', remaining ),
+							remaining
+						) }
+					</span>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						value={ value }
+						onChange={ ( nextValue ) => onChange( { [ id ]: nextValue } ) }
+						label={ hideLabelFromVision ? undefined : field.label }
+						help={ __(
+							'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
+						) }
+						maxLength={ LEGACY_CONTACT_NOTES_MAX_LENGTH }
+						rows={ 3 }
+					/>
+				</div>
 			);
 		},
 	},

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button, TextareaControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
@@ -33,17 +33,30 @@ const fields: Field< LegacyContactFormData >[] = [
 		label: __( 'Notes' ),
 		Edit: ( { data, field, onChange, hideLabelFromVision } ) => {
 			const { id, getValue } = field;
+			const value = getValue( { item: data } ) || '';
+			const remaining = LEGACY_CONTACT_NOTES_MAX_LENGTH - value.length;
 
 			return (
 				<TextareaControl
 					__nextHasNoMarginBottom
-					value={ getValue( { item: data } ) || '' }
-					onChange={ ( value ) => onChange( { [ id ]: value } ) }
-					label={ field.label }
-					hideLabelFromVision={ hideLabelFromVision }
-					help={ __(
-						'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
-					) }
+					value={ value }
+					onChange={ ( nextValue ) => onChange( { [ id ]: nextValue } ) }
+					label={ hideLabelFromVision ? undefined : field.label }
+					help={
+						<>
+							{ __(
+								'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
+							) }
+							<br />
+							<span>
+								{ sprintf(
+									/* translators: %d is the number of characters remaining. */
+									_n( '%d character remaining.', '%d characters remaining.', remaining ),
+									remaining
+								) }
+							</span>
+						</>
+					}
 					maxLength={ LEGACY_CONTACT_NOTES_MAX_LENGTH }
 					rows={ 3 }
 				/>

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -45,7 +45,9 @@ const fields: Field< LegacyContactFormData >[] = [
 						className={ clsx( 'legacy-contact-notes-field__count', {
 							'is-near-limit': isNearLimit,
 						} ) }
-						aria-hidden="true"
+						// Only announce once the user is near the limit, so screen
+						// readers aren't read the count on every keystroke.
+						aria-live={ isNearLimit ? 'polite' : 'off' }
 					>
 						{ sprintf(
 							/* translators: %d is the number of characters remaining. */

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -38,7 +38,7 @@ const fields: Field< LegacyContactFormData >[] = [
 
 			return (
 				<div className="legacy-contact-notes-field">
-					<span className="legacy-contact-notes-field__count">
+					<span className="legacy-contact-notes-field__count" aria-hidden="true">
 						{ sprintf(
 							/* translators: %d is the number of characters remaining. */
 							_n( '%d character remaining', '%d characters remaining', remaining ),

--- a/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
+++ b/client/dashboard/me/security-legacy-contact/legacy-contact-form.tsx
@@ -49,7 +49,8 @@ const fields: Field< LegacyContactFormData >[] = [
 						__nextHasNoMarginBottom
 						value={ value }
 						onChange={ ( nextValue ) => onChange( { [ id ]: nextValue } ) }
-						label={ hideLabelFromVision ? undefined : field.label }
+						label={ field.label }
+						hideLabelFromVision={ hideLabelFromVision }
 						help={ __(
 							'We won’t share these notes with your legacy contact. Record any wishes, such as which sites to transfer.'
 						) }

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -14,6 +14,10 @@
 	line-height: 1.4;
 	color: var( --color-text-subtle );
 	white-space: nowrap;
+
+	&.is-near-limit {
+		color: var( --dashboard__foreground-color-error );
+	}
 }
 
 .legacy-contact-card {

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -2,6 +2,20 @@
 	text-wrap: pretty;
 }
 
+.legacy-contact-notes-field {
+	position: relative;
+}
+
+.legacy-contact-notes-field__count {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-end: 0;
+	font-size: 11px;
+	line-height: 1.4;
+	color: var( --color-text-subtle );
+	white-space: nowrap;
+}
+
 .legacy-contact-card {
 	padding: 12px 16px;
 	border: 1px solid var( --dashboard-surface__border-color );

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -16,6 +16,10 @@
 	white-space: nowrap;
 
 	&.is-near-limit {
+		color: var( --dashboard__foreground-color-warning );
+	}
+
+	&.is-at-limit {
 		color: var( --dashboard__foreground-color-error );
 	}
 }

--- a/client/dashboard/me/security-legacy-contact/test/index.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/index.test.tsx
@@ -105,6 +105,18 @@ describe( '<SecurityLegacyContact />', () => {
 		expect( requestBody ).toEqual( { email: CONTACT.contact_email } );
 	} );
 
+	test( 'counts down the remaining characters as notes are typed', async () => {
+		interceptContacts( [] );
+
+		renderScreen();
+
+		expect( await screen.findByText( '500 characters remaining.' ) ).toBeVisible();
+
+		await userEvent.type( screen.getByRole( 'textbox', { name: 'Notes' } ), 'Hello' );
+
+		expect( screen.getByText( '495 characters remaining.' ) ).toBeVisible();
+	} );
+
 	test( 'opens a confirmation dialog when removing', async () => {
 		interceptContacts( [ CONTACT ] );
 

--- a/client/dashboard/me/security-legacy-contact/test/index.test.tsx
+++ b/client/dashboard/me/security-legacy-contact/test/index.test.tsx
@@ -110,11 +110,11 @@ describe( '<SecurityLegacyContact />', () => {
 
 		renderScreen();
 
-		expect( await screen.findByText( '500 characters remaining.' ) ).toBeVisible();
+		expect( await screen.findByText( '500 characters remaining' ) ).toBeVisible();
 
 		await userEvent.type( screen.getByRole( 'textbox', { name: 'Notes' } ), 'Hello' );
 
-		expect( screen.getByText( '495 characters remaining.' ) ).toBeVisible();
+		expect( screen.getByText( '495 characters remaining' ) ).toBeVisible();
 	} );
 
 	test( 'opens a confirmation dialog when removing', async () => {


### PR DESCRIPTION
Fixes RSM-4644. Follow-up to #112107.

## Proposed Changes

* Add a live **character counter** to the legacy contact **notes** field. As you type, a counter at the top right of the field — level with the **Notes** label — shows how many characters remain (out of 500).
* The privacy hint remains in the help text below the field.
* The 500-character cap was already enforced, but previously the input simply stopped at the limit with no explanation. The counter makes the limit visible.


### Example

<img width="690" height="494" alt="Screenshot 2026-07-07 at 1 13 23 PM" src="https://github.com/user-attachments/assets/21c36a21-ad35-424b-b86b-00103da9ca65" />

### Example - Count within threshold (warning-colored)

<img width="681" height="491" alt="Screenshot 2026-07-08 at 11 20 25 AM" src="https://github.com/user-attachments/assets/004202b6-6a13-4920-8420-9bfec75705dc" />

### Example - Count at limit (error-colored)

<img width="684" height="501" alt="Screenshot 2026-07-08 at 11 20 39 AM" src="https://github.com/user-attachments/assets/15e2ad2f-9c5a-4e43-82d2-d36a50f0e669" />

## Why are these changes being made?

The notes field has a 500-character limit, but there was no on-screen indication of it — the textarea silently stopped accepting input once the cap was reached. Surfacing a running count sets expectations while writing and avoids the confusing "why won't it type?" moment.

There is no shared `@wordpress/components`/DataViews equivalent of the old Calypso `CountedTextarea`, and adding one to the design system isn't warranted for a single use. This implements the counter locally on the existing `TextareaControl` instead, positioned at the top right of the field.

## Testing Instructions

* Go to **Me → Security → Legacy contact**.
* In the add form, confirm the **Notes** field shows "500 characters remaining" at the top right, level with the field label.
* Type into the field and confirm the count decrements accordingly (e.g. 5 characters typed → "495 characters remaining").
* Confirm the count stops at 0 and the field will not accept further input beyond the limit.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
