### PR TITLE
Account Recovery: exclude fully-secured users from the interstitial experiment

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -109,7 +109,11 @@ export default function AccountRecoveryInterstitial() {
 
 	// Eligible once the data has loaded and the snooze (if any) has elapsed.
 	const isEligible =
-		isAccountRecoveryLoaded && isUserSettingsLoaded && isSnoozeLoaded && ! isSnoozed;
+		isAccountRecoveryLoaded &&
+		isUserSettingsLoaded &&
+		isSnoozeLoaded &&
+		! isSnoozed &&
+		securityLevel !== 'strong';
 
 	// Gate the interstitial behind an A/B experiment. Mark the user eligible only once they would
 	// otherwise qualify, so the exposure event fires for the right population and the control vs.
@@ -124,7 +128,7 @@ export default function AccountRecoveryInterstitial() {
 	// Fully-secured users (variant === 'strong') are left alone — we only nudge people who are still
 	// missing a recovery method, 2FA, or backup codes. The modal is also not shown to users who are
 	// not in the experiment control group.
-	if ( isDismissed || ! isEligible || securityLevel === 'strong' || ! isInExperimentControl ) {
+	if ( isDismissed || ! isEligible || ! isInExperimentControl ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Fold the `securityLevel !== 'strong'` check into `isEligible` in the Dashboard account-recovery interstitial, and drop the now-redundant `securityLevel === 'strong'` guard from the render return.

## Why are these changes being made?

The interstitial is gated behind an A/B experiment. Eligibility is what drives when the user is assigned to the experiment and the exposure event fires. Previously, fully-secured (`strong`) users were marked eligible and only filtered out at render time. That meant they triggered exposure for a population that can never see the modal or convert, diluting the control vs. variant comparison. Excluding `strong` users from `isEligible` keeps the exposure event scoped to the target population — users still missing a recovery method, 2FA, or backup codes.

## Testing Instructions

* As a user with a `strong` security level, confirm the interstitial does not render and no experiment exposure event fires.
* As a user missing a recovery method / 2FA / backup codes, confirm behavior is unchanged: eligible users in the experiment control group still see the modal.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
