### PR TITLE
Replace lodash merge in the ESLint config with native composition

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,20 @@
 const path = require( 'path' );
 const { nodeConfig, lodashRestrictedImports } = require( '@automattic/calypso-eslint-overrides' );
 const wpI18nConfig = require( '@wordpress/eslint-plugin/eslintrc' ).configs.i18n;
-const { merge } = require( 'lodash' );
 const reactVersion = require( './client/package.json' ).dependencies.react;
+
+// ESLint doesn't allow the `extends` field inside `overrides`, so the TypeScript
+// config is composed from plugin fragments by hand. Every key other than `rules`
+// comes from a single fragment, so a shallow assign of the fragments plus a
+// separately-merged `rules` object reproduces the intended config.
+function composeConfig( ...fragments ) {
+	return Object.assign( {}, ...fragments, {
+		rules: Object.assign(
+			{},
+			...fragments.map( ( fragment ) => fragment.rules ).filter( Boolean )
+		),
+	} );
+}
 
 module.exports = {
 	root: true,
@@ -94,10 +106,7 @@ module.exports = {
 				'react/display-name': 'off',
 			},
 		},
-		merge(
-			// ESLint doesn't allow the `extends` field inside `overrides`, so we need to compose
-			// the TypeScript config manually using internal bits from various plugins
-			{},
+		composeConfig(
 			// base TypeScript config: parser options, add plugin with rules
 			require( '@typescript-eslint/eslint-plugin' ).configs.base,
 			// basic recommended rules config from the TypeScript plugin

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,32 @@ const wpI18nConfig = require( '@wordpress/eslint-plugin/eslintrc' ).configs.i18n
 const reactVersion = require( './client/package.json' ).dependencies.react;
 
 // ESLint doesn't allow the `extends` field inside `overrides`, so the TypeScript
-// config is composed from plugin fragments by hand. Every key other than `rules`
-// comes from a single fragment, so a shallow assign of the fragments plus a
-// separately-merged `rules` object reproduces the intended config.
+// override is assembled by hand from several partial configs ("fragments"). The
+// `rules` object from each fragment is merged into one combined `rules`; every
+// other setting (`parser`, `parserOptions`, `plugins`, `files`, …) is copied
+// as-is, which is correct only because each of those is set by a single fragment.
 function composeConfig( ...fragments ) {
+	// Enforce that last point: if two fragments set the same setting — say a
+	// plugin upgrade makes both the base config and Prettier config define
+	// `parserOptions` — the copy below would keep only the last and silently drop
+	// the other, quietly producing the wrong config. Catch that and fail loudly.
+	const seenKeys = new Set();
+	for ( const fragment of fragments ) {
+		for ( const key of Object.keys( fragment ) ) {
+			if ( key === 'rules' ) {
+				continue;
+			}
+			if ( seenKeys.has( key ) ) {
+				throw new Error(
+					`composeConfig: the setting \`${ key }\` is set by more than one fragment. ` +
+						'Only `rules` is merged across fragments; every other setting is copied ' +
+						'from a single fragment, so combine this one explicitly.'
+				);
+			}
+			seenKeys.add( key );
+		}
+	}
+
 	return Object.assign( {}, ...fragments, {
 		rules: Object.assign(
 			{},

--- a/packages/calypso-eslint-overrides/lodash-restricted-imports.js
+++ b/packages/calypso-eslint-overrides/lodash-restricted-imports.js
@@ -275,9 +275,9 @@ const patterns = [
 // backstopped by the `eslint-plugin-you-dont-need-lodash-underscore` rules in
 // the root config, but that plugin ships no rule for these, so they get their
 // own namespace/CommonJS guards below. Only add a function here once its
-// namespace/CommonJS usages are also gone — e.g. `merge` is guarded for ES
-// imports above but still destructured from `require( 'lodash' )` in the repo's
-// own `.eslintrc.js`, so it stays out until that is migrated.
+// namespace/CommonJS usages are also gone: a function can be guarded for ES
+// imports above while a lingering `require( 'lodash' )` destructure elsewhere
+// keeps it out of this list until that usage is migrated.
 const NAMESPACE_GUARDED = [
 	{ name: 'isEmpty', message: JS_UTILS_MESSAGE },
 	{ name: 'memoize', message: JS_UTILS_MESSAGE },
@@ -301,6 +301,7 @@ const NAMESPACE_GUARDED = [
 	{ name: 'maxBy', message: EXTREMUM_MESSAGE },
 	{ name: 'orderBy', message: SORT_MESSAGE },
 	{ name: 'debounce', message: COMPOSE_MESSAGE },
+	{ name: 'merge', message: MERGE_MESSAGE },
 ];
 
 // `no-restricted-properties`: namespace member access (`_.fn( … )` / `lodash.fn( … )`).


### PR DESCRIPTION
## Proposed Changes

* Replace lodash `merge` in the root `.eslintrc.js` (used to compose the TypeScript plugin config fragments into one `overrides` entry) with a small native helper — a shallow `Object.assign` of the fragments plus a separately-merged `rules` object.
* Add `merge` to the namespace/CommonJS lint guard now that its last such usage is gone (the ES-import form was already guarded), and refresh the guard comment that referenced this file.

## Why are these changes being made?

Part of the ongoing effort to drop lodash from the codebase.

A full deep merge turned out to be unnecessary here: across all resolved rules, a deep merge produces output identical to a plain last-wins combine, because only the `rules` objects need combining — every other config key comes from a single fragment. So the composition is done natively with `Object.assign`, avoiding both lodash and any hand-rolled deep-merge helper. (A shallow spread would drop the nested `rules` from earlier fragments, and the `deepmerge` package concatenates arrays where lodash replaces by index, so neither is a drop-in — hence the small explicit helper.)

The decisive check for a config change: running `eslint --print-config` on a `.ts` file before and after produces a **byte-identical resolved config** apart from the intended new guard entries, so linting behavior is unchanged. This was the last lodash `merge` usage outside the js-utils parity tests, so it's now locked at the namespace/CommonJS level too.

## Testing Instructions

* Run `yarn eslint <some .ts file>` and confirm no new lint output; optionally diff `yarn eslint --print-config <file>` against trunk and confirm the only differences are the added `merge` restricted-import entries.
* `yarn lint:js` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
