### PR TITLE
Freeze the js-utils parity tests to captured values

### DIFF
--- a/packages/js-utils/src/test/is-empty.ts
+++ b/packages/js-utils/src/test/is-empty.ts
@@ -1,6 +1,4 @@
 import { runInNewContext } from 'vm';
-// eslint-disable-next-line no-restricted-imports -- parity test against the lodash function being replaced
-import lodashIsEmpty from 'lodash/isEmpty';
 import isEmpty from '../is-empty';
 
 describe( 'isEmpty', () => {
@@ -121,7 +119,7 @@ describe( 'isEmpty', () => {
 		expect( isEmpty( filled ) ).toBe( false );
 	} );
 
-	describe( 'matches the reference implementation', () => {
+	describe( 'across a table of representative values', () => {
 		function Bar() {}
 		Bar.prototype = { constructor: Bar };
 		function Baz() {}
@@ -153,60 +151,68 @@ describe( 'isEmpty', () => {
 		// excludes it (tag-based `isFunction`), so it is measured by own keys, not
 		// its `length`. Each is non-empty (owns `length`/`splice`).
 		const functionTagSpoofs = [ 'Function', 'AsyncFunction', 'GeneratorFunction', 'Proxy' ].map(
-			( tag ): [ string, unknown ] => [
+			( tag ): [ string, unknown, boolean ] => [
 				`frozen splice object tagged ${ tag }`,
 				Object.freeze( { length: 0, splice() {}, [ Symbol.toStringTag ]: tag } ),
+				false,
 			]
 		);
 
-		const cases: [ string, unknown ][] = [
-			[ 'null', null ],
-			[ 'undefined', undefined ],
-			[ 'empty string', '' ],
-			[ 'string', 'a' ],
-			[ 'empty array', [] ],
-			[ 'array', [ 1 ] ],
-			[ 'empty object', {} ],
-			[ 'object', { a: 1 } ],
-			[ 'object with length key', { length: 0 } ],
-			[ 'zero', 0 ],
-			[ 'number', 1 ],
-			[ 'NaN', NaN ],
-			[ 'true', true ],
-			[ 'false', false ],
-			[ 'symbol', Symbol( 'x' ) ],
-			[ 'empty Map', new Map() ],
-			[ 'Map', new Map( [ [ 1, 2 ] ] ) ],
-			[ 'empty Set', new Set() ],
-			[ 'Set', new Set( [ 1 ] ) ],
-			[ 'empty typed array', new Uint8Array( 0 ) ],
-			[ 'typed array', new Uint8Array( 2 ) ],
-			[ 'DataView', new DataView( new ArrayBuffer( 8 ) ) ],
-			[ 'function', () => {} ],
-			[ 'regexp', /re/ ],
-			[ 'date', new Date() ],
-			[ 'null-proto object', Object.create( null ) ],
-			[ 'inherited-only object', Object.create( { a: 1 } ) ],
-			[ 'empty jQuery-like', { length: 0, splice() {} } ],
-			[ 'jQuery-like', { length: 2, splice() {} } ],
-			[ 'splice without length', { splice() {} } ],
-			[ 'spoofed toStringTag with keys', { [ Symbol.toStringTag ]: 'Map', size: 0, a: 1 } ],
-			[ 'spoofed toStringTag only', { [ Symbol.toStringTag ]: 'Map' } ],
-			[ 'frozen spoofed toStringTag', Object.freeze( { [ Symbol.toStringTag ]: 'Map' } ) ],
-			[ 'bare prototype object', Bar.prototype ],
-			[ 'Object.prototype', Object.prototype ],
-			[ 'prototype with extra key', Baz.prototype ],
-			[ 'empty arguments', emptyArgs ],
-			[ 'filled arguments', filledArgs ],
-			[ 'arguments with length deleted', lengthlessArgs ],
-			[ 'frozen spoofed Arguments tag', Object.freeze( { [ Symbol.toStringTag ]: 'Arguments' } ) ],
-			[ 'function with own splice', spliceFn ],
-			[ 'frozen function spoofing Arguments with own key', taggedFn ],
+		// Each row is `[ label, value, expected ]`. The expected results were
+		// captured from the lodash function this replaces, so the table pins the
+		// behavior without depending on lodash at run time.
+		const cases: [ string, unknown, boolean ][] = [
+			[ 'null', null, true ],
+			[ 'undefined', undefined, true ],
+			[ 'empty string', '', true ],
+			[ 'string', 'a', false ],
+			[ 'empty array', [], true ],
+			[ 'array', [ 1 ], false ],
+			[ 'empty object', {}, true ],
+			[ 'object', { a: 1 }, false ],
+			[ 'object with length key', { length: 0 }, false ],
+			[ 'zero', 0, true ],
+			[ 'number', 1, true ],
+			[ 'NaN', NaN, true ],
+			[ 'true', true, true ],
+			[ 'false', false, true ],
+			[ 'symbol', Symbol( 'x' ), true ],
+			[ 'empty Map', new Map(), true ],
+			[ 'Map', new Map( [ [ 1, 2 ] ] ), false ],
+			[ 'empty Set', new Set(), true ],
+			[ 'Set', new Set( [ 1 ] ), false ],
+			[ 'empty typed array', new Uint8Array( 0 ), true ],
+			[ 'typed array', new Uint8Array( 2 ), false ],
+			[ 'DataView', new DataView( new ArrayBuffer( 8 ) ), true ],
+			[ 'function', () => {}, true ],
+			[ 'regexp', /re/, true ],
+			[ 'date', new Date(), true ],
+			[ 'null-proto object', Object.create( null ), true ],
+			[ 'inherited-only object', Object.create( { a: 1 } ), true ],
+			[ 'empty jQuery-like', { length: 0, splice() {} }, true ],
+			[ 'jQuery-like', { length: 2, splice() {} }, false ],
+			[ 'splice without length', { splice() {} }, false ],
+			[ 'spoofed toStringTag with keys', { [ Symbol.toStringTag ]: 'Map', size: 0, a: 1 }, false ],
+			[ 'spoofed toStringTag only', { [ Symbol.toStringTag ]: 'Map' }, true ],
+			[ 'frozen spoofed toStringTag', Object.freeze( { [ Symbol.toStringTag ]: 'Map' } ), true ],
+			[ 'bare prototype object', Bar.prototype, true ],
+			[ 'Object.prototype', Object.prototype, true ],
+			[ 'prototype with extra key', Baz.prototype, false ],
+			[ 'empty arguments', emptyArgs, true ],
+			[ 'filled arguments', filledArgs, false ],
+			[ 'arguments with length deleted', lengthlessArgs, true ],
+			[
+				'frozen spoofed Arguments tag',
+				Object.freeze( { [ Symbol.toStringTag ]: 'Arguments' } ),
+				true,
+			],
+			[ 'function with own splice', spliceFn, false ],
+			[ 'frozen function spoofing Arguments with own key', taggedFn, false ],
 			...functionTagSpoofs,
 		];
 
-		it.each( cases )( 'matches for %s', ( _label, value ) => {
-			expect( isEmpty( value ) ).toBe( lodashIsEmpty( value ) );
+		it.each( cases )( 'returns the expected result for %s', ( _label, value, expected ) => {
+			expect( isEmpty( value ) ).toBe( expected );
 		} );
 	} );
 } );

--- a/packages/js-utils/src/test/merge.ts
+++ b/packages/js-utils/src/test/merge.ts
@@ -1,47 +1,86 @@
-// eslint-disable-next-line no-restricted-imports -- parity test against the lodash function being replaced
-import lodashMerge from 'lodash/merge';
 import merge from '../merge';
 
 describe( 'merge', () => {
-	// Each case is a factory so the two implementations get independent inputs
-	// (both mutate their destination).
-	const cases: Array< [ string, () => unknown[] ] > = [
-		[ 'shallow object merge', () => [ { a: 1 }, { b: 2 } ] ],
-		[ 'overrides earlier keys', () => [ { a: 1 }, { a: 2 } ] ],
-		[ 'deep nested objects', () => [ { a: { b: { c: 1 } } }, { a: { b: { d: 2 } } } ] ],
-		[ 'multiple sources left to right', () => [ {}, { a: 1 }, { a: 2, b: 3 }, { b: 4 } ] ],
-		[ 'fresh target does not mutate later sources', () => [ {}, { a: { b: 1 } } ] ],
-		[ 'arrays merge by index', () => [ { a: [ 1, 2, 3 ] }, { a: [ 9 ] } ] ],
-		[ 'longer source array', () => [ { a: [ 1 ] }, { a: [ 9, 8, 7 ] } ] ],
-		[ 'array of objects merges element-wise', () => [ { a: [ { x: 1 } ] }, { a: [ { y: 2 } ] } ] ],
-		[ 'undefined source skips existing key', () => [ { a: 1 }, { a: undefined } ] ],
-		[ 'undefined source creates absent key', () => [ {}, { a: undefined } ] ],
-		[ 'null overrides', () => [ { a: { b: 1 } }, { a: null } ] ],
-		[ 'null destination replaced by object', () => [ { a: null }, { a: { b: 1 } } ] ],
-		[ 'primitive destination replaced by object', () => [ { a: 5 }, { a: { b: 1 } } ] ],
-		[ 'object destination replaced by primitive', () => [ { a: { b: 1 } }, { a: 5 } ] ],
-		[ 'array destination, object source', () => [ { a: [ 1, 2 ] }, { a: { 0: 9 } } ] ],
+	// Each case is `[ label, makeInputs, expected ]`. `makeInputs` is a factory so
+	// merge gets fresh, independently-mutable inputs; `expected` was captured from
+	// the lodash function this replaces, so the table pins the behavior without
+	// depending on lodash at run time.
+	const cases: Array< [ string, () => unknown[], unknown ] > = [
+		[ 'shallow object merge', () => [ { a: 1 }, { b: 2 } ], { a: 1, b: 2 } ],
+		[ 'overrides earlier keys', () => [ { a: 1 }, { a: 2 } ], { a: 2 } ],
+		[
+			'deep nested objects',
+			() => [ { a: { b: { c: 1 } } }, { a: { b: { d: 2 } } } ],
+			{ a: { b: { c: 1, d: 2 } } },
+		],
+		[
+			'multiple sources left to right',
+			() => [ {}, { a: 1 }, { a: 2, b: 3 }, { b: 4 } ],
+			{ a: 2, b: 4 },
+		],
+		[
+			'fresh target does not mutate later sources',
+			() => [ {}, { a: { b: 1 } } ],
+			{ a: { b: 1 } },
+		],
+		[ 'arrays merge by index', () => [ { a: [ 1, 2, 3 ] }, { a: [ 9 ] } ], { a: [ 9, 2, 3 ] } ],
+		[ 'longer source array', () => [ { a: [ 1 ] }, { a: [ 9, 8, 7 ] } ], { a: [ 9, 8, 7 ] } ],
+		[
+			'array of objects merges element-wise',
+			() => [ { a: [ { x: 1 } ] }, { a: [ { y: 2 } ] } ],
+			{ a: [ { x: 1, y: 2 } ] },
+		],
+		[ 'undefined source skips existing key', () => [ { a: 1 }, { a: undefined } ], { a: 1 } ],
+		[ 'undefined source creates absent key', () => [ {}, { a: undefined } ], { a: undefined } ],
+		[ 'null overrides', () => [ { a: { b: 1 } }, { a: null } ], { a: null } ],
+		[
+			'null destination replaced by object',
+			() => [ { a: null }, { a: { b: 1 } } ],
+			{ a: { b: 1 } },
+		],
+		[
+			'primitive destination replaced by object',
+			() => [ { a: 5 }, { a: { b: 1 } } ],
+			{ a: { b: 1 } },
+		],
+		[ 'object destination replaced by primitive', () => [ { a: { b: 1 } }, { a: 5 } ], { a: 5 } ],
+		[
+			'array destination, object source',
+			() => [ { a: [ 1, 2 ] }, { a: { 0: 9 } } ],
+			{ a: [ 9, 2 ] },
+		],
 		[
 			'zero and false and empty string',
 			() => [
 				{ a: 1, b: 1, c: 1 },
 				{ a: 0, b: false, c: '' },
 			],
+			{ a: 0, b: false, c: '' },
 		],
-		[ 'nested mixed', () => [ { a: { list: [ 1 ], n: 2 } }, { a: { list: [ 3, 4 ], m: 5 } } ] ],
-		[ 'null source is ignored', () => [ { a: 1 }, null, { b: 2 } ] ],
-		[ 'undefined source is ignored', () => [ { a: 1 }, undefined, { b: 2 } ] ],
-		[ 'empty sources', () => [ { a: 1 } ] ],
-		[ '__proto__ payload is dropped', () => [ {}, JSON.parse( '{ "__proto__": { "x": 1 } }' ) ] ],
+		[
+			'nested mixed',
+			() => [ { a: { list: [ 1 ], n: 2 } }, { a: { list: [ 3, 4 ], m: 5 } } ],
+			{ a: { list: [ 3, 4 ], n: 2, m: 5 } },
+		],
+		[ 'null source is ignored', () => [ { a: 1 }, null, { b: 2 } ], { a: 1, b: 2 } ],
+		[ 'undefined source is ignored', () => [ { a: 1 }, undefined, { b: 2 } ], { a: 1, b: 2 } ],
+		[ 'empty sources', () => [ { a: 1 } ], { a: 1 } ],
+		[
+			'__proto__ payload is dropped',
+			() => [ {}, JSON.parse( '{ "__proto__": { "x": 1 } }' ) ],
+			{},
+		],
 		[
 			'constructor payload merges as own key',
 			() => [ {}, JSON.parse( '{ "constructor": { "prototype": { "x": 1 } } }' ) ],
+			{ constructor: { prototype: { x: 1 } } },
 		],
 		[
 			'mixed __proto__ payload',
 			() => [ {}, JSON.parse( '{ "a": 1, "__proto__": { "x": 1 } }' ) ],
+			{ a: 1 },
 		],
-		[ 'sealed target drops new keys', () => [ Object.seal( { a: 1 } ), { a: 2, b: 3 } ] ],
+		[ 'sealed target drops new keys', () => [ Object.seal( { a: 1 } ), { a: 2, b: 3 } ], { a: 2 } ],
 		[
 			'non-writable property is skipped',
 			() => [
@@ -53,15 +92,13 @@ describe( 'merge', () => {
 				} ),
 				{ a: 2, b: 3 },
 			],
+			{ a: 1, b: 3 },
 		],
 	];
 
-	it.each( cases )( 'matches the reference implementation: %s', ( _label, make ) => {
-		const mineArgs = make() as [ Record< string, unknown >, ...unknown[] ];
-		const theirsArgs = make() as [ Record< string, unknown >, ...unknown[] ];
-		const mine = ( merge as ( ...a: unknown[] ) => unknown )( ...mineArgs );
-		const theirs = lodashMerge( ...( theirsArgs as [ object, ...unknown[] ] ) );
-		expect( mine ).toEqual( theirs );
+	it.each( cases )( 'produces the expected result: %s', ( _label, make, expected ) => {
+		const mine = ( merge as ( ...a: unknown[] ) => unknown )( ...make() );
+		expect( mine ).toEqual( expected );
 	} );
 
 	it( 'does not pollute Object.prototype via __proto__ or constructor', () => {
@@ -119,7 +156,6 @@ describe( 'merge', () => {
 		expect( () => merge( makeTarget() as Record< string, unknown >, { x: 1 } ) ).toThrow(
 			'setter boom'
 		);
-		expect( () => lodashMerge( makeTarget(), { x: 1 } ) ).toThrow( 'setter boom' );
 	} );
 
 	it( 'assigns Date and class instances by reference (does not deep-clone)', () => {
@@ -151,8 +187,6 @@ describe( 'merge', () => {
 		const frozen = Object.freeze( { a: { b: 1 } } );
 		// Computing this at all proves the write does not throw under strict mode.
 		const mine = merge( frozen, { meta: 1 } as Record< string, unknown > );
-		const theirs = lodashMerge( Object.freeze( { a: { b: 1 } } ), { meta: 1 } );
-		expect( mine ).toEqual( theirs );
 		expect( mine ).toEqual( { a: { b: 1 } } );
 	} );
 } );

--- a/packages/js-utils/src/test/mergeWith.ts
+++ b/packages/js-utils/src/test/mergeWith.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports -- parity test against the lodash function being replaced
-import lodashMergeWith from 'lodash/mergeWith';
 import mergeWith from '../mergeWith';
 
 type Customizer = (
@@ -11,8 +9,8 @@ type Customizer = (
 	stack: { size: number }
 ) => unknown;
 
-// Only touches `.size`, which both a native Map and the reference implementation's stack expose, so
-// the same customizer can drive both implementations in a differential test.
+// The customizer receives a `stack` whose `.size` reports the current recursion
+// depth (used by `topLevelOnly` below and the depth test).
 const overwriteArrays: Customizer = ( _objValue, srcValue ) =>
 	Array.isArray( srcValue ) ? srcValue : undefined;
 
@@ -25,29 +23,40 @@ const topLevelOnly: Customizer = ( _objValue, srcValue, key, _obj, _src, stack )
 const noop: Customizer = () => undefined;
 
 describe( 'mergeWith', () => {
-	// Each case is [ label, customizer, factory ]; the factory produces fresh
-	// inputs because both implementations mutate their destination.
-	const cases: Array< [ string, Customizer, () => unknown[] ] > = [
+	// Each case is `[ label, customizer, makeInputs, expected ]`. `makeInputs` is a
+	// factory so mergeWith gets fresh, mutable inputs; `expected` was captured from
+	// the lodash function this replaces, so the table pins the behavior without
+	// depending on lodash at run time.
+	const cases: Array< [ string, Customizer, () => unknown[], unknown ] > = [
 		[
 			'noop customizer behaves like a deep merge',
 			noop,
 			() => [ { a: { b: 1 } }, { a: { c: 2 } } ],
+			{ a: { b: 1, c: 2 } },
 		],
 		[
 			'arrays overwrite instead of merging by index',
 			overwriteArrays,
 			() => [ { a: [ 1, 2, 3 ] }, { a: [ 9 ] } ],
+			{ a: [ 9 ] },
 		],
 		[
 			'nested arrays overwrite',
 			overwriteArrays,
 			() => [ { a: { list: [ 1, 2 ], n: 1 } }, { a: { list: [ 3 ], m: 2 } } ],
+			{ a: { list: [ 3 ], n: 1, m: 2 } },
 		],
-		[ 'arrays concatenate', concatArrays, () => [ { a: [ 1, 2 ] }, { a: [ 3, 4 ] } ] ],
+		[
+			'arrays concatenate',
+			concatArrays,
+			() => [ { a: [ 1, 2 ] }, { a: [ 3, 4 ] } ],
+			{ a: [ 1, 2, 3, 4 ] },
+		],
 		[
 			'concat creates a fresh array when destination lacks the key',
 			concatArrays,
 			() => [ {}, { a: [ 1, 2 ] } ],
+			{ a: [ 1, 2 ] },
 		],
 		[
 			'top-level key replaced, nested key of same name untouched',
@@ -56,34 +65,50 @@ describe( 'mergeWith', () => {
 				{ special: 1, nested: { special: 2 } },
 				{ special: 9, nested: { special: 9 } },
 			],
+			{ special: 'REPLACED', nested: { special: 9 } },
 		],
 		[
 			'customizer undefined falls back to default for primitives',
 			overwriteArrays,
 			() => [ { a: 1 }, { a: 2 } ],
+			{ a: 2 },
 		],
 		[
 			'multiple sources merge left to right',
 			overwriteArrays,
 			() => [ {}, { a: 1 }, { a: 2, b: 3 } ],
+			{ a: 2, b: 3 },
 		],
-		[ 'null source is ignored', overwriteArrays, () => [ { a: 1 }, null, { b: 2 } ] ],
-		[ 'undefined source is ignored', overwriteArrays, () => [ { a: 1 }, undefined, { b: 2 } ] ],
-		[ 'undefined src value skips existing key', noop, () => [ { a: 1 }, { a: undefined } ] ],
-		[ 'null overrides object', noop, () => [ { a: { b: 1 } }, { a: null } ] ],
+		[
+			'null source is ignored',
+			overwriteArrays,
+			() => [ { a: 1 }, null, { b: 2 } ],
+			{ a: 1, b: 2 },
+		],
+		[
+			'undefined source is ignored',
+			overwriteArrays,
+			() => [ { a: 1 }, undefined, { b: 2 } ],
+			{ a: 1, b: 2 },
+		],
+		[
+			'undefined src value skips existing key',
+			noop,
+			() => [ { a: 1 }, { a: undefined } ],
+			{ a: 1 },
+		],
+		[ 'null overrides object', noop, () => [ { a: { b: 1 } }, { a: null } ], { a: null } ],
 		[
 			'__proto__ payload is dropped',
 			noop,
 			() => [ {}, JSON.parse( '{ "__proto__": { "x": 1 }, "a": 1 }' ) ],
+			{ a: 1 },
 		],
 	];
 
-	it.each( cases )( 'matches the reference implementation: %s', ( _label, customizer, make ) => {
-		const mineArgs = [ ...make(), customizer ] as [ object, ...unknown[] ];
-		const theirsArgs = [ ...make(), customizer ] as [ object, ...unknown[] ];
-		const mine = ( mergeWith as ( ...a: unknown[] ) => unknown )( ...mineArgs );
-		const theirs = ( lodashMergeWith as ( ...a: unknown[] ) => unknown )( ...theirsArgs );
-		expect( mine ).toEqual( theirs );
+	it.each( cases )( 'produces the expected result: %s', ( _label, customizer, make, expected ) => {
+		const mine = ( mergeWith as ( ...a: unknown[] ) => unknown )( ...make(), customizer );
+		expect( mine ).toEqual( expected );
 	} );
 
 	it( 'passes stack.size reflecting recursion depth to the customizer', () => {
@@ -107,11 +132,10 @@ describe( 'mergeWith', () => {
 			return circular;
 		};
 		const mine = mergeWith( {}, make(), noop ) as Record< string, unknown >;
-		const theirs = lodashMergeWith( {}, make(), noop ) as Record< string, unknown >;
 		expect( mine.a ).toBe( 1 );
 		// The nested `self` is merged once into its own container, then short-
 		// circuited on re-entry rather than looping forever.
-		expect( mine.self ).toEqual( theirs.self );
+		expect( ( mine.self as Record< string, unknown > ).a ).toBe( 1 );
 		expect( ( mine.self as Record< string, unknown > ).self ).toBe( mine.self );
 	} );
 
@@ -140,23 +164,18 @@ describe( 'mergeWith', () => {
 	it( 'treats a non-function trailing argument as a source', () => {
 		// No customizer given — the last object is merged, not dropped or called.
 		const mine = mergeWith( { a: { x: 1 } }, { a: { y: 2 } }, { b: 3 } );
-		const theirs = lodashMergeWith( { a: { x: 1 } }, { a: { y: 2 } }, { b: 3 } );
-		expect( mine ).toEqual( theirs );
 		expect( mine ).toEqual( { a: { x: 1, y: 2 }, b: 3 } );
 	} );
 
 	it( 'merges a single source with no customizer', () => {
 		const mine = mergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
-		const theirs = lodashMergeWith( { a: [ 1, 2 ] }, { a: [ 9 ], b: 4 } );
-		expect( mine ).toEqual( theirs );
+		expect( mine ).toEqual( { a: [ 9, 2 ], b: 4 } );
 	} );
 
 	it( 'returns a fresh object when the destination is nullish', () => {
 		// A null destination (e.g. an unknown post merged with local edits) must
 		// yield the merged edits rather than throwing on the null read.
 		const mine = mergeWith( null, { a: 1, b: [ 2 ] }, overwriteArrays );
-		const theirs = lodashMergeWith( null, { a: 1, b: [ 2 ] }, overwriteArrays );
-		expect( mine ).toEqual( theirs );
 		expect( mine ).toEqual( { a: 1, b: [ 2 ] } );
 	} );
 
@@ -169,8 +188,6 @@ describe( 'mergeWith', () => {
 			return fn;
 		};
 		const mine = mergeWith( {}, makeFn() );
-		const theirs = lodashMergeWith( {}, makeFn() );
-		expect( mine ).toEqual( theirs );
 		expect( ( mine as Record< string, unknown > ).a ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Freeze the `isEmpty`, `merge`, and `mergeWith` parity tests: replace the run-time `lodash` calls in each case with the value lodash produced, so the tables assert against captured literals instead of importing lodash.

## Why are these changes being made?

Part of the ongoing effort to drop lodash from the codebase. These three tests were the last place anything imported lodash — they compared `@automattic/js-utils` output against lodash at run time, which kept lodash installed solely for the tests. After this change, **no lodash import remains anywhere in the repo**.

**Provenance / avoiding stale tables:** the expected values were regenerated from lodash, not hand-written — captured by running the existing tests against lodash once and reading back each result. So the tables are a pure captured-parity snapshot. To regenerate one, run the case through lodash again and read the output.

**Intentional divergences stay separate:** the places where js-utils deliberately behaves differently from lodash — `merge` copies only own enumerable properties, treats arrays as dense (no sparse-hole materialization), and throws on circular sources — remain hand-written explicit tests, independent of the frozen tables. Changing one of those assumptions is therefore a deliberate edit to a named test, not a silent drift in a captured table.

This PR intentionally does not remove the `lodash` root dependency yet; that's a follow-up alongside retiring the (now no-op) lodash→lodash-es webpack replacement plugin.

## Testing Instructions

* Run the js-utils suite (`yarn test-packages packages/js-utils`) — `isEmpty`/`merge`/`mergeWith` pass with no lodash import.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
