### PR TITLE
Account recovery interstitial: shorten the 2FA CTA label

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/copy.ts
+++ b/client/dashboard/app/account-recovery-interstitial/copy.ts
@@ -105,7 +105,7 @@ export function getInterstitialCopy(
 			},
 			secondaryCta: {
 				id: 'add_two_factor',
-				label: __( 'Add two-step authentication and backup codes' ),
+				label: __( 'Add two-step authentication' ),
 				route: securityTwoStepAuthRoute.fullPath,
 			},
 		},

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -95,9 +95,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Set up recovery email or phone' } )
 		).toBeVisible();
-		expect(
-			screen.getByRole( 'button', { name: 'Add two-step authentication and backup codes' } )
-		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Add two-step authentication' } ) ).toBeVisible();
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_account_recovery_nudge_interstitial_impression',


### PR DESCRIPTION
## Proposed Changes

* Shorten the secondary CTA in the account-recovery interstitial from "Add two-step authentication and backup codes" to "Add two-step authentication".
* Update the matching assertion in the interstitial test.

## Why are these changes being made?

The longer label overflowed the button width in some languages (for example Portuguese: "Adicionar autenticação em duas etapas e códigos de backup"), pushing the text past the button edges. The shorter label fits within the button across languages. Backup codes are still covered by the dedicated download-backup-codes step users reach afterward.

### Screenshots

| Before | After |
| --- | --- |
| <img width="446" height="593" alt="Screenshot 2026-07-06 at 16 20 38" src="https://github.com/user-attachments/assets/17388bfb-c15a-4dda-a263-b6269ff15c17" /> | <img width="454" height="604" alt="Screenshot 2026-07-06 at 16 23 09" src="https://github.com/user-attachments/assets/1914ba5e-eea9-4472-be5f-0701aec063c9" /> |

## Testing Instructions

* Open the account-recovery interstitial as a user with no recovery method and no 2FA.
* Confirm the secondary button reads "Add two-step authentication" and its text stays within the button, including in a longer language such as Portuguese.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
