### PR TITLE
Dashboard: gate the Performance "Frontend" page title on the APM flag

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -609,7 +609,7 @@ export const sitePerformanceFrontendRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Frontend' ),
+				title: isEnabled( 'performance/apm' ) ? __( 'Frontend' ) : undefined,
 			},
 		],
 	} ),


### PR DESCRIPTION
## Proposed Changes

* Only set the Performance **Frontend** route's page title when the `performance/apm` feature flag is enabled; otherwise leave it unset so it falls back to the parent **Performance** title.

## Why are these changes being made?

* The Backend performance routes only exist when `performance/apm` is enabled. With the flag on, the section has Frontend/Backend views, so a "Frontend" page title is meaningful.
* With the flag off there is a single performance view, so titling it "Frontend" is redundant and slightly confusing — there is no Backend to distinguish it from. Falling back to the "Performance" title reads correctly in that case.

## Testing Instructions

1. With `performance/apm` **disabled**, open a site's **Performance** page. The browser tab / page title should read **Performance** (no "Frontend").
2. With `performance/apm` **enabled**, open the same page. The title should read **Frontend**, and the Backend view remains titled **Backend**.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
