### PR TITLE
Plugins per-plugin "Get started": show the plans grid instead of forcing Business

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1,6 +1,11 @@
 import { getTracksAnonymousUserId, recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { WPCOM_DIFM_LITE, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import {
+	WPCOM_DIFM_LITE,
+	PRODUCT_1GB_SPACE,
+	getPlan,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site, AddOns } from '@automattic/data-stores';
 import { STORAGE_ADD_ONS } from '@automattic/data-stores/src/add-ons';
@@ -466,6 +471,21 @@ export function submitWebsiteContent( callback, { siteSlug }, step, reduxStore )
 		} );
 }
 
+/**
+ * Maps the plan the user selected to the marketplace plugin's subscription term (MONTHLY or
+ * ANNUALLY), so the plan and plugin terms stay in sync. Multi-year plans use the plugin's annual
+ * term. Falls back to `fallbackBillingPeriod` (the CTA default) when the plan term is unknown.
+ */
+export function getPluginBillingPeriodForPlan( planSlug, fallbackBillingPeriod ) {
+	const planTerm = planSlug ? getPlan( planSlug )?.term : undefined;
+
+	if ( ! planTerm ) {
+		return fallbackBillingPeriod;
+	}
+
+	return planTerm === TERM_MONTHLY ? 'MONTHLY' : 'ANNUALLY';
+}
+
 function findMarketplacePlugin( state, pluginSlug, billingPeriod = '' ) {
 	const plugins = getMarketplaceProducts( state, pluginSlug );
 	const billingPeriodToTerm = {
@@ -597,7 +617,17 @@ export function addWithPluginPlanToCart( callback, dependencies, stepProvidedIte
 	const { cartItems, lastKnownFlow } = stepProvidedItems;
 
 	reduxStore.dispatch( requestProductsList( { type: 'all' } ) ).then( () => {
-		const marketplacePlugin = findMarketplacePlugin( reduxStore.getState(), plugin, billingPeriod );
+		const state = reduxStore.getState();
+
+		// Match the plugin's subscription term to the plan the user picked in the grid, so the
+		// plan and plugin terms don't diverge (billing_period from the CTA is only the default).
+		// Fall back to the CTA term, then to any available plugin variant.
+		const planSlug = getPlanCartItem( cartItems )?.product_slug;
+		const pluginBillingPeriod = getPluginBillingPeriodForPlan( planSlug, billingPeriod );
+
+		const marketplacePlugin =
+			findMarketplacePlugin( state, plugin, pluginBillingPeriod ) ||
+			findMarketplacePlugin( state, plugin );
 		const providedDependencies = { cartItems };
 
 		const newCartItems = [ ...( cartItems ? cartItems : [] ), marketplacePlugin ].filter(

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -4,7 +4,12 @@
 
 import nock from 'nock';
 import flows from 'calypso/signup/config/flows';
-import { createSiteWithCart, isDomainFulfilled, isPlanFulfilled } from '../step-actions';
+import {
+	createSiteWithCart,
+	isDomainFulfilled,
+	isPlanFulfilled,
+	getPluginBillingPeriodForPlan,
+} from '../step-actions';
 
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
 jest.mock( 'calypso/signup/config/flows', () => require( './mocks/signup/config/flows' ) );
@@ -261,5 +266,25 @@ describe( 'isPlanFulfilled()', () => {
 
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 		expect( submitSignupStep ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getPluginBillingPeriodForPlan()', () => {
+	it( 'matches the plugin term to a monthly plan', () => {
+		expect( getPluginBillingPeriodForPlan( 'personal-bundle-monthly', 'ANNUALLY' ) ).toBe(
+			'MONTHLY'
+		);
+	} );
+
+	it( 'matches the plugin term to an annual plan', () => {
+		expect( getPluginBillingPeriodForPlan( 'personal-bundle', 'MONTHLY' ) ).toBe( 'ANNUALLY' );
+	} );
+
+	it( 'maps multi-year plans to the annual plugin term', () => {
+		expect( getPluginBillingPeriodForPlan( 'business-bundle-2y', 'MONTHLY' ) ).toBe( 'ANNUALLY' );
+	} );
+
+	it( 'falls back to the CTA billing period when no plan is selected', () => {
+		expect( getPluginBillingPeriodForPlan( undefined, 'ANNUALLY' ) ).toBe( 'ANNUALLY' );
 	} );
 } );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -122,10 +122,11 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-plugin',
-			steps: [ userSocialStep, 'domains', 'plans-business-with-plugin' ],
+			steps: [ userSocialStep, 'domains', 'plans-with-plugin' ],
 			destination: getWithPluginDestination,
-			description: 'Preselect a plugin to activate/buy, a Business plan is needed',
-			lastModified: '2023-10-11',
+			description:
+				'Preselect a plugin to activate/buy, then show the paid plans grid to pick a qualifying plan.',
+			lastModified: '2026-07-07',
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'plugin', 'billing_period' ],
 			hideProgressIndicator: true,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -19,7 +19,7 @@ const stepNameToModuleName = {
 	plans: 'plans',
 	'plans-new': 'plans',
 	'plans-business': 'plans',
-	'plans-business-with-plugin': 'plans',
+	'plans-with-plugin': 'plans',
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
 	'plans-personal': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -269,15 +269,17 @@ export function generateSteps( {
 			},
 		},
 
-		'plans-business-with-plugin': {
-			stepName: 'plans-business-with-plugin',
+		'plans-with-plugin': {
+			stepName: 'plans-with-plugin',
 			apiRequestFunction: addWithPluginPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug', 'plugin', 'billing_period' ],
 			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
 			optionalDependencies: [ 'themeSlugWithRepo' ],
-			defaultDependencies: {
-				cartItem: PLAN_BUSINESS,
+			props: {
+				// Show the paid plans grid (no free plan) and let the user pick any qualifying plan,
+				// rather than forcing Business. The selected plugin is preserved in the cart.
+				intent: 'plans-plugins-lp',
 			},
 		},
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -194,6 +194,11 @@ export const usePlanTypesWithIntent = ( {
 				TYPE_ECOMMERCE,
 			];
 			break;
+		// Logged-out Plugins marketplace "Get started": plugins run on any paid plan, so offer
+		// all paid plans and no free plan.
+		case 'plans-plugins-lp':
+			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			break;
 		case 'plans-upgrade': {
 			// Show current plan plus all higher-tier plans (upgrade options only)
 			const upgradePlanTypes = [

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -70,6 +70,7 @@ export type PlansIntent =
 	| 'plans-new-hosted-site'
 	| 'plans-new-hosted-site-business-only'
 	| 'plans-plugins'
+	| 'plans-plugins-lp'
 	| 'plans-jetpack-app'
 	| 'plans-jetpack-app-site-creation'
 	| 'plans-import'

--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -1,0 +1,98 @@
+import {
+	CartCheckoutPage,
+	DataHelper,
+	DomainSearchComponent,
+	NewUserResponse,
+	PlansPage,
+	RestAPIClient,
+	UserSignupPage,
+} from '@automattic/calypso-e2e';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+
+/**
+ * Verifies the logged-out Plugins marketplace "Get started" signup flow shows the paid plans
+ * grid (with the free plan hidden) and keeps the selected plugin in the cart — instead of
+ * forcing the Business plan / skipping the grid.
+ *
+ * Keywords: Plugins, Marketplace, Signup, Get started, Plan, Checkout
+ */
+test.describe(
+	'Plugins: "Get started" shows the paid plans grid',
+	{ tag: [ tags.CALYPSO_RELEASE ] },
+	() => {
+		const planName = 'Personal';
+		// A paid marketplace plugin, so the flow carries a plugin product into the cart.
+		const pluginSlug = 'sensei-pro';
+		const pluginName = 'Sensei Pro';
+
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'pluginlp' } );
+		let newUserDetails: NewUserResponse | undefined;
+
+		test.afterAll( async () => {
+			if ( ! newUserDetails ) {
+				return;
+			}
+			const restAPIClient = new RestAPIClient(
+				{ username: testUser.username, password: testUser.password },
+				newUserDetails.body.bearer_token
+			);
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
+		} );
+
+		test( 'As a logged-out user, plugin "Get started" leads to the paid plans grid', async ( {
+			page,
+		} ) => {
+			// Signup + site creation dominate the runtime; the 120s default isn't enough.
+			test.setTimeout( 180 * 1000 );
+
+			await test.step( 'When I open the with-plugin flow from a plugin "Get started" CTA', async () => {
+				// The URL the logged-out per-plugin "Get started" CTA builds
+				// (client/my-sites/plugins/plugin-details-CTA/index.jsx).
+				await page.goto(
+					DataHelper.getCalypsoURL( 'start/with-plugin', {
+						plugin: pluginSlug,
+						ref: 'plugins-lp',
+						billing_period: 'ANNUALLY',
+					} )
+				);
+			} );
+
+			await test.step( 'When I sign up as a new user', async () => {
+				const userSignupPage = new UserSignupPage( page );
+				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			await test.step( 'When I choose a free domain', async () => {
+				const domainSearch = new DomainSearchComponent( page );
+				await domainSearch.search( testUser.siteName );
+				await domainSearch.skipPurchase();
+			} );
+
+			await test.step( 'Then the plans step hides the free plan and shows paid plans', async () => {
+				// Plugins require a paid plan, so no free-plan action button is offered.
+				await expect( page.getByRole( 'button', { name: /free/i } ) ).toHaveCount( 0 );
+				// Paid plans are shown (the plan button renders once per grid view, so scope to
+				// the first, matching how PlansPage.selectPlan handles the duplicate).
+				await expect(
+					page.getByRole( 'button', { name: 'Get Personal plan' } ).first()
+				).toBeVisible();
+			} );
+
+			await test.step( `When I select the ${ planName } plan`, async () => {
+				const plansPage = new PlansPage( page );
+				await plansPage.selectPlan( planName );
+			} );
+
+			await test.step( `Then checkout contains the ${ planName } plan and the plugin`, async () => {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+				await cartCheckoutPage.validateCartItem( pluginName );
+			} );
+		} );
+	}
+);


### PR DESCRIPTION
Part of DOTPAR-16

## Proposed Changes

- The per-plugin "Get started" CTA (`/start/with-plugin`) no longer force-adds the Business plan and skips the plans grid. It now shows the plans grid so the user can pick a qualifying plan, keeps the selected plugin in the cart, and matches the plugin's billing term to the plan the user chooses.

## Why are these changes being made?

"Get started" on a plugin pushed logged-out users straight into a forced Business checkout. Showing the plans grid lets users choose their plan while preserving the plugin they came for.

## Scope

- This PR covers only the **per-plugin** "Get started" flow (`/start/with-plugin`).
- The **generic** marketplace "Get started" CTAs (discovery footer/in-page CTA and the universal header) are intentionally left as-is and will be handled in a separate follow-up.

## Testing Instructions

1. Log out (or use an incognito window).
2. Open a plugin's page and click "Get started".
3. Create an account and pick/confirm a domain.
4. Confirm you land on the **plans grid** (not a forced Business checkout).
5. Pick a plan; confirm checkout has the selected plan and the plugin, with matching billing terms.

`yarn typecheck-client` passes; unit tests cover the plan/plugin term mapping and the signup step/flow config. An e2e spec drives the flow (`@calypso-release`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
