### PR TITLE
Replace lodash in the assets-writer webpack plugin

### DIFF
--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -76,9 +76,9 @@ Object.assign( AssetsWriter.prototype, {
 			}
 
 			statsToOutput.assets = Object.fromEntries(
-				Object.entries( stats.namedChunkGroups ).map( ( [ groupName, { assets } ] ) => [
+				Object.entries( stats.namedChunkGroups ?? {} ).map( ( [ groupName, { assets } ] ) => [
 					groupName,
-					assets
+					( assets ?? [] )
 						.filter(
 							( { name } ) =>
 								! (

--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -1,6 +1,5 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
-const _ = require( 'lodash' );
 
 function AssetsWriter( options ) {
 	this.options = Object.assign(
@@ -76,14 +75,20 @@ Object.assign( AssetsWriter.prototype, {
 				}
 			}
 
-			statsToOutput.assets = _.mapValues( stats.namedChunkGroups, ( { assets } ) =>
-				_.reject(
-					assets,
-					( { name } ) =>
-						isDevelopmentAsset( name ) ||
-						name.startsWith( this.options.manifestFile ) ||
-						name.startsWith( this.options.runtimeFile )
-				).map( ( { name } ) => fixupPath( name ) )
+			statsToOutput.assets = Object.fromEntries(
+				Object.entries( stats.namedChunkGroups ).map( ( [ groupName, { assets } ] ) => [
+					groupName,
+					assets
+						.filter(
+							( { name } ) =>
+								! (
+									isDevelopmentAsset( name ) ||
+									name.startsWith( this.options.manifestFile ) ||
+									name.startsWith( this.options.runtimeFile )
+								)
+						)
+						.map( ( { name } ) => fixupPath( name ) ),
+				] )
 			);
 
 			self.outputStream.end( JSON.stringify( statsToOutput, null, '\t' ), callback );

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -295,6 +295,7 @@ const NAMESPACE_GUARDED = [
 	{ name: 'mapKeys', message: JS_UTILS_MESSAGE },
 	{ name: 'pick', message: JS_UTILS_MESSAGE },
 	{ name: 'chain', message: CHAIN_MESSAGE },
+	{ name: 'reject', message: REJECT_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).


### PR DESCRIPTION
## Proposed Changes

* Remove lodash from the assets-writer webpack plugin: build the per-chunk-group asset lists with native `Object.fromEntries` + `array.filter` in place of `_.mapValues` / `_.reject`.
* With no `_.reject` left anywhere in the repo, add it to the namespace/CommonJS lint guard.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase. This is an un-transpiled CommonJS webpack plugin, so it uses native replacements rather than a shared built utility. The native form produces output identical to the previous `mapValues`/`reject` (verified against lodash for a representative `namedChunkGroups` input, including empty groups and dev/manifest/runtime filtering). Locking `reject` at the namespace level prevents reintroduction now that its last usage is gone.

## Testing Instructions

* Run a production webpack build and confirm the generated assets stats file (`assets.json`) is unchanged — each chunk group still lists its non-development, non-manifest, non-runtime assets with fixed-up paths.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
