### PR TITLE
Plugins per-plugin "Get started": show the plans grid instead of forcing Business

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -477,7 +477,7 @@ export function submitWebsiteContent( callback, { siteSlug }, step, reduxStore )
  * term. Falls back to `fallbackBillingPeriod` (the CTA default) when the plan term is unknown.
  */
 export function getPluginBillingPeriodForPlan( planSlug, fallbackBillingPeriod ) {
-	const planTerm = planSlug ? getPlan( planSlug )?.term : undefined;
+	const planTerm = getPlan( planSlug )?.term;
 
 	if ( ! planTerm ) {
 		return fallbackBillingPeriod;
@@ -498,16 +498,10 @@ export function pickMarketplacePluginVariant( variants, billingPeriod = '' ) {
 		MONTHLY: 'month',
 		ANNUALLY: 'year',
 	};
-	const term = ( billingPeriod && billingPeriodToTerm[ billingPeriod ] ) || '';
+	const term = billingPeriodToTerm[ billingPeriod ] || '';
+	const match = term && variants?.find( ( variant ) => variant.product_term === term );
 
-	if ( term ) {
-		const match = variants?.find( ( variant ) => variant.product_term === term );
-		if ( match ) {
-			return match;
-		}
-	}
-
-	return variants?.[ 0 ] || null;
+	return match || variants?.[ 0 ] || null;
 }
 
 function findMarketplacePlugin( state, pluginSlug, billingPeriod = '' ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1,6 +1,11 @@
 import { getTracksAnonymousUserId, recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { WPCOM_DIFM_LITE, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import {
+	WPCOM_DIFM_LITE,
+	PRODUCT_1GB_SPACE,
+	getPlan,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site, AddOns } from '@automattic/data-stores';
 import { STORAGE_ADD_ONS } from '@automattic/data-stores/src/add-ons';
@@ -466,6 +471,21 @@ export function submitWebsiteContent( callback, { siteSlug }, step, reduxStore )
 		} );
 }
 
+/**
+ * Maps the plan the user picked to the marketplace plugin's subscription term (MONTHLY or
+ * ANNUALLY) so the plan and plugin terms stay in sync. Multi-year plans map to the plugin's annual
+ * term. Falls back to `fallbackBillingPeriod` (the CTA default) when the plan term is unknown.
+ */
+export function getPluginBillingPeriodForPlan( planSlug, fallbackBillingPeriod ) {
+	const planTerm = planSlug ? getPlan( planSlug )?.term : undefined;
+
+	if ( ! planTerm ) {
+		return fallbackBillingPeriod;
+	}
+
+	return planTerm === TERM_MONTHLY ? 'MONTHLY' : 'ANNUALLY';
+}
+
 function findMarketplacePlugin( state, pluginSlug, billingPeriod = '' ) {
 	const plugins = getMarketplaceProducts( state, pluginSlug );
 	const billingPeriodToTerm = {
@@ -597,7 +617,17 @@ export function addWithPluginPlanToCart( callback, dependencies, stepProvidedIte
 	const { cartItems, lastKnownFlow } = stepProvidedItems;
 
 	reduxStore.dispatch( requestProductsList( { type: 'all' } ) ).then( () => {
-		const marketplacePlugin = findMarketplacePlugin( reduxStore.getState(), plugin, billingPeriod );
+		const state = reduxStore.getState();
+
+		// Match the plugin's subscription term to the plan the user picked in the grid, so the plan
+		// and plugin terms don't diverge (billing_period from the CTA is only the default). Fall
+		// back to the CTA term, then to any available plugin variant.
+		const planSlug = getPlanCartItem( cartItems )?.product_slug;
+		const pluginBillingPeriod = getPluginBillingPeriodForPlan( planSlug, billingPeriod );
+
+		const marketplacePlugin =
+			findMarketplacePlugin( state, plugin, pluginBillingPeriod ) ||
+			findMarketplacePlugin( state, plugin );
 		const providedDependencies = { cartItems };
 
 		const newCartItems = [ ...( cartItems ? cartItems : [] ), marketplacePlugin ].filter(

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -486,19 +486,32 @@ export function getPluginBillingPeriodForPlan( planSlug, fallbackBillingPeriod )
 	return planTerm === TERM_MONTHLY ? 'MONTHLY' : 'ANNUALLY';
 }
 
-function findMarketplacePlugin( state, pluginSlug, billingPeriod = '' ) {
-	const plugins = getMarketplaceProducts( state, pluginSlug );
+/**
+ * Picks the marketplace plugin variant whose subscription term matches `billingPeriod` (MONTHLY or
+ * ANNUALLY). When no billing period is given, or the requested term has no variant, returns the
+ * first available variant instead of nothing: the plugin subscription and the plan bill as
+ * independent line items, so we keep the product the user came to install rather than dropping it
+ * when its term can't match the chosen plan.
+ */
+export function pickMarketplacePluginVariant( variants, billingPeriod = '' ) {
 	const billingPeriodToTerm = {
 		MONTHLY: 'month',
 		ANNUALLY: 'year',
 	};
 	const term = ( billingPeriod && billingPeriodToTerm[ billingPeriod ] ) || '';
 
-	if ( ! term ) {
-		return plugins?.[ 0 ] || null;
+	if ( term ) {
+		const match = variants?.find( ( variant ) => variant.product_term === term );
+		if ( match ) {
+			return match;
+		}
 	}
 
-	return plugins?.find( ( plugin ) => plugin.product_term === term ) || null;
+	return variants?.[ 0 ] || null;
+}
+
+function findMarketplacePlugin( state, pluginSlug, billingPeriod = '' ) {
+	return pickMarketplacePluginVariant( getMarketplaceProducts( state, pluginSlug ), billingPeriod );
 }
 
 export function addWithThemePlanToCart( callback, dependencies, stepProvidedItems, reduxStore ) {
@@ -620,14 +633,11 @@ export function addWithPluginPlanToCart( callback, dependencies, stepProvidedIte
 		const state = reduxStore.getState();
 
 		// Match the plugin's subscription term to the plan the user picked in the grid, so the plan
-		// and plugin terms don't diverge (billing_period from the CTA is only the default). Fall
-		// back to the CTA term, then to any available plugin variant.
+		// and plugin terms don't diverge (billing_period from the CTA is only the default).
 		const planSlug = getPlanCartItem( cartItems )?.product_slug;
 		const pluginBillingPeriod = getPluginBillingPeriodForPlan( planSlug, billingPeriod );
 
-		const marketplacePlugin =
-			findMarketplacePlugin( state, plugin, pluginBillingPeriod ) ||
-			findMarketplacePlugin( state, plugin );
+		const marketplacePlugin = findMarketplacePlugin( state, plugin, pluginBillingPeriod );
 		const providedDependencies = { cartItems };
 
 		const newCartItems = [ ...( cartItems ? cartItems : [] ), marketplacePlugin ].filter(

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -2,9 +2,19 @@
  * @jest-environment jsdom
  */
 
+import {
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_BUSINESS_2_YEARS,
+} from '@automattic/calypso-products';
 import nock from 'nock';
 import flows from 'calypso/signup/config/flows';
-import { createSiteWithCart, isDomainFulfilled, isPlanFulfilled } from '../step-actions';
+import {
+	createSiteWithCart,
+	getPluginBillingPeriodForPlan,
+	isDomainFulfilled,
+	isPlanFulfilled,
+} from '../step-actions';
 
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
 jest.mock( 'calypso/signup/config/flows', () => require( './mocks/signup/config/flows' ) );
@@ -261,5 +271,24 @@ describe( 'isPlanFulfilled()', () => {
 
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 		expect( submitSignupStep ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getPluginBillingPeriodForPlan()', () => {
+	test( 'maps a monthly plan to the plugin MONTHLY term', () => {
+		expect( getPluginBillingPeriodForPlan( PLAN_PERSONAL_MONTHLY, 'ANNUALLY' ) ).toBe( 'MONTHLY' );
+	} );
+
+	test( 'maps an annual plan to the plugin ANNUALLY term', () => {
+		expect( getPluginBillingPeriodForPlan( PLAN_PERSONAL, 'MONTHLY' ) ).toBe( 'ANNUALLY' );
+	} );
+
+	test( 'maps a multi-year plan to the plugin ANNUALLY term', () => {
+		expect( getPluginBillingPeriodForPlan( PLAN_BUSINESS_2_YEARS, 'MONTHLY' ) ).toBe( 'ANNUALLY' );
+	} );
+
+	test( 'falls back to the provided billing period when the plan is unknown', () => {
+		expect( getPluginBillingPeriodForPlan( undefined, 'ANNUALLY' ) ).toBe( 'ANNUALLY' );
+		expect( getPluginBillingPeriodForPlan( 'not-a-real-plan', 'MONTHLY' ) ).toBe( 'MONTHLY' );
 	} );
 } );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -14,6 +14,7 @@ import {
 	getPluginBillingPeriodForPlan,
 	isDomainFulfilled,
 	isPlanFulfilled,
+	pickMarketplacePluginVariant,
 } from '../step-actions';
 
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
@@ -290,5 +291,37 @@ describe( 'getPluginBillingPeriodForPlan()', () => {
 	test( 'falls back to the provided billing period when the plan is unknown', () => {
 		expect( getPluginBillingPeriodForPlan( undefined, 'ANNUALLY' ) ).toBe( 'ANNUALLY' );
 		expect( getPluginBillingPeriodForPlan( 'not-a-real-plan', 'MONTHLY' ) ).toBe( 'MONTHLY' );
+	} );
+} );
+
+describe( 'pickMarketplacePluginVariant()', () => {
+	const monthlyVariant = { product_slug: 'plugin-monthly', product_term: 'month' };
+	const yearlyVariant = { product_slug: 'plugin-yearly', product_term: 'year' };
+
+	test( 'returns the monthly variant for a MONTHLY billing period', () => {
+		expect( pickMarketplacePluginVariant( [ monthlyVariant, yearlyVariant ], 'MONTHLY' ) ).toBe(
+			monthlyVariant
+		);
+	} );
+
+	test( 'returns the yearly variant for an ANNUALLY billing period', () => {
+		expect( pickMarketplacePluginVariant( [ monthlyVariant, yearlyVariant ], 'ANNUALLY' ) ).toBe(
+			yearlyVariant
+		);
+	} );
+
+	test( 'keeps the plugin when the requested term has no variant (monthly plan, annual-only plugin)', () => {
+		expect( pickMarketplacePluginVariant( [ yearlyVariant ], 'MONTHLY' ) ).toBe( yearlyVariant );
+	} );
+
+	test( 'returns the first variant when no billing period is given', () => {
+		expect( pickMarketplacePluginVariant( [ yearlyVariant, monthlyVariant ] ) ).toBe(
+			yearlyVariant
+		);
+	} );
+
+	test( 'returns null when there are no variants', () => {
+		expect( pickMarketplacePluginVariant( [], 'MONTHLY' ) ).toBeNull();
+		expect( pickMarketplacePluginVariant( undefined, 'ANNUALLY' ) ).toBeNull();
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -84,13 +84,15 @@ const MarketplaceProductInstall = ( {
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
 	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
 	const [ noDirectAccessError, setNoDirectAccessError ] = useState( false );
+	const [ userDirectInstallationAllowed, setUserDirectInstallationAllowed ] = useState( false );
 	// The signup "Get started" flow reaches this page via a full-page redirect, which drops the
 	// in-memory purchase-flow state that normally authorizes the install. When that redirect marks
-	// itself as trusted, proceed with the install directly instead of waiting on handoff state that
-	// will never arrive (which otherwise leaves the page polling the site forever).
-	const [ directInstallationAllowed, setDirectInstallationAllowed ] = useState(
-		() => new URLSearchParams( window.location.search ).get( 'directInstall' ) === 'true'
+	// itself as trusted (directInstall), proceed with the install directly instead of waiting on
+	// handoff state that will never arrive (which otherwise leaves the page polling forever).
+	const directInstallFromSignup = new URLSearchParams( window.location.search ).has(
+		'directInstall'
 	);
+	const directInstallationAllowed = userDirectInstallationAllowed || directInstallFromSignup;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -466,7 +468,7 @@ const MarketplaceProductInstall = ( {
 								<Button href={ productPage }>{ translate( 'Go to the theme page' ) }</Button>
 
 								{ ! isMarketplaceProduct ? (
-									<Button primary onClick={ () => setDirectInstallationAllowed( true ) }>
+									<Button primary onClick={ () => setUserDirectInstallationAllowed( true ) }>
 										{ translate( 'Activate theme' ) }
 									</Button>
 								) : (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -48,6 +48,7 @@ import {
 	isMarketplaceProduct as isMarketplaceProductSelector,
 	getProductsList,
 } from 'calypso/state/products-list/selectors';
+import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
 import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-progress';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
@@ -89,9 +90,7 @@ const MarketplaceProductInstall = ( {
 	// in-memory purchase-flow state that normally authorizes the install. When that redirect marks
 	// itself as trusted (directInstall), proceed with the install directly instead of waiting on
 	// handoff state that will never arrive (which otherwise leaves the page polling forever).
-	const directInstallFromSignup = new URLSearchParams( window.location.search ).has(
-		'directInstall'
-	);
+	const directInstallFromSignup = useSelector( getCurrentQueryArguments )?.directInstall != null;
 	const directInstallationAllowed = userDirectInstallationAllowed || directInstallFromSignup;
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -84,7 +84,13 @@ const MarketplaceProductInstall = ( {
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
 	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
 	const [ noDirectAccessError, setNoDirectAccessError ] = useState( false );
-	const [ directInstallationAllowed, setDirectInstallationAllowed ] = useState( false );
+	// The signup "Get started" flow reaches this page via a full-page redirect, which drops the
+	// in-memory purchase-flow state that normally authorizes the install. When that redirect marks
+	// itself as trusted, proceed with the install directly instead of waiting on handoff state that
+	// will never arrive (which otherwise leaves the page polling the site forever).
+	const [ directInstallationAllowed, setDirectInstallationAllowed ] = useState(
+		() => new URLSearchParams( window.location.search ).get( 'directInstall' ) === 'true'
+	);
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -17,6 +17,7 @@ import { setQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/route';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-plugins-dialog';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -482,6 +483,10 @@ function GetStartedButton( { onClick, plugin, isMarketplaceProduct, startFreeTri
 			ref: sectionName + '-lp',
 			plugin: plugin.slug,
 			billing_period: isMarketplaceProduct ? billingPeriod : '',
+			// Default the plans grid to the billing interval the user was viewing here, so a
+			// monthly selection isn't silently reset to yearly on the plans step.
+			intervalType:
+				isMarketplaceProduct && billingPeriod === IntervalLength.MONTHLY ? 'monthly' : 'yearly',
 		},
 		startFreeTrial ? 'start/hosting' : '/start/with-plugin'
 	);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -129,6 +129,7 @@ export function generateFlows( {
 			lastModified: '2026-07-07',
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'plugin', 'billing_period', 'intervalType' ],
+			optionalDependenciesInQuery: [ 'intervalType' ],
 			hideProgressIndicator: true,
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -122,10 +122,11 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-plugin',
-			steps: [ userSocialStep, 'domains', 'plans-business-with-plugin' ],
+			steps: [ userSocialStep, 'domains', 'plans-with-plugin' ],
 			destination: getWithPluginDestination,
-			description: 'Preselect a plugin to activate/buy, a Business plan is needed',
-			lastModified: '2023-10-11',
+			description:
+				'Preselect a plugin to activate/buy, then show the paid plans grid to pick a qualifying plan.',
+			lastModified: '2026-07-07',
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'plugin', 'billing_period' ],
 			hideProgressIndicator: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -128,7 +128,7 @@ export function generateFlows( {
 				'Preselect a plugin to activate/buy, then show the paid plans grid to pick a qualifying plan.',
 			lastModified: '2026-07-07',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'plugin', 'billing_period' ],
+			providesDependenciesInQuery: [ 'plugin', 'billing_period', 'intervalType' ],
 			hideProgressIndicator: true,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -192,7 +192,7 @@ function getWithPluginDestination( { siteSlug, pluginParameter, pluginBillingPer
 	// Otherwise send to the installation page. Mark the redirect as trusted (directInstall) so the
 	// page initiates the transfer/install itself — the in-memory purchase-flow handoff it normally
 	// relies on doesn't survive this redirect out of signup.
-	return `/marketplace/plugin/${ pluginParameter }/install/${ siteSlug }?directInstall=true`;
+	return `/marketplace/plugin/${ pluginParameter }/install/${ siteSlug }?directInstall=1`;
 }
 
 function getEditorDestination( dependencies ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -189,8 +189,10 @@ function getWithPluginDestination( { siteSlug, pluginParameter, pluginBillingPer
 		return `/marketplace/thank-you/${ siteSlug }?plugins=${ pluginParameter }`;
 	}
 
-	// otherwise send to installation page
-	return `/marketplace/plugin/${ pluginParameter }/install/${ siteSlug }`;
+	// Otherwise send to the installation page. Mark the redirect as trusted (directInstall) so the
+	// page initiates the transfer/install itself — the in-memory purchase-flow handoff it normally
+	// relies on doesn't survive this redirect out of signup.
+	return `/marketplace/plugin/${ pluginParameter }/install/${ siteSlug }?directInstall=true`;
 }
 
 function getEditorDestination( dependencies ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -25,6 +25,22 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	const isDomainOnly = [ 'domain', DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName );
 	const isGravatarDomain = isDomainForGravatarFlow( flowName );
 
+	// For the with-plugin flow, backing out of checkout should return to the plans grid step, not
+	// the post-purchase thank-you/install destination — that page can't render before the purchase
+	// and would leave the user stuck. Rebuild the plans step URL from the current query.
+	let backDestination = destination;
+	if ( flowName === 'with-plugin' ) {
+		const { plugin, billing_period: billingPeriod, intervalType } = getQueryArgs() ?? {};
+		backDestination = addQueryArgs(
+			{
+				...( plugin && { plugin } ),
+				...( billingPeriod && { billing_period: billingPeriod } ),
+				...( intervalType && { intervalType } ),
+			},
+			`/start/with-plugin/plans-with-plugin${ localeSlug ? `/${ localeSlug }` : '' }`
+		);
+	}
+
 	// checkoutBackUrl is required to be a complete URL, and will be further sanitized within the checkout package.
 	// Due to historical reason, `destination` can be either a path or a complete URL.
 	// Thus, if it is determined as not an URL, we assume it as a path here. We can surely make it more comprehensive,
@@ -32,9 +48,9 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	//
 	// TODO:
 	// the domain only flow has special rule. Ideally they should also be configurable in flows-pure.
-	const checkoutBackUrl = isURL( destination )
-		? destination
-		: pathToUrl( isDomainOnly ? `/start/${ flowName }/domain-only` : destination );
+	const checkoutBackUrl = isURL( backDestination )
+		? backDestination
+		: pathToUrl( isDomainOnly ? `/start/${ flowName }/domain-only` : backDestination );
 
 	// Add celebrateLaunch=true for launch-site flow so the celebration modal shows after checkout
 	const isLaunchSiteFlow = flowName === 'launch-site';

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -24,13 +24,14 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 
 	const isDomainOnly = [ 'domain', DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName );
 	const isGravatarDomain = isDomainForGravatarFlow( flowName );
+	const queryArgs = getQueryArgs() ?? {};
 
 	// For the with-plugin flow, backing out of checkout should return to the plans grid step, not
 	// the post-purchase thank-you/install destination — that page can't render before the purchase
 	// and would leave the user stuck. Rebuild the plans step URL from the current query.
 	let backDestination = destination;
 	if ( flowName === 'with-plugin' ) {
-		const { plugin, billing_period: billingPeriod, intervalType } = getQueryArgs() ?? {};
+		const { plugin, billing_period: billingPeriod, intervalType } = queryArgs;
 		backDestination = addQueryArgs(
 			{
 				...( plugin && { plugin } ),
@@ -63,7 +64,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	return addQueryArgs(
 		{
 			signup: 1,
-			ref: getQueryArgs()?.ref,
+			ref: queryArgs.ref,
 			...( dependencies.coupon && { coupon: dependencies.coupon } ),
 			...( isDomainOnly && { isDomainOnly: 1 } ),
 			...( isGravatarDomain && { isGravatarDomain: 1 } ),

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -19,7 +19,7 @@ const stepNameToModuleName = {
 	plans: 'plans',
 	'plans-new': 'plans',
 	'plans-business': 'plans',
-	'plans-business-with-plugin': 'plans',
+	'plans-with-plugin': 'plans',
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
 	'plans-personal': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -269,15 +269,15 @@ export function generateSteps( {
 			},
 		},
 
-		'plans-business-with-plugin': {
-			stepName: 'plans-business-with-plugin',
+		'plans-with-plugin': {
+			stepName: 'plans-with-plugin',
 			apiRequestFunction: addWithPluginPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug', 'plugin', 'billing_period' ],
 			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
 			optionalDependencies: [ 'themeSlugWithRepo' ],
-			defaultDependencies: {
-				cartItem: PLAN_BUSINESS,
+			props: {
+				hideFreePlan: true,
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -278,6 +278,7 @@ export function generateSteps( {
 			optionalDependencies: [ 'themeSlugWithRepo' ],
 			props: {
 				hideFreePlan: true,
+				hideEnterprisePlan: true,
 			},
 		},
 

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -158,4 +158,21 @@ describe( 'index', () => {
 
 		expect( definedSteps ).toEqual( new Set() );
 	} );
+
+	test( 'intervalType must be an optional query dependency where it is used (it has a default)', () => {
+		// `intervalType` defaults to yearly when absent, so a flow that carries it through the URL
+		// must also mark it optional — otherwise the flow controller rejects otherwise-valid URLs
+		// that omit it.
+		const flowDefinitions = generateFlows();
+
+		const flowsWithMandatoryIntervalType = Object.entries( flowDefinitions )
+			.filter( ( [ , flow ] ) => {
+				const provided = flow.providesDependenciesInQuery ?? [];
+				const optional = flow.optionalDependenciesInQuery ?? [];
+				return provided.includes( 'intervalType' ) && ! optional.includes( 'intervalType' );
+			} )
+			.map( ( [ flowName ] ) => flowName );
+
+		expect( flowsWithMandatoryIntervalType ).toEqual( [] );
+	} );
 } );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -140,6 +140,33 @@ export class PlansPage {
 	}
 
 	/**
+	 * Validates that the plan's selection CTA is offered in the grid.
+	 *
+	 * @param {Plans} plan Name of the plan.
+	 */
+	async validatePlanIsAvailable( plan: Plans ): Promise< void > {
+		await this.page
+			.locator( selectors.selectPlanButton( plan ) )
+			.first()
+			.waitFor( { state: 'visible', timeout: 30_000 } );
+	}
+
+	/**
+	 * Validates that the plan is not offered in the grid (e.g. the free plan is hidden).
+	 *
+	 * @param {Plans} plan Name of the plan.
+	 * @throws If the plan's selection CTA is present.
+	 */
+	async validatePlanIsNotAvailable( plan: Plans ): Promise< void > {
+		const count = await this.page.locator( selectors.selectPlanButton( plan ) ).count();
+		if ( count > 0 ) {
+			throw new Error(
+				`Expected the ${ plan } plan to not be offered, but found ${ count } CTA(s).`
+			);
+		}
+	}
+
+	/**
 	 * Opens the escape hatch modal by clicking the "start with a free plan" trigger link.
 	 */
 	async openEscapeHatch(): Promise< void > {

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -6,7 +6,7 @@ import type { NewSiteResponse } from '../../../types/rest-api-client.types';
  * The plans page URL regex.
  */
 export const plansPageUrl =
-	/.*setup\/onboarding\/plans|setup\/domain\/plans|start\/plans|start\/with-theme\/plans-theme-preselected|start\/domain\/plans-site-selected|start\/launch-site\/plans-launch.*/;
+	/.*setup\/onboarding\/plans|setup\/domain\/plans|start\/plans|start\/with-plugin\/plans-with-plugin|start\/with-theme\/plans-theme-preselected|start\/domain\/plans-site-selected|start\/launch-site\/plans-launch.*/;
 
 /**
  * Represents the Signup > Pick a Plan page.

--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -1,0 +1,100 @@
+import { BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiDeleteSite } from '../shared';
+import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
+
+/**
+ * Verifies the per-plugin "Get started" signup flow (/start/with-plugin) shows the paid plans
+ * grid — with the free plan hidden — and keeps the selected marketplace plugin in the cart,
+ * instead of forcing the Business plan and skipping the grid.
+ *
+ * Keywords: Plugins, Marketplace, Signup, Get started, Plan, Checkout
+ */
+test.describe(
+	'Plugins: "Get started" shows the paid plans grid',
+	{ tag: [ tags.CALYPSO_RELEASE ] },
+	() => {
+		const planName = 'Personal';
+		// A paid marketplace plugin, so the flow carries a plugin product into the cart.
+		const pluginSlug = 'sensei-pro';
+		const pluginName = 'Sensei Pro';
+
+		let siteCreatedFlag = false;
+		let newSiteDetails: NewSiteResponse | undefined;
+		let accountUsed: TestAccount;
+
+		test.afterAll( 'Delete the created site', async () => {
+			if ( ! siteCreatedFlag || ! newSiteDetails || ! accountUsed ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient( {
+				username: accountUsed.credentials.username,
+				password: accountUsed.credentials.password,
+			} );
+
+			await apiDeleteSite( restAPIClient, {
+				url: newSiteDetails.blog_details.url,
+				id: newSiteDetails.blog_details.blogid,
+				name: newSiteDetails.blog_details.blogname,
+			} );
+		} );
+
+		test( 'As a user, plugin "Get started" leads to the paid plans grid with the plugin in the cart', async ( {
+			accountPreRelease,
+			componentDomainSearch,
+			helperData,
+			page,
+			pageCartCheckout,
+			pageSignupPickPlan,
+		} ) => {
+			// Signup + site creation dominate the runtime; the 120s default isn't enough.
+			test.setTimeout( 180 * 1000 );
+
+			await test.step( `Given I am authenticated as '${ accountPreRelease.accountName }'`, async () => {
+				await accountPreRelease.authenticate( page );
+				accountUsed = accountPreRelease;
+			} );
+
+			await test.step( 'And store cookies are set for purchases', async () => {
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			await test.step( 'When I open the with-plugin flow from a plugin "Get started" CTA', async () => {
+				// Mirrors the URL the per-plugin "Get started" CTA builds
+				// (client/my-sites/plugins/plugin-details-CTA/index.jsx). intervalType is
+				// intentionally omitted to confirm the flow treats it as an optional query dependency.
+				await page.goto(
+					helperData.getCalypsoURL( 'start/with-plugin', {
+						plugin: pluginSlug,
+						ref: 'plugins-lp',
+						billing_period: 'ANNUALLY',
+					} )
+				);
+			} );
+
+			await test.step( 'And I skip domain selection', async () => {
+				await componentDomainSearch.search( 'foo' );
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'Then the plans step shows paid plans and hides the free plan', async () => {
+				// The grid rendered (rather than a forced Business checkout): the paid plan CTA is
+				// visible. Assert this first so the grid has finished loading before checking that
+				// no free plan is offered.
+				await expect( page.locator( 'button.is-personal-plan' ).first() ).toBeVisible();
+				await expect( page.locator( 'button.is-free-plan' ) ).toHaveCount( 0 );
+			} );
+
+			await test.step( `When I select the ${ planName } plan`, async () => {
+				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				siteCreatedFlag = true;
+			} );
+
+			await test.step( `Then checkout contains the ${ planName } plan and the ${ pluginName } plugin`, async () => {
+				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
+				await pageCartCheckout.validateCartItem( pluginName );
+			} );
+		} );
+	}
+);

--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -1,5 +1,5 @@
 import { BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { tags, test } from '../../lib/pw-base';
 import { apiDeleteSite } from '../shared';
 import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
 
@@ -46,6 +46,7 @@ test.describe(
 			helperData,
 			page,
 			pageCartCheckout,
+			pagePlans,
 			pageSignupPickPlan,
 		} ) => {
 			// Signup + site creation dominate the runtime; the 120s default isn't enough.
@@ -80,10 +81,10 @@ test.describe(
 
 			await test.step( 'Then the plans step shows paid plans and hides the free plan', async () => {
 				// The grid rendered (rather than a forced Business checkout): the paid plan CTA is
-				// visible. Assert this first so the grid has finished loading before checking that
+				// offered. Assert this first so the grid has finished loading before checking that
 				// no free plan is offered.
-				await expect( page.locator( 'button.is-personal-plan' ).first() ).toBeVisible();
-				await expect( page.locator( 'button.is-free-plan' ) ).toHaveCount( 0 );
+				await pagePlans.validatePlanIsAvailable( planName );
+				await pagePlans.validatePlanIsNotAvailable( 'Free' );
 			} );
 
 			await test.step( `When I select the ${ planName } plan`, async () => {


### PR DESCRIPTION
Part of DOTPAR-16

## Proposed Changes

- The per-plugin "Get started" CTA (`/start/with-plugin`) no longer force-adds the Business plan and skips the plans grid. It now shows the plans grid (with the free plan hidden) so the user can pick any qualifying paid plan, keeps the selected plugin in the cart, and matches the plugin's billing term to the plan the user chooses.
- This reuses the existing plans step and the `hideFreePlan` prop — no new plans-grid intent — so the change stays contained to the signup flow config.

## Why are these changes being made?

Since plugins became available on all paid plans, "Get started" on a plugin shouldn't push logged-out users into a forced Business checkout. Showing the plans grid lets users choose their plan while preserving the plugin they came for.

## Scope

- Covers only the **per-plugin** "Get started" flow (`/start/with-plugin`).
- The generic marketplace "Get started" CTAs (discovery footer / in-page CTA and the universal header, which use `/start/business`) are intentionally left as-is for a separate follow-up.

## Testing Instructions

1. Log out (or use an incognito window).
2. Open a plugin's page and click "Get started".
3. Create an account and pick/confirm a domain.
4. Confirm you land on the **plans grid** with no free plan (not a forced Business checkout).
5. Pick a plan; confirm checkout contains the selected plan and the plugin, with matching billing terms (try both a monthly and an annual plan).

`yarn typecheck-client` passes (the one pre-existing `plans-features-main` error is unrelated and present on trunk). Unit tests cover the plan → plugin term mapping.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
