### PR TITLE
Dashboard: enable account-recovery-interstitial feature flag in all environments

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -29,7 +29,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/omnibar-radical": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -25,7 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -26,6 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": true,
 		"dark-mode": true,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -25,7 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -20,6 +20,7 @@ import type {
 	MyAccountInformationResponse,
 	AccountClosureResponse,
 	SiteDeletionResponse,
+	CalypsoPreferences,
 	CalypsoPreferencesResponse,
 	ErrorResponse,
 	AccountCredentials,
@@ -638,6 +639,27 @@ export class RestAPIClient {
 				Authorization: await this.getAuthorizationHeader( 'bearer' ),
 				'Content-Type': this.getContentTypeHeader( 'json' ),
 			},
+		};
+
+		return await this.sendRequest( this.getRequestURL( '1.1', '/me/preferences' ), params );
+	}
+
+	/**
+	 * Updates Calypso preferences for the user.
+	 *
+	 * @param {Partial<CalypsoPreferences>} preferences Key/value preferences to persist.
+	 * @returns {Promise<CalypsoPreferencesResponse>} JSON response containing the updated Calypso preferences.
+	 */
+	async setCalypsoPreferences(
+		preferences: Partial< CalypsoPreferences >
+	): Promise< CalypsoPreferencesResponse > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( { calypso_preferences: preferences } ),
 		};
 
 		return await this.sendRequest( this.getRequestURL( '1.1', '/me/preferences' ), params );

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -57,10 +57,14 @@ export interface AllDomainsResponse {
 	domains: Array< DomainData >;
 }
 
