### PR TITLE
A4A Dashboard: Add combined Team screen and agency-team data module

### DIFF
--- a/client/dashboard/agency/team/constants.ts
+++ b/client/dashboard/agency/team/constants.ts
@@ -1,0 +1,1 @@
+export const OWNER_ROLE = 'a4a_administrator';

--- a/client/dashboard/agency/team/dataviews/actions.ts
+++ b/client/dashboard/agency/team/dataviews/actions.ts
@@ -1,0 +1,69 @@
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import { OWNER_ROLE } from '../constants';
+import type { TeamMember } from '@automattic/api-core';
+import type { Action } from '@wordpress/dataviews';
+
+export type TeamActionRequest =
+	| { kind: 'cancel-invite'; member: TeamMember }
+	| { kind: 'transfer-ownership'; member: TeamMember }
+	| { kind: 'remove-member'; member: TeamMember; isSelf: boolean };
+
+export function useTeamActions( {
+	canRemove,
+	currentUserEmail,
+	onResendInvite,
+	onConfirmAction,
+}: {
+	canRemove: boolean;
+	currentUserEmail?: string;
+	onResendInvite: ( member: TeamMember ) => void;
+	onConfirmAction: ( request: TeamActionRequest ) => void;
+} ): Action< TeamMember >[] {
+	return useMemo( () => {
+		const isNotOwner = ( item: TeamMember ) => item.role !== OWNER_ROLE;
+		const isSelf = ( item: TeamMember ) => item.email === currentUserEmail;
+		const isInvited = ( item: TeamMember ) =>
+			item.status === 'pending' || item.status === 'expired';
+
+		return [
+			{
+				id: 'resend-user-invite',
+				label: __( 'Resend invite' ),
+				isEligible: ( item: TeamMember ) => isNotOwner( item ) && isInvited( item ),
+				callback: ( items: TeamMember[] ) => onResendInvite( items[ 0 ] ),
+			},
+			{
+				id: 'cancel-user-invite',
+				label: __( 'Cancel invite' ),
+				isEligible: ( item: TeamMember ) => isNotOwner( item ) && isInvited( item ),
+				callback: ( items: TeamMember[] ) =>
+					onConfirmAction( { kind: 'cancel-invite', member: items[ 0 ] } ),
+			},
+			{
+				id: 'transfer-ownership',
+				label: __( 'Transfer ownership' ),
+				isEligible: ( item: TeamMember ) =>
+					isNotOwner( item ) && item.status === 'active' && ! isSelf( item ),
+				callback: ( items: TeamMember[] ) =>
+					onConfirmAction( { kind: 'transfer-ownership', member: items[ 0 ] } ),
+			},
+			{
+				id: 'leave-agency',
+				label: __( 'Leave agency' ),
+				isEligible: ( item: TeamMember ) =>
+					isNotOwner( item ) && item.status === 'active' && isSelf( item ),
+				callback: ( items: TeamMember[] ) =>
+					onConfirmAction( { kind: 'remove-member', member: items[ 0 ], isSelf: true } ),
+			},
+			{
+				id: 'remove-team-member',
+				label: __( 'Remove team member' ),
+				isEligible: ( item: TeamMember ) =>
+					isNotOwner( item ) && item.status === 'active' && ! isSelf( item ) && canRemove,
+				callback: ( items: TeamMember[] ) =>
+					onConfirmAction( { kind: 'remove-member', member: items[ 0 ], isSelf: false } ),
+			},
+		];
+	}, [ canRemove, currentUserEmail, onResendInvite, onConfirmAction ] );
+}

--- a/client/dashboard/agency/team/dataviews/fields.tsx
+++ b/client/dashboard/agency/team/dataviews/fields.tsx
@@ -66,6 +66,16 @@ const STATUS_ELEMENTS: { value: TeamMemberStatus; label: string }[] = [
 	{ value: 'expired', label: __( 'Invite expired' ) },
 ];
 
