### PR TITLE
Replace lodash.mergewith in wp-babel-makepot with native code

### DIFF
--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -34,8 +34,7 @@
 		"@babel/preset-typescript": "^7.27.1",
 		"commander": "^5.1.0",
 		"gettext-parser": "^4.0.3",
-		"glob": "^7.2.3",
-		"lodash.mergewith": "^4.6.2"
+		"glob": "^7.2.3"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/packages/wp-babel-makepot/test/merge-with.js
+++ b/packages/wp-babel-makepot/test/merge-with.js
@@ -1,0 +1,39 @@
+const mergeWith = require( '../utils/merge-with' );
+
+describe( 'mergeWith', () => {
+	afterEach( () => {
+		delete Object.prototype.polluted;
+	} );
+
+	const lastWins = ( left, right ) => ( right === undefined ? left : right );
+
+	it( 'assigns the customizer result for each source key and mutates the destination', () => {
+		const target = { a: 1, b: 2 };
+		const result = mergeWith( target, { b: 3, c: 4 }, lastWins );
+
+		expect( result ).toBe( target );
+		expect( result ).toEqual( { a: 1, b: 3, c: 4 } );
+	} );
+
+	it( 'passes ( destValue, srcValue, key ) to the customizer', () => {
+		const calls = [];
+		mergeWith( { a: 1 }, { a: 2, b: 3 }, ( left, right, key ) => {
+			calls.push( [ left, right, key ] );
+			return right;
+		} );
+
+		expect( calls ).toEqual( [
+			[ 1, 2, 'a' ],
+			[ undefined, 3, 'b' ],
+		] );
+	} );
+
+	it( 'skips a source __proto__ key without polluting Object.prototype', () => {
+		// JSON.parse creates an own enumerable `__proto__` key; an object literal would not.
+		const source = JSON.parse( '{ "__proto__": { "polluted": true }, "safe": 1 }' );
+		const result = mergeWith( {}, source, ( left, right ) => right );
+
+		expect( {}.polluted ).toBeUndefined();
+		expect( Object.keys( result ) ).toEqual( [ 'safe' ] );
+	} );
+} );

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -5,7 +5,11 @@ const glob = require( 'glob' );
 const mergeWith = require( './merge-with' );
 
 const mergeDeep = ( left, right, key ) => {
-	if ( typeof left === 'object' && typeof right === 'object' ) {
+	// `typeof null === 'object'`, so exclude null before recursing — otherwise a
+	// null would be passed to `mergeWith` as if it were a container. Parsed POT
+	// data never contains null, but this keeps the guard honest and matches how
+	// lodash handled a null side (it falls through to the `right || left` below).
+	if ( left !== null && typeof left === 'object' && right !== null && typeof right === 'object' ) {
 		return mergeWith( left, right, mergeDeep );
 	}
 

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -5,21 +5,15 @@ const glob = require( 'glob' );
 
 // Merges each own key of `source` into `object` through `customizer`, which
 // decides the value for that key. `mergeDeep` below always returns a value, so
-// there is no fall-through to a default deep merge to reproduce. `__proto__` is
-// assigned as an own property (never through the prototype) to match lodash.
+// there is no fall-through to a default deep merge to reproduce. A source
+// `__proto__` key is skipped (as lodash does) so it can never read from or
+// merge into a prototype.
 const mergeWith = ( object, source, customizer ) => {
 	for ( const key of Object.keys( source ) ) {
-		const value = customizer( object[ key ], source[ key ], key );
 		if ( key === '__proto__' ) {
-			Object.defineProperty( object, key, {
-				value,
-				writable: true,
-				enumerable: true,
-				configurable: true,
-			} );
-		} else {
-			object[ key ] = value;
+			continue;
 		}
+		object[ key ] = customizer( object[ key ], source[ key ], key );
 	}
 	return object;
 };

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -2,21 +2,7 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const { po } = require( 'gettext-parser' );
 const glob = require( 'glob' );
-
-// Merges each own key of `source` into `object` through `customizer`, which
-// decides the value for that key. `mergeDeep` below always returns a value, so
-// there is no fall-through to a default deep merge to reproduce. A source
-// `__proto__` key is skipped (as lodash does) so it can never read from or
-// merge into a prototype.
-const mergeWith = ( object, source, customizer ) => {
-	for ( const key of Object.keys( source ) ) {
-		if ( key === '__proto__' ) {
-			continue;
-		}
-		object[ key ] = customizer( object[ key ], source[ key ], key );
-	}
-	return object;
-};
+const mergeWith = require( './merge-with' );
 
 const mergeDeep = ( left, right, key ) => {
 	if ( typeof left === 'object' && typeof right === 'object' ) {

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -2,11 +2,31 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const { po } = require( 'gettext-parser' );
 const glob = require( 'glob' );
-const merge = require( 'lodash.mergewith' );
+
+// Merges each own key of `source` into `object` through `customizer`, which
+// decides the value for that key. `mergeDeep` below always returns a value, so
+// there is no fall-through to a default deep merge to reproduce. `__proto__` is
+// assigned as an own property (never through the prototype) to match lodash.
+const mergeWith = ( object, source, customizer ) => {
+	for ( const key of Object.keys( source ) ) {
+		const value = customizer( object[ key ], source[ key ], key );
+		if ( key === '__proto__' ) {
+			Object.defineProperty( object, key, {
+				value,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+			} );
+		} else {
+			object[ key ] = value;
+		}
+	}
+	return object;
+};
 
 const mergeDeep = ( left, right, key ) => {
 	if ( typeof left === 'object' && typeof right === 'object' ) {
-		return merge( left, right, mergeDeep );
+		return mergeWith( left, right, mergeDeep );
 	}
 
 	if ( typeof left === 'undefined' ) {

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -5,10 +5,8 @@ const glob = require( 'glob' );
 const mergeWith = require( './merge-with' );
 
 const mergeDeep = ( left, right, key ) => {
-	// `typeof null === 'object'`, so exclude null before recursing — otherwise a
-	// null would be passed to `mergeWith` as if it were a container. Parsed POT
-	// data never contains null, but this keeps the guard honest and matches how
-	// lodash handled a null side (it falls through to the `right || left` below).
+	// `typeof null === 'object'`, so exclude null before recursing (parsed POT
+	// data has none); a null side falls through to `right || left`, as in lodash.
 	if ( left !== null && typeof left === 'object' && right !== null && typeof right === 'object' ) {
 		return mergeWith( left, right, mergeDeep );
 	}

--- a/packages/wp-babel-makepot/utils/merge-with.js
+++ b/packages/wp-babel-makepot/utils/merge-with.js
@@ -1,11 +1,6 @@
-// Merges each own key of `source` into `object`, using `customizer` to decide
-// the value for every key: `object[ key ] = customizer( object[ key ], source[
-// key ], key )`. Callers here always return a value from the customizer, so
-// there is no fall-through to a default deep merge. A source `__proto__` key is
-// skipped (as lodash does) so it can never read from or merge into a prototype.
-//
-// `object` and `source` must both be non-null objects; the caller (mergeDeep)
-// only recurses here once it has ruled out null and non-object values.
+// Assigns `customizer( object[ key ], source[ key ], key )` for each own key of
+// `source`; both must be non-null objects. Skips `__proto__` (as lodash does) so
+// it can never reach or pollute a prototype.
 module.exports = function mergeWith( object, source, customizer ) {
 	for ( const key of Object.keys( source ) ) {
 		if ( key === '__proto__' ) {

--- a/packages/wp-babel-makepot/utils/merge-with.js
+++ b/packages/wp-babel-makepot/utils/merge-with.js
@@ -3,6 +3,9 @@
 // key ], key )`. Callers here always return a value from the customizer, so
 // there is no fall-through to a default deep merge. A source `__proto__` key is
 // skipped (as lodash does) so it can never read from or merge into a prototype.
+//
+// `object` and `source` must both be non-null objects; the caller (mergeDeep)
+// only recurses here once it has ruled out null and non-object values.
 module.exports = function mergeWith( object, source, customizer ) {
 	for ( const key of Object.keys( source ) ) {
 		if ( key === '__proto__' ) {

--- a/packages/wp-babel-makepot/utils/merge-with.js
+++ b/packages/wp-babel-makepot/utils/merge-with.js
@@ -1,0 +1,14 @@
+// Merges each own key of `source` into `object`, using `customizer` to decide
+// the value for every key: `object[ key ] = customizer( object[ key ], source[
+// key ], key )`. Callers here always return a value from the customizer, so
+// there is no fall-through to a default deep merge. A source `__proto__` key is
+// skipped (as lodash does) so it can never read from or merge into a prototype.
+module.exports = function mergeWith( object, source, customizer ) {
+	for ( const key of Object.keys( source ) ) {
+		if ( key === '__proto__' ) {
+			continue;
+		}
+		object[ key ] = customizer( object[ key ], source[ key ], key );
+	}
+	return object;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2511,7 +2511,6 @@ __metadata:
     glob: "npm:^7.2.3"
     i18n-calypso: "workspace:^"
     jest: "npm:^29.7.0"
-    lodash.mergewith: "npm:^4.6.2"
     react: "npm:^18.3.1"
     rimraf: "npm:^3.0.2"
   bin:
@@ -23062,13 +23061,6 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
-  languageName: node
-  linkType: hard
-
-"lodash.mergewith@npm:^4.6.2":
-  version: 4.6.2
-  resolution: "lodash.mergewith@npm:4.6.2"
-  checksum: 4adbed65ff96fd65b0b3861f6899f98304f90fd71e7f1eb36c1270e05d500ee7f5ec44c02ef979b5ddbf75c0a0b9b99c35f0ad58f4011934c4d4e99e5200b3b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Replace `lodash.mergewith` in the POT concatenator (`wp-babel-makepot`) with a small native `mergeWith` helper, and drop the now-unused `lodash.mergewith` dependency.

## Why are these changes being made?

Part of the ongoing effort to drop lodash from the codebase — this is the last source file that imported it.

The concatenator deep-merges the parsed gettext trees with a customizer that decides the value for every key (accumulating each string's `reference` and `extracted` comments across files, otherwise taking the right-hand value). Because that customizer always returns a value, lodash's default deep-merge path is never reached, so a small native helper that assigns the customizer's result for each source key reproduces the behavior exactly. The package is un-transpiled CommonJS, so it can't consume the ESM `@automattic/js-utils` build and uses local code rather than a shared utility.

Output is unchanged, verified two ways: the existing extraction snapshots still pass, and a differential check against `lodash.mergewith` on a shared-string merge (where `reference`/`extracted` comments concatenate) produces an identical result.

## Testing Instructions

* From `packages/wp-babel-makepot`, run `yarn jest` — the POT extraction and concatenation snapshots pass unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
