### PR TITLE
Masterbar: add Stats link to site-name menu alongside Dashboard

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -13,7 +13,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
 import { navigate } from 'calypso/lib/navigate';
-import { getStatsDefaultSitePage } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -528,6 +527,7 @@ class MasterbarLoggedIn extends Component {
 			sitePlanUrl,
 			sidebarType,
 			canUserViewStats,
+			statsAdminUrl,
 		} = this.props;
 
 		// Only display when a site is selected and is not domain-only site.
@@ -570,7 +570,7 @@ class MasterbarLoggedIn extends Component {
 		if ( canUserViewStats ) {
 			menuItems.push( {
 				label: translate( 'Stats' ),
-				url: getStatsDefaultSitePage( siteSlug ),
+				url: statsAdminUrl,
 				onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_stats_clicked' ),
 			} );
 		}
@@ -1055,6 +1055,7 @@ const ConnectedMasterbarLoggedIn = connect(
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
 			dashboardOptIn: hasDashboardOptIn( state ),
 			canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
+			statsAdminUrl: getSiteAdminUrl( state, siteId, 'admin.php?page=stats' ),
 		};
 	},
 	{

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -558,14 +558,6 @@ class MasterbarLoggedIn extends Component {
 					url: siteAdminUrl,
 					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_dashboard_clicked' ),
 				} );
-
-				if ( canUserViewStats ) {
-					menuItems.push( {
-						label: translate( 'Stats' ),
-						url: getStatsDefaultSitePage( siteSlug ),
-						onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_stats_clicked' ),
-					} );
-				}
 			} else {
 				menuItems.push( {
 					label: translate( 'My Home' ),
@@ -573,6 +565,14 @@ class MasterbarLoggedIn extends Component {
 					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_my_home_clicked' ),
 				} );
 			}
+		}
+
+		if ( canUserViewStats ) {
+			menuItems.push( {
+				label: translate( 'Stats' ),
+				url: getStatsDefaultSitePage( siteSlug ),
+				onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_stats_clicked' ),
+			} );
 		}
 
 		if ( ! site?.is_wpcom_staging_site ) {

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -13,6 +13,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
 import { navigate } from 'calypso/lib/navigate';
+import { getStatsDefaultSitePage } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -25,6 +26,7 @@ import { getCurrentUser, getCurrentUserSiteCount } from 'calypso/state/current-u
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -525,6 +527,7 @@ class MasterbarLoggedIn extends Component {
 			site,
 			sitePlanUrl,
 			sidebarType,
+			canUserViewStats,
 		} = this.props;
 
 		// Only display when a site is selected and is not domain-only site.
@@ -555,6 +558,14 @@ class MasterbarLoggedIn extends Component {
 					url: siteAdminUrl,
 					onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_dashboard_clicked' ),
 				} );
+
+				if ( canUserViewStats ) {
+					menuItems.push( {
+						label: translate( 'Stats' ),
+						url: getStatsDefaultSitePage( siteSlug ),
+						onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_stats_clicked' ),
+					} );
+				}
 			} else {
 				menuItems.push( {
 					label: translate( 'My Home' ),
@@ -1043,6 +1054,7 @@ const ConnectedMasterbarLoggedIn = connect(
 				getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
 			dashboardOptIn: hasDashboardOptIn( state ),
+			canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
 		};
 	},
 	{


### PR DESCRIPTION
## Proposed Changes

* Add a "Stats" item to the masterbar's site-name dropdown, shown whenever a single site is selected.
* Gated behind `canCurrentUser( state, siteId, 'view_stats' )` so it only appears for users who can actually view Stats.
* Always links to the wp-admin Stats page (`admin.php?page=stats`), regardless of whether the site uses the classic or default Calypso interface.

## Why are these changes being made?

Mirrors Automattic/jetpack#50222, which adds a "Stats" link next to "Dashboard" in wp-admin's site-name admin bar submenu so people can jump to Stats without leaving the current page. This brings the same shortcut to Calypso's own masterbar site-name dropdown.

## Testing Instructions

* Visit any site in Calypso with the masterbar site-selector visible.
* Click the site name/title in the masterbar to open the dropdown.
* Confirm a "Stats" link appears in the dropdown, linking to `<site-admin-url>/admin.php?page=stats`.
* Confirm the link does not appear for a user who can't view Stats.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
