### PR TITLE
Plugins: show a loading state instead of a false "0 sites / No results" while loading

### DIFF
--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -4,6 +4,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { SectionHeader } from '../../components/section-header';
+import { TextBlur } from '../../components/text-blur';
 import { SitesWithThisPlugin } from './sites-with-this-plugin';
 import { SitesWithoutThisPlugin } from './sites-without-this-plugin';
 import { SiteWithPluginData } from './use-plugin';
@@ -60,6 +61,17 @@ export function PluginTabs( {
 		[ sitesWithThisPlugin, optimisticDelete ]
 	);
 
+	const installedCount = sitesWithThisPluginExcludingDeleted.length;
+	const installedLabel = sprintf(
+		// translators: %(count)d: the number of sites the plugin is installed on.
+		_n( 'Installed on %(count)d site', 'Installed on %(count)d sites', installedCount ),
+		{ count: installedCount }
+	);
+	// While the site data is still loading the count isn't known yet, so blur the
+	// label into a skeleton instead of asserting a misleading "Installed on 0 sites".
+	const installedTabTitle =
+		isLoading && installedCount === 0 ? <TextBlur>{ installedLabel }</TextBlur> : installedLabel;
+
 	return (
 		<Tabs
 			selectedTabId={ activeTab }
@@ -75,18 +87,7 @@ export function PluginTabs( {
 			 */ }
 			<Tabs.TabList key={ sitesWithThisPluginExcludingDeleted.length } className="plugin-tabs-list">
 				<Tabs.Tab tabId="installed">
-					<SectionHeader
-						level={ 3 }
-						title={ sprintf(
-							// translators: %(count)d: the number of sites the plugin is installed on.
-							_n(
-								'Installed on %(count)d site',
-								'Installed on %(count)d sites',
-								sitesWithThisPluginExcludingDeleted.length
-							),
-							{ count: sitesWithThisPluginExcludingDeleted.length }
-						) }
-					/>
+					<SectionHeader level={ 3 } title={ installedTabTitle } />
 				</Tabs.Tab>
 				<Tabs.Tab tabId="available">
 					<SectionHeader level={ 3 } title={ __( 'Available on' ) } />

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -61,7 +61,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	const availableIcon = useMarketplaceSearchIcon( pluginSlug );
 	const { queries } = useAppContext();
 	const locale = useLocale();
-	// No slug to look up — resolve immediately to avoid a loading flash.
+	// No slug to look up yet — the consumer may still be deriving it.
 	const hasPluginSlug = !! pluginSlug;
 	const {
 		data: sitesPlugins,
@@ -187,10 +187,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 			  isLoadingWpOrgPlugin ||
 			  isLoadingMarketplacePlugins ||
 			  isLoadingSitePlugins
-			: // No slug yet: a consumer may still be deriving it from the plugins
-			  // list (e.g. the manage page defaults to the first plugin). Report
-			  // loading until that list resolves so the detail's DataViews shows a
-			  // spinner instead of latching onto an empty "No results" state.
+			: // Report loading while the slug is pending so DataViews doesn't latch an empty state.
 			  isLoadingSitesPlugins || isLoadingSites,
 		isFetching: isFetchingSitePlugins,
 		pluginBySiteId,

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -181,13 +181,17 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	}
 
 	return {
-		isLoading:
-			hasPluginSlug &&
-			( isLoadingSitesPlugins ||
-				isLoadingSites ||
-				isLoadingWpOrgPlugin ||
-				isLoadingMarketplacePlugins ||
-				isLoadingSitePlugins ),
+		isLoading: hasPluginSlug
+			? isLoadingSitesPlugins ||
+			  isLoadingSites ||
+			  isLoadingWpOrgPlugin ||
+			  isLoadingMarketplacePlugins ||
+			  isLoadingSitePlugins
+			: // No slug yet: a consumer may still be deriving it from the plugins
+			  // list (e.g. the manage page defaults to the first plugin). Report
+			  // loading until that list resolves so the detail's DataViews shows a
+			  // spinner instead of latching onto an empty "No results" state.
+			  isLoadingSitesPlugins || isLoadingSites,
 		isFetching: isFetchingSitePlugins,
 		pluginBySiteId,
 		sitesWithThisPlugin,


### PR DESCRIPTION
## Proposed Changes

On the Manage plugins screen, the plugin detail pane briefly asserted a false empty state while loading — the tab read **“Installed on 0 sites”** and the table showed **“No results”** for a few seconds, even though the plugin list on the left already showed the correct count. It then resolved to the real value.

- `usePlugin`: report `isLoading` while the plugin slug is still being resolved (no slug yet, plugins list still loading), instead of resolving to “not loading”.
- `PluginTabs`: while the site data is still loading, render the “Installed on N sites” tab label as a blurred skeleton rather than asserting “Installed on 0 sites”.

## Why are these changes being made?

The manage page derives the selected plugin from the plugins list, so on a cold load the detail mounts with an **empty slug**. `usePlugin('')` returned `isLoading: false` (a `hasPluginSlug &&` guard meant to short-circuit when there is genuinely no plugin). DataViews latches its “has initially loaded” flag from the first `isLoading` value it sees — so it latched onto empty data and rendered “No results”, and never showed a spinner even once the real slug resolved and data began loading. The tab count showed 0 for the same reason.

Reporting loading during slug resolution lets DataViews show its normal loading state, and gating the tab label avoids briefly claiming the plugin is installed on 0 sites.

## Testing Instructions

1. Open **Plugins → Manage plugins** with a cold cache (hard refresh).
2. Watch the detail pane for the first plugin as it loads.
3. Confirm you see a **loading state** (skeleton tab label + table spinner) rather than “Installed on 0 sites” / “No results”, and that it resolves to the correct count and rows.
4. Select other plugins and confirm the detail still updates correctly.
5. Confirm a plugin that is genuinely installed on 0 sites still shows “Installed on 0 sites” once loaded.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
