### PR TITLE
Legacy contact: reduce access key font size in printable copy

### DIFF
--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -59,7 +59,8 @@
 
 .legacy-contact-print__key {
 	font-family: ui-monospace, monospace;
-	font-size: 1rem;
+	// stylelint-disable-next-line scales/font-sizes -- off-scale size chosen so the 49-char access key fits on one line
+	font-size: 1.2rem;
 	font-weight: 600;
 	line-height: 1.4;
 	width: max-content;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -58,11 +58,12 @@
 }
 
 .legacy-contact-print__key {
-	font-family: monospace;
-	// stylelint-disable-next-line scales/font-sizes -- off-scale size chosen so the access key fits on a single printed line
-	font-size: 1.2rem;
+	font-family: ui-monospace, monospace;
+	font-size: 1rem;
 	font-weight: 600;
 	line-height: 1.4;
+	width: max-content;
+	max-width: 100%;
 	word-break: break-all;
 	padding: 16px;
 	border: 1px solid var( --dashboard-surface__border-color );

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -59,7 +59,7 @@
 
 .legacy-contact-print__key {
 	font-family: monospace;
-	font-size: 1.5rem;
+	font-size: 1.25rem;
 	font-weight: 600;
 	line-height: 1.4;
 	word-break: break-all;

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -63,8 +63,6 @@
 	font-size: 1.2rem;
 	font-weight: 600;
 	line-height: 1.4;
-	width: max-content;
-	max-width: 100%;
 	word-break: break-all;
 	padding: 16px;
 	border: 1px solid var( --dashboard-surface__border-color );

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -59,7 +59,8 @@
 
 .legacy-contact-print__key {
 	font-family: monospace;
-	font-size: 1.25rem;
+	// stylelint-disable-next-line scales/font-sizes -- off-scale size chosen so the access key fits on a single printed line
+	font-size: 1.2rem;
 	font-weight: 600;
 	line-height: 1.4;
 	word-break: break-all;


### PR DESCRIPTION
## Proposed Changes

Reduces the access key font size in the legacy contact printable copy from `1.5rem` to `1.2rem` so the 49-character key fits on a single line.

`1.2rem` is off the repo's sanctioned `scales/font-sizes` scale, so a scoped `stylelint-disable-next-line` (with a rationale comment) is added for that one declaration. Also switches the font stack to `ui-monospace, monospace`.

Part of RSM-4612.

### Testing Instructions

- Navigate to the legacy contact page in the Dashboard and print (or use print preview).
- Confirm the access key renders at `1.2rem` on a single line.

## Pre-merge Checklist

- [ ] Has the general commit checklist been adhered to? [Commit Checklist](https://github.com/Automattic/wp-calypso/blob/trunk/docs/git-workflow.md#commit-checklist)
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you tested the feature in Simple (Dotcom), Atomic, and self-hosted Jetpack sites, if applicable?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used [memoizing](https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578) on expensive computations? [More info](https://reactjs.org/docs/hooks-faq.html#how-to-memoize-calculations)
- [ ] Have you followed the [accessibility guidelines](https://github.com/Automattic/wp-calypso/blob/trunk/docs/accessibility.md) and tested with a keyboard and/or screen reader, if applicable?
