### PR TITLE
Plugins: refactor the sites card layout and clean up custom styles

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -15,27 +15,29 @@ img.plugin-icon {
 }
 
 .plugin-sites-card {
+	max-height: $card-height;
 	overflow-y: hidden;
+	display: flex;
+	flex-direction: column;
+
+	// Card wraps its bodies in an inner content View that defaults to display: block,
+	// which would swallow the flex context; make it a flex column so the tabs body can fill.
+	> div:first-child {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+	}
 }
 
 .plugin-sites-card-body {
-	height: $card-height;
-	padding-inline-start: 0;
-	padding-inline-end: 0;
-	padding-block-end: 0;
 	display: flex;
 	flex-direction: column;
-}
-
-.plugin-sites-card-managed-notice {
-	margin-block-end: 16px;
-	margin-inline: 20px;
+	flex: 1;
+	min-height: 0;
 }
 
 .plugin-sites-card-header {
-	margin-bottom: 8px;
-	padding-inline-start: 20px;
-
 	.dashboard-section-header__decoration {
 		width: 48px;
 		height: 48px;

--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 @import './variables.scss';
 
 .plugin-icon-placeholder {
@@ -15,10 +17,14 @@ img.plugin-icon {
 }
 
 .plugin-sites-card {
-	max-height: $card-height;
-	overflow-y: hidden;
 	display: flex;
 	flex-direction: column;
+
+	// On small viewports the card grows naturally and the page body scrolls.
+	@include break-medium {
+		max-height: $card-height;
+		overflow-y: hidden;
+	}
 
 	// Card wraps its bodies in an inner content View that defaults to display: block,
 	// which would swallow the flex context; make it a flex column so the tabs body can fill.

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -1,7 +1,7 @@
-import { ExternalLink } from '@wordpress/components';
+import { __experimentalVStack as VStack, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card, CardBody } from '../../../components/card';
+import { Card, CardBody, CardHeader } from '../../../components/card';
 import { Notice } from '../../../components/notice';
 import { SectionHeader } from '../../../components/section-header';
 import { Text } from '../../../components/text';
@@ -77,25 +77,33 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 
 	return (
 		<Card className="plugin-sites-card">
-			<CardBody className="plugin-sites-card-body">
-				<SectionHeader
-					className="plugin-sites-card-header"
-					decoration={ decoration() }
-					level={ 2 }
-					title={ title() }
-					description={ description() }
-				/>
-
-				{ isCoreManagedPlugin && (
-					<div className="plugin-sites-card-managed-notice">
+			<CardHeader
+				className="plugin-sites-card-header"
+				isBorderless
+				size={ {
+					blockStart: 'medium',
+					blockEnd: 'none',
+					inlineStart: 'medium',
+					inlineEnd: 'medium',
+				} }
+			>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						decoration={ decoration() }
+						level={ 2 }
+						title={ title() }
+						description={ description() }
+					/>
+					{ isCoreManagedPlugin && (
 						<Notice variant="info">
 							{ __(
 								'This plugin is managed by WordPress.com and is required for your site to work properly, so it can’t be removed.'
 							) }
 						</Notice>
-					</div>
-				) }
-
+					) }
+				</VStack>
+			</CardHeader>
+			<CardBody className="plugin-sites-card-body" size="none">
 				<PluginTabs
 					pluginSlug={ selectedPluginSlug }
 					isLoading={ isLoadingPlugin }

--- a/client/dashboard/plugins/manage/components/variables.scss
+++ b/client/dashboard/plugins/manage/components/variables.scss
@@ -1,4 +1,3 @@
-// take into account header and nav plus border (64+1), page layout padding (32),
-// page title/description (80), gap between title/description and the cards (32),
-// and select button border (1)
-$card-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px - 1px);
+// take into account omnibar, and page layout padding (32), page title/description (80),
+// gap between title/description and select button border (1)
+$card-height: calc(100vh - var(--masterbar-height) - 2 * 32px - 80px - 1px);

--- a/client/dashboard/plugins/plugin/style.scss
+++ b/client/dashboard/plugins/plugin/style.scss
@@ -1,6 +1,8 @@
 @import '../../app/pulse';
 
 .plugin-tabs-list[aria-orientation='horizontal'] {
+	flex-shrink: 0;
+
 	&::before {
 		transform: translateX(calc((var(--selected-start) * var(--direction-factor) * 1px) + 24px)) scaleX(calc(calc(var(--selected-width, 0) - 2 * 24) / var(--antialiasing-factor)));
 	}

--- a/client/dashboard/plugins/plugin/style.scss
+++ b/client/dashboard/plugins/plugin/style.scss
@@ -2,11 +2,11 @@
 
 .plugin-tabs-list[aria-orientation='horizontal'] {
 	&::before {
-		transform: translateX(calc((var(--selected-start) * var(--direction-factor) * 1px) + 20px)) scaleX(calc(calc(var(--selected-width, 0) - 2 * 20) / var(--antialiasing-factor)));
+		transform: translateX(calc((var(--selected-start) * var(--direction-factor) * 1px) + 24px)) scaleX(calc(calc(var(--selected-width, 0) - 2 * 24) / var(--antialiasing-factor)));
 	}
 
 	button {
-		padding-inline: 20px;
+		padding-inline: 24px;
 
 		.dashboard-section-header__heading {
 			font-weight: normal;
@@ -35,22 +35,11 @@
 	}
 }
 
+// Fill the tab panel so DataViews can scroll its table while keeping the
+// filter bar and pagination footer pinned.
 .sites-with-this-plugin {
 	display: flex;
 	flex-direction: column;
 	flex: 1;
 	min-height: 0;
-
-	.dataviews__view-actions, .dataviews-filters__container {
-		padding-inline-start: 20px;
-		padding-inline-end: 20px;
-	}
-
-	.dataviews-view-table tr td:first-child, .dataviews-view-table tr th:first-child {
-		padding-inline-start: 20px;
-	}
-
-	.dataviews-view-table tr td:last-child, .dataviews-view-table tr th:last-child {
-		padding-inline-end: 20px;
-	}
 }


### PR DESCRIPTION
## Proposed Changes

* Refactor the plugin sites card to use `CardHeader` + `CardBody` with the components' built-in `size`/spacing props instead of hand-rolled padding and margins.
* Remove custom plugin card styles: the card body/header padding overrides, the managed-plugin notice margins, and the DataViews filter/cell padding hacks.
* Re-express the card's fixed height as a flex column (move the `$card-height` cap onto the card) so the existing table scroll keeps working through the layout change, and derive `$card-height` from `--masterbar-height`.
* Fix the layout on short/mobile viewports:
  * Only cap the card height (`$card-height` + internal scroll) at `break-medium` and above. Below it the card grows to its natural height and the page body scrolls, so the table is never squeezed into a tiny fixed area.
  * Pin the tab list with `flex-shrink: 0` so it keeps its natural height instead of collapsing and clipping its buttons when the card is short (the `Tabs` root renders no wrapper, so the tab list and panel are direct flex-column children of the card body).

| Before | After |
| - | - |
|<img width="605" height="339" alt="image" src="https://github.com/user-attachments/assets/1313baa2-ceae-4f67-b502-eec783f52d37" />|<img width="604" height="337" alt="image" src="https://github.com/user-attachments/assets/055b4500-5317-429d-86f8-7a3d37f014c4" />|

## Why are these changes being made?

* The DataViews table scroll — with the filter bar and pagination footer pinned — already landed on trunk (#112315). This PR does not change that behavior; it refactors how the card is laid out and removes the custom CSS that had accumulated around it.
* Leaning on the components' `size`/spacing props instead of bespoke padding/margin overrides keeps spacing consistent with the design system and makes the card easier to maintain.
* On short/mobile viewports the fixed height cap squeezed the card, which clipped the tab list and cramped the table; growing naturally and scrolling the page body is the expected mobile behavior.

## Testing Instructions

1. Go to **Plugins → Manage plugins** and select a plugin.
2. Confirm the card layout and spacing look correct — plugin header, tabs, DataViews search/filter bar, table, and footer.
3. With a plugin on many sites, or a short browser height, confirm the table still scrolls while the header, tabs, filter bar, and pagination footer stay pinned (same behavior as trunk).
4. Confirm there is a single scrollbar (no double scroll) and no clipped or unreachable rows.
5. On a narrow/mobile viewport (below `break-medium`, 782px), confirm the card grows to its natural height and the page body scrolls, and that the tab list keeps its full height (buttons are not clipped or squished).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
