### PR TITLE
Jetpack AI sidebar: add Generate Excerpt suggestion and picker (FORNO-309)

### DIFF
--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -97,7 +97,7 @@ Changes here affect AI response quality. The orchestrator uses `selectedBlockCli
 
 ## Checkpoint / Undo
 
-`useCheckpoint` exposes a minimal subset of AM's `UseCheckpointReturn` interface — only `setCheckpoint` / `hasCheckpoint` / `restoreCheckpoint` are implemented; the Big Sky page/navigation stubs are no-ops. Snapshots (post title + excerpt) are stored in a module-level `postSnapshots` map keyed by checkpoint id (the tool call id), so the sync `handleShowComponent` callback and the async React restore path share state.
+`useCheckpoint` exposes a minimal subset of AM's `UseCheckpointReturn` interface — only `setCheckpoint` / `hasCheckpoint` / `restoreCheckpoint` are implemented; the Big Sky page/navigation stubs are no-ops. Snapshots capture only the fields the triggering picker writes (title by default, excerpt for the excerpt picker) and are stored in a module-level `postSnapshots` map keyed by checkpoint id (the tool call id), so the sync `handleShowComponent` callback and the async React restore path share state — and restoring one picker's checkpoint never clobbers another field's later edits.
 
 ## Suggestions
 

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -19,7 +19,7 @@ This package exports the **AM provider contract** — a set of functions the Age
 | `toolProvider`            | Surfaces Jetpack AI's client-side abilities to AM         |
 | `contextProvider`         | Sends Gutenberg editor state to the orchestrator          |
 | `getChatComponent`        | Maps `type` strings → React components for show-component |
-| `useCheckpoint`           | Post-title snapshots for AM's native Undo action          |
+| `useCheckpoint`           | Post title/excerpt snapshots for AM's native Undo action  |
 | `getEmptyViewSuggestions` | Static suggestions shown before conversation starts       |
 | `useSuggestions`          | Block-aware dynamic suggestions during conversation       |
 
@@ -97,7 +97,7 @@ Changes here affect AI response quality. The orchestrator uses `selectedBlockCli
 
 ## Checkpoint / Undo
 
