### PR TITLE
desktop: Use `install_gems` in CI to access cache

### DIFF
--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -27,7 +27,10 @@ cd desktop
 corepack enable
 yarn install --immutable --inline-builds
 
-bundle install
+echo "--- :ruby: Setting up Ruby tooling"
+install_gems
+
+echo "--- Configuring code signing"
 bundle exec fastlane configure_code_signing
 
 # Notarize and staple the `.app` inside electron-builder's afterSign hook

--- a/.buildkite/commands/build-desktop-mac.sh
+++ b/.buildkite/commands/build-desktop-mac.sh
@@ -51,9 +51,13 @@ export APP_STORE_CONNECT_API_KEY_PATH="$ASC_KEY_PATH"
 
 echo "RELEASE_BUILD=$RELEASE_BUILD"
 
+echo "--- Building the app"
 yarn run ci:build-mac
+
+echo "--- Running E2E smoke tests"
 yarn run test:e2e
 
+echo "--- Code signing"
 # The afterSign hook already notarized and stapled the app; this notarizes and
 # staples the `.dmg` wrapper for offline Gatekeeper checks on first mount.
 bundle exec fastlane notarize_app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,7 @@ steps:
       IMAGE_ID: xcode-26.6
     plugins:
       - automattic/nvm#0.6.0
+      - automattic/a8c-ci-toolkit#6.1.0
     command: .buildkite/commands/build-desktop-mac.sh
     artifact_paths:
       - desktop/release/*.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
+# Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buildkite-agent pipeline upload`
 
 steps:
   # The desktop build is resource-intensive and this repo runs many builds,
@@ -13,10 +14,10 @@ steps:
     agents:
       queue: mac
     env:
-      IMAGE_ID: xcode-26.6
+      IMAGE_ID: $IMAGE_ID
     plugins:
-      - automattic/nvm#0.6.0
-      - automattic/a8c-ci-toolkit#6.1.0
+      - $NVM_PLUGIN
+      - $CI_TOOLKIT_PLUGIN
     command: .buildkite/commands/build-desktop-mac.sh
     artifact_paths:
       - desktop/release/*.zip
@@ -34,7 +35,7 @@ steps:
     agents:
       queue: default
     plugins:
-      - docker#v5.13.0:
+      - $DOCKER_PLUGIN:
           image: cimg/node:24.15.0-browsers
           propagate-uid-gid: true
           userns: host
@@ -71,7 +72,7 @@ steps:
     agents:
       queue: windows
     plugins:
-      - automattic/a8c-ci-toolkit#6.1.0
+      - $CI_TOOLKIT_PLUGIN
     command: powershell -NoProfile -ExecutionPolicy Bypass -File .buildkite/commands/build-desktop-windows-nsis.ps1
     artifact_paths:
       - desktop/release/*.exe
@@ -91,7 +92,7 @@ steps:
     agents:
       queue: default
     plugins:
-      - automattic/nvm#0.6.0
+      - $NVM_PLUGIN
     command: .buildkite/commands/publish-desktop-release.sh
     artifact_paths:
       - desktop/release/*

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+# Selects the VM image for the `mac` queue.
+export IMAGE_ID="xcode-26.6"
+
+# https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/6.1.0 (2026-04-27)
+export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#6.1.0"
+
+# https://github.com/Automattic/nvm-buildkite-plugin/releases/tag/0.6.0 (2025-03-06)
+export NVM_PLUGIN="automattic/nvm#0.6.0"
+
+# https://github.com/buildkite-plugins/docker-buildkite-plugin/releases/tag/v5.13.0 (2025-07-07)
+export DOCKER_PLUGIN="docker#v5.13.0"


### PR DESCRIPTION


## Proposed Changes

Addresses https://linear.app/a8c/issue/AINFRA-2510.

A small follow up on the recent Buildkite CI setup for the Desktop apps. Replaces `bundle install` with the CI toolkit `install_gems` command, so that we can access cached gems if available.

## Why are these changes being made?

Slightly faster CI.

## Testing Instructions

TBD: I'll past a screenshot of the build here.

## Pre-merge Checklist

<details>
<summary>N.A. These are CI changes only</summary>


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


</details>