### PR TITLE
Replace lodash debounce in the desktop app with a local helper

### DIFF
--- a/desktop/app/lib/debounce/index.js
+++ b/desktop/app/lib/debounce/index.js
@@ -1,0 +1,55 @@
+/**
+ * Delays invoking `func` until `wait` milliseconds have elapsed since the last
+ * time the returned function was called.
+ *
+ * Supports the `leading` and `trailing` edge options: with `leading`, `func`
+ * runs on the first call of a burst; with `trailing` (the default), it runs
+ * once `wait` ms have passed since the final call. When both are enabled the
+ * trailing call only fires if the burst had more than one invocation.
+ *
+ * `func`'s `this` and arguments from the most recent call are forwarded. Only
+ * the behavior used in this app is implemented — there is no `maxWait`, no
+ * return value, and no `cancel`/`flush`.
+ * @param {Function} func The function to debounce.
+ * @param {number} wait The number of milliseconds to delay.
+ * @param {{ leading?: boolean, trailing?: boolean }} [options] Edge options.
+ * @returns {Function} The debounced function.
+ */
+module.exports = function debounce( func, wait, { leading = false, trailing = true } = {} ) {
+	let timer = null;
+	let lastArgs = null;
+	let lastThis = null;
+
+	function invoke() {
+		const args = lastArgs;
+		const thisArg = lastThis;
+		lastArgs = null;
+		lastThis = null;
+		func.apply( thisArg, args );
+	}
+
+	return function ( ...args ) {
+		const isLeadingEdge = timer === null;
+		lastArgs = args;
+		lastThis = this;
+
+		// clearTimeout( null ) is a no-op, so no guard is needed on the leading edge.
+		clearTimeout( timer );
+
+		timer = setTimeout( () => {
+			timer = null;
+			// Fire the trailing edge only if a call arrived after any leading invoke;
+			// otherwise release the retained args/context so nothing is pinned.
+			if ( trailing && lastArgs ) {
+				invoke();
+			} else {
+				lastArgs = null;
+				lastThis = null;
+			}
+		}, wait );
+
+		if ( isLeadingEdge && leading ) {
+			invoke();
+		}
+	};
+};

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -1,7 +1,7 @@
 const { promisify } = require( 'util' );
 const { ipcMain: ipc, Notification } = require( 'electron' );
-const { debounce } = require( 'lodash' );
 const Config = require( '../../lib/config' );
+const debounce = require( '../../lib/debounce' );
 const isCalypso = require( '../../lib/is-calypso' );
 const log = require( '../../lib/logger' )( 'desktop:notifications' );
 const ViewModel = require( '../../lib/notifications/viewmodel' );

