### PR TITLE
Replace lodash in build-metadata with native code

### DIFF
--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -2,7 +2,27 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const vm = require( 'vm' );
-const _ = require( 'lodash' );
+
+// True for objects and arrays (used to decide whether to recurse).
+const isObject = ( value ) => value !== null && typeof value === 'object';
+
+// Returns the item with the greatest `item[ key ]`, skipping nullish/NaN values
+// and keeping the first on a tie; `undefined` for an empty list.
+function maxBy( array, key ) {
+	let best;
+	let bestValue;
+	for ( const item of array ) {
+		const value = item[ key ];
+		if ( value == null || value !== value ) {
+			continue;
+		}
+		if ( best === undefined || value > bestValue ) {
+			best = item;
+			bestValue = value;
+		}
+	}
+	return best;
+}
 
 const areaCodes = {
 	CA: [
@@ -171,7 +191,7 @@ function deepRemoveUndefinedKeysFromObject( obj ) {
 		if ( obj.hasOwnProperty( key ) ) {
 			if ( typeof obj[ key ] === 'undefined' ) {
 				delete obj[ key ];
-			} else if ( _.isObject( obj[ key ] ) ) {
+			} else if ( isObject( obj[ key ] ) ) {
 				deepRemoveUndefinedKeysFromObject( obj[ key ] );
 			}
 		}
@@ -189,7 +209,7 @@ function generateDeepRemoveEmptyArraysFromObject( allowedKeys ) {
 					obj[ key ].length === 0
 				) {
 					delete obj[ key ];
-				} else if ( _.isObject( obj[ key ] ) ) {
+				} else if ( isObject( obj[ key ] ) ) {
 					deepRemoveEmptyArraysFromObject( obj[ key ] );
 				}
 			}
@@ -199,7 +219,7 @@ function generateDeepRemoveEmptyArraysFromObject( allowedKeys ) {
 }
 
 function removeAllNumberKeys( obj ) {
-	return _.omitBy( obj, ( val, key ) => /^\d+$/.test( key ) );
+	return Object.fromEntries( Object.entries( obj ).filter( ( [ key ] ) => ! /^\d+$/.test( key ) ) );
 }
 
 function removeRegionCodeAndCountryDialCodeIfSameWithCountryDialCode( countryData ) {
@@ -248,12 +268,10 @@ function processLibPhoneNumberMetadata( libPhoneNumberData ) {
 		}
 	}
 
-	const noPattern = Object.values( data ).filter(
-		_.conforms( { patterns: ( patterns ) => patterns.length === 0 } )
-	);
-	_.forIn( noPattern, function ( country ) {
+	const noPattern = Object.values( data ).filter( ( country ) => country.patterns.length === 0 );
+	noPattern.forEach( function ( country ) {
 		country.patternRegion = (
-			_.maxBy(
+			maxBy(
 				Object.values( data ).filter( ( c ) => c.dialCode === country.dialCode ),
 				'priority'
 			) || {}
@@ -367,15 +385,22 @@ function generateDialCodeMap( metadata ) {
 			res[ key ].push( value );
 		}
 	}
-	_.forIn( metadata, function ( country ) {
+	Object.values( metadata ).forEach( function ( country ) {
 		addValue( country.dialCode, country.isoCode );
 		( country.areaCodes || [] ).forEach( ( areaCode ) =>
 			addValue( country.dialCode + areaCode, country.isoCode )
 		);
 	} );
 
-	return _.mapValues( res, ( countryCodes ) =>
-		_.orderBy( countryCodes, ( countryCode ) => metadata[ countryCode ].priority || 0, 'desc' )
+	// Order each dial code's countries by priority, highest first (a stable sort
+	// keeps the original order among equal priorities).
+	return Object.fromEntries(
+		Object.entries( res ).map( ( [ dialCode, countryCodes ] ) => [
+			dialCode,
+			[ ...countryCodes ].sort(
+				( a, b ) => ( metadata[ b ].priority || 0 ) - ( metadata[ a ].priority || 0 )
+			),
+		] )
 	);
 }
 

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -296,6 +296,10 @@ const NAMESPACE_GUARDED = [
 	{ name: 'pick', message: JS_UTILS_MESSAGE },
 	{ name: 'chain', message: CHAIN_MESSAGE },
 	{ name: 'reject', message: REJECT_MESSAGE },
+	{ name: 'mapValues', message: JS_UTILS_MESSAGE },
+	{ name: 'omitBy', message: JS_UTILS_MESSAGE },
+	{ name: 'maxBy', message: EXTREMUM_MESSAGE },
+	{ name: 'orderBy', message: SORT_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).


### PR DESCRIPTION
## Proposed Changes

* Remove lodash from the phone-number metadata generator: add small local `isObject` and `maxBy` helpers, and use native `Object.fromEntries`/`Object.entries`/`filter`/`sort` in place of `isObject`, `omitBy`, `conforms`, `forIn`, `maxBy`, `mapValues`, and `orderBy`.
* With their last namespace usages gone, add `mapValues`, `omitBy`, `maxBy`, and `orderBy` to the namespace/CommonJS lint guard.

## Why are these changes being made?

* Part of the ongoing effort to drop lodash from the codebase — this is the last source file that imported it. It is an un-transpiled CommonJS build script, so it uses native replacements and small local helpers rather than a shared built utility. The rewrite is faithful (the local `maxBy` mirrors lodash's nullish/NaN skipping; `orderBy` desc becomes a stable descending sort), and running both the old and new versions against the same live libphonenumber data produces a **byte-identical** generated `data.js`.

## Testing Instructions

* Run `node bin/build-metadata.js` and confirm `client/components/phone-input/data.js` is regenerated unchanged (byte-identical to the committed file).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
