### PR TITLE
Domain search: add Exact match badge with bullseye icon to featured card

### DIFF
--- a/packages/domain-search/.storybook/index.scss
+++ b/packages/domain-search/.storybook/index.scss
@@ -14,3 +14,15 @@
 html {
 	font-family: $default-font;
 }
+
+// Mirror of the `.domain-search` design tokens (src/page/style.scss) so components
+// that read them render with real colors in isolated stories.
+:root {
+	--domain-search-promotional-price-color: #048015;
+	--domain-search-warning-badge-border-color: #f4df7b;
+	--domain-search-warning-badge-background-color: #f9edb4;
+	--domain-search-success-badge-border-color: #b8e5be;
+	--domain-search-success-badge-background-color: #d1eed5;
+	--domain-search-secondary-action-color: #1e1e1e;
+	--domain-search-secondary-action-box-shadow-color: #949494;
+}

--- a/packages/domain-search/src/components/featured-search-results/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/item.tsx
@@ -8,6 +8,7 @@ import { DomainPriceRule, useSuggestion } from '../../hooks/use-suggestion';
 import { useDomainSuggestionBadges } from '../../hooks/use-suggestion-badges';
 import { useDomainSearch } from '../../page/context';
 import { DomainSuggestion, DomainSuggestionBadge } from '../../ui';
+import { bullseyeIcon } from '../../ui/icons/bullseye-icon';
 import { DomainSuggestionCTA } from '../suggestion-cta';
 import { DomainSuggestionPrice } from '../suggestion-price';
 
