### PR TITLE
Date Range: reset selection when clicking a non-endpoint day

### DIFF
--- a/client/components/date-range/test/add-date-to-range.js
+++ b/client/components/date-range/test/add-date-to-range.js
@@ -36,32 +36,25 @@ describe( 'addDayToRange', () => {
 		expect( result.to ).toEqual( moment( '2023-01-05' ) );
 	} );
 
-	test( 'should update "from" if day is before current "from"', () => {
+	test( 'should reset the range with day as "from" when day is before a complete range', () => {
 		const range = { from: moment( '2023-01-05' ), to: moment( '2023-01-10' ) };
 		const result = addDayToRange( moment( '2023-01-01' ), range );
 		expect( result.from ).toEqual( moment( '2023-01-01' ) );
-		expect( result.to ).toEqual( range.to );
+		expect( result.to ).toBeNull();
 	} );
 
-	test( 'should update "to" if day is after current "to"', () => {
+	test( 'should reset the range with day as "from" when day is after a complete range', () => {
 		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-05' ) };
 		const result = addDayToRange( moment( '2023-01-10' ), range );
-		expect( result.from ).toEqual( range.from );
-		expect( result.to ).toEqual( moment( '2023-01-10' ) );
+		expect( result.from ).toEqual( moment( '2023-01-10' ) );
+		expect( result.to ).toBeNull();
 	} );
 
-	test( 'should update "from" if day is closer to "from" than "to"', () => {
+	test( 'should reset the range with day as "from" when day is inside a complete range', () => {
 		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-10' ) };
 		const result = addDayToRange( moment( '2023-01-04' ), range );
 		expect( result.from ).toEqual( moment( '2023-01-04' ) );
-		expect( result.to ).toEqual( range.to );
-	} );
-
-	test( 'should update "to" if day is closer to "to" than "from"', () => {
-		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-10' ) };
-		const result = addDayToRange( moment( '2023-01-07' ), range );
-		expect( result.from ).toEqual( range.from );
-		expect( result.to ).toEqual( moment( '2023-01-07' ) );
+		expect( result.to ).toBeNull();
 	} );
 
 	test( 'should ignore time fractions', () => {

--- a/client/components/date-range/utils.ts
+++ b/client/components/date-range/utils.ts
@@ -30,17 +30,7 @@ function addDayToRange( day: Moment, range: DateRange ): DateRange {
 		return { ...range, to: day };
 	}
 
-	if ( day.isBefore( from ) ) {
-		return { ...range, from: day };
-	}
-	if ( day.isAfter( to ) ) {
-		return { ...range, to: day };
-	}
-
-	const daysFromStart = Math.abs( from.diff( day, 'days' ) );
-	const daysFromEnd = Math.abs( to.diff( day, 'days' ) );
-
-	return daysFromStart < daysFromEnd ? { ...range, from: day } : { ...range, to: day };
+	return { ...range, from: day, to: null };
 }
 
 export { addDayToRange };


### PR DESCRIPTION
Fixes STATS-289

## Proposed Changes

* When a complete date range is already selected, clicking any day that is **not** the current start or end date now resets the selection and starts a fresh range from the clicked day. Previously such a click shrank or expanded the existing range depending on where it landed, which was hard to predict.

Behavior summary of `addDayToRange`:

* Click on the existing start or end date → clears that endpoint (unchanged).
* No start selected → clicked day becomes the start (unchanged).
* Start selected, no end → clicked day becomes the end (unchanged; an out-of-order pair is auto-normalized downstream, so clicking an earlier day still produces a valid range).
* A complete range exists and a non-endpoint day is clicked → **reset the range, starting a new selection from the clicked day** (new behavior; replaces the old shrink/expand logic).

## Why are these changes being made?

The previous shrink/expand-toward-nearest-endpoint behavior made one of the most basic actions in Stats feel broken. Selecting a start date in the left calendar and an end date in the right calendar only worked when the picker happened to start from an empty state; when a range was already selected, the second click would quietly move the nearest boundary instead of starting a new range. This resets to the familiar Airbnb / Google Flights pattern where a new click begins a fresh selection.

## Testing Instructions

* Open Stats and click the date range picker.
* With a range already selected, click a day inside the range → the range should collapse to just that day as the new start (end cleared).
* Click a second, later day → it becomes the end, forming the new range.
* Click a day before or after an existing complete range → it should also reset and start a new selection from that day.
* Click directly on the current start or end date → that endpoint is cleared.
* Run the unit tests: `yarn test-client client/components/date-range/test/add-date-to-range.js`.


https://github.com/user-attachments/assets/e5db04ab-8bdc-47be-9797-2bc0be175ced



## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
