### PR TITLE
Trim stale lodash references from docs and comments

### DIFF
--- a/apps/notifications/src/panel/suggestions/index.jsx
+++ b/apps/notifications/src/panel/suggestions/index.jsx
@@ -20,8 +20,8 @@ const KEY_DOWN = 40;
 const suggestionMatcher = /(?:^|\s)@([^\s]*)$/i;
 
 /**
- * This pattern looks for special regex characters.
- * Extracted directly from lodash@4.17.21.
+ * Matches characters that carry special meaning inside a regular expression,
+ * so they can be escaped before the query is used to build one.
  */
 const reRegExpChars = /[\\^$.*+?()[\]{}|]/g;
 const reHasRegExpChars = RegExp( reRegExpChars.source );
@@ -120,7 +120,7 @@ class Suggestions extends Component {
 
 		const [ , suggestion ] = match;
 
-		// NOTE: This test logic was extracted directly from lodash@4.17.21.
+		// Escape any regex metacharacters so the suggestion can be safely used in a pattern.
 		if ( suggestion && reHasRegExpChars.test( suggestion ) ) {
 			return suggestion.replace( reRegExpChars, '\\$&' );
 		}

--- a/bin/audit-svg-colors.js
+++ b/bin/audit-svg-colors.js
@@ -18,8 +18,8 @@ const PALETTE = require( '@automattic/color-studio' );
 const chroma = require( 'chroma-js' );
 
 /**
- * Native Sort - replacement of _.sortBy Lodash function
- * @returns Sorted array.
+ * Comparator that orders entries alphabetically by `to.name`.
+ * @returns A negative, zero, or positive number for use with `Array#sort`.
  */
 const compareByName = ( objA, objB ) => {
 	if ( objA.to.name > objB.to.name ) {
@@ -35,8 +35,7 @@ const compareByName = ( objA, objB ) => {
  */
 
 /**
- * pickBy function is a replacement for the Lodash _.pickby
- *
+ * Returns a new object containing only the entries for which `fn( value, key )` is truthy.
  */
 const pickBy = ( palette, fn ) =>
 	Object.keys( palette ?? {} )

--- a/client/blocks/dismissible-card/README.md
+++ b/client/blocks/dismissible-card/README.md
@@ -38,7 +38,7 @@ Any addition classes to pass to the card component.
 <table>
 	<tr><td>Type</td><td>Function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>lodash/noop</code></td></tr>
+	<tr><td>Default</td><td><code>undefined</code></td></tr>
 </table>
 
 This function will fire when a user clicks on the cross icon

--- a/client/components/data/query-jetpack-settings/README.md
+++ b/client/components/data/query-jetpack-settings/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import { map } from 'lodash';
 import { connect } from 'react-redux';
 import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings';
 import getJetpackSettings from 'calypso/state/selectors/get-jetpack-settings';
@@ -16,7 +15,7 @@ function MyJetpackSettings( { settings, siteId } ) {
 	return (
 		<div>
 			<QueryJetpackSettings siteId={ siteId } />
-			{ map( settings, ( value, name ) => (
+			{ Object.entries( settings ).map( ( [ name, value ] ) => (
 				<div>
 					{ name }: { value.toString() }
 				</div>

--- a/client/components/forms/clipboard-button/README.md
+++ b/client/components/forms/clipboard-button/README.md
@@ -30,7 +30,7 @@ The text to copy to the user's clipboard upon clicking the button.
 <table>
 	<tr><td>Type</td><td>Function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>lodash/noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 Function to invoke after the text has been copied to the user's clipboard. This will not be triggered if the a prompt is shown in place of direct clipboard copy, in cases where the browser does not grant clipboard access.

--- a/client/lib/analytics/with-tracking-tool/README.md
+++ b/client/lib/analytics/with-tracking-tool/README.md
@@ -26,7 +26,7 @@ When combined with other wrappers (like `localize()`):
 
 ```js
 import { localize } from 'i18n-calypso';
-import { flowRight } from 'lodash';
+import { compose } from 'redux';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 
 class MyComponent {
@@ -35,5 +35,5 @@ class MyComponent {
 	}
 }
 
-export default flowRight( localize, withTrackingTool( 'HotJar' ) )( MyComponent );
+export default compose( localize, withTrackingTool( 'HotJar' ) )( MyComponent );
 ```

--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -124,7 +124,7 @@ describe( 'Data Layer', () => {
 			},
 		};
 
-		test( 'lodash native backwards/cross compatiblity', () => {
+		test( 'native backwards/cross compatibility', () => {
 			expect( convertKeysBy( snakeObject, kebabCase ) ).toEqual(
 				convertKeysBy( camelObject, kebabCase )
 			);

--- a/packages/eslint-plugin-wpcalypso/docs/rules/redux-no-bound-selectors.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/redux-no-bound-selectors.md
@@ -4,7 +4,7 @@ Disallows the anti-pattern of creating functions within the function that gets p
 
 ## Rule details
 
-Any function, whether anonymous or referred to using a variable, that is passed as `connect`'s first argument cannot contain any sort of function creation within its body. This includes explicit function creation and implicit creation using `Function#bind` and `lodash#bind`, as well as `lodash#partial` and `lodash#partialRight`.
+Any function, whether anonymous or referred to using a variable, that is passed as `connect`'s first argument cannot contain any sort of function creation within its body. This includes explicit function creation and implicit creation using `Function#bind` or partial-application helpers.
 
 ### Forbidden
 


### PR DESCRIPTION
## Proposed Changes

Housekeeping sweep to remove stale or low-value lodash references from documentation, code comments, and a test name. No behavior changes.

* README usage examples now use native / redux equivalents (`Object.entries().map`, redux `compose`) instead of importing from lodash.
* Corrected two stale prop-default tables: the `dismissible-card` `onClick` prop has no default (it is optional), and `clipboard-button` `onCopy` defaults to a local no-op.
* Comments that merely narrated "replacement of Lodash `_.x`" now describe the code on its own terms.
* Renamed a data-layer test and fixed a typo in its name.

## Why are these changes being made?

Part of the ongoing effort to reduce lodash across the codebase. These are the textual leftovers — outdated example imports, stale prop docs, and comments narrating a since-completed migration — that no longer earn their keep. The `@automattic/js-utils` differential parity tests intentionally keep their lodash imports, since they compare the replacement implementations against lodash at runtime; those are left untouched.

## Testing Instructions

* No runtime behavior changes — all edits are to Markdown docs, comments, and a test description string.
* `yarn eslint` passes on the changed JS/JSX files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
