### PR TITLE
Dashboard opt-in notice: make the mobile banner dismissable

### DIFF
--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { closeSmall } from '@wordpress/icons';
 import { type TranslateResult, useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
@@ -88,8 +89,10 @@ function getBannerCopy(
 
 export default function HostingDashboardOptInBanner( {
 	isMobile = false,
+	onDismiss,
 }: {
 	isMobile?: boolean;
+	onDismiss?: () => void;
 } ) {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
@@ -191,15 +194,22 @@ export default function HostingDashboardOptInBanner( {
 		</Button>
 	);
 
+	const dismissButton = onDismiss && (
+		<Button icon={ closeSmall } aria-label={ translate( 'Dismiss' ) } onClick={ onDismiss } />
+	);
+
 	return (
 		<Card style={ { width: '100%' } }>
 			<CardBody style={ { padding: '12px' } }>
 				{ isMobile ? (
 					<VStack spacing={ 2 } alignment="flex-start">
-						<VStack spacing={ 0 }>
-							{ heading }
-							{ description }
-						</VStack>
+						<HStack spacing={ 2 } alignment="flex-start" justify="space-between">
+							<VStack spacing={ 0 }>
+								{ heading }
+								{ description }
+							</VStack>
+							{ dismissButton }
+						</HStack>
 						{ button }
 					</VStack>
 				) : (

--- a/client/sites/components/sites-dashboard-banners/use-dashboard-opt-in-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-dashboard-opt-in-banner.tsx
@@ -1,20 +1,30 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import { useSelector } from 'react-redux';
+import { dismissCard } from 'calypso/blocks/dismissible-card/actions';
+import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
 import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isAdvancedNoticeVisible } from 'calypso/state/dashboard/selectors';
 
 export function useDashboardOptInBanner() {
 	const id = 'dashboard-opt-in';
+	const dispatch = useDispatch();
 	const isDesktop = useBreakpoint( '>=782px' );
 	const isVisible = useSelector( isAdvancedNoticeVisible );
+	const isDismissed = useSelector( isCardDismissed( id ) );
+
+	const handleDismiss = () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_dashboard_advance_notice_banner_dismiss' ) );
+		dispatch( dismissCard( id ) );
+	};
 
 	return {
 		id,
 		shouldShow() {
-			return ! isDesktop && isVisible;
+			return ! isDesktop && isVisible && ! isDismissed;
 		},
 		render() {
-			return <HostingDashboardOptInBanner isMobile />;
+			return <HostingDashboardOptInBanner isMobile onDismiss={ handleDismiss } />;
 		},
 	};
 }


### PR DESCRIPTION

## Proposed Changes

* Add a dismiss (X) button to the hosting-dashboard opt-in notice on mobile.
* Dismissal persists per-account via the existing `dismissible-card` preference, so it stays hidden across reloads.
* Records a `calypso_hosting_dashboard_advance_notice_banner_dismiss` Tracks event on dismiss.
* Desktop (sidebar) rendering is unchanged — the close button only appears when the mobile hook passes an `onDismiss` handler.

**Recording**

<img width="300" alt="Screen Recording on 2026-07-07 at 01-04-45" src="https://github.com/user-attachments/assets/4b6dc950-a0ba-4493-9c67-6e439ac68fea" />



## Why are these changes being made?

The Sites list on mobile isn't scrollable, so the dashboard opt-in notice takes up fixed space at the top with no way to get past it. A dismiss button lets people clear it and use the page.

## Testing Instructions

* Log in and open the Sites list (`/sites`) with a viewport below 782px (the banner is mobile-only).
* You need to be in the advance-notice rollout cohort for it to appear; to force it locally, bypass the cohort check in `isAdvancedNoticeVisible` (`client/dashboard/utils/hosting-dashboard-enrollment.ts`).
* Confirm the X appears top-right of the notice, dismisses it on click, and that it stays hidden after a reload.
* To re-show after dismissing, reset the `dismissible-card-dashboard-opt-in` preference.

## Considerations

The dismiss button matches the dashboard `Notice` component's treatment (`closeSmall` icon, `Dismiss` aria-label, default tap-target size) for consistency. Persistence uses `dismissible-card` — the same pattern as the sibling migration banner — rather than session-only state, since re-showing an advance notice on every load defeats the purpose.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)