### PR TITLE
react-transition-group: upgrade to 4.4.5 and use nodeRef for React 19

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import { PropsWithChildren, useContext, useCallback } from 'react';
+import { PropsWithChildren, useContext, useCallback, useRef } from 'react';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
@@ -30,9 +30,22 @@ interface LicenseTransitionProps {
 	exit?: boolean;
 }
 
-const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > ) => (
-	<CSSTransition { ...props } classNames="license-list__license-transition" timeout={ 150 } />
-);
+const LicenseTransition = ( {
+	children,
+	...props
+}: PropsWithChildren< LicenseTransitionProps > ) => {
+	const nodeRef = useRef< HTMLDivElement >( null );
+	return (
+		<CSSTransition
+			{ ...props }
+			nodeRef={ nodeRef }
+			classNames="license-list__license-transition"
+			timeout={ 150 }
+		>
+			<div ref={ nodeRef }>{ children }</div>
+		</CSSTransition>
+	);
+};
 
 export default function LicenseList() {
 	const translate = useTranslate();

--- a/client/package.json
+++ b/client/package.json
@@ -207,7 +207,7 @@
 		"react-redux": "^9.2.0",
 		"react-router-dom": "6.30.4",
 		"react-slider": "^2.0.6",
-		"react-transition-group": "^4.3.0",
+		"react-transition-group": "^4.4.5",
 		"redux": "^5.0.1",
 		"redux-dynamic-middlewares": "^2.2.0",
 		"redux-thunk": "^3.1.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -63,7 +63,7 @@
 		"clsx": "^2.1.1",
 		"i18n-calypso": "workspace:^",
 		"react-intersection-observer": "^9.4.3",
-		"react-transition-group": "^4.3.0"
+		"react-transition-group": "^4.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/i18n": "^6.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,7 +2055,7 @@ __metadata:
     msw: "npm:^2.2.14"
     msw-storybook-addon: "npm:^2.0.7"
     react-intersection-observer: "npm:^9.4.3"
-    react-transition-group: "npm:^4.3.0"
+    react-transition-group: "npm:^4.4.5"
     resize-observer-polyfill: "npm:^1.5.1"
     storybook: "npm:^9.1.20"
     typescript: "npm:^6.0.3"
@@ -14509,7 +14509,7 @@ __metadata:
     react-router-dom: "npm:6.30.4"
     react-slider: "npm:^2.0.6"
     react-test-renderer: "npm:^18.3.1"
-    react-transition-group: "npm:^4.3.0"
+    react-transition-group: "npm:^4.4.5"
     redux: "npm:^5.0.1"
     redux-dynamic-middlewares: "npm:^2.2.0"
     redux-mock-store: "npm:^1.5.5"
@@ -27759,9 +27759,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "react-transition-group@npm:4.3.0"
+"react-transition-group@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "react-transition-group@npm:4.4.5"
   dependencies:
     "@babel/runtime": "npm:^7.5.5"
     dom-helpers: "npm:^5.0.1"
@@ -27770,7 +27770,7 @@ __metadata:
   peerDependencies:
     react: ">=16.6.0"
     react-dom: ">=16.6.0"
-  checksum: 1ece0f3c86bfaa42b8f44b8bf8e809bc618ad5dc0ea037cedbf55a49b0e48e49a30c4dccbb0743b9bf4ab24b7a7d12b68bbe399ed4541428e2d40b999e4d2cd6
+  checksum: 2ba754ba748faefa15f87c96dfa700d5525054a0141de8c75763aae6734af0740e77e11261a1e8f4ffc08fd9ab78510122e05c21c2d79066c38bb6861a886c82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Upgrade `react-transition-group` from `4.3.0` to `4.4.5` (in `client` and `packages/plans-grid-next`).
* Pass a `nodeRef` to the A4A licenses list `CSSTransition` (`client/a8c-for-agencies/.../license-list`) so the library reads the transitioning node from the ref instead of `ReactDOM.findDOMNode`.

Fix this issue: p1783358886041719/1783358435.166639-slack-C02DQP0FP

## Why are these changes being made?

React 19 removed `ReactDOM.findDOMNode`. `react-transition-group@4.3.0` calls it in `Transition.updateStatus` every time an enter/exit transition runs, so under React 19 the A4A licenses page (`/purchases/licenses`) throws `Uncaught TypeError: findDOMNode is not a function` (at `Transition.updateStatus` ← `componentDidMount`/`componentDidUpdate`) and renders blank.

`nodeRef` (added in `react-transition-group@4.4.0`) is the library's documented way to avoid `findDOMNode`. Both the version bump **and** the `nodeRef` wiring are required — verified against React 19.2.7 in isolation:

| react-transition-group | `nodeRef` | result |
| --- | --- | --- |
| 4.3.0 | ✗ | ❌ `findDOMNode is not a function` |
| 4.3.0 | ✓ | ❌ (4.3.0 ignores `nodeRef`) |
| 4.4.5 | ✗ | ❌ (still falls back to `findDOMNode`) |
| 4.4.5 | ✓ | ✅ renders + transitions cleanly |

The change is backward-compatible with React 18, so it is safe to land on trunk ahead of the React 19 upgrade.

> [!NOTE]
> `packages/plans-grid-next/.../popup-messages.tsx` also uses `CSSTransition` and has the same React 19 incompatibility. Fixing it requires threading a `nodeRef` to the `.popover` node through the portal-based, shared `Popover`/`PopoverInner` component (its transition CSS is keyed to `.popover-*` classes on that element, so a wrapper `div` won't work). That is a larger, riskier change to a shared component and is left as a follow-up.

## Testing Instructions

* With a React 19 build, visit A4A `/purchases/licenses` and confirm the list renders (no `findDOMNode` console error) and that rows animate in/out as data loads/paginates.
* On the current React 18 trunk, confirm the licenses list still renders and animates as before (no regression).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)