### PR TITLE
A4A WooPayments: bring commissions dashboard components up to MSD standard

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
@@ -1,6 +1,6 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
 import A4ATablePlaceholder from 'calypso/a8c-for-agencies/components/a4a-table-placeholder';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
@@ -22,8 +22,6 @@ const AddWooPaymentsToSiteTable = ( {
 	selectedSite: WooPaymentsSiteItem | null;
 	setSelectedSite: ( site: WooPaymentsSiteItem | null ) => void;
 } ) => {
-	const translate = useTranslate();
-
 	const dispatch = useDispatch();
 
 	const { items, isLoading } = useFetchManagedSites();
@@ -57,7 +55,7 @@ const AddWooPaymentsToSiteTable = ( {
 	const fields = useMemo( () => {
 		const siteColumn = {
 			id: 'site',
-			label: translate( 'Site' ),
+			label: __( 'Site' ),
 			getValue: ( { item }: { item: WooPaymentsSiteItem } ) => item.site,
 			render: ( { item }: { item: WooPaymentsSiteItem } ) => (
 				<div>
@@ -76,7 +74,7 @@ const AddWooPaymentsToSiteTable = ( {
 		};
 
 		return [ siteColumn ];
-	}, [ onSelectSite, selectedSite?.id, translate ] );
+	}, [ onSelectSite, selectedSite?.id ] );
 
 	const { data: allSites, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( availableSites as WooPaymentsSiteItem[], dataViewsState, fields );

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/index.tsx
@@ -1,14 +1,13 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSiteModal from './modal';
 
 const AddWooPaymentsToSite = () => {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const showModal = getQueryArg( window.location.href, 'add-woopayments-to-site' ) === 'true';
@@ -34,7 +33,7 @@ const AddWooPaymentsToSite = () => {
 	return (
 		<>
 			<Button __next40pxDefaultSize variant="primary" onClick={ handleOpenModal }>
-				{ translate( 'Add WooPayments to site' ) }
+				{ __( 'Add WooPayments to site' ) }
 			</Button>
 
 			{ isOpen && <AddWooPaymentsToSiteModal onClose={ () => setIsOpen( false ) } /> }

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -1,7 +1,8 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import {
@@ -13,7 +14,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
 
 const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
@@ -31,30 +31,30 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 
 	return (
 		<A4AModal
-			title={ translate( 'Which site would you like to add WooPayments to?' ) }
-			subtile={ translate(
-				"If you don't see the site in the list, connect it first via the {{a}}Sites Dashboard{{/a}}.",
+			title={ __( 'Which site would you like to add WooPayments to?' ) }
+			subtile={ createInterpolateElement(
+				__(
+					"If you don't see the site in the list, connect it first via the <a>Sites Dashboard</a>."
+				),
 				{
-					components: {
-						a: (
-							<a
-								href={ A4A_SITES_LINK }
-								onClick={ () =>
-									dispatch(
-										recordTracksEvent(
-											'calypso_a4a_woopayments_add_site_modal_sites_dashboard_click'
-										)
+					a: (
+						<a
+							href={ A4A_SITES_LINK }
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent(
+										'calypso_a4a_woopayments_add_site_modal_sites_dashboard_click'
 									)
-								}
-							/>
-						),
-					},
+								)
+							}
+						/>
+					),
 				}
 			) }
 			onClose={ onClose }
 			extraActions={
 				<Button variant="primary" onClick={ handleAddSite } disabled={ ! selectedSite }>
-					{ translate( 'Add WooPayments to selected site' ) }
+					{ __( 'Add WooPayments to selected site' ) }
 				</Button>
 			}
 		>

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import {
 	ConsolidatedStatsCard,
 	ConsolidatedStatsGroup,
@@ -10,7 +11,6 @@ import PayoutCards from '../../referrals/consolidated-view/payout-cards';
 import { useWooPaymentsContext } from '../context';
 
 const WooPaymentsConsolidatedViews = () => {
-	const translate = useTranslate();
 	const { showSupportGuide } = useHelpCenter();
 
 	const { woopaymentsData, isLoadingWooPaymentsData } = useWooPaymentsContext();
@@ -24,25 +24,24 @@ const WooPaymentsConsolidatedViews = () => {
 		<ConsolidatedStatsGroup className="consolidated-view">
 			<ConsolidatedStatsCard
 				value={ formatCurrency( totalCommission, 'USD' ) }
-				footerText={ translate( 'Total WooPayments commissions paid' ) }
-				popoverTitle={ translate( 'Total WooPayments commissions paid' ) }
-				popoverContent={ translate(
-					'The total amount of transactions processed through WooPayments across all your client sites. ' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
+				footerText={ __( 'Total WooPayments commissions paid' ) }
+				popoverTitle={ __( 'Total WooPayments commissions paid' ) }
+				popoverContent={ createInterpolateElement(
+					__(
+						'The total amount of transactions processed through WooPayments across all your client sites. <br/><br/><a>Learn more</a>'
+					),
 					{
-						components: {
-							a: (
-								<Button
-									variant="link"
-									onClick={ () =>
-										showSupportGuide(
-											'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
-										)
-									}
-								/>
-							),
-							br: <br />,
-						},
+						br: <br />,
+						a: (
+							<Button
+								variant="link"
+								onClick={ () =>
+									showSupportGuide(
+										'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
+									)
+								}
+							/>
+						),
 					}
 				) }
 				isLoading={ isLoadingWooPaymentsData }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import {
 	ListItemCards,
 	ListItemCard,
@@ -26,7 +26,6 @@ export default function SitesWithWooPaymentsMobileView( {
 	items: SitesWithWooPaymentsState[];
 	actions: Action[];
 } ) {
-	const translate = useTranslate();
 	const { woopaymentsData, isLoadingWooPaymentsData } = useWooPaymentsContext();
 
 	return (
@@ -35,12 +34,12 @@ export default function SitesWithWooPaymentsMobileView( {
 				{ items.map( ( item ) => (
 					<ListItemCard key={ item.blogId }>
 						<ListItemCardActions actions={ actions } item={ item } />
-						<ListItemCardContent title={ translate( 'Site' ) }>
+						<ListItemCardContent title={ __( 'Site' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								<SiteColumn site={ item.siteUrl } />
 							</div>
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Transactions' ) }>
+						<ListItemCardContent title={ __( 'Transactions' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								{ isLoadingWooPaymentsData ? (
 									<TextPlaceholder />
@@ -51,7 +50,7 @@ export default function SitesWithWooPaymentsMobileView( {
 								) }
 							</div>
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Commissions paid' ) }>
+						<ListItemCardContent title={ __( 'Commissions paid' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								{ isLoadingWooPaymentsData ? (
 									<TextPlaceholder />
@@ -62,7 +61,7 @@ export default function SitesWithWooPaymentsMobileView( {
 								) }
 							</div>
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Timeframe commissions' ) }>
+						<ListItemCardContent title={ __( 'Timeframe commissions' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								{ isLoadingWooPaymentsData ? (
 									<TextPlaceholder />
@@ -73,10 +72,10 @@ export default function SitesWithWooPaymentsMobileView( {
 								) }
 							</div>
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'WooPayments status' ) }>
+						<ListItemCardContent title={ __( 'WooPayments status' ) }>
 							<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Commission eligibility' ) }>
+						<ListItemCardContent title={ __( 'Commission eligibility' ) }>
 							<CommissionEligibilityColumn
 								state={ item.state }
 								siteId={ item.blogId }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -1,14 +1,12 @@
-import { BadgeType, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Button } from '@wordpress/components';
+import { Badge } from '@automattic/ui';
+import { Button, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { memo, useState, useRef } from 'react';
-import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
-import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
+import { Icon, info } from '@wordpress/icons';
+import { memo, useState } from 'react';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -106,7 +104,7 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 		);
 	}
 
-	const getStatusProps = () => {
+	const getStatusProps = (): { statusText: string; statusType: 'success' | 'error' } | null => {
 		switch ( state ) {
 			case 'active':
 				return {
@@ -131,12 +129,7 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 
 	return (
 		<div className="woopayments-status-column">
-			<StatusBadge
-				statusProps={ {
-					children: statusProps.statusText,
-					type: statusProps.statusType as BadgeType,
-				} }
-			/>
+			<Badge intent={ statusProps.statusType }>{ statusProps.statusText }</Badge>
 		</div>
 	);
 };
@@ -151,7 +144,7 @@ export const CommissionEligibilityColumn = ( {
 	woopaymentsData?: WooPaymentsData;
 } ) => {
 	const [ showPopover, setShowPopover ] = useState( false );
-	const wrapperRef = useRef< HTMLDivElement | null >( null );
+	const [ infoIconAnchor, setInfoIconAnchor ] = useState< HTMLButtonElement | null >( null );
 
 	// Don't show eligibility status if WooPayments is not active.
 	if ( state !== 'active' ) {
@@ -169,13 +162,13 @@ export const CommissionEligibilityColumn = ( {
 	const statusProps = isCommissionEligible
 		? {
 				statusText: __( 'Eligible' ),
-				statusType: 'success' as BadgeType,
+				statusType: 'success' as const,
 				showInfoIcon: false,
 				ineligibleReason: undefined,
 		  }
 		: {
 				statusText: __( 'Not eligible' ),
-				statusType: 'error' as BadgeType,
+				statusType: 'error' as const,
 				showInfoIcon: true,
 				ineligibleReason: ineligibleSite?.ineligible_reason,
 		  };
@@ -197,32 +190,29 @@ export const CommissionEligibilityColumn = ( {
 	);
 
 	return (
-		<div ref={ wrapperRef } className="woopayments-status-column">
-			<StatusBadge
-				statusProps={ {
-					children: statusProps.statusText,
-					type: statusProps.statusType,
-				} }
-			/>
+		<div className="woopayments-status-column">
+			<Badge intent={ statusProps.statusType }>{ statusProps.statusText }</Badge>
 			{ statusProps.showInfoIcon && (
 				<>
-					<A4APopoverTrigger
+					<Button
+						ref={ setInfoIconAnchor }
 						className="woopayments-status-column__info-icon"
 						aria-label={ __( 'More information about commission eligibility' ) }
-						onActivate={ () => setShowPopover( true ) }
+						onClick={ () => setShowPopover( ( visible ) => ! visible ) }
 					>
-						<Gridicon icon="info-outline" size={ 16 } />
-					</A4APopoverTrigger>
+						<Icon icon={ info } size={ 16 } />
+					</Button>
 					{ showPopover && (
-						<A4APopover
-							title=""
+						<Popover
+							className="woopayments-eligibility-popover"
+							anchor={ infoIconAnchor }
+							placement="bottom"
 							offset={ 12 }
-							wrapperRef={ wrapperRef }
 							focusOnMount
 							onFocusOutside={ () => setShowPopover( false ) }
 						>
 							{ popoverContent }
-						</A4APopover>
+						</Popover>
 					) }
 				</>
 			) }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -2,7 +2,7 @@ import { BadgeType, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import { memo, useState, useRef } from 'react';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
@@ -13,36 +13,32 @@ import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { WooPaymentsData } from '@automattic/api-core';
-import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
 interface IneligibleReasonInfo {
-	message: TranslateResult;
+	message: string;
 	link: string;
-	linkText: TranslateResult;
+	linkText: string;
 }
 
-const getIneligibleReasonInfo = (
-	reason: string,
-	translate: ( text: string ) => TranslateResult
-): IneligibleReasonInfo => {
+const getIneligibleReasonInfo = ( reason: string ): IneligibleReasonInfo => {
 	const defaultLink =
 		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
-	const defaultLinkText = translate( 'Learn more about the incentive ↗' );
+	const defaultLinkText = __( 'Learn more about the incentive ↗' );
 
 	switch ( reason ) {
 		case 'rejected_stripe_account':
 			return {
-				message: translate(
+				message: __(
 					"This WooPayments site isn't eligible for commission because its Stripe account was rejected."
 				),
 				link: 'https://support.stripe.com/',
-				linkText: translate( 'Contact Stripe support ↗' ),
+				linkText: __( 'Contact Stripe support ↗' ),
 			};
 		case 'internal_account_owner':
 			return {
-				message: translate(
+				message: __(
 					"This WooPayments site isn't eligible for commission because it's owned by an internal account."
 				),
 				link: defaultLink,
@@ -50,7 +46,7 @@ const getIneligibleReasonInfo = (
 			};
 		case 'existing_merchant_after_30_days':
 			return {
-				message: translate(
+				message: __(
 					"This WooPayments site isn't eligible for commission because it's an existing site that was connected to the agency account more than 30 days after the account was created."
 				),
 				link: defaultLink,
@@ -59,7 +55,7 @@ const getIneligibleReasonInfo = (
 		// Add more error code mappings here as needed
 		default:
 			return {
-				message: translate(
+				message: __(
 					"This WooPayments site isn't eligible for commission under the current program criteria."
 				),
 				link: defaultLink,
@@ -94,7 +90,6 @@ export const TimeframeCommissionsColumn = memo(
 TimeframeCommissionsColumn.displayName = 'TimeframeCommissionsColumn';
 
 export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; siteId: number } ) => {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	if ( ! state ) {
@@ -106,7 +101,7 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 				variant="tertiary"
 				href={ `${ A4A_WOOPAYMENTS_SITE_SETUP_LINK }/?site_id=${ siteId }` }
 			>
-				{ translate( 'Continue setup' ) }
+				{ __( 'Continue setup' ) }
 			</Button>
 		);
 	}
@@ -115,12 +110,12 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 		switch ( state ) {
 			case 'active':
 				return {
-					statusText: translate( 'Active' ),
+					statusText: __( 'Active' ),
 					statusType: 'success',
 				};
 			case 'disconnected':
 				return {
-					statusText: translate( 'Disconnected' ),
+					statusText: __( 'Disconnected' ),
 					statusType: 'error',
 				};
 			default:
@@ -155,7 +150,6 @@ export const CommissionEligibilityColumn = ( {
 	siteId: number;
 	woopaymentsData?: WooPaymentsData;
 } ) => {
-	const translate = useTranslate();
 	const [ showPopover, setShowPopover ] = useState( false );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 
@@ -174,19 +168,19 @@ export const CommissionEligibilityColumn = ( {
 
 	const statusProps = isCommissionEligible
 		? {
-				statusText: translate( 'Eligible' ),
+				statusText: __( 'Eligible' ),
 				statusType: 'success' as BadgeType,
 				showInfoIcon: false,
 				ineligibleReason: undefined,
 		  }
 		: {
-				statusText: translate( 'Not eligible' ),
+				statusText: __( 'Not eligible' ),
 				statusType: 'error' as BadgeType,
 				showInfoIcon: true,
 				ineligibleReason: ineligibleSite?.ineligible_reason,
 		  };
 
-	const reasonInfo = getIneligibleReasonInfo( statusProps.ineligibleReason ?? '', translate );
+	const reasonInfo = getIneligibleReasonInfo( statusProps.ineligibleReason ?? '' );
 
 	const popoverContent = (
 		<div className="woopayments-status-popover">
@@ -214,7 +208,7 @@ export const CommissionEligibilityColumn = ( {
 				<>
 					<A4APopoverTrigger
 						className="woopayments-status-column__info-icon"
-						aria-label={ translate( 'More information about commission eligibility' ) }
+						aria-label={ __( 'More information about commission eligibility' ) }
 						onActivate={ () => setShowPopover( true ) }
 					>
 						<Gridicon icon="info-outline" size={ 16 } />

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -74,7 +74,7 @@ export default function SitesWithWooPayments() {
 		() => [
 			{
 				id: 'site',
-				label: __( 'Site' ).toUpperCase(),
+				label: __( 'Site' ),
 				getValue: () => '-',
 				render: ( { item }: { item: SitesWithWooPaymentsState } ) => (
 					<SiteColumn site={ item.siteUrl } />
@@ -84,7 +84,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'transactions',
-				label: __( 'Transactions' ).toUpperCase(),
+				label: __( 'Transactions' ),
 				getValue: () => '-',
 				render: ( { item } ) => {
 					if ( isLoadingWooPaymentsData ) {
@@ -98,7 +98,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'commissionsPaid',
-				label: __( 'Commissions paid' ).toUpperCase(),
+				label: __( 'Commissions paid' ),
 				getValue: () => '-',
 				render: ( { item } ) => {
 					if ( isLoadingWooPaymentsData ) {
@@ -112,7 +112,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'timeframeCommissions',
-				label: __( 'Timeframe commissions' ).toUpperCase(),
+				label: __( 'Timeframe commissions' ),
 				getValue: () => '-',
 				render: ( { item } ) => {
 					if ( isLoadingWooPaymentsData ) {
@@ -126,7 +126,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'woopaymentsStatus',
-				label: __( 'WooPayments status' ).toUpperCase(),
+				label: __( 'WooPayments status' ),
 				getValue: () => '-',
 				render: ( { item } ) => (
 					<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
@@ -136,7 +136,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'commissionEligibility',
-				label: __( 'Commission eligibility' ).toUpperCase(),
+				label: __( 'Commission eligibility' ),
 				getValue: () => '-',
 				render: ( { item } ) => (
 					<CommissionEligibilityColumn

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -20,7 +20,7 @@ import {
 	CommissionEligibilityColumn,
 } from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
-import type { View } from '@wordpress/dataviews';
+import type { Field, View } from '@wordpress/dataviews';
 
 export default function SitesWithWooPayments() {
 	const {
@@ -70,7 +70,7 @@ export default function SitesWithWooPayments() {
 		},
 	} );
 
-	const fields = useMemo(
+	const fields = useMemo< Field< SitesWithWooPaymentsState >[] >(
 		() => [
 			{
 				id: 'site',

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -1,14 +1,10 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { __experimentalHStack as HStack, Button, Modal, Spinner } from '@wordpress/components';
-import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Icon, external, download, close } from '@wordpress/icons';
 import { useMemo, useState, useCallback } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
-import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import { DataViews } from 'calypso/components/dataviews';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useWooPaymentsContext } from '../context';
@@ -24,6 +20,7 @@ import {
 	CommissionEligibilityColumn,
 } from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
+import type { View } from '@wordpress/dataviews';
 
 export default function SitesWithWooPayments() {
 	const {
@@ -46,8 +43,13 @@ export default function SitesWithWooPayments() {
 		isLoading: false,
 	} );
 
-	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
-		...initialDataViewsState,
+	const [ view, setView ] = useState< View >( {
+		type: 'table',
+		page: 1,
+		perPage: 50,
+		search: '',
+		filters: [],
+		sort: { field: '', direction: 'asc' },
 		fields: [
 			'site',
 			'transactions',
@@ -151,8 +153,8 @@ export default function SitesWithWooPayments() {
 	);
 
 	const { data, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( items, dataViewsState, fields );
-	}, [ items, dataViewsState, fields ] );
+		return filterSortAndPaginate( items, view, fields );
+	}, [ items, view, fields ] );
 
 	const handleDownloadCommissionsReport = useCallback(
 		async ( selectedItems: SitesWithWooPaymentsState[] ) => {
@@ -220,18 +222,16 @@ export default function SitesWithWooPayments() {
 				<SitesWithWooPaymentsMobileView items={ items } actions={ actions } />
 			) : (
 				<div className="redesigned-a8c-table full-width">
-					<ItemsDataViews
-						data={ {
-							items: data,
-							getItemId: ( item: SitesWithWooPaymentsState ) => `${ item.blogId }`,
-							pagination: paginationInfo,
-							enableSearch: false,
-							fields,
-							actions,
-							setDataViewsState,
-							dataViewsState,
-							defaultLayouts: { table: {} },
-						} }
+					<DataViews< SitesWithWooPaymentsState >
+						data={ data }
+						getItemId={ ( item ) => `${ item.blogId }` }
+						paginationInfo={ paginationInfo }
+						search={ false }
+						fields={ fields }
+						actions={ actions }
+						view={ view }
+						onChangeView={ setView }
+						defaultLayouts={ { table: {} } }
 					>
 						<HStack
 							className="dataviews__view-actions"
@@ -242,7 +242,7 @@ export default function SitesWithWooPayments() {
 						</HStack>
 						<DataViews.Layout />
 						<DataViews.Footer />
-					</ItemsDataViews>
+					</DataViews>
 				</div>
 			) }
 

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -1,8 +1,8 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { __experimentalHStack as HStack, Button, Modal, Spinner } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 import { Icon, external, download, close } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState, useCallback } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
@@ -26,7 +26,6 @@ import {
 import type { SitesWithWooPaymentsState } from '../types';
 
 export default function SitesWithWooPayments() {
-	const translate = useTranslate();
 	const {
 		sitesWithPluginsStates: items,
 		woopaymentsData,
@@ -73,7 +72,7 @@ export default function SitesWithWooPayments() {
 		() => [
 			{
 				id: 'site',
-				label: translate( 'Site' ).toUpperCase(),
+				label: __( 'Site' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: SitesWithWooPaymentsState } ) => (
 					<SiteColumn site={ item.siteUrl } />
@@ -83,7 +82,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'transactions',
-				label: translate( 'Transactions' ).toUpperCase(),
+				label: __( 'Transactions' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => {
 					if ( isLoadingWooPaymentsData ) {
@@ -97,7 +96,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'commissionsPaid',
-				label: translate( 'Commissions paid' ).toUpperCase(),
+				label: __( 'Commissions paid' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => {
 					if ( isLoadingWooPaymentsData ) {
@@ -111,7 +110,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'timeframeCommissions',
-				label: translate( 'Timeframe commissions' ).toUpperCase(),
+				label: __( 'Timeframe commissions' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => {
 					if ( isLoadingWooPaymentsData ) {
@@ -125,7 +124,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'woopaymentsStatus',
-				label: translate( 'WooPayments status' ).toUpperCase(),
+				label: __( 'WooPayments status' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => (
 					<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
@@ -135,7 +134,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'commissionEligibility',
-				label: translate( 'Commission eligibility' ).toUpperCase(),
+				label: __( 'Commission eligibility' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => (
 					<CommissionEligibilityColumn
@@ -148,7 +147,7 @@ export default function SitesWithWooPayments() {
 				enableSorting: false,
 			},
 		],
-		[ isLoadingWooPaymentsData, translate, woopaymentsData ]
+		[ isLoadingWooPaymentsData, woopaymentsData ]
 	);
 
 	const { data, paginationInfo } = useMemo( () => {
@@ -187,7 +186,7 @@ export default function SitesWithWooPayments() {
 		() => [
 			{
 				id: 'visit-wp-admin',
-				label: translate( 'Visit WP Admin' ),
+				label: __( 'Visit WP Admin' ),
 				icon: external,
 				callback( items: SitesWithWooPaymentsState[] ) {
 					const isInstalled = items[ 0 ].state === 'active';
@@ -204,7 +203,7 @@ export default function SitesWithWooPayments() {
 			},
 			{
 				id: 'download-commissions-report',
-				label: translate( 'Download commissions report' ),
+				label: __( 'Download commissions report' ),
 				icon: download,
 				callback: handleDownloadCommissionsReport,
 				isEligible( item: SitesWithWooPaymentsState ) {
@@ -212,7 +211,7 @@ export default function SitesWithWooPayments() {
 				},
 			},
 		],
-		[ translate, dispatch, handleDownloadCommissionsReport ]
+		[ dispatch, handleDownloadCommissionsReport ]
 	);
 
 	return (
@@ -256,20 +255,20 @@ export default function SitesWithWooPayments() {
 					<Button
 						className="download-commissions-modal__close-button"
 						onClick={ handleCancelDownload }
-						aria-label={ translate( 'Close' ) }
+						aria-label={ __( 'Close' ) }
 					>
 						<Icon size={ 24 } icon={ close } />
 					</Button>
 					<h1 className="download-commissions-modal__title">
-						{ translate( 'Generating commissions report' ) }
+						{ __( 'Generating commissions report' ) }
 					</h1>
 
 					<div className="download-commissions-modal__instruction">
 						<Spinner />
 						<div className="download-commissions-modal__instruction-text">
-							{ translate( 'Your report is being prepared.' ) }
+							{ __( 'Your report is being prepared.' ) }
 							<br />
-							{ translate( 'The download will begin automatically.' ) }
+							{ __( 'The download will begin automatically.' ) }
 						</div>
 					</div>
 				</Modal>

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -129,3 +129,10 @@
 		}
 	}
 }
+
+.woopayments-eligibility-popover {
+	.components-popover__content {
+		width: 300px;
+		padding: 16px;
+	}
+}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -2,6 +2,12 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 
+// The commissions table renders bare @wordpress/dataviews. The dashboard loads
+// DataViews styles globally, but a8c-for-agencies loads them per-page, so pull
+// them in here (otherwise the table loses its styling on a full page load).
+@import '@wordpress/theme/design-tokens.css';
+@import '@wordpress/dataviews/build-style/style.css';
+
 .sites-with-woopayments-list-mobile-view__column {
 	@include body-medium;
 }

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayment-landing/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayment-landing/index.tsx
@@ -1,3 +1,8 @@
+import {
+	JetpackLicenseFilter,
+	JetpackLicenseSortField,
+	JetpackLicenseSortDirection,
+} from '@automattic/api-core';
 import { jetpackAgencyLicensesQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { useQuery } from '@tanstack/react-query';
@@ -8,11 +13,6 @@ import {
 	A4A_WOOPAYMENTS_DASHBOARD_LINK,
 	A4A_WOOPAYMENTS_OVERVIEW_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import {
-	LicenseFilter,
-	LicenseSortField,
-	LicenseSortDirection,
-} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -24,10 +24,10 @@ const WooPaymentsLanding = () => {
 
 	const { data: licenses, isFetched } = useQuery( {
 		...jetpackAgencyLicensesQuery( agencyId ?? 0, {
-			filter: LicenseFilter.Attached,
+			filter: JetpackLicenseFilter.Attached,
 			search: 'woopayments',
-			sortField: LicenseSortField.IssuedAt,
-			sortDirection: LicenseSortDirection.Descending,
+			sortField: JetpackLicenseSortField.IssuedAt,
+			sortDirection: JetpackLicenseSortDirection.Descending,
 		} ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -32,7 +32,7 @@ const WooPaymentsDashboardEmptyState = () => {
 				</div>
 			</div>
 			<VStack className="woopayments-dashboard-empty-state__step" spacing={ 3 }>
-				<Heading level={ 3 }>{ __( 'How do I start?' ) }</Heading>
+				<Heading level={ 4 }>{ __( 'How do I start?' ) }</Heading>
 				<Card>
 					<CardBody>
 						<HStack justify="space-between">
@@ -50,7 +50,7 @@ const WooPaymentsDashboardEmptyState = () => {
 				spacing={ 2 }
 				alignment="flex-start"
 			>
-				<Heading level={ 3 }>{ __( 'Learn more about the program' ) }</Heading>
+				<Heading level={ 4 }>{ __( 'Learn more about the program' ) }</Heading>
 				<Button
 					variant="link"
 					onClick={ () => {

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -1,7 +1,13 @@
-import { Button } from '@wordpress/components';
+import {
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import StepSection from 'calypso/a8c-for-agencies/components/step-section';
-import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import wooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/woopayments/logo.svg';
 import { useDispatch } from 'calypso/state';
@@ -25,17 +31,26 @@ const WooPaymentsDashboardEmptyState = () => {
 					) }
 				</div>
 			</div>
-			<StepSection heading={ __( 'How do I start?' ) }>
-				<StepSectionItem
-					heading={ __( 'Add WooPayments to a site for free' ) }
-					description={ __( 'Start by picking the site' ) }
-				>
-					<div className="woopayments-dashboard-empty-state__button">
-						<AddWooPaymentsToSite />
-					</div>
-				</StepSectionItem>
-			</StepSection>
-			<StepSection heading={ __( 'Learn more about the program' ) }>
+			<VStack className="woopayments-dashboard-empty-state__step" spacing={ 3 }>
+				<Heading level={ 3 }>{ __( 'How do I start?' ) }</Heading>
+				<Card>
+					<CardBody>
+						<HStack justify="space-between">
+							<VStack spacing={ 1 }>
+								<Text weight={ 600 }>{ __( 'Add WooPayments to a site for free' ) }</Text>
+								<Text variant="muted">{ __( 'Start by picking the site' ) }</Text>
+							</VStack>
+							<AddWooPaymentsToSite />
+						</HStack>
+					</CardBody>
+				</Card>
+			</VStack>
+			<VStack
+				className="woopayments-dashboard-empty-state__step"
+				spacing={ 2 }
+				alignment="flex-start"
+			>
+				<Heading level={ 3 }>{ __( 'Learn more about the program' ) }</Heading>
 				<Button
 					variant="link"
 					onClick={ () => {
@@ -49,7 +64,7 @@ const WooPaymentsDashboardEmptyState = () => {
 				>
 					{ __( 'Check out the full details in the Knowledge Base' ) }
 				</Button>
-			</StepSection>
+			</VStack>
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
@@ -9,7 +9,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 
 const WooPaymentsDashboardEmptyState = () => {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { showSupportGuide } = useHelpCenter();
 
@@ -18,25 +17,25 @@ const WooPaymentsDashboardEmptyState = () => {
 			<img src={ wooPaymentsLogo } alt="WooPayments" />
 			<div>
 				<div className="woopayments-dashboard-empty-state__heading">
-					{ translate( 'Earn Revenue Share when clients use WooPayments' ) }
+					{ __( 'Earn Revenue Share when clients use WooPayments' ) }
 				</div>
 				<div className="woopayments-dashboard-empty-state__description">
-					{ translate(
+					{ __(
 						'When new clients sign up to use the WooPayments gateway on WooCommerce stores that you build or manage for them, you will receive a revenue share of 5 basis points on the Total Payments Volume (“TPV”).'
 					) }
 				</div>
 			</div>
-			<StepSection heading={ translate( 'How do I start?' ) }>
+			<StepSection heading={ __( 'How do I start?' ) }>
 				<StepSectionItem
-					heading={ translate( 'Add WooPayments to a site for free' ) }
-					description={ translate( 'Start by picking the site' ) }
+					heading={ __( 'Add WooPayments to a site for free' ) }
+					description={ __( 'Start by picking the site' ) }
 				>
 					<div className="woopayments-dashboard-empty-state__button">
 						<AddWooPaymentsToSite />
 					</div>
 				</StepSectionItem>
 			</StepSection>
-			<StepSection heading={ translate( 'Learn more about the program' ) }>
+			<StepSection heading={ __( 'Learn more about the program' ) }>
 				<Button
 					variant="link"
 					onClick={ () => {
@@ -48,7 +47,7 @@ const WooPaymentsDashboardEmptyState = () => {
 						);
 					} }
 				>
-					{ translate( 'Check out the full details in the Knowledge Base' ) }
+					{ __( 'Check out the full details in the Knowledge Base' ) }
 				</Button>
 			</StepSection>
 		</div>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -1,4 +1,9 @@
 import {
+	JetpackLicenseFilter,
+	JetpackLicenseSortField,
+	JetpackLicenseSortDirection,
+} from '@automattic/api-core';
+import {
 	agencySitesWithPluginsQuery,
 	agencyWooPaymentsDataQuery,
 	jetpackAgencyLicensesQuery,
@@ -13,11 +18,6 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-pa
 import { PageBodyPlaceholder } from 'calypso/a8c-for-agencies/components/page-placeholder';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import MissingPaymentSettingsNotice from 'calypso/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice';
-import {
-	LicenseFilter,
-	LicenseSortField,
-	LicenseSortDirection,
-} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
@@ -64,10 +64,10 @@ const WooPaymentsDashboard = () => {
 
 	const { data: licenseSites, isLoading: isLoadingLicensesWithWooPayments } = useQuery( {
 		...jetpackAgencyLicensesQuery( agencyId ?? 0, {
-			filter: LicenseFilter.Attached,
+			filter: JetpackLicenseFilter.Attached,
 			search: 'woopayments',
-			sortField: LicenseSortField.IssuedAt,
-			sortDirection: LicenseSortDirection.Descending,
+			sortField: JetpackLicenseSortField.IssuedAt,
+			sortDirection: JetpackLicenseSortDirection.Descending,
 		} ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -5,8 +5,8 @@ import {
 } from '@automattic/api-queries';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -56,11 +56,9 @@ const sortByState = ( a: SitesWithWooPaymentsState, b: SitesWithWooPaymentsState
 };
 
 const WooPaymentsDashboard = () => {
-	const translate = useTranslate();
-
 	const isDesktop = useDesktopBreakpoint();
 
-	const title = translate( 'WooPayments commissions' );
+	const title = __( 'WooPayments commissions' );
 
 	const agencyId = useSelector( getActiveAgencyId );
 

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -2,8 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-$woocommerce-purple-50: #720EEC;
-
 .woopayments-dashboard {
 	.hosting-dashboard-layout__header-actions {
 		display: flex;
@@ -64,19 +62,6 @@ $woocommerce-purple-50: #720EEC;
 	}
 }
 
-a.components-button.woopayments-dashboard-empty-state__button {
-	&,
-	&:hover,
-	&:focus,
-	&:focus-visible {
-		color: $woocommerce-purple-50;
-		background-color: var(--color-surface);
-		border: none;
-		outline: none;
-		box-shadow: none;
-	}
-}
-
 .woopayments-dashboard__actions {
 	@include body-small;
 	display: flex;
@@ -95,25 +80,5 @@ a.components-button.woopayments-dashboard-empty-state__button {
 
 	svg {
 		margin: 0
-	}
-}
-
-.woopayments-dashboard-empty-state__button {
-	margin-block-start: 16px;
-	margin-inline-start: auto;
-
-	button {
-		width: 100%;
-		height: 40px;
-
-		@include break-large {
-			min-width: 100px;
-			width: auto;
-			height: inherit;
-		}
-	}
-
-	@include break-large {
-		margin-block-start: 0;
 	}
 }

--- a/packages/api-core/src/jetpack-agency-licenses/types.ts
+++ b/packages/api-core/src/jetpack-agency-licenses/types.ts
@@ -40,9 +40,28 @@ export interface JetpackLicense {
 	subscription?: JetpackLicenseSubscription | null;
 }
 
+export enum JetpackLicenseFilter {
+	NotRevoked = 'not_revoked',
+	Detached = 'detached',
+	Attached = 'attached',
+	Revoked = 'revoked',
+	Standard = 'standard',
+}
+
+export enum JetpackLicenseSortField {
+	IssuedAt = 'issued_at',
+	AttachedAt = 'attached_at',
+	RevokedAt = 'revoked_at',
+}
+
+export enum JetpackLicenseSortDirection {
+	Ascending = 'asc',
+	Descending = 'desc',
+}
+
 export interface FetchJetpackLicensesOptions {
-	filter: string;
+	filter: JetpackLicenseFilter;
 	search?: string;
-	sortField: string;
-	sortDirection: string;
+	sortField: JetpackLicenseSortField;
+	sortDirection: JetpackLicenseSortDirection;
 }


### PR DESCRIPTION
Part of the A4A Multi-site Dashboard (MSD) migration.

> **Stacked PR.** This targets the data-layer branch (#112324), not `trunk`, and should be reviewed/merged after it. It contains only the component-refactor commits on top of that work.

## Proposed Changes

Brings the A4A **WooPayments commissions dashboard** components up to the MSD coding standard **in place** (the page stays in `client/a8c-for-agencies/`; the actual move to `client/dashboard/` is a later effort). No behavior changes — this is a standards/quality refactor. Delivered as one commit per concern:

1. **i18n** — `i18n-calypso` (`useTranslate`/`translate`) → `@wordpress/i18n` (`__`, `createInterpolateElement` for the component-interpolation strings).
2. **Components** — swap Calypso/A4A UI for platform primitives: `StatusBadge` → `Badge` (`@automattic/ui`), `A4APopover` → `@wordpress/components` `Popover`, `Gridicon` → `@wordpress/icons`, `StepSection` → `Card` + `@wordpress` layout primitives.
3. **CSS/SCSS** — remove dead empty-state styles orphaned by the component swap, which also removes the one hardcoded hex color; the in-scope SCSS otherwise already follows the conventions.
4. **DataViews** — migrate the commissions table from `ItemsDataViews`/`calypso/components/dataviews` to bare `@wordpress/dataviews`, keeping the `redesigned-a8c-table` wrapper and importing the DataViews stylesheet per-page so the classic layout is preserved.
5. **License enums** — move the Jetpack license filter/sort enums into the `@automattic/api-core` `jetpack-licenses` resource, so the dashboard/landing components import them from the data layer instead of `jetpack-cloud/partner-portal`.

### Scope & deferrals

In scope: the commissions dashboard and its embedded pieces. Intentionally **left as-is** because they carry bespoke layout/CSS and get rebuilt when the page moves to the dashboard: the add-site modal (`A4AModal`) and its `FormRadio` picker, the add-site-table's DataViews, and the display components `ConsolidatedStatsCard`, `ListItemCards` (mobile view), and `TextPlaceholder`. The marketing overview page, site-setup flow, and payment-settings are out of scope.

<img width="1523" height="774" alt="Screenshot 2026-07-06 at 11 39 47 PM" src="https://github.com/user-attachments/assets/e24ceadc-70fd-4c16-9d73-414ba45832ad" />
<img width="1085" height="485" alt="Screenshot 2026-07-06 at 11 39 36 PM" src="https://github.com/user-attachments/assets/a39a7356-a14f-4b40-aa3a-fc05c7d5c7ee" />



### Follow-up work

A follow-up PR will cover the remaining items deliberately deferred here:
- The deferred components above (`A4AModal`/`FormRadio`, the add-site-table DataViews, `ConsolidatedStatsCard`, `ListItemCards`, `TextPlaceholder`).
- The optional logic-hygiene extraction of the dashboard's inline data orchestration into a `useWooPaymentsDashboardData()` hook.

## Why are these changes being made?

The WooPayments page will move to the new Multi-site Dashboard, which uses `@wordpress/i18n`, `@wordpress/components`/`@automattic/ui`, `@wordpress/dataviews`, and the shared `@automattic/api-core` data layer. Standardizing the components in place — one reviewable concern at a time — keeps the eventual UI port small and low-risk, and each of these changes survives the port (unlike swaps of bespoke components, which is why those are deferred).

## Testing Instructions

Automated:
- `yarn eslint` and `yarn stylelint` on the changed files — clean.
- `yarn typecheck-client` — no new type errors introduced by this branch (the commissions table's fields/actions are now type-checked against `@wordpress/dataviews` rather than `any`).
- `yarn typecheck-packages` — clean (the license-enum change compiles in `@automattic/api-core`/`@automattic/api-queries`).

Manual (needs an A4A agency account):
1. Open the A4A WooPayments commissions dashboard. Confirm the **table** renders with correct column layout/gutters, the view-config control, and pagination.
2. Confirm the status/eligibility **badges** render and the eligibility **info popover** opens as a compact box.
3. Confirm the **empty state** (no sites/licenses) shows the intro + the "How do I start?" card and the "Learn more" link.
4. Confirm the **Add WooPayments to site** modal still opens and a site can be selected (unchanged in this PR).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (The i18n migration re-registers the dashboard's strings under `@wordpress/i18n` and changes the interpolation markup, so translation review may apply.)
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
