### PR TITLE
Masterbar: add Stats sparkline to admin bar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -9,6 +9,7 @@ import { parse } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
+import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
@@ -109,6 +110,8 @@ class MasterbarLoggedIn extends Component {
 		isGlobalSidebarVisible: PropTypes.bool,
 		isGravatarDomain: PropTypes.bool,
 		dashboardOptIn: PropTypes.bool,
+		canUserViewStats: PropTypes.bool,
+		statsAdminUrl: PropTypes.string,
 		useUnifiedAgent: PropTypes.bool,
 		launchButton: PropTypes.node,
 		sitePlanUrl: PropTypes.string,
@@ -703,6 +706,30 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
+	clickStatsSparkline = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_stats_sparkline_clicked' );
+	};
+
+	renderStatsSparkline() {
+		const { siteId, translate, domainOnlySite, canUserViewStats, statsAdminUrl } = this.props;
+
+		if ( ! siteId || domainOnlySite || ! canUserViewStats ) {
+			return null;
+		}
+
+		return (
+			<Item
+				className="masterbar__item-stats-sparkline"
+				url={ statsAdminUrl }
+				tooltip={ translate( 'Views over 48 hours. Click for more Stats.' ) }
+				onClick={ this.clickStatsSparkline }
+				hasGlobalBorderStyle
+			>
+				<StatsSparkline siteId={ siteId } />
+			</Item>
+		);
+	}
+
 	renderLaunchButton() {
 		const { isA4ADevSite, isUnlaunchedSite, siteId, isManageSiteOptionsEnabled, launchButton } =
 			this.props;
@@ -974,6 +1001,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderUpdatesMenu() }
 					{ this.renderCommentsMenu() }
 					{ this.renderSiteActionMenu() }
+					{ this.renderStatsSparkline() }
 					{ this.renderLanguageSwitcher() }
 					{ this.renderLaunchButton() }
 				</div>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -9,7 +9,6 @@ import { parse } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
-import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
@@ -72,6 +71,7 @@ import HelpIcon from './masterbar-agents-manager/help-icon';
 import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
 import { MasterbarLaunchButton } from './masterbar-launch-button';
 import Notifications from './masterbar-notifications/notifications-button';
+import MasterbarStatsSparkline from './masterbar-stats-sparkline';
 
 const loadCheckout = () =>
 	import( /* webpackChunkName: "async-load-calypso-layout-masterbar-checkout" */ './checkout.tsx' );
@@ -725,7 +725,7 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.clickStatsSparkline }
 				hasGlobalBorderStyle
 			>
-				<StatsSparkline siteId={ siteId } height={ 32 } />
+				<MasterbarStatsSparkline siteId={ siteId } />
 			</Item>
 		);
 	}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -717,11 +717,14 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
+		const label = translate( 'Views over 48 hours. Click for more Stats.' );
+
 		return (
 			<Item
 				className="masterbar__item-stats-sparkline"
 				url={ statsAdminUrl }
-				tooltip={ translate( 'Views over 48 hours. Click for more Stats.' ) }
+				tooltip={ label }
+				ariaLabel={ label }
 				onClick={ this.clickStatsSparkline }
 				hasGlobalBorderStyle
 			>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -725,7 +725,7 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.clickStatsSparkline }
 				hasGlobalBorderStyle
 			>
-				<StatsSparkline siteId={ siteId } />
+				<StatsSparkline siteId={ siteId } height={ 32 } />
 			</Item>
 		);
 	}

--- a/client/layout/masterbar/masterbar-stats-sparkline.jsx
+++ b/client/layout/masterbar/masterbar-stats-sparkline.jsx
@@ -3,10 +3,11 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
+// Matches wp-admin's own admin bar sparkline (wp-includes/charts/admin-bar-hours-scale.php),
+// whose <img> is 24px tall inside a 32px-tall toolbar item.
 const CHART_HEIGHT = 24;
 const BAR_WIDTH = 2;
 const BAR_GAP = 1;
