### PR TITLE
Domain search: restyle bundle card + extract BundleTldChips/BundlePrice primitives

### DIFF
--- a/packages/domain-search/.storybook/index.scss
+++ b/packages/domain-search/.storybook/index.scss
@@ -16,7 +16,8 @@ html {
 }
 
 // Mirror of the `.domain-search` design tokens (src/page/style.scss) so components
-// that read them render with real colors in isolated stories.
+// that read them render with real colors in isolated stories (the stories don't
+// mount the `.domain-search` page root that normally defines these).
 :root {
 	--domain-search-promotional-price-color: #048015;
 	--domain-search-warning-badge-border-color: #f4df7b;

--- a/packages/domain-search/src/components/bundle-card/bundle-card.stories.tsx
+++ b/packages/domain-search/src/components/bundle-card/bundle-card.stories.tsx
@@ -29,18 +29,28 @@ const buildDomain = (
 const buildSuggestion = (
 	domains: BundleSuggestionDomain[],
 	overrides: Partial< BundleSuggestion > = {}
-): BundleSuggestion => ( {
-	sld: 'example',
-	domains,
-	bundle_price: 60,
-	original_price: 75,
-	discount_percent: 20,
-	category: 'business',
-	bundle_id: 'bundle-1',
-	bundle_group_id: 'group-1',
-	catalogue_version: '2024-01-01',
-	...overrides,
-} );
+): BundleSuggestion => {
+	const base = {
+		sld: 'example',
+		bundle_price: 60,
+		original_price: 75,
+		discount_percent: 20,
+		category: 'business',
+		bundle_id: 'bundle-1',
+		bundle_group_id: 'group-1',
+		catalogue_version: '2024-01-01',
+		...overrides,
+	};
+
+	return {
+		...base,
+		domains,
+		// The card prefers the formatted `*_cost` strings over the raw numbers, so
+		// derive them from the final prices to mirror what the backend returns.
+		bundle_cost: base.bundle_cost ?? `$${ base.bundle_price }`,
+		original_cost: base.original_cost ?? `$${ base.original_price }`,
+	};
+};
 
 const meta: Meta< typeof BundleCard > = {
 	title: 'Components/BundleCard',

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -5,8 +5,9 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
-import { arrowRight, Icon, lock } from '@wordpress/icons';
+import { arrowRight, Icon, lockOutline, plus, shield } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { Fragment } from 'react';
 import { getTld } from '../../helpers/get-tld';
 import { BundlePrice, BundleTldChips, DomainSearchNotice, DomainSuggestionBadge } from '../../ui';
 import type { BundleSuggestion } from '@automattic/api-core';
@@ -50,7 +51,6 @@ export const BundleCard = ( {
 	const displayOriginalPrice = String( original_cost ?? original_price );
 
 	const tlds = domains.map( ( domain ) => getTld( domain.domain ) );
-	const memberDomains = domains.map( ( domain ) => domain.domain ).join( ', ' );
 
 	const cta = isAddedToCart ? (
 		<Button
@@ -68,7 +68,8 @@ export const BundleCard = ( {
 	) : (
 		<Button
 			className="bundle-card__cta"
-			variant="primary"
+			variant="secondary"
+			icon={ plus }
 			__next40pxDefaultSize
 			isBusy={ isBusy }
 			disabled={ disabled }
@@ -88,12 +89,12 @@ export const BundleCard = ( {
 					className="bundle-card__header"
 				>
 					<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
-						<Icon icon={ lock } size={ 20 } className="bundle-card__lock-icon" />
+						<Icon icon={ lockOutline } size={ 20 } className="bundle-card__lock-icon" />
 						<Text size={ 14 } weight={ 500 }>
 							{ __( 'Protect your brand' ) }
 						</Text>
 					</HStack>
-					<DomainSuggestionBadge variation="success">
+					<DomainSuggestionBadge variation="warning">
 						{ sprintf(
 							// translators: %(percent)d is the bundle discount percentage, e.g. 20.
 							__( 'Bundle and save %(percent)d%%' ),
@@ -105,7 +106,17 @@ export const BundleCard = ( {
 				<BundleTldChips tlds={ tlds } size={ 28 } className="bundle-card__tlds" />
 
 				<Text variant="muted" className="bundle-card__members">
-					{ memberDomains }
+					{ domains.map( ( domain, index ) => {
+						const tld = getTld( domain.domain );
+						const sld = tld ? domain.domain.slice( 0, -( tld.length + 1 ) ) : domain.domain;
+						return (
+							<Fragment key={ domain.domain }>
+								{ index > 0 && ', ' }
+								{ sld }
+								{ tld && <span className="bundle-card__member-tld">.{ tld }</span> }
+							</Fragment>
+						);
+					} ) }
 				</Text>
 
 				{ hasPremiumDomain && (
@@ -135,9 +146,12 @@ export const BundleCard = ( {
 				</HStack>
 
 				<div className="bundle-card__footer">
-					<Text size={ 12 } variant="muted" className="bundle-card__tagline">
-						{ __( 'Claim popular domain extensions to avoid copycats' ) }
-					</Text>
+					<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+						<Icon icon={ shield } size={ 20 } className="bundle-card__footer-icon" />
+						<Text size={ 12 } variant="muted" className="bundle-card__tagline">
+							{ __( 'Claim popular domain extensions to avoid copycats' ) }
+						</Text>
+					</HStack>
 				</div>
 			</VStack>
 		</div>

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -5,9 +5,10 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
-import { arrowRight } from '@wordpress/icons';
+import { arrowRight, Icon, lock } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { DomainSearchNotice, DomainSuggestionBadge } from '../../ui';
+import { getTld } from '../../helpers/get-tld';
+import { BundlePrice, BundleTldChips, DomainSearchNotice, DomainSuggestionBadge } from '../../ui';
 import type { BundleSuggestion } from '@automattic/api-core';
 
 import './style.scss';
@@ -41,60 +42,71 @@ export const BundleCard = ( {
 		);
 	}
 
-	const {
-		sld,
-		domains,
-		bundle_price,
-		bundle_cost,
-		original_price,
-		original_cost,
-		discount_percent,
-	} = suggestion;
+	const { domains, bundle_price, bundle_cost, original_price, original_cost, discount_percent } =
+		suggestion;
 
 	const hasPremiumDomain = domains.some( ( domain ) => domain.is_premium );
-	const displayBundlePrice = bundle_cost ?? bundle_price;
-	const displayOriginalPrice = original_cost ?? original_price;
+	const displayBundlePrice = String( bundle_cost ?? bundle_price );
+	const displayOriginalPrice = String( original_cost ?? original_price );
+
+	const tlds = domains.map( ( domain ) => getTld( domain.domain ) );
+	const memberDomains = domains.map( ( domain ) => domain.domain ).join( ', ' );
+
+	const cta = isAddedToCart ? (
+		<Button
+			className="bundle-card__cta bundle-card__cta--continue"
+			isPressed
+			aria-pressed="mixed"
+			__next40pxDefaultSize
+			icon={ arrowRight }
+			label={ __( 'Continue' ) }
+			disabled={ disabled }
+			onClick={ () => onContinue?.() }
+		>
+			{ __( 'Continue' ) }
+		</Button>
+	) : (
+		<Button
+			className="bundle-card__cta"
+			variant="primary"
+			__next40pxDefaultSize
+			isBusy={ isBusy }
+			disabled={ disabled }
+			onClick={ () => onAddToCart?.( suggestion ) }
+		>
+			{ __( 'Get bundle' ) }
+		</Button>
+	);
 
 	return (
 		<div className="bundle-card">
 			<VStack spacing={ 4 }>
-				<Text as="h3" size={ 24 } weight={ 500 } className="bundle-card__sld">
-					{ sld }
-				</Text>
-
-				<ul className="bundle-card__domains">
-					{ domains.map( ( domain ) => (
-						<li key={ domain.domain } className="bundle-card__domain">
-							<HStack alignment="edge" spacing={ 2 }>
-								<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
-									<Text className="bundle-card__domain-name">{ domain.domain }</Text>
-									{ domain.is_premium && (
-										<DomainSuggestionBadge>{ __( 'Premium' ) }</DomainSuggestionBadge>
-									) }
-								</HStack>
-								<Text className="bundle-card__domain-cost">{ domain.cost }</Text>
-							</HStack>
-						</li>
-					) ) }
-				</ul>
-
-				<div className="bundle-card__pricing">
-					<HStack alignment="center" justify="flex-start" spacing={ 2 } expanded={ false }>
-						<Text size={ 20 } weight={ 500 } className="bundle-card__bundle-price">
-							{ displayBundlePrice }
-						</Text>
-						<Text className="bundle-card__original-price">
-							<s>{ displayOriginalPrice }</s>
+				<HStack
+					justify="flex-start"
+					spacing={ 3 }
+					expanded={ false }
+					className="bundle-card__header"
+				>
+					<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+						<Icon icon={ lock } size={ 20 } className="bundle-card__lock-icon" />
+						<Text size={ 14 } weight={ 500 }>
+							{ __( 'Protect your brand' ) }
 						</Text>
 					</HStack>
-					<Text className="bundle-card__discount">
+					<DomainSuggestionBadge variation="success">
 						{ sprintf(
 							// translators: %(percent)d is the bundle discount percentage, e.g. 20.
-							__( 'Save %(percent)d%%' ),
+							__( 'Bundle and save %(percent)d%%' ),
 							{ percent: discount_percent }
 						) }
-					</Text>
-				</div>
+					</DomainSuggestionBadge>
+				</HStack>
+
+				<BundleTldChips tlds={ tlds } size={ 28 } className="bundle-card__tlds" />
+
+				<Text variant="muted" className="bundle-card__members">
+					{ memberDomains }
+				</Text>
 
 				{ hasPremiumDomain && (
 					<Text size={ 12 } className="bundle-card__premium-notice">
@@ -106,31 +118,27 @@ export const BundleCard = ( {
 
 				{ errorMessage && <DomainSearchNotice status="error">{ errorMessage }</DomainSearchNotice> }
 
-				{ isAddedToCart ? (
-					<Button
-						className="bundle-card__cta bundle-card__cta--continue"
-						isPressed
-						aria-pressed="mixed"
-						__next40pxDefaultSize
-						icon={ arrowRight }
-						label={ __( 'Continue' ) }
-						disabled={ disabled }
-						onClick={ () => onContinue?.() }
-					>
-						{ __( 'Continue' ) }
-					</Button>
-				) : (
-					<Button
-						className="bundle-card__cta"
-						variant="primary"
-						__next40pxDefaultSize
-						isBusy={ isBusy }
-						disabled={ disabled }
-						onClick={ () => onAddToCart?.( suggestion ) }
-					>
-						{ __( 'Get bundle' ) }
-					</Button>
-				) }
+				<HStack
+					alignment="center"
+					justify="space-between"
+					spacing={ 4 }
+					className="bundle-card__price-row"
+				>
+					<BundlePrice
+						originalPrice={ displayOriginalPrice }
+						bundlePrice={ displayBundlePrice }
+						renewalPrice={ displayOriginalPrice }
+						size={ 24 }
+						alignment="left"
+					/>
+					<div className="bundle-card__cta-wrapper">{ cta }</div>
+				</HStack>
+
+				<div className="bundle-card__footer">
+					<Text size={ 12 } variant="muted" className="bundle-card__tagline">
+						{ __( 'Claim popular domain extensions to avoid copycats' ) }
+					</Text>
+				</div>
 			</VStack>
 		</div>
 	);

--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -14,6 +14,10 @@
 	word-break: break-all;
 }
 
+.bundle-card__member-tld {
+	color: #2c3338;
+}
+
 .bundle-card__cta-wrapper {
 	flex-shrink: 0;
 }
@@ -23,6 +27,16 @@
 	border-top: 1px solid rgba( 0, 0, 0, 0.08 );
 }
 
+.bundle-card__footer-icon {
+	fill: #757575;
+	flex-shrink: 0;
+}
+
 .bundle-card__cta {
 	justify-content: center;
+
+	&.is-secondary {
+		color: var( --domain-search-secondary-action-color );
+		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
+	}
 }

--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -1,38 +1,26 @@
 .bundle-card {
 	box-sizing: border-box;
 	padding: 24px;
-	border-radius: 4px;
-	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 );
+	border-radius: 8px;
+	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 ), 0 1px 2px rgba( 0, 0, 0, 0.05 );
 }
 
-.bundle-card__sld {
+.bundle-card__lock-icon {
+	fill: currentColor;
+	flex-shrink: 0;
+}
+
+.bundle-card__members {
 	word-break: break-all;
 }
 
-.bundle-card__domains {
-	margin: 0;
-	padding: 0;
-	list-style: none;
+.bundle-card__cta-wrapper {
+	flex-shrink: 0;
 }
 
-.bundle-card__domain {
-	padding-block: 8px;
-
-	& + & {
-		border-top: 1px solid rgba( 0, 0, 0, 0.05 );
-	}
-}
-
-.bundle-card__domain-name {
-	word-break: break-all;
-}
-
-.bundle-card__domain-cost {
-	white-space: nowrap;
-}
-
-.bundle-card__original-price s {
-	opacity: 0.7;
+.bundle-card__footer {
+	padding-top: 16px;
+	border-top: 1px solid rgba( 0, 0, 0, 0.08 );
 }
 
 .bundle-card__cta {

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -47,18 +47,23 @@ describe( 'BundleCard', () => {
 	} );
 
 	it( 'renders a TLD chip for each member domain', () => {
-		render( <BundleCard suggestion={ buildSuggestion( fourDomains ) } /> );
+		// Scoped to the chips row: the member line below also renders ".com" etc.
+		const { container } = render( <BundleCard suggestion={ buildSuggestion( fourDomains ) } /> );
+		const chips = container.querySelector( '.bundle-card__tlds' ) as HTMLElement;
 
-		expect( screen.getByText( '.com' ) ).toBeInTheDocument();
-		expect( screen.getByText( '.net' ) ).toBeInTheDocument();
-		expect( screen.getByText( '.org' ) ).toBeInTheDocument();
-		expect( screen.getByText( '.io' ) ).toBeInTheDocument();
+		expect( getByText( chips, '.com' ) ).toBeInTheDocument();
+		expect( getByText( chips, '.net' ) ).toBeInTheDocument();
+		expect( getByText( chips, '.org' ) ).toBeInTheDocument();
+		expect( getByText( chips, '.io' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the member domains as a comma-joined line', () => {
-		render( <BundleCard suggestion={ buildSuggestion( threeDomains ) } /> );
+		// The TLD of each member is wrapped in its own span for emphasis, so assert
+		// on the line's combined text rather than a single text node.
+		const { container } = render( <BundleCard suggestion={ buildSuggestion( threeDomains ) } /> );
+		const members = container.querySelector( '.bundle-card__members' ) as HTMLElement;
 
-		expect( screen.getByText( 'example.com, example.net, example.org' ) ).toBeInTheDocument();
+		expect( members.textContent ).toBe( 'example.com, example.net, example.org' );
 	} );
 
 	it( 'renders the bundle price and the struck-through original price', () => {

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -40,28 +40,25 @@ const threeDomains = [ ...twoDomains, buildDomain( { domain: 'example.org', cost
 const fourDomains = [ ...threeDomains, buildDomain( { domain: 'example.io', cost: '$30.00' } ) ];
 
 describe( 'BundleCard', () => {
-	it( 'renders the SLD as a heading', () => {
+	it( 'renders the protect-your-brand header', () => {
 		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( screen.getByRole( 'heading', { name: 'example' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Protect your brand' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders exactly 2 companion rows for a 2-domain bundle', () => {
-		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
-
-		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 2 );
-	} );
-
-	it( 'renders exactly 3 companion rows for a 3-domain bundle', () => {
-		render( <BundleCard suggestion={ buildSuggestion( threeDomains ) } /> );
-
-		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 3 );
-	} );
-
-	it( 'renders exactly 4 companion rows for a 4-domain bundle', () => {
+	it( 'renders a TLD chip for each member domain', () => {
 		render( <BundleCard suggestion={ buildSuggestion( fourDomains ) } /> );
 
-		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 4 );
+		expect( screen.getByText( '.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.net' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.org' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.io' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the member domains as a comma-joined line', () => {
+		render( <BundleCard suggestion={ buildSuggestion( threeDomains ) } /> );
+
+		expect( screen.getByText( 'example.com, example.net, example.org' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the bundle price and the struck-through original price', () => {
@@ -103,10 +100,10 @@ describe( 'BundleCard', () => {
 	it( 'renders the discount percent text', () => {
 		render( <BundleCard suggestion={ buildSuggestion( twoDomains, { discount_percent: 20 } ) } /> );
 
-		expect( screen.getByText( 'Save 20%' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Bundle and save 20%' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the premium badge and legal notice when a domain is premium', () => {
+	it( 'renders the premium legal notice when a domain is premium', () => {
 		render(
 			<BundleCard
 				suggestion={ buildSuggestion( [
@@ -116,16 +113,14 @@ describe( 'BundleCard', () => {
 			/>
 		);
 
-		expect( screen.getByText( 'Premium' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( /Premium domains are subject to different pricing/ )
 		).toBeInTheDocument();
 	} );
 
-	it( 'does not render the premium badge or notice for a non-premium bundle', () => {
+	it( 'does not render the premium notice for a non-premium bundle', () => {
 		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( screen.queryByText( 'Premium' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByText( /Premium domains are subject to different pricing/ )
 		).not.toBeInTheDocument();

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -31,6 +31,20 @@ const buildBundleSuggestion = ( sld: string ): BundleSuggestion => ( {
 	catalogue_version: 'mock',
 } );
 
+// The restyled bundle card renders each member domain as its SLD plus a separate
+// `.tld` span, so a full member domain is no longer a single text node. Match on
+// the member line's combined text, scoped to the members element so ancestor
+// containers (which also contain the text) don't produce multiple matches.
+const memberLineHas =
+	( domain: string ) =>
+	( _content: string, element: Element | null ): boolean =>
+		element?.classList.contains( 'bundle-card__members' ) === true &&
+		( element.textContent ?? '' ).includes( domain );
+
+const findBundleMember = ( domain: string ) => screen.findByText( memberLineHas( domain ) );
+const getBundleMember = ( domain: string ) => screen.getByText( memberLineHas( domain ) );
+const queryBundleMember = ( domain: string ) => screen.queryByText( memberLineHas( domain ) );
+
 describe( 'ResultsPage', () => {
 	it( 'renders the search bar, filters and cart', () => {
 		render(
@@ -1039,7 +1053,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-permanent.net' ) ).toBeInTheDocument();
+			expect( await findBundleMember( 'test-bundle-permanent.net' ) ).toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
@@ -1050,7 +1064,7 @@ describe( 'ResultsPage', () => {
 			await waitFor( () => {
 				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
 			} );
-			expect( screen.queryByText( 'test-bundle-permanent.net' ) ).not.toBeInTheDocument();
+			expect( queryBundleMember( 'test-bundle-permanent.net' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'keeps the stale bundle hidden when the permanent-failure refetch returns the same bundle group', async () => {
@@ -1085,7 +1099,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-same-group.net' ) ).toBeInTheDocument();
+			expect( await findBundleMember( 'test-bundle-same-group.net' ) ).toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
@@ -1096,7 +1110,7 @@ describe( 'ResultsPage', () => {
 			await waitFor( () => {
 				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
 			} );
-			expect( screen.queryByText( 'test-bundle-same-group.net' ) ).not.toBeInTheDocument();
+			expect( queryBundleMember( 'test-bundle-same-group.net' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'does not hide or refetch the next query when an old bundle add fails permanently', async () => {
@@ -1146,7 +1160,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-late-stale.net' ) ).toBeInTheDocument();
+			expect( await findBundleMember( 'test-bundle-late-stale.net' ) ).toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
@@ -1160,7 +1174,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByText( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
+			expect( await findBundleMember( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
 
 			await act( async () => {
 				rejectAddBundle(
@@ -1171,7 +1185,7 @@ describe( 'ResultsPage', () => {
 			} );
 
 			expect( freshRefetchRequest.isDone() ).toBe( false );
-			expect( screen.getByText( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
+			expect( getBundleMember( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
 		} );
 

--- a/packages/domain-search/src/ui/bundle-price/bundle-price.stories.tsx
+++ b/packages/domain-search/src/ui/bundle-price/bundle-price.stories.tsx
@@ -1,0 +1,19 @@
+import { BundlePrice } from '.';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta< typeof BundlePrice > = {
+	title: 'UI/BundlePrice',
+	component: BundlePrice,
+};
+
+export default meta;
+
+export const LeftAligned = () => (
+	<BundlePrice originalPrice="$75" bundlePrice="$60" renewalPrice="$75" />
+);
+
+export const RightAligned = () => (
+	<BundlePrice originalPrice="$75" bundlePrice="$60" renewalPrice="$75" alignment="right" />
+);
+
+export const WithoutRenewal = () => <BundlePrice originalPrice="$75" bundlePrice="$60" />;

--- a/packages/domain-search/src/ui/bundle-price/index.tsx
+++ b/packages/domain-search/src/ui/bundle-price/index.tsx
@@ -1,0 +1,84 @@
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
+
+import './style.scss';
+
+interface BundlePriceProps {
+	originalPrice: string;
+	bundlePrice: string;
+	renewalPrice?: string;
+	size?: number;
+	alignment?: 'left' | 'right';
+	className?: string;
+}
+
+/**
+ * Render a bundle price: the struck-through original followed by the discounted
+ * bundle price in green, with an optional "For first year. X/year renewal."
+ * subline. Modelled on `DomainSuggestionPrice` but context-free — size and
+ * alignment are props instead of being read from the suggestion list context.
+ */
+export const BundlePrice = ( {
+	originalPrice,
+	bundlePrice,
+	renewalPrice,
+	size = 20,
+	alignment = 'left',
+	className,
+}: BundlePriceProps ) => {
+	const { __ } = useI18n();
+
+	const subText = renewalPrice
+		? createInterpolateElement(
+				sprintf(
+					// translators: %(price)s is the renewal price of the domain bundle.
+					__( 'For first year. <span>%(price)s/year renewal.</span>' ),
+					{ price: renewalPrice }
+				),
+				{ span: <span style={ { whiteSpace: 'nowrap' } } /> }
+		  )
+		: null;
+
+	return (
+		<VStack spacing={ 0 } className={ clsx( 'bundle-price', className ) }>
+			<HStack spacing={ 2 } justify={ alignment === 'left' ? 'start' : 'end' } expanded={ false }>
+				<Text
+					as="s"
+					size={ size }
+					variant="muted"
+					className="bundle-price__original"
+					aria-label={ sprintf(
+						// translators: %(price)s is the original price of the domain bundle.
+						__( 'Original price: %(price)s' ),
+						{ price: originalPrice }
+					) }
+				>
+					{ originalPrice }
+				</Text>
+				<Text
+					size={ size }
+					color="var( --domain-search-promotional-price-color )"
+					aria-label={ sprintf(
+						// translators: %(price)s is the discounted bundle price.
+						__( 'Bundle price: %(price)s' ),
+						{ price: bundlePrice }
+					) }
+				>
+					{ bundlePrice }
+				</Text>
+			</HStack>
+			{ subText && (
+				<Text size="body" align={ alignment } variant="muted" className="bundle-price__sub-text">
+					{ subText }
+				</Text>
+			) }
+		</VStack>
+	);
+};

--- a/packages/domain-search/src/ui/bundle-price/style.scss
+++ b/packages/domain-search/src/ui/bundle-price/style.scss
@@ -1,0 +1,9 @@
+.bundle-price__original {
+	text-decoration: line-through;
+}
+
+.bundle-price__sub-text {
+	a {
+		color: inherit;
+	}
+}

--- a/packages/domain-search/src/ui/bundle-tld-chips/bundle-tld-chips.stories.tsx
+++ b/packages/domain-search/src/ui/bundle-tld-chips/bundle-tld-chips.stories.tsx
@@ -1,0 +1,15 @@
+import { BundleTldChips } from '.';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta< typeof BundleTldChips > = {
+	title: 'UI/BundleTldChips',
+	component: BundleTldChips,
+};
+
+export default meta;
+
+export const TwoTlds = () => <BundleTldChips tlds={ [ 'com', 'net' ] } />;
+
+export const ThreeTlds = () => <BundleTldChips tlds={ [ 'com', 'org', 'net' ] } />;
+
+export const LongTlds = () => <BundleTldChips tlds={ [ 'photography', 'international', 'com' ] } />;

--- a/packages/domain-search/src/ui/bundle-tld-chips/index.tsx
+++ b/packages/domain-search/src/ui/bundle-tld-chips/index.tsx
@@ -1,0 +1,46 @@
+import { __experimentalText as Text, __experimentalHStack as HStack } from '@wordpress/components';
+import clsx from 'clsx';
+import { Fragment, ReactNode } from 'react';
+
+import './style.scss';
+
+interface BundleTldChipsProps {
+	tlds: string[];
+	separator?: ReactNode;
+	size?: number;
+	className?: string;
+}
+
+/**
+ * Render a bundle's member TLDs as a prominent line, e.g. `.com + .org + .net`,
+ * with each TLD bold/dark and the separators muted. Context-free so both the
+ * bundle card and a future inline bundle row can reuse it.
+ */
+export const BundleTldChips = ( {
+	tlds,
+	separator = '+',
+	size = 24,
+	className,
+}: BundleTldChipsProps ) => {
+	return (
+		<HStack
+			spacing={ 2 }
+			justify="flex-start"
+			expanded={ false }
+			className={ clsx( 'bundle-tld-chips', className ) }
+		>
+			{ tlds.map( ( tld, index ) => (
+				<Fragment key={ `${ tld }-${ index }` }>
+					{ index > 0 && (
+						<Text size={ size } aria-hidden="true" className="bundle-tld-chips__separator">
+							{ separator }
+						</Text>
+					) }
+					<Text size={ size } weight={ 600 } className="bundle-tld-chips__tld">
+						.{ tld }
+					</Text>
+				</Fragment>
+			) ) }
+		</HStack>
+	);
+};

--- a/packages/domain-search/src/ui/bundle-tld-chips/style.scss
+++ b/packages/domain-search/src/ui/bundle-tld-chips/style.scss
@@ -1,0 +1,7 @@
+.bundle-tld-chips__tld {
+	word-break: keep-all;
+}
+
+.bundle-tld-chips__separator {
+	opacity: 0.3;
+}

--- a/packages/domain-search/src/ui/index.ts
+++ b/packages/domain-search/src/ui/index.ts
@@ -12,6 +12,8 @@ export { FeaturedDomainSuggestionsList } from './featured-domain-suggestions-lis
 export { DomainSuggestion } from './domain-suggestion';
 export { DomainSuggestionBadge } from './domain-suggestion-badge';
 export { DomainSuggestionPrice } from './domain-suggestion-price';
+export { BundleTldChips } from './bundle-tld-chips';
+export { BundlePrice } from './bundle-price';
 export * from './domain-suggestion-cta';
 export { DomainSuggestionLoadMore } from './domain-suggestion-load-more';
 export { DomainSuggestionFilterReset } from './domain-suggestion-filter-reset';


### PR DESCRIPTION
Related to DOMAINS-2189

## Proposed Changes

Restyles the top-of-results domain **bundle card** from the current vertical layout into the new horizontal design, and extracts two reusable, context-free UI primitives so the upcoming in-line bundle row can share them.

- **`BundleCard`** (`packages/domain-search/src/components/bundle-card/`) rebuilt: lock + "Protect your brand" header, "Bundle and save X%" badge, prominent TLD chips (`.com + .org + .net`), muted comma-joined member line, price + CTA row, and a footer tagline. Empty-state, premium notice, error notice, and the added/`Continue` vs `Get bundle` CTA toggle are all preserved; props are unchanged.
- **New primitives** in `packages/domain-search/src/ui/` (exported from `ui/index.ts`), neither calling `useDomainSuggestionContainerContext()` so they work in a standalone card and in a list row:
  - `BundleTldChips` — bold TLDs with faded `+` separators.
  - `BundlePrice` — strikethrough original + green bundle price + optional renewal subline.
- Stories updated for the new markup; stories added for the two primitives.

<img width="984" height="628" alt="CleanShot 2026-07-06 at 14 39 39@2x" src="https://github.com/user-attachments/assets/e509c7a4-308a-4915-b068-c978b12e3fc2" />


## Why

Design polish for the domain-bundle upsell, and prep for in-line bundles (a later PR) which reuse `BundleTldChips` / `BundlePrice`.

## Testing Instructions

<details>
<summary>Checks</summary>

- `yarn tsc --noEmit -p packages/domain-search/tsconfig.json` — clean
- `yarn eslint` on changed files — clean
- `yarn jest -c=test/packages/jest.config.js bundle-card` — 17/17 pass
- Storybook: `cd packages/domain-search && yarn storybook:start` → **Components/BundleCard**, **UI/BundleTldChips**, **UI/BundlePrice**

</details>

Note: built to the written design spec without the reference mockup — proportions/spacing worth an eyeball in Storybook before marking ready-for-review.

Co-Authored-By: Claude <noreply@anthropic.com>
