### PR TITLE
MSD advance notice: update copy and launch

### DIFF
--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import {
 	Button,
 	Card,
@@ -7,7 +8,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { type TranslateResult, useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -22,12 +23,76 @@ import {
 import illustratioUrl from './illustration.svg';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 
+interface BannerCopy {
+	heading: TranslateResult;
+	description: TranslateResult;
+	button: TranslateResult;
+}
+
+function getBannerCopy(
+	isOptedInCopy: boolean,
+	hasEnTranslation: ReturnType< typeof useHasEnTranslation >,
+	translate: ReturnType< typeof useTranslate >
+): BannerCopy {
+	if ( isOptedInCopy ) {
+		const hasUpdatedOptedInTranslations =
+			hasEnTranslation( 'New dashboard is here to stay' ) &&
+			hasEnTranslation(
+				'The new dashboard you’ve been using becomes the default for everyone, and this classic view will be retired.'
+			);
+
+		if ( hasUpdatedOptedInTranslations ) {
+			return {
+				heading: translate( 'New dashboard is here to stay' ),
+				description: translate(
+					'The new dashboard you’ve been using becomes the default for everyone, and this classic view will be retired.'
+				),
+				button: translate( 'Go to new dashboard' ),
+			};
+		}
+
+		return {
+			heading: translate( 'The new dashboard is here to stay' ),
+			description: translate(
+				'Soon, the Hosting Dashboard you’ve been using becomes the default for everyone, and this classic view will be retired. Your content and settings stay the same.'
+			),
+			button: translate( 'Go to new dashboard' ),
+		};
+	}
+
+	const hasUpdatedTranslations =
+		hasEnTranslation( 'Dashboard layout is changing' ) &&
+		hasEnTranslation(
+			'WordPress.com’s layout is getting more consistent and easier to use. Your content and settings won’t change. Can’t wait?'
+		) &&
+		hasEnTranslation( 'Switch now' );
+
+	if ( hasUpdatedTranslations ) {
+		return {
+			heading: translate( 'Dashboard layout is changing' ),
+			description: translate(
+				'WordPress.com’s layout is getting more consistent and easier to use. Your content and settings won’t change. Can’t wait?'
+			),
+			button: translate( 'Switch now' ),
+		};
+	}
+
+	return {
+		heading: translate( 'A new dashboard is on the way' ),
+		description: translate(
+			'Soon, navigation in the Hosting Dashboard is changing to be more consistent with WordPress Admin and easier to get around. Your content and settings stay exactly as they are. Can’t wait?'
+		),
+		button: translate( 'Try it now' ),
+	};
+}
+
 export default function HostingDashboardOptInBanner( {
 	isMobile = false,
 }: {
 	isMobile?: boolean;
 } ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const dispatch = useDispatch();
 
 	const savedPreference = useSelector(
@@ -99,23 +164,18 @@ export default function HostingDashboardOptInBanner( {
 		return null;
 	}
 
+	const isOptedInCopy = hasOptedIn && ! isSubmitting;
+	const copy = getBannerCopy( isOptedInCopy, hasEnTranslation, translate );
+
 	const heading = (
 		<Text as="p" weight={ 500 } size={ isMobile ? 14 : 15 }>
-			{ hasOptedIn && ! isSubmitting
-				? translate( 'New dashboard is here to stay' )
-				: translate( 'Dashboard layout is changing' ) }
+			{ copy.heading }
 		</Text>
 	);
 
 	const description = (
 		<Text as="p" variant="muted" size={ isMobile ? 12 : 13 }>
-			{ hasOptedIn && ! isSubmitting
-				? translate(
-						'The new dashboard you’ve been using becomes the default for everyone, and this classic view will be retired.'
-				  )
-				: translate(
-						'WordPress.com’s layout is getting more consistent and easier to use. Your content and settings won’t change. Can’t wait?'
-				  ) }
+			{ copy.description }
 		</Text>
 	);
 
@@ -127,9 +187,7 @@ export default function HostingDashboardOptInBanner( {
 			href={ dashboardLink() }
 			onClick={ handleClick }
 		>
-			{ hasOptedIn && ! isSubmitting
-				? translate( 'Go to new dashboard' )
-				: translate( 'Switch now' ) }
+			{ copy.button }
 		</Button>
 	);
 

--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -102,8 +102,8 @@ export default function HostingDashboardOptInBanner( {
 	const heading = (
 		<Text as="p" weight={ 500 } size={ isMobile ? 14 : 15 }>
 			{ hasOptedIn && ! isSubmitting
-				? translate( 'The new dashboard is here to stay' )
-				: translate( 'A new dashboard is on the way' ) }
+				? translate( 'New dashboard is here to stay' )
+				: translate( 'Dashboard layout is changing' ) }
 		</Text>
 	);
 
@@ -114,7 +114,7 @@ export default function HostingDashboardOptInBanner( {
 						'Soon, the Hosting Dashboard you’ve been using becomes the default for everyone, and this classic view will be retired. Your content and settings stay the same.'
 				  )
 				: translate(
-						'Soon, navigation in the Hosting Dashboard is changing to be more consistent with WordPress Admin and easier to get around. Your content and settings stay exactly as they are. Can’t wait?'
+						'WordPress.com’s layout is getting more consistent and easier to use. Your content and settings won’t change. Can’t wait?'
 				  ) }
 		</Text>
 	);
@@ -129,7 +129,7 @@ export default function HostingDashboardOptInBanner( {
 		>
 			{ hasOptedIn && ! isSubmitting
 				? translate( 'Go to new dashboard' )
-				: translate( 'Try it now' ) }
+				: translate( 'Switch now' ) }
 		</Button>
 	);
 

--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -111,7 +111,7 @@ export default function HostingDashboardOptInBanner( {
 		<Text as="p" variant="muted" size={ isMobile ? 12 : 13 }>
 			{ hasOptedIn && ! isSubmitting
 				? translate(
-						'Soon, the Hosting Dashboard you’ve been using becomes the default for everyone, and this classic view will be retired. Your content and settings stay the same.'
+						'The new dashboard you’ve been using becomes the default for everyone, and this classic view will be retired.'
 				  )
 				: translate(
 						'WordPress.com’s layout is getting more consistent and easier to use. Your content and settings won’t change. Can’t wait?'

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,7 +35,7 @@
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,
-		"dashboard/rollout-advance-notice": false,
+		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,
 		"design-picker/use-assembler-styles": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,7 +46,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,
-		"dashboard/rollout-advance-notice": false,
+		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"dolly/telegram": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,7 +44,7 @@
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-welcome-modal": false,
-		"dashboard/rollout-advance-notice": false,
+		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"dev/preferences-helper": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,7 @@
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,
-		"dashboard/rollout-advance-notice": false,
+		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"design-picker/use-assembler-styles": true,


### PR DESCRIPTION
Fixes DOTMSD-1174

## Proposed Changes

> [!IMPORTANT]
> Shows the advance notice in prod

Also updates the copy in the Hosting Dashboard opt-in banner (advance-notice / not-yet-opted-in state). Adds translation checks so the new copy is only shown if _all_ elements in the notice have been translated. That way we don't see half the text from before and half from after the update.

<img width="282" alt="CleanShot 2026-07-07 at 12 00 32@2x" src="https://github.com/user-attachments/assets/d208c6ab-09d5-4885-b2a1-43a4a3fc36e6" />


<img width="282" alt="CleanShot 2026-07-07 at 11 59 36@2x" src="https://github.com/user-attachments/assets/f3d7d050-c6a2-4078-bf58-79ad9772ecb9" />


## Why are these changes being made?

* Notify users of the coming change.
* Refine the messaging shown to users before the new dashboard becomes the default, making it clearer and more concise.

## Testing Instructions

* Load a site where the Hosting Dashboard opt-in banner is shown and confirm the updated heading, body, and CTA copy render correctly in both the not-yet-opted-in and opted-in states.
* If your test user ID is `id % 100 >= 50` then you may need to hardcode the `ROLLOUT_PERCENTAGE` constant.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
