### PR TITLE
Desktop: Follow up on Azure signing review

### DIFF
--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -18,6 +18,11 @@ cd desktop
 corepack enable
 yarn install --immutable --inline-builds
 
+# The only desktop step that runs on trunk, so this doubles as the post-merge
+# guard for the signing routing/arg logic.
+echo "--- :jest: Running unit tests"
+yarn run test:unit
+
 echo "--- :ruby: Setting up Ruby tooling"
 install_gems
 

--- a/.buildkite/commands/build-desktop-windows-nsis.ps1
+++ b/.buildkite/commands/build-desktop-windows-nsis.ps1
@@ -86,6 +86,9 @@ function Assert-Signed {
 
 Write-Output "--- :mag: Verifying signatures on packed binaries"
 $unpacked = @(Get-ChildItem -Path release -Directory -Filter 'win*-unpacked')
+if ($unpacked.Count -eq 0) {
+    throw "No win*-unpacked directory in desktop/release - native-binary signing was never verified."
+}
 foreach ($dir in $unpacked) {
     $binaries = @(Get-ChildItem -Path $dir.FullName -Recurse -Include '*.exe', '*.node', '*.dll' -File)
     Assert-Signed -Binaries $binaries -Label $dir.Name

--- a/desktop/bin/windows-sign.js
+++ b/desktop/bin/windows-sign.js
@@ -6,6 +6,13 @@
 const { resolveSigner, signFile } = require( './windows-signing-core' );
 
 module.exports = async function ( configuration ) {
+	// Gate to CI, matching the afterPack native-binary pass: a local Windows build
+	// has no signing env, so signing here would throw in resolveSigner() instead
+	// of producing an (unsigned) dev build.
+	if ( ! process.env.CI ) {
+		console.log( `[windows-sign] Skipping ${ configuration.path } (not CI)` );
+		return;
+	}
 	// electron-builder iterates its default sha1 + sha256 hashes and calls this
 	// once per hash. Azure Artifact Signing is SHA256-only, so skip the sha1 pass.
 	if ( configuration.hash === 'sha1' ) {

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -52,10 +52,12 @@ describe( 'win.sign callback', () => {
 		jest.dontMock( '../../bin/windows-signing-core' );
 	} );
 
+	const mockSigner = { kind: 'azure' };
+
 	function loadSignWithMockedCore() {
 		jest.resetModules();
 		jest.doMock( '../../bin/windows-signing-core', () => ( {
-			resolveSigner: jest.fn(),
+			resolveSigner: jest.fn( () => mockSigner ),
 			signFile: jest.fn(),
 		} ) );
 		return {
@@ -79,10 +81,11 @@ describe( 'win.sign callback', () => {
 		expect( core.signFile ).not.toHaveBeenCalled();
 	} );
 
-	it( 'signs the SHA256 pass on CI', async () => {
+	it( 'signs the SHA256 pass on CI with the resolved signer', async () => {
 		process.env.CI = 'true';
 		const { core, sign } = loadSignWithMockedCore();
 		await sign( { path: 'app.exe', hash: 'sha256' } );
-		expect( core.signFile ).toHaveBeenCalledWith( undefined, 'app.exe' );
+		expect( core.resolveSigner ).toHaveBeenCalled();
+		expect( core.signFile ).toHaveBeenCalledWith( mockSigner, 'app.exe' );
 	} );
 } );

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -42,16 +42,47 @@ describe( 'buildSignToolArgs', () => {
 } );
 
 describe( 'win.sign callback', () => {
-	it( 'skips the SHA1 pass without signing', async () => {
+	const originalCI = process.env.CI;
+	afterEach( () => {
+		if ( originalCI === undefined ) {
+			delete process.env.CI;
+		} else {
+			process.env.CI = originalCI;
+		}
+		jest.dontMock( '../../bin/windows-signing-core' );
+	} );
+
+	function loadSignWithMockedCore() {
 		jest.resetModules();
 		jest.doMock( '../../bin/windows-signing-core', () => ( {
 			resolveSigner: jest.fn(),
 			signFile: jest.fn(),
 		} ) );
-		const core = require( '../../bin/windows-signing-core' );
-		const sign = require( '../../bin/windows-sign' );
+		return {
+			core: require( '../../bin/windows-signing-core' ),
+			sign: require( '../../bin/windows-sign' ),
+		};
+	}
+
+	it( 'skips the SHA1 pass without signing', async () => {
+		process.env.CI = 'true';
+		const { core, sign } = loadSignWithMockedCore();
 		await sign( { path: 'app.exe', hash: 'sha1' } );
 		expect( core.signFile ).not.toHaveBeenCalled();
-		jest.dontMock( '../../bin/windows-signing-core' );
+	} );
+
+	it( 'skips signing off CI, without resolving a signer', async () => {
+		delete process.env.CI;
+		const { core, sign } = loadSignWithMockedCore();
+		await sign( { path: 'app.exe', hash: 'sha256' } );
+		expect( core.resolveSigner ).not.toHaveBeenCalled();
+		expect( core.signFile ).not.toHaveBeenCalled();
+	} );
+
+	it( 'signs the SHA256 pass on CI', async () => {
+		process.env.CI = 'true';
+		const { core, sign } = loadSignWithMockedCore();
+		await sign( { path: 'app.exe', hash: 'sha256' } );
+		expect( core.signFile ).toHaveBeenCalledWith( undefined, 'app.exe' );
 	} );
 } );


### PR DESCRIPTION
Part of [AINFRA-2237](https://linear.app/a8c/issue/AINFRA-2237). Follow-up to @iangmaia  review comments on #111902, tracked in [AINFRA-2572](https://linear.app/a8c/issue/AINFRA-2572).

Rebased onto trunk now that #112290 has landed. The `FORCE_PFX_SIGNING` truthiness fix that used to lead this list went with the block it guarded, so it is no longer here.

Verified via #112302 — the screenshot predates that rebase:

<img width="1760" height="754" alt="image" src="https://github.com/user-attachments/assets/690e954f-a30b-44f4-91bf-8ffd1ff470b4" />


## Proposed Changes

- **Empty `win*-unpacked`** — throw instead of silently skipping native-binary signature verification if the packaged layout changes.
- **`win.sign` off CI** — skip signing when `CI` is unset so a local Windows build produces an unsigned dev build instead of throwing in `resolveSigner()`; mirrors the existing `afterPack` gate.
- **`test:unit` unwired** — run it in the mac desktop step (the only one on `trunk`) so the signing routing/arg logic is guarded, including post-merge.

<details>
<summary>AI-generated details</summary>

## Why are these changes being made?

Reviewer approved #111902 to unblock but flagged these to consider; committed to following up here rather than blocking the merge.

## Testing Instructions

- `cd desktop && yarn test:unit` — 22 pass, including new cases for the off-CI skip and the SHA256-on-CI path. The latter now asserts the resolved signer reaches `signFile`, rather than asserting on the `undefined` a bare mock returned.
- CI: watch the mac desktop step run `test:unit`, and the signed Windows NSIS step stay green.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


</details>