+export interface CalypsoPreferences {
+	recentSites?: number[];
+	'account-recovery-interstitial-snoozed-until'?: number;
+	[ key: string ]: unknown;
+}
+
 export interface CalypsoPreferencesResponse {
-	calypso_preferences: {
-		recentSites: number[];
-	};
+	calypso_preferences: CalypsoPreferences;
 }
 
 export interface MyAccountInformationResponse {

--- a/test/e2e/lib/dashboard-helpers.ts
+++ b/test/e2e/lib/dashboard-helpers.ts
@@ -1,0 +1,20 @@
+import type { RestAPIClient } from '@automattic/calypso-e2e';
+
+/**
+ * Snoozes the account-recovery interstitial for the given user.
+ *
+ * The interstitial is an app-level modal that mounts over every dashboard route
+ * for users with incomplete account-recovery setup. It traps focus and blocks
+ * the UI the dashboard specs interact with (and adds its own heading to the
+ * page). Persisting a far-future snooze keeps it from rendering, matching the
+ * `account-recovery-interstitial-snoozed-until` preference the dashboard reads
+ * (a unix timestamp, in seconds).
+ *
+ * @param client - REST API client authenticated as the user to snooze.
+ */
+export async function snoozeAccountRecoveryInterstitial( client: RestAPIClient ): Promise< void > {
+	const tenYearsFromNowInSeconds = Math.floor( Date.now() / 1000 ) + 10 * 365 * 24 * 60 * 60;
+	await client.setCalypsoPreferences( {
+		'account-recovery-interstitial-snoozed-until': tenYearsFromNowInSeconds,
+	} );
+}

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -95,6 +95,7 @@ import {
 	apiWaitForEmailVerification,
 } from '../specs/shared';
 import { useBlackboxTestKeyForCollect } from './blackbox-test-key';
+import { snoozeAccountRecoveryInterstitial } from './dashboard-helpers';
 import { getAccount } from './get-account';
 
 export type CustomOptions = {
@@ -665,6 +666,10 @@ export const test = base.extend<
 			) as string;
 			await page.goto( activationLink );
 			await apiWaitForEmailVerification( restAPIClient, testUser.email );
+			// Fresh accounts have no recovery method set up, so the dashboard's
+			// account-recovery interstitial would mount over every route and block
+			// specs that load the dashboard with this fixture. Snooze it up front.
+			await snoozeAccountRecoveryInterstitial( restAPIClient );
 			await use( site );
 		} finally {
 			if ( site ) {

--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -4,6 +4,7 @@ import type { Locator, Page } from '@playwright/test';
 
 const COLOR_SCHEME_PREFERENCE = 'hosting-dashboard-color-scheme';
 const DASHBOARD_OPT_IN_PREFERENCE = 'hosting-dashboard-opt-in';
+const ACCOUNT_RECOVERY_SNOOZE_PREFERENCE = 'account-recovery-interstitial-snoozed-until';
 const REQUIRED_TOKENS = [
 	'--dashboard__background-color',
 	'--dashboard-surface__background-color',
@@ -64,6 +65,10 @@ function addDarkModePreference(
 		calypso_preferences: {
 			...calypsoPreferences,
 			[ COLOR_SCHEME_PREFERENCE ]: 'dark',
+			// Snooze the account-recovery interstitial (a unix timestamp, in seconds)
+			// so it doesn't mount over the dashboard routes this suite asserts on.
+			[ ACCOUNT_RECOVERY_SNOOZE_PREFERENCE ]:
+				Math.floor( Date.now() / 1000 ) + 10 * 365 * 24 * 60 * 60,
 			// Themes dark mode is additionally gated behind the dashboard opt-in
 			// (#110825 `shouldEnableThemesColorScheme`), so the preference override
 			// must also satisfy `hasDashboardOptIn` for the Themes suite.

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -1,3 +1,4 @@
+import { snoozeAccountRecoveryInterstitial } from '../../lib/dashboard-helpers';
 import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe(
@@ -6,10 +7,12 @@ test.describe(
 	() => {
 		test( 'As a WordPress.com user, I can see the new Multi-site Dashboard page as a list of my sites', async ( {
 			accountGivenByEnvironment,
+			clientRestAPI,
 			page,
 			pageDashboard,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
+				await snoozeAccountRecoveryInterstitial( clientRestAPI );
 				// Skip waiting for Calypso sidebar — we navigate to the dashboard immediately after.
 				await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 			} );
@@ -26,10 +29,12 @@ test.describe(
 
 		test( 'As a WordPress.com user, I can see a 404 page for a non-existent dashboard page', async ( {
 			accountGivenByEnvironment,
+			clientRestAPI,
 			page,
 			pageDashboard,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
+				await snoozeAccountRecoveryInterstitial( clientRestAPI );
 				// Skip waiting for Calypso sidebar — we navigate to the dashboard immediately after.
 				await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 			} );

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -1,3 +1,4 @@
+import { snoozeAccountRecoveryInterstitial } from '../../lib/dashboard-helpers';
 import { expect, tags, test } from '../../lib/pw-base';
 
 interface PerfNavEvent {
@@ -73,12 +74,14 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 
 	test( 'Full page load to site list sends perf.nav with correct ID', async ( {
 		accountGivenByEnvironment,
+		clientRestAPI,
 		page,
 		pageDashboard,
 	} ) => {
 		const events = observeLogstash( page );
 
 		await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
+			await snoozeAccountRecoveryInterstitial( clientRestAPI );
 			await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 		} );
 
@@ -102,6 +105,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 
 	test( 'In-app navigation sends perf.nav with fullPage false', async ( {
 		accountGivenByEnvironment,
+		clientRestAPI,
 		page,
 		pageDashboard,
 		viewportName,
@@ -109,6 +113,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 		const events = observeLogstash( page );
 
 		await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
+			await snoozeAccountRecoveryInterstitial( clientRestAPI );
 			await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 		} );
 


### PR DESCRIPTION
## Proposed Changes

* Enable the `dashboard/account-recovery-interstitial` feature flag in all dashboard environments: production, development, horizon, and stage. In production the key was previously absent (so effectively `false`); in the other three it was explicitly `false`.
* Update the Dashboard E2E tests to account for the modal: the affected specs snooze the account-recovery interstitial so it doesn't mount over the dashboard routes they exercise.

## Why are these changes being made?

The account-recovery login interstitial only mounts when this feature flag is on (`client/dashboard/app/root/index.tsx`). Turning it on lets the modal render for the A/B experiment launch. Which users actually see the modal is still governed by the ExPlat experiment `calypso_onboarding_account_recovery_modal_202606` (control sees it, the `no_recovery_modal` holdout does not) and by the per-user eligibility checks in the component. This flag is only the on/off switch for mounting the feature.

## Testing Instructions

* Confirm `dashboard/account-recovery-interstitial` is `true` in the production, development, horizon, and stage configs.
* Load the Multi-Site Dashboard as an eligible user (incomplete recovery setup) in the experiment control group and confirm the interstitial renders.
* Confirm a user in the `no_recovery_modal` holdout does not see it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)