### PR TITLE
E2E: probe the domain add-to-cart availability pre-check flake

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -1,5 +1,6 @@
-import { Locator, Page, Response } from 'playwright';
+import { Locator, Page, Request, Response } from 'playwright';
 import { reloadAndRetry, waitForElementEnabled } from '../../element-helper';
+import { flakeProbe } from '../flake-probe';
 
 type CartResponseDiagnostic = {
 	method: string;
@@ -11,12 +12,41 @@ type CartResponseDiagnostic = {
 	responseError?: string;
 };
 
+// ponytail: throwaway. The add-to-cart mutation runs a domain-availability
+// pre-check (GET /domains/<name>/is-available) before POSTing to the cart. When
+// that GET fails transiently the CTA flips to the error state, but the existing
+// diagnostics only capture the shopping-cart POSTs, so the real failure is
+// invisible. Captures the availability request too. Remove with flake-probe.ts.
+type AvailabilityDiagnostic = {
+	kind: 'response' | 'requestfailed';
+	method: string;
+	url: string;
+	status?: number;
+	ok?: boolean;
+	durationMs?: number;
+	failureText?: string;
+	bodyError?: string;
+};
+
 const isShoppingCartResponse = ( response: Response ): boolean => {
 	try {
 		return new URL( response.url() ).pathname.includes( '/me/shopping-cart/' );
 	} catch {
 		return response.url().includes( '/me/shopping-cart/' );
 	}
+};
+
+const isAvailabilityRequest = ( url: string ): boolean => {
+	try {
+		return new URL( url ).pathname.includes( '/is-available' );
+	} catch {
+		return url.includes( '/is-available' );
+	}
+};
+
+const requestDurationMs = ( request: Request ): number | undefined => {
+	const responseEnd = request.timing().responseEnd;
+	return responseEnd >= 0 ? Math.round( responseEnd ) : undefined;
 };
 
 const normalizeText = ( value?: string | null ): string =>
@@ -62,6 +92,44 @@ const summarizeCartResponse = async ( response: Response ): Promise< CartRespons
 
 	return diagnostic;
 };
+
+// ponytail: throwaway. Summarizes an availability GET response, including a
+// short read of the JSON body's error fields when present. Remove with
+// flake-probe.ts.
+const summarizeAvailabilityResponse = async (
+	response: Response
+): Promise< AvailabilityDiagnostic > => {
+	const diagnostic: AvailabilityDiagnostic = {
+		kind: 'response',
+		method: response.request().method(),
+		url: response.url(),
+		status: response.status(),
+		ok: response.ok(),
+		durationMs: requestDurationMs( response.request() ),
+	};
+
+	try {
+		const body = await response.json();
+		if ( body?.error || body?.message ) {
+			diagnostic.bodyError = [ body.error, body.message ].filter( Boolean ).join( ': ' );
+		}
+	} catch ( error ) {
+		diagnostic.bodyError = formatError( error );
+	}
+
+	return diagnostic;
+};
+
+// ponytail: throwaway. The availability GET can fail at the network layer
+// (aborted/reset), which never emits a `response` event. Remove with
+// flake-probe.ts.
+const summarizeAvailabilityFailure = ( request: Request ): AvailabilityDiagnostic => ( {
+	kind: 'requestfailed',
+	method: request.method(),
+	url: request.url(),
+	durationMs: requestDurationMs( request ),
+	failureText: request.failure()?.errorText ?? 'unknown',
+} );
 
 /**
  * Component for the domain search feature.
@@ -278,6 +346,22 @@ export class DomainSearchComponent {
 
 		this.page.on( 'response', trackCartResponse );
 
+		// ponytail: throwaway availability-precheck tracking. Remove with flake-probe.ts.
+		const availabilitySummaries: Promise< AvailabilityDiagnostic >[] = [];
+		const trackAvailabilityResponse = ( response: Response ) => {
+			if ( isAvailabilityRequest( response.url() ) ) {
+				availabilitySummaries.push( summarizeAvailabilityResponse( response ) );
+			}
+		};
+		const trackAvailabilityFailure = ( request: Request ) => {
+			if ( isAvailabilityRequest( request.url() ) ) {
+				availabilitySummaries.push( Promise.resolve( summarizeAvailabilityFailure( request ) ) );
+			}
+		};
+		this.page.on( 'response', trackAvailabilityResponse );
+		this.page.on( 'requestfailed', trackAvailabilityFailure );
+		const clickStartedAt = Date.now();
+
 		// The add-to-cart API call can sometimes fail, leaving the button in an
 		// error state (domain-suggestion-cta--error) instead of detaching it.
 		// Retry the click up to 3 times when this happens.
@@ -303,6 +387,8 @@ export class DomainSearchComponent {
 								addToCartButton,
 								selectedDomain,
 								cartResponseSummaries,
+								availabilitySummaries,
+								elapsedMs: Date.now() - clickStartedAt,
 								originalError: error,
 							} )
 						);
@@ -311,6 +397,8 @@ export class DomainSearchComponent {
 			}
 		} finally {
 			this.page.off( 'response', trackCartResponse );
+			this.page.off( 'response', trackAvailabilityResponse );
+			this.page.off( 'requestfailed', trackAvailabilityFailure );
 		}
 
 		if ( waitForContinueButton ) {
@@ -329,6 +417,8 @@ export class DomainSearchComponent {
 	 * @param {Locator} params.addToCartButton Add to cart button in the selected row.
 	 * @param {string} params.selectedDomain Domain name being selected.
 	 * @param {Promise<CartResponseDiagnostic>[]} params.cartResponseSummaries Observed shopping cart responses.
+	 * @param {Promise<AvailabilityDiagnostic>[]} params.availabilitySummaries Observed availability pre-check requests.
+	 * @param {number} params.elapsedMs Wall-clock ms from the add-to-cart click to failure.
 	 * @param {unknown} params.originalError Original Playwright error.
 	 * @returns {Promise<string>} Error message with selected domain, button state, and cart responses.
 	 */