+function formatAddedDate( value?: string ): string | null {
+	if ( ! value ) {
+		return null;
+	}
+	// Active members provide a Unix-seconds timestamp; invites provide an ISO date string.
+	const numeric = Number( value );
+	const date = Number.isNaN( numeric ) ? new Date( value ) : new Date( numeric * 1000 );
+	return Number.isNaN( date.getTime() ) ? null : dateI18n( 'F j, Y', date );
+}
+
 export function useTeamFields(): Field< TeamMember >[] {
 	return [
 		{
@@ -98,8 +108,8 @@ export function useTeamFields(): Field< TeamMember >[] {
 			enableSorting: false,
 			getValue: ( { item } ) => item.dateAdded ?? '',
 			render: ( { item } ) => {
-				const timestamp = Number( item.dateAdded );
-				return timestamp ? <>{ dateI18n( 'F j, Y', new Date( timestamp * 1000 ) ) }</> : <>—</>;
+				const formatted = formatAddedDate( item.dateAdded );
+				return formatted ? <>{ formatted }</> : <>—</>;
 			},
 		},
 	];

--- a/client/dashboard/agency/team/dataviews/fields.tsx
+++ b/client/dashboard/agency/team/dataviews/fields.tsx
@@ -46,14 +46,14 @@ function StatusBadge( { status }: { status: TeamMemberStatus } ) {
 function MemberCell( { member }: { member: TeamMember } ) {
 	const name = member.displayName ?? __( 'Team member' );
 	return (
-		<HStack spacing={ 3 } justify="flex-start" className="agency-team-member">
+		<HStack spacing={ 3 } justify="flex-start">
 			{ member.avatar ? (
 				<img className="agency-team-member__avatar" src={ member.avatar } alt="" />
 			) : (
 				<span className="agency-team-member__avatar agency-team-member__avatar-placeholder" />
 			) }
-			<VStack spacing={ 0 } className="agency-team-member__details">
-				<span className="agency-team-member__name">{ name }</span>
+			<VStack spacing={ 0 }>
+				<span>{ name }</span>
 				<Text variant="muted">{ member.email }</Text>
 			</VStack>
 		</HStack>
@@ -82,7 +82,7 @@ export function useTeamFields(): Field< TeamMember >[] {
 			id: 'name',
 			label: __( 'Name' ),
 			enableHiding: false,
-			enableSorting: false,
+			enableSorting: true,
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => [ item.displayName, item.email ].filter( Boolean ).join( ' ' ),
 			render: ( { item } ) => <MemberCell member={ item } />,

--- a/client/dashboard/agency/team/dataviews/fields.tsx
+++ b/client/dashboard/agency/team/dataviews/fields.tsx
@@ -1,0 +1,106 @@
+import { Badge } from '@automattic/ui';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import { OWNER_ROLE } from '../constants';
+import type { TeamMember, TeamMemberStatus } from '@automattic/api-core';
+import type { Field, Operator } from '@wordpress/dataviews';
+
+function getRoleLabel( role?: string ): string {
+	// Currently there are only two roles: owner and member. More may come later.
+	return role === OWNER_ROLE ? __( 'Agency owner' ) : __( 'Team member' );
+}
+
+function getStatusLabel( status: TeamMemberStatus ): string {
+	switch ( status ) {
+		case 'active':
+			return __( 'Active' );
+		case 'expired':
+			return __( 'Invite expired' );
+		case 'pending':
+		default:
+			return __( 'Invite pending' );
+	}
+}
+
+function getStatusIntent( status: TeamMemberStatus ): 'success' | 'warning' | 'error' {
+	switch ( status ) {
+		case 'active':
+			return 'success';
+		case 'expired':
+			return 'error';
+		case 'pending':
+		default:
+			return 'warning';
+	}
+}
+
+function StatusBadge( { status }: { status: TeamMemberStatus } ) {
+	return <Badge intent={ getStatusIntent( status ) }>{ getStatusLabel( status ) }</Badge>;
+}
+
+function MemberCell( { member }: { member: TeamMember } ) {
+	const name = member.displayName ?? __( 'Team member' );
+	return (
+		<HStack spacing={ 3 } justify="flex-start" className="agency-team-member">
+			{ member.avatar ? (
+				<img className="agency-team-member__avatar" src={ member.avatar } alt="" />
+			) : (
+				<span className="agency-team-member__avatar agency-team-member__avatar-placeholder" />
+			) }
+			<VStack spacing={ 0 } className="agency-team-member__details">
+				<span className="agency-team-member__name">{ name }</span>
+				<Text variant="muted">{ member.email }</Text>
+			</VStack>
+		</HStack>
+	);
+}
+
+const STATUS_ELEMENTS: { value: TeamMemberStatus; label: string }[] = [
+	{ value: 'active', label: __( 'Active' ) },
+	{ value: 'pending', label: __( 'Invite pending' ) },
+	{ value: 'expired', label: __( 'Invite expired' ) },
+];
+
+export function useTeamFields(): Field< TeamMember >[] {
+	return [
+		{
+			id: 'name',
+			label: __( 'Name' ),
+			enableHiding: false,
+			enableSorting: false,
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => [ item.displayName, item.email ].filter( Boolean ).join( ' ' ),
+			render: ( { item } ) => <MemberCell member={ item } />,
+		},
+		{
+			id: 'role',
+			label: __( 'Role' ),
+			enableSorting: false,
+			getValue: ( { item } ) => ( item.status === 'active' ? getRoleLabel( item.role ) : '' ),
+		},
+		{
+			id: 'status',
+			label: __( 'Status' ),
+			enableSorting: false,
+			getValue: ( { item } ) => item.status,
+			elements: STATUS_ELEMENTS,
+			filterBy: { operators: [ 'isAny' as Operator ] },
+			render: ( { item } ) => <StatusBadge status={ item.status } />,
+		},
+		{
+			id: 'added',
+			label: __( 'Added' ),
+			enableSorting: false,
+			getValue: ( { item } ) => item.dateAdded ?? '',
+			render: ( { item } ) => {
+				const timestamp = Number( item.dateAdded );
+				return timestamp ? <>{ dateI18n( 'F j, Y', new Date( timestamp * 1000 ) ) }</> : <>—</>;
+			},
+		},
+	];
+}

--- a/client/dashboard/agency/team/dataviews/test/actions.test.ts
+++ b/client/dashboard/agency/team/dataviews/test/actions.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { OWNER_ROLE } from '../../constants';
+import { useTeamActions } from '../actions';
+import type { TeamMember } from '@automattic/api-core';
+import type { Action } from '@wordpress/dataviews';
+
+const CURRENT_USER_EMAIL = 'me@example.com';
+
+const owner: TeamMember = {
+	id: 1,
+	email: 'owner@example.com',
+	role: OWNER_ROLE,
+	status: 'active',
+};
+const activeOther: TeamMember = {
+	id: 2,
+	email: 'other@example.com',
+	role: 'member',
+	status: 'active',
+};
+const activeSelf: TeamMember = {
+	id: 3,
+	email: CURRENT_USER_EMAIL,
+	role: 'member',
+	status: 'active',
+};
+const pendingInvite: TeamMember = { id: 4, email: 'pending@example.com', status: 'pending' };
+const expiredInvite: TeamMember = { id: 5, email: 'expired@example.com', status: 'expired' };
+
+function setup( { canRemove = true }: { canRemove?: boolean } = {} ) {
+	const { result } = renderHook( () =>
+		useTeamActions( {
+			canRemove,
+			currentUserEmail: CURRENT_USER_EMAIL,
+			onResendInvite: () => {},
+			onConfirmAction: () => {},
+		} )
+	);
+	return ( id: string, item: TeamMember ) => {
+		const action = result.current.find( ( a: Action< TeamMember > ) => a.id === id );
+		if ( ! action || ! action.isEligible ) {
+			throw new Error( `Action "${ id }" not found or has no isEligible` );
+		}
+		return action.isEligible( item );
+	};
+}
+
+describe( 'useTeamActions eligibility', () => {
+	it( 'offers no actions for the agency owner', () => {
+		const isEligible = setup();
+		for ( const id of [
+			'resend-user-invite',
+			'cancel-user-invite',
+			'transfer-ownership',
+			'leave-agency',
+			'remove-team-member',
+		] ) {
+			expect( isEligible( id, owner ) ).toBe( false );
+		}
+	} );
+
+	it( 'allows resend/cancel only for invited members', () => {
+		const isEligible = setup();
+		for ( const invite of [ pendingInvite, expiredInvite ] ) {
+			expect( isEligible( 'resend-user-invite', invite ) ).toBe( true );
+			expect( isEligible( 'cancel-user-invite', invite ) ).toBe( true );
+			expect( isEligible( 'transfer-ownership', invite ) ).toBe( false );
+			expect( isEligible( 'leave-agency', invite ) ).toBe( false );
+			expect( isEligible( 'remove-team-member', invite ) ).toBe( false );
+		}
+		expect( isEligible( 'resend-user-invite', activeOther ) ).toBe( false );
+		expect( isEligible( 'cancel-user-invite', activeOther ) ).toBe( false );
+	} );
+
+	it( 'allows transfer/remove for other active members', () => {
+		const isEligible = setup();
+		expect( isEligible( 'transfer-ownership', activeOther ) ).toBe( true );
+		expect( isEligible( 'remove-team-member', activeOther ) ).toBe( true );
+		expect( isEligible( 'leave-agency', activeOther ) ).toBe( false );
+	} );
+
+	it( 'offers leave-agency (not transfer/remove) for the current user', () => {
+		const isEligible = setup();
+		expect( isEligible( 'leave-agency', activeSelf ) ).toBe( true );
+		expect( isEligible( 'transfer-ownership', activeSelf ) ).toBe( false );
+		expect( isEligible( 'remove-team-member', activeSelf ) ).toBe( false );
+	} );
+
+	it( 'gates remove-team-member behind the remove capability', () => {
+		const isEligible = setup( { canRemove: false } );
+		expect( isEligible( 'remove-team-member', activeOther ) ).toBe( false );
+		// Transfer stays available; it is not capability-gated.
+		expect( isEligible( 'transfer-ownership', activeOther ) ).toBe( true );
+	} );
+} );

--- a/client/dashboard/agency/team/dataviews/views.ts
+++ b/client/dashboard/agency/team/dataviews/views.ts
@@ -1,0 +1,21 @@
+import type { SupportedLayouts, View } from '@wordpress/dataviews';
+
+export const DEFAULT_PER_PAGE = 25;
+
+export const DEFAULT_LAYOUTS: SupportedLayouts = {
+	table: {
+		showMedia: false,
+		titleField: 'name',
+	},
+};
+
+// No default sort: the list preserves the order the endpoints return it in —
+// active members from /users (agency owner first) followed by /user-invites.
+export const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: DEFAULT_PER_PAGE,
+	titleField: 'name',
+	fields: [ 'role', 'status', 'added' ],
+	filters: [],
+};

--- a/client/dashboard/agency/team/index.tsx
+++ b/client/dashboard/agency/team/index.tsx
@@ -9,7 +9,7 @@ import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
@@ -47,7 +47,10 @@ export default function AgencyTeam() {
 		agencyTeamInvitesQuery( agencyId )
 	);
 
-	const allMembers: TeamMember[] = [ ...members, ...invites ];
+	const allMembers = useMemo< TeamMember[] >(
+		() => [ ...members, ...invites ],
+		[ members, invites ]
+	);
 
 	const canRemove = !! activeAgency?.user?.capabilities?.includes( REMOVE_USERS_CAPABILITY );
 

--- a/client/dashboard/agency/team/index.tsx
+++ b/client/dashboard/agency/team/index.tsx
@@ -1,0 +1,121 @@
+import {
+	activeAgencyQuery,
+	agencyTeamMembersQuery,
+	agencyTeamInvitesQuery,
+	agencyTeamResendInviteMutation,
+} from '@automattic/api-queries';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useCallback, useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { useAuth } from '../../app/auth';
+import { usePersistentView } from '../../app/hooks/use-persistent-view';
+import { agencyTeamRoute } from '../../app/router/agency';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { useTeamActions, type TeamActionRequest } from './dataviews/actions';
+import { DEFAULT_VIEW } from './dataviews/views';
+import InviteTeamMemberModal from './invite-team-member-modal';
+import TeamActionModal from './team-action-modal';
+import TeamMembersContent from './team-members-content';
+import type { TeamMember } from '@automattic/api-core';
+
+const REMOVE_USERS_CAPABILITY = 'a4a_remove_users';
+
+export default function AgencyTeam() {
+	const { recordTracksEvent } = useAnalytics();
+	const { user } = useAuth();
+	const { data: activeAgency } = useQuery( activeAgencyQuery() );
+	const agencyId = activeAgency?.id ?? 0;
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const searchParams = agencyTeamRoute.useSearch();
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'agency-team',
+		defaultView: DEFAULT_VIEW,
+		queryParams: searchParams,
+	} );
+
+	const { data: members = [], isLoading: isLoadingMembers } = useQuery(
+		agencyTeamMembersQuery( agencyId )
+	);
+	const { data: invites = [], isLoading: isLoadingInvites } = useQuery(
+		agencyTeamInvitesQuery( agencyId )
+	);
+
+	const allMembers: TeamMember[] = [ ...members, ...invites ];
+
+	const canRemove = !! activeAgency?.user?.capabilities?.includes( REMOVE_USERS_CAPABILITY );
+
+	const [ activeRequest, setActiveRequest ] = useState< TeamActionRequest | null >( null );
+	const [ isInviteOpen, setIsInviteOpen ] = useState( false );
+
+	const { mutate: resendInvite } = useMutation( agencyTeamResendInviteMutation( agencyId ) );
+
+	const onResendInvite = useCallback(
+		( member: TeamMember ) => {
+			recordTracksEvent( 'calypso_dashboard_team_resend_invite_click' );
+			resendInvite( member.id, {
+				onSuccess: () =>
+					createSuccessNotice( __( 'The invitation has been resent.' ), { type: 'snackbar' } ),
+				onError: () =>
+					createErrorNotice( __( 'Failed to resend the invitation.' ), { type: 'snackbar' } ),
+			} );
+		},
+		[ recordTracksEvent, resendInvite, createSuccessNotice, createErrorNotice ]
+	);
+
+	const actions = useTeamActions( {
+		canRemove,
+		currentUserEmail: user?.email,
+		onResendInvite,
+		onConfirmAction: setActiveRequest,
+	} );
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Team' ) }
+					description={ __( 'Manage team members and invitations for your agency.' ) }
+					actions={
+						<Button
+							variant="primary"
+							__next40pxDefaultSize
+							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_team_invite_member_click' );
+								setIsInviteOpen( true );
+							} }
+						>
+							{ __( 'Invite a team member' ) }
+						</Button>
+					}
+				/>
+			}
+		>
+			<TeamMembersContent
+				members={ allMembers }
+				actions={ actions }
+				view={ view }
+				onChangeView={ updateView }
+				onReset={ resetView }
+				isLoading={ isLoadingMembers || isLoadingInvites }
+			/>
+			{ activeRequest && (
+				<TeamActionModal
+					agencyId={ agencyId }
+					agencyName={ activeAgency?.name ?? '' }
+					request={ activeRequest }
+					onClose={ () => setActiveRequest( null ) }
+				/>
+			) }
+			{ isInviteOpen && (
+				<InviteTeamMemberModal agencyId={ agencyId } onClose={ () => setIsInviteOpen( false ) } />
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/team/invite-team-member-modal.tsx
+++ b/client/dashboard/agency/team/invite-team-member-modal.tsx
@@ -1,0 +1,92 @@
+import { agencyTeamInviteMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	Modal,
+	TextControl,
+	TextareaControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
+
+interface InviteTeamMemberModalProps {
+	agencyId: number;
+	onClose: () => void;
+}
+
+export default function InviteTeamMemberModal( { agencyId, onClose }: InviteTeamMemberModalProps ) {
+	const [ login, setLogin ] = useState( '' );
+	const [ message, setMessage ] = useState( '' );
+	const [ error, setError ] = useState( '' );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const invite = useMutation( agencyTeamInviteMutation( agencyId ) );
+
+	const onSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		if ( ! login.trim() ) {
+			setError( __( 'Please enter a valid email or WordPress.com username.' ) );
+			return;
+		}
+		invite.mutate(
+			{ login: login.trim(), message: message.trim() },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'The invitation has been successfully sent.' ), {
+						type: 'snackbar',
+					} );
+					onClose();
+				},
+				onError: () =>
+					createErrorNotice( __( 'Failed to send the invitation.' ), { type: 'snackbar' } ),
+			}
+		);
+	};
+
+	return (
+		<Modal title={ __( 'Invite a team member' ) } onRequestClose={ onClose } size="medium">
+			<form onSubmit={ onSubmit }>
+				<VStack spacing={ 4 }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Email or WordPress.com username' ) }
+						placeholder={ __( 'team-member@example.com' ) }
+						value={ login }
+						help={ error || undefined }
+						onChange={ ( value ) => {
+							setLogin( value );
+							setError( '' );
+						} }
+					/>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={ __( 'Message' ) }
+						help={ __(
+							'Optional: Include a custom message to provide more context to your team member.'
+						) }
+						value={ message }
+						onChange={ setMessage }
+					/>
+					<ButtonStack justify="flex-end">
+						<Button variant="tertiary" __next40pxDefaultSize onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							type="submit"
+							__next40pxDefaultSize
+							isBusy={ invite.isPending }
+							disabled={ invite.isPending }
+						>
+							{ __( 'Send invite' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			</form>
+		</Modal>
+	);
+}

--- a/client/dashboard/agency/team/style.scss
+++ b/client/dashboard/agency/team/style.scss
@@ -1,0 +1,11 @@
+.agency-team-member__avatar {
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	object-fit: cover;
+	flex-shrink: 0;
+}
+
+.agency-team-member__avatar-placeholder {
+	background: var( --color-surface-backdrop );
+}

--- a/client/dashboard/agency/team/team-action-modal.tsx
+++ b/client/dashboard/agency/team/team-action-modal.tsx
@@ -1,0 +1,157 @@
+import {
+	agencyTeamCancelInviteMutation,
+	agencyTeamRemoveMemberMutation,
+	agencyTeamTransferOwnershipMutation,
+} from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import ConfirmModal from '../../components/confirm-modal';
+import type { TeamActionRequest } from './dataviews/actions';
+
+interface TeamActionModalProps {
+	agencyId: number;
+	agencyName: string;
+	request: TeamActionRequest;
+	onClose: () => void;
+}
+
+export default function TeamActionModal( {
+	agencyId,
+	agencyName,
+	request,
+	onClose,
+}: TeamActionModalProps ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const cancelInvite = useMutation( agencyTeamCancelInviteMutation( agencyId ) );
+	const removeMember = useMutation( agencyTeamRemoveMemberMutation( agencyId ) );
+	const transferOwnership = useMutation( agencyTeamTransferOwnershipMutation( agencyId ) );
+
+	const member = request.member;
+	const memberName = member.displayName ?? member.email;
+
+	const notifyError = ( message: string ) => createErrorNotice( message, { type: 'snackbar' } );
+	const notifySuccess = ( message: string ) => createSuccessNotice( message, { type: 'snackbar' } );
+
+	if ( request.kind === 'cancel-invite' ) {
+		return (
+			<ConfirmModal
+				title={ __( 'Cancel invitation' ) }
+				confirmButtonProps={ {
+					label: __( 'Cancel invitation' ),
+					isDestructive: true,
+					isBusy: cancelInvite.isPending,
+					disabled: cancelInvite.isPending,
+				} }
+				isOpen
+				onCancel={ onClose }
+				onConfirm={ () =>
+					cancelInvite.mutate( member.id, {
+						onSuccess: () => {
+							notifySuccess( __( 'The invitation has been successfully cancelled.' ) );
+							onClose();
+						},
+						onError: () => notifyError( __( 'Failed to cancel the invitation.' ) ),
+					} )
+				}
+			>
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: %s is the invited member's name or email. */
+						__( 'Are you sure you want to cancel the invitation for <b>%s</b>?' ),
+						memberName
+					),
+					{ b: <strong /> }
+				) }
+			</ConfirmModal>
+		);
+	}
+
+	if ( request.kind === 'transfer-ownership' ) {
+		return (
+			<ConfirmModal
+				title={ __( 'Transfer agency ownership' ) }
+				confirmButtonProps={ {
+					label: __( 'Transfer ownership' ),
+					isBusy: transferOwnership.isPending,
+					disabled: transferOwnership.isPending,
+				} }
+				isOpen
+				onCancel={ onClose }
+				onConfirm={ () =>
+					transferOwnership.mutate( member.id, {
+						onSuccess: () => {
+							notifySuccess( __( 'Ownership has been successfully transferred.' ) );
+							onClose();
+						},
+						onError: () => notifyError( __( 'Failed to transfer ownership.' ) ),
+					} )
+				}
+			>
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: %1$s is the agency name, %2$s is the member's name or email. */
+						__(
+							'Are you sure you want to transfer ownership of %1$s to <b>%2$s</b>? This action cannot be undone and you will become a regular team member.'
+						),
+						agencyName,
+						memberName
+					),
+					{ b: <strong /> }
+				) }
+			</ConfirmModal>
+		);
+	}
+
+	const isSelf = request.isSelf;
+
+	return (
+		<ConfirmModal
+			title={
+				isSelf
+					? sprintf(
+							/* translators: %s is the agency name. */
+							__( 'Are you sure you want to leave %s?' ),
+							agencyName
+					  )
+					: __( 'Remove team member' )
+			}
+			confirmButtonProps={ {
+				label: isSelf ? __( 'Leave agency' ) : __( 'Remove team member' ),
+				isDestructive: true,
+				isBusy: removeMember.isPending,
+				disabled: removeMember.isPending,
+			} }
+			isOpen
+			onCancel={ onClose }
+			onConfirm={ () =>
+				removeMember.mutate( member.id, {
+					onSuccess: () => {
+						if ( isSelf ) {
+							window.location.href = 'https://automattic.com/for/agencies';
+							return;
+						}
+						notifySuccess( __( 'The member has been successfully removed.' ) );
+						onClose();
+					},
+					onError: () => notifyError( __( 'Failed to remove the member.' ) ),
+				} )
+			}
+		>
+			{ isSelf
+				? __(
+						'By proceeding, you’ll lose management access of all sites that belong to this agency and you will be removed from this dashboard. The agency owner will need to re-invite you if you wish to gain access again.'
+				  )
+				: createInterpolateElement(
+						sprintf(
+							/* translators: %s is the member's name or email. */
+							__( 'Are you sure you want to remove <b>%s</b>?' ),
+							memberName
+						),
+						{ b: <strong /> }
+				  ) }
+		</ConfirmModal>
+	);
+}

