### PR TITLE
Plugins: pin DataViews footer to bottom of the plugin sites card

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -19,10 +19,12 @@ img.plugin-icon {
 }
 
 .plugin-sites-card-body {
-	max-height: $card-height;
+	height: $card-height;
 	padding-inline-start: 0;
 	padding-inline-end: 0;
-	overflow-y: auto;
+	padding-block-end: 0;
+	display: flex;
+	flex-direction: column;
 }
 
 .plugin-sites-card-managed-notice {

--- a/client/dashboard/plugins/plugin/style.scss
+++ b/client/dashboard/plugins/plugin/style.scss
@@ -17,8 +17,7 @@
 .plugin-tabs-panel {
 	border-top: 1px solid rgba(0, 0, 0, 0.1);
 
-	// Scope the flex fill to the visible panel so it doesn't override the
-	// inactive panel's hidden (display: none) state.
+	// :not([hidden]) is required because display: flex overrides the hidden attribute's display: none.
 	&:not([hidden]) {
 		display: flex;
 		flex-direction: column;

--- a/client/dashboard/plugins/plugin/style.scss
+++ b/client/dashboard/plugins/plugin/style.scss
@@ -16,6 +16,15 @@
 
 .plugin-tabs-panel {
 	border-top: 1px solid rgba(0, 0, 0, 0.1);
+
+	// Scope the flex fill to the visible panel so it doesn't override the
+	// inactive panel's hidden (display: none) state.
+	&:not([hidden]) {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+	}
 }
 
 .plugin-tabs-list,
@@ -28,6 +37,11 @@
 }
 
 .sites-with-this-plugin {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+
 	.dataviews__view-actions, .dataviews-filters__container {
 		padding-inline-start: 20px;
 		padding-inline-end: 20px;


### PR DESCRIPTION
## Proposed Changes

Pin the DataViews footer (pagination / bulk-selection bar) to the bottom of the plugin sites card, and remove the dead space that appeared below it.

- Give the card body a definite `height` and make it a flex column so the DataViews wrapper can fill it and its footer lands at the bottom.
- Let the tab panel and the sites table flex to fill that height, so the DataViews scroll region absorbs the leftover space instead of the whole card body scrolling.
- Zero the card body's bottom padding so the footer sits flush against the card edge.

## Why are these changes being made?

On the Manage plugins screen the footer floated directly beneath the last table row, with empty card space below it, instead of being anchored to the bottom of the card.

The card body used `max-height` + `overflow-y: auto`, so it had no definite height and was just a scroll box. DataViews pins its footer via an internal flex column (`height: 100%`, a middle region with `flex: 1`, and a `flex-shrink: 0` footer), but that only works when the ancestor chain gives the wrapper a real height to distribute. It didn't, so the footer collapsed to content height and the leftover card space showed as a gap. A residual 16px came from the card body's default bottom padding.

## Screenshots

The footer ("1 Item" bulk-selection bar) now sits at the bottom of the card instead of floating directly under the last row.

| Before | After |
|--------|-------|
| ![Before](https://files.catbox.moe/vywvvr.png) | ![After](https://files.catbox.moe/ugxm5d.png) |
|<img width="790" height="81" alt="image" src="https://github.com/user-attachments/assets/5605072d-2823-4408-a5be-56bd9dad51c3" />|<img width="790" height="67" alt="image" src="https://github.com/user-attachments/assets/a450606c-e5bf-4ea1-a743-d1f15e56425c" />|

## Testing Instructions

1. Go to **Plugins → Manage plugins**.
2. Select a plugin that is installed on a few sites (fewer rows than fill the card).
3. Confirm the footer is anchored to the bottom of the card, flush with the card edge, with no empty gap beneath it.
4. Select a plugin installed on many sites and confirm the table scrolls within the card while the footer stays pinned.
5. Switch between the **Installed on** and **Available on** tabs and confirm both behave the same.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

