### PR TITLE
Reader Spaces: actionable empty state with an Add sources CTA

### DIFF
--- a/client/reader/spaces/feed/components/states.tsx
+++ b/client/reader/spaces/feed/components/states.tsx
@@ -32,16 +32,37 @@ export function SpaceFeedLoadingMore() {
 }
 
 /** Shown when the stream has loaded but holds no posts. Copy differs per variant. */
-export function SpaceFeedEmpty( { variant = 'feed' }: { variant?: 'feed' | 'discover' } ) {
+export function SpaceFeedEmpty( {
+	variant = 'feed',
+	onAddSources,
+}: {
+	variant?: 'feed' | 'discover';
+	onAddSources?: () => void;
+} ) {
 	const translate = useTranslate();
+
+	if ( variant === 'discover' ) {
+		return (
+			<div className="space-feed__status">
+				<p className="space-feed__status-title">{ translate( 'Nothing here yet' ) }</p>
+				<p className="space-feed__status-line">
+					{ translate( 'On-topic posts you don’t already follow will show up here.' ) }
+				</p>
+			</div>
+		);
+	}
+
 	return (
 		<div className="space-feed__status">
-			<p className="space-feed__status-title">{ translate( 'Nothing here yet' ) }</p>
+			<p className="space-feed__status-title">{ translate( 'Add sources to get started' ) }</p>
 			<p className="space-feed__status-line">
-				{ variant === 'discover'
-					? translate( 'On-topic posts you don’t already follow will show up here.' )
-					: translate( 'Posts from this space’s sources will show up here.' ) }
+				{ translate( 'Follow blogs, tags, or sites to fill this space with posts you’ll love.' ) }
 			</p>
+			{ onAddSources && (
+				<Button variant="primary" onClick={ onAddSources }>
+					{ translate( 'Add sources' ) }
+				</Button>
+			) }
 		</div>
 	);
 }

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -39,6 +39,8 @@ interface Props {
 	// feeds + tags) or Discover (`space_discover:<id>`, recommended on-topic posts
 	// the user doesn't follow). Both share this shell and the same layouts.
 	variant?: 'feed' | 'discover';
+	// Opens the Customize modal's Sources tab; wired to the Feed empty-state CTA.
+	onAddSources?: () => void;
 }
 
 export function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
@@ -69,7 +71,7 @@ export function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
  * — is the layout while the detail is still loading or missing that field. Both
  * variants share the same layouts.
  */
-export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
+export function SpaceFeed( { spaceId, layoutView, variant = 'feed', onAddSources }: Props ) {
 	// The detail loads in parallel with the stream and only refines the layout, so
 	// the feed never blocks on it. `refetchSpace` backs the stream's retry.
 	const { data: space, refetch: refetchSpace } = useSpace( spaceId );
@@ -182,6 +184,7 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 					isPostSelected={ isPostSelected }
 					selectPost={ selectPost }
 					showTimestamp={ ! isDiscover }
+					emptyContent={ <SpaceFeedEmpty variant={ variant } onAddSources={ onAddSources } /> }
 				/>
 			);
 		}
