### PR TITLE
Masterbar: route mobile submenu taps through TanStack (alternative to #112299)

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -10,7 +10,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		return;
 	}
 
-	container.addEventListener( 'click', ( event ) => {
+	const handleLinkActivation = ( event: MouseEvent | TouchEvent ) => {
 		if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
 			return;
 		}
@@ -26,7 +26,25 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		}
 
 		events.linkClick.emit( { href, event } );
-	} );
+	};
+
+	container.addEventListener( 'click', handleLinkActivation );
+
+	// On touch, top-level items already navigate via the compat click and parent
+	// items toggle their submenu, so only submenu links need intercepting here —
+	// the masterbar prevents *their* compat click and navigates them manually.
+	// Scope to those to avoid hijacking taps that open a submenu. `passive: false`
+	// lets the linkClick handler `preventDefault()` a matched route.
+	container.addEventListener(
+		'touchend',
+		( event ) => {
+			if ( ! ( event.target as Element ).closest( '.masterbar__item-subitems' ) ) {
+				return;
+			}
+			handleLinkActivation( event );
+		},
+		{ passive: false }
+	);
 
 	// Create a per-tree i18n-calypso instance loaded with the user's locale so
 	// the first client render matches the SSR-translated HTML. Provided via

--- a/client/dashboard/app/omnibar/events.ts
+++ b/client/dashboard/app/omnibar/events.ts
@@ -26,7 +26,7 @@ export const omnibarEvents = {
 	notificationsOpen: createOmnibarEvent< boolean >(),
 	siteSwitcher: createOmnibarEvent(),
 	siteSwitcherAnchor: createOmnibarEvent< HTMLElement | null >(),
-	linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
+	linkClick: createOmnibarEvent< { href: string; event: MouseEvent | TouchEvent } >(),
 };
 
 export type OmnibarEvents = typeof omnibarEvents;

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -205,6 +205,10 @@ class MasterbarItem extends Component< MasterbarItemWithInnerRef > {
 		event: React.TouchEvent | React.KeyboardEvent,
 		onClick?: () => void
 	) => {
+		// The interim omnibar intercepts touch navigations and routes matching links
+		// through TanStack, marking the event handled via `preventDefault()`. Read that
+		// before our own `preventDefault()` below so we don't navigate a second time.
+		const handledByOmnibar = event.nativeEvent.defaultPrevented;
 		// We must prevent the default anchor behavior and navigate manually. Otherwise there is a
 		// race condition between the click on the anchor firing and the menu closing before that
 		// can happen. Because we preventDefault here, the anchor's `onClick` won't fire on the
@@ -212,7 +216,7 @@ class MasterbarItem extends Component< MasterbarItemWithInnerRef > {
 		event.preventDefault();
 		const url = event.currentTarget.getAttribute( 'href' );
 		onClick?.();
-		if ( url ) {
+		if ( url && ! handledByOmnibar ) {
 			navigate( url );
 		}
 		this.setState( { isOpenForNonMouseFlow: false } );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -110,9 +110,6 @@ class MasterbarLoggedIn extends Component {
 		dashboardOptIn: PropTypes.bool,
 		useUnifiedAgent: PropTypes.bool,
 		launchButton: PropTypes.node,
-		// When provided, the "Plan" menu item navigates to this URL via a regular
-		// anchor instead of calling the page.js router. The interim omnibar (which
-		// runs outside the page.js routing context) passes this so the link works.
 		sitePlanUrl: PropTypes.string,
 	};
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,7 +1,6 @@
 import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
 import { localize } from 'i18n-calypso';
@@ -13,6 +12,7 @@ import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
+import { navigate } from 'calypso/lib/navigate';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -204,7 +204,7 @@ class MasterbarLoggedIn extends Component {
 
 	goToCheckout = ( siteId ) => {
 		this.props.recordTracksEvent( 'calypso_masterbar_cart_go_to_checkout' );
-		page( `/checkout/${ siteId }` );
+		navigate( `/checkout/${ siteId }` );
 	};
 
 	onRemoveCartProduct = ( uuid = 'coupon' ) => {
@@ -577,14 +577,11 @@ class MasterbarLoggedIn extends Component {
 						</div>
 					</div>
 				),
-				// In the interim omnibar `page.js` routing is unavailable, so navigate
-				// via a regular anchor using the provided `sitePlanUrl`. Elsewhere, fall
-				// back to client-side routing.
 				...( sitePlanUrl && { url: sitePlanUrl } ),
 				onClick: () => {
 					this.props.recordTracksEvent( 'calypso_masterbar_plan_clicked' );
 					if ( ! sitePlanUrl ) {
-						page( `/plans/${ siteSlug }` );
+						navigate( `/plans/${ siteSlug }` );
 					}
 				},
 			} );

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -11,6 +11,14 @@ function isCurrentPathOutOfScope( currentPath: string ): boolean {
 	return paths.some( ( path ) => currentPath.startsWith( path ) );
 }
 
+// `page.current` stays '' until the page.js router starts and performs its
+// first navigation. Apps that don't use page.js (e.g. the Dashboard, which
+// embeds the masterbar) never start it, so calling `page.show()` there throws.
+// Detect that case and fall back to a full page load.
+function isRouterRunning(): boolean {
+	return page.current !== '';
+}
+
 function shouldNavigateWithinSamePage( path: string ): boolean {
 	const currentPath = window.location.pathname;
 	const targetUrl = new URL( path, window.location.origin );
@@ -55,6 +63,8 @@ export function navigate( path: string, openInNewTab = false, forceReload = fals
 					container: getScrollableContainer( element as HTMLElement ),
 				} );
 			}
+		} else if ( ! isRouterRunning() ) {
+			window.location.href = path;
 		} else {
 			page.show( path );
 		}

--- a/client/lib/navigate/test/index.ts
+++ b/client/lib/navigate/test/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { navigate } from '..';
+
+describe( 'navigate', () => {
+	let originalLocation: Location;
+	let showSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		originalLocation = window.location;
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: {
+				href: 'http://localhost/sites',
+				origin: 'http://localhost',
+				pathname: '/sites',
+			},
+		} );
+		showSpy = jest.spyOn( page, 'show' ).mockImplementation( () => undefined as never );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+		showSpy.mockRestore();
+		page.current = '';
+	} );
+
+	it( 'does a full page load for same-origin paths when the page.js router is not running', () => {
+		page.current = '';
+
+		navigate( '/me/account' );
+
+		expect( window.location.href ).toBe( '/me/account' );
+		expect( showSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses client-side routing for same-origin paths when the page.js router is running', () => {
+		page.current = '/sites';
+
+		navigate( '/me/account' );
+
+		expect( showSpy ).toHaveBeenCalledWith( '/me/account' );
+		expect( window.location.href ).toBe( 'http://localhost/sites' );
+	} );
+} );


