### PR TITLE
Manage Purchase: stack cramped notice CTAs on mobile (delayed-downgrade + other-upgrades)

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -421,7 +421,9 @@
 	margin-bottom: 6px;
 }
 
+.manage-purchase__delayed-downgrade-pending-notice.calypso-notice,
 .manage-purchase__expiring-credit-card-notice.calypso-notice,
+.manage-purchase__other-renewable-purchases-notice.calypso-notice,
 .manage-purchase__purchase-expiring-notice.calypso-notice {
 	// Inset the notice to match its neighbors. width:auto is required: the base
 	// .calypso-notice is width:100% border-box, so margin-inline alone overflows.


### PR DESCRIPTION
Resolves CHE-502

## Proposed Changes

* Add `.manage-purchase__delayed-downgrade-pending-notice` and `.manage-purchase__other-renewable-purchases-notice` to the shared notice rule in `manage-purchase/style.scss` (the block CHE-498 introduced), so these two notices get the same inset and mobile CTA treatment as the credit-card-expiring and purchase-expiring notices.

## Why are these changes being made?

On narrow/mobile viewports (`<660px`) the action button on these two notices ("Cancel downgrade", "Renew Now") was crammed inline next to the notice text, squeezing the message into a narrow column. CHE-498 already fixed this exact cramping for two other notices on the same page. These two were left with the same problem - this extends the same rule to cover them.

The visible fix is the mobile wrap: `flex-wrap: wrap` + the CTA at `flex-basis: 100%`, so the button drops to its own full-width line under 660px and stays inline above it.

| Scenario | Before | After |
|----------|--------|-------|
| Delayed-downgrade notice, `<660px` | CTA cramped inline right of the text | CTA on its own full-width line |
| Other-upgrades notice, `<660px` | CTA cramped inline right of the text | CTA on its own full-width line |
| Both notices, `>660px` | CTA inline | Unchanged - CTA stays inline |

## Testing Instructions

These two notices only render for specific, hard-to-reproduce purchase states, so force-render the delayed-downgrade one. The other-upgrades notice shares the exact same rule - it's covered via a class swap in step 5.

**Setup:** In `client/me/purchases/manage-purchase/notices.tsx`, in `renderDelayedDowngradePendingNotice()` (~line 193), temporarily comment out the guard `if ( ! purchase.isDelayedDowngradePending ) { return null; }`. The "Cancel downgrade" CTA renders on its own (its handler is always passed).

**Steps:**
1. Open any Purchase Settings page: `/me/purchases/:site/:purchaseId`.
2. Set the browser to a mobile viewport (DevTools device mode, ~375px).
3. Verify the delayed-downgrade notice is inset from the screen edges and "Cancel downgrade" sits on its own full-width row below the text, not cramped inline.
4. Widen above 660px and verify the CTA returns inline.
5. Other-upgrades notice (same shared rule): in DevTools, change the notice element's class `manage-purchase__delayed-downgrade-pending-notice` to `manage-purchase__other-renewable-purchases-notice` and confirm the CTA still wraps to its own row at `<660px`.
6. Regression: confirm the existing `manage-purchase__purchase-expiring-notice` / `manage-purchase__expiring-credit-card-notice` (CHE-498) still wrap on mobile - unchanged.
7. Revert the commented-out guard.

### Screenshots (mobile, 390px)

**Delayed-downgrade notice** - "Cancel downgrade" moves from cramped inline to its own full-width line.

| Before | After |
|--------|-------|
| <img width="400" alt="Delayed-downgrade notice, before" src="https://github.com/user-attachments/assets/2b88b5ac-8164-4b29-8f0a-94773fed1612" /> | <img width="400" alt="Delayed-downgrade notice, after" src="https://github.com/user-attachments/assets/fd1897ef-736c-4cb3-9552-cefa97132a3e" /> |

**Other-upgrades notice** - "Renew Now" moves from cramped inline to its own full-width line.

| Before | After |
|--------|-------|
| <img width="400" alt="Other-upgrades notice, before" src="https://github.com/user-attachments/assets/a282c526-dbcf-4e96-810e-f6f33ced7ea5" /> | <img width="400" alt="Other-upgrades notice, after" src="https://github.com/user-attachments/assets/d3f61a4b-2c69-418f-a6e0-09865007b0ff" /> |

**Lint:**
```
yarn stylelint client/me/purchases/manage-purchase/style.scss
```

Note: the rule's `margin-inline` computes to `0` at runtime (a pre-existing env override hitting all four selectors, CHE-498 included) - the inset comes from parent padding, so this PR's real effect is the mobile CTA stacking.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