@@ -210,7 +213,7 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed' }: Props ) {
 			);
 		}
 		if ( posts.length === 0 ) {
-			return <SpaceFeedEmpty variant={ variant } />;
+			return <SpaceFeedEmpty variant={ variant } onAddSources={ onAddSources } />;
 		}
 		return (
 			<Layout

--- a/client/reader/spaces/feed/layouts/legacy/index.tsx
+++ b/client/reader/spaces/feed/layouts/legacy/index.tsx
@@ -17,13 +17,19 @@ import './style.scss';
  * them on its Discover tab. Suppressing them there would require changes in the
  * shared classic stream, out of scope for the per-space layouts.
  */
-export function LegacyLayout( { streamKey, scrollElement, restoreKey }: SpaceFeedLayoutProps ) {
+export function LegacyLayout( {
+	streamKey,
+	scrollElement,
+	restoreKey,
+	emptyContent,
+}: SpaceFeedLayoutProps ) {
 	return (
 		<ReaderStreamV2
 			streamKey={ streamKey }
 			scrollElement={ scrollElement }
 			className="space-feed-legacy"
 			restoreKey={ restoreKey }
+			emptyContent={ emptyContent }
 		/>
 	);
 }

--- a/client/reader/spaces/feed/layouts/types.ts
+++ b/client/reader/spaces/feed/layouts/types.ts
@@ -1,4 +1,5 @@
 import type { ReadStreamPost } from '@automattic/api-core';
+import type { ReactNode } from 'react';
 
 /**
  * The contract every space-feed layout implements. The shell owns the data and
@@ -34,6 +35,12 @@ export interface SpaceFeedLayoutProps {
 	 * label would misrepresent the ordering.
 	 */
 	showTimestamp: boolean;
+	/**
+	 * The empty state to render when the stream has no posts. Only the legacy
+	 * layout uses it (it owns its own empty branch via ReaderStreamV2); the other
+	 * layouts render empty through the shell, so they ignore it.
+	 */
+	emptyContent?: ReactNode;
 }
 
 /**

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -207,10 +207,52 @@ describe( 'SpaceFeed', () => {
 		expect( screen.queryByText( 'Couldn’t load this feed' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'shows the empty state when the stream has no posts', () => {
-		render( WORK );
+	it( 'shows an actionable empty state with an Add sources CTA when the feed has no posts', async () => {
+		const user = userEvent.setup();
+		const onAddSources = jest.fn();
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
+
+		renderWithProvider( <SpaceFeed spaceId={ WORK.id } onAddSources={ onAddSources } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		expect( screen.getByText( 'Add sources to get started' ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add sources' } ) );
+
+		expect( onAddSources ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows the Add sources CTA in the legacy layout empty state', async () => {
+		const user = userEvent.setup();
+		const onAddSources = jest.fn();
+		const legacy = makeSpace( 'work-id', 'Work', 'legacy' );
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		queryClient.setQueryData( readSpaceQuery( legacy.id ).queryKey, legacy );
+
+		renderWithProvider( <SpaceFeed spaceId={ legacy.id } onAddSources={ onAddSources } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Add sources' } ) );
+
+		expect( onAddSources ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows the Discover empty state without an Add sources CTA', () => {
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
+
+		renderWithProvider(
+			<SpaceFeed spaceId={ WORK.id } variant="discover" onAddSources={ jest.fn() } />,
+			{ queryClient, initialState: { currentUser: { id: 1 } } }
+		);
 
 		expect( screen.getByText( 'Nothing here yet' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Add sources' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'requests the space posts stream keyed by the space id', () => {
@@ -351,7 +393,7 @@ describe( 'SpaceFeed', () => {
 	it( 'shows the empty state for the legacy layout when the legacy stream has no posts', () => {
 		render( makeSpace( 'work-id', 'Work', 'legacy' ) );
 
-		expect( screen.getByText( 'Nothing here yet' ) ).toBeVisible();
+		expect( screen.getByText( 'Add sources to get started' ) ).toBeVisible();
 	} );
 
 	it( 'shows an error with a retry for the legacy layout when the legacy stream fails', async () => {

--- a/client/reader/spaces/test/view.test.tsx
+++ b/client/reader/spaces/test/view.test.tsx
@@ -3,7 +3,7 @@
  */
 import { readSpaceQuery, readSpacesQuery } from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
-import { screen, waitFor, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SpacesView } from '../view';
@@ -170,6 +170,27 @@ describe( 'SpacesView', () => {
 
 		const dialog = screen.getByRole( 'dialog', { name: 'Customize space' } );
 		expect( within( dialog ).getByLabelText( 'Name' ) ).toHaveValue( 'Work' );
+	} );
+
+	it( 'opens the Customize modal on the Sources tab from the feed Add sources CTA', async () => {
+		render( <SpacesView id={ WORK.id } /> );
+
+		// The feed tab's SpaceFeed is wired with the empty-state CTA handler.
+		const feedProps = mockSpaceFeed.mock.calls
+			.map( ( [ props ] ) => props as { onAddSources?: () => void } )
+			.find( ( props ) => typeof props.onAddSources === 'function' );
+		act( () => feedProps?.onAddSources?.() );
+
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_spaces_add_sources_clicked',
+			{ space_id: WORK.id }
+		);
+
+		const dialog = await screen.findByRole( 'dialog', { name: 'Customize space' } );
+		expect( within( dialog ).getByRole( 'tab', { name: 'Sources' } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
 	} );
 
 	it( 'does not open the modal from the route alone', () => {

--- a/client/reader/spaces/view.tsx
+++ b/client/reader/spaces/view.tsx
@@ -70,7 +70,18 @@ export function SpacesView( { id, tab = 'feed' }: Props ) {
 			tab === 'discover' ? (
 				<SpaceFeed spaceId={ id } layoutView={ layoutView } variant="discover" />
 			) : (
-				<SpaceFeed spaceId={ id } layoutView={ layoutView } />
+				<SpaceFeed
+					spaceId={ id }
+					layoutView={ layoutView }
+					onAddSources={ () => {
+						dispatch(
+							recordReaderTracksEvent( 'calypso_reader_spaces_add_sources_clicked', {
+								space_id: id,
+							} )
+						);
+						setCustomizeTab( 'sources' );
+					} }
+				/>
 			);
 	}
 

--- a/client/reader/stream/stream-v2.tsx
+++ b/client/reader/stream/stream-v2.tsx
@@ -16,7 +16,7 @@ import { useSelectedPostCommands } from './use-selected-post-commands';
 import { useStreamKeyboardShortcuts } from './use-stream-keyboard-shortcuts';
 import { useStreamPostKeySelection } from './use-stream-post-key-selection';
 import type { StreamItem } from 'calypso/reader/data/stream/types';
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 // The card calls this when a post (or its comment button) is clicked.
 type PostClickArgs = { comments?: boolean };
@@ -43,6 +43,8 @@ interface ReaderStreamV2Props {
 	scrollElement: HTMLElement | null;
 	className?: string;
 	restoreKey?: string;
+	/** Replaces the default "nothing here yet" state when the stream is empty. */
+	emptyContent?: ReactNode;
 }
 
 /**
@@ -60,6 +62,7 @@ export function ReaderStreamV2( {
 	scrollElement,
 	className,
 	restoreKey,
+	emptyContent,
 }: ReaderStreamV2Props ) {
 	const translate = useTranslate();
 	const blockedSites = useSelector( getBlockedSites );
@@ -164,6 +167,9 @@ export function ReaderStreamV2( {
 	}
 
 	if ( items.length === 0 ) {
+		if ( emptyContent ) {
+			return <>{ emptyContent }</>;
+		}
 		return (
 			<div className="space-feed__status">
 				<p className="space-feed__status-title">{ translate( 'Nothing here yet' ) }</p>

--- a/client/reader/stream/stream-v2.tsx
+++ b/client/reader/stream/stream-v2.tsx
@@ -167,7 +167,9 @@ export function ReaderStreamV2( {
 	}
 
 	if ( items.length === 0 ) {
-		if ( emptyContent ) {
+		// `undefined` means the caller passed nothing; any explicitly provided node
+		// (including `null` to render nothing) overrides the default empty state.
+		if ( emptyContent !== undefined ) {
 			return <>{ emptyContent }</>;
 		}
 		return (


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR.
-->

Fixes RSM-4540

## Proposed Changes

* On a Space's **Feed** tab, replace the passive "Nothing here yet" empty state with an actionable one: "Add sources to get started" plus an **Add sources** primary button.
* The button opens the existing Customize modal on its **Sources** tab (and records a `calypso_reader_spaces_add_sources_clicked` Tracks event).
* The actionable empty state now works across every Space layout, including the **legacy** layout (the default for newly created Spaces): `ReaderStreamV2` gained an optional `emptyContent` slot that the legacy layout forwards.
* The **Discover** tab keeps its own distinct empty copy and shows no CTA.

## Why are these changes being made?

The generic empty state gave a user with an empty Space no guidance or way forward. A clear call to action routes them straight to the source picker so the Space can be populated, turning a dead end into the natural next step.

## Testing Instructions

### Scenario 1 - Empty Feed shows the CTA:
- Go to `/reader/spaces/:id` for a Space whose Feed has no posts (e.g. a freshly created Space with no sources).
- Check that you can see the heading "Add sources to get started" and an "Add sources" button.

### Scenario 2 - CTA opens the source picker:
- From that empty Feed, click "Add sources".
- Check that the Customize modal opens with the **Sources** tab active.

### Scenario 3 - Discover tab is unchanged:
- Go to `/reader/spaces/:id/discover` for a Space with no Discover results.
- Check that you see "Nothing here yet" and there is no "Add sources" button.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
