### PR TITLE
Masterbar: fall back to full page load when page.js router isn't running

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -110,9 +110,6 @@ class MasterbarLoggedIn extends Component {
 		dashboardOptIn: PropTypes.bool,
 		useUnifiedAgent: PropTypes.bool,
 		launchButton: PropTypes.node,
-		// When provided, the "Plan" menu item navigates to this URL via a regular
-		// anchor instead of calling the page.js router. The interim omnibar (which
-		// runs outside the page.js routing context) passes this so the link works.
 		sitePlanUrl: PropTypes.string,
 	};
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,7 +1,6 @@
 import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
 import { localize } from 'i18n-calypso';
@@ -13,6 +12,7 @@ import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
+import { navigate } from 'calypso/lib/navigate';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -204,7 +204,7 @@ class MasterbarLoggedIn extends Component {
 
 	goToCheckout = ( siteId ) => {
 		this.props.recordTracksEvent( 'calypso_masterbar_cart_go_to_checkout' );
-		page( `/checkout/${ siteId }` );
+		navigate( `/checkout/${ siteId }` );
 	};
 
 	onRemoveCartProduct = ( uuid = 'coupon' ) => {
@@ -577,14 +577,11 @@ class MasterbarLoggedIn extends Component {
 						</div>
 					</div>
 				),
-				// In the interim omnibar `page.js` routing is unavailable, so navigate
-				// via a regular anchor using the provided `sitePlanUrl`. Elsewhere, fall
-				// back to client-side routing.
 				...( sitePlanUrl && { url: sitePlanUrl } ),
 				onClick: () => {
 					this.props.recordTracksEvent( 'calypso_masterbar_plan_clicked' );
 					if ( ! sitePlanUrl ) {
-						page( `/plans/${ siteSlug }` );
+						navigate( `/plans/${ siteSlug }` );
 					}
 				},
 			} );

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -11,6 +11,14 @@ function isCurrentPathOutOfScope( currentPath: string ): boolean {
 	return paths.some( ( path ) => currentPath.startsWith( path ) );
 }
 
+// `page.current` stays '' until the page.js router starts and performs its
+// first navigation. Apps that don't use page.js (e.g. the Dashboard, which
+// embeds the masterbar) never start it, so calling `page.show()` there throws.
+// Detect that case and fall back to a full page load.
+function isRouterRunning(): boolean {
+	return page.current !== '';
+}
+
 function shouldNavigateWithinSamePage( path: string ): boolean {
 	const currentPath = window.location.pathname;
 	const targetUrl = new URL( path, window.location.origin );
@@ -55,6 +63,8 @@ export function navigate( path: string, openInNewTab = false, forceReload = fals
 					container: getScrollableContainer( element as HTMLElement ),
 				} );
 			}
+		} else if ( ! isRouterRunning() ) {
+			window.location.href = path;
 		} else {
 			page.show( path );
 		}

--- a/client/lib/navigate/test/index.ts
+++ b/client/lib/navigate/test/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { navigate } from '..';
+
+describe( 'navigate', () => {
+	let originalLocation: Location;
+	let showSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		originalLocation = window.location;
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: {
+				href: 'http://localhost/sites',
+				origin: 'http://localhost',
+				pathname: '/sites',
+			},
+		} );
+		showSpy = jest.spyOn( page, 'show' ).mockImplementation( () => undefined as never );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+		showSpy.mockRestore();
+		page.current = '';
+	} );
+
+	it( 'does a full page load for same-origin paths when the page.js router is not running', () => {
+		page.current = '';
+
+		navigate( '/me/account' );
+
+		expect( window.location.href ).toBe( '/me/account' );
+		expect( showSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses client-side routing for same-origin paths when the page.js router is running', () => {
+		page.current = '/sites';
+
+		navigate( '/me/account' );
+
+		expect( showSpy ).toHaveBeenCalledWith( '/me/account' );
+		expect( window.location.href ).toBe( 'http://localhost/sites' );
+	} );
+} );


### PR DESCRIPTION
Fixes DOTMSD-1391

## Proposed Changes

* Guard `navigate()` to do a full page load for same-origin paths when the page.js router isn't running.
* Route the masterbar's two direct `page()` calls (Checkout, Plan fallback) through `navigate()` so they inherit the same fallback.

## Why are these changes being made?

The interim omnibar embeds the legacy masterbar in the Dashboard, which uses TanStack Router and never starts page.js. Same-origin masterbar links that route through page.js crash in its `Context` constructor (`Cannot read properties of undefined (reading 'document')`), because the router's window reference is never initialized.

The crash surfaced through two paths:
- **Mobile touch:** sub-item links (Sites, Domains, Plan, My WordPress.com Account) are handled manually via `navigate()` → `page.show()`. Desktop dodged it by following the native anchor `href`.
- **All devices:** direct `page()` calls (Checkout, and the latent Plan fallback) bypass anchors entirely.

Cross-origin links were unaffected because `navigate()` already sends those through `window.open`.

`page.current` stays empty until page.js starts and performs its first navigation, so it's a reliable signal for "router not running." In Calypso the router is always started, so behavior there is unchanged.

## Testing Instructions

1. Open the Dashboard (interim omnibar) on a mobile viewport.
2. Open the account menu and tap **My WordPress.com Account**, **Domains**, and **Sites** — each should navigate instead of throwing a console `TypeError`.
3. With items in the cart, tap **Checkout** on both desktop and mobile — should navigate.
4. In Calypso, confirm the same masterbar links still soft-navigate (no full reload).

New unit tests cover both branches of the `navigate()` fallback (router running vs. not).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
