### PR TITLE
domains-table: de-flake row href assertions by widening the async waitFor window

### DIFF
--- a/packages/domains-table/jest.config.js
+++ b/packages/domains-table/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	setupFilesAfterEnv: [ '@automattic/calypso-build/jest/mocks/match-media' ],
+	setupFilesAfterEnv: [
+		'@automattic/calypso-build/jest/mocks/match-media',
+		'<rootDir>/jest.setup.js',
+	],
 };

--- a/packages/domains-table/jest.setup.js
+++ b/packages/domains-table/jest.setup.js
@@ -1,0 +1,8 @@
+const { configure } = require( '@testing-library/react' );
+
+// Domain-row assertions wait on an async React Query transition: the link href starts with the
+// numeric blog_id and switches to the site slug once the site query resolves. RTL's default 1000ms
+// waitFor window occasionally times out on the stale blog_id under a rare CI event-loop stall.
+// Measured CI transition latency tops out ~200ms over 500 samples, so 2000ms (2x the flaky default,
+// ~10x the measured tail) absorbs the rare stall without over-provisioning.
+configure( { asyncUtilTimeout: 2000 } );


### PR DESCRIPTION
_No linked issue._

## Proposed Changes

* Raise React Testing Library's `asyncUtilTimeout` from the 1000ms default to 2000ms for the `packages/domains-table` unit tests, via a new `jest.setup.js` wired into the package `jest.config.js`.

## Why are these changes being made?

The domain-row link href is rendered from an async React Query transition: it starts with the numeric `blog_id` (`/domains/manage/example.com/edit/123`) and switches to the site slug (`/edit/my-site.com`) once the site query resolves. The row tests assert the resolved slug with `waitFor`. RTL's default 1000ms window can time out on the stale `blog_id` under a rare CI event-loop stall, flaking those assertions.

Sizing is data-backed, not a guess. A throwaway timing probe run across 500 samples on 5 CI unit-test builds put the transition latency at ~25ms median and ~200ms worst case (0 of 500 exceeded even 500ms). 2000ms is 2x the known-flaky default and ~10x the measured tail: enough to absorb a rare stall without over-provisioning. The value cannot drop to 1000ms or below, that is the window that already flakes.

No per-test `testTimeout` override is needed: with a 2000ms async ceiling a failing `waitFor` caps at 2000ms, and a test fails on its first ceiling-hit, so Jest's default 5000ms `testTimeout` stays comfortably above it.

## Testing Instructions

* `yarn jest --config packages/domains-table/jest.config.js packages/domains-table` passes (70/70).
* The change only widens the async assertion window for this package; it does not alter product code or test behavior, so no functional regression surface.