@@ -337,17 +427,49 @@ export class DomainSearchComponent {
 		addToCartButton,
 		selectedDomain,
 		cartResponseSummaries,
+		availabilitySummaries,
+		elapsedMs,
 		originalError,
 	}: {
 		row: Locator;
 		addToCartButton: Locator;
 		selectedDomain: string;
 		cartResponseSummaries: Promise< CartResponseDiagnostic >[];
+		availabilitySummaries?: Promise< AvailabilityDiagnostic >[];
+		elapsedMs?: number;
 		originalError: unknown;
 	} ): Promise< string > {
 		const cartResponses = ( await Promise.allSettled( cartResponseSummaries ) ).map( ( result ) =>
 			result.status === 'fulfilled' ? result.value : { error: formatError( result.reason ) }
 		);
+
+		// ponytail: throwaway. Resolve the availability captures and read the CTA
+		// error text (rendered as a Tooltip, so hover to surface it). Emit a
+		// greppable [FLAKE-PROBE] line. Remove with flake-probe.ts.
+		const availabilityResponses = ( await Promise.allSettled( availabilitySummaries ?? [] ) ).map(
+			( result ) =>
+				result.status === 'fulfilled' ? result.value : { error: formatError( result.reason ) }
+		);
+
+		const ctaErrorText = await ( async () => {
+			try {
+				await addToCartButton.hover( { timeout: 2000 } );
+				return normalizeText(
+					await this.page.locator( '[role="tooltip"]' ).first().innerText( { timeout: 2000 } )
+				);
+			} catch ( error ) {
+				return `<<unavailable: ${ formatError( error ) }>>`;
+			}
+		} )();
+
+		flakeProbe( 'domain-add-to-cart', {
+			selectedDomain,
+			elapsedMs,
+			ctaErrorText,
+			availabilityResponses,
+			cartResponseCount: cartResponses.length,
+			originalError: formatError( originalError ),
+		} );
 
 		const allAddToCartButtons = await this.getContainer()
 			.getByRole( 'button', { name: 'Add to cart' } )
@@ -383,6 +505,9 @@ export class DomainSearchComponent {
 			},
 			allAddToCartButtons,
 			cartResponses: cartResponses.slice( -5 ),
+			availabilityResponses: availabilityResponses.slice( -5 ),
+			ctaErrorText,
+			elapsedMs,
 		};
 
 		return [

--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -403,7 +403,27 @@ export class DomainSearchComponent {
 
 		if ( waitForContinueButton ) {
 			const continueButton = row.getByRole( 'button', { name: 'Continue' } );
-			await continueButton.waitFor( { timeout: 30000 } );
+			try {
+				await continueButton.waitFor( { timeout: 30000 } );
+			} catch ( error ) {
+				// ponytail: throwaway. Add-to-cart resolved (button detached) but
+				// Continue never rendered. Emit availability + cart state so a
+				// stalled/failed cart POST can be told from a healthy add that just
+				// failed to advance. Remove with flake-probe.ts.
+				const settle = async < T >( items: Promise< T >[] ) =>
+					( await Promise.allSettled( items ) ).map( ( r ) =>
+						r.status === 'fulfilled' ? r.value : { error: formatError( r.reason ) }
+					);
+				flakeProbe( 'domain-continue-missing', {
+					selectedDomain,
+					elapsedMs: Date.now() - clickStartedAt,
+					addToCartButtonDetached: ( await addToCartButton.count() ) === 0,
+					availabilityResponses: ( await settle( availabilitySummaries ) ).slice( -5 ),
+					cartResponses: ( await settle( cartResponseSummaries ) ).slice( -5 ),
+					originalError: formatError( error ),
+				} );
+				throw error;
+			}
 		}
 
 		return selectedDomain;

--- a/packages/calypso-e2e/src/lib/flake-probe.ts
+++ b/packages/calypso-e2e/src/lib/flake-probe.ts
@@ -1,0 +1,37 @@
+import { Page } from 'playwright';
+
+// ponytail: throwaway diagnostics for the signup/importer flakes tracked in
+// fix/e2e-signup-importer-flake-probes. Emits greppable [FLAKE-PROBE] lines to
+// the CI build log. Remove this file and its call sites once the timing/failure
+// data has been collected.
+
+const PREFIX = '[FLAKE-PROBE]';
+
+/**
+ * Emits a single greppable diagnostic line to stdout (captured in the CI log).
+ */
+export function flakeProbe( label: string, data: Record< string, unknown > ): void {
+	console.log( `${ PREFIX } ${ label } ${ JSON.stringify( data ) }` );
+}
+
+/**
+ * Captures cheap page state at a failure point. Never throws and never waits on
+ * elements, so it cannot itself hang or mask the original failure.
+ */
+export async function capturePageState( page: Page ): Promise< Record< string, unknown > > {
+	const safe = async < T >( fn: () => Promise< T >, fallback: T ): Promise< T > => {
+		try {
+			return await fn();
+		} catch {
+			return fallback;
+		}
+	};
+
+	return {
+		url: page.url(),
+		headings: ( await safe( () => page.locator( 'h1, h2' ).allInnerTexts(), [] ) ).slice( 0, 8 ),
+		errors: (
+			await safe( () => page.locator( '[class*="error"], [role="alert"]' ).allInnerTexts(), [] )
+		).slice( 0, 8 ),
+	};
+}

--- a/packages/calypso-e2e/src/lib/flake-probe.ts
+++ b/packages/calypso-e2e/src/lib/flake-probe.ts
@@ -9,9 +9,12 @@ const PREFIX = '[FLAKE-PROBE]';
 
 /**
  * Emits a single greppable diagnostic line to stdout (captured in the CI log).
+ *
+ * Uses process.stdout.write, not console.log: CI runs the suites with --silent,
+ * which mutes console.* but not direct stdout writes.
  */
 export function flakeProbe( label: string, data: Record< string, unknown > ): void {
-	console.log( `${ PREFIX } ${ label } ${ JSON.stringify( data ) }` );
+	process.stdout.write( `${ PREFIX } ${ label } ${ JSON.stringify( data ) }\n` );
 }
 
 /**


### PR DESCRIPTION
Part of the investigation into the muted "Domain: Upsell (Skip Plan)" flake (mute id 1480) and its sibling `domain-upsell__my-home` spec.

## Proposed Changes

Log-only `[FLAKE-PROBE]` instrumentation on the domain add-to-cart path in `DomainSearchComponent`. On the add-to-cart failure (CTA stuck in the `domain-suggestion-cta--error` state) it now captures:

- The domain-availability pre-check request (`GET /domains/<name>/is-available`): status + body error, or the network-layer failure that emits no `response` event at all.
- Its timing (ms) and the wall-clock click→failure window.
- The CTA error text, which renders as a Tooltip (not visible button text) and was therefore never captured before.

Emits a single greppable `[FLAKE-PROBE] domain-add-to-cart {...}` line and rethrows the original diagnostics error unchanged. No timeout bumps, no assertion changes.

Reuses the throwaway `flake-probe.ts` helper introduced in #112272; kept as a separate branch/commit so it can land independently.

## Why are these changes being made?

The add-to-cart mutation runs the availability pre-check before the cart POST. When that GET fails transiently the CTA flips to the destructive error state and the step fails. The existing diagnostics only logged shopping-cart POSTs, so every occurrence looked like "cart 200 but button errored" and misdirected triage. This probe records the request that actually fails.

Throwaway: remove `flake-probe.ts` and its call sites once the data is collected.

## Testing Instructions

The probe only fires on the intermittent failure path, so it produces no output on a passing run.

1. Run the affected specs against staging (repeat to catch the flake):
   - `test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts`
   - `test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts`
2. On a run where the add-to-cart step fails, grep the build log for `[FLAKE-PROBE] domain-add-to-cart`. Each hit is one JSON line; check `availabilityResponses[]` for the failing request (non-200/`bodyError`, or a `requestfailed` with `failureText`). An empty `availabilityResponses` on failure means the GET never fired.
