### PR TITLE
Remove dead developer.wordpress.com/calypso links from README and SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Calypso is the new WordPress.com front-end – a beautiful redesign of the WordP
 
 It’s built with JavaScript – a very light [node](https://nodejs.org/) plus [express](https://expressjs.com/) server, [React.js](https://reactjs.org/), [Redux](https://redux.js.org/), [wpcom.js](https://wpcomjs.com/), and many other wonderful libraries on the front-end.
 
-You can read more about Calypso at [developer.wordpress.com/calypso](https://developer.wordpress.com/calypso/).
-
 ## Getting Started
 
 You can try out the user-side of Calypso on [WordPress.com](https://wordpress.com/) (a lot of the logged-in area is Calypso; if in doubt, view source), you can poke around the code here on GitHub, or you can install it and run it locally. The latter is the most fun.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Only the latest version of WordPress desktop is supported. To receive security u
 
 ## Reporting a Vulnerability
 
-[Calypso](https://developer.wordpress.com/calypso/) is an open-source wp-admin replacement. Our HackerOne program covers the software.
+Calypso is an open-source wp-admin replacement. Our HackerOne program covers the software.
 
 <!--eslint ignore no-emphasis-as-heading-->
 


### PR DESCRIPTION
Fixes #112204

## Proposed Changes

* Remove the dead `developer.wordpress.com/calypso` link from `README.md` and `SECURITY.md`.

## Why are these changes being made?

`developer.wordpress.com/calypso` now 301-redirects to `wpcalypso.wordpress.com/devdocs`, which returns a 404 — the old Calypso devdocs site has been retired. In `README.md` the whole sentence was just that dead pointer, so it's removed; in `SECURITY.md` the descriptive sentence reads fine unlinked.

## Testing Instructions

* Confirm `https://developer.wordpress.com/calypso/` redirects to a 404 (`wpcalypso.wordpress.com/devdocs`).
* View the rendered `README.md` and `SECURITY.md` on this branch and confirm no dead Calypso devdocs link remains.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
