### PR TITLE
Remove redundant lodash ESLint rules and the unused @types/lodash dep

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -28,14 +28,6 @@ module.exports = {
 							'@testing-library/jest-dom is already globally provided by our test setup framework.',
 					},
 				],
-				paths: [
-					// Use Redux's `compose` instead of lodash's `flowRight`.
-					{
-						name: 'lodash',
-						importNames: [ 'flowRight' ],
-						message: "Please use `compose` from 'redux' instead.",
-					},
-				],
 			},
 		],
 		'jest/no-mocks-import': 'off',

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -88,11 +88,6 @@ module.exports = {
 						],
 						message: 'Importing from @automattic/ is not allowed in the dashboard folder.',
 					},
-					{
-						group: [ 'lodash' ],
-						message:
-							'Lodash is not allowed in the dashboard folder. Use native JavaScript methods instead.',
-					},
 				],
 				paths: [
 					{
@@ -113,10 +108,6 @@ module.exports = {
 					{
 						name: 'i18n-calypso',
 						message: 'Please use the @wordpress/i18n package instead of the i18n-calypso package.',
-					},
-					{
-						name: 'lodash',
-						message: 'Please use native JavaScript instead of lodash.',
 					},
 					{
 						name: 'moment',

--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
 		"@types/debug": "^4.1.12",
 		"@types/fast-json-stable-stringify": "^2.0.0",
 		"@types/jest": "^29.5.14",
-		"@types/lodash": "^4.17.17",
 		"@types/node": "^24.12.2",
 		"@types/page": "^1.11.9",
 		"@types/qs": "^6.9.7",

--- a/packages/i18n-utils/.eslintrc.js
+++ b/packages/i18n-utils/.eslintrc.js
@@ -1,23 +1,4 @@
 module.exports = {
-	rules: {
-		'no-restricted-imports': [
-			'warn',
-			{
-				paths: [
-					{
-						name: 'lodash',
-						message: 'Please use native JavaScript instead of lodash in this package.',
-					},
-				],
-				patterns: [
-					{
-						group: [ 'lodash/*' ],
-						message: 'Please use native JavaScript instead of lodash in this package.',
-					},
-				],
-			},
-		],
-	},
 	overrides: [
 		{
 			files: [ '*.md.js' ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9507,7 +9507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.14.172, @types/lodash@npm:^4.17.17":
+"@types/lodash@npm:^4.14.172":
   version: 4.17.17
   resolution: "@types/lodash@npm:4.17.17"
   checksum: 8e75df02a15f04d4322c5a503e4efd0e7a92470570ce80f17e9f11ce2b1f1a7c994009c9bcff39f07e0f9ffd8ccaff09b3598997c404b801abd5a7eee5a639dc
@@ -33630,7 +33630,6 @@ __metadata:
     "@types/gtag.js": "npm:^0.0.20"
     "@types/jest": "npm:^29.5.14"
     "@types/jest-when": "npm:^3.5.5"
-    "@types/lodash": "npm:^4.17.17"
     "@types/node": "npm:^24.12.2"
     "@types/page": "npm:^1.11.9"
     "@types/qs": "npm:^6.9.7"


### PR DESCRIPTION
## Proposed Changes

* Remove the per-folder lodash `no-restricted-imports` entries in the client, dashboard, and i18n-utils ESLint configs.
* Drop the now-unused `@types/lodash` direct devDependency from the root manifest.

## Why are these changes being made?

`wpcalypso/no-import-lodash` already bans every lodash import globally (`lodash`, `lodash/*`, and `lodash-es`), so the per-folder `no-restricted-imports` lodash rules can never fire on their own — they only produced duplicate errors on the same import (in the dashboard folder, a lodash import reported up to three times). Removing them keeps full coverage while eliminating the redundancy.

No first-party code imports lodash, so its type package is no longer needed as a direct devDependency. It remains in the dependency tree transitively (several `@visx` packages depend on it), so nothing that relies on it breaks; this only drops a dead entry from the root manifest.

## Testing Instructions

* `yarn eslint <file in client/, client/dashboard/, or packages/i18n-utils/>` — configs load cleanly.
* Add `import { map } from 'lodash';` to a file in each of those folders and lint — reported exactly once, by `wpcalypso/no-import-lodash`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
