### PR TITLE
Dashboard: redirect to purchases list after domain removal

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useCallback } from 'react';
-import { purchaseSettingsRoute } from '../../../app/router/me';
+import { purchasesRoute } from '../../../app/router/me';
 import DomainRemovalConfirmationStep from './domain-removal-confirmation-step';
 import DomainRemovalWarningStep from './domain-removal-warning-step';
 import type { Purchase } from '@automattic/api-core';
@@ -45,10 +45,7 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 					),
 					{ type: 'snackbar' }
 				);
-				navigate( {
-					to: purchaseSettingsRoute.fullPath,
-					params: { purchaseId: purchase.ID },
-				} );
+				navigate( { to: purchasesRoute.to } );
 			},
 			onError: () => {
 				const domainName = purchase.meta || purchase.product_name;


### PR DESCRIPTION
## Proposed Changes

* After confirming a domain removal in the Dashboard cancel-purchase flow, redirect to the purchases list instead of the removed purchase's settings page.

## Why are these changes being made?

* The domain removal flow navigated to the settings page of the purchase it had just deleted. The purchase no longer exists at that point, so the user landed on a stale page for the removed domain (rendered from cached data) instead of being taken somewhere meaningful.
* Every other removal path in the cancel-purchase flow already navigates to the purchases list after a successful removal; this brings domain removal in line with them.

## Testing Instructions

1. In the new Dashboard, go to a registered domain you own → Domain overview → Actions → Delete domain.
2. From the purchase settings page, choose Remove and continue through the two-step domain removal flow, then confirm.
3. Verify you are redirected to the purchases list (`/me/billing/purchases`) and a snackbar confirms the domain was removed.
4. Verify you are no longer left on a page for the deleted domain/purchase.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
