### PR TITLE
Remove stale lodash references from comments, test fixtures, and docs

### DIFF
--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -35,7 +35,7 @@ yarn add <dependency>
 
 # Example:
 # cd packages/calypso-analytics
-# yarn add lodash
+# yarn add uuid
 ```
 
 You should add dependencies to the root project _only_ when it will be used to test and/or build other packages. To do this, run:
@@ -65,13 +65,13 @@ yarn remove <dependency>
 
 # Example:
 # cd packages/calypso-analytics
-# yarn remove lodash
+# yarn remove uuid
 ```
 
 To delete a dependency of the root project, run:
 
 ```
-yarn remove -w lodash
+yarn remove -w uuid
 ```
 
 ### Update a dependency

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -66,7 +66,7 @@ function IncrementalProgressPlugin() {
 const nodeModulesToTranspile = [
 	// general form is <package-name>/.
 	// The trailing slash makes sure we're not matching these as prefixes
-	// In some cases we do want prefix style matching (lodash. for lodash.assign)
+	// In some cases we do want prefix style matching (e.g. `foo.` to match `foo.bar`)
 	'@automattic/calypso-polyfills/',
 	'@automattic/lasagna/',
 	'@github/webauthn-json/',

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-unsafe-wp-apis.js
@@ -12,12 +12,12 @@ const options = [ { '@wordpress/package': [ '__experimentalSafe', '__unstableSaf
 
 ruleTester.run( 'no-unsafe-wp-apis', rule, {
 	valid: [
-		{ code: "import _ from 'lodash';", options },
-		{ code: "import { map } from 'lodash';", options },
-		{ code: "import { __experimentalFoo } from 'lodash';", options },
-		{ code: "import { __unstableFoo } from 'lodash';", options },
-		{ code: "import _, { __unstableFoo } from 'lodash';", options },
-		{ code: "import * as _ from 'lodash';", options },
+		{ code: "import _ from 'external-module';", options },
+		{ code: "import { map } from 'external-module';", options },
+		{ code: "import { __experimentalFoo } from 'external-module';", options },
+		{ code: "import { __unstableFoo } from 'external-module';", options },
+		{ code: "import _, { __unstableFoo } from 'external-module';", options },
+		{ code: "import * as _ from 'external-module';", options },
 
 		{ code: "import _ from './x';", options },
 		{ code: "import { map } from './x';", options },

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -6,7 +6,7 @@ const mergeWith = require( './merge-with' );
 
 const mergeDeep = ( left, right, key ) => {
 	// `typeof null === 'object'`, so exclude null before recursing (parsed POT
-	// data has none); a null side falls through to `right || left`, as in lodash.
+	// data has none); a null side falls through to `right || left`.
 	if ( left !== null && typeof left === 'object' && right !== null && typeof right === 'object' ) {
 		return mergeWith( left, right, mergeDeep );
 	}

--- a/packages/wp-babel-makepot/utils/merge-with.js
+++ b/packages/wp-babel-makepot/utils/merge-with.js
@@ -1,5 +1,5 @@
 // Assigns `customizer( object[ key ], source[ key ], key )` for each own key of
-// `source`; both must be non-null objects. Skips `__proto__` (as lodash does) so
+// `source`; both must be non-null objects. Skips `__proto__` so
 // it can never reach or pollute a prototype.
 module.exports = function mergeWith( object, source, customizer ) {
 	for ( const key of Object.keys( source ) ) {


### PR DESCRIPTION
## Proposed Changes

Remove incidental, non-load-bearing references to lodash that lingered after lodash was dropped from application code and banned by lint:

- Rule-tester fixtures in `no-unsafe-wp-apis` that used `lodash` as an arbitrary stand-in module name (the rule only concerns `@wordpress/*` imports) — swapped for a neutral name.
- "As lodash does" / "as in lodash" parity asides in two homegrown merge helpers, where the behavior is already explained on its own terms.
- A stale prefix-matching example in the webpack transpile list, generalized off lodash.
- `yarn add/remove` example snippets in the dependency-management guide.

Intentionally **kept** the references that are load-bearing: the test-oracle provenance comments in `@automattic/js-utils` (they document that the expected-value tables are a captured behavioral spec, not arbitrary), and the deprecation note in the tech-behind guide.

No behavior or public-API changes; comment/test/doc only.

## Why are these changes being made?

These references were false positives for anyone auditing the tree for remaining lodash usage, and using a lint-banned package as an example is misleading. Clearing them keeps the codebase consistent with the lodash removal without touching anything that still relies on the name.

## Testing Instructions

- `yarn test-packages` — the `no-unsafe-wp-apis` rule test passes with the renamed fixtures (verified locally: 24/24).
- Remaining changes are comment/doc only.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
