### PR TITLE
Dashboard: fix mobile site/domain switcher opening off-screen

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -23,7 +23,8 @@ export type SwitcherProps< T > = {
 	icon?: React.JSX.Element;
 	onItemClick?: () => void;
 	renderToggle?: RenderToggle;
-} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' | 'popoverProps' >;
+	headerTitle?: string;
+} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >;
 
 const DEFAULT_POPOVER_PROPS: ComponentProps< typeof Dropdown >[ 'popoverProps' ] = {
 	placement: 'bottom-start',
@@ -51,10 +52,13 @@ function Switcher< T >( {
 	onToggle,
 	defaultOpen,
 	renderToggle,
-	popoverProps,
+	headerTitle,
 }: SwitcherProps< T > ) {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const isDesktop = useViewportMatch( 'medium' );
+	// Below the medium breakpoint the Popover renders as a full-screen sheet
+	// (expandOnMobile); the 100% content width relies on that, so both flip here.
+	const isMobile = ! isDesktop;
 	const renderDropdownToggle: RenderToggle = ( { isOpen, onToggle, ...props } ) => {
 		if ( renderToggle ) {
 			return renderToggle( { isOpen, onToggle, ...props } );
@@ -91,8 +95,8 @@ function Switcher< T >( {
 			open={ open }
 			onToggle={ onToggle }
 			defaultOpen={ defaultOpen }
-			expandOnMobile={ ! isDesktop }
-			popoverProps={ { ...DEFAULT_POPOVER_PROPS, ...popoverProps } }
+			expandOnMobile={ isMobile }
+			popoverProps={ { ...DEFAULT_POPOVER_PROPS, headerTitle } }
 			renderToggle={ renderDropdownToggle }
 			renderContent={ ( { onClose } ) => (
 				<SwitcherContent
@@ -102,7 +106,7 @@ function Switcher< T >( {
 					renderItem={ renderItem }
 					view={ view }
 					onChangeView={ setView }
-					width={ isDesktop ? '280px' : '100%' }
+					width={ isMobile ? '100%' : '280px' }
 					onClose={ onClose }
 					onItemClick={ onItemClick }
 				>

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -23,7 +23,13 @@ export type SwitcherProps< T > = {
 	icon?: React.JSX.Element;
 	onItemClick?: () => void;
 	renderToggle?: RenderToggle;
-} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >;
+} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' | 'popoverProps' >;
+
+const DEFAULT_POPOVER_PROPS: ComponentProps< typeof Dropdown >[ 'popoverProps' ] = {
+	placement: 'bottom-start',
+	offset: 4,
+	shift: true,
+};
 
 const DEFAULT_VIEW: View = {
 	type: 'list',
@@ -45,6 +51,7 @@ function Switcher< T >( {
 	onToggle,
 	defaultOpen,
 	renderToggle,
+	popoverProps,
 }: SwitcherProps< T > ) {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const isDesktop = useViewportMatch( 'medium' );
@@ -84,6 +91,7 @@ function Switcher< T >( {
 			open={ open }
 			onToggle={ onToggle }
 			defaultOpen={ defaultOpen }
+			popoverProps={ { ...DEFAULT_POPOVER_PROPS, ...popoverProps } }
 			renderToggle={ renderDropdownToggle }
 			renderContent={ ( { onClose } ) => (
 				<SwitcherContent

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -91,6 +91,7 @@ function Switcher< T >( {
 			open={ open }
 			onToggle={ onToggle }
 			defaultOpen={ defaultOpen }
+			expandOnMobile={ ! isDesktop }
 			popoverProps={ { ...DEFAULT_POPOVER_PROPS, ...popoverProps } }
 			renderToggle={ renderDropdownToggle }
 			renderContent={ ( { onClose } ) => (
@@ -101,6 +102,7 @@ function Switcher< T >( {
 					renderItem={ renderItem }
 					view={ view }
 					onChangeView={ setView }
+					width={ isDesktop ? '280px' : '100%' }
 					onClose={ onClose }
 					onItemClick={ onItemClick }
 				>

--- a/client/dashboard/components/switcher/switcher-content.scss
+++ b/client/dashboard/components/switcher/switcher-content.scss
@@ -1,4 +1,11 @@
+@import '@wordpress/base-styles/variables';
+
+.components-dropdown__content .components-menu-group.switcher-content__search {
+	padding-block: $grid-unit-20 $grid-unit-10;
+	padding-inline: $grid-unit-10 + $grid-unit-15;
+}
+
 .switcher-content__no-results {
 	display: block;
-	padding: 8px 12px;
+	padding: $grid-unit-10 $grid-unit-15;
 }

--- a/client/dashboard/components/switcher/switcher-content.scss
+++ b/client/dashboard/components/switcher/switcher-content.scss
@@ -5,6 +5,7 @@
 	padding-inline: $grid-unit-10 + $grid-unit-15;
 }
 
+.switcher-content__loading,
 .switcher-content__no-results {
 	display: block;
 	padding: $grid-unit-10 $grid-unit-15;

--- a/client/dashboard/components/switcher/switcher-content.scss
+++ b/client/dashboard/components/switcher/switcher-content.scss
@@ -1,7 +1,7 @@
 @import '@wordpress/base-styles/variables';
 
-.components-dropdown__content .components-menu-group.switcher-content__search {
-	padding-block: $grid-unit-20 $grid-unit-10;
+.switcher-content__search {
+	padding-block: $grid-unit-20 $grid-unit-05 * 0.5;
 	padding-inline: $grid-unit-10 + $grid-unit-15;
 }
 

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -18,7 +18,7 @@ export default function SwitcherContent< T >( {
 	itemClassName,
 	items,
 	searchableFields,
-	searchClassName,
+	searchClassName = 'switcher-content__search',
 	view,
 	onChangeView,
 	width = '280px',
@@ -65,7 +65,11 @@ export default function SwitcherContent< T >( {
 	}, [ searchableFields, filterField ] );
 
 	if ( ! items ) {
-		return __( 'Loading…' );
+		return (
+			<Text variant="muted" className="switcher-content__loading">
+				{ __( 'Loading…' ) }
+			</Text>
+		);
 	}
 
 	const { data: filteredData } = filterSortAndPaginate( items, view, fields );
@@ -83,16 +87,14 @@ export default function SwitcherContent< T >( {
 
 	return (
 		<NavigableMenu style={ { width } }>
-			<div className="switcher-content__search">
-				{ filter ? (
-					<HStack justify="flex-start">
-						{ search }
-						{ filter }
-					</HStack>
-				) : (
-					search
-				) }
-			</div>
+			{ filter ? (
+				<HStack justify="flex-start">
+					{ search }
+					{ filter }
+				</HStack>
+			) : (
+				search
+			) }
 			<MenuGroup hideSeparator>
 				{ filteredData.length === 0 ? (
 					<Text variant="muted" className="switcher-content__no-results">

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -83,7 +83,7 @@ export default function SwitcherContent< T >( {
 
 	return (
 		<NavigableMenu style={ { width } }>
-			<MenuGroup>
+			<MenuGroup className="switcher-content__search">
 				{ filter ? (
 					<HStack justify="flex-start">
 						{ search }

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -83,7 +83,7 @@ export default function SwitcherContent< T >( {
 
 	return (
 		<NavigableMenu style={ { width } }>
-			<MenuGroup className="switcher-content__search">
+			<div className="switcher-content__search">
 				{ filter ? (
 					<HStack justify="flex-start">
 						{ search }
@@ -92,7 +92,7 @@ export default function SwitcherContent< T >( {
 				) : (
 					search
 				) }
-			</MenuGroup>
+			</div>
 			<MenuGroup hideSeparator>
 				{ filteredData.length === 0 ? (
 					<Text variant="muted" className="switcher-content__no-results">

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -21,7 +21,7 @@ export default function SwitcherContent< T >( {
 	searchClassName,
 	view,
 	onChangeView,
-	width = '280px',
+	width = 'min(280px, calc(100vw - 32px))',
 	getItemUrl,
 	renderItem,
 	resetScroll = true,

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -21,7 +21,7 @@ export default function SwitcherContent< T >( {
 	searchClassName,
 	view,
 	onChangeView,
-	width = 'min(280px, calc(100vw - 32px))',
+	width = '280px',
 	getItemUrl,
 	renderItem,
 	resetScroll = true,

--- a/client/dashboard/domains/domain-switcher/index.tsx
+++ b/client/dashboard/domains/domain-switcher/index.tsx
@@ -1,6 +1,7 @@
 import { DomainSubtype } from '@automattic/api-core';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
@@ -41,6 +42,7 @@ export default function DomainSwitcher( {
 			items={ domains }
 			value={ domain }
 			searchableFields={ searchableFields }
+			popoverProps={ { headerTitle: __( 'Switch domain' ) } }
 			getItemUrl={ ( d ) => buildCurrentRouteLink( { params: { domainName: d.domain } } ) }
 			renderToggle={ renderToggle }
 			renderItem={ ( { item, context } ) => (

--- a/client/dashboard/domains/domain-switcher/index.tsx
+++ b/client/dashboard/domains/domain-switcher/index.tsx
@@ -42,7 +42,7 @@ export default function DomainSwitcher( {
 			items={ domains }
 			value={ domain }
 			searchableFields={ searchableFields }
-			popoverProps={ { headerTitle: __( 'Switch domain' ) } }
+			headerTitle={ __( 'Switch domain' ) }
 			getItemUrl={ ( d ) => buildCurrentRouteLink( { params: { domainName: d.domain } } ) }
 			renderToggle={ renderToggle }
 			renderItem={ ( { item, context } ) => (

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/breakpoints';
 @import './variables.scss';
 
 .plugin-switcher-card {
@@ -8,6 +9,10 @@
 	max-height: $card-height;
 	padding: 8px 0 0;
 	overflow-y: auto;
+
+	@media ( max-width: $break-medium ) {
+		padding-block-start: 0;
+	}
 }
 
 .plugin-switcher-search {

--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -65,7 +65,7 @@ export const SiteSwitcherBase = (
 			items={ sites }
 			value={ site }
 			searchableFields={ searchableFields }
-			popoverProps={ { headerTitle: __( 'Switch site' ) } }
+			headerTitle={ __( 'Switch site' ) }
 			getItemUrl={ ( site ) => {
 				if ( canManageSite( site ) ) {
 					return buildCurrentRouteLink( { params: { siteSlug: site.slug } } );

--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
@@ -64,6 +65,7 @@ export const SiteSwitcherBase = (
 			items={ sites }
 			value={ site }
 			searchableFields={ searchableFields }
+			popoverProps={ { headerTitle: __( 'Switch site' ) } }
 			getItemUrl={ ( site ) => {
 				if ( canManageSite( site ) ) {
 					return buildCurrentRouteLink( { params: { siteSlug: site.slug } } );


### PR DESCRIPTION
Fixes DOTMSD-1394

## Proposed Changes

- On mobile, the site and domain switchers now open as a full-screen sheet with a titled header ("Switch site" / "Switch domain") and a close button, instead of a fixed-width dropdown anchored under the small toggle.
- On desktop the switcher is unchanged — the compact anchored dropdown — but it now enables the popover's `shift` so it can't spill past the viewport edge.
- Aligned the search field's padding with the item list so it no longer sits flush against the panel edge. The padding is applied via the shared `searchClassName` (defaulting to `switcher-content__search`), so consumers that provide their own search class — e.g. the plugin switcher — opt out and keep their own layout. Its 20px inline padding mirrors the item inset (menu-group padding + button padding); all values use grid-unit tokens rather than hardcoded pixels.
- Wrapped the switcher's loading/empty states in a padded `Text` so "Loading…" and "No results" line up with the rest of the panel instead of sitting flush.
- On mobile (below the medium breakpoint), dropped the plugin switcher card's top padding, which looked cramped.

**Screenshot**

| Before | After |
|--------|--------|
| <img width="750" height="1334" alt="my wordpress com_sites_abstracting blog(iPhone SE) (1)" src="https://github.com/user-attachments/assets/84f0b2b2-9033-41aa-8a76-398be24b495d" /> | <img width="750" height="1334" alt="my localhost_3000_domains(iPhone SE)" src="https://github.com/user-attachments/assets/bf89ec7e-4aab-4ff2-a9ca-016ba5c305b5" /> |
| <img width="750" height="1334" alt="my wordpress com_sites_abstracting blog(iPhone SE)" src="https://github.com/user-attachments/assets/bd6ec2f8-32bb-447b-ba7d-665ca1dd98a7" /> | <img width="750" height="1334" alt="my localhost_3000_sites_abstracting blog(iPhone SE)" src="https://github.com/user-attachments/assets/c004d224-f1e3-48bb-aa0d-59245ef2b068" /> | 


## Why are these changes being made?

The switcher dropdown was rendered with no viewport constraint, so on narrow screens it opened partially off the left edge, clipping site icons and text. A fixed-width dropdown anchored under a tiny toggle is a desktop pattern; cramming it onto a phone always looks wrong. Presenting it as a full-screen sheet below the mobile breakpoint is clearer and gives it room to breathe.

The fix lives in the shared switcher, so both the site switcher (sidebar) and the domain switcher are covered.

## Testing Instructions

Mobile (or narrow the window below ~782px):
1. Open the Multi-site Dashboard and enter a single site.
2. In the sidebar header, tap the up/down switch toggle.
3. Expect a full-screen sheet titled "Switch site" with the search box, site list, and a close (X) — nothing clipped off-screen.
4. Repeat on a domain's page for the domain switcher ("Switch domain").

Desktop (≥782px):
- The switcher still opens as the compact dropdown, and stays within the viewport.

## Considerations

The first pass just enabled `shift` to stop the clipping, but that only kept the panel on-screen while it was still cramped against the edge. Switching to a full-screen sheet on mobile (via the Popover's `expandOnMobile`) addresses the actual UX problem; `shift` remains as a safety net for the desktop dropdown.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

