### PR TITLE
Domain search: in-line domain bundles (Stream 3b)

### DIFF
--- a/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { fetchBundleSuggestion } from '..';
+import { fetchBundleForDomain, fetchBundleSuggestion, fetchBundleTriggers } from '..';
 import type { BundleSuggestion } from '../types';
 
 const BASE = 'https://public-api.wordpress.com';
@@ -70,5 +70,70 @@ describe( 'fetchBundleSuggestion', () => {
 		} );
 
 		expect( await fetchBundleSuggestion( 'example' ) ).toBeNull();
+	} );
+} );
+
+describe( 'fetchBundleTriggers', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'requests with_bundles=1 and returns the bundle_triggers list', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query( ( query ) => query.with_bundles === '1' && query.query === 'example' )
+			.reply( 200, {
+				domain_suggestions: [],
+				bundle_suggestion: null,
+				bundle_triggers: [ 'com' ],
+			} );
+
+		const triggers = await fetchBundleTriggers( 'example' );
+
+		expect( scope.isDone() ).toBe( true );
+		expect( triggers ).toEqual( [ 'com' ] );
+	} );
+
+	it( 'returns an empty array when the response carries no triggers', async () => {
+		nock( BASE ).get( '/rest/v1.1/domains/suggestions' ).query( true ).reply( 200, {
+			domain_suggestions: [],
+			bundle_suggestion: null,
+		} );
+
+		expect( await fetchBundleTriggers( 'example' ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'fetchBundleForDomain', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'requests the v2 /domains/bundle endpoint with the fqdn and returns the bundle', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/domains/bundle' )
+			.query( ( query ) => query.query === 'flowers.com' )
+			.reply( 200, { bundle_suggestion: bundleSuggestion } );
+
+		const bundle = await fetchBundleForDomain( 'flowers.com' );
+
+		expect( scope.isDone() ).toBe( true );
+		expect( bundle ).toEqual( bundleSuggestion );
+	} );
+
+	it( 'lowercases the fqdn before sending it', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/domains/bundle' )
+			.query( ( query ) => query.query === 'flowers.com' )
+			.reply( 200, { bundle_suggestion: bundleSuggestion } );
+
+		await fetchBundleForDomain( 'Flowers.com' );
+
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'returns null when the endpoint carries no bundle suggestion', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/domains/bundle' )
+			.query( true )
+			.reply( 200, { bundle_suggestion: null } );
+
+		expect( await fetchBundleForDomain( 'flowers.com' ) ).toBeNull();
 	} );
 } );

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -102,3 +102,56 @@ export async function fetchBundleSuggestion( search: string ): Promise< BundleSu
 
 	return response.bundle_suggestion ?? null;
 }
