### PR TITLE
Bump @wordpress/ui to 0.17.0

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
-		"@wordpress/ui": "^0.15.0",
+		"@wordpress/ui": "^0.17.0",
 		"autoprefixer": "^10.4.21",
 		"calypso": "workspace:^",
 		"clsx": "^2.1.1",

--- a/apps/wpcom-smart-dictation/package.json
+++ b/apps/wpcom-smart-dictation/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
 		"@wordpress/plugins": "^7.48.0",
-		"@wordpress/ui": "^0.15.0",
+		"@wordpress/ui": "^0.17.0",
 		"clsx": "^2.1.1",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/client/package.json
+++ b/client/package.json
@@ -122,7 +122,7 @@
 		"@wordpress/private-apis": "^1.48.0",
 		"@wordpress/react-i18n": "^4.48.0",
 		"@wordpress/theme": "^0.15.0",
-		"@wordpress/ui": "^0.15.0",
+		"@wordpress/ui": "^0.17.0",
 		"@wordpress/viewport": "^6.48.0",
 		"@wordpress/warning": "^3.48.0",
 		"autosize": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -459,7 +459,7 @@
 		"@wordpress/url": "^4.48.0",
 		"@wordpress/viewport": "^6.48.0",
 		"@wordpress/theme": "0.15.0",
-		"@wordpress/ui": "0.15.0",
+		"@wordpress/ui": "0.17.0",
 		"@wordpress/warning": "3.48.0",
 		"@wordpress/widgets": "4.48.0",
 		"@wordpress/wordcount": "4.48.0",

--- a/packages/content-research/package.json
+++ b/packages/content-research/package.json
@@ -46,7 +46,7 @@
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
-		"@wordpress/ui": "^0.15.0",
+		"@wordpress/ui": "^0.17.0",
 		"@wordpress/url": "^4.48.0",
 		"clsx": "^2.1.1",
 		"wpcom-proxy-request": "workspace:^"

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -47,7 +47,7 @@
 		"@wordpress/base-styles": "^9.1.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/icons": "^13.3.0",
-		"@wordpress/ui": "^0.15.0",
+		"@wordpress/ui": "^0.17.0",
 		"clsx": "^2.1.1",
 		"social-logos": "^3.1.18",
 		"tslib": "^2.8.1",

--- a/packages/omnibar/package.json
+++ b/packages/omnibar/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/compose": "^8.2.0",
 		"@wordpress/icons": "^13.3.0",
 		"@wordpress/private-apis": "^1.48.0",
-		"@wordpress/ui": "^0.15.0"
+		"@wordpress/ui": "^0.17.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.48.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,7 +46,7 @@
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
 		"@wordpress/primitives": "^4.48.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/ui": "^0.17.0",
 		"clsx": "^2.1.1",
 		"date-fns": "^4.1.0",
 		"react-day-picker": "^9.7.0"

--- a/packages/wpcom-smart-dictation/package.json
+++ b/packages/wpcom-smart-dictation/package.json
@@ -47,7 +47,7 @@
 		"@wordpress/data": "^10.48.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
-		"@wordpress/ui": "^0.15.0",
+		"@wordpress/ui": "^0.17.0",
 		"clsx": "^2.1.1",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,7 +979,7 @@ __metadata:
     "@wordpress/components": "npm:^35.0.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     "@wordpress/url": "npm:^4.48.0"
     clsx: "npm:^2.1.1"
     typescript: "npm:^6.0.3"
@@ -1712,7 +1712,7 @@ __metadata:
     "@wordpress/base-styles": "npm:^9.1.0"
     "@wordpress/components": "npm:^35.0.0"
     "@wordpress/icons": "npm:^13.3.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     clsx: "npm:^2.1.1"
     msw: "npm:^2.1.7"
     msw-storybook-addon: "npm:2.0.7"
@@ -1802,7 +1802,7 @@ __metadata:
     "@wordpress/element": "npm:^8.0.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     autoprefixer: "npm:^10.4.21"
     calypso: "workspace:^"
     clsx: "npm:^2.1.1"
@@ -1974,7 +1974,7 @@ __metadata:
     "@wordpress/compose": "npm:^8.2.0"
     "@wordpress/icons": "npm:^13.3.0"
     "@wordpress/private-apis": "npm:^1.48.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     typescript: "npm:^6.0.3"
   peerDependencies:
     "@wordpress/data": ^10.48.0
@@ -2344,7 +2344,7 @@ __metadata:
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
     "@wordpress/primitives": "npm:^4.48.0"
-    "@wordpress/ui": "npm:0.13.0"
+    "@wordpress/ui": "npm:^0.17.0"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^4.1.0"
     esbuild: "npm:^0.25.5"
@@ -2621,7 +2621,7 @@ __metadata:
     "@wordpress/icons": "npm:^13.3.0"
     "@wordpress/plugins": "npm:^7.48.0"
     "@wordpress/readable-js-assets-webpack-plugin": "npm:^3.24.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     clsx: "npm:^2.1.1"
     typescript: "npm:^6.0.3"
     webpack: "npm:^5.99.8"
