### PR TITLE
Reader Spaces: fix sidebar header crash and make the whole header clickable

### DIFF
--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -112,10 +112,14 @@ export const ExpandableSidebarMenu = ( menuProps ) => {
 				<ExpandableSidebarHeading
 					title={ title }
 					count={ count }
-					onClick={ ( event ) => {
-						setSubmenuHovered( false );
-						onClick( event );
-					} }
+					onClick={
+						typeof onClick === 'function'
+							? ( event ) => {
+									setSubmenuHovered( false );
+									onClick( event );
+							  }
+							: undefined
+					}
 					customIcon={ customIcon }
 					icon={ icon }
 					materialIcon={ materialIcon }

--- a/client/reader/sidebar/spaces/index.tsx
+++ b/client/reader/sidebar/spaces/index.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { Icon, category } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import { useSpaces } from 'calypso/reader/data/spaces';
@@ -136,6 +136,8 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 		setIsCreateModalOpen( true );
 	};
 
+	const handleToggleExpand = useCallback( () => setIsOpen( ( open ) => ! open ), [] );
+
 	const markOnboardingSeen = () => {
 		dispatch( savePreference( READER_SPACES_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
 		setIsOnboardingOpen( false );
@@ -156,7 +158,8 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 				expanded={ isOpen }
 				title={ translate( 'Spaces' ) }
 				customIcon={ <Icon className="sidebar__menu-icon" icon={ category } /> }
-				expandableIconClick={ () => setIsOpen( ! isOpen ) }
+				onClick={ handleToggleExpand }
+				expandableIconClick={ handleToggleExpand }
 				disableFlyout
 				className={ ! isOpen && isOnSpaces ? 'sidebar__menu--selected' : undefined }
 				count={ undefined }

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -219,6 +219,17 @@ describe( 'ReaderSidebarSpaces', () => {
 		expect( screen.queryByRole( 'heading', { name: 'Meet Spaces' } ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'expands the section when the Spaces header body is clicked, like the other menus', async () => {
+		const user = userEvent.setup();
+		render( <ReaderSidebarSpaces path="/reader" /> );
+
+		expect( screen.getByRole( 'button', { name: 'Expand menu' } ) ).toBeVisible();
+
+		await user.click( screen.getByText( 'Spaces' ) );
+
+		expect( screen.getByRole( 'button', { name: 'Collapse menu' } ) ).toBeVisible();
+	} );
+
 	it( 'redirects to the new space after creating it', async () => {
 		const user = userEvent.setup();
 		nock( 'https://public-api.wordpress.com' )


### PR DESCRIPTION
Fixes RSM-4645

## Proposed Changes

- Guard the optional `onClick` call in the shared `ExpandableSidebarMenu` (`onClick?.( event )`) so a chevron-only consumer no longer throws `onClick is not a function`.
- Wire the Reader "Spaces" sidebar header to toggle from both the header row and the chevron — matching the other sections (tags, lists) — with the handler memoized via `useCallback`.
- Added a regression test covering the clickable header.

## Why are these changes being made?

The "Spaces" section was the only expandable sidebar menu passing `expandableIconClick` without an `onClick`, so clicking the header body invoked an undefined handler and crashed; every other section stays clickable because it passes `onClick`. This restores consistent, keyboard-accessible behavior and hardens the shared component against future chevron-only consumers.

## Testing Instructions

### Scenario 1 - Header body is clickable without errors:
- Go to /reader
- Open the browser console, then click the "Spaces" label in the sidebar
- Check that the section expands/collapses and no `onClick is not a function` error appears in the console

### Scenario 2 - Chevron still toggles:
- Go to /reader
- Click the chevron on the "Spaces" row
- Check that the section expands and collapses

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