### PR DESCRIPTION
Fixes DOTMSD-1391

Alternative to #112299. Includes that PR's crash guard, and additionally implements **option 1** from its review: mobile submenu links route through TanStack instead of a full page reload.

## Proposed Changes

* Intercept `touchend` on the interim omnibar (mirroring the existing `click` interception) so mobile taps on masterbar submenu links route through TanStack.
* Scope the touch interception to submenu links only, so taps that open a parent flyout (Me, Sites) still toggle the menu instead of navigating.
* Skip the masterbar's manual `navigate()` fallback when the omnibar has already routed the tap, to avoid a double navigation.

## Why are these changes being made?

#112299 stops the crash by falling back to a full page reload for masterbar links when the page.js router isn't running (as it isn't in the Dashboard). That works, but the reload is heavier than needed — on desktop these same links already soft-navigate through TanStack.

The gap is touch: the masterbar handles submenu taps on `touchend`, prevents the compat click, and navigates manually — so those taps never reach the omnibar's `click` interception and fall back to the reload. Mirroring the interception on `touchend` lets mobile submenu links soft-navigate too.

Non-routable links (and the programmatic Checkout / Plan navigations) still use the reload fallback from #112299.

## Testing Instructions

1. Open the Dashboard (interim omnibar) on a mobile viewport.
2. Tap the account avatar and the Sites item — each should **open its flyout menu**, not navigate.
3. From an open flyout, tap a submenu link that maps to a Dashboard route (e.g. Sites, Domains) — should soft-navigate (no full reload / flash).
4. Tap a submenu link that isn't a Dashboard route — should still navigate via full page load.
5. On desktop, confirm the same masterbar links behave as before.
6. In classic Calypso, confirm masterbar links still soft-navigate.

## Considerations

Two "proper fix" directions came out of the #112299 review:

1. **(this PR)** Mirror the omnibar's click interception on `touchend`.
2. Add an explicit `onLinkClick` prop to the masterbar so all activations route through one handler.

Option 1 is the smaller change but keeps the DOM-delegation approach: the omnibar must know which taps are submenu links, and the masterbar defers to the omnibar via `event.defaultPrevented`. Option 2 would make that contract explicit and is likely where an embeddable omnibar component ends up. Opening this so the two can be compared directly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)