### PR TITLE
Pricing grid redesign: add the hook for the experiment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
+import usePlansGridRedesignExperiment from '../use-plans-grid-redesign-experiment';
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+const CONTROL_RESULT = {
+	isLoading: false,
+	variant: 'control',
+	usePlansGridRedesign: false,
+	showDifferentiatorHeader: false,
+	showEnterpriseBottomCard: false,
+	showWooCommerceBottomCard: false,
+	isExperimentVariant: true,
+};
+
+const INELIGIBLE_RESULT = {
+	...CONTROL_RESULT,
+	isExperimentVariant: false,
+};
+
+const mockUseExperiment = useExperiment as jest.Mock;
+const mockUseSelector = useSelector as jest.Mock;
+
+function mockSite( isGatingBusinessQ1: boolean | undefined ) {
+	mockUseSelector.mockImplementation( () =>
+		isGatingBusinessQ1 !== undefined
+			? { ID: 123, options: { is_gating_business_q1: isGatingBusinessQ1 } }
+			: null
+	);
+}
+
+describe( 'usePlansGridRedesignExperiment', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockSite( undefined );
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'control' } ] );
+	} );
+
+	test( 'is eligible for onboarding signups without a siteId', () => {
+		renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202612', {
+			isEligible: true,
+		} );
+	} );
+
+	test( 'is eligible for existing sites with the gating flag', () => {
+		mockSite( true );
+
+		renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'not-onboarding',
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202612', {
+			isEligible: true,
+		} );
+	} );
+
+	test( 'is not eligible for onboarding flows with an existing site and no gating flag', () => {
+		mockSite( false );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: 123,
+			} )
+		);
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202612', {
+			isEligible: false,
+		} );
+		expect( result.current ).toEqual( INELIGIBLE_RESULT );
+	} );
+
+	test( 'returns control for eligible users assigned to control', () => {
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( CONTROL_RESULT );
+	} );
+
+	test( 'returns control while the experiment assignment is loading', () => {
+		mockUseExperiment.mockReturnValue( [ true, { variationName: 'six_plan_new_features' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			isLoading: true,
+		} );
+	} );
+
+	test( 'falls back to control for an unknown variation name', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'unknown_future_arm' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( CONTROL_RESULT );
+	} );
+
+	test( 'enables the differentiator header for six_plan_new_features', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'six_plan_new_features' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'six_plan_new_features',
+			usePlansGridRedesign: true,
+			showDifferentiatorHeader: true,
+		} );
+	} );
+
+	test( 'enables the Enterprise bottom card for five_plan_new_description', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'five_plan_new_description' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'five_plan_new_description',
+			usePlansGridRedesign: true,
+			showEnterpriseBottomCard: true,
+		} );
+	} );
+
+	test( 'enables the WooCommerce bottom card for four_plan_new_description', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'four_plan_new_description' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'four_plan_new_description',
+			usePlansGridRedesign: true,
+			showWooCommerceBottomCard: true,
+		} );
+	} );
+} );

--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -56,7 +56,7 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			} )
 		);
 
-		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202612', {
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202607', {
 			isEligible: true,
 		} );
 	} );
@@ -72,7 +72,7 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			} )
 		);
 
-		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202612', {
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202607', {
 			isEligible: true,
 		} );
 	} );
@@ -88,7 +88,7 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			} )
 		);
 
-		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202612', {
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202607', {
 			isEligible: false,
 		} );
 		expect( result.current ).toEqual( INELIGIBLE_RESULT );