-const PEAK_MARKER_HEIGHT = 18;
 
 const getHourlyViews = createSelector(
 	( state, siteId ) => {
@@ -33,12 +34,7 @@ export default function MasterbarStatsSparkline( { siteId } ) {
 function MasterbarStatsSparklineChart( { hourlyViews } ) {
 	const highestViews = Math.max( ...hourlyViews );
 	const chartWidth = hourlyViews.length * ( BAR_WIDTH + BAR_GAP ) - BAR_GAP;
-	// The SVG's own box is just the bars (tight, no reserved space), so the
-	// item's resting size is unaffected by the peak marker. The marker is
-	// drawn below that box (y > CHART_HEIGHT) and only escapes clipping via
-	// "overflow: visible" on hover, the same show/hide-on-hover technique
-	// wp-admin's own admin bar sparkline uses for its width.
-	const backdropWidth = chartWidth + 24 + String( highestViews ).length * 8;
+	const peakCenterY = CHART_HEIGHT / 2;
 
 	return (
 		<svg
@@ -67,38 +63,21 @@ function MasterbarStatsSparklineChart( { hourlyViews } ) {
 					/>
 				);
 			} ) }
+			{ /* Sits just past the bars, clipped by "overflow: hidden" on
+			     .masterbar__stats-sparkline until hover switches it to
+			     "overflow: visible" — same reveal technique wp-admin uses
+			     (there, widening the image's clipped container). */ }
 			<g className="masterbar__stats-sparkline-peak">
-				<rect
-					className="masterbar__stats-sparkline-backdrop"
-					x={ 0 }
-					y={ CHART_HEIGHT }
-					width={ backdropWidth }
-					height={ PEAK_MARKER_HEIGHT }
-				/>
-				<line
-					className="masterbar__stats-sparkline-baseline"
-					x1={ 0 }
-					y1={ CHART_HEIGHT }
-					x2={ chartWidth }
-					y2={ CHART_HEIGHT }
-				/>
-				<line
-					className="masterbar__stats-sparkline-tick"
-					x1={ chartWidth }
-					y1={ CHART_HEIGHT }
-					x2={ chartWidth }
-					y2={ CHART_HEIGHT + 10 }
-				/>
 				<polygon
 					className="masterbar__stats-sparkline-arrow"
-					points={ `${ chartWidth + 6 },${ CHART_HEIGHT + 6 } ${ chartWidth + 6 },${
-						CHART_HEIGHT + 14
-					} ${ chartWidth },${ CHART_HEIGHT + 10 }` }
+					points={ `${ chartWidth + 10 },${ peakCenterY - 4 } ${ chartWidth + 10 },${
+						peakCenterY + 4
+					} ${ chartWidth + 4 },${ peakCenterY }` }
 				/>
 				<text
 					className="masterbar__stats-sparkline-label"
-					x={ chartWidth + 8 }
-					y={ CHART_HEIGHT + 14 }
+					x={ chartWidth + 12 }
+					y={ peakCenterY + 4 }
 				>
 					{ highestViews }
 				</text>

--- a/client/layout/masterbar/masterbar-stats-sparkline.jsx
+++ b/client/layout/masterbar/masterbar-stats-sparkline.jsx
@@ -3,12 +3,25 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
-// Matches wp-admin's own admin bar sparkline (wp-includes/charts/admin-bar-hours-scale.php):
-// 24px tall, and 48 hourly bars at a 2px pitch come out to the same 95px
-// width wp-admin's chart image displays at rest.
-const CHART_HEIGHT = 24;
+// Matches wp-admin's own admin bar sparkline
+// (wp-includes/charts/admin-bar-hours-scale.php): 48 hourly bars at a 2px
+// pitch come out to the same 95px width wp-admin's chart image displays at
+// rest. wp-admin also leaves a margin above and below the bars — the
+// server-rendered chart reserves its own inset within the image on top of
+// the toolbar's own margin, so bars there never touch the item's edges —
+// hence the 6px (not the item's literal 4px) margin here.
+const CHART_HEIGHT = 20;
 const BAR_WIDTH = 1;
 const BAR_GAP = 1;
+
+// wp-admin's chart scales bars within chart_height - 10 (its own file's
+// constant), reserving room above the tallest bar for the peak arrow +
+// label, which it anchors to the *top of the tallest bar* — not the
+// vertical center of the chart. Since our tallest bar always reaches
+// exactly this reserved headroom by construction, the marker's Y is a
+// fixed offset, not data-dependent to compute.
+const PEAK_HEADROOM = 4;
+const DATA_HEIGHT = CHART_HEIGHT - PEAK_HEADROOM;
 
 const getHourlyViews = createSelector(
 	( state, siteId ) => {
@@ -35,7 +48,7 @@ export default function MasterbarStatsSparkline( { siteId } ) {
 function MasterbarStatsSparklineChart( { hourlyViews } ) {
 	const highestViews = Math.max( ...hourlyViews );
 	const chartWidth = hourlyViews.length * ( BAR_WIDTH + BAR_GAP ) - BAR_GAP;
-	const peakCenterY = CHART_HEIGHT / 2;
+	const peakY = PEAK_HEADROOM;
 
 	return (
 		<svg
@@ -50,7 +63,7 @@ function MasterbarStatsSparklineChart( { hourlyViews } ) {
 
 				// if the chart is all zeros, show just the flat baseline
 				if ( highestViews > 0 ) {
-					barHeight += ( value / highestViews ) * ( CHART_HEIGHT - 1 );
+					barHeight += ( value / highestViews ) * ( DATA_HEIGHT - 1 );
 				}
 
 				return (
@@ -67,19 +80,17 @@ function MasterbarStatsSparklineChart( { hourlyViews } ) {
 			{ /* Sits just past the bars, clipped by "overflow: hidden" on
 			     .masterbar__stats-sparkline until hover switches it to
 			     "overflow: visible" — same reveal technique wp-admin uses
-			     (there, widening the image's clipped container). */ }
+			     (there, widening the image's clipped container). Anchored
+			     to PEAK_HEADROOM (the tallest bar's top), not the chart's
+			     vertical center, matching wp-admin's own positioning. */ }
 			<g className="masterbar__stats-sparkline-peak">
 				<polygon
 					className="masterbar__stats-sparkline-arrow"
-					points={ `${ chartWidth + 10 },${ peakCenterY - 4 } ${ chartWidth + 10 },${
-						peakCenterY + 4
-					} ${ chartWidth + 4 },${ peakCenterY }` }
+					points={ `${ chartWidth + 10 },${ peakY - 3 } ${ chartWidth + 10 },${ peakY + 3 } ${
+						chartWidth + 4
+					},${ peakY }` }
 				/>
-				<text
-					className="masterbar__stats-sparkline-label"
-					x={ chartWidth + 12 }
-					y={ peakCenterY + 4 }
-				>
+				<text className="masterbar__stats-sparkline-label" x={ chartWidth + 12 } y={ peakY + 3 }>
 					{ highestViews }
 				</text>
 			</g>

--- a/client/layout/masterbar/masterbar-stats-sparkline.jsx
+++ b/client/layout/masterbar/masterbar-stats-sparkline.jsx
@@ -1,0 +1,95 @@
+import { createSelector } from '@automattic/state-utils';
+import { useSelector } from 'react-redux';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+
+const CHART_HEIGHT = 22;
+const LABEL_AREA_HEIGHT = 12;
+const LABEL_AREA_WIDTH = 18;
+const BAR_WIDTH = 1;
+const BAR_GAP = 1;
+
+const getHourlyViews = createSelector(
+	( state, siteId ) => {
+		const statsInsights = getSiteStatsNormalizedData( state, siteId, 'statsInsights' );
+		return statsInsights.hourlyViews ? Object.values( statsInsights.hourlyViews ) : null;
+	},
+	( state, siteId ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights' )
+);
+
+/**
+ * @param {{ siteId?: number }} props
+ */
+export default function MasterbarStatsSparkline( { siteId } ) {
+	const hourlyViews = useSelector( ( state ) => getHourlyViews( state, siteId ) );
+
+	return (
+		<>
+			<QuerySiteStats siteId={ siteId } statType="statsInsights" />
+			{ hourlyViews && <MasterbarStatsSparklineChart hourlyViews={ hourlyViews } /> }
+		</>
+	);
+}
+
+function MasterbarStatsSparklineChart( { hourlyViews } ) {
+	const highestViews = Math.max( ...hourlyViews );
+	const chartWidth = hourlyViews.length * ( BAR_WIDTH + BAR_GAP ) - BAR_GAP;
+	// The bars sit below the reserved label area, so their baseline is at
+	// LABEL_AREA_HEIGHT + CHART_HEIGHT and everything drawn stays within the
+	// viewBox (no negative coordinates, which would get clipped by the
+	// fixed-position masterbar rather than by the SVG itself).
+	const baseline = LABEL_AREA_HEIGHT + CHART_HEIGHT;
+
+	return (
+		<svg
+			className="masterbar__stats-sparkline"
+			width={ chartWidth + LABEL_AREA_WIDTH }
+			height={ baseline }
+			viewBox={ `0 0 ${ chartWidth + LABEL_AREA_WIDTH } ${ baseline }` }
+		>
+			{ hourlyViews.map( ( value, i ) => {
+				// for zero value, show a baseline bar with 1px height
+				let barHeight = 1;
+
+				// if the chart is all zeros, show just the flat baseline
+				if ( highestViews > 0 ) {
+					barHeight += ( value / highestViews ) * ( CHART_HEIGHT - 1 );
+				}
+
+				return (
+					<rect
+						key={ i }
+						className="masterbar__stats-sparkline-bar"
+						x={ i * ( BAR_WIDTH + BAR_GAP ) }
+						y={ baseline - barHeight }
+						width={ BAR_WIDTH }
+						height={ barHeight }
+					/>
+				);
+			} ) }
+			<g className="masterbar__stats-sparkline-peak">
+				<line
+					className="masterbar__stats-sparkline-baseline"
+					x1={ 0 }
+					y1={ baseline }
+					x2={ chartWidth }
+					y2={ baseline }
+				/>
+				<line
+					className="masterbar__stats-sparkline-tick"
+					x1={ chartWidth }
+					y1={ baseline }
+					x2={ chartWidth }
+					y2={ 2 }
+				/>
+				<polygon
+					className="masterbar__stats-sparkline-arrow"
+					points={ `${ chartWidth + 6 },2 ${ chartWidth + 6 },10 ${ chartWidth },6` }
+				/>
+				<text className="masterbar__stats-sparkline-label" x={ chartWidth + 8 } y={ 10 }>
+					{ highestViews }
+				</text>
+			</g>
+		</svg>
+	);
+}

--- a/client/layout/masterbar/masterbar-stats-sparkline.jsx
+++ b/client/layout/masterbar/masterbar-stats-sparkline.jsx
@@ -3,10 +3,11 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
-// Matches wp-admin's own admin bar sparkline (wp-includes/charts/admin-bar-hours-scale.php),
-// whose <img> is 24px tall inside a 32px-tall toolbar item.
+// Matches wp-admin's own admin bar sparkline (wp-includes/charts/admin-bar-hours-scale.php):
+// 24px tall, and 48 hourly bars at a 2px pitch come out to the same 95px
+// width wp-admin's chart image displays at rest.
 const CHART_HEIGHT = 24;
-const BAR_WIDTH = 2;
+const BAR_WIDTH = 1;
 const BAR_GAP = 1;
 
 const getHourlyViews = createSelector(

--- a/client/layout/masterbar/masterbar-stats-sparkline.jsx
+++ b/client/layout/masterbar/masterbar-stats-sparkline.jsx
@@ -3,11 +3,10 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
-const CHART_HEIGHT = 22;
-const LABEL_AREA_HEIGHT = 12;
-const LABEL_AREA_WIDTH = 18;
-const BAR_WIDTH = 1;
+const CHART_HEIGHT = 24;
+const BAR_WIDTH = 2;
 const BAR_GAP = 1;
+const PEAK_MARKER_HEIGHT = 18;
 
 const getHourlyViews = createSelector(
 	( state, siteId ) => {
@@ -34,18 +33,19 @@ export default function MasterbarStatsSparkline( { siteId } ) {
 function MasterbarStatsSparklineChart( { hourlyViews } ) {
 	const highestViews = Math.max( ...hourlyViews );
 	const chartWidth = hourlyViews.length * ( BAR_WIDTH + BAR_GAP ) - BAR_GAP;
-	// The bars sit below the reserved label area, so their baseline is at
-	// LABEL_AREA_HEIGHT + CHART_HEIGHT and everything drawn stays within the
-	// viewBox (no negative coordinates, which would get clipped by the
-	// fixed-position masterbar rather than by the SVG itself).
-	const baseline = LABEL_AREA_HEIGHT + CHART_HEIGHT;
+	// The SVG's own box is just the bars (tight, no reserved space), so the
+	// item's resting size is unaffected by the peak marker. The marker is
+	// drawn below that box (y > CHART_HEIGHT) and only escapes clipping via
+	// "overflow: visible" on hover, the same show/hide-on-hover technique
+	// wp-admin's own admin bar sparkline uses for its width.
+	const backdropWidth = chartWidth + 24 + String( highestViews ).length * 8;
 
 	return (
 		<svg
 			className="masterbar__stats-sparkline"
-			width={ chartWidth + LABEL_AREA_WIDTH }
-			height={ baseline }
-			viewBox={ `0 0 ${ chartWidth + LABEL_AREA_WIDTH } ${ baseline }` }
+			width={ chartWidth }
+			height={ CHART_HEIGHT }
+			viewBox={ `0 0 ${ chartWidth } ${ CHART_HEIGHT }` }
 		>
 			{ hourlyViews.map( ( value, i ) => {
 				// for zero value, show a baseline bar with 1px height
@@ -61,32 +61,45 @@ function MasterbarStatsSparklineChart( { hourlyViews } ) {
 						key={ i }
 						className="masterbar__stats-sparkline-bar"
 						x={ i * ( BAR_WIDTH + BAR_GAP ) }
-						y={ baseline - barHeight }
+						y={ CHART_HEIGHT - barHeight }
 						width={ BAR_WIDTH }
 						height={ barHeight }
 					/>
 				);
 			} ) }
 			<g className="masterbar__stats-sparkline-peak">
+				<rect
+					className="masterbar__stats-sparkline-backdrop"
+					x={ 0 }
+					y={ CHART_HEIGHT }
+					width={ backdropWidth }
+					height={ PEAK_MARKER_HEIGHT }
+				/>
 				<line
 					className="masterbar__stats-sparkline-baseline"
 					x1={ 0 }
-					y1={ baseline }
+					y1={ CHART_HEIGHT }
 					x2={ chartWidth }
-					y2={ baseline }
+					y2={ CHART_HEIGHT }
 				/>
 				<line
 					className="masterbar__stats-sparkline-tick"
 					x1={ chartWidth }
-					y1={ baseline }
+					y1={ CHART_HEIGHT }
 					x2={ chartWidth }
-					y2={ 2 }
+					y2={ CHART_HEIGHT + 10 }
 				/>
 				<polygon
 					className="masterbar__stats-sparkline-arrow"
-					points={ `${ chartWidth + 6 },2 ${ chartWidth + 6 },10 ${ chartWidth },6` }
+					points={ `${ chartWidth + 6 },${ CHART_HEIGHT + 6 } ${ chartWidth + 6 },${
+						CHART_HEIGHT + 14
+					} ${ chartWidth },${ CHART_HEIGHT + 10 }` }
 				/>
-				<text className="masterbar__stats-sparkline-label" x={ chartWidth + 8 } y={ 10 }>
+				<text
+					className="masterbar__stats-sparkline-label"
+					x={ chartWidth + 8 }
+					y={ CHART_HEIGHT + 14 }
+				>
 					{ highestViews }
 				</text>
 			</g>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -724,6 +724,16 @@ body.is-mobile-app-view {
 .masterbar__item-stats-sparkline {
 	padding: 0 10px;
 
+	// vertical-align on the svg itself is never exactly centered — "middle"
+	// aligns to a point derived from the font baseline, not the line box's
+	// true center. Making the content wrapper its own flex container
+	// centers the svg geometrically instead.
+	.masterbar__item-content {
+		display: flex;
+		align-items: center;
+		height: 100%;
+	}
+
 	// Resting size is just the bars — the peak marker to the right is clipped
 	// by default so it doesn't take up any layout space until hovered, the
 	// same show/hide-on-hover technique wp-admin's own admin bar sparkline
@@ -731,7 +741,6 @@ body.is-mobile-app-view {
 	.masterbar__stats-sparkline {
 		width: auto;
 		height: auto;
-		vertical-align: middle;
 		overflow: hidden;
 	}
 
@@ -750,7 +759,7 @@ body.is-mobile-app-view {
 
 	.masterbar__stats-sparkline-label {
 		fill: var(--color-masterbar-icon);
-		font-size: 11px;
+		font-size: 9px;
 	}
 
 	&:hover {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -762,7 +762,9 @@ body.is-mobile-app-view {
 		font-size: 9px;
 	}
 
-	&:hover {
+	// Keyboard users tabbing to this link get the same reveal a mouse hover does.
+	&:hover,
+	&:focus-visible {
 		.masterbar__stats-sparkline {
 			overflow: visible;
 		}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -722,12 +722,45 @@ body.is-mobile-app-view {
 }
 
 .masterbar__item-stats-sparkline {
-	--color-stats-sparkline: var(--color-masterbar-icon);
 	padding: 0 12px;
 
-	.stats-sparkline svg {
+	.masterbar__stats-sparkline {
 		width: auto;
 		height: auto;
+		vertical-align: middle;
+	}
+
+	.masterbar__stats-sparkline-bar {
+		fill: var(--color-masterbar-icon);
+	}
+
+	.masterbar__stats-sparkline-peak {
+		opacity: 0;
+		transition: opacity 0.15s ease-in;
+	}
+
+	.masterbar__stats-sparkline-baseline {
+		stroke: var(--color-masterbar-icon);
+		stroke-width: 1;
+		stroke-dasharray: 1 1;
+	}
+
+	.masterbar__stats-sparkline-tick {
+		stroke: var(--color-masterbar-icon);
+		stroke-width: 1;
+	}
+
+	.masterbar__stats-sparkline-arrow {
+		fill: var(--color-masterbar-icon);
+	}
+
+	.masterbar__stats-sparkline-label {
+		fill: var(--color-masterbar-icon);
+		font-size: 11px;
+	}
+
+	&:hover .masterbar__stats-sparkline-peak {
+		opacity: 1;
 	}
 
 	@media only screen and (max-width: 781px) {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -722,10 +722,12 @@ body.is-mobile-app-view {
 }
 
 .masterbar__item-stats-sparkline {
-	padding: 0 12px;
+	padding: 0 10px;
 
-	// Resting size is just the bars — the peak marker below is clipped by
-	// default so it doesn't take up any layout space until hovered.
+	// Resting size is just the bars — the peak marker to the right is clipped
+	// by default so it doesn't take up any layout space until hovered, the
+	// same show/hide-on-hover technique wp-admin's own admin bar sparkline
+	// uses (there, widening the chart image's clipped container).
 	.masterbar__stats-sparkline {
 		width: auto;
 		height: auto;
@@ -740,21 +742,6 @@ body.is-mobile-app-view {
 	.masterbar__stats-sparkline-peak {
 		opacity: 0;
 		transition: opacity 0.15s ease-in;
-	}
-
-	.masterbar__stats-sparkline-backdrop {
-		fill: var(--color-masterbar-background);
-	}
-
-	.masterbar__stats-sparkline-baseline {
-		stroke: var(--color-masterbar-icon);
-		stroke-width: 1;
-		stroke-dasharray: 1 1;
-	}
-
-	.masterbar__stats-sparkline-tick {
-		stroke: var(--color-masterbar-icon);
-		stroke-width: 1;
 	}
 
 	.masterbar__stats-sparkline-arrow {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -721,6 +721,15 @@ body.is-mobile-app-view {
 	--color-masterbar-submenu-group-background: #{$gray-100};
 }
 
+.masterbar__item-stats-sparkline {
+	--color-stats-sparkline: var(--color-masterbar-icon);
+	padding: 0 12px;
+
+	@media only screen and (max-width: 781px) {
+		display: none;
+	}
+}
+
 .masterbar__item-launch-site {
 	gap: 6px;
 	cursor: pointer;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -725,6 +725,11 @@ body.is-mobile-app-view {
 	--color-stats-sparkline: var(--color-masterbar-icon);
 	padding: 0 12px;
 
+	.stats-sparkline svg {
+		width: auto;
+		height: auto;
+	}
+
 	@media only screen and (max-width: 781px) {
 		display: none;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -724,10 +724,13 @@ body.is-mobile-app-view {
 .masterbar__item-stats-sparkline {
 	padding: 0 12px;
 
+	// Resting size is just the bars — the peak marker below is clipped by
+	// default so it doesn't take up any layout space until hovered.
 	.masterbar__stats-sparkline {
 		width: auto;
 		height: auto;
 		vertical-align: middle;
+		overflow: hidden;
 	}
 
 	.masterbar__stats-sparkline-bar {
@@ -737,6 +740,10 @@ body.is-mobile-app-view {
 	.masterbar__stats-sparkline-peak {
 		opacity: 0;
 		transition: opacity 0.15s ease-in;
+	}
+
+	.masterbar__stats-sparkline-backdrop {
+		fill: var(--color-masterbar-background);
 	}
 
 	.masterbar__stats-sparkline-baseline {
@@ -759,8 +766,14 @@ body.is-mobile-app-view {
 		font-size: 11px;
 	}
 
-	&:hover .masterbar__stats-sparkline-peak {
-		opacity: 1;
+	&:hover {
+		.masterbar__stats-sparkline {
+			overflow: visible;
+		}
+
+		.masterbar__stats-sparkline-peak {
+			opacity: 1;
+		}
 	}
 
 	@media only screen and (max-width: 781px) {


### PR DESCRIPTION
Fixes STATS-288

## Proposed Changes

* Add the `StatsSparkline` block (already used in the classic sidebar's Stats menu item) to Calypso's own masterbar, linking to the wp-admin Stats page.
* Gate it on the `view_stats` capability and hide it when there's no selected site or on domain-only sites.
* Hide it below 782px to avoid crowding the admin bar on narrow screens.

## Why are these changes being made?

The Stats sparkline already shows up in the site's public-facing admin bar and in wp-admin's Jetpack admin bar, but Calypso's own masterbar has never had it, so Calypso admin looks inconsistent with wp-admin/frontend for the same site.

## Testing Instructions

1. Visit a site you can view Stats for in Calypso admin (e.g. `/home/<site>`).
2. Confirm a sparkline chart now appears in the masterbar, to the right of the "New" button, linking to the site's wp-admin Stats page.
3. Confirm it's hidden on domain-only sites and for users without `view_stats` capability.
4. Resize the window below ~782px and confirm the sparkline is hidden.

<img width="555" height="218" alt="image" src="https://github.com/user-attachments/assets/7b62adbe-f2ec-4744-be11-485d1bfc49fd" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?