--- a/client/dashboard/agency/team/team-action-modal.tsx
+++ b/client/dashboard/agency/team/team-action-modal.tsx
@@ -58,12 +58,8 @@ export default function TeamActionModal( {
 				}
 			>
 				{ createInterpolateElement(
-					sprintf(
-						/* translators: %s is the invited member's name or email. */
-						__( 'Are you sure you want to cancel the invitation for <b>%s</b>?' ),
-						memberName
-					),
-					{ b: <strong /> }
+					__( 'Are you sure you want to cancel the invitation for <memberName />?' ),
+					{ memberName: <strong>{ memberName }</strong> }
 				) }
 			</ConfirmModal>
 		);
@@ -91,15 +87,13 @@ export default function TeamActionModal( {
 				}
 			>
 				{ createInterpolateElement(
-					sprintf(
-						/* translators: %1$s is the agency name, %2$s is the member's name or email. */
-						__(
-							'Are you sure you want to transfer ownership of %1$s to <b>%2$s</b>? This action cannot be undone and you will become a regular team member.'
-						),
-						agencyName,
-						memberName
+					__(
+						'Are you sure you want to transfer ownership of <agencyName /> to <memberName />? This action cannot be undone and you will become a regular team member.'
 					),
-					{ b: <strong /> }
+					{
+						agencyName: <>{ agencyName }</>,
+						memberName: <strong>{ memberName }</strong>,
+					}
 				) }
 			</ConfirmModal>
 		);
@@ -144,14 +138,9 @@ export default function TeamActionModal( {
 				? __(
 						'By proceeding, you’ll lose management access of all sites that belong to this agency and you will be removed from this dashboard. The agency owner will need to re-invite you if you wish to gain access again.'
 				  )
-				: createInterpolateElement(
-						sprintf(
-							/* translators: %s is the member's name or email. */
-							__( 'Are you sure you want to remove <b>%s</b>?' ),
-							memberName
-						),
-						{ b: <strong /> }
-				  ) }
+				: createInterpolateElement( __( 'Are you sure you want to remove <memberName />?' ), {
+						memberName: <strong>{ memberName }</strong>,
+				  } ) }
 		</ConfirmModal>
 	);
 }

