### PR TITLE
Roll back the dashboard advance notice launch

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,7 +35,7 @@
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,
-		"dashboard/rollout-advance-notice": true,
+		"dashboard/rollout-advance-notice": false,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,
 		"design-picker/use-assembler-styles": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,7 +46,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,
-		"dashboard/rollout-advance-notice": true,
+		"dashboard/rollout-advance-notice": false,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"dolly/telegram": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,7 +44,7 @@
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-welcome-modal": false,
-		"dashboard/rollout-advance-notice": true,
+		"dashboard/rollout-advance-notice": false,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"dev/preferences-helper": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,7 @@
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,
-		"dashboard/rollout-advance-notice": true,
+		"dashboard/rollout-advance-notice": false,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"design-picker/use-assembler-styles": true,


### PR DESCRIPTION
Related: #112350

## Proposed Changes

* Partially revert #112350 by disabling dashboard/rollout-advance-notice in horizon, production, stage, and wpcalypso configs.

## Why are these changes being made?

This is a just-in-case PR ready to go in case we want to revert.

## Testing Instructions

* Confirmed the edited JSON files parse successfully.
* Config only change, should be good for a quick revert

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?