### PR TITLE
Pricing grid redesign: add the new design

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1487,7 +1487,9 @@ const PlansFeaturesMain = ( {
 											{ gridPlansForComparisonGridFinal && gridPlansForPlanTypeSelector && (
 												<ComparisonGrid
 													allFeaturesList={ getFeaturesList() }
-													className="plans-features-main__comparison-grid"
+													className={ clsx( 'plans-features-main__comparison-grid', {
+														'is-plans-grid-redesign-experiment': usePlansGridRedesign,
+													} ) }
 													coupon={ coupon }
 													currentSitePlanSlug={ sitePlanSlug }
 													gridPlans={ gridPlansForComparisonGridFinal }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1454,6 +1454,7 @@ const PlansFeaturesMain = ( {
 										showSimplifiedBillingDescription={ isInSignup }
 										showBillingDescriptionForIncreasedRenewalPrice={ renewalPricingVariation }
 										isExperimentVariant={ isExperimentVariant }
+										showFeatureCheckmarks={ usePlansGridRedesign }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -82,6 +82,7 @@ import {
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import usePlanDifferentiatorsExperiment from 'calypso/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
+import usePlansGridRedesignExperiment from 'calypso/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
@@ -686,6 +687,11 @@ const PlansFeaturesMain = ( {
 		useFocusedNewCopyTaglines,
 		isExperimentVariant,
 	} = usePlanDifferentiatorsExperiment( { isInSignup, siteId } );
+	const {
+		isLoading: isPlansGridRedesignExperimentLoading,
+		showDifferentiatorHeader: showPlansGridRedesignDifferentiatorHeader,
+		usePlansGridRedesign,
+	} = usePlansGridRedesignExperiment( { flowName, isInSignup, siteId } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
@@ -1159,7 +1165,8 @@ const PlansFeaturesMain = ( {
 	const isPlansGridReady =
 		! isLoadingGridPlans &&
 		! resolvedSubdomainName.isLoading &&
-		! isRenewalPricingExperimentLoading;
+		! isRenewalPricingExperimentLoading &&
+		! isPlansGridRedesignExperimentLoading;
 
 	useEffect( () => {
 		if ( isPlansGridReady ) {
@@ -1365,7 +1372,9 @@ const PlansFeaturesMain = ( {
 					renderFreePlanCtaInStepContainerV2={ renderFreePlanCtaInStepContainerV2 }
 					onFreePlanCTAClick={ onFreePlanCTAClick }
 					intent={ intent }
-					showDifferentiatorHeader={ showDifferentiatorHeader }
+					showDifferentiatorHeader={
+						showDifferentiatorHeader || showPlansGridRedesignDifferentiatorHeader
+					}
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
@@ -1402,9 +1411,10 @@ const PlansFeaturesMain = ( {
 								{ gridPlansForFeaturesGrid && (
 									<FeaturesGrid
 										allFeaturesList={ getFeaturesList() }
-										className={ `plans-features-main__features-grid${
-											isExperimentVariant ? ' is-plan-differentiators-experiment' : ''
-										}` }
+										className={ clsx( 'plans-features-main__features-grid', {
+											'is-plan-differentiators-experiment': isExperimentVariant,
+											'is-plans-grid-redesign-experiment': usePlansGridRedesign,
+										} ) }
 										coupon={ coupon }
 										currentSitePlanSlug={ sitePlanSlug }
 										generatedWPComSubdomain={ resolvedSubdomainName }

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -24,6 +24,17 @@ jest.mock( '../hooks/use-suggested-free-domain-from-paid-domain', () => () => ( 
 jest.mock( '../hooks/use-renewal-price-experiment', () => ( {
 	useRenewalPricingExperiment: jest.fn( () => [ false, null ] ),
 } ) );
+jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment', () =>
+	jest.fn( () => ( {
+		isLoading: false,
+		variant: 'control',
+		usePlansGridRedesign: false,
+		showDifferentiatorHeader: false,
+		showEnterpriseBottomCard: false,
+		showWooCommerceBottomCard: false,
+		isExperimentEligible: false,
+	} ) )
+);
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getByPurchaseId: jest.fn(),
 } ) );

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -734,6 +734,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 							) }
 							{ hasFeature && ! featureLabel && (
 								<Gridicon
+									className="plan-comparison-grid__available-checkmark"
 									icon="checkmark"
 									color="var(--studio-wordpress-blue-50)"
 									aria-label={ translate( 'Feature available' ) }

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -307,3 +307,10 @@
 		justify-content: flex-end;
 	}
 }
+
+.plans-grid-next.is-plans-grid-redesign-experiment {
+	.plan-comparison-grid__available-checkmark {
+		color: var( --studio-green-60 );
+		fill: var( --studio-green-60 );
+	}
+}

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -313,4 +313,10 @@
 		color: var( --studio-green-60 );
 		fill: var( --studio-green-60 );
 	}
+
+	.plans-grid-next-header-price__pricing-group.is-large-currency {
+		align-items: last baseline;
+		flex-direction: row-reverse;
+		justify-content: flex-end;
+	}
 }

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -314,6 +314,10 @@
 		fill: var( --studio-green-60 );
 	}
 
+	.plans-grid-next-comparison-grid .plans-grid-next-header-price {
+		padding: 0;
+	}
+
 	.plans-grid-next-header-price__pricing-group.is-large-currency {
 		align-items: last baseline;
 		flex-direction: row-reverse;

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -401,6 +401,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		showSimplifiedBillingDescription,
 		showBillingDescriptionForIncreasedRenewalPrice,
 		isExperimentVariant,
+		showFeatureCheckmarks,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -464,6 +465,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 					showBillingDescriptionForIncreasedRenewalPrice
 				}
 				isExperimentVariant={ isExperimentVariant }
+				showFeatureCheckmarks={ showFeatureCheckmarks }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -924,7 +924,7 @@
 			gap: 6px;
 
 			&:has( .plan-features-2023-grid__item-info.is-available )::before {
-				border: solid var( --studio-wordpress-blue-50 );
+				border: solid var( --studio-green-60 );
 				border-width: 0 2px 2px 0;
 				box-sizing: border-box;
 				content: '';

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -692,6 +692,356 @@
 	}
 }
 
+.plans-grid-next.is-plans-grid-redesign-experiment {
+	.plan-features-2023-grid__content,
+	.plan-features-2023-grid__desktop-view,
+	.plan-features-2023-grid__tablet-view {
+		max-width: 1408px;
+		margin-inline: auto;
+	}
+
+	.plan-features-2023-grid__table {
+		border-color: #e0e0e0;
+		border-radius: 8px;
+		box-shadow: none;
+
+		&.has-highlighted-plan {
+			margin-top: 37px;
+		}
+
+		&.has-6-cols {
+			max-width: 1408px;
+		}
+	}
+
+	.plan-features-2023-grid__table-top,
+	.plan-features-2023-grid__table-bottom {
+		.plan-features-2023-grid__table {
+			max-width: 100%;
+		}
+	}
+
+	.plan-features-2023-grid__table-item {
+		background-color: var( --studio-white );
+
+		&:is( td, th ) {
+			border-left-color: #e0e0e0;
+		}
+
+		&.plans-grid-next-plan-storage {
+			padding: 0 16px 20px;
+		}
+
+		&.plan-features-2023-grid__header-billing-info {
+			color: var( --studio-gray-50 );
+			font-size: 12px;
+			line-height: 16px;
+			padding: 0 16px 20px;
+		}
+	}
+
+	thead tr:first-child .plan-features-2023-grid__table-item {
+		height: 0;
+	}
+
+	.plan-features-2023-grid__header-logo {
+		display: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.plan-features-2023-grid__header {
+		align-items: flex-start;
+		background-color: transparent;
+		flex-direction: column;
+		padding: 28px 16px 0;
+	}
+
+	.plan-features-2023-grid__header-title {
+		color: var( --studio-gray-100 );
+		font-family: 'SF Pro Display', $sans;
+		font-size: 26px;
+		font-weight: 400;
+		letter-spacing: 0;
+		line-height: 30px;
+		margin-bottom: 8px;
+	}
+
+	.plan-features-2023-grid__header-badge {
+		background-color: var( --studio-gray-0 );
+		color: var( --studio-gray-80 );
+		font-size: 11px;
+		line-height: 18px;
+		margin-top: 2px;
+	}
+
+	.plan-features-2023-grid__header-tagline {
+		color: var( --studio-gray-80 );
+		font-size: 13px;
+		line-height: 20px;
+		min-height: 76px;
+		padding: 0 16px 18px;
+		text-wrap: pretty;
+	}
+
+	.plans-grid-next-header-price {
+		margin-bottom: 8px;
+		padding: 0 16px;
+
+		.plan-price {
+			font-family: 'SF Pro Display', $sans;
+			line-height: 1;
+
+			&.is-original {
+				color: var( --studio-gray-40 );
+				font-family: 'SF Pro Display', $sans;
+				font-size: 24px;
+				margin-bottom: 3px;
+
+				.plan-price__currency-symbol,
+				.plan-price__integer,
+				.plan-price__tax-amount {
+					color: var( --studio-gray-40 );
+				}
+
+				.plan-price__integer {
+					font-size: 24px;
+				}
+			}
+		}
+
+		.plan-price__currency-symbol,
+		.plan-price.is-discounted .plan-price__currency-symbol {
+			font-size: 14px;
+			margin-top: 3px;
+		}
+
+		.plan-price__integer {
+			font-size: 36px;
+			letter-spacing: 0;
+		}
+
+		.plan-price__term {
+			font-size: 12px;
+		}
+	}
+
+	.plans-grid-next-header-price__badge {
+		background-color: rgba( 184, 230, 191, 0.68 );
+		border-radius: 2px;
+		color: var( --studio-green-80 );
+		font-size: 11px;
+		font-weight: 500;
+		height: 20px;
+		letter-spacing: 0;
+		line-height: 20px;
+		margin-bottom: 10px;
+		padding: 0 8px;
+	}
+
+	.plans-grid-next-header-price__pricing-group {
+		align-items: last baseline;
+		gap: 8px;
+		justify-content: flex-start;
+	}
+
+	.plan-features-2023-grid__table-item.is-top-buttons {
+		padding: 0 16px 20px;
+
+		button {
+			margin: 0;
+		}
+	}
+
+	.button.plan-features-2023-grid__actions-button {
+		background-color: var( --studio-white );
+		border: 0;
+		border-radius: 2px;
+		box-shadow: inset 0 0 0 1px var( --studio-wordpress-blue-50 );
+		color: var( --studio-wordpress-blue-50 );
+		font-size: 13px;
+		font-weight: 500;
+		height: 40px;
+		line-height: 20px;
+		padding: 8px 12px;
+
+		&:hover {
+			background-color: var( --studio-white );
+			box-shadow: inset 0 0 0 1px var( --studio-wordpress-blue-70 );
+			color: var( --studio-wordpress-blue-70 );
+		}
+
+		&.is-premium-plan,
+		&.is-business-plan {
+			background-color: var( --studio-wordpress-blue-50 );
+			box-shadow: none;
+			color: var( --studio-white );
+
+			&:hover {
+				background-color: var( --studio-wordpress-blue-60 );
+				color: var( --studio-white );
+			}
+		}
+
+		&.is-current-plan {
+			background-color: var( --studio-gray-0 );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
+			color: var( --studio-gray-100 );
+		}
+
+		&.is-borderless {
+			background: transparent;
+			box-shadow: none;
+			color: var( --studio-wordpress-blue-50 );
+			height: auto;
+			padding: 0;
+		}
+	}
+
+	.plans-grid-next-action-button__label {
+		color: var( --studio-gray-50 );
+		font-size: 11px;
+		line-height: 16px;
+		margin-top: 8px;
+	}
+
+	.plans-grid-next-features-grid__feature-group-row {
+		> .plan-features-2023-grid__table-item {
+			padding-top: 0;
+		}
+
+		&.is-first-feature-group-row > .plan-features-2023-grid__table-item {
+			padding-top: 0;
+		}
+	}
+
+	.plan-features-2023-grid__item {
+		padding: 0 16px 10px;
+
+		&.plan-features-2023-grid__item-available .plan-features-2023-grid__item-info-container {
+			align-items: flex-start;
+			display: flex;
+			gap: 6px;
+
+			&:has( .plan-features-2023-grid__item-info.is-available )::before {
+				border: solid var( --studio-wordpress-blue-50 );
+				border-width: 0 2px 2px 0;
+				box-sizing: border-box;
+				content: '';
+				flex: 0 0 16px;
+				height: 10px;
+				margin: 2px 0 0 4px;
+				transform: rotate( 45deg );
+				width: 6px;
+			}
+		}
+
+		.plan-features-2023-grid__common-title + & {
+			padding-top: 10px;
+		}
+	}
+
+	.plan-features-2023-grid__item-info {
+		min-width: 0;
+
+		.plan-features-2023-grid__item-title {
+			color: var( --studio-gray-80 );
+			font-size: 12px;
+			line-height: 16px;
+			text-wrap: pretty;
+		}
+	}
+
+	.plans-grid-next-features-grid__feature-group-title,
+	.plan-features-2023-grid__common-title {
+		color: var( --studio-gray-100 );
+		font-size: 12px;
+		line-height: 16px;
+		margin-bottom: 8px;
+	}
+
+	.plans-grid-next-storage-feature-label__container {
+		gap: 4px;
+	}
+
+	.plans-grid-next-storage-feature-label__volume {
+		font-size: 12px;
+		line-height: 16px;
+		padding: 0;
+	}
+
+	.plan-features-2023-grid__table-item.popular-plan-parent-class {
+		.plan-features-2023-grid__popular-badge {
+			@include plans-grid-medium-large {
+				background: transparent;
+				border: 0;
+				height: 37px;
+				left: -1px;
+				margin: 0;
+				padding: 0;
+				position: absolute;
+				right: -1px;
+				top: -37px;
+				width: auto;
+
+				.plans-grid__plan-pill {
+					align-items: center;
+					background-color: var( --studio-white );
+					border: 1px solid #e0e0e0;
+					border-bottom: 0;
+					border-radius: 8px 8px 0 0;
+					bottom: 0;
+					color: var( --studio-gray-100 );
+					display: flex;
+					font-family: 'SF Pro Display', $sans;
+					font-size: 12px;
+					font-weight: 500;
+					height: 36px;
+					justify-content: center;
+					left: 0;
+					letter-spacing: 0;
+					line-height: 16px;
+					padding: 0 12px;
+					position: absolute;
+					right: 0;
+					text-transform: none;
+					top: auto;
+					transform: none;
+					width: auto;
+				}
+
+				&.is-business-plan .plans-grid__plan-pill {
+					background-color: var( --studio-gray-100 );
+					border-color: var( --studio-gray-100 );
+					color: var( --studio-white );
+				}
+			}
+		}
+	}
+
+	.is-sticky-top-buttons-row {
+		.is-top-buttons.plan-features-2023-grid__table-item {
+			background-color: var( --studio-white );
+			box-shadow: 0 2px 2px rgba( 0, 0, 0, 0.04 );
+		}
+	}
+
+	&.is-small {
+		.plans-grid-next-features-grid__mobile-plan-card {
+			border-radius: 8px;
+			padding-block: 24px;
+		}
+
+		.plan-features-2023-grid__header {
+			padding-top: 0;
+		}
+
+		.plan-features-2023-grid__header-tagline {
+			min-height: 0;
+		}
+	}
+}
+
 // Conditional styles for visual split layout (website-builder and wordpress-hosting intents)
 .plans-features-main__group.is-visual-split-layout {
 	.plans-grid-next-features-grid__feature-group-row {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -674,6 +674,10 @@
 			background-color: #f9f9f9;
 			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
 		}
+
+		.plans-grid-next-action-button__label {
+			margin-bottom: 16px;
+		}
 	}
 
 	.plan-features-2023-grid__header {
@@ -868,6 +872,11 @@
 		font-size: 11px;
 		line-height: 16px;
 		margin-top: 8px;
+
+		&.is-left-aligned {
+			font-size: 12px;
+			margin-bottom: 16px;
+		}
 	}
 
 	.plans-grid-next-features-grid__feature-group-row {
@@ -1048,6 +1057,10 @@
 		.button.plan-features-2023-grid__actions-button {
 			height: auto;
 			min-height: 40px;
+		}
+
+		.plans-grid-next-action-button__label {
+			margin-bottom: 16px;
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -803,7 +803,6 @@
 
 			&.is-original {
 				color: var( --studio-gray-40 );
-				font-family: 'SF Pro Display', $sans;
 				font-size: 24px;
 				margin-bottom: 3px;
 
@@ -881,10 +880,6 @@
 
 	.plans-grid-next-features-grid__feature-group-row {
 		> .plan-features-2023-grid__table-item {
-			padding-top: 0;
-		}
-
-		&.is-first-feature-group-row > .plan-features-2023-grid__table-item {
 			padding-top: 0;
 		}
 	}

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -948,6 +948,18 @@
 
 	.plans-grid-next-storage-feature-label__container {
 		gap: 4px;
+
+		&.is-add-more {
+			align-items: flex-start;
+			flex-direction: column;
+
+			.plans-grid-next-storage-feature-label__volume,
+			.plans-grid-next-storage-feature-label__text,
+			.plans-grid-next-storage-feature-label__add-more,
+			.plans-grid-next-storage-feature-label__offset-price {
+				white-space: nowrap;
+			}
+		}
 	}
 
 	.plans-grid-next-storage-feature-label__volume {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -706,7 +706,7 @@
 		box-shadow: none;
 
 		&.has-highlighted-plan {
-			margin-top: 37px;
+			margin-top: 12px;
 		}
 
 		&.has-6-cols {
@@ -754,7 +754,7 @@
 		align-items: flex-start;
 		background-color: transparent;
 		flex-direction: column;
-		padding: 28px 16px 0;
+		padding: 36px 16px 0;
 	}
 
 	.plan-features-2023-grid__header-title {
@@ -779,7 +779,7 @@
 		color: var( --studio-gray-80 );
 		font-size: 13px;
 		line-height: 20px;
-		min-height: 76px;
+		min-height: 6px;
 		padding: 0 16px 18px;
 		text-wrap: pretty;
 	}
@@ -938,42 +938,48 @@
 		width: 17px;
 	}
 
-	.plan-features-2023-grid__table-item.popular-plan-parent-class {
-		.plan-features-2023-grid__popular-badge {
-			@include plans-grid-medium-large {
+	&.is-smedium,
+	&.is-medium,
+	&.is-large,
+	&.is-xlarge {
+		thead tr:first-child .plan-features-2023-grid__table-item.popular-plan-parent-class {
+			height: 0;
+			padding: 0;
+
+			.plan-features-2023-grid__popular-badge {
 				background: transparent;
 				border: 0;
-				height: 37px;
-				left: -1px;
+				height: 0;
+				left: 0;
 				margin: 0;
 				padding: 0;
 				position: absolute;
-				right: -1px;
-				top: -37px;
+				right: 0;
+				top: 0;
 				width: auto;
+				z-index: 1;
 
 				.plans-grid__plan-pill {
 					align-items: center;
 					background-color: var( --studio-white );
 					border: 1px solid #e0e0e0;
-					border-bottom: 0;
-					border-radius: 8px 8px 0 0;
-					bottom: 0;
+					border-radius: 4px;
+					bottom: auto;
 					color: var( --studio-gray-100 );
 					display: flex;
 					font-family: 'SF Pro Display', $sans;
 					font-size: 12px;
 					font-weight: 500;
-					height: 36px;
+					height: 24px;
 					justify-content: center;
-					left: 0;
+					left: 16px;
 					letter-spacing: 0;
 					line-height: 16px;
-					padding: 0 12px;
+					padding: 0 10px;
 					position: absolute;
-					right: 0;
+					right: auto;
 					text-transform: none;
-					top: auto;
+					top: -12px;
 					transform: none;
 					width: auto;
 				}

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -938,6 +938,22 @@
 		width: 17px;
 	}
 
+	.plans-grid-next-storage-feature-label__text {
+		font-weight: 500;
+	}
+
+	.plans-grid-next-storage-feature-label__add-more {
+		appearance: none;
+		background: none;
+		border: 0;
+		color: #1e1e1ea3;
+		cursor: pointer;
+		font: inherit;
+		line-height: inherit;
+		padding: 0;
+		text-decoration: underline;
+	}
+
 	&.is-smedium,
 	&.is-medium,
 	&.is-large,

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -848,6 +848,11 @@
 		align-items: last baseline;
 		gap: 8px;
 		justify-content: flex-end;
+
+		&.is-large-currency {
+			align-items: flex-start;
+			justify-content: flex-start;
+		}
 	}
 
 	.plan-features-2023-grid__table-item.is-top-buttons {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -853,51 +853,6 @@
 		}
 	}
 
-	.button.plan-features-2023-grid__actions-button {
-		background-color: var( --studio-white );
-		border: 0;
-		border-radius: 2px;
-		box-shadow: inset 0 0 0 1px var( --studio-wordpress-blue-50 );
-		color: var( --studio-wordpress-blue-50 );
-		font-size: 13px;
-		font-weight: 500;
-		height: 40px;
-		line-height: 20px;
-		padding: 8px 12px;
-
-		&:hover {
-			background-color: var( --studio-white );
-			box-shadow: inset 0 0 0 1px var( --studio-wordpress-blue-70 );
-			color: var( --studio-wordpress-blue-70 );
-		}
-
-		&.is-premium-plan,
-		&.is-business-plan {
-			background-color: var( --studio-wordpress-blue-50 );
-			box-shadow: none;
-			color: var( --studio-white );
-
-			&:hover {
-				background-color: var( --studio-wordpress-blue-60 );
-				color: var( --studio-white );
-			}
-		}
-
-		&.is-current-plan {
-			background-color: var( --studio-gray-0 );
-			box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
-			color: var( --studio-gray-100 );
-		}
-
-		&.is-borderless {
-			background: transparent;
-			box-shadow: none;
-			color: var( --studio-wordpress-blue-50 );
-			height: auto;
-			padding: 0;
-		}
-	}
-
 	.plans-grid-next-action-button__label {
 		color: var( --studio-gray-50 );
 		font-size: 11px;

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -920,6 +920,7 @@
 
 	.plan-features-2023-grid__feature-badge {
 		flex: 0 0 auto;
+		font-weight: 500;
 		margin-inline-start: auto;
 	}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -922,18 +922,6 @@
 			align-items: flex-start;
 			display: flex;
 			gap: 6px;
-
-			&:has( .plan-features-2023-grid__item-info.is-available )::before {
-				border: solid var( --studio-green-60 );
-				border-width: 0 2px 2px 0;
-				box-sizing: border-box;
-				content: '';
-				flex: 0 0 16px;
-				height: 10px;
-				margin: 2px 0 0 4px;
-				transform: rotate( 45deg );
-				width: 6px;
-			}
 		}
 
 		.plan-features-2023-grid__common-title + & {
@@ -950,6 +938,16 @@
 			line-height: 16px;
 			text-wrap: pretty;
 		}
+	}
+
+	.plan-features-2023-grid__item-checkmark {
+		color: var( --studio-green-60 );
+		display: block;
+		fill: var( --studio-green-60 );
+		flex: 0 0 16px;
+		height: 16px;
+		margin-top: 0;
+		width: 16px;
 	}
 
 	.plans-grid-next-features-grid__feature-group-title,

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -923,9 +923,19 @@
 	}
 
 	.plans-grid-next-storage-feature-label__volume {
+		align-items: center;
+		display: flex;
 		font-size: 12px;
+		gap: 4px;
 		line-height: 16px;
 		padding: 0;
+	}
+
+	.plans-grid-next-storage-feature-label__icon {
+		color: #000;
+		flex: 0 0 17px;
+		height: 12px;
+		width: 17px;
 	}
 
 	.plan-features-2023-grid__table-item.popular-plan-parent-class {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -792,6 +792,11 @@
 			font-family: 'SF Pro Display', $sans;
 			line-height: 1;
 
+			&.is-discounted,
+			&.is-original {
+				margin-right: 0;
+			}
+
 			&.is-original {
 				color: var( --studio-gray-40 );
 				font-family: 'SF Pro Display', $sans;
@@ -842,7 +847,7 @@
 	.plans-grid-next-header-price__pricing-group {
 		align-items: last baseline;
 		gap: 8px;
-		justify-content: flex-start;
+		justify-content: flex-end;
 	}
 
 	.plan-features-2023-grid__table-item.is-top-buttons {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -856,10 +856,10 @@
 	}
 
 	.plan-features-2023-grid__table-item.is-top-buttons {
-		padding: 0 16px 20px;
+		padding: 0 16px;
 
 		button {
-			margin: 0;
+			margin: 16px 0;
 		}
 	}
 
@@ -1043,6 +1043,11 @@
 		.is-top-buttons.plan-features-2023-grid__table-item {
 			background-color: var( --studio-white );
 			box-shadow: 0 2px 2px rgba( 0, 0, 0, 0.04 );
+		}
+
+		.button.plan-features-2023-grid__actions-button {
+			height: auto;
+			min-height: 40px;
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -895,6 +895,7 @@
 	}
 
 	.plan-features-2023-grid__item-info {
+		flex: 1;
 		min-width: 0;
 
 		.plan-features-2023-grid__item-title {
@@ -903,6 +904,23 @@
 			line-height: 16px;
 			text-wrap: pretty;
 		}
+	}
+
+	.plan-features-2023-grid__item-text-content {
+		align-items: flex-start;
+		display: flex;
+		gap: 8px;
+		justify-content: space-between;
+		width: 100%;
+	}
+
+	.plan-features-2023-grid__item-title-label {
+		min-width: 0;
+	}
+
+	.plan-features-2023-grid__feature-badge {
+		flex: 0 0 auto;
+		margin-inline-start: auto;
 	}
 
 	.plan-features-2023-grid__item-checkmark {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -953,6 +953,12 @@
 		gap: 4px;
 		line-height: 16px;
 		padding: 0;
+
+		&.is-badge {
+			justify-content: center;
+			padding: 2px 8px;
+			text-align: center;
+		}
 	}
 
 	.plans-grid-next-storage-feature-label__icon {

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -204,11 +204,15 @@ const PlanFeatures2023GridFeatures: React.FC< {
 										>
 											<>
 												<span className="plan-features-2023-grid__item-text-content">
-													{ currentFeature.getTitle( {
-														domainName: paidDomainName,
-													} ) }
+													<span className="plan-features-2023-grid__item-title-label">
+														{ currentFeature.getTitle( {
+															domainName: paidDomainName,
+														} ) }
+													</span>
 													{ currentFeature.badgeText && (
-														<FeatureBadge>{ currentFeature.badgeText }</FeatureBadge>
+														<FeatureBadge className="plan-features-2023-grid__feature-badge">
+															{ currentFeature.badgeText }
+														</FeatureBadge>
 													) }
 												</span>
 												{ shouldBreakAfterAiWebsiteBuilderTitle && (

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -4,7 +4,7 @@ import {
 	FEATURE_CUSTOM_DOMAIN,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { LoadingPlaceholder } from '@automattic/components';
+import { Gridicon, LoadingPlaceholder } from '@automattic/components';
 import styled from '@emotion/styled';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -102,7 +102,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	setActiveTooltipId,
 } ) => {
 	const translate = useTranslate();
-	const { enableFeatureTooltips, gridPlans, isExperimentVariant } = usePlansGridContext();
+	const { enableFeatureTooltips, gridPlans, isExperimentVariant, showFeatureCheckmarks } =
+		usePlansGridContext();
 
 	return (
 		<>
@@ -142,6 +143,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					! isFreePlan( planSlug );
 				const shouldHighlightDomainFeature =
 					isCustomDomainFeatureWithPaidDomain && isExperimentVariant;
+				const isFeatureAvailable =
+					isFreePlanAndCustomDomainFeature || currentFeature.availableForCurrentPlan;
 
 				const divClasses = clsx( '', getPlanClass( planSlug ), {
 					'is-last-feature': featureIndex + 1 === features.length,
@@ -150,8 +153,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				} );
 				const spanClasses = clsx( 'plan-features-2023-grid__item-info', {
 					'is-annual-plan-feature': currentFeature.availableOnlyForAnnualPlans,
-					'is-available':
-						isFreePlanAndCustomDomainFeature || currentFeature.availableForCurrentPlan,
+					'is-available': isFeatureAvailable,
 				} );
 				const itemTitleClasses = clsx( 'plan-features-2023-grid__item-title', {
 					'is-bold': isHighlightedFeature,
@@ -161,6 +163,15 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				return (
 					<div key={ key } className={ divClasses }>
 						<PlanFeaturesItem>
+							{ showFeatureCheckmarks && isFeatureAvailable && (
+								<Gridicon
+									className="plan-features-2023-grid__item-checkmark"
+									icon="checkmark"
+									size={ 16 }
+									aria-hidden="true"
+									focusable="false"
+								/>
+							) }
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
 									{ isFreePlanAndCustomDomainFeature ? (

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -202,3 +202,50 @@
 		}
 	}
 }
+
+.plans-grid-next.is-plans-grid-redesign-experiment {
+	.button.plan-features-2023-grid__actions-button {
+		background-color: var( --studio-white );
+		border: 0;
+		border-radius: 2px;
+		box-shadow: inset 0 0 0 1px var( --studio-wordpress-blue-50 );
+		color: var( --studio-wordpress-blue-50 );
+		font-size: 13px;
+		font-weight: 500;
+		height: 40px;
+		line-height: 20px;
+		padding: 8px 12px;
+
+		&:hover {
+			background-color: var( --studio-white );
+			box-shadow: inset 0 0 0 1px var( --studio-wordpress-blue-70 );
+			color: var( --studio-wordpress-blue-70 );
+		}
+
+		&.is-premium-plan,
+		&.is-business-plan {
+			background-color: var( --studio-wordpress-blue-50 );
+			box-shadow: none;
+			color: var( --studio-white );
+
+			&:hover {
+				background-color: var( --studio-wordpress-blue-60 );
+				color: var( --studio-white );
+			}
+		}
+
+		&.is-current-plan {
+			background-color: var( --studio-gray-0 );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
+			color: var( --studio-gray-100 );
+		}
+
+		&.is-borderless {
+			background: transparent;
+			box-shadow: none;
+			color: var( --studio-wordpress-blue-50 );
+			height: auto;
+			padding: 0;
+		}
+	}
+}

--- a/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
@@ -1,6 +1,6 @@
 import { type PlanSlug, isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { usePlansGridContext } from '../../../../grid-context';
 import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
 import StorageDropdown from './storage-dropdown';
@@ -23,8 +23,34 @@ const PlanStorage = ( {
 }: Props ) => {
 	const { siteId, gridPlansIndex, showFeatureCheckmarks } = usePlansGridContext();
 	const [ isStorageDropdownVisible, setIsStorageDropdownVisible ] = useState( false );
+	const storageDropdownRef = useRef< HTMLDivElement >( null );
 	const { availableForPurchase, current, planTitle } = gridPlansIndex[ planSlug ];
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
+
+	useEffect( () => {
+		if ( ! showFeatureCheckmarks || ! isStorageDropdownVisible ) {
+			return;
+		}
+
+		const handleClick = ( event: MouseEvent ) => {
+			const target = event.target;
+
+			if ( target instanceof Node && storageDropdownRef.current?.contains( target ) ) {
+				return;
+			}
+
+			setIsStorageDropdownVisible( false );
+		};
+
+		const addClickListenerTimeout = window.setTimeout( () => {
+			document.addEventListener( 'click', handleClick );
+		}, 0 );
+
+		return () => {
+			window.clearTimeout( addClickListenerTimeout );
+			document.removeEventListener( 'click', handleClick );
+		};
+	}, [ isStorageDropdownVisible, showFeatureCheckmarks ] );
 
 	if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
 		return null;
@@ -50,7 +76,7 @@ const PlanStorage = ( {
 			/>
 		);
 	} else if ( canUpgradeStorageForPlan ) {
-		storageContent = (
+		const storageDropdown = (
 			<StorageDropdown
 				planSlug={ planSlug }
 				onStorageAddOnClick={ onStorageAddOnClick }
@@ -58,6 +84,12 @@ const PlanStorage = ( {
 					showFeatureCheckmarks ? () => setIsStorageDropdownVisible( false ) : undefined
 				}
 			/>
+		);
+
+		storageContent = showFeatureCheckmarks ? (
+			<div ref={ storageDropdownRef }>{ storageDropdown }</div>
+		) : (
+			storageDropdown
 		);
 	}
 

--- a/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
@@ -1,5 +1,6 @@
 import { type PlanSlug, isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
+import { useState } from '@wordpress/element';
 import { usePlansGridContext } from '../../../../grid-context';
 import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
 import StorageDropdown from './storage-dropdown';
@@ -20,7 +21,8 @@ const PlanStorage = ( {
 	options,
 	showUpgradeableStorage,
 }: Props ) => {
-	const { siteId, gridPlansIndex } = usePlansGridContext();
+	const { siteId, gridPlansIndex, showFeatureCheckmarks } = usePlansGridContext();
+	const [ isStorageDropdownVisible, setIsStorageDropdownVisible ] = useState( false );
 	const { availableForPurchase, current, planTitle } = gridPlansIndex[ planSlug ];
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
 
@@ -37,13 +39,31 @@ const PlanStorage = ( {
 		availableStorageAddOns.length &&
 		ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug );
 
+	let storageContent = <StorageFeatureLabel planSlug={ planSlug } />;
+
+	if ( canUpgradeStorageForPlan && showFeatureCheckmarks && ! isStorageDropdownVisible ) {
+		storageContent = (
+			<StorageFeatureLabel
+				planSlug={ planSlug }
+				showAddMore
+				onAddMoreClick={ () => setIsStorageDropdownVisible( true ) }
+			/>
+		);
+	} else if ( canUpgradeStorageForPlan ) {
+		storageContent = (
+			<StorageDropdown
+				planSlug={ planSlug }
+				onStorageAddOnClick={ onStorageAddOnClick }
+				onStorageOptionChange={
+					showFeatureCheckmarks ? () => setIsStorageDropdownVisible( false ) : undefined
+				}
+			/>
+		);
+	}
+
 	return (
 		<div className="plans-grid-next-plan-storage" data-plan-title={ planTitle }>
-			{ canUpgradeStorageForPlan ? (
-				<StorageDropdown planSlug={ planSlug } onStorageAddOnClick={ onStorageAddOnClick } />
-			) : (
-				<StorageFeatureLabel planSlug={ planSlug } />
-			) }
+			{ storageContent }
 		</div>
 	);
 };

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -14,6 +14,7 @@ import type { PlanSlug, WPComPlanStorageFeatureSlug } from '@automattic/calypso-
 type StorageDropdownProps = {
 	planSlug: PlanSlug;
 	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
+	onStorageOptionChange?: () => void;
 };
 
 type StorageDropdownOptionProps = {
@@ -72,7 +73,11 @@ const StorageDropdownOption = ( {
 	);
 };
 
-const StorageDropdown = ( { planSlug, onStorageAddOnClick }: StorageDropdownProps ) => {
+const StorageDropdown = ( {
+	planSlug,
+	onStorageAddOnClick,
+	onStorageOptionChange,
+}: StorageDropdownProps ) => {
 	const translate = useTranslate();
 	const { siteId } = usePlansGridContext();
 
@@ -88,13 +93,12 @@ const StorageDropdown = ( { planSlug, onStorageAddOnClick }: StorageDropdownProp
 	const planStorage = usePlanStorage( planSlug );
 
 	useEffect( () => {
-		if ( ! selectedStorageOptionForPlan ) {
-			defaultStorageOptionSlug &&
-				setSelectedStorageOptionForPlan( {
-					addOnSlug: defaultStorageOptionSlug,
-					planSlug,
-					siteId,
-				} );
+		if ( ! selectedStorageOptionForPlan && defaultStorageOptionSlug ) {
+			setSelectedStorageOptionForPlan( {
+				addOnSlug: defaultStorageOptionSlug,
+				planSlug,
+				siteId,
+			} );
 		}
 	}, [
 		defaultStorageOptionSlug,
@@ -172,11 +176,20 @@ const StorageDropdown = ( { planSlug, onStorageAddOnClick }: StorageDropdownProp
 			const addOnSlug = selectedItem?.key as AddOns.StorageAddOnSlug;
 
 			if ( addOnSlug ) {
-				onStorageAddOnClick && onStorageAddOnClick( addOnSlug );
+				if ( onStorageAddOnClick ) {
+					onStorageAddOnClick( addOnSlug );
+				}
 				setSelectedStorageOptionForPlan( { addOnSlug, planSlug, siteId } );
+				onStorageOptionChange?.();
 			}
 		},
-		[ onStorageAddOnClick, planSlug, setSelectedStorageOptionForPlan, siteId ]
+		[
+			onStorageAddOnClick,
+			onStorageOptionChange,
+			planSlug,
+			setSelectedStorageOptionForPlan,
+			siteId,
+		]
 	);
 
 	return (

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -2,6 +2,7 @@ import { PlanSlug } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useId } from 'react';
 import { usePlansGridContext } from '../../../../grid-context';
 import useIsLargeCurrency from '../../../../hooks/use-is-large-currency';
 import usePlanStorage from '../hooks/use-plan-storage';
@@ -14,7 +15,11 @@ interface Props {
 
 const StorageFeatureLabel = ( { planSlug }: Props ) => {
 	const translate = useTranslate();
-	const { gridPlansIndex, enableStorageAsBadge = true } = usePlansGridContext();
+	const {
+		gridPlansIndex,
+		enableStorageAsBadge = true,
+		showFeatureCheckmarks,
+	} = usePlansGridContext();
 	const {
 		pricing: { currencyCode },
 	} = gridPlansIndex[ planSlug ];
@@ -34,6 +39,7 @@ const StorageFeatureLabel = ( { planSlug }: Props ) => {
 	const totalStorageString = useStorageString(
 		planStorage + ( purchasedStorageAddOn?.quantity ?? 0 )
 	);
+	const storageCloudMaskId = `plans-grid-next-storage-cloud-mask-${ useId().replace( /:/g, '' ) }`;
 
 	const containerClasses = clsx( 'plans-grid-next-storage-feature-label__container', {
 		'is-row': ! isLargeCurrency,
@@ -45,6 +51,27 @@ const StorageFeatureLabel = ( { planSlug }: Props ) => {
 		</div>
 	) : (
 		<div className="plans-grid-next-storage-feature-label__volume">
+			{ showFeatureCheckmarks && (
+				<svg
+					className="plans-grid-next-storage-feature-label__icon"
+					width="17"
+					height="12"
+					viewBox="0 0 17 12"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					aria-hidden="true"
+					focusable="false"
+				>
+					<mask id={ storageCloudMaskId } fill="white">
+						<path d="M8.30664 0C10.5453 0 12.4108 1.59411 12.832 3.70898C14.953 3.896 16.6162 5.67714 16.6162 7.84668C16.616 9.98525 14.9996 11.745 12.9219 11.9736V12H3.69141V11.9736C1.61495 11.7436 0 9.98349 0 7.8457C0.000230272 5.67769 1.66132 3.89782 3.78027 3.70898C4.20142 1.59404 6.06793 7.12951e-05 8.30664 0Z" />
+					</mask>
+					<path
+						d="M8.30664 0V-1.5H8.30659L8.30664 0ZM12.832 3.70898L11.3609 4.00201L11.5805 5.10445L12.7003 5.20319L12.832 3.70898ZM16.6162 7.84668L18.1162 7.84684V7.84668H16.6162ZM12.9219 11.9736L12.7578 10.4826L11.4219 10.6297V11.9736H12.9219ZM12.9219 12V13.5H14.4219V12H12.9219ZM3.69141 12H2.19141V13.5H3.69141V12ZM3.69141 11.9736H5.19141V10.6306L3.85655 10.4828L3.69141 11.9736ZM0 7.8457L-1.5 7.84554V7.8457H0ZM3.78027 3.70898L3.91342 5.20306L5.03206 5.10337L5.25139 4.00193L3.78027 3.70898ZM8.30664 0V1.5C9.81555 1.5 11.0766 2.57467 11.3609 4.00201L12.832 3.70898L14.3031 3.41596C13.7449 0.613552 11.2751 -1.5 8.30664 -1.5V0ZM12.832 3.70898L12.7003 5.20319C14.0537 5.32253 15.1162 6.46133 15.1162 7.84668H16.6162H18.1162C18.1162 4.89294 15.8523 2.46948 12.9638 2.21478L12.832 3.70898ZM16.6162 7.84668L15.1162 7.84652C15.1161 9.2112 14.0842 10.3366 12.7578 10.4826L12.9219 11.9736L13.086 13.4646C15.9149 13.1533 18.1159 10.7593 18.1162 7.84684L16.6162 7.84668ZM12.9219 11.9736H11.4219V12H12.9219H14.4219V11.9736H12.9219ZM12.9219 12V10.5H3.69141V12V13.5H12.9219V12ZM3.69141 12H5.19141V11.9736H3.69141H2.19141V12H3.69141ZM3.69141 11.9736L3.85655 10.4828C2.5313 10.336 1.5 9.21028 1.5 7.8457H0H-1.5C-1.5 10.7567 0.698607 13.1513 3.52626 13.4645L3.69141 11.9736ZM0 7.8457L1.5 7.84586C1.50015 6.46158 2.56121 5.32357 3.91342 5.20306L3.78027 3.70898L3.64712 2.21491C0.76142 2.47207 -1.49969 4.8938 -1.5 7.84554L0 7.8457ZM3.78027 3.70898L5.25139 4.00193C5.53552 2.57508 6.79723 1.50005 8.30669 1.5L8.30664 0L8.30659 -1.5C5.33863 -1.49991 2.86733 0.612993 2.30916 3.41604L3.78027 3.70898Z"
+						fill="currentColor"
+						mask={ `url(#${ storageCloudMaskId })` }
+					/>
+				</svg>
+			) }
 			{ translate( '%s storage', {
 				args: [ totalStorageString ],
 				comment: '%s is the amount of storage, including the unit. For example "10 GB"',

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -58,7 +58,8 @@ const StorageFeatureLabel = ( { planSlug, onAddMoreClick, showAddMore }: Props )
 	} );
 
 	const containerClasses = clsx( 'plans-grid-next-storage-feature-label__container', {
-		'is-row': ! isLargeCurrency,
+		'is-row': ! isLargeCurrency && ! showAddMore,
+		'is-add-more': showAddMore,
 	} );
 
 	const volumeJSX =
@@ -102,7 +103,7 @@ const StorageFeatureLabel = ( { planSlug, onAddMoreClick, showAddMore }: Props )
 			</div>
 		);
 
-	return formattedMonthlyAddedCost && ! showAddMore ? (
+	return formattedMonthlyAddedCost ? (
 		<div className={ containerClasses }>
 			{ volumeJSX }
 			<div className="plans-grid-next-storage-feature-label__offset-price">

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -35,9 +35,9 @@ const StorageFeatureLabel = ( { planSlug, onAddMoreClick, showAddMore }: Props )
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, siteId ),
 		[ planSlug, siteId ]
 	);
-	const selectedStorageAddOn = storageAddOns.find(
-		( addOn ) => addOn?.addOnSlug === selectedStorageOptionForPlan
-	);
+	const selectedStorageAddOn = showFeatureCheckmarks
+		? storageAddOns.find( ( addOn ) => addOn?.addOnSlug === selectedStorageOptionForPlan )
+		: null;
 	const storageAddOn = selectedStorageAddOn ?? purchasedStorageAddOn;
 
 	const monthlyAddedCost = storageAddOn?.prices?.monthlyPrice ?? 0;
@@ -52,15 +52,10 @@ const StorageFeatureLabel = ( { planSlug, onAddMoreClick, showAddMore }: Props )
 	} );
 	const totalStorageString = useStorageString( planStorage + ( storageAddOn?.quantity ?? 0 ) );
 	const storageCloudMaskId = `plans-grid-next-storage-cloud-mask-${ useId().replace( /:/g, '' ) }`;
-	const storageLabel = showAddMore
-		? translate( '%s storage', {
-				args: [ totalStorageString ],
-				comment: '%s is the amount of storage, including the unit. For example "10 GB"',
-		  } )
-		: translate( '%s storage', {
-				args: [ totalStorageString ],
-				comment: '%s is the amount of storage, including the unit. For example "10 GB"',
-		  } );
+	const storageLabel = translate( '%s storage', {
+		args: [ totalStorageString ],
+		comment: '%s is the amount of storage, including the unit. For example "10 GB"',
+	} );
 
 	const containerClasses = clsx( 'plans-grid-next-storage-feature-label__container', {
 		'is-row': ! isLargeCurrency,

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -1,5 +1,7 @@
 import { PlanSlug } from '@automattic/calypso-products';
+import { AddOns, WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
+import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useId } from 'react';
@@ -11,22 +13,34 @@ import useStorageString from '../hooks/use-storage-string';
 
 interface Props {
 	planSlug: PlanSlug;
+	onAddMoreClick?: () => void;
+	showAddMore?: boolean;
 }
 
-const StorageFeatureLabel = ( { planSlug }: Props ) => {
+const StorageFeatureLabel = ( { planSlug, onAddMoreClick, showAddMore }: Props ) => {
 	const translate = useTranslate();
 	const {
 		gridPlansIndex,
 		enableStorageAsBadge = true,
 		showFeatureCheckmarks,
+		siteId,
 	} = usePlansGridContext();
 	const {
 		pricing: { currencyCode },
 	} = gridPlansIndex[ planSlug ];
 	const planStorage = usePlanStorage( planSlug );
 	const purchasedStorageAddOn = usePurchasedStorageAddOn();
+	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
+	const selectedStorageOptionForPlan = useSelect(
+		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, siteId ),
+		[ planSlug, siteId ]
+	);
+	const selectedStorageAddOn = storageAddOns.find(
+		( addOn ) => addOn?.addOnSlug === selectedStorageOptionForPlan
+	);
+	const storageAddOn = selectedStorageAddOn ?? purchasedStorageAddOn;
 
-	const monthlyAddedCost = purchasedStorageAddOn?.prices?.monthlyPrice ?? 0;
+	const monthlyAddedCost = storageAddOn?.prices?.monthlyPrice ?? 0;
 	const formattedMonthlyAddedCost =
 		monthlyAddedCost &&
 		currencyCode &&
@@ -36,50 +50,64 @@ const StorageFeatureLabel = ( { planSlug }: Props ) => {
 		isAddOn: true,
 		currencyCode: currencyCode ?? 'USD',
 	} );
-	const totalStorageString = useStorageString(
-		planStorage + ( purchasedStorageAddOn?.quantity ?? 0 )
-	);
+	const totalStorageString = useStorageString( planStorage + ( storageAddOn?.quantity ?? 0 ) );
 	const storageCloudMaskId = `plans-grid-next-storage-cloud-mask-${ useId().replace( /:/g, '' ) }`;
+	const storageLabel = showAddMore
+		? translate( '%s storage', {
+				args: [ totalStorageString ],
+				comment: '%s is the amount of storage, including the unit. For example "10 GB"',
+		  } )
+		: translate( '%s storage', {
+				args: [ totalStorageString ],
+				comment: '%s is the amount of storage, including the unit. For example "10 GB"',
+		  } );
 
 	const containerClasses = clsx( 'plans-grid-next-storage-feature-label__container', {
 		'is-row': ! isLargeCurrency,
 	} );
 
-	const volumeJSX = enableStorageAsBadge ? (
-		<div className="plans-grid-next-storage-feature-label__volume is-badge">
-			{ totalStorageString }
-		</div>
-	) : (
-		<div className="plans-grid-next-storage-feature-label__volume">
-			{ showFeatureCheckmarks && (
-				<svg
-					className="plans-grid-next-storage-feature-label__icon"
-					width="17"
-					height="12"
-					viewBox="0 0 17 12"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-					aria-hidden="true"
-					focusable="false"
-				>
-					<mask id={ storageCloudMaskId } fill="white">
-						<path d="M8.30664 0C10.5453 0 12.4108 1.59411 12.832 3.70898C14.953 3.896 16.6162 5.67714 16.6162 7.84668C16.616 9.98525 14.9996 11.745 12.9219 11.9736V12H3.69141V11.9736C1.61495 11.7436 0 9.98349 0 7.8457C0.000230272 5.67769 1.66132 3.89782 3.78027 3.70898C4.20142 1.59404 6.06793 7.12951e-05 8.30664 0Z" />
-					</mask>
-					<path
-						d="M8.30664 0V-1.5H8.30659L8.30664 0ZM12.832 3.70898L11.3609 4.00201L11.5805 5.10445L12.7003 5.20319L12.832 3.70898ZM16.6162 7.84668L18.1162 7.84684V7.84668H16.6162ZM12.9219 11.9736L12.7578 10.4826L11.4219 10.6297V11.9736H12.9219ZM12.9219 12V13.5H14.4219V12H12.9219ZM3.69141 12H2.19141V13.5H3.69141V12ZM3.69141 11.9736H5.19141V10.6306L3.85655 10.4828L3.69141 11.9736ZM0 7.8457L-1.5 7.84554V7.8457H0ZM3.78027 3.70898L3.91342 5.20306L5.03206 5.10337L5.25139 4.00193L3.78027 3.70898ZM8.30664 0V1.5C9.81555 1.5 11.0766 2.57467 11.3609 4.00201L12.832 3.70898L14.3031 3.41596C13.7449 0.613552 11.2751 -1.5 8.30664 -1.5V0ZM12.832 3.70898L12.7003 5.20319C14.0537 5.32253 15.1162 6.46133 15.1162 7.84668H16.6162H18.1162C18.1162 4.89294 15.8523 2.46948 12.9638 2.21478L12.832 3.70898ZM16.6162 7.84668L15.1162 7.84652C15.1161 9.2112 14.0842 10.3366 12.7578 10.4826L12.9219 11.9736L13.086 13.4646C15.9149 13.1533 18.1159 10.7593 18.1162 7.84684L16.6162 7.84668ZM12.9219 11.9736H11.4219V12H12.9219H14.4219V11.9736H12.9219ZM12.9219 12V10.5H3.69141V12V13.5H12.9219V12ZM3.69141 12H5.19141V11.9736H3.69141H2.19141V12H3.69141ZM3.69141 11.9736L3.85655 10.4828C2.5313 10.336 1.5 9.21028 1.5 7.8457H0H-1.5C-1.5 10.7567 0.698607 13.1513 3.52626 13.4645L3.69141 11.9736ZM0 7.8457L1.5 7.84586C1.50015 6.46158 2.56121 5.32357 3.91342 5.20306L3.78027 3.70898L3.64712 2.21491C0.76142 2.47207 -1.49969 4.8938 -1.5 7.84554L0 7.8457ZM3.78027 3.70898L5.25139 4.00193C5.53552 2.57508 6.79723 1.50005 8.30669 1.5L8.30664 0L8.30659 -1.5C5.33863 -1.49991 2.86733 0.612993 2.30916 3.41604L3.78027 3.70898Z"
-						fill="currentColor"
-						mask={ `url(#${ storageCloudMaskId })` }
-					/>
-				</svg>
-			) }
-			{ translate( '%s storage', {
-				args: [ totalStorageString ],
-				comment: '%s is the amount of storage, including the unit. For example "10 GB"',
-			} ) }
-		</div>
-	);
+	const volumeJSX =
+		enableStorageAsBadge && ! showAddMore ? (
+			<div className="plans-grid-next-storage-feature-label__volume is-badge">
+				{ totalStorageString }
+			</div>
+		) : (
+			<div className="plans-grid-next-storage-feature-label__volume">
+				{ showFeatureCheckmarks && (
+					<svg
+						className="plans-grid-next-storage-feature-label__icon"
+						width="17"
+						height="12"
+						viewBox="0 0 17 12"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+						focusable="false"
+					>
+						<mask id={ storageCloudMaskId } fill="white">
+							<path d="M8.30664 0C10.5453 0 12.4108 1.59411 12.832 3.70898C14.953 3.896 16.6162 5.67714 16.6162 7.84668C16.616 9.98525 14.9996 11.745 12.9219 11.9736V12H3.69141V11.9736C1.61495 11.7436 0 9.98349 0 7.8457C0.000230272 5.67769 1.66132 3.89782 3.78027 3.70898C4.20142 1.59404 6.06793 7.12951e-05 8.30664 0Z" />
+						</mask>
+						<path
+							d="M8.30664 0V-1.5H8.30659L8.30664 0ZM12.832 3.70898L11.3609 4.00201L11.5805 5.10445L12.7003 5.20319L12.832 3.70898ZM16.6162 7.84668L18.1162 7.84684V7.84668H16.6162ZM12.9219 11.9736L12.7578 10.4826L11.4219 10.6297V11.9736H12.9219ZM12.9219 12V13.5H14.4219V12H12.9219ZM3.69141 12H2.19141V13.5H3.69141V12ZM3.69141 11.9736H5.19141V10.6306L3.85655 10.4828L3.69141 11.9736ZM0 7.8457L-1.5 7.84554V7.8457H0ZM3.78027 3.70898L3.91342 5.20306L5.03206 5.10337L5.25139 4.00193L3.78027 3.70898ZM8.30664 0V1.5C9.81555 1.5 11.0766 2.57467 11.3609 4.00201L12.832 3.70898L14.3031 3.41596C13.7449 0.613552 11.2751 -1.5 8.30664 -1.5V0ZM12.832 3.70898L12.7003 5.20319C14.0537 5.32253 15.1162 6.46133 15.1162 7.84668H16.6162H18.1162C18.1162 4.89294 15.8523 2.46948 12.9638 2.21478L12.832 3.70898ZM16.6162 7.84668L15.1162 7.84652C15.1161 9.2112 14.0842 10.3366 12.7578 10.4826L12.9219 11.9736L13.086 13.4646C15.9149 13.1533 18.1159 10.7593 18.1162 7.84684L16.6162 7.84668ZM12.9219 11.9736H11.4219V12H12.9219H14.4219V11.9736H12.9219ZM12.9219 12V10.5H3.69141V12V13.5H12.9219V12ZM3.69141 12H5.19141V11.9736H3.69141H2.19141V12H3.69141ZM3.69141 11.9736L3.85655 10.4828C2.5313 10.336 1.5 9.21028 1.5 7.8457H0H-1.5C-1.5 10.7567 0.698607 13.1513 3.52626 13.4645L3.69141 11.9736ZM0 7.8457L1.5 7.84586C1.50015 6.46158 2.56121 5.32357 3.91342 5.20306L3.78027 3.70898L3.64712 2.21491C0.76142 2.47207 -1.49969 4.8938 -1.5 7.84554L0 7.8457ZM3.78027 3.70898L5.25139 4.00193C5.53552 2.57508 6.79723 1.50005 8.30669 1.5L8.30664 0L8.30659 -1.5C5.33863 -1.49991 2.86733 0.612993 2.30916 3.41604L3.78027 3.70898Z"
+							fill="currentColor"
+							mask={ `url(#${ storageCloudMaskId })` }
+						/>
+					</svg>
+				) }
+				<span className="plans-grid-next-storage-feature-label__text">{ storageLabel }</span>
+				{ showAddMore && (
+					<button
+						className="plans-grid-next-storage-feature-label__add-more"
+						type="button"
+						onClick={ onAddMoreClick }
+					>
+						{ translate( 'Add more' ) }
+					</button>
+				) }
+			</div>
+		);
 
-	return formattedMonthlyAddedCost ? (
+	return formattedMonthlyAddedCost && ! showAddMore ? (
 		<div className={ containerClasses }>
 			{ volumeJSX }
 			<div className="plans-grid-next-storage-feature-label__offset-price">

--- a/packages/plans-grid-next/src/components/test/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/test/plan-storage.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( '@automattic/data-stores', () => ( {
+	AddOns: {
+		useAvailableStorageAddOns: jest.fn(),
+	},
+} ) );
+jest.mock( '../../grid-context', () => ( { usePlansGridContext: jest.fn() } ) );
+jest.mock( '../shared/storage/components/storage-dropdown', () => {
+	const ReactActual = jest.requireActual< typeof import('react') >( 'react' );
+
+	return {
+		__esModule: true,
+		default: () => ReactActual.createElement( 'div', { 'data-testid': 'storage-dropdown' } ),
+	};
+} );
+jest.mock( '../shared/storage/components/storage-feature-label', () => {
+	const ReactActual = jest.requireActual< typeof import('react') >( 'react' );
+
+	return {
+		__esModule: true,
+		default: ( { onAddMoreClick, showAddMore } ) =>
+			showAddMore
+				? ReactActual.createElement( 'button', { onClick: onAddMoreClick }, 'Add more' )
+				: ReactActual.createElement( 'div', { 'data-testid': 'storage-label' } ),
+	};
+} );
+
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { AddOns } from '@automattic/data-stores';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { usePlansGridContext } from '../../grid-context';
+import PlanStorage from '../shared/storage/components/plan-storage';
+
+describe( 'PlanStorage', () => {
+	const mockPlansGridContext = ( showFeatureCheckmarks: boolean ) => {
+		( usePlansGridContext as jest.Mock ).mockReturnValue( {
+			gridPlansIndex: {
+				[ PLAN_BUSINESS ]: {
+					availableForPurchase: true,
+					current: false,
+					planTitle: 'Business',
+				},
+			},
+			showFeatureCheckmarks,
+			siteId: 1,
+		} );
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( AddOns.useAvailableStorageAddOns as jest.Mock ).mockReturnValue( [
+			{ addOnSlug: 'add-on-100gb-storage' },
+		] );
+	} );
+
+	test( 'closes the redesign storage dropdown when clicking outside', async () => {
+		mockPlansGridContext( true );
+
+		render(
+			<>
+				<PlanStorage planSlug={ PLAN_BUSINESS } showUpgradeableStorage />
+				<button type="button">Outside</button>
+			</>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add more' } ) );
+
+		expect( screen.getByTestId( 'storage-dropdown' ) ).toBeInTheDocument();
+
+		await new Promise( ( resolve ) => window.setTimeout( resolve, 0 ) );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Outside' } ) );
+
+		expect( screen.queryByTestId( 'storage-dropdown' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Add more' } ) ).toBeInTheDocument();
+	} );
+
+	test( 'keeps the control storage dropdown visible after clicking outside', () => {
+		mockPlansGridContext( false );
+
+		render(
+			<>
+				<PlanStorage planSlug={ PLAN_BUSINESS } showUpgradeableStorage />
+				<button type="button">Outside</button>
+			</>
+		);
+
+		expect( screen.getByTestId( 'storage-dropdown' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Outside' } ) );
+
+		expect( screen.getByTestId( 'storage-dropdown' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/plans-grid-next/src/components/test/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/test/storage-feature-label.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	combineReducers: jest.fn(),
+	createReduxStore: jest.fn(),
+	createSelector: jest.fn(),
+	register: jest.fn(),
+	registerStore: jest.fn(),
+} ) );
+jest.mock( '@automattic/data-stores', () => ( {
+	AddOns: {
+		useStorageAddOns: jest.fn(),
+	},
+	Purchases: {
+		useSitePurchasesByProductSlug: jest.fn(),
+	},
+	WpcomPlansUI: {
+		store: null,
+	},
+} ) );
+jest.mock( '../../grid-context', () => ( { usePlansGridContext: jest.fn() } ) );
+jest.mock( '../../hooks/use-is-large-currency', () => jest.fn() );
+
+import { FEATURE_50GB_STORAGE, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { AddOns, Purchases } from '@automattic/data-stores';
+import { render } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import React from 'react';
+import { usePlansGridContext } from '../../grid-context';
+import useIsLargeCurrency from '../../hooks/use-is-large-currency';
+import StorageFeatureLabel from '../shared/storage/components/storage-feature-label';
+
+describe( 'StorageFeatureLabel', () => {
+	const selectedStorageAddOn = {
+		addOnSlug: 'add-on-100gb-storage',
+		quantity: 100,
+		prices: {
+			monthlyPrice: 1000,
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( AddOns.useStorageAddOns as jest.Mock ).mockReturnValue( [ selectedStorageAddOn ] );
+		( Purchases.useSitePurchasesByProductSlug as jest.Mock ).mockReturnValue( null );
+		( useSelect as jest.Mock ).mockReturnValue( selectedStorageAddOn.addOnSlug );
+		( useIsLargeCurrency as jest.Mock ).mockReturnValue( false );
+	} );
+
+	const mockPlansGridContext = ( showFeatureCheckmarks: boolean ) => {
+		( usePlansGridContext as jest.Mock ).mockReturnValue( {
+			gridPlansIndex: {
+				[ PLAN_BUSINESS ]: {
+					pricing: {
+						currencyCode: 'USD',
+					},
+					features: {
+						storageFeature: {
+							getSlug: () => FEATURE_50GB_STORAGE,
+						},
+					},
+				},
+			},
+			showFeatureCheckmarks,
+			siteId: 1,
+		} );
+	};
+
+	test( 'ignores selected but unpurchased storage add-ons outside the redesign', () => {
+		mockPlansGridContext( false );
+
+		const { container } = render( <StorageFeatureLabel planSlug={ PLAN_BUSINESS } /> );
+
+		expect( container ).toHaveTextContent( '50 GB' );
+		expect( container ).not.toHaveTextContent( '150 GB' );
+		expect( container ).not.toHaveTextContent( '+ $10/month' );
+	} );
+
+	test( 'shows selected storage add-ons in the redesign collapsed label', () => {
+		mockPlansGridContext( true );
+
+		const { container } = render( <StorageFeatureLabel planSlug={ PLAN_BUSINESS } showAddMore /> );
+
+		expect( container ).toHaveTextContent( '150 GB storage' );
+		expect( container ).toHaveTextContent( 'Add more' );
+		expect( container ).not.toHaveTextContent( '+ $10/month' );
+	} );
+} );

--- a/packages/plans-grid-next/src/components/test/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/test/storage-feature-label.tsx
@@ -88,6 +88,6 @@ describe( 'StorageFeatureLabel', () => {
 
 		expect( container ).toHaveTextContent( '150 GB storage' );
 		expect( container ).toHaveTextContent( 'Add more' );
-		expect( container ).not.toHaveTextContent( '+ $10/month' );
+		expect( container ).toHaveTextContent( '+ $10.00/month' );
 	} );
 } );

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -35,6 +35,7 @@ interface PlansGridContext {
 	showSimplifiedBillingDescription?: boolean;
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 	isExperimentVariant?: boolean;
+	showFeatureCheckmarks?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -64,6 +65,7 @@ const PlansGridContextProvider = ( {
 	showSimplifiedBillingDescription,
 	showBillingDescriptionForIncreasedRenewalPrice,
 	isExperimentVariant,
+	showFeatureCheckmarks,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -102,6 +104,7 @@ const PlansGridContextProvider = ( {
 				showSimplifiedBillingDescription,
 				showBillingDescriptionForIncreasedRenewalPrice,
 				isExperimentVariant,
+				showFeatureCheckmarks,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -288,6 +288,11 @@ export type GridContextProps = {
 	 * Used to display cohort-specific feature titles in the comparison grid.
 	 */
 	isExperimentVariant?: boolean;
+
+	/**
+	 * Display availability checkmarks next to features in the features grid.
+	 */
+	showFeatureCheckmarks?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-17769

## Proposed Changes

* Implement the new design for the experiment.

<img width="1410" height="710" alt="Screenshot 2026-07-06 at 23 22 29" src="https://github.com/user-attachments/assets/f66d48b0-e51e-4f31-b9d0-be13b509e4d6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Regression testing: go to /setup/onboarding/plans on calypso.live or calypso.localhost and confirm that it looks exactly like the current production version.
* Assign yourself to any of the treatment variants or edit usePlansGridRedesignExperiment to return one and confirm that the design works correctly and matches Figma.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
