### PR TITLE
Site Logs: add time-of-day range filtering

### DIFF
--- a/client/dashboard/app/hooks/use-date-range.ts
+++ b/client/dashboard/app/hooks/use-date-range.ts
@@ -1,8 +1,8 @@
 import { useRouter } from '@tanstack/react-router';
 import { getUnixTime, fromUnixTime, isValid as isValidDate, subDays, isSameSecond } from 'date-fns';
 import { useState, useRef, useEffect } from 'react';
-import { buildTimeRangeInSeconds } from '../../sites/logs/utils';
-import { formatYmd, parseYmdLocal } from '../../utils/datetime';
+import { buildTimeRangeInSeconds, DAY_START_TIME, DAY_END_TIME } from '../../sites/logs/utils';
+import { formatYmd, formatSiteHm, parseYmdLocal } from '../../utils/datetime';
 
 interface UseDateRangeOptions {
 	timezoneString?: string;
@@ -27,10 +27,31 @@ export function useDateRange( {
 		() => initialFromUrl ?? initial
 	);
 
+	// Time of day ("HH:MM", site clock) paired with the start/end dates. Seeded from
+	// the URL's from/to instants so a bookmarked sub-day window restores correctly.
+	const [ startTime, setStartTime ] = useState( () =>
+		initialFromUrl
+			? formatSiteHm( initialFromUrl.start, timezoneString, gmtOffset )
+			: DAY_START_TIME
+	);
+	const [ endTime, setEndTime ] = useState( () =>
+		initialFromUrl ? formatSiteHm( initialFromUrl.end, timezoneString, gmtOffset ) : DAY_END_TIME
+	);
+
 	const lastUrlRangeRef = useRef< { from: number; to: number } | null >( null );
 
-	const handleDateRangeChange = ( next: { start: Date; end: Date } ) => {
-		setDateRange( next );
+	const handleDateRangeChange = ( next: {
+		start: Date;
+		end: Date;
+		startTime?: string;
+		endTime?: string;
+	} ) => {
+		setDateRange( { start: next.start, end: next.end } );
+
+		const nextStartTime = next.startTime ?? startTime;
+		const nextEndTime = next.endTime ?? endTime;
+		setStartTime( nextStartTime );
+		setEndTime( nextEndTime );
 
 		// Sync from/to to the URL as UNIX seconds
 		const url = new URL( window.location.href );
@@ -38,7 +59,9 @@ export function useDateRange( {
 			next.start,
 			next.end,
 			timezoneString,
-			gmtOffset
+			gmtOffset,
+			nextStartTime,
+			nextEndTime
 		);
 
 		url.searchParams.set( 'from', String( startSec ) );
@@ -83,6 +106,8 @@ export function useDateRange( {
 	return {
 		dateRange,
 		handleDateRangeChange,
+		startTime,
+		endTime,
 	};
 }
 

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -28,6 +28,10 @@ import './style.scss';
 type SiteLogsDataViewsPropsActivity = SiteLogsDataViewsProps & {
 	logType: typeof LogType.ACTIVITY;
 	hasActivityLogsAccess: boolean;
+	// "HH:MM" site-clock times of day. Unlike PHP/Web logs, Activity derives its
+	// window solely from the date range, so the times must be threaded in here.
+	startTime?: string;
+	endTime?: string;
 };
 
 const ACTIVITY_LOGS_DEFAULT_PAGE_SIZE = 20;
@@ -37,14 +41,24 @@ function SiteActivityLogsDataViews( {
 	site,
 	dateRange,
 	dateRangeVersion,
+	startTime,
+	endTime,
 	hasActivityLogsAccess,
 }: SiteLogsDataViewsPropsActivity ) {
 	const { recordTracksEvent } = useAnalytics();
 	const locale = useLocale();
 
 	const { startSec, endSec } = useMemo(
-		() => buildTimeRangeInSeconds( dateRange.start, dateRange.end, timezoneString, gmtOffset ),
-		[ dateRange.start, dateRange.end, gmtOffset, timezoneString ]
+		() =>
+			buildTimeRangeInSeconds(
+				dateRange.start,
+				dateRange.end,
+				timezoneString,
+				gmtOffset,
+				startTime,
+				endTime
+			),
+		[ dateRange.start, dateRange.end, gmtOffset, timezoneString, startTime, endTime ]
 	);
 
 	const searchParams = siteLogsActivityRoute.useSearch();

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -1,6 +1,6 @@
 import { HostingFeatures, LogType, type Site, type SiteSettings } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { DateRangePicker, isLast7Days } from '@automattic/date-range-picker';
+import { DateRangePicker, isLast7Days, hasCustomTimeOfDay } from '@automattic/date-range-picker';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -122,7 +122,7 @@ function SiteLogsContent( {
 		}
 	}, [] );
 
-	const { dateRange, handleDateRangeChange } = useDateRange( {
+	const { dateRange, handleDateRangeChange, startTime, endTime } = useDateRange( {
 		timezoneString,
 		gmtOffset,
 		autoRefresh,
@@ -131,8 +131,18 @@ function SiteLogsContent( {
 	// this is used to track changes across the dateRange to ensure the components can react to changes when they are triggered by a change in the DateRangePicker
 	const [ dateRangeVersion, setDateRangeVersion ] = useState( 0 );
 
-	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
-		if ( autoRefresh && ! isLast7Days( next, timezoneString, gmtOffset ) ) {
+	// Auto-refresh is a live tail of the last 7 days; a custom time of day narrows
+	// to a fixed window, so it can't compose with auto-refresh.
+	const handleDateRangeChangeWrapper = ( next: {
+		start: Date;
+		end: Date;
+		startTime?: string;
+		endTime?: string;
+	} ) => {
+		const autoRefreshEligible =
+			isLast7Days( next, timezoneString, gmtOffset ) &&
+			! hasCustomTimeOfDay( next.startTime, next.endTime );
+		if ( autoRefresh && ! autoRefreshEligible ) {
 			setAutoRefresh( false );
 			setAutoRefreshDisabledReason( __( 'Auto-refresh only works with "Last 7 days" preset' ) );
 		} else {
@@ -146,7 +156,11 @@ function SiteLogsContent( {
 	};
 
 	const handleAutoRefreshToggle = ( isChecked: boolean ) => {
-		if ( isChecked && ! isLast7Days( dateRange, timezoneString, gmtOffset ) ) {
+		if (
+			isChecked &&
+			( ! isLast7Days( dateRange, timezoneString, gmtOffset ) ||
+				hasCustomTimeOfDay( startTime, endTime ) )
+		) {
 			setAutoRefreshDisabledReason( __( 'Auto-refresh only works with "Last 7 days" preset' ) );
 			return false;
 		}
@@ -181,6 +195,9 @@ function SiteLogsContent( {
 								timezoneString={ timezoneString }
 								locale={ locale }
 								onChange={ handleDateRangeChangeWrapper }
+								showTimeInputs
+								startTime={ startTime }
+								endTime={ endTime }
 							/>
 						) : undefined
 					}
@@ -234,6 +251,8 @@ function SiteLogsContent( {
 								logType={ logType }
 								dateRange={ dateRange }
 								dateRangeVersion={ dateRangeVersion }
+								startTime={ startTime }
+								endTime={ endTime }
 								autoRefresh={ autoRefresh }
 								setAutoRefresh={ setAutoRefresh }
 								gmtOffset={ gmtOffset }

--- a/client/dashboard/sites/logs/test/utils.test.ts
+++ b/client/dashboard/sites/logs/test/utils.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import { buildTimeRangeInSeconds } from '../utils';
+
+describe( 'buildTimeRangeInSeconds', () => {
+	// Fixed local date components; the function reads getFullYear/getMonth/getDate,
+	// so these assertions are independent of the test runner's timezone.
+	const start = new Date( 2026, 6, 3 ); // Jul 3, 2026 (local midnight)
+	const end = new Date( 2026, 6, 3 );
+
+	describe( 'site UTC offset branch', () => {
+		it( 'defaults to the full day (backward-compatibility guard)', () => {
+			const { startSec, endSec } = buildTimeRangeInSeconds( start, end, undefined, 0 );
+			expect( startSec ).toBe( Math.floor( Date.UTC( 2026, 6, 3, 0, 0, 0 ) / 1000 ) );
+			expect( endSec ).toBe( Math.floor( Date.UTC( 2026, 6, 3, 23, 59, 59 ) / 1000 ) );
+			expect( endSec - startSec ).toBe( 86399 );
+		} );
+
+		it( 'applies a custom window: start at :00, end inclusive to :59', () => {
+			const { startSec, endSec } = buildTimeRangeInSeconds(
+				start,
+				end,
+				undefined,
+				0,
+				'09:30',
+				'17:00'
+			);
+			expect( startSec ).toBe( Math.floor( Date.UTC( 2026, 6, 3, 9, 30, 0 ) / 1000 ) );
+			expect( endSec ).toBe( Math.floor( Date.UTC( 2026, 6, 3, 17, 0, 59 ) / 1000 ) );
+		} );
+
+		it( 'accounts for a positive site UTC offset', () => {
+			const { startSec, endSec } = buildTimeRangeInSeconds(
+				start,
+				end,
+				undefined,
+				2,
+				'09:00',
+				'10:00'
+			);
+			expect( startSec ).toBe(
+				Math.floor( ( Date.UTC( 2026, 6, 3, 9, 0, 0 ) - 2 * 3_600_000 ) / 1000 )
+			);
+			expect( endSec ).toBe(
+				Math.floor( ( Date.UTC( 2026, 6, 3, 10, 0, 59 ) - 2 * 3_600_000 ) / 1000 )
+			);
+		} );
+
+		it( 'clamps malformed times to safe bounds', () => {
+			const { startSec, endSec } = buildTimeRangeInSeconds(
+				start,
+				end,
+				undefined,
+				0,
+				'99:99',
+				'oops'
+			);
+			// start hour clamps to 23, minute to 59; unparsable end falls back to 00:00 -> :59
+			expect( startSec ).toBe( Math.floor( Date.UTC( 2026, 6, 3, 23, 59, 0 ) / 1000 ) );
+			expect( endSec ).toBe( Math.floor( Date.UTC( 2026, 6, 3, 0, 0, 59 ) / 1000 ) );
+		} );
+	} );
+
+	describe( 'named timezone branch (span assertions, timezone-data independent)', () => {
+		it( 'default spans a full day', () => {
+			const { startSec, endSec } = buildTimeRangeInSeconds( start, end, 'UTC' );
+			expect( endSec - startSec ).toBe( 86399 );
+		} );
+
+		it( 'custom times narrow the span to the requested window', () => {
+			const { startSec, endSec } = buildTimeRangeInSeconds(
+				start,
+				end,
+				'UTC',
+				undefined,
+				'09:00',
+				'17:00'
+			);
+			// 09:00:00 -> 17:00:59 = 8h + 59s
+			expect( endSec - startSec ).toBe( 8 * 3600 + 59 );
+		} );
+	} );
+} );

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -1,13 +1,42 @@
+import { DEFAULT_START_TIME, DEFAULT_END_TIME } from '@automattic/date-range-picker';
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
-import { startOfDay, endOfDay, fromUnixTime, isValid as isValidDate } from 'date-fns';
+import { fromUnixTime, isValid as isValidDate } from 'date-fns';
 import { formatDateWithOffset, getUtcOffsetDisplay } from '../../utils/datetime';
 import type { PHPLog, ServerLog } from '@automattic/api-core';
 
 type DateRange = { start: Date; end: Date };
 
 const HOUR_MS = 3_600_000;
-const SECONDS_PER_DAY = 86_400;
+
+// Reuse the picker's whole-day defaults so "is this a custom time?" checks stay
+// in sync. These reproduce the previous behavior: the range starts at the very
+// beginning of the start day and ends at the last second of the end day.
+export const DAY_START_TIME = DEFAULT_START_TIME;
+export const DAY_END_TIME = DEFAULT_END_TIME;
+
+type TimeOfDay = { hour: number; minute: number; second: number };
+
+/**
+ * Parse an "HH:MM" string into hour/minute. `second` fills the seconds slot —
+ * pass 0 for a range start and 59 for a range end so a whole-minute selection
+ * is inclusive of that entire minute (e.g. end "17:00" covers 17:00:00–17:00:59).
+ */
+const parseTimeOfDay = ( value: string, second: number ): TimeOfDay => {
+	const [ rawHour, rawMinute ] = value.split( ':' );
+	const hour = Number.parseInt( rawHour, 10 );
+	const minute = Number.parseInt( rawMinute, 10 );
+	return {
+		hour: Number.isFinite( hour ) ? Math.min( Math.max( hour, 0 ), 23 ) : 0,
+		minute: Number.isFinite( minute ) ? Math.min( Math.max( minute, 0 ), 59 ) : 0,
+		second,
+	};
+};
+
+const formatTimeOfDay = ( { hour, minute, second }: TimeOfDay ): string =>
+	`${ String( hour ).padStart( 2, '0' ) }:${ String( minute ).padStart( 2, '0' ) }:${ String(
+		second
+	).padStart( 2, '0' ) }`;
 
 /**
  * Helper function to convert a date to epoch seconds (UTC).
@@ -27,32 +56,57 @@ const toUtcSecForSiteClock = (
 
 /**
  * Convert a local date range to inclusive epoch-second boundaries (UTC).
- * Covers the full start and end calendar days.
+ * `startTime`/`endTime` are "HH:MM" times of day in the site clock; the defaults
+ * cover the full start and end calendar days (unchanged from the prior behavior).
  */
 export function buildTimeRangeInSeconds(
 	start: Date,
 	end: Date,
 	timezoneString?: string,
-	gmtOffset?: number
+	gmtOffset?: number,
+	startTime: string = DAY_START_TIME,
+	endTime: string = DAY_END_TIME
 ): { startSec: number; endSec: number } {
+	const startOfRange = parseTimeOfDay( startTime, 0 );
+	const endOfRange = parseTimeOfDay( endTime, 59 );
+
 	if ( timezoneString ) {
 		const startYmd = dateI18n( 'Y-m-d', start, timezoneString );
 		const endYmd = dateI18n( 'Y-m-d', end, timezoneString );
-		const startSec = Number( dateI18n( 'U', `${ startYmd } 00:00:00`, timezoneString ) );
-		const endSec = Number( dateI18n( 'U', `${ endYmd } 23:59:59`, timezoneString ) );
+		const startSec = Number(
+			dateI18n( 'U', `${ startYmd } ${ formatTimeOfDay( startOfRange ) }`, timezoneString )
+		);
+		const endSec = Number(
+			dateI18n( 'U', `${ endYmd } ${ formatTimeOfDay( endOfRange ) }`, timezoneString )
+		);
 		if ( Number.isFinite( startSec ) && Number.isFinite( endSec ) ) {
 			return { startSec, endSec };
 		}
 	}
 	if ( typeof gmtOffset === 'number' ) {
-		const startSec = toUtcSecForSiteClock( start, 0, 0, 0, gmtOffset );
-		const endSec = toUtcSecForSiteClock( end, 0, 0, 0, gmtOffset ) + SECONDS_PER_DAY - 1;
+		const startSec = toUtcSecForSiteClock(
+			start,
+			startOfRange.hour,
+			startOfRange.minute,
+			startOfRange.second,
+			gmtOffset
+		);
+		const endSec = toUtcSecForSiteClock(
+			end,
+			endOfRange.hour,
+			endOfRange.minute,
+			endOfRange.second,
+			gmtOffset
+		);
 		return { startSec, endSec };
 	}
 	// last-resort fallback: browser local
-	const startSec = Math.floor( startOfDay( start ).getTime() / 1000 );
-	const endSec = Math.floor( endOfDay( end ).getTime() / 1000 );
-	return { startSec, endSec };
+	const applyTime = ( d: Date, { hour, minute, second }: TimeOfDay ) => {
+		const copy = new Date( d );
+		copy.setHours( hour, minute, second, 0 );
+		return Math.floor( copy.getTime() / 1000 );
+	};
+	return { startSec: applyTime( start, startOfRange ), endSec: applyTime( end, endOfRange ) };
 }
 
 /**

--- a/client/dashboard/utils/datetime.ts
+++ b/client/dashboard/utils/datetime.ts
@@ -294,6 +294,23 @@ export function formatYmd( date: Date, timezoneString?: string, gmtOffset?: numb
 }
 
 /**
+ * Format the time-of-day portion of a date in the site's clock as "HH:MM" (24h).
+ * Mirrors formatYmd so the returned time reflects the same site-local instant.
+ */
+export function formatSiteHm( date: Date, timezoneString?: string, gmtOffset?: number ) {
+	if ( timezoneString ) {
+		return dateI18n( 'H:i', date, timezoneString );
+	}
+	if ( typeof gmtOffset === 'number' ) {
+		const shifted = new Date( date.getTime() + gmtOffset * HOUR_MS );
+		const hours = String( shifted.getUTCHours() ).padStart( 2, '0' );
+		const minutes = String( shifted.getUTCMinutes() ).padStart( 2, '0' );
+		return `${ hours }:${ minutes }`;
+	}
+	return dateI18n( 'H:i', date );
+}
+
+/**
  * Format a Date that already represents a site calendar day.
  * This avoids reapplying timezone math to dates coming from the picker or URL.
  */

--- a/packages/date-range-picker/README.md
+++ b/packages/date-range-picker/README.md
@@ -2,8 +2,8 @@
 
 A date-range picker built on top of `@automattic/ui`'s `DateRangeCalendar`. It
 provides a popover-style trigger, keyboard-navigable preset shortcuts (last 7
-days, month-to-date, etc.), accessible date inputs, and timezone-aware
-site-day handling.
+days, month-to-date, etc.), accessible date inputs, optional time-of-day
+inputs, and timezone-aware site-day handling.
 
 ## Installation
 
@@ -38,19 +38,35 @@ need a Sass loader.
 
 ### Props
 
-| Prop                    | Type                                              | Default          | Description                                                                                                                |
-| ----------------------- | ------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `start`                 | `Date`                                            | _required_       | Start of the selected range.                                                                                               |
-| `end`                   | `Date`                                            | _required_       | End of the selected range.                                                                                                 |
-| `onChange`              | `( next: { start: Date; end: Date } ) => void`    | _required_       | Called when the user applies a new range.                                                                                  |
-| `locale`                | `string`                                          | _required_       | BCP 47 locale used to format the trigger label (e.g. `"en-US"`).                                                           |
-| `timezoneString`        | `string`                                          | `undefined`      | Optional IANA timezone for the calendar (e.g. `"America/New_York"`).                                                       |
-| `gmtOffset`             | `number`                                          | `undefined`      | Fallback offset in hours when `timezoneString` is not available.                                                           |
-| `disableFuture`         | `boolean`                                         | `true`           | Disable days after today.                                                                                                  |
-| `disabledBefore`        | `Date`                                            | `undefined`      | Disable days before this date.                                                                                             |
-| `defaultFallbackPreset` | `PresetId`                                        | `'last-7-days'`  | Preset applied when the user clicks Apply with no dates selected.                                                          |
-| `hiddenPresets`         | `PresetId[]`                                      | `[]`             | Presets to hide from the listbox. Use to scope down the default set per consumer.                                          |
-| `inputsProps`           | `{ onStartFocus?, onEndFocus?, onStartBlur?, … }` | `undefined`      | Focus/blur callbacks for the date inputs (analytics hooks, etc.).                                                          |
+| Prop                    | Type                                                                                 | Default         | Description                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------- |
+| `start`                 | `Date`                                                                               | _required_      | Start of the selected range.                                                                               |
+| `end`                   | `Date`                                                                               | _required_      | End of the selected range.                                                                                 |
+| `onChange`              | `( next: { start: Date; end: Date; startTime?: string; endTime?: string } ) => void` | _required_      | Called when the user applies a new range. `startTime`/`endTime` are included when `showTimeInputs` is set. |
+| `locale`                | `string`                                                                             | _required_      | BCP 47 locale used to format the trigger label (e.g. `"en-US"`).                                           |
+| `timezoneString`        | `string`                                                                             | `undefined`     | Optional IANA timezone for the calendar (e.g. `"America/New_York"`).                                       |
+| `gmtOffset`             | `number`                                                                             | `undefined`     | Fallback offset in hours when `timezoneString` is not available.                                           |
+| `disableFuture`         | `boolean`                                                                            | `true`          | Disable days after today.                                                                                  |
+| `disabledBefore`        | `Date`                                                                               | `undefined`     | Disable days before this date.                                                                             |
+| `defaultFallbackPreset` | `PresetId`                                                                           | `'last-7-days'` | Preset applied when the user clicks Apply with no dates selected.                                          |
+| `hiddenPresets`         | `PresetId[]`                                                                         | `[]`            | Presets to hide from the listbox. Use to scope down the default set per consumer.                          |
+| `inputsProps`           | `{ onStartFocus?, onEndFocus?, onStartBlur?, … }`                                    | `undefined`     | Focus/blur callbacks for the date inputs (analytics hooks, etc.).                                          |
+| `showTimeInputs`        | `boolean`                                                                            | `false`         | Show a start/end time-of-day input (`HH:MM`, site clock) paired under each date.                           |
+| `startTime`             | `string`                                                                             | `'00:00'`       | Start time of day (`"HH:MM"`), used when `showTimeInputs` is set.                                          |
+| `endTime`               | `string`                                                                             | `'23:59'`       | End time of day (`"HH:MM"`), used when `showTimeInputs` is set.                                            |
+
+### Time of day
+
+Set `showTimeInputs` to pair a `HH:MM` time input under each date. The times are
+interpreted in the site clock, applied to the range as `startTime:00`–`endTime:59`
+(so a whole-minute end is inclusive), and returned via `onChange`. When both times
+are the whole-day defaults (`00:00`/`23:59`) the range is treated as date-only.
+
+On Apply the boundaries are normalized so the start is never after the end: the
+dates are ordered first (each time stays anchored to its start/end role, so the
+defaults are preserved), then the times are ordered within a single day. A
+cross-day window such as `17:00`→`09:00` the next day is a valid overnight range
+and is left intact.
 
 ### Exports
 
@@ -61,6 +77,9 @@ import {
 	presetDefs,
 	getActivePresetId,
 	computePresetRange,
+	hasCustomTimeOfDay,
+	DEFAULT_START_TIME,
+	DEFAULT_END_TIME,
 	type PresetId,
 } from '@automattic/date-range-picker';
 ```
@@ -100,11 +119,11 @@ import '@automattic/ui/style.css';
 The picker honours these CSS custom properties on a wrapping element, with
 sensible defaults when they're not set:
 
-| Custom property                         | Default       | Purpose                                |
-| --------------------------------------- | ------------- | -------------------------------------- |
-| `--dashboard-surface__background-color` | `#fff`        | Trigger button background.             |
-| `--dashboard__text-color`               | `#1e1e1e`     | Trigger button text and icon colour.   |
-| `--dashboard-field__border-color`       | `#949494`     | Trigger button border colour.          |
+| Custom property                         | Default   | Purpose                              |
+| --------------------------------------- | --------- | ------------------------------------ |
+| `--dashboard-surface__background-color` | `#fff`    | Trigger button background.           |
+| `--dashboard__text-color`               | `#1e1e1e` | Trigger button text and icon colour. |
+| `--dashboard-field__border-color`       | `#949494` | Trigger button border colour.        |
 
 Set them on `:root` (or any ancestor of the picker) to theme it. The Calypso
 dashboard shell sets these globally; outside Calypso, set whichever you'd like

--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/date-range-picker/src/date-inputs.tsx
+++ b/packages/date-range-picker/src/date-inputs.tsx
@@ -28,6 +28,12 @@ type DateInputsProps = {
 	onToFocus?: ( e: FocusEvent< HTMLInputElement > ) => void;
 	onFromBlur?: ( e: FocusEvent< HTMLInputElement > ) => void;
 	onToBlur?: ( e: FocusEvent< HTMLInputElement > ) => void;
+	// Optional time-of-day inputs, paired below each date input.
+	showTime?: boolean;
+	fromTime?: string;
+	toTime?: string;
+	onFromTimeChange?: ( v: string ) => void;
+	onToTimeChange?: ( v: string ) => void;
 };
 
 export function DateInputs( {
@@ -46,47 +52,100 @@ export function DateInputs( {
 	onToFocus,
 	onFromBlur,
 	onToBlur,
+	showTime = false,
+	fromTime = '',
+	toTime = '',
+	onFromTimeChange,
+	onToTimeChange,
 }: DateInputsProps ) {
+	// One side of the range: a date input, optionally with a time input paired
+	// below it. Width styles live on the wrapper so the date and time inputs
+	// align into a single column.
+	const side = ( {
+		dateLabel,
+		timeLabel,
+		value,
+		onChange,
+		onFocus,
+		onBlur,
+		min,
+		max,
+		style,
+		timeValue,
+		onTimeChange,
+	}: {
+		dateLabel: string;
+		timeLabel: string;
+		value: string;
+		onChange: ( v: string ) => void;
+		onFocus?: ( e: FocusEvent< HTMLInputElement > ) => void;
+		onBlur?: ( e: FocusEvent< HTMLInputElement > ) => void;
+		min?: string;
+		max?: string;
+		style?: React.CSSProperties;
+		timeValue: string;
+		onTimeChange?: ( v: string ) => void;
+	} ) => (
+		<VStack as="div" spacing={ 2 } style={ style }>
+			<InputControl
+				type="date"
+				label={ dateLabel }
+				value={ value }
+				onFocus={ onFocus }
+				onBlur={ onBlur }
+				onChange={ ( next?: string ) => onChange( next ?? '' ) }
+				autoComplete="off"
+				min={ min }
+				max={ max }
+				style={ { width: '100%' } }
+				__next40pxDefaultSize
+			/>
+			{ showTime && (
+				<InputControl
+					type="time"
+					label={ timeLabel }
+					value={ timeValue }
+					onChange={ ( next?: string ) => onTimeChange?.( next ?? '' ) }
+					autoComplete="off"
+					style={ { width: '100%' } }
+					__next40pxDefaultSize
+				/>
+			) }
+		</VStack>
+	);
+
+	const fromSide = side( {
+		dateLabel: __( 'Start date' ),
+		timeLabel: __( 'Start time' ),
+		value: fromStr,
+		onChange: onFromChange,
+		onFocus: onFromFocus,
+		onBlur: onFromBlur,
+		min: minStr,
+		max: toStr || todayStr,
+		style: fromStyle,
+		timeValue: fromTime,
+		onTimeChange: onFromTimeChange,
+	} );
+
+	const toSide = side( {
+		dateLabel: __( 'End date' ),
+		timeLabel: __( 'End time' ),
+		value: toStr,
+		onChange: onToChange,
+		onFocus: onToFocus,
+		onBlur: onToBlur,
+		min: fromStr || minStr,
+		style: toStyle,
+		timeValue: toTime,
+		onTimeChange: onToTimeChange,
+	} );
+
 	if ( stack ) {
 		return (
-			<VStack as="div" spacing={ 2 } className="daterange-inputs" style={ containerStyle }>
-				<InputControl
-					type="date"
-					label={ __( 'Start date' ) }
-					value={ fromStr }
-					onFocus={ ( e: FocusEvent< HTMLInputElement > ) => {
-						onFromFocus?.( e );
-					} }
-					onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-						onFromBlur?.( e );
-					} }
-					onChange={ ( value?: string ) => {
-						onFromChange( value ?? '' );
-					} }
-					autoComplete="off"
-					min={ minStr }
-					max={ toStr || todayStr }
-					style={ { width: '100%', ...( fromStyle || {} ) } }
-					__next40pxDefaultSize
-				/>
-				<InputControl
-					type="date"
-					label={ __( 'End date' ) }
-					value={ toStr }
-					onFocus={ ( e: FocusEvent< HTMLInputElement > ) => {
-						onToFocus?.( e );
-					} }
-					onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-						onToBlur?.( e );
-					} }
-					onChange={ ( value?: string ) => {
-						onToChange( value ?? '' );
-					} }
-					autoComplete="off"
-					min={ fromStr || minStr }
-					style={ { width: '100%', ...( toStyle || {} ) } }
-					__next40pxDefaultSize
-				/>
+			<VStack as="div" spacing={ 3 } className="daterange-inputs" style={ containerStyle }>
+				{ fromSide }
+				{ toSide }
 			</VStack>
 		);
 	}
@@ -96,47 +155,13 @@ export function DateInputs( {
 			as="div"
 			spacing={ 8 }
 			justify={ justify }
+			alignment="flex-start"
 			className="daterange-inputs"
 			wrap={ false }
 			style={ containerStyle }
 		>
-			<InputControl
-				type="date"
-				label={ __( 'Start date' ) }
-				value={ fromStr }
-				onFocus={ ( e: FocusEvent< HTMLInputElement > ) => {
-					onFromFocus?.( e );
-				} }
-				onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-					onFromBlur?.( e );
-				} }
-				onChange={ ( value?: string ) => {
-					onFromChange( value ?? '' );
-				} }
-				autoComplete="off"
-				min={ minStr }
-				max={ toStr || todayStr }
-				style={ fromStyle }
-				__next40pxDefaultSize
-			/>
-			<InputControl
-				type="date"
-				label={ __( 'End date' ) }
-				value={ toStr }
-				onFocus={ ( e: FocusEvent< HTMLInputElement > ) => {
-					onToFocus?.( e );
-				} }
-				onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-					onToBlur?.( e );
-				} }
-				onChange={ ( value?: string ) => {
-					onToChange( value ?? '' );
-				} }
-				autoComplete="off"
-				min={ fromStr || minStr }
-				style={ toStyle }
-				__next40pxDefaultSize
-			/>
+			{ fromSide }
+			{ toSide }
 		</HStack>
 	);
 }

--- a/packages/date-range-picker/src/date-range-content.tsx
+++ b/packages/date-range-picker/src/date-range-content.tsx
@@ -12,7 +12,15 @@ import { ButtonStack } from './button-stack';
 import { DateInputs } from './date-inputs';
 import { formatYmd, formatSiteYmd, parseYmdLocal } from './datetime';
 import { PresetsListbox } from './presets-listbox';
-import { computePresetRange, getActivePresetId, PresetId, presetDefs } from './utils';
+import {
+	computePresetRange,
+	DEFAULT_END_TIME,
+	DEFAULT_START_TIME,
+	getActivePresetId,
+	hasCustomTimeOfDay,
+	PresetId,
+	presetDefs,
+} from './utils';
 
 type DateRangeContentProps = {
 	isSmall: boolean;
@@ -27,8 +35,11 @@ type DateRangeContentProps = {
 	setToStr: ( string: string ) => void;
 	timezoneString?: string;
 	gmtOffset?: number;
-	onChange: ( next: { start: Date; end: Date } ) => void;
+	onChange: ( next: { start: Date; end: Date; startTime?: string; endTime?: string } ) => void;
 	onClose?: () => void;
+	showTimeInputs?: boolean;
+	startTime?: string;
+	endTime?: string;
 	compositeActiveId: string | null;
 	setCompositeActiveId: ( id: string | null ) => void;
 	today: Date;
@@ -63,6 +74,9 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 		gmtOffset,
 		onChange,
 		onClose,
+		showTimeInputs = false,
+		startTime,
+		endTime,
 		compositeActiveId,
 		setCompositeActiveId,
 		today,
@@ -93,12 +107,16 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 	const timeZoneForCalendar = isValidIanaTimeZone( timezoneString ) ? timezoneString : undefined;
 	const [ isTyping, setIsTyping ] = useState( false );
 	const [ inputsVersion, setInputsVersion ] = useState( 0 );
+	const [ fromTime, setFromTime ] = useState( () => startTime ?? DEFAULT_START_TIME );
+	const [ toTime, setToTime ] = useState( () => endTime ?? DEFAULT_END_TIME );
 
 	const clear = () => {
 		setFromDraft( undefined );
 		setToDraft( undefined );
 		setFromStr( '' );
 		setToStr( '' );
+		setFromTime( DEFAULT_START_TIME );
+		setToTime( DEFAULT_END_TIME );
 		setIsTyping( false );
 		// Force controlled inputs to remount so any internal buffers are reset
 		setInputsVersion( ( version ) => version + 1 );
@@ -110,16 +128,29 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 
 	const apply = () => {
 		if ( fromDraft && toDraft ) {
-			const [ startPoint, endPoint ] =
-				fromDraft <= toDraft ? [ fromDraft, toDraft ] : [ toDraft, fromDraft ];
-			onChange( { start: startPoint, end: endPoint } );
+			// Keep each time paired with its date if the range is entered backwards.
+			const [ startPoint, endPoint, startPointTime, endPointTime ] =
+				fromDraft <= toDraft
+					? [ fromDraft, toDraft, fromTime, toTime ]
+					: [ toDraft, fromDraft, toTime, fromTime ];
+			onChange( {
+				start: startPoint,
+				end: endPoint,
+				startTime: startPointTime,
+				endTime: endPointTime,
+			} );
 			onClose?.();
 			return;
 		}
 		if ( canDefaultApply ) {
 			const range = computePresetRange( defaultFallbackPreset, today );
 			if ( range ) {
-				onChange( { start: range.from, end: range.to } );
+				onChange( {
+					start: range.from,
+					end: range.to,
+					startTime: DEFAULT_START_TIME,
+					endTime: DEFAULT_END_TIME,
+				} );
 				onClose?.();
 			}
 		}
@@ -134,11 +165,24 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 		setToDraft( range.to );
 		setFromStr( formatYmd( range.from, timezoneString, gmtOffset ) );
 		setToStr( formatYmd( range.to, timezoneString, gmtOffset ) );
-		onChange( { start: range.from, end: range.to } );
+		// Presets are whole-day ranges — reset any custom time of day.
+		setFromTime( DEFAULT_START_TIME );
+		setToTime( DEFAULT_END_TIME );
+		onChange( {
+			start: range.from,
+			end: range.to,
+			startTime: DEFAULT_START_TIME,
+			endTime: DEFAULT_END_TIME,
+		} );
 		onClose?.();
 	};
 
 	const activePresetId: PresetId | undefined = ( () => {
+		// A non-default time of day is always a custom range, even if the dates
+		// themselves match a preset.
+		if ( fromDraft && toDraft && hasCustomTimeOfDay( fromTime, toTime ) ) {
+			return 'custom';
+		}
 		const preset = getActivePresetId( fromDraft, toDraft, today );
 		if ( preset ) {
 			return preset;
@@ -200,7 +244,7 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 	return (
 		<VStack as="div" spacing={ 3 } style={ { padding: 12 } }>
 			<Text as="div" weight={ 600 } align="center" size="smallTitle">
-				{ __( 'Date Range' ) }
+				{ showTimeInputs ? __( 'Date & time range' ) : __( 'Date Range' ) }
 			</Text>
 
 			{ isSmall ? (
@@ -252,6 +296,11 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 							}
 							inputsProps?.onEndBlur?.( e );
 						} }
+						showTime={ showTimeInputs }
+						fromTime={ fromTime }
+						toTime={ toTime }
+						onFromTimeChange={ ( value ) => setFromTime( value || DEFAULT_START_TIME ) }
+						onToTimeChange={ ( value ) => setToTime( value || DEFAULT_END_TIME ) }
 						stack
 						fromStyle={ { minWidth: 140 } }
 						toStyle={ { minWidth: 140 } }
@@ -304,6 +353,11 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 							}
 							inputsProps?.onEndBlur?.( e );
 						} }
+						showTime={ showTimeInputs }
+						fromTime={ fromTime }
+						toTime={ toTime }
+						onFromTimeChange={ ( value ) => setFromTime( value || DEFAULT_START_TIME ) }
+						onToTimeChange={ ( value ) => setToTime( value || DEFAULT_END_TIME ) }
 						fromStyle={ { minWidth: 220, flex: '0 0 auto' } }
 						toStyle={ { minWidth: 220, flex: '0 0 auto' } }
 						justify="flex-end"

--- a/packages/date-range-picker/src/date-range-content.tsx
+++ b/packages/date-range-picker/src/date-range-content.tsx
@@ -18,6 +18,7 @@ import {
 	DEFAULT_START_TIME,
 	getActivePresetId,
 	hasCustomTimeOfDay,
+	orderRangeBoundaries,
 	PresetId,
 	presetDefs,
 } from './utils';
@@ -128,16 +129,12 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 
 	const apply = () => {
 		if ( fromDraft && toDraft ) {
-			// Keep each time paired with its date if the range is entered backwards.
-			const [ startPoint, endPoint, startPointTime, endPointTime ] =
-				fromDraft <= toDraft
-					? [ fromDraft, toDraft, fromTime, toTime ]
-					: [ toDraft, fromDraft, toTime, fromTime ];
+			const ordered = orderRangeBoundaries( fromDraft, toDraft, fromTime, toTime );
 			onChange( {
-				start: startPoint,
-				end: endPoint,
-				startTime: startPointTime,
-				endTime: endPointTime,
+				start: ordered.start,
+				end: ordered.end,
+				startTime: ordered.startTime,
+				endTime: ordered.endTime,
 			} );
 			onClose?.();
 			return;

--- a/packages/date-range-picker/src/date-range-picker.tsx
+++ b/packages/date-range-picker/src/date-range-picker.tsx
@@ -12,7 +12,7 @@ import './style.scss';
 export type DateRangePickerProps = {
 	start: Date;
 	end: Date;
-	onChange: ( next: { start: Date; end: Date } ) => void;
+	onChange: ( next: { start: Date; end: Date; startTime?: string; endTime?: string } ) => void;
 	timezoneString?: string;
 	gmtOffset?: number;
 	locale: string;
@@ -20,6 +20,10 @@ export type DateRangePickerProps = {
 	disabledBefore?: Date;
 	defaultFallbackPreset?: PresetId; // preset to apply when inputs are empty and user presses Apply
 	hiddenPresets?: PresetId[];
+	// Opt-in "HH:MM" time-of-day inputs paired with the start/end dates.
+	showTimeInputs?: boolean;
+	startTime?: string;
+	endTime?: string;
 	inputsProps?: {
 		onStartFocus?: ( e: React.FocusEvent< HTMLInputElement > ) => void;
 		onEndFocus?: ( e: React.FocusEvent< HTMLInputElement > ) => void;
@@ -40,6 +44,9 @@ export function DateRangePicker( {
 	defaultFallbackPreset = 'last-7-days',
 	hiddenPresets,
 	inputsProps,
+	showTimeInputs = false,
+	startTime,
+	endTime,
 }: DateRangePickerProps ) {
 	const isSmall = useMediaQuery( '(max-width: 600px)' );
 	// Use a wider breakpoint to decide when two calendars can fit comfortably
@@ -48,7 +55,7 @@ export function DateRangePicker( {
 	const mobileLabelId = `presets-label-${ instanceId }-mobile`;
 	const desktopLabelId = `presets-label-${ instanceId }-desktop`;
 
-	const label = formatLabel( start, end, locale );
+	const label = formatLabel( start, end, locale, startTime, endTime );
 
 	// Reset internal draft state when key inputs change by remounting the inner component
 	const resetKey = [
@@ -56,6 +63,8 @@ export function DateRangePicker( {
 		formatSiteYmd( end ),
 		timezoneString ?? '',
 		gmtOffset ?? '',
+		startTime ?? '',
+		endTime ?? '',
 	].join( '|' );
 
 	return (
@@ -104,6 +113,9 @@ export function DateRangePicker( {
 					defaultFallbackPreset={ defaultFallbackPreset }
 					hiddenPresets={ hiddenPresets }
 					inputsProps={ inputsProps }
+					showTimeInputs={ showTimeInputs }
+					startTime={ startTime }
+					endTime={ endTime }
 				/>
 			) }
 		/>
@@ -126,6 +138,9 @@ function DateRangePickerInner( {
 	defaultFallbackPreset,
 	hiddenPresets,
 	inputsProps,
+	showTimeInputs,
+	startTime,
+	endTime,
 }: {
 	isSmall: boolean;
 	showTwoMonths: boolean;
@@ -133,7 +148,7 @@ function DateRangePickerInner( {
 	end: Date;
 	timezoneString?: string;
 	gmtOffset?: number;
-	onChange: ( next: { start: Date; end: Date } ) => void;
+	onChange: ( next: { start: Date; end: Date; startTime?: string; endTime?: string } ) => void;
 	onClose: () => void;
 	mobileLabelId: string;
 	desktopLabelId: string;
@@ -141,6 +156,9 @@ function DateRangePickerInner( {
 	disabledBefore?: Date;
 	defaultFallbackPreset: PresetId;
 	hiddenPresets?: PresetId[];
+	showTimeInputs?: boolean;
+	startTime?: string;
+	endTime?: string;
 	inputsProps?: {
 		onStartFocus?: ( e: React.FocusEvent< HTMLInputElement > ) => void;
 		onEndFocus?: ( e: React.FocusEvent< HTMLInputElement > ) => void;
@@ -192,6 +210,9 @@ function DateRangePickerInner( {
 			defaultFallbackPreset={ defaultFallbackPreset }
 			hiddenPresets={ hiddenPresets }
 			inputsProps={ inputsProps }
+			showTimeInputs={ showTimeInputs }
+			startTime={ startTime }
+			endTime={ endTime }
 		/>
 	);
 }

--- a/packages/date-range-picker/src/index.ts
+++ b/packages/date-range-picker/src/index.ts
@@ -2,8 +2,11 @@ export { DateRangePicker } from './date-range-picker';
 export type { DateRangePickerProps } from './date-range-picker';
 export {
 	computePresetRange,
+	DEFAULT_START_TIME,
+	DEFAULT_END_TIME,
 	formatLabel,
 	getActivePresetId,
+	hasCustomTimeOfDay,
 	isLast7Days,
 	presetDefs,
 } from './utils';

--- a/packages/date-range-picker/src/test/date-range-picker.test.tsx
+++ b/packages/date-range-picker/src/test/date-range-picker.test.tsx
@@ -294,6 +294,71 @@ describe( 'DateRangePicker (new)', () => {
 		).toBeVisible();
 	} );
 
+	function renderWithTimes( {
+		startTime = '00:00',
+		endTime = '23:59',
+	}: { startTime?: string; endTime?: string } = {} ) {
+		const onChange = jest.fn();
+		function Harness() {
+			const [ range, setRange ] = useState( {
+				start: new Date( 2025, 7, 19 ),
+				end: new Date( 2025, 7, 25 ),
+				startTime,
+				endTime,
+			} );
+			return (
+				<DateRangePicker
+					start={ range.start }
+					end={ range.end }
+					startTime={ range.startTime }
+					endTime={ range.endTime }
+					showTimeInputs
+					onChange={ ( next ) => {
+						onChange( next );
+						setRange( ( prev ) => ( { ...prev, ...next } ) );
+					} }
+					timezoneString=""
+					gmtOffset={ 0 }
+					locale="en-US"
+				/>
+			);
+		}
+		return { ...render( <Harness /> ), onChange };
+	}
+
+	test( 'showTimeInputs renders Start time / End time inputs with the given values', async () => {
+		const { getByRole, getByLabelText } = renderWithTimes();
+		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
+		expect( getByLabelText( 'Start time' ) ).toBeVisible();
+		expect( getByLabelText( 'End time' ) ).toBeVisible();
+		expect( getByLabelText( 'Start time' ) ).toHaveValue( '00:00' );
+		expect( getByLabelText( 'End time' ) ).toHaveValue( '23:59' );
+	} );
+
+	test( 'time inputs are absent unless showTimeInputs is set', async () => {
+		const { getByRole, queryByLabelText } = renderDateRangePicker();
+		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
+		expect( queryByLabelText( 'Start time' ) ).toBeNull();
+		expect( queryByLabelText( 'End time' ) ).toBeNull();
+	} );
+
+	test( 'toggle label includes the time of day when a custom time is set', () => {
+		const { getByRole } = renderWithTimes( { startTime: '09:00', endTime: '17:00' } );
+		const btn = getByRole( 'button', { name: /Date range:/i } );
+		// en-US short time: 09:00 -> "9:00 AM", 17:00 -> "5:00 PM"
+		expect( btn ).toHaveAccessibleName( expect.stringContaining( '9:00' ) );
+		expect( btn ).toHaveAccessibleName( expect.stringContaining( '5:00' ) );
+	} );
+
+	test( 'Apply passes the current times of day to onChange', async () => {
+		const { getByRole, onChange } = renderWithTimes();
+		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
+		await userEvent.click( getByRole( 'button', { name: /Apply/i } ) );
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( { startTime: '00:00', endTime: '23:59' } )
+		);
+	} );
+
 	test( 'invalid IANA timezone falls back gracefully (no crash, label correct)', async () => {
 		// Silence and assert the Moment Timezone warning for invalid zone
 		const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );

--- a/packages/date-range-picker/src/test/date-range-picker.test.tsx
+++ b/packages/date-range-picker/src/test/date-range-picker.test.tsx
@@ -329,8 +329,8 @@ describe( 'DateRangePicker (new)', () => {
 	test( 'showTimeInputs renders Start time / End time inputs with the given values', async () => {
 		const { getByRole, getByLabelText } = renderWithTimes();
 		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
-		expect( getByLabelText( 'Start time' ) ).toBeVisible();
-		expect( getByLabelText( 'End time' ) ).toBeVisible();
+		// getByLabelText throws if the input is absent; assert the seeded values.
+		// (Popover content is portal-rendered, so toBeVisible() is unreliable in jsdom.)
 		expect( getByLabelText( 'Start time' ) ).toHaveValue( '00:00' );
 		expect( getByLabelText( 'End time' ) ).toHaveValue( '23:59' );
 	} );

--- a/packages/date-range-picker/src/test/utils.test.ts
+++ b/packages/date-range-picker/src/test/utils.test.ts
@@ -1,7 +1,13 @@
 /**
  * @jest-environment jsdom
  */
-import { computePresetRange, formatLabel, getActivePresetId, presetDefs } from '../utils';
+import {
+	computePresetRange,
+	formatLabel,
+	getActivePresetId,
+	orderRangeBoundaries,
+	presetDefs,
+} from '../utils';
 
 describe( 'formatLabel', () => {
 	const locale = 'en-US';
@@ -54,5 +60,76 @@ describe( 'last-90-days preset', () => {
 
 	test( 'getActivePresetId identifies a 90-day range ending today', () => {
 		expect( getActivePresetId( new Date( 2025, 4, 28 ), base, base ) ).toBe( 'last-90-days' );
+	} );
+} );
+
+describe( 'orderRangeBoundaries', () => {
+	const jul3 = new Date( 2026, 6, 3 );
+	const jul4 = new Date( 2026, 6, 4 );
+	const jul5 = new Date( 2026, 6, 5 );
+
+	test( 'case 1: ordered dates, ordered times — unchanged', () => {
+		expect( orderRangeBoundaries( jul3, jul5, '09:00', '17:00' ) ).toEqual( {
+			start: jul3,
+			end: jul5,
+			startTime: '09:00',
+			endTime: '17:00',
+		} );
+	} );
+
+	test( 'case 2: same day, ordered times — unchanged', () => {
+		expect( orderRangeBoundaries( jul3, jul3, '09:00', '17:00' ) ).toEqual( {
+			start: jul3,
+			end: jul3,
+			startTime: '09:00',
+			endTime: '17:00',
+		} );
+	} );
+
+	test( 'case 3: same day, equal times — unchanged (single-minute window)', () => {
+		expect( orderRangeBoundaries( jul3, jul3, '09:00', '09:00' ) ).toEqual( {
+			start: jul3,
+			end: jul3,
+			startTime: '09:00',
+			endTime: '09:00',
+		} );
+	} );
+
+	test( 'case 4: same day, inverted times — times reordered', () => {
+		expect( orderRangeBoundaries( jul3, jul3, '17:00', '09:00' ) ).toEqual( {
+			start: jul3,
+			end: jul3,
+			startTime: '09:00',
+			endTime: '17:00',
+		} );
+	} );
+
+	test( 'case 5: inverted dates, default full-day times — dates swap, times stay on role', () => {
+		// The regression guard: 00:00/23:59 must NOT travel with the dates,
+		// or the full range collapses to a ~1-minute window.
+		expect( orderRangeBoundaries( jul5, jul3, '00:00', '23:59' ) ).toEqual( {
+			start: jul3,
+			end: jul5,
+			startTime: '00:00',
+			endTime: '23:59',
+		} );
+	} );
+
+	test( 'case 6: inverted dates, custom times — dates swap, times stay on role', () => {
+		expect( orderRangeBoundaries( jul5, jul3, '09:00', '17:00' ) ).toEqual( {
+			start: jul3,
+			end: jul5,
+			startTime: '09:00',
+			endTime: '17:00',
+		} );
+	} );
+
+	test( 'case 7: cross-day overnight window — left intact (not reordered)', () => {
+		expect( orderRangeBoundaries( jul3, jul4, '17:00', '09:00' ) ).toEqual( {
+			start: jul3,
+			end: jul4,
+			startTime: '17:00',
+			endTime: '09:00',
+		} );
 	} );
 } );

--- a/packages/date-range-picker/src/utils.ts
+++ b/packages/date-range-picker/src/utils.ts
@@ -151,13 +151,57 @@ export function getActivePresetId( from?: Date, to?: Date, baseDate?: Date ): Pr
 	return undefined;
 }
 
-// UI-specific: Date range label for the picker
-export function formatLabel( start: Date, end: Date, locale: string ) {
+// Default whole-day times of day. A range with these times is treated as
+// date-only, so the label omits the time and presets stay non-"custom".
+export const DEFAULT_START_TIME = '00:00';
+export const DEFAULT_END_TIME = '23:59';
+
+export function hasCustomTimeOfDay( startTime?: string, endTime?: string ): boolean {
+	return (
+		( startTime !== undefined && startTime !== DEFAULT_START_TIME ) ||
+		( endTime !== undefined && endTime !== DEFAULT_END_TIME )
+	);
+}
+
+// Render an "HH:MM" time of day using the locale's short time style (e.g. "9:00 AM").
+function formatTimeOfDayLabel( time: string, locale: string ): string {
+	const [ hour, minute ] = time.split( ':' ).map( ( part ) => Number.parseInt( part, 10 ) );
+	if ( ! Number.isFinite( hour ) || ! Number.isFinite( minute ) ) {
+		return time;
+	}
+	const date = new Date();
+	date.setHours( hour, minute, 0, 0 );
+	return formatDate( date, locale, { timeStyle: 'short' } );
+}
+
+// UI-specific: Date range label for the picker. When a non-default time of day
+// is set, each side shows its time alongside the date.
+export function formatLabel(
+	start: Date,
+	end: Date,
+	locale: string,
+	startTime?: string,
+	endTime?: string
+) {
+	const showTime = hasCustomTimeOfDay( startTime, endTime );
+	const formatSide = ( date: Date, time?: string ) => {
+		const dateLabel = formatDate( date, locale, { dateStyle: 'medium' } );
+		if ( ! showTime || ! time ) {
+			return dateLabel;
+		}
+		return sprintf(
+			/* translators: %1$s: date, %2$s: time of day */
+			__( '%1$s %2$s' ),
+			dateLabel,
+			formatTimeOfDayLabel( time, locale )
+		);
+	};
+
 	return sprintf(
-		/* translators: %1$s: start date, %2$s: end date */
+		/* translators: %1$s: start date (and time), %2$s: end date (and time) */
 		__( '%1$s to %2$s' ),
-		formatDate( start, locale, { dateStyle: 'medium' } ),
-		formatDate( end, locale, { dateStyle: 'medium' } )
+		formatSide( start, startTime ),
+		formatSide( end, endTime )
 	);
 }
 

--- a/packages/date-range-picker/src/utils.ts
+++ b/packages/date-range-picker/src/utils.ts
@@ -8,7 +8,7 @@ import {
 	startOfYear,
 	differenceInCalendarDays,
 } from 'date-fns';
-import { formatDate, parseYmdLocal, formatYmd } from './datetime';
+import { formatDate, parseYmdLocal, formatYmd, formatSiteYmd } from './datetime';
 
 // Range helpers (inclusive)
 const lastNDays = ( date: Date, number: number ) => ( {
@@ -161,6 +161,32 @@ export function hasCustomTimeOfDay( startTime?: string, endTime?: string ): bool
 		( startTime !== undefined && startTime !== DEFAULT_START_TIME ) ||
 		( endTime !== undefined && endTime !== DEFAULT_END_TIME )
 	);
+}
+
+/**
+ * Normalize a drafted range so the start boundary is never after the end.
+ *
+ * Dates are ordered first, with each time kept anchored to its start/end role
+ * (so the whole-day defaults 00:00/23:59 stay on the correct boundary even when
+ * the dates are entered backwards). Times are only reordered within a single
+ * day — a cross-day window like 17:00 on day 1 → 09:00 on day 2 is a valid
+ * overnight range and is left intact.
+ */
+export function orderRangeBoundaries(
+	fromDate: Date,
+	toDate: Date,
+	fromTime: string,
+	toTime: string
+): { start: Date; end: Date; startTime: string; endTime: string } {
+	const datesInOrder = fromDate <= toDate;
+	const start = datesInOrder ? fromDate : toDate;
+	const end = datesInOrder ? toDate : fromDate;
+	let startTime = fromTime;
+	let endTime = toTime;
+	if ( formatSiteYmd( start ) === formatSiteYmd( end ) && startTime > endTime ) {
+		[ startTime, endTime ] = [ endTime, startTime ];
+	}
+	return { start, end, startTime, endTime };
 }
 
 // Render an "HH:MM" time of day using the locale's short time style (e.g. "9:00 AM").


### PR DESCRIPTION
## Proposed Changes

Site logs can be filtered by date range, but not by time of day. This adds optional start/end time inputs to the logs date range picker, so a range can be narrowed to specific hours and minutes (in the site's time zone). It applies to the PHP, web server, and activity logs.

- `@automattic/date-range-picker` gains an opt-in `showTimeInputs` prop that pairs a time input with each date in the popover and carries the times through `onChange`. It is off by default, so other consumers (e.g. Backups) are unchanged.
- `buildTimeRangeInSeconds` gains optional start/end times; the defaults reproduce the previous whole-day window exactly.
- The logs page owns the times, seeds them from the URL's `from`/`to` params, and disables live auto-refresh while a custom time is set.

## Why are these changes being made?

The CSV export is capped at 10,000 entries, so on high-traffic sites a single day can be truncated even after date filtering. Time-of-day filtering lets users narrow to the window they actually need. The API already accepts second-precision boundaries — the picker previously always expanded the range to the full day — so this exposes an existing capability in the UI.

## Testing Instructions

1. Open a site's Logs → Web server (also try PHP errors and Activity).
2. Open the date range picker — there are now **Start time** / **End time** inputs paired under each date.
3. Set a narrow window (e.g. `09:00`–`10:00`) on a single day and Apply.
4. Confirm the log list narrows to that window, and that the CSV export (web/PHP) respects it.
5. Confirm presets (e.g. "Last 7 days") reset the times to the full day.
6. Confirm auto-refresh turns off when a custom time is set.
7. Confirm the **Backups** date picker is unchanged (time inputs appear on Logs only).

The default `00:00`–`23:59` reproduces the previous whole-day behavior.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? (new strings: "Start time", "End time", "Date & time range")