-`useCheckpoint` exposes a minimal subset of AM's `UseCheckpointReturn` interface — only `setCheckpoint` / `hasCheckpoint` / `restoreCheckpoint` are implemented; the Big Sky page/navigation stubs are no-ops. Snapshots are stored in a module-level `titleSnapshots` map keyed by checkpoint id (the tool call id), so the sync `handleShowComponent` callback and the async React restore path share state.
+`useCheckpoint` exposes a minimal subset of AM's `UseCheckpointReturn` interface — only `setCheckpoint` / `hasCheckpoint` / `restoreCheckpoint` are implemented; the Big Sky page/navigation stubs are no-ops. Snapshots (post title + excerpt) are stored in a module-level `postSnapshots` map keyed by checkpoint id (the tool call id), so the sync `handleShowComponent` callback and the async React restore path share state.
 
 ## Suggestions
 

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
@@ -71,6 +71,14 @@ describe( 'ExcerptPicker', () => {
 		expect( onComplete ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'renders no options without crashing when the excerpts prop is malformed', () => {
+		render( <ExcerptPicker excerpts={ undefined as any } /> );
+		expect( document.querySelectorAll( 'button' ) ).toHaveLength( 0 );
+
+		render( <ExcerptPicker excerpts={ 'not-an-array' as any } /> );
+		expect( document.querySelectorAll( 'button' ) ).toHaveLength( 0 );
+	} );
+
 	it( 'marks the option matching the current post excerpt as applied on mount', () => {
 		mockCurrentExcerpt = excerpts[ 0 ].excerpt;
 		render( <ExcerptPicker excerpts={ excerpts } /> );

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import ExcerptPicker from './excerpt-picker';
+
+const mockEditPost = jest.fn();
+let mockCurrentExcerpt: string | undefined;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: ( store: string ) => {
+		if ( store === 'core/editor' ) {
+			return { editPost: mockEditPost };
+		}
+		return {};
+	},
+	useSelect: ( mapSelect: any ) =>
+		mapSelect( ( store: string ) => {
+			if ( store === 'core/editor' ) {
+				return {
+					getEditedPostAttribute: ( attr: string ) =>
+						attr === 'excerpt' ? mockCurrentExcerpt : undefined,
+				};
+			}
+			return {};
+		} ),
+} ) );
+
+describe( 'ExcerptPicker', () => {
+	beforeEach( () => {
+		mockEditPost.mockClear();
+		mockCurrentExcerpt = undefined;
+	} );
+
+	const excerpts = [
+		{
+			excerpt: 'A hands-on beginner guide to planning and planting a first vegetable garden.',
+			explanation: 'a',
+		},
+		{
+			excerpt: 'Learn the essentials of starting a vegetable garden, from soil to harvest.',
+			explanation: 'b',
+		},
+	];
+
+	it( 'renders every suggested excerpt', () => {
+		render( <ExcerptPicker excerpts={ excerpts } /> );
+		expect( screen.getByText( excerpts[ 0 ].excerpt ) ).toBeInTheDocument();
+		expect( screen.getByText( excerpts[ 1 ].excerpt ) ).toBeInTheDocument();
+	} );
+
+	it( 'writes the chosen excerpt to the post on click', () => {
+		render( <ExcerptPicker excerpts={ excerpts } /> );
+		fireEvent.click( screen.getByText( excerpts[ 0 ].excerpt ) );
+		expect( mockEditPost ).toHaveBeenCalledWith( { excerpt: excerpts[ 0 ].excerpt } );
+	} );
+
+	it( 'highlights the applied option and calls onComplete', () => {
+		const onComplete = jest.fn();
+		render( <ExcerptPicker excerpts={ excerpts } onComplete={ onComplete } /> );
+		const button = screen
+			.getByText( excerpts[ 1 ].excerpt )
+			.closest( 'button' ) as HTMLButtonElement;
+		fireEvent.click( button );
+		expect( button ).toHaveAttribute( 'aria-pressed', 'true' );
+		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'marks the option matching the current post excerpt as applied on mount', () => {
+		mockCurrentExcerpt = excerpts[ 0 ].excerpt;
+		render( <ExcerptPicker excerpts={ excerpts } /> );
+		const applied = screen
+			.getByText( excerpts[ 0 ].excerpt )
+			.closest( 'button' ) as HTMLButtonElement;
+		expect( applied ).toHaveAttribute( 'aria-pressed', 'true' );
+		expect( screen.getByText( 'Excerpt updated.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
@@ -54,13 +54,21 @@ export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerPr
 		[ editPost, onComplete ]
 	);
 
+	// The props arrive from an orchestrator tool payload, so guard the shape
+	// instead of trusting the TypeScript type.
+	const options = Array.isArray( excerpts )
+		? excerpts
+				.map( ( option ) => option?.excerpt )
+				.filter( ( excerpt ): excerpt is string => typeof excerpt === 'string' )
+		: [];
+
 	return (
 		<BaseSuggestionPicker
 			intro={ __(
 				'Choose an excerpt for your post — ask for a different length or tone if you’d like:',
 				'jetpack'
 			) }
-			options={ excerpts.map( ( option ) => option.excerpt ) }
+			options={ options }
 			onApply={ handleApply }
 			appliedMessage={ __( 'Excerpt updated.', 'jetpack' ) }
 			currentValue={ typeof currentExcerpt === 'string' ? currentExcerpt : undefined }

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
@@ -1,0 +1,69 @@
+/**
+ * ExcerptPicker — renders post excerpt suggestions in the chat sidebar.
+ *
+ * Displayed when the orchestrator renders a show-component response with
+ * data.type set to 'excerpt-picker' (from the jetpack-ai/generate-excerpt
+ * ability). Clicking a card applies it to the post excerpt via editPost.
+ * Thin wrapper over the shared BaseSuggestionPicker.
+ */
+
+/**
+ * External dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import BaseSuggestionPicker from './base-suggestion-picker';
+
+/**
+ * Props for the ExcerptPicker component.
+ */
+interface ExcerptOption {
+	excerpt: string;
+	explanation?: string;
+}
+
+interface ExcerptPickerProps {
+	excerpts: ExcerptOption[];
+	onComplete?: () => void;
+}
+
+/**
+ * ExcerptPicker component for the chat sidebar.
+ * @param {ExcerptPickerProps} props - Component props.
+ * @returns {import('react').ReactElement} The rendered component.
+ */
+export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerProps ) {
+	const { editPost } = useDispatch( 'core/editor' );
+	const currentExcerpt = useSelect( ( select ) => {
+		return (
+			select( 'core/editor' ) as {
+				getEditedPostAttribute?: ( attr: string ) => unknown;
+			}
+		 )?.getEditedPostAttribute?.( 'excerpt' );
+	}, [] );
+
+	const handleApply = useCallback(
+		( excerpt: string ) => {
+			editPost( { excerpt } );
+			onComplete?.();
+		},
+		[ editPost, onComplete ]
+	);
+
+	return (
+		<BaseSuggestionPicker
+			intro={ __(
+				'Choose an excerpt for your post — ask for a different length or tone if you’d like:',
+				'jetpack'
+			) }
+			options={ excerpts.map( ( option ) => option.excerpt ) }
+			onApply={ handleApply }
+			appliedMessage={ __( 'Excerpt updated.', 'jetpack' ) }
+			currentValue={ typeof currentExcerpt === 'string' ? currentExcerpt : undefined }
+		/>
+	);
+}

--- a/packages/jetpack-ai-sidebar/src/global.d.ts
+++ b/packages/jetpack-ai-sidebar/src/global.d.ts
@@ -26,6 +26,7 @@ declare const agentsManagerData:
 					blockToolbarButton?: boolean;
 					optimizeTitleSuggestion?: boolean;
 					seoSuggestions?: boolean;
+					excerptSuggestion?: boolean;
 				};
 			};
 	  }

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -183,7 +183,11 @@ function installWpDataMock( initialTitle: string, postId = 123, initialExcerpt =
 	return state;
 }
 
-function installPostTypeMock( postType?: string, postId: number | null = 123 ) {
+function installPostTypeMock(
+	postType?: string,
+	postId: number | null = 123,
+	supportsExcerpt: boolean = postType === 'post'
+) {
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
@@ -198,6 +202,12 @@ function installPostTypeMock( postType?: string, postId: number | null = 123 ) {
 						getSelectedBlock: () => mockSelectedBlock,
 						getBlock: ( clientId: string ) => mockBlocksByClientId[ clientId ],
 						getBlocks: () => [],
+					};
+				}
+				if ( store === 'core' ) {
+					return {
+						getPostType: ( name: string ) =>
+							name === postType ? { supports: { excerpt: supportsExcerpt } } : undefined,
 					};
 				}
 				return undefined;
@@ -1104,6 +1114,45 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( labels ).not.toContain( 'Optimize Title' );
 		expect( labels ).toContain( 'AI Editorial Review' );
 		expect( labels ).not.toContain( 'Generate Feedback' );
+	} );
+
+	it( 'shows Generate Excerpt when the excerptSuggestion feature is enabled', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		installPostTypeMock( 'post' );
+
+		const excerptChip = getEmptyViewSuggestions().find(
+			( suggestion ) => suggestion.id === 'generate-excerpt'
+		);
+
+		expect( excerptChip?.label ).toBe( 'Generate Excerpt' );
+		expect( excerptChip?.prompt ).toBe( 'Generate an excerpt for this post' );
+	} );
+
+	it( 'hides Generate Excerpt when the feature is disabled', () => {
+		installAiEditorialReviewData( { excerptSuggestion: false } );
+		installPostTypeMock( 'post' );
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-excerpt' );
+	} );
+
+	it( 'hides Generate Excerpt when the post type does not support excerpts', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		installPostTypeMock( 'page' );
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-excerpt' );
+	} );
+
+	it( 'hides Generate Excerpt until the post type is known', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		installPostTypeMock();
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-excerpt' );
 	} );
 
 	it( 'shows the SEO Enhancer dropdown when the seoSuggestions feature is enabled', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -142,16 +142,23 @@ jest.mock( '@wordpress/data', () => ( {
 
 // Stub @wordpress/data on window so useCheckpoint / handleShowComponent
 // can read/write the post title and current post id via the core/editor store.
-function installWpDataMock( initialTitle: string, postId = 123 ) {
-	const state = { title: initialTitle };
+function installWpDataMock( initialTitle: string, postId = 123, initialExcerpt = '' ) {
+	const state = { title: initialTitle, excerpt: initialExcerpt };
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
 				if ( store === 'core/editor' ) {
 					return {
 						getCurrentPostId: () => postId,
-						getEditedPostAttribute: ( attr: string ) =>
-							attr === 'title' ? state.title : undefined,
+						getEditedPostAttribute: ( attr: string ) => {
+							if ( attr === 'title' ) {
+								return state.title;
+							}
+							if ( attr === 'excerpt' ) {
+								return state.excerpt;
+							}
+							return undefined;
+						},
 					};
 				}
 				return undefined;
@@ -159,9 +166,12 @@ function installWpDataMock( initialTitle: string, postId = 123 ) {
 			dispatch: ( store: string ) => {
 				if ( store === 'core/editor' ) {
 					return {
-						editPost: ( attrs: { title?: string } ) => {
+						editPost: ( attrs: { title?: string; excerpt?: string } ) => {
 							if ( typeof attrs.title === 'string' ) {
 								state.title = attrs.title;
+							}
+							if ( typeof attrs.excerpt === 'string' ) {
+								state.excerpt = attrs.excerpt;
 							}
 						},
 					};
@@ -2156,6 +2166,25 @@ describe( 'useCheckpoint', () => {
 
 		// Restore.
 		await api.restoreCheckpoint( 'cp-1' );
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
+		).toBe( 'Original Title' );
+	} );
+
+	it( 'snapshots the post excerpt alongside the title and restores both', async () => {
+		installWpDataMock( 'Original Title', 123, 'Original excerpt' );
+		const api = useCheckpoint();
+
+		api.setCheckpoint( 'cp-excerpt' );
+
+		( window as any ).wp.data
+			.dispatch( 'core/editor' )
+			.editPost( { title: 'AI Title', excerpt: 'AI generated excerpt' } );
+		await api.restoreCheckpoint( 'cp-excerpt' );
+
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'excerpt' )
+		).toBe( 'Original excerpt' );
 		expect(
 			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
 		).toBe( 'Original Title' );

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -186,7 +186,8 @@ function installWpDataMock( initialTitle: string, postId = 123, initialExcerpt =
 function installPostTypeMock(
 	postType?: string,
 	postId: number | null = 123,
-	supportsExcerpt: boolean = postType === 'post'
+	supportsExcerpt: boolean = postType === 'post',
+	postTypeRecordResolved = true
 ) {
 	( window as any ).wp = {
 		data: {
@@ -207,7 +208,9 @@ function installPostTypeMock(
 				if ( store === 'core' ) {
 					return {
 						getPostType: ( name: string ) =>
-							name === postType ? { supports: { excerpt: supportsExcerpt } } : undefined,
+							postTypeRecordResolved && name === postType
+								? { supports: { excerpt: supportsExcerpt } }
+								: undefined,
 					};
 				}
 				return undefined;
@@ -1149,6 +1152,24 @@ describe( 'getEmptyViewSuggestions', () => {
 	it( 'hides Generate Excerpt until the post type is known', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		installPostTypeMock();
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-excerpt' );
+	} );
+
+	it( 'shows Generate Excerpt for posts while the post type record is still resolving', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		installPostTypeMock( 'post', 123, true, false );
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-excerpt' );
+	} );
+
+	it( 'hides Generate Excerpt for pages while the post type record is still resolving', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		installPostTypeMock( 'page', 123, false, false );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
@@ -2220,15 +2241,15 @@ describe( 'useCheckpoint', () => {
 		).toBe( 'Original Title' );
 	} );
 
-	it( 'snapshots the post excerpt alongside the title and restores both', async () => {
+	it( 'restores only the excerpt for an excerpt checkpoint, leaving later title edits intact', async () => {
 		installWpDataMock( 'Original Title', 123, 'Original excerpt' );
 		const api = useCheckpoint();
 
-		api.setCheckpoint( 'cp-excerpt' );
+		api.setCheckpoint( 'cp-excerpt', [ 'excerpt' ] );
 
 		( window as any ).wp.data
 			.dispatch( 'core/editor' )
-			.editPost( { title: 'AI Title', excerpt: 'AI generated excerpt' } );
+			.editPost( { title: 'Edited Title', excerpt: 'AI generated excerpt' } );
 		await api.restoreCheckpoint( 'cp-excerpt' );
 
 		expect(
@@ -2236,7 +2257,26 @@ describe( 'useCheckpoint', () => {
 		).toBe( 'Original excerpt' );
 		expect(
 			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
+		).toBe( 'Edited Title' );
+	} );
+
+	it( 'restores only the title for a default checkpoint, leaving later excerpt edits intact', async () => {
+		installWpDataMock( 'Original Title', 123, 'Original excerpt' );
+		const api = useCheckpoint();
+
+		api.setCheckpoint( 'cp-title' );
+
+		( window as any ).wp.data
+			.dispatch( 'core/editor' )
+			.editPost( { title: 'AI Title', excerpt: 'User excerpt' } );
+		await api.restoreCheckpoint( 'cp-title' );
+
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
 		).toBe( 'Original Title' );
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'excerpt' )
+		).toBe( 'User excerpt' );
 	} );
 
 	it( 'keeps the checkpoint after restore so Undo can be used repeatedly', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1158,6 +1158,28 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( ids ).not.toContain( 'generate-excerpt' );
 	} );
 
+	it( 'shows Generate Excerpt on pages when the page post type supports excerpts', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		// WordPress.com Simple / any site with the Jetpack SEO Tools module adds
+		// excerpt support to pages — the legacy AI Excerpt panel shows there too.
+		installPostTypeMock( 'page', 123, true );
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-excerpt' );
+	} );
+
+	it( 'hides Generate Excerpt for templates and patterns even though they support excerpts', () => {
+		installAiEditorialReviewData( { excerptSuggestion: true } );
+		// Core registers excerpt support for wp_block (patterns), but the excerpt
+		// field acts as a description there — the legacy panel excludes these types.
+		installPostTypeMock( 'wp_block', 123, true );
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-excerpt' );
+	} );
+
 	it( 'shows Generate Excerpt for posts while the post type record is still resolving', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		installPostTypeMock( 'post', 123, true, false );

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -10,6 +10,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
+import ExcerptPicker from './components/excerpt-picker';
 import ImageAltTextPicker from './components/image-alt-text-picker';
 import PostFeedback from './components/post-feedback';
 import Proofread from './components/proofread';
@@ -310,6 +311,10 @@ describe( 'getChatComponent', () => {
 
 	it( 'returns ImageAltTextPicker for type "image-alt-text-picker"', () => {
 		expect( getChatComponent( 'image-alt-text-picker' ) ).toBe( ImageAltTextPicker );
+	} );
+
+	it( 'returns ExcerptPicker for type "excerpt-picker"', () => {
+		expect( getChatComponent( 'excerpt-picker' ) ).toBe( ExcerptPicker );
 	} );
 
 	it( 'returns null for an unknown type', () => {
@@ -1956,6 +1961,20 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.type ).toBe( 'seo-description-picker' );
 			expect( parsed.data.props ).toEqual( { descriptions } );
 			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_seo_desc' );
+		} );
+
+		it( 'returns an agentMessage envelope with an Undo checkpoint for an excerpt-picker call', async () => {
+			const excerpts = [ { excerpt: 'A short summary.', explanation: 'a' } ];
+			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
+				type: 'excerpt-picker',
+				props: { excerpts },
+				toolCallId: 'call_excerpt',
+			} ) ) as any;
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( parsed.data.type ).toBe( 'excerpt-picker' );
+			expect( parsed.data.props ).toEqual( { excerpts } );
+			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_excerpt' );
 		} );
 
 		it( 'returns an agentMessage envelope with an Undo checkpoint for an image-alt-text-picker call', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -719,33 +719,40 @@ export function getChatComponent( type: string ): ComponentType | null {
 
 /**
  * Provider hook consumed by AM's `use-checkpoint-action` so Undo buttons
- * can attach to show-component messages. Snapshots the post title on
- * `setCheckpoint(id)` and restores it on `restoreCheckpoint(id)` via
+ * can attach to show-component messages. Snapshots the post title and excerpt
+ * on `setCheckpoint(id)` and restores them on `restoreCheckpoint(id)` via
  * `core/editor` dispatch. Stubs the rest of AM's `UseCheckpointReturn`
  * interface — only the three methods above are used on this path.
  * @returns {Object} The checkpoint API AM consumes.
  */
-const titleSnapshots: Map< string, string > = new Map();
+// Snapshots cover every post field the pickers can write (title, excerpt).
+// Restoring a checkpoint resets all snapshot fields to their tool-call-time
+// values, matching the snapshot-at-tool-call model used for the title.
+const postSnapshots: Map< string, { title: string; excerpt: string } > = new Map();
 
 export function useCheckpoint(): any {
 	const api: CheckpointApi = {
 		setCheckpoint( id: string ) {
-			const wpData = ( window as any ).wp?.data;
-			const current =
-				( wpData?.select?.( 'core/editor' )?.getEditedPostAttribute?.( 'title' ) as string ) ?? '';
-			titleSnapshots.set( id, current );
+			const editor = ( window as any ).wp?.data?.select?.( 'core/editor' );
+			postSnapshots.set( id, {
+				title: ( editor?.getEditedPostAttribute?.( 'title' ) as string ) ?? '',
+				excerpt: ( editor?.getEditedPostAttribute?.( 'excerpt' ) as string ) ?? '',
+			} );
 		},
 		hasCheckpoint( id: string ): boolean {
-			return titleSnapshots.has( id );
+			return postSnapshots.has( id );
 		},
 		async restoreCheckpoint( id: string ): Promise< void > {
-			const previous = titleSnapshots.get( id );
+			const previous = postSnapshots.get( id );
 			if ( previous === undefined ) {
 				return;
 			}
 			const wpData = ( window as any ).wp?.data;
-			wpData?.dispatch?.( 'core/editor' )?.editPost?.( { title: previous } );
-			// Keep snapshot so the user can re-Undo back to the original title.
+			wpData?.dispatch?.( 'core/editor' )?.editPost?.( {
+				title: previous.title,
+				excerpt: previous.excerpt,
+			} );
+			// Keep snapshot so the user can re-Undo back to the original values.
 			// clearCheckpoint() removes it when AM resets the session.
 		},
 	};
@@ -763,7 +770,7 @@ export function useCheckpoint(): any {
 		addPageRemovalToCheckpoint: () => undefined,
 		getLatestUserMessageId: () => undefined,
 		clearCheckpoint: ( id: string ) => {
-			titleSnapshots.delete( id );
+			postSnapshots.delete( id );
 		},
 	};
 }

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -15,6 +15,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import ExcerptPicker from './components/excerpt-picker';
 import './components/feedback-list.scss';
 import ImageAltTextPicker from './components/image-alt-text-picker';
 import './components/image-alt-text-picker.scss';
@@ -372,6 +373,7 @@ function handleShowComponent( input: any ): any {
 
 	if (
 		type === 'title-picker' ||
+		type === 'excerpt-picker' ||
 		type === 'seo-title-picker' ||
 		type === 'seo-description-picker' ||
 		type === 'image-alt-text-picker'
@@ -686,6 +688,9 @@ export const contextProvider = {
  * @returns {ComponentType|null} The matching component, or null.
  */
 export function getChatComponent( type: string ): ComponentType | null {
+	if ( type === 'excerpt-picker' ) {
+		return ExcerptPicker as ComponentType;
+	}
 	if ( type === 'title-picker' ) {
 		return TitlePicker as ComponentType;
 	}

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -30,6 +30,7 @@ import TitlePicker from './components/title-picker';
 import './auto-scroll-fix.scss';
 import {
 	type CheckpointApi,
+	type CheckpointField,
 	applyReviewEdit,
 	findBlockElement,
 	findBlockListLayout,
@@ -199,6 +200,25 @@ function getCurrentEditorPostId(): number | undefined {
 	return typeof postId === 'number' && postId > 0 ? postId : undefined;
 }
 
+/**
+ * Whether a post type supports excerpts, given its (possibly still-resolving)
+ * core store record. While the record is unresolved, fall back to the core
+ * default — only 'post' supports excerpts — so one-shot callers (the empty
+ * view suggestions) don't permanently hide the chip on a slow resolution.
+ */
+function postTypeRecordSupportsExcerpt(
+	currentPostType: string | undefined,
+	postTypeRecord: { supports?: Record< string, boolean > } | undefined
+): boolean {
+	if ( ! currentPostType ) {
+		return false;
+	}
+	if ( ! postTypeRecord ) {
+		return currentPostType === 'post';
+	}
+	return postTypeRecord.supports?.excerpt === true;
+}
+
 function currentPostTypeSupportsExcerpt(
 	currentPostType: string | undefined = getCurrentEditorPostType()
 ): boolean {
@@ -208,14 +228,19 @@ function currentPostTypeSupportsExcerpt(
 	const postTypeRecord = ( window as any ).wp?.data
 		?.select?.( 'core' )
 		?.getPostType?.( currentPostType );
-	return postTypeRecord?.supports?.excerpt === true;
+	return postTypeRecordSupportsExcerpt( currentPostType, postTypeRecord );
 }
 
 function isExcerptSuggestionAvailable(
 	currentPostType: string | undefined = getCurrentEditorPostType(),
-	supportsExcerpt: boolean = currentPostTypeSupportsExcerpt( currentPostType )
+	supportsExcerpt?: boolean
 ): boolean {
-	return isExcerptSuggestionEnabled() && supportsExcerpt;
+	// Check the flag first: on flag-off sites the core-store getPostType read
+	// (which can trigger a REST resolution) never runs.
+	if ( ! isExcerptSuggestionEnabled() ) {
+		return false;
+	}
+	return supportsExcerpt ?? currentPostTypeSupportsExcerpt( currentPostType );
 }
 
 function isAiEditorialReviewAvailable(
@@ -419,13 +444,17 @@ function handleShowComponent( input: any ): any {
 	) {
 		// Snapshot state for Undo (these pickers mutate post data / block
 		// attributes). Tool call id doubles as the checkpoint id so it matches
-		// the identifier AM reads from the rendered message.
+		// the identifier AM reads from the rendered message. Only the fields
+		// this picker can write are snapshot, so restoring its checkpoint
+		// cannot clobber later edits to other fields.
+		const checkpointFields: CheckpointField[] =
+			type === 'excerpt-picker' ? [ 'excerpt' ] : [ 'title' ];
 		const checkpointId: string =
 			input?.toolCallId || input?.calypsoCheckpointId || `show-component-${ type }-${ Date.now() }`;
 		const checkpointApi = getModuleCheckpointApi();
 		if ( checkpointApi && ! checkpointApi.hasCheckpoint( checkpointId ) ) {
 			try {
-				checkpointApi.setCheckpoint( checkpointId );
+				checkpointApi.setCheckpoint( checkpointId, checkpointFields );
 			} catch {
 				// Non-fatal — Undo just won't attach if the snapshot fails.
 			}
@@ -758,25 +787,26 @@ export function getChatComponent( type: string ): ComponentType | null {
 
 /**
  * Provider hook consumed by AM's `use-checkpoint-action` so Undo buttons
- * can attach to show-component messages. Snapshots the post title and excerpt
- * on `setCheckpoint(id)` and restores them on `restoreCheckpoint(id)` via
- * `core/editor` dispatch. Stubs the rest of AM's `UseCheckpointReturn`
- * interface — only the three methods above are used on this path.
+ * can attach to show-component messages. Snapshots the post fields the
+ * triggering picker can write (title by default, excerpt for the excerpt
+ * picker) on `setCheckpoint(id, fields)` and restores exactly those fields on
+ * `restoreCheckpoint(id)` via `core/editor` dispatch — restoring one picker's
+ * checkpoint must not clobber another field's later edits. Stubs the rest of
+ * AM's `UseCheckpointReturn` interface — only the three methods above are
+ * used on this path.
  * @returns {Object} The checkpoint API AM consumes.
  */
-// Snapshots cover every post field the pickers can write (title, excerpt).
-// Restoring a checkpoint resets all snapshot fields to their tool-call-time
-// values, matching the snapshot-at-tool-call model used for the title.
-const postSnapshots: Map< string, { title: string; excerpt: string } > = new Map();
+const postSnapshots: Map< string, Partial< Record< CheckpointField, string > > > = new Map();
 
 export function useCheckpoint(): any {
 	const api: CheckpointApi = {
-		setCheckpoint( id: string ) {
+		setCheckpoint( id: string, fields: CheckpointField[] = [ 'title' ] ) {
 			const editor = ( window as any ).wp?.data?.select?.( 'core/editor' );
-			postSnapshots.set( id, {
-				title: ( editor?.getEditedPostAttribute?.( 'title' ) as string ) ?? '',
-				excerpt: ( editor?.getEditedPostAttribute?.( 'excerpt' ) as string ) ?? '',
-			} );
+			const snapshot: Partial< Record< CheckpointField, string > > = {};
+			for ( const field of fields ) {
+				snapshot[ field ] = ( editor?.getEditedPostAttribute?.( field ) as string ) ?? '';
+			}
+			postSnapshots.set( id, snapshot );
 		},
 		hasCheckpoint( id: string ): boolean {
 			return postSnapshots.has( id );
@@ -787,10 +817,7 @@ export function useCheckpoint(): any {
 				return;
 			}
 			const wpData = ( window as any ).wp?.data;
-			wpData?.dispatch?.( 'core/editor' )?.editPost?.( {
-				title: previous.title,
-				excerpt: previous.excerpt,
-			} );
+			wpData?.dispatch?.( 'core/editor' )?.editPost?.( { ...previous } );
 			// Keep snapshot so the user can re-Undo back to the original values.
 			// clearCheckpoint() removes it when AM resets the session.
 		},
@@ -1080,9 +1107,10 @@ export function useSuggestions(
 			selectedBlock: blockEditor?.getSelectedBlock?.() ?? null,
 			postId: editor?.getCurrentPostId?.(),
 			postType,
-			supportsExcerpt: postType
-				? core?.getPostType?.( postType )?.supports?.excerpt === true
-				: false,
+			supportsExcerpt:
+				postType && isExcerptSuggestionEnabled()
+					? postTypeRecordSupportsExcerpt( postType, core?.getPostType?.( postType ) )
+					: false,
 		};
 	}, [] );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -454,9 +454,10 @@ function handleShowComponent( input: any ): any {
 	) {
 		// Snapshot state for Undo (these pickers mutate post data / block
 		// attributes). Tool call id doubles as the checkpoint id so it matches
-		// the identifier AM reads from the rendered message. Only the fields
-		// this picker can write are snapshot, so restoring its checkpoint
-		// cannot clobber later edits to other fields.
+		// the identifier AM reads from the rendered message. Only the
+		// supported post fields for this picker are snapshot (title/excerpt —
+		// meta and block-attribute changes aren't checkpointed), so restoring
+		// its checkpoint cannot clobber later edits to other fields.
 		const checkpointFields: CheckpointField[] =
 			type === 'excerpt-picker' ? [ 'excerpt' ] : [ 'title' ];
 		const checkpointId: string =
@@ -797,13 +798,15 @@ export function getChatComponent( type: string ): ComponentType | null {
 
 /**
  * Provider hook consumed by AM's `use-checkpoint-action` so Undo buttons
- * can attach to show-component messages. Snapshots the post fields the
- * triggering picker can write (title by default, excerpt for the excerpt
- * picker) on `setCheckpoint(id, fields)` and restores exactly those fields on
+ * can attach to show-component messages. Snapshots the selected top-level
+ * post fields (title by default, excerpt for the excerpt picker) on
+ * `setCheckpoint(id, fields)` and restores exactly those fields on
  * `restoreCheckpoint(id)` via `core/editor` dispatch — restoring one picker's
- * checkpoint must not clobber another field's later edits. Stubs the rest of
- * AM's `UseCheckpointReturn` interface — only the three methods above are
- * used on this path.
+ * checkpoint must not clobber another field's later edits. Only title and
+ * excerpt are supported: meta (SEO pickers) and block-attribute (image alt
+ * text) changes are not checkpointed. Stubs the rest of AM's
+ * `UseCheckpointReturn` interface — only the three methods above are used on
+ * this path.
  * @returns {Object} The checkpoint API AM consumes.
  */
 const postSnapshots: Map< string, Partial< Record< CheckpointField, string > > > = new Map();

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -231,6 +231,13 @@ function currentPostTypeSupportsExcerpt(
 	return postTypeRecordSupportsExcerpt( currentPostType, postTypeRecord );
 }
 
+/**
+ * Post types where the excerpt field acts as a description (templates,
+ * template parts, patterns). Core registers excerpt support for wp_block, but
+ * the legacy AI Excerpt panel excludes these types and so does the chip.
+ */
+const EXCERPT_EXCLUDED_POST_TYPES = [ 'wp_template', 'wp_template_part', 'wp_block' ];
+
 function isExcerptSuggestionAvailable(
 	currentPostType: string | undefined = getCurrentEditorPostType(),
 	supportsExcerpt?: boolean
@@ -238,6 +245,9 @@ function isExcerptSuggestionAvailable(
 	// Check the flag first: on flag-off sites the core-store getPostType read
 	// (which can trigger a REST resolution) never runs.
 	if ( ! isExcerptSuggestionEnabled() ) {
+		return false;
+	}
+	if ( ! currentPostType || EXCERPT_EXCLUDED_POST_TYPES.includes( currentPostType ) ) {
 		return false;
 	}
 	return supportsExcerpt ?? currentPostTypeSupportsExcerpt( currentPostType );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -48,6 +48,7 @@ import {
 import {
 	isAiEditorialReviewEnabled,
 	isBlockTransformationsEnabled,
+	isExcerptSuggestionEnabled,
 	isGenerateFeedbackEnabled,
 	isProofreadEnabled,
 	isOptimizeTitleSuggestionEnabled,
@@ -94,6 +95,18 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
 	label: __( 'Optimize Title', 'jetpack' ),
 	prompt: __( 'Optimize the title of this post', 'jetpack' ),
+};
+
+/**
+ * Post-level suggestion to generate the post excerpt. Routes through the
+ * orchestrator to the jetpack-ai/generate-excerpt ability, which returns the
+ * excerpt picker. The prompt is deliberately parameter-free: words/tone
+ * defaults live server-side, and the picker intro invites adjustments.
+ */
+const GENERATE_EXCERPT_SUGGESTION = {
+	id: 'generate-excerpt',
+	label: __( 'Generate Excerpt', 'jetpack' ),
+	prompt: __( 'Generate an excerpt for this post', 'jetpack' ),
 };
 
 /**
@@ -186,6 +199,25 @@ function getCurrentEditorPostId(): number | undefined {
 	return typeof postId === 'number' && postId > 0 ? postId : undefined;
 }
 
+function currentPostTypeSupportsExcerpt(
+	currentPostType: string | undefined = getCurrentEditorPostType()
+): boolean {
+	if ( ! currentPostType ) {
+		return false;
+	}
+	const postTypeRecord = ( window as any ).wp?.data
+		?.select?.( 'core' )
+		?.getPostType?.( currentPostType );
+	return postTypeRecord?.supports?.excerpt === true;
+}
+
+function isExcerptSuggestionAvailable(
+	currentPostType: string | undefined = getCurrentEditorPostType(),
+	supportsExcerpt: boolean = currentPostTypeSupportsExcerpt( currentPostType )
+): boolean {
+	return isExcerptSuggestionEnabled() && supportsExcerpt;
+}
+
 function isAiEditorialReviewAvailable(
 	// Default arguments run at call time, so callers can omit this when they
 	// want the current editor state read live.
@@ -223,9 +255,16 @@ function getAiEditorialReviewSuggestions( currentPostType?: string ) {
 	return [ AI_EDITORIAL_REVIEW_SUGGESTION ];
 }
 
-function getPostLevelSuggestions( currentPostType?: string, currentPostId?: number | null ) {
+function getPostLevelSuggestions(
+	currentPostType?: string,
+	currentPostId?: number | null,
+	supportsExcerpt?: boolean
+) {
 	return [
 		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
+		...( isExcerptSuggestionAvailable( currentPostType, supportsExcerpt )
+			? [ GENERATE_EXCERPT_SUGGESTION ]
+			: [] ),
 		...( isGenerateFeedbackAvailable( currentPostType, currentPostId )
 			? [ POST_FEEDBACK_SUGGESTION ]
 			: [] ),
@@ -1033,10 +1072,17 @@ export function useSuggestions(
 			getCurrentPostId?: () => number | null | undefined;
 			getCurrentPostType?: () => string | undefined;
 		};
+		const core = select( 'core' ) as {
+			getPostType?: ( name: string ) => { supports?: Record< string, boolean > } | undefined;
+		};
+		const postType = editor?.getCurrentPostType?.();
 		return {
 			selectedBlock: blockEditor?.getSelectedBlock?.() ?? null,
 			postId: editor?.getCurrentPostId?.(),
-			postType: editor?.getCurrentPostType?.(),
+			postType,
+			supportsExcerpt: postType
+				? core?.getPostType?.( postType )?.supports?.excerpt === true
+				: false,
 		};
 	}, [] );
 
@@ -1047,8 +1093,13 @@ export function useSuggestions(
 
 	const selectedBlock = editorContext.selectedBlock;
 	const postLevelSuggestions = useMemo(
-		() => getPostLevelSuggestions( editorContext.postType, editorContext.postId ),
-		[ editorContext.postId, editorContext.postType ]
+		() =>
+			getPostLevelSuggestions(
+				editorContext.postType,
+				editorContext.postId,
+				editorContext.supportsExcerpt
+			),
+		[ editorContext.postId, editorContext.postType, editorContext.supportsExcerpt ]
 	);
 	const blockTransformationsEnabled = isBlockTransformationsEnabled();
 	const applicable = useMemo(

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -11,11 +11,18 @@ import { dispatch, select } from '@wordpress/data';
 import { countOccurrences } from './blocks';
 
 /**
+ * Post fields a picker checkpoint can snapshot and restore.
+ */
+export type CheckpointField = 'title' | 'excerpt';
+
+/**
  * Checkpoint API shared between the React `useCheckpoint` hook (which AM
- * calls) and the synchronous `handleShowComponent` callback.
+ * calls) and the synchronous `handleShowComponent` callback. `setCheckpoint`
+ * captures only the fields the triggering picker can write, so restoring one
+ * picker's checkpoint never clobbers another field's later edits.
  */
 export interface CheckpointApi {
-	setCheckpoint: ( id: string ) => void;
+	setCheckpoint: ( id: string, fields?: CheckpointField[] ) => void;
 	hasCheckpoint: ( id: string ) => boolean;
 	restoreCheckpoint: ( id: string ) => Promise< void >;
 }

--- a/packages/jetpack-ai-sidebar/src/utils/preview-features.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/preview-features.ts
@@ -5,7 +5,8 @@ type SidebarFeature =
 	| 'blockTransformations'
 	| 'blockToolbarButton'
 	| 'optimizeTitleSuggestion'
-	| 'seoSuggestions';
+	| 'seoSuggestions'
+	| 'excerptSuggestion';
 
 function getAgentsManagerData() {
 	return typeof agentsManagerData !== 'undefined' ? agentsManagerData : undefined;
@@ -38,6 +39,14 @@ export function isOptimizeTitleSuggestionEnabled(): boolean {
  */
 export function isSeoSuggestionsEnabled(): boolean {
 	return isSidebarFeatureEnabled( 'seoSuggestions', false );
+}
+
+/**
+ * Generate Excerpt suggestion (jetpack-ai/generate-excerpt via the excerpt
+ * picker). The host (Jetpack) populates `features.excerptSuggestion`.
+ */
+export function isExcerptSuggestionEnabled(): boolean {
+	return isSidebarFeatureEnabled( 'excerptSuggestion', false );
 }
 
 export function isBlockTransformationsEnabled(): boolean {


### PR DESCRIPTION
Part of FORNO-309

## Proposed Changes

* Add an `ExcerptPicker` chat component (thin `BaseSuggestionPicker` wrapper): renders the excerpt options returned by the new wpcom `jetpack-ai/generate-excerpt` ability, applies the chosen one via `editPost( { excerpt } )`, derives applied state from the live post excerpt, and guards against malformed orchestrator payloads.
* Register the `excerpt-picker` show-component type in `getChatComponent()` and in the Undo checkpoint list.
* Scope Undo checkpoints per picker field: snapshots now capture only the field the triggering picker writes (title by default, excerpt for the excerpt picker), so restoring one picker's checkpoint can no longer clobber another field's later edits.
* Add a "Generate Excerpt" post-level suggestion chip, gated by the new `excerptSuggestion` preview feature flag (populated by the host — companion Jetpack PR) and by post-type excerpt support (same predicate as the legacy panel's `PostTypeSupportCheck supportKeys="excerpt"`), with a resolving-record fallback so the one-shot empty view doesn't miss the chip.

<img width="724" height="907" alt="image" src="https://github.com/user-attachments/assets/11ec52fa-bb06-4ed2-8058-d9c0c72c31e3" />


## Why are these changes being made?

* FORNO-309 migrates the AI Excerpt (Content Lens) feature to the orchestrator-backed sidebar, following the Title Optimization and SEO Enhancer migrations. Length/tone controls move from panel widgets to natural language (the ability's `words`/`tone` inputs); the picker intro invites adjustments conversationally. This PR is inert until the Jetpack `excerptSuggestion` flag ships (companion PRs below).
* Companion PRs: wpcom PR 226823 (internal — the `jetpack-ai/generate-excerpt` ability) and Jetpack https://github.com/Automattic/jetpack/pull/50254 (feature flag).

## Testing Instructions

* `yarn test-packages packages/jetpack-ai-sidebar` — 242 tests across 13 suites (picker rendering/apply/applied-state/malformed props, registry, per-field checkpoint restore, chip gating on flag + post-type support + resolving records).
* `yarn workspace @automattic/jetpack-ai-sidebar typecheck`
* Manual (internal testing environment, with the companion wpcom + Jetpack PRs): in the post editor open the Jetpack AI sidebar → the "Generate Excerpt" chip appears with no block selected → clicking it renders the excerpt picker → applying an option updates the excerpt in the post settings panel → AM's Undo on the picker message restores the previous excerpt without touching the title.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