@@ -41,6 +42,10 @@ export const FeaturedSearchResultsItem = ( {
 	const badges = useMemo( () => {
 		if ( reason === 'exact-match' && suggestion.price_rule !== DomainPriceRule.DOMAIN_MOVE_PRICE ) {
 			return [
+				<DomainSuggestionBadge key="exact-match">
+					{ bullseyeIcon }
+					{ __( 'Exact match' ) }
+				</DomainSuggestionBadge>,
 				<DomainSuggestionBadge key="available" variation="success">
 					{ __( "It's available!" ) }
 				</DomainSuggestionBadge>,

--- a/packages/domain-search/src/components/featured-search-results/test/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/test/item.tsx
@@ -163,6 +163,7 @@ describe( 'FeaturedSearchResultsItem', () => {
 
 			await waitFor( () => screen.getByTitle( 'test-exact-match.com' ) );
 
+			expect( screen.getByText( 'Exact match' ) ).toBeInTheDocument();
 			expect( screen.getByText( "It's available!" ) ).toBeInTheDocument();
 		} );
 

--- a/packages/domain-search/src/ui/domain-suggestion/featured.stories.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.stories.tsx
@@ -1,6 +1,7 @@
 import { DomainSuggestionBadge } from '../domain-suggestion-badge';
 import { DomainSuggestionPrimaryCTA } from '../domain-suggestion-cta';
 import { DomainSuggestionPrice } from '../domain-suggestion-price';
+import { bullseyeIcon } from '../icons/bullseye-icon';
 import { DomainSuggestion } from '.';
 import type { Meta } from '@storybook/react';
 
@@ -51,6 +52,30 @@ export const Highlighted = () => {
 			<DomainSuggestion.Featured
 				badges={
 					<DomainSuggestionBadge variation="success">It's available!</DomainSuggestionBadge>
+				}
+				domain="example"
+				tld="com"
+				isHighlighted
+				matchReasons={ [ 'Exact match', '.com is the most common extension' ] }
+				price={ <DomainSuggestionPrice salePrice="$97" price="$22" /> }
+				cta={ <DomainSuggestionPrimaryCTA>Add to cart</DomainSuggestionPrimaryCTA> }
+			/>
+		</StoryWrapper>
+	);
+};
+
+export const ExactMatch = () => {
+	return (
+		<StoryWrapper>
+			<DomainSuggestion.Featured
+				badges={
+					<>
+						<DomainSuggestionBadge>
+							{ bullseyeIcon }
+							Exact match
+						</DomainSuggestionBadge>
+						<DomainSuggestionBadge variation="success">It's available!</DomainSuggestionBadge>
+					</>
 				}
 				domain="example"
 				tld="com"

--- a/packages/domain-search/src/ui/domain-suggestion/featured.stories.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.stories.tsx
@@ -77,11 +77,11 @@ export const ExactMatch = () => {
 						<DomainSuggestionBadge variation="success">It's available!</DomainSuggestionBadge>
 					</>
 				}
-				domain="example"
-				tld="com"
+				domain="thalasso"
+				tld="blog"
 				isHighlighted
-				matchReasons={ [ 'Exact match', '.com is the most common extension' ] }
-				price={ <DomainSuggestionPrice salePrice="$97" price="$22" /> }
+				matchReasons={ [ '".blog" is the natural home for your writing' ] }
+				price={ <DomainSuggestionPrice salePrice="$3.30" price="$33" renewPrice="$33" /> }
 				cta={ <DomainSuggestionPrimaryCTA>Add to cart</DomainSuggestionPrimaryCTA> }
 			/>
 		</StoryWrapper>

--- a/packages/domain-search/src/ui/icons/bullseye-icon.tsx
+++ b/packages/domain-search/src/ui/icons/bullseye-icon.tsx
@@ -1,0 +1,27 @@
+import { Path, SVG } from '@wordpress/primitives';
+
+export const bullseyeIcon = (
+	<SVG width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			d="M11.3334 7.9974C11.3334 9.83833 9.84101 11.3307 8.00008 11.3307C6.15913 11.3307 4.66675 9.83833 4.66675 7.9974C4.66675 6.15645 6.15913 4.66406 8.00008 4.66406"
+			stroke="currentColor"
+			strokeWidth="1.25"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Path
+			d="M9.33325 1.4693C8.90245 1.38184 8.45652 1.33594 7.99992 1.33594C4.31802 1.33594 1.33325 4.3207 1.33325 8.0026C1.33325 11.6845 4.31802 14.6693 7.99992 14.6693C11.6818 14.6693 14.6666 11.6845 14.6666 8.0026C14.6666 7.546 14.6207 7.10007 14.5333 6.66927"
+			stroke="currentColor"
+			strokeWidth="1.25"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Path
+			d="M10.6667 5.3369V3.3369L12.6579 1.34571C12.6616 1.34194 12.6681 1.3439 12.6691 1.34912L12.9991 2.99921C12.9997 3.00185 13.0017 3.00392 13.0043 3.00444L14.6545 3.33446C14.6597 3.3355 14.6616 3.34194 14.6579 3.34571L12.6686 5.33495L12.6639 5.3369H10.6667ZM10.6667 5.3369L8 8.00357"
+			stroke="currentColor"
+			strokeWidth="1.25"
+			strokeLinecap="square"
+			strokeLinejoin="round"
+		/>
+	</SVG>
+);


### PR DESCRIPTION
Related to DOMAINS-2189

## Proposed Changes

Adds an **"Exact match"** badge to the featured domain search result card (the highlighted "exact match" card in `packages/domain-search`).

- New neutral badge rendered **before** the existing green "It's available!" badge, in the `exact-match` branch of the `badges` `useMemo` in `featured-search-results/item.tsx`.
- The badge leads with a small hand-rolled inline SVG **bullseye/target icon** (`src/ui/icons/bullseye-icon.tsx`), following the existing local `shopping-cart-icon.tsx` pattern. The icon uses `currentColor`, so it inherits the badge's neutral text color, and renders at 16px.
- The neutral variation (no `variation` prop) makes it visually distinct from the green success badge.

<img width="1038" height="392" alt="CleanShot 2026-07-06 at 15 02 25@2x" src="https://github.com/user-attachments/assets/cb0d6d33-d356-4efd-bf86-a414f104ce48" />


The match-reason footer plumbing (`parseMatchReasons` -> `DomainSuggestion.Featured` -> `DomainSuggestionMatchReasons`) already renders "Exact match" for the exact-match path; no change was needed there.

## Why are these changes being made?

Design polish for the domain-bundle featured "exact match" card: the exact-match result should be clearly labeled with a distinct badge + bullseye icon, separate from the availability badge.

## Testing Instructions

1. Run a domain search where the query is a fully-qualified available domain (e.g. `test-exact-match.com`) so the featured card renders in the `exact-match` state.
2. Confirm the featured card shows a neutral **"Exact match"** badge (with a bullseye icon) to the left of the green **"It's available!"** badge.
3. Confirm premium/sale/policy badges still render after those two when applicable.

Automated (from repo root):

<details>
<summary>Package checks</summary>

```
# eslint (changed files) — clean
yarn eslint packages/domain-search/src/ui/icons/bullseye-icon.tsx \
  packages/domain-search/src/components/featured-search-results/item.tsx \
  packages/domain-search/src/components/featured-search-results/test/item.tsx

# typecheck — clean
cd packages/domain-search && tsc --noEmit -p tsconfig.json

# unit tests — 22/22 pass
jest --config packages/domain-search/jest.config.js \
  src/components/featured-search-results/test/item.tsx
```
</details>

## Open question (not addressed here)

The mockup shows a per-TLD tagline like `"'.blog' is the natural home for your writing"`. That is a product/copy decision (and likely needs a new backend `match_reason`), so it is intentionally out of scope. It would plug in at `packages/domain-search/src/helpers/parse-match-reasons.ts` (`getMatchReasonPhrasesMap`, plus a matching entry in `VALID_MATCH_REASONS`).

Co-Authored-By: Claude <noreply@anthropic.com>