+
+/**
+ * Fetch the inline-bundle trigger TLDs for a search query.
+ *
+ * Reads the `bundle_triggers` field off the same `with_bundles=1` opt-in on
+ * `/domains/suggestions` (DOMAINS-2207). This is a cheap, catalogue-only list of
+ * the TLDs (currently just `com`) that, when added to the cart from a bare-term
+ * search, offer an inline bundle. The backend returns `[]` when the discounts
+ * flag is off; this fetcher normalises a missing field to `[]` as well.
+ * @param search The bare-term domain search query.
+ * @returns The trigger TLDs, or an empty array when no triggers apply.
+ */
+export async function fetchBundleTriggers( search: string ): Promise< string[] > {
+	const response: { bundle_triggers?: string[] } = await wpcom.req.get(
+		{
+			apiVersion: '1.1',
+			path: '/domains/suggestions',
+		},
+		{
+			query: search.trim().toLocaleLowerCase(),
+			vendor: 'variation2_front',
+			with_bundles: 1,
+		}
+	);
+
+	return response.bundle_triggers ?? [];
+}
+
+/**
+ * Fetch the bundle suggestion for a single fully-qualified domain.
+ *
+ * Calls the per-FQDN `GET /wpcom/v2/domains/bundle` endpoint (DOMAINS-2207),
+ * used lazily by the inline-bundle frontend once the user adds a trigger domain
+ * (e.g. `flowers.com`) to the cart. The endpoint is logged-in only (401 when
+ * anonymous), flag-gated (404 when off) and query-guarded (400 on empty query);
+ * it returns `{ bundle_suggestion: BundleSuggestion | null }`, where the added
+ * domain is the `primary` member and the rest are `companion`s.
+ * @param fqdn The fully-qualified trigger domain (e.g. "flowers.com").
+ * @returns A bundle suggestion, or null when no bundle applies.
+ */
+export async function fetchBundleForDomain( fqdn: string ): Promise< BundleSuggestion | null > {
+	const response: { bundle_suggestion?: BundleSuggestion | null } = await wpcom.req.get(
+		{
+			path: '/domains/bundle',
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			query: fqdn.trim().toLocaleLowerCase(),
+		}
+	);
+
+	return response.bundle_suggestion ?? null;
+}

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -247,6 +247,16 @@ export interface BundleSuggestionDomain {
 	 * Whether this domain supports privacy
 	 */
 	supports_privacy?: boolean;
+
+	/**
+	 * The domain's role within the bundle. The `primary` member is the anchor
+	 * (the trigger domain the user searched/added); the `companion` members are
+	 * the additional extensions offered alongside it. Present on the per-FQDN
+	 * `/domains/bundle` (v2) response; the inline bundle row shows only the
+	 * companions while pricing the full bundle.
+	 * @example "primary"
+	 */
+	role?: 'primary' | 'companion';
 }
 
 export interface BundleSuggestion {

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -6,7 +6,9 @@ import {
 	DomainUpdateStatus,
 	fetchAvailableTlds,
 	fetchBulkDomainUpdateStatus,
+	fetchBundleForDomain,
 	fetchBundleSuggestion,
+	fetchBundleTriggers,
 	fetchDomains,
 	fetchDomainSuggestions,
 	fetchFreeDomainSuggestion,
@@ -47,6 +49,20 @@ export const bundleSuggestionQuery = ( query: string ) =>
 	queryOptions( {
 		queryKey: [ 'bundle-suggestion', query ],
 		queryFn: () => fetchBundleSuggestion( query ),
+		meta: { persist: false },
+	} );
+
+export const bundleTriggersQuery = ( query: string ) =>
+	queryOptions( {
+		queryKey: [ 'bundle-triggers', query ],
+		queryFn: () => fetchBundleTriggers( query ),
+		meta: { persist: false },
+	} );
+
+export const bundleForDomainQuery = ( fqdn: string ) =>
+	queryOptions( {
+		queryKey: [ 'bundle-for-domain', fqdn ],
+		queryFn: () => fetchBundleForDomain( fqdn ),
 		meta: { persist: false },
 	} );
 

--- a/packages/domain-search/src/components/inline-bundle-row/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/index.tsx
@@ -112,7 +112,12 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 				className="inline-bundle-row__content"
 			>
 				<VStack spacing={ 2 } className="inline-bundle-row__info">
-					<HStack justify="flex-start" spacing={ 3 } expanded={ false }>
+					<HStack
+						justify="flex-start"
+						spacing={ 3 }
+						expanded={ false }
+						className="inline-bundle-row__heading"
+					>
 						<BundleTldChips
 							leadLabel={ primary.domain }
 							tlds={ companionTlds }

--- a/packages/domain-search/src/components/inline-bundle-row/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/index.tsx
@@ -1,0 +1,160 @@
+import { useIsMutating, useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	Spinner,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { getTld } from '../../helpers/get-tld';
+import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
+import { useDomainSearch } from '../../page/context';
+import { BundlePrice, BundleTldChips, DomainSearchNotice, DomainSuggestionBadge } from '../../ui';
+import type { BundleSuggestion } from '@automattic/api-core';
+
+import './style.scss';
+
+interface InlineBundleRowProps {
+	/**
+	 * The bundle for the added trigger domain, or null/undefined while it is
+	 * being fetched or when no bundle applies.
+	 */
+	bundle: BundleSuggestion | null | undefined;
+	/**
+	 * True while the per-FQDN bundle is being fetched. Renders a loading row.
+	 */
+	isLoading: boolean;
+}
+
+/**
+ * An inline bundle offer rendered directly beneath the suggestion row of a
+ * trigger domain the user added to the cart. It advertises the bundle's
+ * companion extensions (the primary/added domain is omitted) while pricing the
+ * full bundle, and a "Get bundle" button adds every member via
+ * `cart.onAddBundle`. Reuses the context-free `BundleTldChips` and `BundlePrice`
+ * primitives so it stays visually consistent with the top bundle card.
+ */
+export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) => {
+	const { __ } = useI18n();
+	const { cart, events } = useDomainSearch();
+	const { mutationId, isCurrentMutation } = useIsCurrentMutation();
+	const isMutating = !! useIsMutating();
+
+	const {
+		mutate: addBundleToCart,
+		error: addBundleError,
+		isPending: isAddingBundle,
+	} = useMutation( {
+		meta: { mutationId },
+		mutationFn: async ( bundleToAdd: BundleSuggestion ) => {
+			if ( ! cart.onAddBundle ) {
+				return;
+			}
+
+			await cart.onAddBundle( bundleToAdd );
+		},
+		onSuccess: ( _result, bundleToAdd ) => {
+			events.onBundleAddToCart( bundleToAdd );
+		},
+		networkMode: 'always',
+		retry: false,
+	} );
+
+	if ( isLoading ) {
+		return (
+			<div className="inline-bundle-row inline-bundle-row--loading" role="listitem">
+				<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+					<Spinner className="inline-bundle-row__spinner" />
+					<Text variant="muted">{ __( 'Finding a bundle for your domain…' ) }</Text>
+				</HStack>
+			</div>
+		);
+	}
+
+	if ( ! bundle || bundle.domains.length === 0 ) {
+		return null;
+	}
+
+	const { bundle_price, bundle_cost, original_price, original_cost, discount_percent } = bundle;
+
+	// The added (primary) domain is already in the cart and shown as its own
+	// suggestion row; the inline row advertises only the companions.
+	const companions = bundle.domains.filter( ( domain ) => domain.role !== 'primary' );
+
+	if ( companions.length === 0 ) {
+		return null;
+	}
+
+	const companionTlds = companions.map( ( domain ) => getTld( domain.domain ) );
+
+	const displayBundlePrice = String( bundle_cost ?? bundle_price );
+	const displayOriginalPrice = String( original_cost ?? original_price );
+
+	const isAddedToCart = bundle.domains.every( ( { domain } ) => cart.hasItem( domain ) );
+
+	const errorMessage =
+		isCurrentMutation && addBundleError
+			? addBundleError.message ||
+			  __( 'Sorry, we couldn’t add the bundle to your cart. Please try again.' )
+			: undefined;
+
+	return (
+		<div className="inline-bundle-row" role="listitem">
+			<HStack
+				alignment="center"
+				justify="space-between"
+				spacing={ 4 }
+				className="inline-bundle-row__content"
+			>
+				<VStack spacing={ 2 } className="inline-bundle-row__info">
+					<HStack justify="flex-start" spacing={ 3 } expanded={ false }>
+						<BundleTldChips
+							tlds={ companionTlds }
+							size={ 20 }
+							className="inline-bundle-row__tlds"
+						/>
+						<DomainSuggestionBadge variation="success">
+							{ sprintf(
+								// translators: %(percent)d is the bundle discount percentage, e.g. 20.
+								__( 'Bundle and save %(percent)d%%' ),
+								{ percent: discount_percent }
+							) }
+						</DomainSuggestionBadge>
+					</HStack>
+					<Text size={ 13 } variant="muted" className="inline-bundle-row__subline">
+						{ __( 'Secure popular domain extensions and protect your brand' ) }
+					</Text>
+				</VStack>
+
+				<HStack
+					alignment="center"
+					justify="flex-end"
+					spacing={ 4 }
+					expanded={ false }
+					className="inline-bundle-row__actions"
+				>
+					<BundlePrice
+						originalPrice={ displayOriginalPrice }
+						bundlePrice={ displayBundlePrice }
+						size={ 20 }
+						alignment="right"
+					/>
+					<Button
+						className="inline-bundle-row__cta"
+						variant="primary"
+						__next40pxDefaultSize
+						isBusy={ isAddingBundle }
+						disabled={ isMutating || isAddedToCart }
+						onClick={ () => addBundleToCart( bundle ) }
+					>
+						{ __( 'Get bundle' ) }
+					</Button>
+				</HStack>
+			</HStack>
+
+			{ errorMessage && <DomainSearchNotice status="error">{ errorMessage }</DomainSearchNotice> }
+		</div>
+	);
+};

--- a/packages/domain-search/src/components/inline-bundle-row/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/index.tsx
@@ -7,6 +7,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
+import { Icon, lockOutline, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { getTld } from '../../helpers/get-tld';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
@@ -30,9 +31,9 @@ interface InlineBundleRowProps {
 
 /**
  * An inline bundle offer rendered directly beneath the suggestion row of a
- * trigger domain the user added to the cart. It advertises the bundle's
- * companion extensions (the primary/added domain is omitted) while pricing the
- * full bundle, and a "Get bundle" button adds every member via
+ * trigger domain the user added to the cart. The line leads with the added
+ * (primary) domain and then the companion extensions the bundle adds, priced as
+ * the full bundle, and a "Get bundle" button adds every member via
  * `cart.onAddBundle`. Reuses the context-free `BundleTldChips` and `BundlePrice`
  * primitives so it stays visually consistent with the top bundle card.
  */
@@ -79,9 +80,11 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 
 	const { bundle_price, bundle_cost, original_price, original_cost, discount_percent } = bundle;
 
-	// The added (primary) domain is already in the cart and shown as its own
-	// suggestion row; the inline row advertises only the companions.
-	const companions = bundle.domains.filter( ( domain ) => domain.role !== 'primary' );
+	// The line leads with the added (primary) domain in full, then the companion
+	// extensions the bundle adds: `thalasso.world + .info + .vip`.
+	const primary =
+		bundle.domains.find( ( domain ) => domain.role === 'primary' ) ?? bundle.domains[ 0 ];
+	const companions = bundle.domains.filter( ( domain ) => domain.domain !== primary.domain );
 
 	if ( companions.length === 0 ) {
 		return null;
@@ -111,11 +114,12 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 				<VStack spacing={ 2 } className="inline-bundle-row__info">
 					<HStack justify="flex-start" spacing={ 3 } expanded={ false }>
 						<BundleTldChips
+							leadLabel={ primary.domain }
 							tlds={ companionTlds }
 							size={ 20 }
 							className="inline-bundle-row__tlds"
 						/>
-						<DomainSuggestionBadge variation="success">
+						<DomainSuggestionBadge variation="warning">
 							{ sprintf(
 								// translators: %(percent)d is the bundle discount percentage, e.g. 20.
 								__( 'Bundle and save %(percent)d%%' ),
@@ -123,9 +127,12 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 							) }
 						</DomainSuggestionBadge>
 					</HStack>
-					<Text size={ 13 } variant="muted" className="inline-bundle-row__subline">
-						{ __( 'Secure popular domain extensions and protect your brand' ) }
-					</Text>
+					<HStack justify="flex-start" spacing={ 2 } expanded={ false }>
+						<Icon icon={ lockOutline } size={ 18 } className="inline-bundle-row__lock-icon" />
+						<Text size={ 13 } variant="muted" className="inline-bundle-row__subline">
+							{ __( 'Secure popular domain extensions and protect your brand' ) }
+						</Text>
+					</HStack>
 				</VStack>
 
 				<HStack
@@ -138,12 +145,14 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 					<BundlePrice
 						originalPrice={ displayOriginalPrice }
 						bundlePrice={ displayBundlePrice }
+						renewalPrice={ displayOriginalPrice }
 						size={ 20 }
 						alignment="right"
 					/>
 					<Button
 						className="inline-bundle-row__cta"
-						variant="primary"
+						variant="secondary"
+						icon={ plus }
 						__next40pxDefaultSize
 						isBusy={ isAddingBundle }
 						disabled={ isMutating || isAddedToCart }

--- a/packages/domain-search/src/components/inline-bundle-row/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/index.tsx
@@ -7,7 +7,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, lockOutline, plus } from '@wordpress/icons';
+import { arrowRight, Icon, lockOutline, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { getTld } from '../../helpers/get-tld';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
@@ -154,17 +154,32 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 						size={ 20 }
 						alignment="right"
 					/>
-					<Button
-						className="inline-bundle-row__cta"
-						variant="secondary"
-						icon={ plus }
-						__next40pxDefaultSize
-						isBusy={ isAddingBundle }
-						disabled={ isMutating || isAddedToCart }
-						onClick={ () => addBundleToCart( bundle ) }
-					>
-						{ __( 'Get bundle' ) }
-					</Button>
+					{ isAddedToCart ? (
+						<Button
+							className="inline-bundle-row__cta inline-bundle-row__cta--continue"
+							isPressed
+							aria-pressed="mixed"
+							__next40pxDefaultSize
+							icon={ arrowRight }
+							label={ __( 'Continue' ) }
+							disabled={ isMutating }
+							onClick={ () => events.onContinue() }
+						>
+							{ __( 'Continue' ) }
+						</Button>
+					) : (
+						<Button
+							className="inline-bundle-row__cta"
+							variant="secondary"
+							icon={ plus }
+							__next40pxDefaultSize
+							isBusy={ isAddingBundle }
+							disabled={ isMutating }
+							onClick={ () => addBundleToCart( bundle ) }
+						>
+							{ __( 'Get bundle' ) }
+						</Button>
+					) }
 				</HStack>
 			</HStack>
 

--- a/packages/domain-search/src/components/inline-bundle-row/inline-bundle-row.stories.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/inline-bundle-row.stories.tsx
@@ -48,18 +48,28 @@ const buildDomain = (
 const buildSuggestion = (
 	domains: BundleSuggestionDomain[],
 	overrides: Partial< BundleSuggestion > = {}
-): BundleSuggestion => ( {
-	sld: 'flowers',
-	domains,
-	bundle_price: 60,
-	original_price: 75,
-	discount_percent: 20,
-	category: 'business',
-	bundle_id: 'bundle-1',
-	bundle_group_id: 'group-1',
-	catalogue_version: '2024-01-01',
-	...overrides,
-} );
+): BundleSuggestion => {
+	const base = {
+		sld: 'flowers',
+		bundle_price: 60,
+		original_price: 75,
+		discount_percent: 20,
+		category: 'business',
+		bundle_id: 'bundle-1',
+		bundle_group_id: 'group-1',
+		catalogue_version: '2024-01-01',
+		...overrides,
+	};
+
+	return {
+		...base,
+		domains,
+		// The row prefers the formatted `*_cost` strings; derive them from the
+		// final prices so stories render "$60" rather than a bare "60".
+		bundle_cost: base.bundle_cost ?? `$${ base.bundle_price }`,
+		original_cost: base.original_cost ?? `$${ base.original_price }`,
+	};
+};
 
 const meta: Meta< typeof InlineBundleRow > = {
 	title: 'Components/InlineBundleRow',

--- a/packages/domain-search/src/components/inline-bundle-row/inline-bundle-row.stories.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/inline-bundle-row.stories.tsx
@@ -20,9 +20,20 @@ const storyContextValue = {
 	},
 };
 
-const StoryWrapper = ( { children }: { children: React.ReactNode } ) => (
+const StoryWrapper = ( {
+	children,
+	addedToCart = false,
+}: {
+	children: React.ReactNode;
+	addedToCart?: boolean;
+} ) => (
 	<QueryClientProvider client={ queryClient }>
-		<DomainSearchContext.Provider value={ storyContextValue }>
+		<DomainSearchContext.Provider
+			value={ {
+				...storyContextValue,
+				cart: { ...storyContextValue.cart, hasItem: () => addedToCart },
+			} }
+		>
 			<div
 				style={ {
 					margin: '0 auto',
@@ -125,5 +136,22 @@ export const LongTlds = () => (
 export const Loading = () => (
 	<StoryWrapper>
 		<InlineBundleRow bundle={ undefined } isLoading />
+	</StoryWrapper>
+);
+
+// Once every member is in the cart the row stays visible and its CTA swaps to a
+// black "Continue" button, mirroring the top BundleCard's added-to-cart state.
+export const AddedToCart = () => (
+	<StoryWrapper addedToCart>
+		<InlineBundleRow
+			bundle={ buildSuggestion(
+				[
+					buildDomain( { domain: 'flowers.com', cost: '$22.00', role: 'primary' } ),
+					buildDomain( { domain: 'flowers.net', cost: '$18.00', role: 'companion' } ),
+				],
+				{ bundle_price: 36, original_price: 40, discount_percent: 10 }
+			) }
+			isLoading={ false }
+		/>
 	</StoryWrapper>
 );

--- a/packages/domain-search/src/components/inline-bundle-row/inline-bundle-row.stories.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/inline-bundle-row.stories.tsx
@@ -1,0 +1,119 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DEFAULT_CONTEXT_VALUE, DomainSearchContext } from '../../page/context';
+import { DomainSuggestionsList } from '../../ui';
+import { InlineBundleRow } from '.';
+import type { BundleSuggestion, BundleSuggestionDomain } from '@automattic/api-core';
+import type { Meta } from '@storybook/react';
+
+const queryClient = new QueryClient();
+
+// InlineBundleRow reads the DomainSearch cart/events context and runs an
+// add-to-cart mutation, so stories provide a minimal context (a no-op cart)
+// plus a QueryClient. Spreading DEFAULT_CONTEXT_VALUE avoids the sentinel guard
+// in useDomainSearch.
+const storyContextValue = {
+	...DEFAULT_CONTEXT_VALUE,
+	cart: {
+		...DEFAULT_CONTEXT_VALUE.cart,
+		onAddBundle: () => Promise.resolve(),
+		hasItem: () => false,
+	},
+};
+
+const StoryWrapper = ( { children }: { children: React.ReactNode } ) => (
+	<QueryClientProvider client={ queryClient }>
+		<DomainSearchContext.Provider value={ storyContextValue }>
+			<div
+				style={ {
+					margin: '0 auto',
+					boxSizing: 'border-box',
+					width: '100%',
+					maxWidth: '640px',
+				} }
+			>
+				<DomainSuggestionsList>{ children }</DomainSuggestionsList>
+			</div>
+		</DomainSearchContext.Provider>
+	</QueryClientProvider>
+);
+
+const buildDomain = (
+	overrides: Partial< BundleSuggestionDomain > & Pick< BundleSuggestionDomain, 'domain' | 'cost' >
+): BundleSuggestionDomain => ( {
+	raw_price: 22,
+	product_slug: 'domain_reg',
+	...overrides,
+} );
+
+const buildSuggestion = (
+	domains: BundleSuggestionDomain[],
+	overrides: Partial< BundleSuggestion > = {}
+): BundleSuggestion => ( {
+	sld: 'flowers',
+	domains,
+	bundle_price: 60,
+	original_price: 75,
+	discount_percent: 20,
+	category: 'business',
+	bundle_id: 'bundle-1',
+	bundle_group_id: 'group-1',
+	catalogue_version: '2024-01-01',
+	...overrides,
+} );
+
+const meta: Meta< typeof InlineBundleRow > = {
+	title: 'Components/InlineBundleRow',
+	component: InlineBundleRow,
+};
+
+export default meta;
+
+export const TwoCompanions = () => (
+	<StoryWrapper>
+		<InlineBundleRow
+			bundle={ buildSuggestion(
+				[
+					buildDomain( { domain: 'flowers.com', cost: '$22.00', role: 'primary' } ),
+					buildDomain( { domain: 'flowers.net', cost: '$18.00', role: 'companion' } ),
+					buildDomain( { domain: 'flowers.org', cost: '$20.00', role: 'companion' } ),
+				],
+				{ bundle_price: 60, original_price: 75, discount_percent: 20 }
+			) }
+			isLoading={ false }
+		/>
+	</StoryWrapper>
+);
+
+export const SingleCompanion = () => (
+	<StoryWrapper>
+		<InlineBundleRow
+			bundle={ buildSuggestion(
+				[
+					buildDomain( { domain: 'flowers.com', cost: '$22.00', role: 'primary' } ),
+					buildDomain( { domain: 'flowers.net', cost: '$18.00', role: 'companion' } ),
+				],
+				{ bundle_price: 36, original_price: 40, discount_percent: 10 }
+			) }
+			isLoading={ false }
+		/>
+	</StoryWrapper>
+);
+
+export const LongTlds = () => (
+	<StoryWrapper>
+		<InlineBundleRow
+			bundle={ buildSuggestion( [
+				buildDomain( { domain: 'flowers.com', cost: '$22.00', role: 'primary' } ),
+				buildDomain( { domain: 'flowers.photography', cost: '$48.00', role: 'companion' } ),
+				buildDomain( { domain: 'flowers.international', cost: '$52.00', role: 'companion' } ),
+			] ) }
+			isLoading={ false }
+		/>
+	</StoryWrapper>
+);
+
+export const Loading = () => (
+	<StoryWrapper>
+		<InlineBundleRow bundle={ undefined } isLoading />
+	</StoryWrapper>
+);

--- a/packages/domain-search/src/components/inline-bundle-row/style.scss
+++ b/packages/domain-search/src/components/inline-bundle-row/style.scss
@@ -1,0 +1,33 @@
+@import '@wordpress/base-styles/colors';
+
+.inline-bundle-row {
+	box-sizing: border-box;
+	padding: 16px 24px;
+	background: rgba( 4, 128, 21, 0.04 );
+	border-left: 3px solid var( --domain-search-promotional-price-color, #048015 );
+}
+
+.inline-bundle-row--loading {
+	display: flex;
+	align-items: center;
+}
+
+.inline-bundle-row__spinner {
+	margin: 0;
+}
+
+.inline-bundle-row__info {
+	min-width: 0;
+}
+
+.inline-bundle-row__subline {
+	word-break: break-word;
+}
+
+.inline-bundle-row__actions {
+	flex-shrink: 0;
+}
+
+.inline-bundle-row__cta {
+	justify-content: center;
+}

--- a/packages/domain-search/src/components/inline-bundle-row/style.scss
+++ b/packages/domain-search/src/components/inline-bundle-row/style.scss
@@ -1,10 +1,8 @@
-@import '@wordpress/base-styles/colors';
-
 .inline-bundle-row {
 	box-sizing: border-box;
 	padding: 16px 24px;
-	background: rgba( 4, 128, 21, 0.04 );
-	border-left: 3px solid var( --domain-search-promotional-price-color, #048015 );
+	border: 1px solid rgba( 0, 0, 0, 0.1 );
+	border-radius: 8px;
 }
 
 .inline-bundle-row--loading {
@@ -20,6 +18,11 @@
 	min-width: 0;
 }
 
+.inline-bundle-row__lock-icon {
+	fill: #757575;
+	flex-shrink: 0;
+}
+
 .inline-bundle-row__subline {
 	word-break: break-word;
 }
@@ -30,4 +33,9 @@
 
 .inline-bundle-row__cta {
 	justify-content: center;
+
+	&.is-secondary {
+		color: var( --domain-search-secondary-action-color );
+		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
+	}
 }

--- a/packages/domain-search/src/components/inline-bundle-row/style.scss
+++ b/packages/domain-search/src/components/inline-bundle-row/style.scss
@@ -18,6 +18,12 @@
 	min-width: 0;
 }
 
+.inline-bundle-row__heading {
+	// Let the badge wrap below the domain chips instead of overlapping them when
+	// the row is narrow.
+	flex-wrap: wrap;
+}
+
 .inline-bundle-row__lock-icon {
 	fill: #757575;
 	flex-shrink: 0;

--- a/packages/domain-search/src/components/inline-bundle-row/test/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/test/index.tsx
@@ -62,13 +62,14 @@ describe( 'InlineBundleRow', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'shows only the companion TLDs, omitting the primary', () => {
+	it( 'leads with the primary domain, then the companion TLDs', () => {
 		renderRow();
 
-		// Companions are surfaced as chips; the primary (.com) is not.
+		// The line reads `flowers.com + .net + .org`: the primary in full, then
+		// the companion extensions the bundle adds.
+		expect( screen.getByText( 'flowers.com' ) ).toBeInTheDocument();
 		expect( screen.getByText( '.net' ) ).toBeInTheDocument();
 		expect( screen.getByText( '.org' ) ).toBeInTheDocument();
-		expect( screen.queryByText( '.com' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'prices the full bundle', () => {

--- a/packages/domain-search/src/components/inline-bundle-row/test/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/test/index.tsx
@@ -104,9 +104,20 @@ describe( 'InlineBundleRow', () => {
 		);
 	} );
 
-	it( 'disables the CTA when every bundle member is already in the cart', () => {
-		renderRow( {}, { hasItem: () => true } );
+	it( 'swaps "Get bundle" for a "Continue" CTA when every bundle member is already in the cart', async () => {
+		const user = userEvent.setup();
+		const onContinue = jest.fn();
 
-		expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeDisabled();
+		render(
+			<TestDomainSearch cart={ buildCart( { hasItem: () => true } ) } events={ { onContinue } }>
+				<InlineBundleRow bundle={ bundleWithRoles } isLoading={ false } />
+			</TestDomainSearch>
+		);
+
+		expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( onContinue ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/domain-search/src/components/inline-bundle-row/test/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/test/index.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InlineBundleRow } from '..';
+import { buildCart } from '../../../test-helpers/factories/cart';
+import { TestDomainSearch } from '../../../test-helpers/renderer';
+import type { BundleSuggestion, BundleSuggestionDomain } from '@automattic/api-core';
+
+const buildDomain = (
+	overrides: Partial< BundleSuggestionDomain > & Pick< BundleSuggestionDomain, 'domain' | 'cost' >
+): BundleSuggestionDomain => ( {
+	raw_price: 22,
+	product_slug: 'domain_reg',
+	...overrides,
+} );
+
+const buildSuggestion = (
+	domains: BundleSuggestionDomain[],
+	overrides: Partial< BundleSuggestion > = {}
+): BundleSuggestion => ( {
+	sld: 'flowers',
+	domains,
+	bundle_price: 60,
+	original_price: 75,
+	discount_percent: 20,
+	category: 'business',
+	bundle_id: 'bundle-1',
+	bundle_group_id: 'group-1',
+	catalogue_version: '2024-01-01',
+	...overrides,
+} );
+
+const bundleWithRoles = buildSuggestion( [
+	buildDomain( { domain: 'flowers.com', cost: '$22.00', role: 'primary' } ),
+	buildDomain( { domain: 'flowers.net', cost: '$18.00', role: 'companion' } ),
+	buildDomain( { domain: 'flowers.org', cost: '$20.00', role: 'companion' } ),
+] );
+
+const renderRow = (
+	props: Partial< React.ComponentProps< typeof InlineBundleRow > > = {},
+	cartOverrides = {}
+) =>
+	render(
+		<TestDomainSearch cart={ buildCart( cartOverrides ) }>
+			<InlineBundleRow bundle={ bundleWithRoles } isLoading={ false } { ...props } />
+		</TestDomainSearch>
+	);
+
+describe( 'InlineBundleRow', () => {
+	it( 'renders a loading state while the bundle is being fetched', () => {
+		renderRow( { bundle: undefined, isLoading: true } );
+
+		expect( screen.getByText( 'Finding a bundle for your domain…' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when there is no bundle and it is not loading', () => {
+		const { container } = renderRow( { bundle: null } );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows only the companion TLDs, omitting the primary', () => {
+		renderRow();
+
+		// Companions are surfaced as chips; the primary (.com) is not.
+		expect( screen.getByText( '.net' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.org' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '.com' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'prices the full bundle', () => {
+		renderRow();
+
+		expect( screen.getByText( '60' ) ).toBeInTheDocument();
+
+		const original = screen.getByText( '75' );
+		expect( original.closest( 's' ) ).not.toBeNull();
+	} );
+
+	it( 'renders the bundle-and-save badge and the protect-your-brand subline', () => {
+		renderRow();
+
+		expect( screen.getByText( 'Bundle and save 20%' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Secure popular domain extensions and protect your brand' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'adds every bundle member via cart.onAddBundle when "Get bundle" is clicked', async () => {
+		const user = userEvent.setup();
+		const onAddBundle = jest.fn().mockResolvedValue( undefined );
+
+		renderRow( {}, { onAddBundle } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
+
+		expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+		expect( onAddBundle ).toHaveBeenCalledWith(
+			expect.objectContaining( { bundle_group_id: 'group-1' } )
+		);
+	} );
+
+	it( 'disables the CTA when every bundle member is already in the cart', () => {
+		renderRow( {}, { hasItem: () => true } );
+
+		expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeDisabled();
+	} );
+} );

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useState } from 'react';
+import { useInlineBundles } from '../../hooks/use-inline-bundles';
 import { useDomainSearch } from '../../page/context';
 import {
 	DomainSuggestionsList,
 	DomainSuggestionFilterReset,
 	DomainSuggestionLoadMore,
 } from '../../ui';
+import { InlineBundleRow } from '../inline-bundle-row';
 import { SearchResultsItem } from './item';
 import { SearchResultsPlaceholder } from './placeholder';
 
@@ -16,6 +18,7 @@ const SearchResults = ( {
 	numberOfInitialVisibleSuggestions?: number;
 } ) => {
 	const { filter, resetFilter, events, config } = useDomainSearch();
+	const { getInlineBundle } = useInlineBundles();
 	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState(
 		numberOfInitialVisibleSuggestions ?? config.numberOfDomainsResultsPerPage
 	);
@@ -45,9 +48,26 @@ const SearchResults = ( {
 	return (
 		<>
 			<DomainSuggestionsList>
-				{ suggestionsToShow.map( ( suggestion ) => (
-					<SearchResultsItem key={ suggestion } domainName={ suggestion } />
-				) ) }
+				{ suggestionsToShow.flatMap( ( suggestion ) => {
+					const row = <SearchResultsItem key={ suggestion } domainName={ suggestion } />;
+					const inlineBundle = getInlineBundle( suggestion );
+
+					// Only emit an inline row when this domain is a trigger in the cart
+					// and it either has a bundle or is still fetching one. DomainSuggestionsList
+					// flattens children and inserts dividers, so an adjacent array slots in.
+					if ( ! inlineBundle || ( ! inlineBundle.isLoading && ! inlineBundle.bundle ) ) {
+						return [ row ];
+					}
+
+					return [
+						row,
+						<InlineBundleRow
+							key={ `${ suggestion }-bundle` }
+							bundle={ inlineBundle.bundle }
+							isLoading={ inlineBundle.isLoading }
+						/>,
+					];
+				} ) }
 			</DomainSuggestionsList>
 			{ shouldShowMoreResultsButton && <DomainSuggestionLoadMore onClick={ showMoreResults } /> }
 		</>

--- a/packages/domain-search/src/helpers/index.ts
+++ b/packages/domain-search/src/helpers/index.ts
@@ -1,5 +1,6 @@
 export { getRootDomain } from './get-root-domain';
 export { getTld } from './get-tld';
+export { isFqdnQuery } from './is-fqdn-query';
 export { isSubdomain } from './is-subdomain';
 export {
 	isBlogSubdomainQuery,

--- a/packages/domain-search/src/helpers/is-fqdn-query.ts
+++ b/packages/domain-search/src/helpers/is-fqdn-query.ts
@@ -1,0 +1,16 @@
+import { getTld } from './get-tld';
+import { isFreeSubdomainQuery } from './is-free-subdomain-query';
+
+/**
+ * Detects whether a search query is a fully-qualified domain (an SLD plus a
+ * TLD, e.g. "flowers.com") rather than a bare term ("flowers") or a free
+ * subdomain ("mysite.wordpress.com").
+ *
+ * This is the gate that splits the two bundle surfaces: an FQDN query shows the
+ * top BundleCard, while a bare-term query shows inline bundle rows (see
+ * useInlineBundles). Keep the callers using this single helper so the two paths
+ * can never disagree.
+ */
+export function isFqdnQuery( query: string ): boolean {
+	return ! isFreeSubdomainQuery( query ) && !! getTld( query );
+}

--- a/packages/domain-search/src/hooks/test/use-inline-bundles.tsx
+++ b/packages/domain-search/src/hooks/test/use-inline-bundles.tsx
@@ -73,7 +73,7 @@ describe( 'useInlineBundles', () => {
 
 		const { result } = renderUseInlineBundles( {
 			query: 'flowers',
-			cart: { items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ] },
+			cart: { items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ] },
 		} );
 
 		await waitFor( () =>
@@ -88,7 +88,7 @@ describe( 'useInlineBundles', () => {
 
 		const { result } = renderUseInlineBundles( {
 			query: 'flowers',
-			cart: { items: [ buildCartItem( { domain: 'flowers.net', tld: 'net' } ) ] },
+			cart: { items: [ buildCartItem( { domain: 'flowers', tld: 'net' } ) ] },
 		} );
 
 		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [ 'com' ] ) );
@@ -98,7 +98,7 @@ describe( 'useInlineBundles', () => {
 	it( 'is gated to bare-term searches: an FQDN query never fetches triggers or bundles', async () => {
 		const { result } = renderUseInlineBundles( {
 			query: 'flowers.com',
-			cart: { items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ] },
+			cart: { items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ] },
 		} );
 
 		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [] ) );
@@ -108,7 +108,7 @@ describe( 'useInlineBundles', () => {
 	it( 'is gated on the bundle flag: nothing is fetched when showBundleSuggestions is off', async () => {
 		const { result } = renderUseInlineBundles( {
 			query: 'flowers',
-			cart: { items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ] },
+			cart: { items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ] },
 			showBundleSuggestions: false,
 		} );
 
@@ -116,7 +116,7 @@ describe( 'useInlineBundles', () => {
 		expect( result.current.getInlineBundle( 'flowers.com' ) ).toBeUndefined();
 	} );
 
-	it( 'does not offer an inline bundle for a domain already added as part of a bundle', async () => {
+	it( 'does not offer an inline bundle for a domain added only as a bundle companion', async () => {
 		mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
 
 		const { result } = renderUseInlineBundles( {
@@ -124,9 +124,9 @@ describe( 'useInlineBundles', () => {
 			cart: {
 				items: [
 					buildCartItem( {
-						domain: 'flowers.com',
+						domain: 'flowers',
 						tld: 'com',
-						bundle: { groupId: 'g1', price: '$36', isPrimary: true },
+						bundle: { groupId: 'g1', price: '$36', isPrimary: false },
 					} ),
 				],
 			},
@@ -134,5 +134,27 @@ describe( 'useInlineBundles', () => {
 
 		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [ 'com' ] ) );
 		expect( result.current.getInlineBundle( 'flowers.com' ) ).toBeUndefined();
+	} );
+
+	it( 'keeps the inline bundle for a trigger the user bundled (its own primary)', async () => {
+		mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+		mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: BUNDLE_FOR_FLOWERS } );
+
+		const { result } = renderUseInlineBundles( {
+			query: 'flowers',
+			cart: {
+				items: [
+					buildCartItem( {
+						domain: 'flowers',
+						tld: 'com',
+						bundle: { groupId: 'g1', price: '$36', isPrimary: true },
+					} ),
+				],
+			},
+		} );
+
+		await waitFor( () =>
+			expect( result.current.getInlineBundle( 'flowers.com' )?.bundle ).toBeTruthy()
+		);
 	} );
 } );

--- a/packages/domain-search/src/hooks/test/use-inline-bundles.tsx
+++ b/packages/domain-search/src/hooks/test/use-inline-bundles.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { buildCart, buildCartItem } from '../../test-helpers/factories/cart';
+import {
+	mockGetBundleForDomainQuery,
+	mockGetBundleTriggersQuery,
+} from '../../test-helpers/queries/suggestions';
+import { queryClient, TestDomainSearch } from '../../test-helpers/renderer';
+import { useInlineBundles } from '../use-inline-bundles';
+import type { DomainSearchCart } from '../../page/types';
+import type { BundleSuggestion } from '@automattic/api-core';
+
+const BUNDLE_FOR_FLOWERS: BundleSuggestion = {
+	sld: 'flowers',
+	domains: [
+		{
+			domain: 'flowers.com',
+			cost: '$22.00',
+			raw_price: 22,
+			product_slug: 'domain_reg',
+			role: 'primary',
+		},
+		{
+			domain: 'flowers.net',
+			cost: '$18.00',
+			raw_price: 18,
+			product_slug: 'domain_reg',
+			role: 'companion',
+		},
+	],
+	bundle_price: 36,
+	original_price: 44,
+	discount_percent: 18,
+	category: 'business',
+	bundle_id: 'flowers-bundle',
+	bundle_group_id: 'v1.flowers.deadbeef',
+	catalogue_version: '1',
+};
+
+const renderUseInlineBundles = ( {
+	query,
+	cart,
+	showBundleSuggestions = true,
+}: {
+	query: string;
+	cart?: Partial< DomainSearchCart >;
+	showBundleSuggestions?: boolean;
+} ) =>
+	renderHook( () => useInlineBundles(), {
+		wrapper: ( { children } ) => (
+			<TestDomainSearch
+				query={ query }
+				cart={ buildCart( cart ) }
+				config={ { showBundleSuggestions } }
+			>
+				{ children }
+			</TestDomainSearch>
+		),
+	} );
+
+describe( 'useInlineBundles', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		queryClient.clear();
+	} );
+
+	it( 'fetches a bundle for a cart item whose TLD is a trigger', async () => {
+		mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+		mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: BUNDLE_FOR_FLOWERS } );
+
+		const { result } = renderUseInlineBundles( {
+			query: 'flowers',
+			cart: { items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ] },
+		} );
+
+		await waitFor( () =>
+			expect( result.current.getInlineBundle( 'flowers.com' )?.bundle ).toBeTruthy()
+		);
+		expect( result.current.bundleTriggers ).toEqual( [ 'com' ] );
+		expect( result.current.getInlineBundle( 'flowers.com' )?.bundle?.sld ).toBe( 'flowers' );
+	} );
+
+	it( 'does not fetch a bundle for a cart item whose TLD is not a trigger', async () => {
+		mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+
+		const { result } = renderUseInlineBundles( {
+			query: 'flowers',
+			cart: { items: [ buildCartItem( { domain: 'flowers.net', tld: 'net' } ) ] },
+		} );
+
+		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [ 'com' ] ) );
+		expect( result.current.getInlineBundle( 'flowers.net' ) ).toBeUndefined();
+	} );
+
+	it( 'is gated to bare-term searches: an FQDN query never fetches triggers or bundles', async () => {
+		const { result } = renderUseInlineBundles( {
+			query: 'flowers.com',
+			cart: { items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ] },
+		} );
+
+		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [] ) );
+		expect( result.current.getInlineBundle( 'flowers.com' ) ).toBeUndefined();
+	} );
+
+	it( 'is gated on the bundle flag: nothing is fetched when showBundleSuggestions is off', async () => {
+		const { result } = renderUseInlineBundles( {
+			query: 'flowers',
+			cart: { items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ] },
+			showBundleSuggestions: false,
+		} );
+
+		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [] ) );
+		expect( result.current.getInlineBundle( 'flowers.com' ) ).toBeUndefined();
+	} );
+
+	it( 'does not offer an inline bundle for a domain already added as part of a bundle', async () => {
+		mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+
+		const { result } = renderUseInlineBundles( {
+			query: 'flowers',
+			cart: {
+				items: [
+					buildCartItem( {
+						domain: 'flowers.com',
+						tld: 'com',
+						bundle: { groupId: 'g1', price: '$36', isPrimary: true },
+					} ),
+				],
+			},
+		} );
+
+		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [ 'com' ] ) );
+		expect( result.current.getInlineBundle( 'flowers.com' ) ).toBeUndefined();
+	} );
+} );

--- a/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
+++ b/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
@@ -27,10 +27,10 @@ const TEST_BUNDLE_SUGGESTION: BundleSuggestion = {
 	catalogue_version: '1',
 };
 
-const renderUseSuggestionsList = ( config?: Partial< DomainSearchConfig > ) =>
+const renderUseSuggestionsList = ( config?: Partial< DomainSearchConfig >, query = 'test' ) =>
 	renderHook( () => useSuggestionsList(), {
 		wrapper: ( { children } ) => (
-			<TestDomainSearch query="test" config={ config }>
+			<TestDomainSearch query={ query } config={ config }>
 				{ children }
 			</TestDomainSearch>
 		),
@@ -42,24 +42,35 @@ describe( 'useSuggestionsList — bundle suggestions', () => {
 		queryClient.clear();
 	} );
 
-	it( 'surfaces a bundle suggestion when showBundleSuggestions is on', async () => {
-		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
+	// The top bundle card is the FQDN path, so bundleSuggestion is only fetched
+	// for an FQDN query (a bare-term search shows inline bundle rows instead).
+	it( 'surfaces a bundle suggestion for an FQDN query when showBundleSuggestions is on', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'test.com' }, suggestions: [] } );
 		mockGetBundleSuggestionQuery( {
-			params: { query: 'test' },
+			params: { query: 'test.com' },
 			bundleSuggestion: TEST_BUNDLE_SUGGESTION,
 		} );
 
-		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true } );
+		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true }, 'test.com' );
 
 		await waitFor( () => expect( result.current.bundleSuggestion ).toBeTruthy() );
 		expect( result.current.bundleSuggestion?.sld ).toBe( 'test' );
 		expect( result.current.bundleSuggestion?.domains.length ).toBeGreaterThan( 0 );
 	} );
 
-	it( 'does not surface a bundle suggestion when the flag is off', async () => {
+	it( 'does not surface a bundle suggestion for a bare-term query', async () => {
 		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
 
-		const { result } = renderUseSuggestionsList( { showBundleSuggestions: false } );
+		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.bundleSuggestion ).toBeUndefined();
+	} );
+
+	it( 'does not surface a bundle suggestion when the flag is off', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'test.com' }, suggestions: [] } );
+
+		const { result } = renderUseSuggestionsList( { showBundleSuggestions: false }, 'test.com' );
 
 		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 		expect( result.current.bundleSuggestion ).toBeUndefined();

--- a/packages/domain-search/src/hooks/use-inline-bundles.ts
+++ b/packages/domain-search/src/hooks/use-inline-bundles.ts
@@ -1,6 +1,6 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { getTld, isFreeSubdomainQuery } from '../helpers';
+import { isFqdnQuery } from '../helpers';
 import { useDomainSearch } from '../page/context';
 import type { BundleSuggestion } from '@automattic/api-core';
 
@@ -29,11 +29,9 @@ export interface InlineBundleEntry {
 export const useInlineBundles = () => {
 	const { query, queries, config, cart } = useDomainSearch();
 
-	// Mirror the fqdn detection in useSuggestionsList: an FQDN search keeps the
-	// top BundleCard path, so inline bundles are gated to bare-term queries.
-	const isFreeSubdomain = isFreeSubdomainQuery( query );
-	const isFqdnQuery = ! isFreeSubdomain && !! getTld( query );
-	const inlineBundlesEnabled = config.showBundleSuggestions && ! isFqdnQuery;
+	// An FQDN search keeps the top BundleCard path, so inline bundles are gated
+	// to bare-term queries (see isFqdnQuery, shared with useSuggestionsList).
+	const inlineBundlesEnabled = config.showBundleSuggestions && ! isFqdnQuery( query );
 
 	const { data: bundleTriggers = [] } = useQuery( {
 		...queries.bundleTriggers( query ),

--- a/packages/domain-search/src/hooks/use-inline-bundles.ts
+++ b/packages/domain-search/src/hooks/use-inline-bundles.ts
@@ -1,0 +1,89 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { getTld, isFreeSubdomainQuery } from '../helpers';
+import { useDomainSearch } from '../page/context';
+import type { BundleSuggestion } from '@automattic/api-core';
+
+export interface InlineBundleEntry {
+	/**
+	 * The bundle for the trigger domain: `undefined` while it is still being
+	 * fetched, `null` when the backend has no bundle for it.
+	 */
+	bundle: BundleSuggestion | null | undefined;
+	/**
+	 * True while the per-FQDN bundle request is in flight.
+	 */
+	isLoading: boolean;
+}
+
+/**
+ * Drives the inline bundle rows shown beneath trigger-domain suggestions.
+ *
+ * Inline bundles only apply to a bare-term search (no TLD in the query) and only
+ * when the `domain-bundling` flag is on (surfaced as `config.showBundleSuggestions`).
+ * When enabled it reads the cheap `bundle_triggers` catalogue list, then, for
+ * every cart item whose TLD is a trigger, lazily fetches that FQDN's bundle from
+ * the per-FQDN `/domains/bundle` (v2) endpoint. Each FQDN is fetched at most once
+ * and cached. Consumers look up a domain's bundle via `getInlineBundle`.
+ */
+export const useInlineBundles = () => {
+	const { query, queries, config, cart } = useDomainSearch();
+
+	// Mirror the fqdn detection in useSuggestionsList: an FQDN search keeps the
+	// top BundleCard path, so inline bundles are gated to bare-term queries.
+	const isFreeSubdomain = isFreeSubdomainQuery( query );
+	const isFqdnQuery = ! isFreeSubdomain && !! getTld( query );
+	const inlineBundlesEnabled = config.showBundleSuggestions && ! isFqdnQuery;
+
+	const { data: bundleTriggers = [] } = useQuery( {
+		...queries.bundleTriggers( query ),
+		enabled: inlineBundlesEnabled,
+	} );
+
+	// A cart item whose TLD is a trigger — and that wasn't itself added as part
+	// of a bundle — offers an inline bundle. Dedupe by FQDN so each domain is
+	// fetched once even if it somehow appears twice in the cart.
+	const triggerFqdns = useMemo( () => {
+		if ( ! inlineBundlesEnabled || bundleTriggers.length === 0 ) {
+			return [];
+		}
+
+		const seen = new Set< string >();
+
+		return cart.items
+			.filter( ( item ) => ! item.bundle && bundleTriggers.includes( item.tld ) )
+			.map( ( item ) => item.domain )
+			.filter( ( domain ) => {
+				if ( seen.has( domain ) ) {
+					return false;
+				}
+
+				seen.add( domain );
+				return true;
+			} );
+	}, [ inlineBundlesEnabled, bundleTriggers, cart.items ] );
+
+	const bundleResults = useQueries( {
+		queries: triggerFqdns.map( ( fqdn ) => ( {
+			...queries.bundleForDomain( fqdn ),
+			enabled: inlineBundlesEnabled,
+		} ) ),
+	} );
+
+	// Derived inline (not memoized): useQueries returns a fresh array each render,
+	// so memoizing on it gains nothing and trips @tanstack/query's no-unstable-deps
+	// rule. This mirrors the availability combinator in useSuggestionsList.
+	const inlineBundles = new Map< string, InlineBundleEntry >();
+	triggerFqdns.forEach( ( fqdn, index ) => {
+		const result = bundleResults[ index ];
+		inlineBundles.set( fqdn, {
+			bundle: result?.data,
+			isLoading: result?.isLoading ?? false,
+		} );
+	} );
+
+	return {
+		bundleTriggers,
+		getInlineBundle: ( fqdn: string ): InlineBundleEntry | undefined => inlineBundles.get( fqdn ),
+	};
+};

--- a/packages/domain-search/src/hooks/use-inline-bundles.ts
+++ b/packages/domain-search/src/hooks/use-inline-bundles.ts
@@ -38,9 +38,13 @@ export const useInlineBundles = () => {
 		enabled: inlineBundlesEnabled,
 	} );
 
-	// A cart item whose TLD is a trigger — and that wasn't itself added as part
-	// of a bundle — offers an inline bundle. Dedupe by FQDN so each domain is
-	// fetched once even if it somehow appears twice in the cart.
+	// A cart item whose TLD is a trigger offers an inline bundle. Keep the row for
+	// an item that is either standalone or the primary of its own bundle: the
+	// primary case is the trigger the user just bundled, whose row stays visible
+	// and swaps its CTA to "Continue" (mirroring the top BundleCard). A domain
+	// added only as a companion of some other bundle is excluded — it doesn't get
+	// its own offer. Dedupe by FQDN so each domain is fetched once even if it
+	// somehow appears twice in the cart.
 	const triggerFqdns = useMemo( () => {
 		if ( ! inlineBundlesEnabled || bundleTriggers.length === 0 ) {
 			return [];
@@ -49,14 +53,17 @@ export const useInlineBundles = () => {
 		const seen = new Set< string >();
 
 		return cart.items
-			.filter( ( item ) => ! item.bundle && bundleTriggers.includes( item.tld ) )
-			.map( ( item ) => item.domain )
-			.filter( ( domain ) => {
-				if ( seen.has( domain ) ) {
+			.filter(
+				( item ) =>
+					bundleTriggers.includes( item.tld ) && ( ! item.bundle || item.bundle.isPrimary )
+			)
+			.map( ( item ) => `${ item.domain }.${ item.tld }` )
+			.filter( ( fqdn ) => {
+				if ( seen.has( fqdn ) ) {
 					return false;
 				}
 
-				seen.add( domain );
+				seen.add( fqdn );
 				return true;
 			} );
 	}, [ inlineBundlesEnabled, bundleTriggers, cart.items ] );

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -49,12 +49,14 @@ export const useSuggestionsList = () => {
 		enabled: config.skippable && ! isFqdnQuery,
 	} );
 
-	// Bundle suggestions are gated behind the frontend `domain-bundling` flag
-	// (surfaced as config.showBundleSuggestions). When off, the query never runs
-	// and bundleSuggestion stays undefined, leaving the rest of the flow unchanged.
+	// The top bundle card is the FQDN path only: a bare-term search shows inline
+	// bundle rows instead (see useInlineBundles), and the backend returns no
+	// bundle_suggestion for a bare term anyway. Gating on isFqdnQuery keeps this
+	// request from duplicating the bare-term bundleTriggers request (same URL).
+	// Still gated behind the frontend `domain-bundling` flag (config.showBundleSuggestions).
 	const { data: bundleSuggestion } = useQuery( {
 		...queries.bundleSuggestion( query ),
-		enabled: config.showBundleSuggestions,
+		enabled: config.showBundleSuggestions && isFqdnQuery,
 	} );
 
 	const { isLoading: isLoadingQueryAvailability, data: fqdnAvailability } = useQuery( {

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -1,12 +1,7 @@
 import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
 import { DefinedUseQueryResult, useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import {
-	getTld,
-	isFreeSubdomainQuery,
-	isWpcomSubdomainQuery,
-	stripWpcomSubdomainSuffix,
-} from '../helpers';
+import { isFqdnQuery, isWpcomSubdomainQuery, stripWpcomSubdomainSuffix } from '../helpers';
 import { addAvailabilityAsSuggestion } from '../helpers/add-availability-as-suggestion';
 import { isSupportedPremiumDomain } from '../helpers/is-supported-premium-domain';
 import { partitionSuggestions } from '../helpers/partition-suggestions';
@@ -32,7 +27,6 @@ const availablePremiumDomainsCombinator = (
 export const useSuggestionsList = () => {
 	const { query, queries, config } = useDomainSearch();
 
-	const isFreeSubdomain = isFreeSubdomainQuery( query );
 	const freeSuggestionQuery = isWpcomSubdomainQuery( query )
 		? stripWpcomSubdomainSuffix( query )
 		: query;
@@ -42,11 +36,11 @@ export const useSuggestionsList = () => {
 		enabled: true,
 	} );
 
-	const isFqdnQuery = ! isFreeSubdomain && !! getTld( query );
+	const isFqdn = isFqdnQuery( query );
 
 	const { isLoading: isLoadingFreeSuggestion } = useQuery( {
 		...queries.freeSuggestion( freeSuggestionQuery ),
-		enabled: config.skippable && ! isFqdnQuery,
+		enabled: config.skippable && ! isFqdn,
 	} );
 
 	// The top bundle card is the FQDN path only: a bare-term search shows inline
@@ -56,12 +50,12 @@ export const useSuggestionsList = () => {
 	// Still gated behind the frontend `domain-bundling` flag (config.showBundleSuggestions).
 	const { data: bundleSuggestion } = useQuery( {
 		...queries.bundleSuggestion( query ),
-		enabled: config.showBundleSuggestions && isFqdnQuery,
+		enabled: config.showBundleSuggestions && isFqdn,
 	} );
 
 	const { isLoading: isLoadingQueryAvailability, data: fqdnAvailability } = useQuery( {
 		...queries.domainAvailability( query ),
-		enabled: isFqdnQuery,
+		enabled: isFqdn,
 	} );
 
 	const premiumSuggestions = useMemo(

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -1,6 +1,8 @@
 import {
 	availableTldsQuery,
+	bundleForDomainQuery,
 	bundleSuggestionQuery,
+	bundleTriggersQuery,
 	domainAvailabilityQuery,
 	domainSuggestionsQuery,
 	freeSuggestionQuery,
@@ -49,6 +51,8 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		domainAvailability: ( domainName: string ) => domainAvailabilityQuery( domainName ),
 		freeSuggestion: ( query: string ) => freeSuggestionQuery( query ),
 		bundleSuggestion: ( query: string ) => bundleSuggestionQuery( query ),
+		bundleTriggers: ( query: string ) => bundleTriggersQuery( query ),
+		bundleForDomain: ( fqdn: string ) => bundleForDomainQuery( fqdn ),
 	},
 	cart: {
 		items: [],
@@ -171,6 +175,20 @@ export const useDomainSearchContextValue = ( {
 				} ),
 				bundleSuggestion: ( query ) => ( {
 					...bundleSuggestionQuery( query ),
+					enabled: false,
+					staleTime: Infinity,
+					refetchOnMount: false,
+					refetchOnWindowFocus: false,
+				} ),
+				bundleTriggers: ( query ) => ( {
+					...bundleTriggersQuery( query ),
+					enabled: false,
+					staleTime: Infinity,
+					refetchOnMount: false,
+					refetchOnWindowFocus: false,
+				} ),
+				bundleForDomain: ( fqdn ) => ( {
+					...bundleForDomainQuery( fqdn ),
 					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -11,6 +11,7 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
+import { getTld, isFreeSubdomainQuery } from '../helpers';
 import { useIsCurrentMutation } from '../hooks/use-is-current-mutation';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
@@ -145,10 +146,14 @@ export const ResultsPage = () => {
 		regularSuggestions,
 		bundleSuggestion,
 	} = useSuggestionsList();
+	// The top BundleCard is the FQDN path only; a bare-term search shows inline
+	// bundle rows beneath trigger suggestions instead (see useInlineBundles).
+	const isFqdnQuery = ! isFreeSubdomainQuery( query ) && !! getTld( query );
 	const visibleBundleSuggestion =
-		unavailableBundle &&
-		bundleSuggestion?.bundle_group_id === unavailableBundle.groupId &&
-		query === unavailableBundle.query
+		! isFqdnQuery ||
+		( unavailableBundle &&
+			bundleSuggestion?.bundle_group_id === unavailableBundle.groupId &&
+			query === unavailableBundle.query )
 			? undefined
 			: bundleSuggestion;
 	const numberOfInitialVisibleSuggestions =

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -11,7 +11,7 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
-import { getTld, isFreeSubdomainQuery } from '../helpers';
+import { isFqdnQuery } from '../helpers';
 import { useIsCurrentMutation } from '../hooks/use-is-current-mutation';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
@@ -148,9 +148,9 @@ export const ResultsPage = () => {
 	} = useSuggestionsList();
 	// The top BundleCard is the FQDN path only; a bare-term search shows inline
 	// bundle rows beneath trigger suggestions instead (see useInlineBundles).
-	const isFqdnQuery = ! isFreeSubdomainQuery( query ) && !! getTld( query );
+	const isFqdn = isFqdnQuery( query );
 	const visibleBundleSuggestion =
-		! isFqdnQuery ||
+		! isFqdn ||
 		( unavailableBundle &&
 			bundleSuggestion?.bundle_group_id === unavailableBundle.groupId &&
 			query === unavailableBundle.query )

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1488,7 +1488,7 @@ describe( 'ResultsPage', () => {
 			render(
 				<TestDomainSearch
 					cart={ buildCart( {
-						items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ],
+						items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ],
 					} ) }
 					config={ { showBundleSuggestions: true } }
 					query="flowers"

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -6,7 +6,9 @@ import { buildCart, buildCartItem } from '../../test-helpers/factories/cart';
 import { buildFreeSuggestion, buildSuggestion } from '../../test-helpers/factories/suggestions';
 import { mockGetAvailabilityQuery } from '../../test-helpers/queries/availability';
 import {
+	mockGetBundleForDomainQuery,
 	mockGetBundleSuggestionQuery,
+	mockGetBundleTriggersQuery,
 	mockGetFreeSuggestionQuery,
 	mockGetSuggestionsQuery,
 } from '../../test-helpers/queries/suggestions';
@@ -904,19 +906,19 @@ describe( 'ResultsPage', () => {
 			const onAddBundle = jest.fn().mockResolvedValue( undefined );
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test' },
-				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
+				params: { query: 'test-bundle-add.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-add.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test' },
-				bundleSuggestion: buildBundleSuggestion( 'test' ),
+				params: { query: 'test-bundle-add.com' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-add' ),
 			} );
 
 			render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test"
+					query="test-bundle-add.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -933,12 +935,12 @@ describe( 'ResultsPage', () => {
 			// app layer untouched.
 			expect( onAddBundle ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					sld: 'test',
-					bundle_group_id: 'mock-test-group',
+					sld: 'test-bundle-add',
+					bundle_group_id: 'mock-test-bundle-add-group',
 					domains: expect.arrayContaining( [
-						expect.objectContaining( { domain: 'test.com' } ),
-						expect.objectContaining( { domain: 'test.net' } ),
-						expect.objectContaining( { domain: 'test.org' } ),
+						expect.objectContaining( { domain: 'test-bundle-add.com' } ),
+						expect.objectContaining( { domain: 'test-bundle-add.net' } ),
+						expect.objectContaining( { domain: 'test-bundle-add.org' } ),
 					] ),
 				} )
 			);
@@ -955,11 +957,11 @@ describe( 'ResultsPage', () => {
 				);
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-error' },
+				params: { query: 'test-bundle-error.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-error.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-error' },
+				params: { query: 'test-bundle-error.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-error' ),
 			} );
 
@@ -969,7 +971,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-error"
+					query="test-bundle-error.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -992,11 +994,11 @@ describe( 'ResultsPage', () => {
 			const onAddBundle = jest.fn().mockRejectedValue( new Error( '' ) );
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-fallback' },
+				params: { query: 'test-bundle-fallback.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-fallback.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-fallback' },
+				params: { query: 'test-bundle-fallback.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-fallback' ),
 			} );
 
@@ -1004,7 +1006,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-fallback"
+					query="test-bundle-fallback.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1031,15 +1033,15 @@ describe( 'ResultsPage', () => {
 			);
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-permanent' },
+				params: { query: 'test-bundle-permanent.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-permanent.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-permanent' },
+				params: { query: 'test-bundle-permanent.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-permanent' ),
 			} );
 			const refetchRequest = mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-permanent' },
+				params: { query: 'test-bundle-permanent.com' },
 				bundleSuggestion: null,
 			} );
 
@@ -1047,7 +1049,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-permanent"
+					query="test-bundle-permanent.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1077,15 +1079,15 @@ describe( 'ResultsPage', () => {
 			);
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-same-group' },
+				params: { query: 'test-bundle-same-group.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-same-group.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-same-group' },
+				params: { query: 'test-bundle-same-group.com' },
 				bundleSuggestion: unavailableBundle,
 			} );
 			const refetchRequest = mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-same-group' },
+				params: { query: 'test-bundle-same-group.com' },
 				bundleSuggestion: unavailableBundle,
 			} );
 
@@ -1093,7 +1095,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-same-group"
+					query="test-bundle-same-group.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1129,24 +1131,24 @@ describe( 'ResultsPage', () => {
 			);
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-late-stale' },
+				params: { query: 'test-bundle-late-stale.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-late-stale.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-late-stale' },
+				params: { query: 'test-bundle-late-stale.com' },
 				bundleSuggestion: staleBundle,
 			} );
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-late-fresh' },
+				params: { query: 'test-bundle-late-fresh.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-late-fresh.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-late-fresh' },
+				params: { query: 'test-bundle-late-fresh.com' },
 				bundleSuggestion: freshBundle,
 			} );
 			const freshRefetchRequest = mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-late-fresh' },
+				params: { query: 'test-bundle-late-fresh.com' },
 				bundleSuggestion: null,
 			} );
 
@@ -1154,7 +1156,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-late-stale"
+					query="test-bundle-late-stale.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1168,7 +1170,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-late-fresh"
+					query="test-bundle-late-fresh.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1197,11 +1199,11 @@ describe( 'ResultsPage', () => {
 				.mockResolvedValueOnce( undefined );
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-retry' },
+				params: { query: 'test-bundle-retry.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-retry.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-retry' },
+				params: { query: 'test-bundle-retry.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-retry' ),
 			} );
 
@@ -1209,7 +1211,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-retry"
+					query="test-bundle-retry.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1236,19 +1238,19 @@ describe( 'ResultsPage', () => {
 			const cart = buildCart( { onAddBundle } );
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-stale' },
+				params: { query: 'test-bundle-stale.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-stale.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-stale' },
+				params: { query: 'test-bundle-stale.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-stale' ),
 			} );
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-fresh' },
+				params: { query: 'test-bundle-fresh.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-fresh.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-fresh' },
+				params: { query: 'test-bundle-fresh.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-fresh' ),
 			} );
 
@@ -1256,7 +1258,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ cart }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-stale"
+					query="test-bundle-stale.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1274,7 +1276,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ cart }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-fresh"
+					query="test-bundle-fresh.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1298,11 +1300,11 @@ describe( 'ResultsPage', () => {
 			);
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-pending' },
+				params: { query: 'test-bundle-pending.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-pending.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-pending' },
+				params: { query: 'test-bundle-pending.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-pending' ),
 			} );
 
@@ -1310,7 +1312,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-pending"
+					query="test-bundle-pending.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1336,11 +1338,11 @@ describe( 'ResultsPage', () => {
 			const onAddBundle = jest.fn().mockRejectedValue( new Error( 'Bundle add failed' ) );
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-supersede' },
+				params: { query: 'test-bundle-supersede.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-supersede.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-supersede' },
+				params: { query: 'test-bundle-supersede.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-supersede' ),
 			} );
 			mockGetAvailabilityQuery( {
@@ -1355,7 +1357,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
-					query="test-bundle-supersede"
+					query="test-bundle-supersede.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1383,11 +1385,11 @@ describe( 'ResultsPage', () => {
 			const onContinue = jest.fn();
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'bundle-added' },
+				params: { query: 'bundle-added.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-added.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'bundle-added' },
+				params: { query: 'bundle-added.com' },
 				bundleSuggestion: buildBundleSuggestion( 'bundle-added' ),
 			} );
 