--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -21,12 +21,12 @@ const CONTROL_RESULT = {
 	showDifferentiatorHeader: false,
 	showEnterpriseBottomCard: false,
 	showWooCommerceBottomCard: false,
-	isExperimentVariant: true,
+	isExperimentEligible: true,
 };
 
 const INELIGIBLE_RESULT = {
 	...CONTROL_RESULT,
-	isExperimentVariant: false,
+	isExperimentEligible: false,
 };
 
 const mockUseExperiment = useExperiment as jest.Mock;

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -1,0 +1,99 @@
+import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
+import getSite from 'calypso/state/sites/selectors/get-site';
+import type { IAppState } from 'calypso/state/types';
+
+const PLANS_GRID_REDESIGN_EXPERIMENT_NAME = 'calypso_pricing_differentiation_202607';
+
+const PLANS_GRID_REDESIGN_EXPERIMENT_VARIANTS = [
+	'control',
+	'five_plan_new_description',
+	'four_plan_new_description',
+	'six_plan_new_description',
+	'six_plan_new_design',
+	'six_plan_new_features',
+] as const;
+
+type PlansGridRedesignExperimentVariant =
+	( typeof PLANS_GRID_REDESIGN_EXPERIMENT_VARIANTS )[ number ];
+
+type PlansGridRedesignExperimentResult = {
+	isLoading: boolean;
+	variant: PlansGridRedesignExperimentVariant;
+	/**
+	 * When true, apply the redesigned pricing grid.
+	 */
+	usePlansGridRedesign: boolean;
+	/**
+	 * When true, show the differentiator header (4 bullet points).
+	 */
+	showDifferentiatorHeader: boolean;
+	/**
+	 * When true, show the Enterprise/VIP card at the bottom.
+	 */
+	showEnterpriseBottomCard: boolean;
+	/**
+	 * When true, show the WooCommerce card at the bottom.
+	 */
+	showWooCommerceBottomCard: boolean;
+	/**
+	 * When true, the user is eligible for the experiment (any arm, including control).
+	 */
+	isExperimentVariant: boolean;
+};
+
+interface UsePlansGridRedesignExperimentParams {
+	flowName?: string | null;
+	isInSignup: boolean;
+	siteId?: number | null;
+}
+
+function isPlansGridRedesignExperimentVariant(
+	variationName?: string | null
+): variationName is PlansGridRedesignExperimentVariant {
+	return PLANS_GRID_REDESIGN_EXPERIMENT_VARIANTS.includes(
+		variationName as PlansGridRedesignExperimentVariant
+	);
+}
+
+function usePlansGridRedesignExperiment( {
+	flowName,
+	isInSignup,
+	siteId,
+}: UsePlansGridRedesignExperimentParams ): PlansGridRedesignExperimentResult {
+	const site = useSelector( ( state: IAppState ) => getSite( state, siteId ) );
+
+	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
+
+	// New-site signups (no siteId yet) are always eligible.
+	// Flows operating on an existing site are eligible only when the gating flag is set.
+	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
+	const isEligible = ( isEligibleSignupFlow && ! siteId ) || hasGatingFlag;
+
+	const [ isLoading, assignment ] = useExperiment( PLANS_GRID_REDESIGN_EXPERIMENT_NAME, {
+		isEligible,
+	} );
+
+	const rawVariationName = assignment?.variationName;
+
+	const variant: PlansGridRedesignExperimentVariant =
+		isEligible && ! isLoading && isPlansGridRedesignExperimentVariant( rawVariationName )
+			? rawVariationName
+			: 'control';
+
+	const isExperimentVariant = isEligible;
+	const usePlansGridRedesign = isExperimentVariant && ! isLoading && variant !== 'control';
+
+	return {
+		isLoading,
+		variant,
+		usePlansGridRedesign,
+		showDifferentiatorHeader: usePlansGridRedesign && variant === 'six_plan_new_features',
+		showEnterpriseBottomCard: usePlansGridRedesign && variant === 'five_plan_new_description',
+		showWooCommerceBottomCard: usePlansGridRedesign && variant === 'four_plan_new_description',
+		isExperimentVariant,
+	};
+}
+
+export default usePlansGridRedesignExperiment;
+export type { PlansGridRedesignExperimentResult, PlansGridRedesignExperimentVariant };

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -39,7 +39,7 @@ type PlansGridRedesignExperimentResult = {
 	/**
 	 * When true, the user is eligible for the experiment (any arm, including control).
 	 */
-	isExperimentVariant: boolean;
+	isExperimentEligible: boolean;
 };
 
 interface UsePlansGridRedesignExperimentParams {
@@ -81,8 +81,7 @@ function usePlansGridRedesignExperiment( {
 			? rawVariationName
 			: 'control';
 
-	const isExperimentVariant = isEligible;
-	const usePlansGridRedesign = isExperimentVariant && ! isLoading && variant !== 'control';
+	const usePlansGridRedesign = isEligible && ! isLoading && variant !== 'control';
 
 	return {
 		isLoading,
@@ -91,7 +90,7 @@ function usePlansGridRedesignExperiment( {
 		showDifferentiatorHeader: usePlansGridRedesign && variant === 'six_plan_new_features',
 		showEnterpriseBottomCard: usePlansGridRedesign && variant === 'five_plan_new_description',
 		showWooCommerceBottomCard: usePlansGridRedesign && variant === 'four_plan_new_description',
-		isExperimentVariant,
+		isExperimentEligible: isEligible,
 	};
 }
 

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -65,7 +65,7 @@ function usePlansGridRedesignExperiment( {
 
 	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
 
-	// New-site signups (no siteId yet) are always eligible.
+	// Onboarding flow is eligible
 	// Flows operating on an existing site are eligible only when the gating flag is set.
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
 	const isEligible = ( isEligibleSignupFlow && ! siteId ) || hasGatingFlag;


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-17768

## Proposed Changes

* Create a hook for loading the experiment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
