### PR TITLE
Reader Spaces: dark mode support & sidebar polish

### DIFF
--- a/client/reader/sidebar/spaces/style.scss
+++ b/client/reader/sidebar/spaces/style.scss
@@ -47,15 +47,17 @@
 // Active row: tint the whole row with the space's own accent so the current
 // space is unmistakable. The shared sidebar only paints a selected background in
 // dark mode, so in light mode this is the only active-state cue — without it the
-// current space reads no differently from the rest until hovered. The name takes
-// on the space's foreground colour.
+// current space reads no differently from the rest until hovered.
+//
+// The name keeps the neutral `--color-text` (just bolder): the accent foreground
+// is the dark `-80` step, which is illegible on the dark selected row, and the
+// row tint + weight + coloured icon already mark the active space.
 .sidebar-spaces__item.selected {
 	.sidebar-spaces__link {
 		background-color: var( --space-color-bg );
 	}
 
 	.sidebar-spaces__name {
-		color: var( --space-color );
 		font-weight: 600;
 	}
 }

--- a/client/reader/spaces/color-picker.scss
+++ b/client/reader/spaces/color-picker.scss
@@ -65,7 +65,11 @@
 }
 
 .space-color-picker__check {
-	fill: var( --color-surface );
+	// The check sits on the swatch's vivid accent fill, so it needs a light mark
+	// in both themes. `--color-surface` was light-only and flipped dark (and thus
+	// invisible on the coloured swatch) in dark mode; `--color-text-inverted`
+	// stays white in both themes.
+	fill: var( --color-text-inverted );
 	pointer-events: none;
 }
 

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -51,6 +51,29 @@
 		border-block-start: 1px solid var( --color-neutral-5 );
 	}
 