@@ -2646,7 +2646,7 @@ __metadata:
     "@wordpress/data": "npm:^10.48.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     clsx: "npm:^2.1.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -4344,7 +4344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base-ui/react@npm:^1.4.1, @base-ui/react@npm:^1.5.0":
+"@base-ui/react@npm:^1.5.0":
   version: 1.5.0
   resolution: "@base-ui/react@npm:1.5.0"
   dependencies:
@@ -12573,6 +12573,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/style-runtime@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@wordpress/style-runtime@npm:0.6.0"
+  checksum: 51134b08c5f381f3ebbdd75c626c2b004d0da5e1861b8ee5faf86a223c1a6c7699d590eee046e433fd04b6fa354aeae083316bec5d10543a740baf72b245b814
+  languageName: node
+  linkType: hard
+
 "@wordpress/stylelint-config@npm:^23.40.0":
   version: 23.40.0
   resolution: "@wordpress/stylelint-config@npm:23.40.0"
@@ -12632,27 +12639,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/ui@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@wordpress/ui@npm:0.15.0"
+"@wordpress/ui@npm:0.17.0":
+  version: 0.17.0
+  resolution: "@wordpress/ui@npm:0.17.0"
   dependencies:
-    "@base-ui/react": "npm:^1.4.1"
-    "@wordpress/a11y": "npm:^4.48.0"
-    "@wordpress/compose": "npm:^8.1.0"
-    "@wordpress/element": "npm:^8.0.0"
-    "@wordpress/i18n": "npm:^6.21.0"
-    "@wordpress/icons": "npm:^13.3.0"
-    "@wordpress/keycodes": "npm:^4.48.0"
-    "@wordpress/primitives": "npm:^4.48.0"
-    "@wordpress/private-apis": "npm:^1.48.0"
-    "@wordpress/style-runtime": "npm:^0.4.0"
-    "@wordpress/theme": "npm:^0.15.0"
+    "@base-ui/react": "npm:^1.5.0"
+    "@wordpress/a11y": "npm:^4.50.0"
+    "@wordpress/compose": "npm:^8.3.0"
+    "@wordpress/element": "npm:^8.2.0"
+    "@wordpress/i18n": "npm:^6.23.0"
+    "@wordpress/icons": "npm:^15.1.0"
+    "@wordpress/keycodes": "npm:^4.50.0"
+    "@wordpress/primitives": "npm:^4.50.0"
+    "@wordpress/private-apis": "npm:^1.50.0"
+    "@wordpress/style-runtime": "npm:^0.6.0"
+    "@wordpress/theme": "npm:^0.17.0"
     clsx: "npm:^2.1.1"
     tabbable: "npm:^6.4.0"
   peerDependencies:
+    "@types/react": ^18.3.27
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 73234b7921b5096edf1681c3a230e2041c680a06805e82c5b058c8d4546b0535f41563d39073eceea835461649918395d9a12e003d36c1b8ed2ca6ab9fc08f0e
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 12bafc81bf47729fa7821f66e2dc1bfa5f87b07e884c50ac7a102ab284e8f7a87c1aa4265e3a645e94119250b3ccc108e180949be58f6be2484e0281d7c3d33c
   languageName: node
   linkType: hard
 
@@ -14496,7 +14507,7 @@ __metadata:
     "@wordpress/private-apis": "npm:^1.48.0"
     "@wordpress/react-i18n": "npm:^4.48.0"
     "@wordpress/theme": "npm:^0.15.0"
-    "@wordpress/ui": "npm:^0.15.0"
+    "@wordpress/ui": "npm:^0.17.0"
     "@wordpress/viewport": "npm:^6.48.0"
     "@wordpress/warning": "npm:^3.48.0"
     autoprefixer: "npm:^10.4.21"


### PR DESCRIPTION
## Proposed Changes

* Bump `@wordpress/ui` from `0.15.0` to `0.17.0` across the monorepo — updating the root `resolutions` pin and the per-package ranges that track it.

## Why are these changes being made?

Older `@wordpress/ui` versions internally consumed private `@wordpress/theme` APIs. As `@wordpress/theme` stabilizes for an upcoming WordPress release, those private APIs are being removed from the WordPress/Gutenberg runtime. Apps that bundle their own `@wordpress/ui` but consume `@wordpress/theme` from the runtime would hit build/runtime failures once the private APIs disappear. `@wordpress/ui` 0.16.1+ no longer touches them, so bumping to the latest (0.17.0) removes the exposure. The bump is applied repo-wide so everything stays on a single deduped version.

No code migration was required: nothing in this repo imports `@wordpress/theme` or its private APIs directly.

## Testing Instructions

* `yarn typecheck-client` and `yarn typecheck-packages` pass (no new errors introduced).
* Verify the affected surfaces still render correctly — notifications app, smart dictation, launchpad checklist badges, omnibar, and login/social badges.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