@@ -1396,7 +1398,7 @@ describe( 'ResultsPage', () => {
 					cart={ buildCart( { hasItem: ( domain ) => domain.startsWith( 'bundle-added.' ) } ) }
 					config={ { showBundleSuggestions: true } }
 					events={ { onContinue } }
-					query="bundle-added"
+					query="bundle-added.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1416,11 +1418,11 @@ describe( 'ResultsPage', () => {
 
 		it( 'keeps Get bundle when only some members are in the cart', async () => {
 			mockGetSuggestionsQuery( {
-				params: { query: 'bundle-partial' },
+				params: { query: 'bundle-partial.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-partial.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'bundle-partial' },
+				params: { query: 'bundle-partial.com' },
 				bundleSuggestion: buildBundleSuggestion( 'bundle-partial' ),
 			} );
 
@@ -1428,13 +1430,100 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					cart={ buildCart( { hasItem: ( domain ) => domain === 'bundle-partial.com' } ) }
 					config={ { showBundleSuggestions: true } }
-					query="bundle-partial"
+					query="bundle-partial.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
 			);
 
 			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'inline bundle', () => {
+		// A bare-term search whose cart holds a trigger domain (flowers.com) shows an
+		// inline bundle row beneath that domain's suggestion row, offering the
+		// companion extensions while pricing the full bundle.
+		const flowersBundle: BundleSuggestion = {
+			sld: 'flowers',
+			domains: [
+				{
+					domain: 'flowers.com',
+					cost: '$22.00',
+					raw_price: 22,
+					product_slug: 'domain_reg',
+					role: 'primary',
+				},
+				{
+					domain: 'flowers.net',
+					cost: '$18.00',
+					raw_price: 18,
+					product_slug: 'domain_reg',
+					role: 'companion',
+				},
+			],
+			bundle_price: 36,
+			original_price: 44,
+			discount_percent: 18,
+			category: 'business',
+			bundle_id: 'flowers-bundle',
+			bundle_group_id: 'v1.flowers.deadbeef',
+			catalogue_version: '1',
+		};
+
+		it( 'renders an inline bundle row beneath a trigger domain that is in the cart', async () => {
+			// Two other suggestions come first so flowers.com lands in the regular
+			// list (where the inline row is injected), not the featured grid.
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'flowers.io' } ),
+					buildSuggestion( { domain_name: 'flowers.co' } ),
+					buildSuggestion( { domain_name: 'flowers.com' } ),
+				],
+			} );
+			mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+			mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: flowersBundle } );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: [ buildCartItem( { domain: 'flowers.com', tld: 'com' } ) ],
+					} ) }
+					config={ { showBundleSuggestions: true } }
+					query="flowers"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+			// The companion (.net) is offered; the primary (.com) is not chipped.
+			expect( screen.getByText( '.net' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Secure popular domain extensions and protect your brand' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'does not render an inline bundle row when no trigger domain is in the cart', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'flowers.io' } ),
+					buildSuggestion( { domain_name: 'flowers.co' } ),
+					buildSuggestion( { domain_name: 'flowers.com' } ),
+				],
+			} );
+			mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+
+			render(
+				<TestDomainSearch config={ { showBundleSuggestions: true } } query="flowers">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'flowers.com' ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -1504,11 +1593,11 @@ describe( 'ResultsPage', () => {
 			const onBundleShown = jest.fn();
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'bundle-shown' },
+				params: { query: 'bundle-shown.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-shown.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'bundle-shown' },
+				params: { query: 'bundle-shown.com' },
 				bundleSuggestion: buildBundleSuggestion( 'bundle-shown' ),
 			} );
 
@@ -1516,7 +1605,7 @@ describe( 'ResultsPage', () => {
 				<TestDomainSearch
 					events={ { onBundleShown } }
 					config={ { showBundleSuggestions: true } }
-					query="bundle-shown"
+					query="bundle-shown.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1566,11 +1655,11 @@ describe( 'ResultsPage', () => {
 			const onBundleAddToCart = jest.fn();
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'bundle-accept' },
+				params: { query: 'bundle-accept.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-accept.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'bundle-accept' },
+				params: { query: 'bundle-accept.com' },
 				bundleSuggestion: buildBundleSuggestion( 'bundle-accept' ),
 			} );
 
@@ -1579,7 +1668,7 @@ describe( 'ResultsPage', () => {
 					cart={ buildCart( { onAddBundle } ) }
 					events={ { onBundleAddToCart } }
 					config={ { showBundleSuggestions: true } }
-					query="bundle-accept"
+					query="bundle-accept.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1608,11 +1697,11 @@ describe( 'ResultsPage', () => {
 			const onBundleAddToCart = jest.fn();
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'bundle-reject' },
+				params: { query: 'bundle-reject.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-reject.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'bundle-reject' },
+				params: { query: 'bundle-reject.com' },
 				bundleSuggestion: buildBundleSuggestion( 'bundle-reject' ),
 			} );
 
@@ -1621,7 +1710,7 @@ describe( 'ResultsPage', () => {
 					cart={ buildCart( { onAddBundle } ) }
 					events={ { onBundleAddToCart } }
 					config={ { showBundleSuggestions: true } }
-					query="bundle-reject"
+					query="bundle-reject.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>
@@ -1643,11 +1732,11 @@ describe( 'ResultsPage', () => {
 			const onBundleAddToCart = jest.fn();
 
 			mockGetSuggestionsQuery( {
-				params: { query: 'bundle-no-handler' },
+				params: { query: 'bundle-no-handler.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'bundle-no-handler.com' } ) ],
 			} );
 			mockGetBundleSuggestionQuery( {
-				params: { query: 'bundle-no-handler' },
+				params: { query: 'bundle-no-handler.com' },
 				bundleSuggestion: buildBundleSuggestion( 'bundle-no-handler' ),
 			} );
 
@@ -1656,7 +1745,7 @@ describe( 'ResultsPage', () => {
 					cart={ buildCart( { onAddBundle: undefined } ) }
 					events={ { onBundleAddToCart } }
 					config={ { showBundleSuggestions: true } }
-					query="bundle-no-handler"
+					query="bundle-no-handler.com"
 				>
 					<ResultsPage />
 				</TestDomainSearch>

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -1,6 +1,8 @@
 import {
 	availableTldsQuery,
+	bundleForDomainQuery,
 	bundleSuggestionQuery,
+	bundleTriggersQuery,
 	domainSuggestionsQuery,
 	freeSuggestionQuery,
 	domainAvailabilityQuery,
@@ -165,6 +167,8 @@ export interface DomainSearchContextType
 		domainAvailability: ( domainName: string ) => ReturnType< typeof domainAvailabilityQuery >;
 		freeSuggestion: ( query: string ) => ReturnType< typeof freeSuggestionQuery >;
 		bundleSuggestion: ( query: string ) => ReturnType< typeof bundleSuggestionQuery >;
+		bundleTriggers: ( query: string ) => ReturnType< typeof bundleTriggersQuery >;
+		bundleForDomain: ( fqdn: string ) => ReturnType< typeof bundleForDomainQuery >;
 	};
 	config: DomainSearchConfig;
 }

--- a/packages/domain-search/src/test-helpers/queries/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/queries/suggestions.ts
@@ -53,6 +53,36 @@ export const mockGetBundleSuggestionQuery = ( {
 		.reply( 200, { bundle_suggestion: bundleSuggestion } );
 };
 
+export const mockGetBundleTriggersQuery = ( {
+	params,
+	bundleTriggers,
+}: {
+	params: Partial< DomainSuggestionQuery >;
+	bundleTriggers: string[];
+} ) => {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/domains/suggestions' )
+		.query( {
+			vendor: 'variation2_front',
+			with_bundles: 1,
+			...params,
+		} )
+		.reply( 200, { bundle_triggers: bundleTriggers } );
+};
+
+export const mockGetBundleForDomainQuery = ( {
+	fqdn,
+	bundleSuggestion,
+}: {
+	fqdn: string;
+	bundleSuggestion: BundleSuggestion | null;
+} ) => {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/wpcom/v2/domains/bundle' )
+		.query( { query: fqdn } )
+		.reply( 200, { bundle_suggestion: bundleSuggestion } );
+};
+
 export const mockGetFreeSuggestionQuery = ( {
 	params,
 	freeSuggestion,

--- a/packages/domain-search/src/ui/bundle-tld-chips/index.tsx
+++ b/packages/domain-search/src/ui/bundle-tld-chips/index.tsx
@@ -6,6 +6,12 @@ import './style.scss';
 
 interface BundleTldChipsProps {
 	tlds: string[];
+	/**
+	 * Optional full label rendered as the first chip before the TLDs, e.g. the
+	 * primary domain `thalasso.world` in the inline row (`thalasso.world + .info
+	 * + .vip`). Omitted by the top card, which shows TLD-only chips.
+	 */
+	leadLabel?: ReactNode;
 	separator?: ReactNode;
 	size?: number;
 	className?: string;
@@ -13,11 +19,13 @@ interface BundleTldChipsProps {
 
 /**
  * Render a bundle's member TLDs as a prominent line, e.g. `.com + .org + .net`,
- * with each TLD bold/dark and the separators muted. Context-free so both the
- * bundle card and a future inline bundle row can reuse it.
+ * with each TLD bold/dark and the separators muted. With `leadLabel`, that label
+ * anchors the line and the TLDs follow (`thalasso.world + .info + .vip`).
+ * Context-free so both the bundle card and the inline bundle row can reuse it.
  */
 export const BundleTldChips = ( {
 	tlds,
+	leadLabel,
 	separator = '+',
 	size = 24,
 	className,
@@ -29,9 +37,14 @@ export const BundleTldChips = ( {
 			expanded={ false }
 			className={ clsx( 'bundle-tld-chips', className ) }
 		>
+			{ leadLabel != null && (
+				<Text size={ size } weight={ 600 } className="bundle-tld-chips__tld">
+					{ leadLabel }
+				</Text>
+			) }
 			{ tlds.map( ( tld, index ) => (
 				<Fragment key={ `${ tld }-${ index }` }>
-					{ index > 0 && (
+					{ ( index > 0 || leadLabel != null ) && (
 						<Text size={ size } aria-hidden="true" className="bundle-tld-chips__separator">
 							{ separator }
 						</Text>

--- a/packages/domain-search/src/ui/bundle-tld-chips/style.scss
+++ b/packages/domain-search/src/ui/bundle-tld-chips/style.scss
@@ -1,7 +1,16 @@
+.bundle-tld-chips {
+	// Keep the block at its content width (so a neighbouring badge can't crush
+	// it) and let the chips wrap rather than overlap when space is tight.
+	flex-shrink: 0;
+	flex-wrap: wrap;
+}
+
 .bundle-tld-chips__tld {
 	word-break: keep-all;
+	flex-shrink: 0;
 }
 
 .bundle-tld-chips__separator {
 	opacity: 0.3;
+	flex-shrink: 0;
 }


### PR DESCRIPTION
Related to #DOMAINS-2189

## Proposed Changes

Implements the **in-line domain bundles** frontend (Stream 3b). On a bare-term search, when the user adds a domain whose TLD is a bundle **trigger** (e.g. `.com`), the bundle for that FQDN is lazily fetched and rendered as a row directly beneath the added domain's suggestion — showing the companion members and the full bundle price, with a "Get bundle" CTA.

- **Data layer** (`api-core`): `fetchBundleTriggers()` (reads `bundle_triggers` off the `with_bundles=1` response) and `fetchBundleForDomain()` (the v2 `/domains/bundle` endpoint). Adds `role?: 'primary'|'companion'` to `BundleSuggestionDomain`.
- **Query layer** (`api-queries`): `bundleTriggersQuery()` and `bundleForDomainQuery()`, keyed per query/FQDN.
- **Hook**: `useInlineBundles()` — gated on `config.showBundleSuggestions && !isFqdnQuery`; maps each cart item whose TLD is a trigger to a lazily-fetched per-FQDN bundle.
- **UI**: `InlineBundleRow` (reuses `BundleTldChips` / `BundlePrice`), injected into the results list beneath the matching suggestion; "Get bundle" calls the existing `cart.onAddBundle`.
- **Top card gated to FQDN** (`results.tsx` + `use-suggestions-list.ts`): the top `BundleCard` now only renders for FQDN queries — the backend returns no bundle for bare terms, so the two presentations no longer overlap.

<img width="2346" height="806" alt="CleanShot 2026-07-07 at 09 02 43@2x" src="https://github.com/user-attachments/assets/a8882b89-a3d7-4f8e-bb6c-a27539b3ae47" />


## For reviewers — known gaps / decisions

- **Featured-trigger gap:** the in-line row injects into the regular results list only. For a bare-term search the exact `.com` match is often a *featured* card, not a list row — so if the added trigger is featured, no in-line row appears. Product decision needed on whether it should.
- **Top-card test conversion:** gating the top card to FQDN-only invalidated the Stream 1 top-card tests that used bare-term queries with a mocked bundle (a case the real backend never produces). They were converted to FQDN queries.

## Testing Instructions

226742-ghe-Automattic/wpcom needs to have been merged or needs to be manually checked out on your sandbox.

### Automated checks

<details>
<summary>Checks</summary>

- `yarn jest -c=test/packages/jest.config.js packages/domain-search` → **378 passed** (incl. the new inline-bundle-row, use-inline-bundles, fetcher, and integration tests).
- Storybook: `InlineBundleRow` stories added (incl. loading + long-TLD). Visual layout of the row inside the list wants an eyeball.
- `tsc` needs the `api-core` / `api-queries` workspace builds first (project references).

</details>

### End-to-end (manual)

This walks the full path: `bundle_triggers` on the suggestions response → adding a trigger domain → the lazy `/domains/bundle` fetch → the in-line row → "Get bundle".

**1. Run the backend on your sandbox.** The inline-bundle backend is not deployed yet, so check out `226742-ghe-Automattic/wpcom` (branch `domain-bundle/inline-backend-triggers`) in `~/public_html` on your sandbox and point your environment at that sandbox. It adds the `bundle_triggers` field and the `GET /wpcom/v2/domains/bundle` endpoint this PR depends on. As an Automattician you get bundles automatically — the `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` kill switch is dark by default but on for a8c — so no flag flip is needed.

**2. Repoint the bundle trigger so the in-line row is reachable.** The production `verisign_promo` catalogue uses a `.com` trigger, and on a bare-term search the exact `.com` match renders as the *featured card*, not a list row — so the in-line row (which injects into the regular results list) never appears (the "Featured-trigger gap" above). To exercise the in-line path, repoint the trigger to a TLD that lands in the regular list, e.g. `.org`.

Edit `wp-content/lib/domains/bundling/catalogue.php` on your sandbox:

```diff
 'verisign_promo' => [
     'display_name' => 'Protect your Name',
     'enabled'      => true,
     'size_min'     => 3,
     'size_max'     => 3,
-    'trigger'      => [ 'tld' => 'com', 'discount_percent' => 0 ],
+    'trigger'      => [ 'tld' => 'org', 'discount_percent' => 0 ],
     'rows'         => [
         [ [ 'tld' => 'net', 'discount_percent' => 90 ] ],
         [ [ 'tld' => 'blog', 'discount_percent' => 95 ] ],
     ],
 ],
```

Also bump `'version'` (e.g. `3` → `999`) to bust cached suggestions. Leave the `net`/`blog` companions as-is — `.org` isn't a companion, so the per-bundle-uniqueness invariant still holds. Revert this edit when you're done.

**3. Run this branch.** Check out `domain-bundle/inline-bundles` (stacked on #112338) and run Calypso against your sandbox.

**4. Walk the flow.**
1. Open the domain search (signup or "Add a domain").
2. Search a **bare term** (not an FQDN) whose `.org`, `.net`, and `.blog` are all available — a coined word works well.
3. Add the **`.org`** result (the trigger).
4. An in-line bundle row should appear directly beneath it, listing the `.net`/`.blog` companions and the full bundle price with a **"Get bundle"** CTA.
5. Click **"Get bundle"** → the companion domains are added to the cart.

Co-Authored-By: Claude <noreply@anthropic.com>