--- a/desktop/app/window-handlers/window-saver/index.js
+++ b/desktop/app/window-handlers/window-saver/index.js
@@ -1,4 +1,4 @@
-const { debounce } = require( 'lodash' );
+const debounce = require( '../../lib/debounce' );
 const Settings = require( '../../lib/settings' );
 
 /**

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,6 @@
 		"electron": "39.8.5",
 		"electron-builder": "24.13.3",
 		"jest": "^29.7.0",
-		"lodash": "^4.18.1",
 		"playwright": "1.57.0",
 		"postcss": "^8.5.3",
 		"react": "^18.3.1",

--- a/desktop/test/unit/debounce.test.js
+++ b/desktop/test/unit/debounce.test.js
@@ -1,0 +1,122 @@
+const debounce = require( '../../app/lib/debounce' );
+
+describe( 'debounce', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	describe( 'trailing (default)', () => {
+		it( 'invokes once, after the wait, with the latest arguments', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 1000 );
+
+			debounced( 'a' );
+			debounced( 'b' );
+			debounced( 'c' );
+			expect( fn ).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime( 999 );
+			expect( fn ).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime( 1 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+			expect( fn ).toHaveBeenCalledWith( 'c' );
+		} );
+
+		it( 'restarts the timer on each call', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 1000 );
+
+			debounced();
+			jest.advanceTimersByTime( 800 );
+			debounced();
+			jest.advanceTimersByTime( 800 );
+			expect( fn ).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime( 200 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'forwards `this` and the latest arguments', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 1000 );
+			const context = { id: 42 };
+
+			debounced.call( context, 'first' );
+			debounced.call( context, 'second' );
+			jest.advanceTimersByTime( 1000 );
+
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+			expect( fn.mock.contexts[ 0 ] ).toBe( context );
+			expect( fn.mock.calls[ 0 ] ).toEqual( [ 'second' ] );
+		} );
+	} );
+
+	describe( 'leading only', () => {
+		const options = { leading: true, trailing: false };
+
+		it( 'invokes immediately on the first call and suppresses the rest of the burst', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 100, options );
+
+			debounced( 1 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+			expect( fn ).toHaveBeenCalledWith( 1 );
+
+			debounced( 2 );
+			debounced( 3 );
+			jest.advanceTimersByTime( 100 );
+
+			// No trailing invoke for the suppressed calls.
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'fires a fresh leading edge after the burst settles', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 100, options );
+
+			debounced( 'first' );
+			debounced( 'suppressed' );
+			jest.advanceTimersByTime( 100 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+
+			debounced( 'second' );
+			expect( fn ).toHaveBeenCalledTimes( 2 );
+			expect( fn ).toHaveBeenLastCalledWith( 'second' );
+		} );
+	} );
+
+	describe( 'leading and trailing', () => {
+		const options = { leading: true, trailing: true };
+
+		it( 'invokes only on the leading edge for a single call', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 100, options );
+
+			debounced( 'solo' );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+
+			jest.advanceTimersByTime( 100 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'invokes on both edges for a burst, trailing with the latest arguments', () => {
+			const fn = jest.fn();
+			const debounced = debounce( fn, 100, options );
+
+			debounced( 'a' );
+			debounced( 'b' );
+			debounced( 'c' );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+			expect( fn ).toHaveBeenCalledWith( 'a' );
+
+			jest.advanceTimersByTime( 100 );
+			expect( fn ).toHaveBeenCalledTimes( 2 );
+			expect( fn ).toHaveBeenLastCalledWith( 'c' );
+		} );
+	} );
+} );

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -300,6 +300,7 @@ const NAMESPACE_GUARDED = [
 	{ name: 'omitBy', message: JS_UTILS_MESSAGE },
 	{ name: 'maxBy', message: EXTREMUM_MESSAGE },
 	{ name: 'orderBy', message: SORT_MESSAGE },
+	{ name: 'debounce', message: COMPOSE_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).

--- a/yarn.lock
+++ b/yarn.lock
@@ -12751,7 +12751,6 @@ __metadata:
     electron-updater: "npm:6.3.0"
     jest: "npm:^29.7.0"
     js-yaml: "npm:4.2.0"
-    lodash: "npm:^4.18.1"
     playwright: "npm:1.57.0"
     postcss: "npm:^8.5.3"
     react: "npm:^18.3.1"


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `debounce` in the desktop (Electron main-process) app with a small local helper at `desktop/app/lib/debounce/index.js`, and point the two window handlers (`window-saver`, `notifications`) at it.
* Add `debounce` to the namespace/CommonJS lint guard now that its last such usage is gone (the ES-import form was already guarded).
* Drop the now-unused `lodash` dependency from the desktop package and update the lockfile.

## Why are these changes being made?

Part of the ongoing effort to drop lodash from the codebase. The desktop app is un-transpiled CommonJS and can't consume the ESM `@wordpress/compose` or `@automattic/js-utils` builds, so it uses a local helper rather than a shared one. The helper implements only the `leading`/`trailing` options the two handlers use — there is no `maxWait`, return value, or `cancel`/`flush`.

The rewrite was verified against lodash for both invocation behavior and memory retention across trailing-only, leading-only, and leading+trailing bursts (including single-call edges): the sequence of invocations matches exactly, and — like lodash — the helper releases the last call's arguments/context once a burst settles without invoking, so nothing is pinned in the closure.

## Testing Instructions

* Build/run the desktop app; confirm window position is still saved shortly after resizing/moving the window (trailing debounce) and the notifications panel still refreshes immediately on a new notification then coalesces rapid follow-ups (leading debounce).
* `yarn eslint desktop/app` passes; `yarn install --immutable` succeeds against the updated lockfile.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