--- a/client/dashboard/agency/team/team-action-modal.tsx
+++ b/client/dashboard/agency/team/team-action-modal.tsx
@@ -11,6 +11,8 @@ import { store as noticesStore } from '@wordpress/notices';
 import ConfirmModal from '../../components/confirm-modal';
 import type { TeamActionRequest } from './dataviews/actions';
 
+const AGENCIES_MARKETING_URL = 'https://automattic.com/for/agencies';
+
 interface TeamActionModalProps {
 	agencyId: number;
 	agencyName: string;
@@ -124,7 +126,7 @@ export default function TeamActionModal( {
 				removeMember.mutate( member.id, {
 					onSuccess: () => {
 						if ( isSelf ) {
-							window.location.href = 'https://automattic.com/for/agencies';
+							window.location.href = AGENCIES_MARKETING_URL;
 							return;
 						}
 						notifySuccess( __( 'The member has been successfully removed.' ) );

--- a/client/dashboard/agency/team/team-members-content.tsx
+++ b/client/dashboard/agency/team/team-members-content.tsx
@@ -59,13 +59,19 @@ export default function TeamMembersContent( {
 					/>
 				}
 			>
-				{ /* Free composition: render our own toolbar so search + cog live in a
-				   wrapper we control (styling/alignment) instead of DataViews' default. */ }
+				{ /* Padding mirrors the default `.dataviews__view-actions` so this custom
+				   toolbar aligns with the table below it. Kept as free composition for
+				   reuse in a8c-for-agencies.
+				   TODO: remove after we sunset a8c-for-agencies. */ }
 				<HStack
-					className="agency-team-members__view-actions"
 					alignment="top"
 					justify="space-between"
 					spacing={ 2 }
+					style={ {
+						boxSizing: 'border-box',
+						padding:
+							'var(--wpds-dimension-padding-lg, 16px) var(--wpds-dimension-padding-2xl, 24px)',
+					} }
 				>
 					<HStack justify="flex-start" spacing={ 3 } expanded={ false }>
 						<WPDataViews.Search />
@@ -73,7 +79,7 @@ export default function TeamMembersContent( {
 					</HStack>
 					<WPDataViews.ViewConfig />
 				</HStack>
-				<WPDataViews.FiltersToggled />
+				<WPDataViews.FiltersToggled className="dataviews-filters__container" />
 				<WPDataViews.Layout />
 				<WPDataViews.Footer />
 			</DataViews>

--- a/client/dashboard/agency/team/team-members-content.tsx
+++ b/client/dashboard/agency/team/team-members-content.tsx
@@ -1,0 +1,82 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { DataViews as WPDataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { DataViews, DataViewsCard, DataViewsEmptyStateLayout } from '../../components/dataviews';
+import { useTeamFields } from './dataviews/fields';
+import { DEFAULT_LAYOUTS } from './dataviews/views';
+import type { TeamMember } from '@automattic/api-core';
+import type { Action, View } from '@wordpress/dataviews';
+
+import './style.scss';
+
+export function getTeamMemberId( item: TeamMember ): string {
+	return `${ item.status === 'active' ? 'member' : 'invite' }-${ item.id }`;
+}
+
+interface TeamMembersContentProps {
+	members: TeamMember[];
+	actions: Action< TeamMember >[];
+	view: View;
+	onChangeView: ( view: View ) => void;
+	onReset?: () => void;
+	isLoading?: boolean;
+}
+
+export default function TeamMembersContent( {
+	members,
+	actions,
+	view,
+	onChangeView,
+	onReset,
+	isLoading,
+}: TeamMembersContentProps ) {
+	const fields = useTeamFields();
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( members, view, fields );
+
+	return (
+		<DataViewsCard>
+			<DataViews< TeamMember >
+				data={ filteredData }
+				fields={ fields }
+				view={ view }
+				actions={ actions }
+				onChangeView={ onChangeView }
+				onReset={ onReset }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				getItemId={ getTeamMemberId }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				empty={
+					<DataViewsEmptyStateLayout
+						title={
+							view.search ? __( 'No team members match your search' ) : __( 'No team members' )
+						}
+						description={
+							view.search
+								? __( 'Try a different search term.' )
+								: __( 'Invite a team member to get started.' )
+						}
+					/>
+				}
+			>
+				{ /* Free composition: render our own toolbar so search + cog live in a
+				   wrapper we control (styling/alignment) instead of DataViews' default. */ }
+				<HStack
+					className="agency-team-members__view-actions"
+					alignment="top"
+					justify="space-between"
+					spacing={ 2 }
+				>
+					<HStack justify="flex-start" spacing={ 3 } expanded={ false }>
+						<WPDataViews.Search />
+						<WPDataViews.FiltersToggle />
+					</HStack>
+					<WPDataViews.ViewConfig />
+				</HStack>
+				<WPDataViews.FiltersToggled />
+				<WPDataViews.Layout />
+				<WPDataViews.Footer />
+			</DataViews>
+		</DataViewsCard>
+	);
+}

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -28,6 +28,7 @@ boot( {
 			learn: true,
 			mcp: true,
 			sites: true,
+			team: true,
 			earn: true,
 		},
 		agencyClient: { subscriptions: true },

--- a/client/dashboard/app-a4a/section.ts
+++ b/client/dashboard/app-a4a/section.ts
@@ -6,6 +6,7 @@ export const A4A_DASHBOARD_SECTION_DEFINITION = {
 export const A4A_DASHBOARD_SECTION_PATHS = [
 	'/',
 	'/sites',
+	'/team',
 	'/oauth/token',
 	'/overview',
 	'/marketplace/exclusive-offers',

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -21,6 +21,7 @@ export type AgencySupports = {
 	learn: boolean;
 	mcp: boolean;
 	sites: boolean;
+	team: boolean;
 	earn: boolean;
 };
 

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -1,7 +1,7 @@
 import { agencyQuery, activeAgencyQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { home, globe, layout, pages, tag, currencyDollar } from '@wordpress/icons';
+import { home, globe, layout, pages, tag, currencyDollar, people } from '@wordpress/icons';
 import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sidebar';
 import { useAppContext } from '../context';
 
@@ -23,6 +23,11 @@ export default function AgencySidebar() {
 			{ supports.agency.sites && (
 				<SidebarMenuItem icon={ layout } to="/sites">
 					{ __( 'Sites' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.agency.team && (
+				<SidebarMenuItem icon={ people } to="/team">
+					{ __( 'Team' ) }
 				</SidebarMenuItem>
 			) }
 			{ supports.agency.tiers && (

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -185,6 +185,22 @@ export const agencySitesRoute = createRoute( {
 	)
 );
 
+// `/team` – manage agency team members and invitations
+export const agencyTeamRoute = createRoute( {
+	head: () => ( {
+		meta: [ { title: __( 'Team' ) } ],
+	} ),
+	getParentRoute: () => agencyRoute,
+	path: 'team',
+	loader: () => queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+} ).lazy( () =>
+	import( '../../agency/team' ).then( ( d ) =>
+		createLazyRoute( 'agency-team' )( {
+			component: d.default,
+		} )
+	)
+);
+
 // `/earn` – summary of the agency's earning programs (default Earn screen)
 const earnOverviewRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Overview' ) } ] } ),
@@ -453,6 +469,7 @@ export const createAgencyRoutes = () => [
 		learnRoute,
 		mcpRoute.addChildren( [ mcpOverviewRoute, mcpAvailableToolsRoute, mcpConnectRoute ] ),
 		agencySitesRoute,
+		agencyTeamRoute,
 		earnOverviewRoute,
 		earnReferralsRoute,
 		earnWooPaymentsRoute,

--- a/packages/api-core/src/agency-team/fetchers.ts
+++ b/packages/api-core/src/agency-team/fetchers.ts
@@ -1,9 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type {
-	AgencyTeamInviteApiResponse,
-	AgencyTeamInviteInput,
-	AgencyTeamMemberApiResponse,
-} from './types';
+import type { AgencyTeamInviteApiResponse, AgencyTeamMemberApiResponse } from './types';
 
 export async function fetchAgencyTeamMembers(
 	agencyId: number
@@ -20,64 +16,5 @@ export async function fetchAgencyTeamInvites(
 	return wpcom.req.get( {
 		path: `/agency/${ agencyId }/user-invites`,
 		apiNamespace: 'wpcom/v2',
-	} );
-}
-
-export async function inviteAgencyTeamMember(
-	agencyId: number,
-	input: AgencyTeamInviteInput
-): Promise< { success: boolean } > {
-	return wpcom.req.post(
-		{
-			path: `/agency/${ agencyId }/user-invites`,
-			apiNamespace: 'wpcom/v2',
-		},
-		input
-	);
-}
-
-export async function resendAgencyTeamInvite(
-	agencyId: number,
-	inviteId: number
-): Promise< { success: boolean } > {
-	return wpcom.req.post( {
-		path: `/agency/${ agencyId }/user-invites/${ inviteId }/resend`,
-		apiNamespace: 'wpcom/v2',
-	} );
-}
-
-export async function cancelAgencyTeamInvite(
-	agencyId: number,
-	inviteId: number
-): Promise< { success: boolean } > {
-	return wpcom.req.post( {
-		path: `/agency/${ agencyId }/user-invites/${ inviteId }`,
-		apiNamespace: 'wpcom/v2',
-		method: 'DELETE',
-	} );
-}
-
-export async function removeAgencyTeamMember(
-	agencyId: number,
-	userId: number
-): Promise< { success: boolean } > {
-	return wpcom.req.post( {
-		path: `/agency/${ agencyId }/users/${ userId }`,
-		apiNamespace: 'wpcom/v2',
-		method: 'DELETE',
-	} );
-}
-
-export async function transferAgencyOwnership(
-	agencyId: number,
-	newOwnerId: number
-): Promise< { success: boolean } > {
-	return wpcom.req.post( {
-		path: `/agency/${ agencyId }/transfer-ownership`,
-		apiNamespace: 'wpcom/v2',
-		method: 'PUT',
-		body: {
-			new_owner_id: newOwnerId,
-		},
 	} );
 }

--- a/packages/api-core/src/agency-team/fetchers.ts
+++ b/packages/api-core/src/agency-team/fetchers.ts
@@ -1,0 +1,83 @@
+import { wpcom } from '../wpcom-fetcher';
+import type {
+	AgencyTeamInviteApiResponse,
+	AgencyTeamInviteInput,
+	AgencyTeamMemberApiResponse,
+} from './types';
+
+export async function fetchAgencyTeamMembers(
+	agencyId: number
+): Promise< AgencyTeamMemberApiResponse[] > {
+	return wpcom.req.get( {
+		path: `/agency/${ agencyId }/users`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function fetchAgencyTeamInvites(
+	agencyId: number
+): Promise< AgencyTeamInviteApiResponse[] > {
+	return wpcom.req.get( {
+		path: `/agency/${ agencyId }/user-invites`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function inviteAgencyTeamMember(
+	agencyId: number,
+	input: AgencyTeamInviteInput
+): Promise< { success: boolean } > {
+	return wpcom.req.post(
+		{
+			path: `/agency/${ agencyId }/user-invites`,
+			apiNamespace: 'wpcom/v2',
+		},
+		input
+	);
+}
+
+export async function resendAgencyTeamInvite(
+	agencyId: number,
+	inviteId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/user-invites/${ inviteId }/resend`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function cancelAgencyTeamInvite(
+	agencyId: number,
+	inviteId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/user-invites/${ inviteId }`,
+		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
+	} );
+}
+
+export async function removeAgencyTeamMember(
+	agencyId: number,
+	userId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/users/${ userId }`,
+		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
+	} );
+}
+
+export async function transferAgencyOwnership(
+	agencyId: number,
+	newOwnerId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/transfer-ownership`,
+		apiNamespace: 'wpcom/v2',
+		method: 'PUT',
+		body: {
+			new_owner_id: newOwnerId,
+		},
+	} );
+}

--- a/packages/api-core/src/agency-team/index.ts
+++ b/packages/api-core/src/agency-team/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/agency-team/index.ts
+++ b/packages/api-core/src/agency-team/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
+export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/agency-team/mutators.ts
+++ b/packages/api-core/src/agency-team/mutators.ts
@@ -1,0 +1,61 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { AgencyTeamInviteInput } from './types';
+
+export async function inviteAgencyTeamMember(
+	agencyId: number,
+	input: AgencyTeamInviteInput
+): Promise< { success: boolean } > {
+	return wpcom.req.post(
+		{
+			path: `/agency/${ agencyId }/user-invites`,
+			apiNamespace: 'wpcom/v2',
+		},
+		input
+	);
+}
+
+export async function resendAgencyTeamInvite(
+	agencyId: number,
+	inviteId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/user-invites/${ inviteId }/resend`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function cancelAgencyTeamInvite(
+	agencyId: number,
+	inviteId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/user-invites/${ inviteId }`,
+		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
+	} );
+}
+
+export async function removeAgencyTeamMember(
+	agencyId: number,
+	userId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/users/${ userId }`,
+		apiNamespace: 'wpcom/v2',
+		method: 'DELETE',
+	} );
+}
+
+export async function transferAgencyOwnership(
+	agencyId: number,
+	newOwnerId: number
+): Promise< { success: boolean } > {
+	return wpcom.req.post( {
+		path: `/agency/${ agencyId }/transfer-ownership`,
+		apiNamespace: 'wpcom/v2',
+		method: 'PUT',
+		body: {
+			new_owner_id: newOwnerId,
+		},
+	} );
+}

--- a/packages/api-core/src/agency-team/types.ts
+++ b/packages/api-core/src/agency-team/types.ts
@@ -1,0 +1,49 @@
+/**
+ * A team member's status within an agency. `active` members have accepted;
+ * `pending` and `expired` are outstanding invitations.
+ */
+export type TeamMemberStatus = 'active' | 'pending' | 'expired';
+
+/**
+ * Normalized team member, shared by the active-members and invited-members
+ * lists so both can render in a single combined list.
+ */
+export interface TeamMember {
+	id: number;
+	email: string;
+	displayName?: string;
+	role?: string;
+	avatar?: string;
+	dateAdded?: string;
+	status: TeamMemberStatus;
+}
+
+/**
+ * Raw active member, as returned by GET /wpcom/v2/agency/{agencyId}/users.
+ */
+export interface AgencyTeamMemberApiResponse {
+	id: number;
+	username: string;
+	email: string;
+	avatar_url: string;
+	role: string;
+	joined_timestamp: string;
+}
+
+/**
+ * Raw invitation, as returned by GET /wpcom/v2/agency/{agencyId}/user-invites.
+ */
+export interface AgencyTeamInviteApiResponse {
+	id: number;
+	email: string;
+	status: string;
+	expires_at: string;
+	created_at: string;
+	avatar_url?: string;
+	username?: string;
+}
+
+export interface AgencyTeamInviteInput {
+	login: string;
+	message?: string;
+}

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -29,6 +29,9 @@ export interface Agency {
 	influenced_revenue?: number;
 	created_at: string;
 	billing_system?: 'billingdragon' | 'legacy';
+	user?: {
+		capabilities: string[];
+	};
 }
 
 /**

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -4,6 +4,7 @@ export * from './error';
 
 export * from './admin-bar';
 export * from './agency';
+export * from './agency-team';
 export * from './akismet-api-key';
 export * from './big-sky-plugin';
 export * from './cancellation-offers';

--- a/packages/api-queries/src/agency-team.ts
+++ b/packages/api-queries/src/agency-team.ts
@@ -40,6 +40,7 @@ export const agencyTeamInvitesQuery = ( agencyId: number ) =>
 				displayName: invite.username,
 				avatar: invite.avatar_url,
 				status: invite.status === 'expired' ? 'expired' : 'pending',
+				dateAdded: invite.created_at,
 			} ) );
 		},
 		enabled: !! agencyId,
@@ -48,6 +49,13 @@ export const agencyTeamInvitesQuery = ( agencyId: number ) =>
 function invalidateAgencyTeam( agencyId: number ) {
 	queryClient.invalidateQueries( { queryKey: [ 'agency', agencyId, 'team-members' ] } );
 	queryClient.invalidateQueries( { queryKey: [ 'agency', agencyId, 'team-invites' ] } );
+}
+
+// Ownership transfer changes the current user's role and capabilities, which
+// the agency identity queries expose (e.g. canRemove, owner/member labels).
+function invalidateActiveAgency() {
+	queryClient.invalidateQueries( { queryKey: [ 'agency' ], exact: true } );
+	queryClient.invalidateQueries( { queryKey: [ 'agency', 'active' ], exact: true } );
 }
 
 export const agencyTeamInviteMutation = ( agencyId: number ) =>
@@ -59,6 +67,7 @@ export const agencyTeamInviteMutation = ( agencyId: number ) =>
 export const agencyTeamResendInviteMutation = ( agencyId: number ) =>
 	mutationOptions( {
 		mutationFn: ( inviteId: number ) => resendAgencyTeamInvite( agencyId, inviteId ),
+		onSuccess: () => invalidateAgencyTeam( agencyId ),
 	} );
 
 export const agencyTeamCancelInviteMutation = ( agencyId: number ) =>
@@ -76,5 +85,8 @@ export const agencyTeamRemoveMemberMutation = ( agencyId: number ) =>
 export const agencyTeamTransferOwnershipMutation = ( agencyId: number ) =>
 	mutationOptions( {
 		mutationFn: ( newOwnerId: number ) => transferAgencyOwnership( agencyId, newOwnerId ),
-		onSuccess: () => invalidateAgencyTeam( agencyId ),
+		onSuccess: () => {
+			invalidateAgencyTeam( agencyId );
+			invalidateActiveAgency();
+		},
 	} );

--- a/packages/api-queries/src/agency-team.ts
+++ b/packages/api-queries/src/agency-team.ts
@@ -14,33 +14,35 @@ import type { AgencyTeamInviteInput, TeamMember } from '@automattic/api-core';
 export const agencyTeamMembersQuery = ( agencyId: number ) =>
 	queryOptions( {
 		queryKey: [ 'agency', agencyId, 'team-members' ] as const,
-		queryFn: () => fetchAgencyTeamMembers( agencyId ),
-		enabled: !! agencyId,
-		select: ( data ): TeamMember[] =>
-			data.map( ( member ) => ( {
+		queryFn: async (): Promise< TeamMember[] > => {
+			const data = await fetchAgencyTeamMembers( agencyId );
+			return data.map( ( member ) => ( {
 				id: member.id,
 				email: member.email,
 				displayName: member.username,
 				avatar: member.avatar_url,
 				role: member.role,
-				status: 'active',
+				status: 'active' as const,
 				dateAdded: member.joined_timestamp,
-			} ) ),
+			} ) );
+		},
+		enabled: !! agencyId,
 	} );
 
 export const agencyTeamInvitesQuery = ( agencyId: number ) =>
 	queryOptions( {
 		queryKey: [ 'agency', agencyId, 'team-invites' ] as const,
-		queryFn: () => fetchAgencyTeamInvites( agencyId ),
-		enabled: !! agencyId,
-		select: ( data ): TeamMember[] =>
-			data.map( ( invite ) => ( {
+		queryFn: async (): Promise< TeamMember[] > => {
+			const data = await fetchAgencyTeamInvites( agencyId );
+			return data.map( ( invite ) => ( {
 				id: invite.id,
 				email: invite.email,
 				displayName: invite.username,
 				avatar: invite.avatar_url,
 				status: invite.status === 'expired' ? 'expired' : 'pending',
-			} ) ),
+			} ) );
+		},
+		enabled: !! agencyId,
 	} );
 
 function invalidateAgencyTeam( agencyId: number ) {

--- a/packages/api-queries/src/agency-team.ts
+++ b/packages/api-queries/src/agency-team.ts
@@ -1,0 +1,78 @@
+import {
+	fetchAgencyTeamMembers,
+	fetchAgencyTeamInvites,
+	inviteAgencyTeamMember,
+	resendAgencyTeamInvite,
+	cancelAgencyTeamInvite,
+	removeAgencyTeamMember,
+	transferAgencyOwnership,
+} from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+import type { AgencyTeamInviteInput, TeamMember } from '@automattic/api-core';
+
+export const agencyTeamMembersQuery = ( agencyId: number ) =>
+	queryOptions( {
+		queryKey: [ 'agency', agencyId, 'team-members' ] as const,
+		queryFn: () => fetchAgencyTeamMembers( agencyId ),
+		enabled: !! agencyId,
+		select: ( data ): TeamMember[] =>
+			data.map( ( member ) => ( {
+				id: member.id,
+				email: member.email,
+				displayName: member.username,
+				avatar: member.avatar_url,
+				role: member.role,
+				status: 'active',
+				dateAdded: member.joined_timestamp,
+			} ) ),
+	} );
+
+export const agencyTeamInvitesQuery = ( agencyId: number ) =>
+	queryOptions( {
+		queryKey: [ 'agency', agencyId, 'team-invites' ] as const,
+		queryFn: () => fetchAgencyTeamInvites( agencyId ),
+		enabled: !! agencyId,
+		select: ( data ): TeamMember[] =>
+			data.map( ( invite ) => ( {
+				id: invite.id,
+				email: invite.email,
+				displayName: invite.username,
+				avatar: invite.avatar_url,
+				status: invite.status === 'expired' ? 'expired' : 'pending',
+			} ) ),
+	} );
+
+function invalidateAgencyTeam( agencyId: number ) {
+	queryClient.invalidateQueries( { queryKey: [ 'agency', agencyId, 'team-members' ] } );
+	queryClient.invalidateQueries( { queryKey: [ 'agency', agencyId, 'team-invites' ] } );
+}
+
+export const agencyTeamInviteMutation = ( agencyId: number ) =>
+	mutationOptions( {
+		mutationFn: ( input: AgencyTeamInviteInput ) => inviteAgencyTeamMember( agencyId, input ),
+		onSuccess: () => invalidateAgencyTeam( agencyId ),
+	} );
+
+export const agencyTeamResendInviteMutation = ( agencyId: number ) =>
+	mutationOptions( {
+		mutationFn: ( inviteId: number ) => resendAgencyTeamInvite( agencyId, inviteId ),
+	} );
+
+export const agencyTeamCancelInviteMutation = ( agencyId: number ) =>
+	mutationOptions( {
+		mutationFn: ( inviteId: number ) => cancelAgencyTeamInvite( agencyId, inviteId ),
+		onSuccess: () => invalidateAgencyTeam( agencyId ),
+	} );
+
+export const agencyTeamRemoveMemberMutation = ( agencyId: number ) =>
+	mutationOptions( {
+		mutationFn: ( userId: number ) => removeAgencyTeamMember( agencyId, userId ),
+		onSuccess: () => invalidateAgencyTeam( agencyId ),
+	} );
+
+export const agencyTeamTransferOwnershipMutation = ( agencyId: number ) =>
+	mutationOptions( {
+		mutationFn: ( newOwnerId: number ) => transferAgencyOwnership( agencyId, newOwnerId ),
+		onSuccess: () => invalidateAgencyTeam( agencyId ),
+	} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -1,6 +1,7 @@
 export * from './query-client';
 
 export * from './agency';
+export * from './agency-team';
 export * from './akismet-api-key';
 export * from './big-sky-plugin';
 export * from './cancellation-offers';


### PR DESCRIPTION
Resolves A4A-2860

**Part 1 of 2** — split from the original PR. This adds the new Team screen to the Dashboard. The follow-up #112374 brings the same screen to the current A4A app.

## Proposed Changes

* Adds a **Team** screen to the A4A Dashboard, reachable from the sidebar (`/team`).
* Shows all team members and pending invitations together in one list, with a status filter (Active / Invite pending / Invite expired) and search by name or email.
* Lets you invite a member, resend or cancel an invite, transfer ownership, and remove a member or leave the agency.
* The screen is built to be shared, so the same experience can be brought to the current A4A app in the follow-up PR.

## Why are these changes being made?

The two separate "Active members" and "Invited members" tabs are being combined into a single list with a status filter, and this brings that new experience to the Dashboard.

## Testing Instructions

* Open the Dashboard (A4A) live link > Replace the /sites with /overview and you'll be redirected to A4A (This is a known issue, will be fixed later) and go to **Team** (`/team`) from the sidebar.
    * Confirm the combined list shows active members (agency owner first) followed by invited members, each with a status badge, and that the **Status** filter works.
    * Confirm filter and search works as expected.
    * Confirm search matches on both name and email, and that the default order is preserved (members from `/users`, then invites from `/user-invites`).
    * Invite a team member (with and without a message), then resend / cancel an invite, transfer ownership, and remove a member / leave the agency — confirm each action works and the list updates.
    * Hard-refresh `/team` and confirm it loads (no "Cannot GET /team").

<img width="1916" height="525" alt="Screenshot 2026-07-06 at 12 33 15 PM" src="https://github.com/user-attachments/assets/fe43f449-177e-4338-a920-06eb53ad4b55" />

<img width="470" height="250" alt="Screenshot 2026-07-06 at 12 33 30 PM" src="https://github.com/user-attachments/assets/c4d365cb-8b23-47ba-94c3-585836b27740" />

<img width="451" height="190" alt="Screenshot 2026-07-06 at 12 33 44 PM" src="https://github.com/user-attachments/assets/a7589fe1-92fa-429e-9cb4-585836b27740" />

<img width="456" height="199" alt="Screenshot 2026-07-06 at 12 34 28 PM" src="https://github.com/user-attachments/assets/86ab7219-19a9-428a-a90c-6a73c123695d" />

<img width="596" height="417" alt="Screenshot 2026-07-06 at 12 34 36 PM" src="https://github.com/user-attachments/assets/676f4ce0-5e4f-456f-8ccf-bc6d1b2f99a5" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
