### PR TITLE
Dashboard: add a language switcher to the interim omnibar in support sessions

### DIFF
--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -2,6 +2,7 @@ import { defaultI18n, type I18n, type LocaleData } from '@wordpress/i18n';
 import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
 import { useEffect, useState, type PropsWithChildren } from 'react';
 import { useAuth } from './auth';
+import { useSessionLocale } from './locale/session-locale';
 import { getUserLanguage } from './shared-locale-loader';
 
 async function fetchLocaleData(
@@ -141,12 +142,12 @@ async function switchWebpackCSS( isRTL: boolean ) {
 	}
 }
 
-// Determine the locale to use. The current implementation reads the logged-in user's
-// locale, but it can be made more flexible and support multiple sources. E.g., a locale
-// slug in the route path.
+// Determine the locale to use. A session locale (set by the omnibar language
+// switcher) takes precedence over the logged-in user's saved locale.
 function useLocaleSlug() {
 	const { user } = useAuth();
-	return getUserLanguage( user );
+	const sessionLocale = useSessionLocale();
+	return sessionLocale ?? getUserLanguage( user );
 }
 
 export function I18nProvider( { children }: PropsWithChildren ) {

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -6,6 +6,7 @@ import {
 	siteHourlyViewsQuery,
 } from '@automattic/api-queries';
 import { isEcommercePlan } from '@automattic/calypso-products';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { localize } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -18,6 +19,7 @@ import { isSimple } from '../../utils/site-types';
 import { getSitePlanUrl } from '../../utils/site-url';
 import { logout } from '../auth';
 import { omnibarEvents, useOmnibarEvent } from '../omnibar/events';
+import { getUserLanguage } from '../shared-locale-loader';
 import { OmnibarLaunchButton } from './omnibar-launch-button';
 import { createOmnibarStore } from './omnibar-store';
 import type { User, Site } from '@automattic/api-core';
@@ -84,7 +86,13 @@ export function InterimOmnibar( {
 	);
 
 	const store = useMemo(
-		() => createOmnibarStore( onToggleNotifications ),
+		() =>
+			createOmnibarStore( {
+				onToggleNotifications,
+				initialLocaleSlug: getUserLanguage( user ),
+			} ),
+		// Seed the store's locale once; later changes flow through the switcher.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ onToggleNotifications ]
 	);
 
@@ -173,7 +181,7 @@ export function InterimOmnibar( {
 					isGravatarDomain={ false }
 					dashboardOptIn
 					useUnifiedAgent={ false }
-					isSupportSession={ false }
+					isSupportSession={ isSupportSession() }
 					isNotificationsShowing={ false }
 					isMigrationInProgress={ false }
 					migrationStatus={ null }

--- a/client/dashboard/app/interim-omnibar/omnibar-store.ts
+++ b/client/dashboard/app/interim-omnibar/omnibar-store.ts
@@ -1,37 +1,76 @@
 import { Provider as ReduxProvider } from 'react-redux';
+import { setSessionLocale } from '../locale/session-locale';
 
 type StoreType = Parameters< typeof ReduxProvider >[ 0 ][ 'store' ];
 
-// Fake Redux store so child components using connect() (e.g. Notifications) don't crash.
-// Intercepts specific actions so the dashboard can handle them.
-export function createOmnibarStore( onToggleNotifications?: () => void ): StoreType {
+type Action = {
+	type?: string;
+	unseenCount?: number;
+	isOpen?: boolean;
+	localeSlug?: string;
+};
+
+type Thunk = (
+	dispatch: ( action: Action | Thunk ) => unknown,
+	getState: () => unknown
+) => unknown;
+
+// Fake Redux store so child components using connect() (e.g. Notifications,
+// QuickLanguageSwitcher) don't crash. It intercepts the specific actions the
+// dashboard handles and supports thunks so Calypso's `setLocale` action runs.
+export function createOmnibarStore( {
+	onToggleNotifications,
+	initialLocaleSlug = 'en',
+}: {
+	onToggleNotifications?: () => void;
+	initialLocaleSlug?: string;
+} = {} ): StoreType {
 	const listeners = new Set< () => void >();
 	let notificationsUnseenCount: number | undefined;
 	let isNotificationsOpen = false;
+	let localeSlug = initialLocaleSlug;
+
+	const getState = () => ( {
+		ui: { section: false, isNotificationsOpen, language: { localeSlug } },
+		notificationsUnseenCount,
+	} );
+
+	const notify = () => listeners.forEach( ( listener ) => listener() );
+
+	const dispatch = ( action: Action | Thunk ): unknown => {
+		// Support thunks (e.g. Calypso's `setLocale`, which switches the locale
+		// before dispatching LOCALE_SET).
+		if ( typeof action === 'function' ) {
+			return action( dispatch, getState );
+		}
+
+		if ( action.type === 'NOTIFICATIONS_PANEL_TOGGLE' ) {
+			isNotificationsOpen = ! isNotificationsOpen;
+			onToggleNotifications?.();
+
+			notificationsUnseenCount = 0;
+			notify();
+		}
+		if ( action.type === 'NOTIFICATIONS_OPEN_SET' ) {
+			isNotificationsOpen = action.isOpen ?? false;
+			notify();
+		}
+		if ( action.type === 'NOTIFICATIONS_UNSEEN_COUNT_SET' ) {
+			notificationsUnseenCount = action.unseenCount;
+			notify();
+		}
+		if ( action.type === 'LOCALE_SET' ) {
+			localeSlug = action.localeSlug ?? 'en';
+			// Drive the dashboard's locale from the switcher's selection.
+			setSessionLocale( localeSlug );
+			notify();
+		}
+		return action;
+	};
 
 	return {
-		getState: () => ( {
-			ui: { section: false, isNotificationsOpen },
-			notificationsUnseenCount,
-		} ),
-		dispatch: ( action: { type: string; unseenCount?: number; isOpen?: boolean } ) => {
-			if ( action.type === 'NOTIFICATIONS_PANEL_TOGGLE' ) {
-				isNotificationsOpen = ! isNotificationsOpen;
-				onToggleNotifications?.();
-
-				notificationsUnseenCount = 0;
-				listeners.forEach( ( listener ) => listener() );
-			}
-			if ( action.type === 'NOTIFICATIONS_OPEN_SET' ) {
-				isNotificationsOpen = action.isOpen ?? false;
-				listeners.forEach( ( listener ) => listener() );
-			}
-			if ( action.type === 'NOTIFICATIONS_UNSEEN_COUNT_SET' ) {
-				notificationsUnseenCount = action.unseenCount;
-				listeners.forEach( ( listener ) => listener() );
-			}
-			return action;
-		},
+		getState,
+		dispatch,
 		subscribe: ( listener: () => void ) => {
 			listeners.add( listener );
 			return () => listeners.delete( listener );

--- a/client/dashboard/app/interim-omnibar/test/omnibar-store.test.ts
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-store.test.ts
@@ -1,0 +1,37 @@
+import { getSessionLocale, setSessionLocale } from '../../locale/session-locale';
+import { createOmnibarStore } from '../omnibar-store';
+
+type MinimalStore = {
+	getState: () => { ui: { language: { localeSlug: string } } };
+	dispatch: ( action: unknown ) => unknown;
+};
+
+describe( 'createOmnibarStore', () => {
+	beforeEach( () => {
+		setSessionLocale( null );
+	} );
+
+	it( 'seeds the locale slug so QuickLanguageSwitcher can read it', () => {
+		const store = createOmnibarStore( { initialLocaleSlug: 'fr' } ) as MinimalStore;
+		expect( store.getState().ui.language.localeSlug ).toBe( 'fr' );
+	} );
+
+	it( 'defaults the locale slug to en', () => {
+		const store = createOmnibarStore() as MinimalStore;
+		expect( store.getState().ui.language.localeSlug ).toBe( 'en' );
+	} );
+
+	it( 'runs thunks with dispatch and getState', () => {
+		const store = createOmnibarStore() as MinimalStore;
+		const thunk = jest.fn();
+		store.dispatch( thunk );
+		expect( thunk ).toHaveBeenCalledWith( store.dispatch, expect.any( Function ) );
+	} );
+
+	it( 'updates the language slice and the session locale on LOCALE_SET', () => {
+		const store = createOmnibarStore() as MinimalStore;
+		store.dispatch( { type: 'LOCALE_SET', localeSlug: 'de' } );
+		expect( store.getState().ui.language.localeSlug ).toBe( 'de' );
+		expect( getSessionLocale() ).toBe( 'de' );
+	} );
+} );

--- a/client/dashboard/app/locale/index.ts
+++ b/client/dashboard/app/locale/index.ts
@@ -1,4 +1,5 @@
 import { useAuth } from '../auth';
+import { useSessionLocale } from './session-locale';
 
 type ComputedAttributes = {
 	localeSlug?: string;
@@ -7,6 +8,11 @@ type ComputedAttributes = {
 
 export function useLocale() {
 	const { user } = useAuth();
+	const sessionLocale = useSessionLocale();
+	if ( sessionLocale ) {
+		return sessionLocale;
+	}
+
 	const u = user as typeof user & ComputedAttributes;
 	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
 }

--- a/client/dashboard/app/locale/session-locale.ts
+++ b/client/dashboard/app/locale/session-locale.ts
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Session-local locale set by the omnibar language switcher. Changes the
+ * dashboard's language for the current session without touching the account
+ * setting. A module singleton so the omnibar and app (separate React trees,
+ * one JS realm) share it; not persisted.
+ */
+let sessionLocale: string | null = null;
+const listeners = new Set< () => void >();
+
+export function getSessionLocale(): string | null {
+	return sessionLocale;
+}
+
+export function setSessionLocale( locale: string | null ): void {
+	if ( locale === sessionLocale ) {
+		return;
+	}
+	sessionLocale = locale;
+	listeners.forEach( ( listener ) => listener() );
+}
+
+function subscribe( listener: () => void ): () => void {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+export function useSessionLocale(): string | null {
+	return useSyncExternalStore( subscribe, getSessionLocale, getSessionLocale );
+}


### PR DESCRIPTION
Fixes DOTMSD-1269

## Proposed Changes

* Show Calypso's `QuickLanguageSwitcher` (the globe language picker) on the Multi-site Dashboard's interim omnibar during support sessions, by passing `isSupportSession()` to `MasterbarLoggedIn` instead of the hardcoded `false`. This matches the classic Calypso masterbar, which renders the switcher when `isSupportSession || config.isEnabled( 'quick-language-switcher' )`.
* Add a **session-local locale override** (`client/dashboard/app/locale/session-locale.ts`) — a plain module singleton exposed through a `useSyncExternalStore` hook. The omnibar and the main app mount as separate React trees but share one JS realm, so a singleton is the simplest way for both to read/write the override.
* `app/i18n.tsx` now prefers the override over the account locale (`override ?? getUserLanguage( user )`), so selecting a language actually retranslates the dashboard content.
* The interim omnibar's fake Redux store (`omnibar-store.ts`) now supports **thunks** (so Calypso's `setLocale` action runs) and carries a `ui.language` slice; when it sees `LOCALE_SET` it writes the chosen locale to the override. The store is seeded with the user's current locale so the switcher shows the right "current" language.
* Adds unit tests for the store's locale wiring.

## Why are these changes being made?

Support agents use the language switcher to view a customer's site in the customer's language. Calypso's masterbar offers this in support sessions; the dashboard's interim omnibar hardcoded `isSupportSession={ false }`, so the switcher never appeared and, even if shown, wouldn't have worked (the fake store didn't run thunks and the dashboard content is translated by a separate `@wordpress/i18n` instance).

The override is **not persisted** and resets on reload — mirroring Calypso's masterbar switcher, which changes the locale locally for the session only and never touches the account's saved language.

## Testing Instructions

* Start Calypso (`yarn start`) and open the dashboard (`http://my.localhost:3000/sites`).
* Enter a support session (impersonate a user via support tooling).
* Confirm a globe language switcher appears in the omnibar. Open it, pick a language, and confirm the **dashboard content** retranslates to that language.
* Reload and confirm the locale reverts to the account's saved language (the override is session-local).
* Confirm a normal (non-support) session shows **no** switcher and is unaffected.
* Automated: `yarn test-client client/dashboard/app/interim-omnibar/test/` (9 tests, incl. the new `omnibar-store.test.ts`).

### Known limitation

The interim omnibar renders Calypso's masterbar through its own per-tree `i18n-calypso` instance, so the **masterbar's own labels** (e.g. "Reader", "Help") stay in the base locale after switching; the dashboard content and the switcher's current-locale indicator update correctly. Calypso's `setLocale` thunk still runs its global side effects (html `lang`/`dir`, RTL stylesheet swap), which are consistent with what `app/i18n.tsx` already applies on locale change.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (No new strings — reuses Calypso's existing switcher.)
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

