### PR TITLE
Update classic Simple-to-Atomic entry points to match the dashboard

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,4 +1,5 @@
 import { Card, Badge } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import DOMPurify from 'dompurify';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
@@ -20,20 +21,40 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 			{ warnings.map( ( { name, description, supportPostId, supportUrl, domainNames }, index ) => (
 				<div className="eligibility-warnings__warning" key={ index }>
 					<div className="eligibility-warnings__message">
-						{ context !== 'plugin-details' && context !== 'hosting-features' && (
+						{ ! domainNames && context !== 'plugin-details' && context !== 'hosting-features' && (
 							<Fragment>
 								<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 							</Fragment>
 						) }
 						<span className="eligibility-warnings__message-description">
-							<span
-								dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( description ) } } // eslint-disable-line react/no-danger
-							/>
-							{ domainNames && displayDomainNames( domainNames ) }
-							{ supportUrl && (
-								<InlineSupportLink supportLink={ supportUrl } supportPostId={ supportPostId }>
-									{ translate( 'Learn more.' ) }
-								</InlineSupportLink>
+							{ domainNames ? (
+								<>
+									{ translate(
+										'Turning on this feature will update {{strong}}your site’s default address by changing the subdomain{{/strong}}. We’ll automatically redirect visitors from the current address to the new one.',
+										{ components: { strong: <strong /> } }
+									) }{ ' ' }
+									<InlineSupportLink
+										supportPostId={ 11280 }
+										showIcon={ false }
+										supportLink={ localizeUrl(
+											'https://wordpress.com/support/changing-site-address/#change-a-wpcomstaging-com-address'
+										) }
+									>
+										{ translate( 'Learn more.' ) }
+									</InlineSupportLink>
+									{ displayDomainNames( domainNames ) }
+								</>
+							) : (
+								<>
+									<span
+										dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( description ) } } // eslint-disable-line react/no-danger
+									/>
+									{ supportUrl && (
+										<InlineSupportLink supportLink={ supportUrl } supportPostId={ supportPostId }>
+											{ translate( 'Learn more.' ) }
+										</InlineSupportLink>
+									) }
+								</>
 							) }
 						</span>
 					</div>

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -1,33 +1,30 @@
 import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { CompactCard, Dialog } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Page } from '@wordpress/admin-ui';
-import clsx from 'clsx';
+import { Icon, Modal } from '@wordpress/components';
+import { backup } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
-import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import {
-	default as HoldList,
 	getBlockingMessages,
 	HardBlockingNotice,
 	hasBlockingHold as hasBlockingHoldFunc,
 } from 'calypso/blocks/eligibility-warnings/hold-list';
-import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAutomatedTransferEligibility from 'calypso/components/data/query-atat-eligibility';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import PromoCard from 'calypso/components/promo-section/promo-card';
 import SpinnerButton from 'calypso/components/spinner-button';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import BackupsCalloutIllustration from 'calypso/my-sites/backup/backups-callout-illustration.svg';
 import WPCOMUpsellPage from 'calypso/my-sites/backup/wpcom-upsell';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
@@ -76,10 +73,12 @@ export interface AtomicContentSwitch {
 	header: string;
 	subTitle?: string;
 	primaryPromo: {
+		icon?: JSX.Element;
 		image: { path: string };
 		promoCTA: { loadingText: string; text: string };
 		title: string;
 		content: string;
+		secondaryContent?: string;
 	};
 	getProductUrl: ( siteSlug: string ) => string;
 	/** Optional hook for product-specific activation handling */
@@ -91,11 +90,13 @@ const vaultpressContent: AtomicContentSwitch = {
 	header: translate( 'Backup' ) as string,
 	subTitle: translate( 'Save changes and restore quickly with one-click recovery.' ) as string,
 	primaryPromo: {
-		title: translate( 'Get time travel for your site with Jetpack VaultPress Backup' ),
-		image: { path: JetpackBackupSVG },
+		icon: backup,
+		title: translate( 'Activate Jetpack VaultPress Backup' ),
+		image: { path: BackupsCalloutIllustration },
 		content: translate(
-			'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+			'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
 		),
+		secondaryContent: translate( 'Get time travel for your site with Jetpack VaultPress Backup.' ),
 		promoCTA: {
 			text: translate( 'Activate Jetpack VaultPress Backup now' ),
 			loadingText: translate( 'Activating Jetpack VaultPress Backup' ),
@@ -328,71 +329,69 @@ export default function WPCOMBusinessAT( {
 					transferStatus={ automatedTransferStatus as TransferStatus }
 					productName={ content.header }
 				/>
-				<PromoCard
-					title={ content.primaryPromo.title }
-					image={ content.primaryPromo.image }
-					isPrimary
-				>
-					<p>{ content.primaryPromo.content }</p>
-					<div className="wpcom-business-at__cta">
-						<SpinnerButton
-							text={ content.primaryPromo.promoCTA.text }
-							loadingText={ content.primaryPromo.promoCTA.loadingText }
-							loading={
-								automatedTransferStatus === START ||
-								( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
-								isRewindActivating
-							}
-							onClick={ () => {
-								if ( rewindAtomicDeactivated ) {
-									setIsRewindActivating( true );
-									dispatch( autoConfigCredentials( siteId ) );
-									page( content.getProductUrl( siteSlug ) );
-									return;
+				<div className="wpcom-business-at__callout">
+					<div className="wpcom-business-at__callout-content">
+						{ content.primaryPromo.icon && (
+							<Icon
+								className="wpcom-business-at__callout-icon"
+								icon={ content.primaryPromo.icon }
+							/>
+						) }
+						<h2 className="wpcom-business-at__callout-title">{ content.primaryPromo.title }</h2>
+						<p className="wpcom-business-at__callout-description">
+							{ content.primaryPromo.content }
+						</p>
+						{ content.primaryPromo.secondaryContent && (
+							<p className="wpcom-business-at__callout-description">
+								{ content.primaryPromo.secondaryContent }
+							</p>
+						) }
+						<div className="wpcom-business-at__cta">
+							<SpinnerButton
+								text={ translate( 'Activate' ) }
+								loadingText={ content.primaryPromo.promoCTA.loadingText }
+								loading={
+									automatedTransferStatus === START ||
+									( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
+									isRewindActivating
 								}
-								initiateATOrShowWarnings();
-							} }
-							disabled={
-								( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
-							}
-						/>
+								onClick={ () => {
+									if ( rewindAtomicDeactivated ) {
+										setIsRewindActivating( true );
+										dispatch( autoConfigCredentials( siteId ) );
+										page( content.getProductUrl( siteSlug ) );
+										return;
+									}
+									initiateATOrShowWarnings();
+								} }
+								disabled={
+									( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
+								}
+							/>
+						</div>
 					</div>
-				</PromoCard>
-
-				{ ! isJetpackCloud() && <WhatIsJetpack className="wpcom-business-at__footer" /> }
+					<div className="wpcom-business-at__callout-image" aria-hidden="true">
+						<img src={ content.primaryPromo.image.path } alt="" />
+					</div>
+				</div>
 			</Page>
 			{ ! isJetpackCloud() && <JetpackFooter /> }
 
-			<Dialog
-				isVisible={ showDialog }
-				onClose={ onClose }
-				buttons={ [
-					{ action: 'cancel', label: translate( 'Cancel' ) },
-					{
-						action: 'continue',
-						label: translate( 'Continue' ),
-						onClick: trackInitiateAT,
-						isPrimary: true,
-					},
-				] }
-				className={ clsx(
-					'wpcom-business-at__dialog',
-					'eligibility-warnings',
-					'eligibility-warnings--without-title',
-					{
-						'eligibility-warnings--with-indent': warnings?.length,
-					}
-				) }
-			>
-				{ !! holds?.length && (
-					<HoldList holds={ holds } context="backup" isPlaceholder={ false } />
-				) }
-				{ !! warnings?.length && (
-					<CompactCard className="eligibility-warnings__warnings-card">
-						<WarningList warnings={ warnings } context="backup" />
-					</CompactCard>
-				) }
-			</Dialog>
+			{ showDialog && (
+				<Modal
+					className="wpcom-business-at__dialog"
+					title={ translate( 'Before you continue' ) }
+					onRequestClose={ onClose }
+					size="medium"
+				>
+					<EligibilityWarnings
+						currentContext="hosting-features"
+						standaloneProceed
+						onDismiss={ onClose }
+						onProceed={ trackInitiateAT }
+					/>
+				</Modal>
+			) }
 		</Main>
 	);
 }

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -75,7 +75,6 @@ export interface AtomicContentSwitch {
 	primaryPromo: {
 		icon?: JSX.Element;
 		image: { path: string };
-		promoCTA: { loadingText: string; text: string };
 		title: string;
 		content: string;
 		secondaryContent?: string;
@@ -97,10 +96,6 @@ const vaultpressContent: AtomicContentSwitch = {
 			'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
 		),
 		secondaryContent: translate( 'Get time travel for your site with Jetpack VaultPress Backup.' ),
-		promoCTA: {
-			text: translate( 'Activate Jetpack VaultPress Backup now' ),
-			loadingText: translate( 'Activating Jetpack VaultPress Backup' ),
-		},
 	},
 
 	getProductUrl: ( siteSlug: string ) => `/backup/${ siteSlug }`,
@@ -349,7 +344,7 @@ export default function WPCOMBusinessAT( {
 						<div className="wpcom-business-at__cta">
 							<SpinnerButton
 								text={ translate( 'Activate' ) }
-								loadingText={ content.primaryPromo.promoCTA.loadingText }
+								loadingText={ translate( 'Activating…' ) }
 								loading={
 									automatedTransferStatus === START ||
 									( automatedTransferStatus === COMPLETE && ! isJetpack ) ||

--- a/client/components/jetpack/wpcom-business-at/style.scss
+++ b/client/components/jetpack/wpcom-business-at/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "calypso/assets/stylesheets/shared/mixins/placeholder";
 
@@ -46,5 +47,71 @@
 		@include breakpoint-deprecated( ">480px" ) {
 			height: 250px;
 		}
+	}
+}
+
+.wpcom-business-at__callout {
+	display: flex;
+	align-items: stretch;
+	gap: 24px;
+	max-width: 600px;
+	margin-block: 48px;
+	margin-inline: auto;
+	padding: 24px;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	background: var(--color-surface);
+
+	@include breakpoint-deprecated( "<660px" ) {
+		flex-direction: column;
+	}
+}
+
+.wpcom-business-at__callout-content {
+	display: flex;
+	flex: 1 1 0;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 16px;
+}
+
+.wpcom-business-at__callout-icon {
+	fill: var(--color-text);
+}
+
+.wpcom-business-at__callout-title {
+	@include heading-large;
+	margin: 0;
+	color: var(--color-text);
+}
+
+.wpcom-business-at__callout-description {
+	@include body-medium;
+	margin: 0;
+	color: var(--color-text-subtle);
+}
+
+.wpcom-business-at__callout .wpcom-business-at__cta {
+	margin: 8px 0 0;
+
+	> div {
+		justify-content: flex-start;
+	}
+}
+
+.wpcom-business-at__callout-image {
+	position: relative;
+	flex: 1 1 0;
+
+	img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		display: none;
 	}
 }

--- a/client/my-sites/backup/backups-callout-illustration.svg
+++ b/client/my-sites/backup/backups-callout-illustration.svg
@@ -1,0 +1,49 @@
+<svg width="256" height="296" viewBox="0 0 256 296" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_6624_160429)">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H252C254.209 0 256 1.79086 256 4V292C256 294.209 254.209 296 252 296H4C1.79086 296 0 294.209 0 292V4Z" fill="#F6F7F7"/>
+<g opacity="0.5">
+<rect x="-14" y="16" width="285" height="268" fill="url(#pattern0_6624_160429)"/>
+<rect x="-14" y="16" width="285" height="268" fill="url(#paint0_radial_6624_160429)"/>
+</g>
+<rect x="32" y="181" width="4" height="5" fill="#F6F7F7"/>
+<rect x="25" y="68" width="4" height="5" fill="#F6F7F7"/>
+<rect x="181" y="67" width="4" height="5" fill="#F6F7F7"/>
+<rect x="193" y="79" width="4" height="5" fill="#F6F7F7"/>
+<rect x="205" y="92" width="4" height="11" fill="#F6F7F7"/>
+<rect x="216" y="103" width="4" height="11" fill="#F6F7F7"/>
+<rect x="56" y="204" width="4" height="5" fill="#F6F7F7"/>
+<rect x="68" y="217" width="4" height="5" fill="#F6F7F7"/>
+<rect x="26" y="69" width="159" height="113" rx="4.62" fill="#F6F7F7" stroke="#C3C4C7"/>
+<rect x="37" y="80" width="159" height="113" rx="4.62" fill="#F6F7F7" stroke="#C3C4C7"/>
+<rect x="48" y="91" width="159" height="113" rx="4.62" fill="#F6F7F7" stroke="#C3C4C7"/>
+<rect x="59" y="102" width="159" height="113" rx="4.62" fill="#F6F7F7" stroke="#C3C4C7"/>
+<rect x="70" y="113" width="159" height="113" rx="4.62" fill="#F6F7F7" stroke="url(#paint1_linear_6624_160429)"/>
+<circle cx="80.8274" cy="122.617" r="2.04229" fill="#F6F7F7" stroke="#C3C4C7"/>
+<circle cx="88.9993" cy="122.617" r="2.04229" fill="#F6F7F7" stroke="#C3C4C7"/>
+<circle cx="97.1673" cy="122.617" r="2.04229" fill="#F6F7F7" stroke="#C3C4C7"/>
+<g clip-path="url(#clip1_6624_160429)">
+<rect x="137.5" y="157.5" width="24" height="24" rx="1.48829" fill="#3858E9"/>
+<path d="M144.063 169.5H145.444L143.472 171.75L141.5 169.5H142.88C142.88 168.146 143.362 166.831 144.247 165.77C145.133 164.71 146.369 163.965 147.756 163.657C149.143 163.349 150.599 163.497 151.887 164.075C153.174 164.654 154.218 165.63 154.848 166.845C155.479 168.059 155.658 169.44 155.358 170.764C155.058 172.088 154.296 173.277 153.195 174.136C152.095 174.996 150.721 175.476 149.297 175.499C147.873 175.522 146.483 175.086 145.352 174.262L146.068 173.367C146.985 174.037 148.115 174.393 149.272 174.375C150.429 174.357 151.546 173.968 152.441 173.27C153.336 172.572 153.956 171.607 154.201 170.531C154.446 169.455 154.3 168.333 153.789 167.346C153.277 166.358 152.429 165.565 151.383 165.094C150.337 164.623 149.154 164.503 148.027 164.753C146.9 165.002 145.895 165.607 145.175 166.469C144.455 167.331 144.064 168.399 144.063 169.5ZM151.58 170.977L149.782 169.267V166.875C149.782 166.726 149.719 166.583 149.608 166.477C149.497 166.372 149.347 166.312 149.19 166.312C149.033 166.312 148.883 166.372 148.772 166.477C148.661 166.583 148.599 166.726 148.599 166.875V169.5C148.598 169.574 148.614 169.647 148.643 169.715C148.673 169.783 148.716 169.845 148.771 169.897L149.782 169.267L148.772 169.898L150.744 171.773C150.799 171.827 150.864 171.87 150.936 171.899C151.008 171.929 151.086 171.944 151.164 171.945C151.243 171.945 151.321 171.931 151.393 171.903C151.466 171.874 151.532 171.833 151.588 171.78C151.643 171.727 151.687 171.664 151.717 171.595C151.747 171.526 151.761 171.452 151.761 171.377C151.76 171.302 151.744 171.229 151.713 171.16C151.682 171.091 151.637 171.029 151.58 170.977Z" fill="white"/>
+</g>
+</g>
+<defs>
+<pattern id="pattern0_6624_160429" patternContentUnits="objectBoundingBox" width="0.154864" height="0.164688">
+<use xlink:href="#image0_6624_160429" transform="scale(0.00120988 0.00128662)"/>
+</pattern>
+<radialGradient id="paint0_radial_6624_160429" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(128.5 150) rotate(90) scale(134 142.5)">
+<stop stop-color="#F6F7F7" stop-opacity="0"/>
+<stop offset="1" stop-color="#F6F7F7"/>
+</radialGradient>
+<linearGradient id="paint1_linear_6624_160429" x1="81.1579" y1="158.2" x2="215.092" y2="158.83" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<clipPath id="clip0_6624_160429">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H252C254.209 0 256 1.79086 256 4V292C256 294.209 254.209 296 252 296H4C1.79086 296 0 294.209 0 292V4Z" fill="white"/>
+</clipPath>
+<clipPath id="clip1_6624_160429">
+<rect x="137.5" y="157.5" width="24" height="24" rx="1.48829" fill="white"/>
+</clipPath>
+<image id="image0_6624_160429" width="128" height="128" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAEbSURBVHgB7d0xqgJBFETRHldgIu5/eWLiDhSDATH31WCdAz/qZBou6BTCXyvofLk+33+r1BHuf1oAADDJW4C3AMIEUE4AAADMsgPYAQgTQDkBAAAwyw5gByBMAOUEAADALDtA/v7b/gCP+237PPh+MOf/ee41kBwfAd33BwBK+RLo9wCECaCcAAAAmGUHsAMQJoByAgAAYJYdwA5AmADKCQAAgFl2ADsAYQIoJwAAAGbZAewAhAmgnAAAAJhlB7ADECaAcgIAAGCWHcAOQJgAygkAAIBZdoD8/bf9AY76/+2d//bcayA5PgK67w8AlPIl0O8BCBNAOQEAADDLDmAHIEwA5QQAAMAsO4AdgDABlBMAAACz7AB2AFbWCzh24FOfquB3AAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -179,6 +179,64 @@ body.is-section-backup {
 			}
 		}
 	}
+
+	.backup__upsell-callout {
+		display: flex;
+		align-items: stretch;
+		gap: 24px;
+		max-width: 600px;
+		margin-block: 48px;
+		margin-inline: auto;
+		padding: 24px;
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 8px;
+		background: var(--color-surface);
+
+		@include breakpoint-deprecated( "<660px" ) {
+			flex-direction: column;
+		}
+	}
+
+	.backup__upsell-callout-content {
+		display: flex;
+		flex: 1 1 0;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+	}
+
+	.backup__upsell-callout-icon {
+		fill: var(--color-text);
+	}
+
+	.backup__upsell-callout-title {
+		@include heading-large;
+		margin: 0;
+		color: var(--color-text);
+	}
+
+	.backup__upsell-callout-description {
+		@include body-medium;
+		margin: 0;
+		color: var(--color-text-subtle);
+	}
+
+	.backup__upsell-callout-image {
+		position: relative;
+		flex: 1 1 0;
+
+		img {
+			position: absolute;
+			inset: 0;
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			display: none;
+		}
+	}
 }
 
 /* Jetpack.com-only changes */

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -1,10 +1,8 @@
-import {
-	PLAN_BUSINESS,
-	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
-	getPlan,
-} from '@automattic/calypso-products';
-import { Button, Gridicon } from '@automattic/components';
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { Page } from '@wordpress/admin-ui';
+import { Icon } from '@wordpress/components';
+import { backup } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
@@ -13,13 +11,10 @@ import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
-import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import PromoCard from 'calypso/components/promo-section/promo-card';
-import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -28,10 +23,11 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import illustrationUrl from './backups-callout-illustration.svg';
 import BackupDownloadFlowExpiredPlan from './rewind-flow/download-expired-plan';
+
 import './style.scss';
 
 const JetpackBackupErrorSVG = '/calypso/images/illustrations/jetpack-cloud-backup-error.svg';
@@ -166,78 +162,97 @@ const BackupUpsellBody = () => {
 		undefined,
 		isWPcomSite ? 'calypso_jetpack_backup_business_upsell' : 'calypso_jetpack_backup_upsell'
 	);
-	const hasFullActivityLogFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG )
-	);
-	const promos: PromoSectionProps = {
-		promos: [
-			{
-				title: translate( 'Activity Log' ),
-				body: translate(
-					'A complete record of everything that happens on your site, with history that spans over 30 days.'
-				),
-				image: <Gridicon icon="history" className="backup__upsell-icon" />,
-			},
-		],
-	};
+
+	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
+	const commercePlanName = getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '';
 
 	return (
 		<>
-			<PromoCard
-				title={ preventWidows(
-					translate( 'Get time travel for your site with Jetpack VaultPress Backup' )
-				) }
-				image={ { path: JetpackBackupSVG } }
-				isPrimary
-			>
-				<p>
-					{ preventWidows(
-						translate(
-							'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
-						)
-					) }
-				</p>
-				{ ! isAdmin && (
-					<Notice
-						status="is-warning"
-						text={ translate(
-							'Only site administrators can upgrade to access VaultPress Backup.'
-						) }
-						showDismiss={ false }
-					/>
-				) }
-				{ isAdmin && isWPcomSite && (
-					<PromoCardCTA
-						cta={ {
-							text: translate( 'Upgrade to %(planName)s Plan', {
-								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-							} ),
-							action: {
-								url: `${ checkoutHost }/checkout/${ siteSlug }/business`,
-								onClick: onUpgradeClick,
-								selfTarget: true,
-							},
-						} }
-					/>
-				) }
-				{ isAdmin && ! isWPcomSite && (
-					<div className="backup__wpcom-ctas">
-						<Button
-							className="backup__wpcom-cta"
-							href={ addQueryArgs(
-								`${ checkoutHost }/checkout/${ siteSlug }/jetpack_backup_t1_yearly`,
-								{
-									redirect_to: postCheckoutUrl,
-								}
+			{ isWPcomSite ? (
+				<div className="backup__upsell-callout">
+					<div className="backup__upsell-callout-content">
+						<Icon className="backup__upsell-callout-icon" icon={ backup } />
+						<h2 className="backup__upsell-callout-title">
+							{ translate( 'Secure your content with Jetpack VaultPress Backup' ) }
+						</h2>
+						<p className="backup__upsell-callout-description">
+							{ translate(
+								'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
 							) }
-							onClick={ onUpgradeClick }
-							primary
-						>
-							{ translate( 'Get backups' ) }
-						</Button>
+						</p>
+						<p className="backup__upsell-callout-description">
+							{ translate(
+								// translators: %(businessPlanName)s is the Business plan name, %(commercePlanName)s is the Commerce plan name
+								'Available on the WordPress.com %(businessPlanName)s and %(commercePlanName)s plans.',
+								{ args: { businessPlanName, commercePlanName } }
+							) }
+						</p>
+						{ isAdmin ? (
+							<Button
+								className="backup__upsell-callout-button"
+								href={ `${ checkoutHost }/checkout/${ siteSlug }/business` }
+								onClick={ onUpgradeClick }
+								primary
+							>
+								{ translate( 'Upgrade plan' ) }
+							</Button>
+						) : (
+							<Notice
+								status="is-warning"
+								showDismiss={ false }
+								text={ translate(
+									'Only site administrators can upgrade to access VaultPress Backup.'
+								) }
+							/>
+						) }
 					</div>
-				) }
-			</PromoCard>
+					<div className="backup__upsell-callout-image" aria-hidden="true">
+						<img src={ illustrationUrl } alt="" />
+					</div>
+				</div>
+			) : (
+				<PromoCard
+					title={ preventWidows(
+						translate( 'Get time travel for your site with Jetpack VaultPress Backup' )
+					) }
+					image={ { path: JetpackBackupSVG } }
+					isPrimary
+				>
+					<p>
+						{ preventWidows(
+							translate(
+								'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+							)
+						) }
+					</p>
+					{ ! isAdmin && (
+						<Notice
+							status="is-warning"
+							text={ translate(
+								'Only site administrators can upgrade to access VaultPress Backup.'
+							) }
+							showDismiss={ false }
+						/>
+					) }
+					{ isAdmin && (
+						<div className="backup__wpcom-ctas">
+							<Button
+								className="backup__wpcom-cta"
+								href={ addQueryArgs(
+									`${ checkoutHost }/checkout/${ siteSlug }/jetpack_backup_t1_yearly`,
+									{
+										redirect_to: postCheckoutUrl,
+									}
+								) }
+								onClick={ onUpgradeClick }
+								primary
+							>
+								{ translate( 'Get backups' ) }
+							</Button>
+						</div>
+					) }
+				</PromoCard>
+			) }
 			{ isRevertedWithValidBackup && backupPeriodDate && rewindId && siteSlug && siteId && (
 				<BackupDownloadFlowExpiredPlan
 					backupDisplayDate={ backupPeriodDate }
@@ -246,19 +261,6 @@ const BackupUpsellBody = () => {
 					siteUrl={ siteSlug }
 				/>
 			) }
-			{ isWPcomSite && ! hasFullActivityLogFeature && (
-				<>
-					<h2 className="backup__subheader">
-						{ translate( 'Also included in the %(planName)s Plan', {
-							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						} ) }
-					</h2>
-
-					<PromoSection { ...promos } />
-				</>
-			) }
-
-			{ ! isJetpackCloud() && isWPcomSite && <WhatIsJetpack /> }
 		</>
 	);
 };

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -1,10 +1,8 @@
 import {
 	FEATURE_SFTP,
 	FEATURE_UPLOAD_PLUGINS,
-	PLAN_BUSINESS,
 	PLAN_PERSONAL,
 	getPlan,
-	isFreePlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
@@ -107,28 +105,24 @@ class PluginUpload extends Component {
 	};
 
 	renderUpgradeBanner() {
-		const { siteSlug, needsBusinessPlan, translate } = this.props;
+		const { siteSlug, translate } = this.props;
 		const redirectTo = encodeURIComponent( `/plugins/upload/${ siteSlug }` );
 
-		const upsellPlan = needsBusinessPlan ? PLAN_BUSINESS : PLAN_PERSONAL;
 		const title = translate(
-			// translators: %(planName)s the short-hand version of the plan name
+			// translators: %(planName)s the short-hand version of the Personal plan name
 			'Upgrade to the %(planName)s plan to access the plugin install features',
 			{
-				args: { planName: getPlan( upsellPlan )?.getTitle() ?? '' },
+				args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
 			}
 		);
-		const upgradeUrl = `/checkout/${ siteSlug }/${
-			needsBusinessPlan ? 'business' : 'personal'
-		}?redirect_to=${ redirectTo }`;
 
 		return (
 			<UpsellNudge
 				className="plugin-upload__upgrade-nudge"
 				title={ title }
 				event="calypso_plugin_install_upgrade_click"
-				href={ upgradeUrl }
-				plan={ upsellPlan }
+				href={ `/checkout/${ siteSlug }/personal?redirect_to=${ redirectTo }` }
+				plan={ PLAN_PERSONAL }
 				feature={ FEATURE_UPLOAD_PLUGINS }
 				showIcon
 			/>
@@ -269,7 +263,6 @@ const mapStateToProps = ( state ) => {
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
-	const isOnPaidPlan = site?.plan?.product_slug ? ! isFreePlan( site.plan.product_slug ) : false;
 
 	return {
 		siteId,
@@ -280,7 +273,6 @@ const mapStateToProps = ( state ) => {
 		hasUploadPluginsFeature,
 		canUpload,
 		isStandaloneJetpack,
-		needsBusinessPlan: isOnPaidPlan && ! hasUploadPluginsFeature,
 		inProgress: isPluginUploadInProgress( state, siteId ),
 		complete: isPluginUploadComplete( state, siteId ),
 		failed: !! error,

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -1,4 +1,11 @@
-import { FEATURE_SFTP, FEATURE_UPLOAD_PLUGINS } from '@automattic/calypso-products';
+import {
+	FEATURE_SFTP,
+	FEATURE_UPLOAD_PLUGINS,
+	PLAN_BUSINESS,
+	PLAN_PERSONAL,
+	getPlan,
+	isFreePlan,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { isEmpty } from '@automattic/js-utils';
@@ -8,7 +15,9 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import UploadDropZone from 'calypso/blocks/upload-drop-zone';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FeatureExample from 'calypso/components/feature-example';
 import HeaderCake from 'calypso/components/header-cake';
@@ -31,6 +40,10 @@ import {
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import { uploadPlugin, clearPluginUpload } from 'calypso/state/plugins/upload/actions';
+import {
+	isFetchingSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
@@ -47,6 +60,8 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+
+import './style.scss';
 
 class PluginUpload extends Component {
 	state = {
@@ -90,6 +105,35 @@ class PluginUpload extends Component {
 			isTransferring: false,
 		} );
 	};
+
+	renderUpgradeBanner() {
+		const { siteSlug, needsBusinessPlan, translate } = this.props;
+		const redirectTo = encodeURIComponent( `/plugins/upload/${ siteSlug }` );
+
+		const upsellPlan = needsBusinessPlan ? PLAN_BUSINESS : PLAN_PERSONAL;
+		const title = translate(
+			// translators: %(planName)s the short-hand version of the plan name
+			'Upgrade to the %(planName)s plan to access the plugin install features',
+			{
+				args: { planName: getPlan( upsellPlan )?.getTitle() ?? '' },
+			}
+		);
+		const upgradeUrl = `/checkout/${ siteSlug }/${
+			needsBusinessPlan ? 'business' : 'personal'
+		}?redirect_to=${ redirectTo }`;
+
+		return (
+			<UpsellNudge
+				className="plugin-upload__upgrade-nudge"
+				title={ title }
+				event="calypso_plugin_install_upgrade_click"
+				href={ upgradeUrl }
+				plan={ upsellPlan }
+				feature={ FEATURE_UPLOAD_PLUGINS }
+				showIcon
+			/>
+		);
+	}
 
 	renderUploadCard() {
 		const { inProgress, complete, isJetpack, hasSftpFeature, hasUploadPluginsFeature } = this.props;
@@ -171,21 +215,27 @@ class PluginUpload extends Component {
 			isTrialSite,
 			isAtomic,
 			hasUploadPluginsFeature,
+			canUpload,
+			isStandaloneJetpack,
+			isFetchingPurchases,
 		} = this.props;
 		const { showEligibility, isTransferring } = this.state;
 
 		const showEligibilityWarnings = showEligibility && ! isTransferring && ! isTrialSite;
+		const showUpgradeBanner = ! isFetchingPurchases && ! canUpload && ! isStandaloneJetpack;
 
 		return (
 			<Main>
 				<PageViewTracker path="/plugins/upload/:site" title="Plugins > Upload" />
 				<QueryEligibility siteId={ siteId } />
+				<QuerySitePurchases siteId={ siteId } />
 				<NavigationHeader navigationItems={ [] } title={ translate( 'Plugins' ) } />
 				<HeaderCake onClick={ this.back }>{ translate( 'Install plugin' ) }</HeaderCake>
 				{ ! isJetpack && (
 					<HostingActivateStatus context="plugin" onTick={ this.requestUpdatedSiteData } />
 				) }
 				{ isJetpackMultisite && this.renderNotAvailableForMultisite() }
+				{ showUpgradeBanner && this.renderUpgradeBanner() }
 				{ showEligibilityWarnings && (
 					<EligibilityWarnings
 						backUrl={ `/plugins/${ siteSlug }` }
@@ -210,6 +260,8 @@ const mapStateToProps = ( state ) => {
 	const isJetpackMultisite = isJetpackSiteMultiSite( state, siteId );
 	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 	const hasUploadPluginsFeature = siteHasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS );
+	const canUpload = hasSftpFeature || hasUploadPluginsFeature;
+	const isStandaloneJetpack = isJetpack && ! isAtomic;
 	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
@@ -217,6 +269,7 @@ const mapStateToProps = ( state ) => {
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
+	const isOnPaidPlan = site?.plan?.product_slug ? ! isFreePlan( site.plan.product_slug ) : false;
 
 	return {
 		siteId,
@@ -225,6 +278,9 @@ const mapStateToProps = ( state ) => {
 		isAtomic,
 		hasSftpFeature,
 		hasUploadPluginsFeature,
+		canUpload,
+		isStandaloneJetpack,
+		needsBusinessPlan: isOnPaidPlan && ! hasUploadPluginsFeature,
 		inProgress: isPluginUploadInProgress( state, siteId ),
 		complete: isPluginUploadComplete( state, siteId ),
 		failed: !! error,
@@ -232,8 +288,12 @@ const mapStateToProps = ( state ) => {
 		error,
 		isJetpackMultisite,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
-		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
+		// Only surface eligibility warnings once the site is on a plan that can
+		// upload plugins; otherwise we show an upgrade banner instead.
+		showEligibility: ! isJetpack && canUpload && ( hasEligibilityMessages || ! isEligible ),
 		isTrialSite: isHostingTrialSite( site ),
+		isFetchingPurchases:
+			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 	};
 };
 

--- a/client/my-sites/plugins/plugin-upload/style.scss
+++ b/client/my-sites/plugins/plugin-upload/style.scss
@@ -1,0 +1,14 @@
+// Overrides the section-wide `.is-section-plugins .main .upsell-nudge` margin
+// (see my-sites/plugins/style.scss) for the upload page's upgrade banner.
+.is-section-plugins .main .upsell-nudge.plugin-upload__upgrade-nudge {
+	margin-block-start: 16px;
+}
+
+// When the drop zone is gated behind a plan it's wrapped in `FeatureExample`,
+// whose gradient overlay already dims (and click-shields) it. Drop the drop
+// zone's own `opacity: 0.2` so the two don't stack into a washed-out card. The
+// zone stays `disabled` — `DropZone` listens on `window` and hit-tests by
+// coordinates, so the overlay alone wouldn't block a native file drop.
+.is-section-plugins .main .feature-example .upload-drop-zone.is-disabled {
+	opacity: 1;
+}

--- a/client/my-sites/scan/scan-callout-illustration.svg
+++ b/client/my-sites/scan/scan-callout-illustration.svg
@@ -1,0 +1,54 @@
+<svg width="256" height="244" viewBox="0 0 256 244" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_5936_20173)">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H252C254.209 0 256 1.79086 256 4V240C256 242.209 254.209 244 252 244H4C1.79086 244 0 242.209 0 240V4Z" fill="#F6F7F7"/>
+<rect opacity="0.8" x="3" y="-25" width="419" height="301" fill="url(#pattern0_5936_20173)"/>
+<rect x="151" y="63" width="1" height="91" fill="#F6F7F7"/>
+<rect x="40" y="154" width="2" height="91" fill="#F6F7F7"/>
+<rect x="216" y="170" width="2" height="98" fill="#F6F7F7"/>
+<rect x="85" y="112" width="1" height="91" fill="#F6F7F7"/>
+<rect x="62" y="133" width="1.99999" height="143" transform="rotate(-90 62 133)" fill="#F6F7F7"/>
+<rect x="20" y="45.2878" width="189" height="116.455" rx="6" stroke="#E0E0E0"/>
+<rect x="30" y="54.5303" width="189" height="116.455" rx="6" stroke="#CCCCCC"/>
+<rect x="38" y="63.7727" width="189" height="116.455" rx="6" fill="#F6F7F7" stroke="url(#paint0_linear_5936_20173)"/>
+<path d="M205 69C205 70.9569 205 87.4247 205 102.133C205 113.178 196.046 122.13 185 122.13H80C68.9543 122.13 60 131.084 60 142.13V174" stroke="url(#paint1_linear_5936_20173)" stroke-dasharray="2 2"/>
+<circle cx="52" cy="83" r="3" stroke="#3858E9"/>
+<circle cx="64" cy="83" r="3" stroke="#3858E9"/>
+<circle cx="76" cy="83" r="3" stroke="#3858E9"/>
+<path d="M133 98.6143C151.786 98.6143 165.712 116.462 169.168 121.34C169.705 122.099 169.769 123.056 169.319 123.87C166.551 128.874 155.222 146.506 133 146.506C110.763 146.506 99.4337 128.85 96.6757 123.86C96.2292 123.052 96.2888 122.101 96.8181 121.345C100.228 116.473 114.019 98.6143 133 98.6143Z" fill="#F6F7F7" stroke="url(#paint2_linear_5936_20173)" stroke-width="1.36366"/>
+<path d="M132.979 137.792C124.583 137.792 117.777 130.986 117.777 122.591C117.777 114.195 124.583 107.39 132.979 107.39C141.374 107.39 148.18 114.195 148.18 122.591C148.18 130.986 141.374 137.792 132.979 137.792Z" stroke="url(#paint3_linear_5936_20173)" stroke-dasharray="2 2"/>
+<path d="M133.182 116.683C136.382 116.683 138.978 119.278 138.978 122.479C138.977 125.679 136.382 128.274 133.182 128.274C129.981 128.274 127.386 125.679 127.386 122.479C127.386 119.278 129.981 116.683 133.182 116.683Z" fill="#F6F7F7" stroke="#3858E9" stroke-width="2.04548"/>
+<path d="M245 211C234.369 211 182.218 211 152.976 211C141.93 211 133 202.046 133 191L133 178.713L133 147" stroke="url(#paint4_linear_5936_20173)"/>
+<circle cx="237" cy="211" r="8" fill="#069E08"/>
+</g>
+<defs>
+<pattern id="pattern0_5936_20173" patternContentUnits="objectBoundingBox" width="0.0324582" height="0.0451827">
+<use xlink:href="#image0_5936_20173" transform="scale(0.000477327 0.000664452)"/>
+</pattern>
+<linearGradient id="paint0_linear_5936_20173" x1="51.2632" y1="110.355" x2="210.467" y2="111.218" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint1_linear_5936_20173" x1="56.3291" y1="176.625" x2="68.4521" y2="55.361" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373" stop-opacity="0"/>
+<stop offset="0.125009" stop-color="#737373"/>
+<stop offset="0.913481" stop-color="#737373"/>
+<stop offset="1" stop-color="#737373" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_5936_20173" x1="105.375" y1="122.56" x2="162.375" y2="122.669" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint3_linear_5936_20173" x1="132.979" y1="107.39" x2="132.979" y2="113.296" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373"/>
+<stop offset="1" stop-color="#737373"/>
+</linearGradient>
+<linearGradient id="paint4_linear_5936_20173" x1="150.287" y1="178.999" x2="255.391" y2="179.277" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<clipPath id="clip0_5936_20173">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H252C254.209 0 256 1.79086 256 4V240C256 242.209 254.209 244 252 244H4C1.79086 244 0 242.209 0 240V4Z" fill="white"/>
+</clipPath>
+<image id="image0_5936_20173" width="68" height="68" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAylpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDkuMC1jMDAxIDc5LmMwMjA0YjJkZWYsIDIwMjMvMDIvMDItMTI6MTQ6MjQgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCAyNC41IChNYWNpbnRvc2gpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkU4MTBCRTc4NkI2QTExRjBCOTI1QjRCNzdDOENGRkMzIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkU4MTBCRTc5NkI2QTExRjBCOTI1QjRCNzdDOENGRkMzIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6RTgxMEJFNzY2QjZBMTFGMEI5MjVCNEI3N0M4Q0ZGQzMiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6RTgxMEJFNzc2QjZBMTFGMEI5MjVCNEI3N0M4Q0ZGQzMiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5uSzX6AAAA2UlEQVR42uzaTQ6CMBAGUMaw0FtwET28XoRb6K6OCYk/29aC5n3JBFYd+gIlaRqllEGe2SEAAgQIECBAgAABAgQIECBA/j1j7QARMeXllPXYWLlkzZ3n8Na/lDKv/YYcs/ZZh+XBeqdp/xYg8XK/xvZb0/4tQM5Z16zb8sn0TtP+UbunmmvIphbF2vn4ywABAgQIECBAgAABAgQIECBAgAARIECAAAECBAgQIBvM2GCMadjQ+ZDa/s6HfAHE+ZCPOB/iLwMEiAABAgQIECBAgAABAgTID+cuwADKAy+BgXQl5gAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -196,6 +196,64 @@ body.is-section-scan,
 		height: 120px;
 		width: auto;
 	}
+
+	.scan__upsell-callout {
+		display: flex;
+		align-items: stretch;
+		gap: 24px;
+		max-width: 600px;
+		margin-block: 48px;
+		margin-inline: auto;
+		padding: 24px;
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 8px;
+		background: var(--color-surface);
+
+		@include breakpoint-deprecated( "<660px" ) {
+			flex-direction: column;
+		}
+	}
+
+	.scan__upsell-callout-content {
+		display: flex;
+		flex: 1 1 0;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+	}
+
+	.scan__upsell-callout-icon {
+		fill: var(--color-text);
+	}
+
+	.scan__upsell-callout-title {
+		@include heading-large;
+		margin: 0;
+		color: var(--color-text);
+	}
+
+	.scan__upsell-callout-description {
+		@include body-medium;
+		margin: 0;
+		color: var(--color-text-subtle);
+	}
+
+	.scan__upsell-callout-image {
+		position: relative;
+		flex: 1 1 0;
+
+		img {
+			position: absolute;
+			inset: 0;
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			display: none;
+		}
+	}
 }
 
 .scan__wpcom-ctas {

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -1,9 +1,9 @@
 import { WPCOM_FEATURES_SCAN_SELF_SERVE } from '@automattic/calypso-products';
 import { Page } from '@wordpress/admin-ui';
+import { shield } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
@@ -22,6 +22,7 @@ import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpa
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ScanCalloutIllustration from './scan-callout-illustration.svg';
 import type { AppState } from 'calypso/types';
 
 // Loading placeholder component
@@ -92,11 +93,13 @@ const ScanAtomicTransferWrapper = () => {
 		header: translate( 'Scan' ) as string,
 		subTitle: translate( 'Automated malware scanning and firewall protection.' ) as string,
 		primaryPromo: {
-			title: translate( 'We guard your site. You run your business.' ),
-			image: { path: JetpackScanSVG },
+			icon: shield,
+			title: translate( 'Activate Jetpack Scan' ),
+			image: { path: ScanCalloutIllustration },
 			content: translate(
-				'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
+				'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
 			),
+			secondaryContent: translate( 'We guard your site. You run your business.' ),
 			promoCTA: {
 				text: translate( 'Activate Jetpack Scan now' ),
 				loadingText: translate( 'Activating Jetpack Scan' ),

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -100,10 +100,6 @@ const ScanAtomicTransferWrapper = () => {
 				'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
 			),
 			secondaryContent: translate( 'We guard your site. You run your business.' ),
-			promoCTA: {
-				text: translate( 'Activate Jetpack Scan now' ),
-				loadingText: translate( 'Activating Jetpack Scan' ),
-			},
 		},
 
 		getProductUrl: ( siteSlug: string ) => `/scan/${ siteSlug }`,

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -1,18 +1,17 @@
-import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import { Page } from '@wordpress/admin-ui';
+import { Button, Icon } from '@wordpress/components';
+import { shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import PromoCard from 'calypso/components/promo-section/promo-card';
-import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import illustrationUrl from './scan-callout-illustration.svg';
 
 import './style.scss';
 
@@ -22,6 +21,7 @@ export default function WPCOMScanUpsellPage() {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
+	const commercePlanName = getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '';
 
 	return (
 		<Main fullWidthLayout className="scan scan__wpcom-upsell">
@@ -34,34 +34,38 @@ export default function WPCOMScanUpsellPage() {
 				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
 				subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
 			>
-				<PromoCard
-					title={ translate( 'We guard your site. You run your business.' ) }
-					image={ { path: JetpackScanSVG } }
-					isPrimary
-				>
-					<p>
-						{ translate(
-							'Scan gives you automated scanning and one-click fixes ' +
-								'to keep your site ahead of security threats.'
-						) }
-					</p>
-					<PromoCardCTA
-						cta={ {
-							text: translate( 'Upgrade to %(planName)s Plan', {
-								args: {
-									planName: businessPlanName,
-								},
-							} ),
-							action: {
-								url: `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`,
-								onClick: onUpgradeClick,
-								selfTarget: true,
-							},
-						} }
-					/>
-				</PromoCard>
-
-				<WhatIsJetpack />
+				<div className="scan__upsell-callout">
+					<div className="scan__upsell-callout-content">
+						<Icon className="scan__upsell-callout-icon" icon={ shield } />
+						<h2 className="scan__upsell-callout-title">
+							{ translate( 'Scan for security threats' ) }
+						</h2>
+						<p className="scan__upsell-callout-description">
+							{ translate(
+								'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
+							) }
+						</p>
+						<p className="scan__upsell-callout-description">
+							{ translate(
+								// translators: %(businessPlanName)s is the Business plan name, %(commercePlanName)s is the Commerce plan name
+								'Available on the WordPress.com %(businessPlanName)s and %(commercePlanName)s plans.',
+								{ args: { businessPlanName, commercePlanName } }
+							) }
+						</p>
+						<Button
+							className="scan__upsell-callout-button"
+							variant="primary"
+							href={ `/checkout/${ siteSlug }/${ PLAN_BUSINESS }` }
+							onClick={ onUpgradeClick }
+							__next40pxDefaultSize
+						>
+							{ translate( 'Upgrade plan' ) }
+						</Button>
+					</div>
+					<div className="scan__upsell-callout-image" aria-hidden="true">
+						<img src={ illustrationUrl } alt="" />
+					</div>
+				</div>
 			</Page>
 			<JetpackFooter />
 		</Main>

--- a/client/sites/hosting/components/hosting-activation-button.tsx
+++ b/client/sites/hosting/components/hosting-activation-button.tsx
@@ -5,9 +5,14 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	getEligibility,
+	isEligibleForAutomatedTransfer,
+} from 'calypso/state/automated-transfer/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { ComponentProps } from 'react';
@@ -30,6 +35,17 @@ export default function HostingActivationButton( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const hasSftpFeature = useSelector( ( state ) => siteHasFeature( state, siteId, FEATURE_SFTP ) );
+
+	// Resolve eligibility up front so a click can skip the modal when there is
+	// nothing to surface. A cleanly eligible site starts the transfer directly,
+	// using the optimal (default) data center.
+	const eligibility = useSelector( ( state ) => getEligibility( state, siteId ) );
+	const isEligible = useSelector( ( state ) => isEligibleForAutomatedTransfer( state, siteId ) );
+	const canStartTransferDirectly =
+		!! eligibility.lastUpdate &&
+		isEligible &&
+		( eligibility.eligibilityHolds?.length ?? 0 ) === 0 &&
+		( eligibility.eligibilityWarnings?.length ?? 0 ) === 0;
 
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
 		dispatch( recordTracksEvent( 'calypso_hosting_features_activate_confirm' ) );
@@ -61,6 +77,7 @@ export default function HostingActivationButton( {
 
 	return (
 		<>
+			{ siteId && <QueryEligibility siteId={ siteId } /> }
 			<HostingHeroButton
 				{ ...props }
 				text={ text ?? translate( 'Activate now' ) }
@@ -72,8 +89,13 @@ export default function HostingActivationButton( {
 					dispatch(
 						recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_click', {
 							path,
+							show_modal: ! canStartTransferDirectly,
 						} )
 					);
+
+					if ( canStartTransferDirectly ) {
+						return handleTransfer( {} );
+					}
 
 					return setShowEligibility( true );
 				} }


### PR DESCRIPTION
Part of DOTCOM-17666

## Proposed Changes

Aligns the classic Calypso Simple-to-Atomic activation and upsell surfaces with the Multi-site Dashboard and the wp-admin entry point.

**Plugin installation**

Before | After
--- | ---
<img width="1279" height="757" alt="Screenshot 2026-07-06 at 17 57 06" src="https://github.com/user-attachments/assets/baa38bf6-8f6a-4306-ad9e-24fbe0acb9b6" /> | <img width="1276" height="782" alt="Screenshot 2026-07-06 at 18 06 20" src="https://github.com/user-attachments/assets/89a6a1b6-b22f-4df9-8f25-dfe5e0dc8714" />
<img width="1279" height="755" alt="Screenshot 2026-07-06 at 17 57 38" src="https://github.com/user-attachments/assets/03af99f4-80fd-4c0a-919e-6935962c45d2" /> | <img width="1280" height="795" alt="Screenshot 2026-07-06 at 18 06 51" src="https://github.com/user-attachments/assets/4956f318-c430-4fc3-afcd-2a24175080e5" />


**Plugin upload**

Before | After
--- | ---
<img width="1278" height="751" alt="Screenshot 2026-07-06 at 17 59 03" src="https://github.com/user-attachments/assets/4f06016f-3636-4e48-b271-e10ae312defa" /> | <img width="1280" height="789" alt="Screenshot 2026-07-06 at 18 07 12" src="https://github.com/user-attachments/assets/0da07645-2d40-473c-85fc-678308a17c40" />
<img width="1277" height="752" alt="Screenshot 2026-07-06 at 17 59 14" src="https://github.com/user-attachments/assets/88f0446a-0186-4886-b752-32acb458777b" /> | <img width="1278" height="784" alt="Screenshot 2026-07-06 at 18 07 25" src="https://github.com/user-attachments/assets/1a91d97b-a708-435b-89f6-a95a8c490966" />


**Theme upload**

Before | After
--- | ---
<img width="1278" height="753" alt="Screenshot 2026-07-06 at 17 58 43" src="https://github.com/user-attachments/assets/3fbabc3a-7969-46a8-944e-e579975c27f4" /> | <img width="1274" height="784" alt="Screenshot 2026-07-06 at 18 07 42" src="https://github.com/user-attachments/assets/0236c38e-fafd-4a26-80f4-6d8d464d1300" />


**Jetpack Scan**

Before | After
--- | ---
<img width="1277" height="753" alt="Screenshot 2026-07-06 at 18 00 19" src="https://github.com/user-attachments/assets/4e29fb18-5ea8-46ee-94c6-70f7b3449d7b" /> | <img width="1274" height="784" alt="Screenshot 2026-07-06 at 18 08 03" src="https://github.com/user-attachments/assets/3abbc7ea-3364-472a-a366-e8a7372be3bf" />
<img width="1280" height="757" alt="Screenshot 2026-07-06 at 18 00 30" src="https://github.com/user-attachments/assets/673b299e-7e05-40d8-9db6-6d62e02b5ec6" /> | <img width="1278" height="787" alt="Screenshot 2026-07-06 at 18 08 10" src="https://github.com/user-attachments/assets/328c6f0b-e720-461b-a68d-28e92f7060db" />
<img width="1277" height="753" alt="Screenshot 2026-07-06 at 18 00 35" src="https://github.com/user-attachments/assets/a573f624-2d82-4e05-b8dd-b4bdae2bc316" /> | <img width="1278" height="788" alt="Screenshot 2026-07-06 at 18 08 15" src="https://github.com/user-attachments/assets/37412c49-2f10-4326-bcfb-0564ff517f1f" />


**Jetpack Backup**

Before | After
--- | ---
<img width="1274" height="756" alt="Screenshot 2026-07-06 at 18 01 42" src="https://github.com/user-attachments/assets/a7aff6d5-f6cc-4f35-8a47-54ffbdc81733" /> | <img width="1275" height="789" alt="Screenshot 2026-07-06 at 18 08 30" src="https://github.com/user-attachments/assets/785ffabc-643b-41df-b1a6-ba04e447ee02" />
<img width="1277" height="757" alt="Screenshot 2026-07-06 at 18 01 52" src="https://github.com/user-attachments/assets/4b939a16-9381-4e1d-962c-63698264027f" /> | <img width="1279" height="782" alt="Screenshot 2026-07-06 at 18 08 40" src="https://github.com/user-attachments/assets/3234e087-da14-4a10-95ce-33b20cd15d99" />
<img width="1277" height="755" alt="Screenshot 2026-07-06 at 18 01 58" src="https://github.com/user-attachments/assets/5e32db13-583d-4eef-81b1-5cbe69e5122f" /> | <img width="1277" height="782" alt="Screenshot 2026-07-06 at 18 08 47" src="https://github.com/user-attachments/assets/0fa09671-1627-4a82-a078-6e650fba4818" />

## Why are these changes being made?

To reduce user friction and to align the UI with recent changes in wp-admin and MSD.

## Testing Instructions

- Use the Calypso live link below
- Visit all the entry points:
  - Plugins -> Plugin details -> CTA
  - Plugins -> Upload
  - Appearance -> Themes -> Upload
  - Jetpack -> Scan
  - Jetpack -> Backup
- Make sure the layout and copy is ok for both free and paid sites
- Make sure the domain warning does not show up if the site has a custom domain

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? This PR adds and changes user-facing strings.
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