+	// Keep the tab labels in sync with `section-nav-tabs`, which colours its
+	// labels with the theme-aware `--color-neutral-100` / `--color-neutral-70`
+	// tokens so they stay legible in dark mode. The WP TabPanel defaults rely on
+	// `--wpds-color-*-interactive-neutral` tokens that Calypso never defines, so
+	// they fall back to hardcoded light-mode values and vanish on a dark surface.
+	.components-tab-panel__tabs-item {
+		color: var( --color-neutral-100 );
+
+		&:hover,
+		&:focus-visible {
+			color: var( --color-neutral-100 );
+		}
+
+		&.is-active {
+			background: transparent;
+			color: var( --color-neutral-100 );
+
+			&::after {
+				background: var( --color-neutral-70 );
+			}
+		}
+	}
+
 	.components-tab-panel__tab-content {
 		display: flex;
 		flex: 1;

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -184,6 +184,10 @@
 	border-radius: 8px;
 	background: var( --space-color-bg );
 	color: var( --space-color );
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 @each $color in space-colors.$space-colors {

--- a/client/reader/spaces/feed/style.scss
+++ b/client/reader/spaces/feed/style.scss
@@ -1,4 +1,5 @@
 @use 'calypso/reader/spaces/colors' as space-colors;
+@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
 
 .space-feed {
 	display: flex;
@@ -24,6 +25,31 @@
 		.reader-post-actions {
 			--color-text-subtle: var( --space-color );
 			--color-link: var( --space-color-hover );
+		}
+
+		// The accent's default foreground sits at the dark `-80` step, which is
+		// legible on the light feed but disappears against the dark surface. Lift
+		// the accent to lighter studio steps in dark mode so titles and actions
+		// keep the space's colour while staying readable. Only the on-surface text
+		// tokens change here; the chip tokens (`--space-color-bg` etc., used as a
+		// tinted-background + dark-glyph pair) are left untouched.
+		//
+		// The dark theme remaps only the `studio-blue` and `studio-gray` palettes
+		// (see `dark-theme.scss`), where the semantics flip so the high `-80` step
+		// is already a bright foreground — those two already read correctly, and
+		// lifting them to `-30` would instead land on the dark surface tint. Skip
+		// them; the remaining, non-remapped hues keep the original ramp where the
+		// low `-30`/`-20` steps are the light ones.
+		@if $color != 'blue' and $color != 'gray' {
+			@include ui-mixins.when-dark-theme {
+				--space-color: var( --studio-#{$color}-30 );
+				--space-color-hover: var( --studio-#{$color}-20 );
+				--space-color-visited: color-mix(
+					in srgb,
+					var( --studio-#{$color}-30 ) 40%,
+					var( --color-text-subtle )
+				);
+			}
 		}
 	}
 }

--- a/client/reader/spaces/icon-picker.scss
+++ b/client/reader/spaces/icon-picker.scss
@@ -15,6 +15,10 @@
 	color: var( --color-text );
 	cursor: pointer;
 
+	svg {
+		fill: currentColor;
+	}
+
 	&[data-selected='true'] {
 		border-color: var( --color-primary );
 		box-shadow: 0 0 0 1px var( --color-primary );

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -169,6 +169,42 @@ describe( 'read spaces mutations', () => {
 			} );
 		} );
 
+		it( 'optimistically patches the list summary before the server responds', async () => {
+			const client = newClient();
+			client.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, [
+				{ id: '3', name: 'Old', layout: { color: 'blue', icon: 'inbox', iconColor: 'blue' } },
+			] );
+
+			// Run just `onMutate` — the sidebar reads this list, so the icon/colour must
+			// update from the mutation variables without waiting for the round-trip.
+			await updateReadSpaceMutation( client ).onMutate?.( {
+				spaceId: '3',
+				params: { name: 'New', layout: { icon: 'star', iconColor: 'pink' } },
+			} );
+
+			// `layout` is merged (color kept, icon/iconColor overridden), name replaced.
+			expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( [
+				{ id: '3', name: 'New', layout: { color: 'blue', icon: 'star', iconColor: 'pink' } },
+			] );
+		} );
+
+		it( 'rolls back the optimistic list patch when the update fails', async () => {
+			const client = newClient();
+			const seeded: ReadSpace[] = [
+				{ id: '3', name: 'Old', layout: { color: 'blue', icon: 'inbox', iconColor: 'blue' } },
+			];
+			client.setQueryData< ReadSpace[] >( readSpacesQuery().queryKey, seeded );
+			nock( BASE ).put( '/wpcom/v2/reader/spaces/3' ).reply( 500, { error: 'boom' } );
+
+			await runMutation( client, updateReadSpaceMutation( client ), {
+				spaceId: '3',
+				params: { name: 'New', layout: { icon: 'star', iconColor: 'pink' } },
+			} );
+
+			// The optimistic patch is reverted to the pre-mutation summary.
+			expect( client.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey ) ).toEqual( seeded );
+		} );
+
 		it( "resets both of the space's streams so they reload after a tag/feed/language edit", async () => {
 			const client = newClient();
 			const spy = jest.spyOn( client, 'resetQueries' );

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -128,8 +128,49 @@ type UpdateReadSpaceVariables = {
 };
 
 export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
-	mutationOptions< ReadSpaceDetails, unknown, UpdateReadSpaceVariables >( {
+	mutationOptions<
+		ReadSpaceDetails,
+		unknown,
+		UpdateReadSpaceVariables,
+		{ previousList: ReadSpace[] | undefined }
+	>( {
 		mutationFn: ( { spaceId, params } ) => updateReadSpace( spaceId, params ),
+		// Optimistically patch the cached list summary so the sidebar — which reads
+		// `useSpaces()` (this list) and renders each item's icon and colour from
+		// `layout` via `resolveSpaceIconColor` — reflects a name/icon/colour change
+		// the instant the user saves, without waiting for the round-trip. `onSuccess`
+		// then writes the canonical server detail over the top.
+		onMutate: async ( { spaceId, params } ) => {
+			// `cancelQueries` is best-effort per the TanStack docs; if it rejects we
+			// must still apply the optimistic write and let the mutationFn run.
+			try {
+				await queryClient.cancelQueries( { queryKey: readSpacesQuery().queryKey } );
+			} catch {
+				// no-op — fall through to the optimistic write below.
+			}
+			const previousList = queryClient.getQueryData< ReadSpace[] >( readSpacesQuery().queryKey );
+			// `params.layout` is a partial merge (see `UpdateReadSpaceParams`), so merge
+			// it onto the existing layout rather than replacing it.
+			queryClient.setQueryData< ReadSpace[] >(
+				readSpacesQuery().queryKey,
+				( previous ) =>
+					previous?.map( ( item ) =>
+						item.id === spaceId
+							? {
+									...item,
+									...( params.name !== undefined ? { name: params.name } : {} ),
+									layout: { ...item.layout, ...params.layout },
+							  }
+							: item
+					)
+			);
+			return { previousList };
+		},
+		onError: ( _error, _variables, context ) => {
+			if ( context?.previousList ) {
+				queryClient.setQueryData( readSpacesQuery().queryKey, context.previousList );
+			}
+		},
 		onSuccess: ( space ) => {
 			// Update may change summary fields (title/layout), so refresh the matching
 			// list item as well as the detail cache.


### PR DESCRIPTION
<!-- Linear: umbrella RSM-4647 -->

Closes RSM-4647
Closes RSM-4648
Closes RSM-4649
Closes RSM-4650
Closes RSM-4658
Closes RSM-4659
Closes RSM-4660

## Proposed Changes

Dark-mode fixes and related polish across the Reader Spaces create/edit surfaces and the sidebar.

- **Icons in the create flow (RSM-4648):** `@wordpress/icons` glyphs render a `<path>` with no `fill`, so they defaulted to black — invisible on the dark modal. Map the SVG `fill` to `currentColor` in the icon picker and the footer preview icon so they follow the theme-aware `--color-text` / accent colour.
- **Color picker check (RSM-4649):** the selected-swatch check used `--color-surface` (white in light mode, dark in dark mode), so it vanished on the vivid swatch in dark mode. Use `--color-text-inverted`, which stays white in both themes.
- **Tab labels (RSM-4650):** the WP `TabPanel` colours labels with `--wpds-color-*-interactive-neutral` tokens Calypso never defines, so they fell back to hardcoded light-mode values. Align the tabs with the `section-nav-tabs` implementation (`--color-neutral-100` / `--color-neutral-70`) and drop the light active-tab background box.
- **Feed accent colours (RSM-4658):** space feed titles and post actions use `--space-color` (`studio-{color}-80`), too dark to read on the dark surface for the non-remapped hues. Lift the accent to lighter studio steps in dark mode, scoped to the feed's on-surface text tokens; `blue`/`gray` are skipped because their palettes are already remapped by the dark theme.
- **Sidebar selected name (RSM-4659):** the selected sidebar row coloured the space name with the dark accent, illegible on the dark row. Keep the name on the neutral `--color-text` (bolded); the row tint, weight, and coloured icon already mark the active space.
- **Sidebar icon colour lag (RSM-4660):** `updateReadSpaceMutation` only wrote the updated summary to the spaces list in `onSuccess`, so the sidebar lagged the save by a round-trip. Add an `onMutate` optimistic patch of the list summary (name + merged `layout`) with `onError` rollback, keeping the existing `onSuccess` reconciliation.

## Why are these changes being made?

The Reader Spaces UI shipped with light-mode-only styling on several create/edit and sidebar surfaces, leaving icons, colour swatches, tab labels, feed accents, and the selected sidebar name invisible or illegible in dark mode. This makes those surfaces theme-aware. The optimistic-update change removes a visible lag between saving a space's icon/colour and the sidebar reflecting it.

## Testing Instructions

1. Enable dark mode (Calypso dark theme or system dark).
2. Open the Reader Spaces **Customize space** modal (create and edit a space):
   - Icon picker glyphs are visible; the selected tile uses the primary colour.
   - Color picker: the check on the selected swatch is clearly visible on the coloured swatches.
   - Tab labels (Identity / Layout / Sources / Delete) are legible; the active tab is clear.
   - Footer preview icon uses the accent colour and is visible.
3. Open a Space's feed in dark mode: post titles and action icons/counts are legible for every accent colour (try a red/pink/green space and a blue/gray space).
4. In the sidebar, the selected space name is legible in dark mode.
5. Edit a space's icon colour and save: the sidebar icon colour updates immediately (no round-trip lag). If the save fails, the sidebar reverts.
6. Re-check all of the above in light mode for regressions.

`yarn test-client`/package tests cover the optimistic update: `packages/api-queries/src/__tests__/read-spaces.test.tsx`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
