### PR TITLE
CI: validate Azure desktop signing (stacked on #112298)

### DIFF
--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -18,6 +18,11 @@ cd desktop
 corepack enable
 yarn install --immutable --inline-builds
 
+# The only desktop step that runs on trunk, so this doubles as the post-merge
+# guard for the signing routing/arg logic.
+echo "--- :jest: Running unit tests"
+yarn run test:unit
+
 echo "--- :ruby: Setting up Ruby tooling"
 install_gems
 

--- a/.buildkite/commands/build-desktop-windows-nsis.ps1
+++ b/.buildkite/commands/build-desktop-windows-nsis.ps1
@@ -86,6 +86,9 @@ function Assert-Signed {
 
 Write-Output "--- :mag: Verifying signatures on packed binaries"
 $unpacked = @(Get-ChildItem -Path release -Directory -Filter 'win*-unpacked')
+if ($unpacked.Count -eq 0) {
+    throw "No win*-unpacked directory in desktop/release - native-binary signing was never verified."
+}
 foreach ($dir in $unpacked) {
     $binaries = @(Get-ChildItem -Path $dir.FullName -Recurse -Include '*.exe', '*.node', '*.dll' -File)
     Assert-Signed -Binaries $binaries -Label $dir.Name

--- a/desktop/bin/windows-sign.js
+++ b/desktop/bin/windows-sign.js
@@ -6,6 +6,13 @@
 const { resolveSigner, signFile } = require( './windows-signing-core' );
 
 module.exports = async function ( configuration ) {
+	// Gate to CI, matching the afterPack native-binary pass: a local Windows build
+	// has no signing env, so signing here would throw in resolveSigner() instead
+	// of producing an (unsigned) dev build.
+	if ( ! process.env.CI ) {
+		console.log( `[windows-sign] Skipping ${ configuration.path } (not CI)` );
+		return;
+	}
 	// electron-builder iterates its default sha1 + sha256 hashes and calls this
 	// once per hash. Azure Artifact Signing is SHA256-only, so skip the sha1 pass.
 	if ( configuration.hash === 'sha1' ) {

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -52,10 +52,12 @@ describe( 'win.sign callback', () => {
 		jest.dontMock( '../../bin/windows-signing-core' );
 	} );
 
+	const mockSigner = { kind: 'azure' };
+
 	function loadSignWithMockedCore() {
 		jest.resetModules();
 		jest.doMock( '../../bin/windows-signing-core', () => ( {
-			resolveSigner: jest.fn(),
+			resolveSigner: jest.fn( () => mockSigner ),
 			signFile: jest.fn(),
 		} ) );
 		return {
@@ -79,10 +81,11 @@ describe( 'win.sign callback', () => {
 		expect( core.signFile ).not.toHaveBeenCalled();
 	} );
 
-	it( 'signs the SHA256 pass on CI', async () => {
+	it( 'signs the SHA256 pass on CI with the resolved signer', async () => {
 		process.env.CI = 'true';
 		const { core, sign } = loadSignWithMockedCore();
 		await sign( { path: 'app.exe', hash: 'sha256' } );
-		expect( core.signFile ).toHaveBeenCalledWith( undefined, 'app.exe' );
+		expect( core.resolveSigner ).toHaveBeenCalled();
+		expect( core.signFile ).toHaveBeenCalledWith( mockSigner, 'app.exe' );
 	} );
 } );

--- a/desktop/test/unit/windows-signing-core.test.js
+++ b/desktop/test/unit/windows-signing-core.test.js
@@ -42,16 +42,47 @@ describe( 'buildSignToolArgs', () => {
 } );
 
 describe( 'win.sign callback', () => {
-	it( 'skips the SHA1 pass without signing', async () => {
+	const originalCI = process.env.CI;
+	afterEach( () => {
+		if ( originalCI === undefined ) {
+			delete process.env.CI;
+		} else {
+			process.env.CI = originalCI;
+		}
+		jest.dontMock( '../../bin/windows-signing-core' );
+	} );
+
+	function loadSignWithMockedCore() {
 		jest.resetModules();
 		jest.doMock( '../../bin/windows-signing-core', () => ( {
 			resolveSigner: jest.fn(),
 			signFile: jest.fn(),
 		} ) );
-		const core = require( '../../bin/windows-signing-core' );
-		const sign = require( '../../bin/windows-sign' );
+		return {
+			core: require( '../../bin/windows-signing-core' ),
+			sign: require( '../../bin/windows-sign' ),
+		};
+	}
+
+	it( 'skips the SHA1 pass without signing', async () => {
+		process.env.CI = 'true';
+		const { core, sign } = loadSignWithMockedCore();
 		await sign( { path: 'app.exe', hash: 'sha1' } );
 		expect( core.signFile ).not.toHaveBeenCalled();
-		jest.dontMock( '../../bin/windows-signing-core' );
+	} );
+
+	it( 'skips signing off CI, without resolving a signer', async () => {
+		delete process.env.CI;
+		const { core, sign } = loadSignWithMockedCore();
+		await sign( { path: 'app.exe', hash: 'sha256' } );
+		expect( core.resolveSigner ).not.toHaveBeenCalled();
+		expect( core.signFile ).not.toHaveBeenCalled();
+	} );
+
+	it( 'signs the SHA256 pass on CI', async () => {
+		process.env.CI = 'true';
+		const { core, sign } = loadSignWithMockedCore();
+		await sign( { path: 'app.exe', hash: 'sha256' } );
+		expect( core.signFile ).toHaveBeenCalledWith( undefined, 'app.exe' );
 	} );
 } );


### PR DESCRIPTION
Stacked on #112298 (base branch `ainfra-2572-follow-up-on-code-review-for-azure-integration-in-wp-desktop`). Part of [AINFRA-2237](https://linear.app/a8c/issue/AINFRA-2237) / [AINFRA-2572](https://linear.app/a8c/issue/AINFRA-2572).

## Proposed Changes

Empty commit only. This branch exists solely to exercise the desktop signed build in CI.

## Why are these changes being made?

The follow-up fixes in #112298 live on an `ainfra-2572-*` branch, which does **not** match the desktop build steps' filters (`trunk release/* desktop/* desktop-v*`), so those steps never run there. Prefixing this branch `desktop/` triggers them — most importantly the **signed Windows NSIS** step — so we can confirm the Azure signing path and the four fixes work end-to-end before merging #112298.

**Validation only — do not merge.** Close once the desktop builds are confirmed green; the actual changes ship via #112298.

## Testing Instructions

Watch the desktop build steps on this PR, in particular `:windows: Build desktop (windows nsis, signed)` (Azure path + the signature-verify gate) and `:desktop_computer: Build desktop (mac)` (now runs `yarn test:unit`).

## Pre-merge Checklist

- [ ] Not for merge — validation PR.
