### PR TITLE
Agents Manager: remove the Big Sky onboarding chat-hide rule and dead onboarding CSS

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -532,11 +532,6 @@ body.post-new-php.agents-manager-sidebar-container {
 				display: none;
 			}
 
-			.big-sky-onboarding__chat-view & {
-				padding-right: 0;
-				justify-content: start !important;
-			}
-
 			.big-sky__chat-components & {
 				padding-right: 0;
 			}
@@ -628,10 +623,6 @@ body.post-new-php.agents-manager-sidebar-container {
 				margin: 0;
 			}
 		}
-	}
-
-	.big-sky-onboarding__chat-view .big-sky__chat-actions__carousel__item {
-		max-width: 190px;
 	}
 
 	.big-sky__chat-actions::before:not( .has-confirmation-actions ),
@@ -734,14 +725,6 @@ body.post-new-php.agents-manager-sidebar-container {
 			outline: 1px solid #0000004d;
 			overflow: hidden;
 		}
-	}
-}
-
-// Hide the chat while Big Sky's full-screen onboarding overlay is open.
-body:has( .big-sky-onboarding.components-popover ) {
-	.agents-manager-chat,
-	.agents-manager-sidebar-fab {
-		display: none !important;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* Remove the `body:has( .big-sky-onboarding.components-popover )` rule (from #112217) that hid the AM chat panel and sidebar FAB while Big Sky's full-screen onboarding overlay was open.
* Remove two dead `.big-sky-onboarding__chat-view` rules (carousel padding/alignment, item max-width) — nothing has applied that class since `4997-gh-Automattic/big-sky-plugin` (Nov 2025), so they could never match.

## Why are these changes being made?

* The `body:has( .big-sky-onboarding.components-popover )` hide rule is no longer needed because of `6061-gh-Automattic/big-sky-plugin`: the site-building onboarding was reworked — the full-screen "site is brewing" build overlay is gone, the user lands directly in the editor, and the unified chat opens docked at build start — so the chat is now a first-class part of the onboarding flow rather than something to hide behind an overlay.
* The `.big-sky-onboarding__chat-view` rules are dead CSS that could never match, left behind by earlier onboarding iterations.

**Expected behavior change:** the `.big-sky-onboarding` popover still renders for the spec-entry screen (`SiteSpecLanding`), and with the hide rule removed the AM chat FAB/panel is no longer suppressed there — this is intended with the new onboarding flow.

## Testing Instructions

1. Sandbox `6061-gh-Automattic/big-sky-plugin`
2. Sandbox this PR (`cd apps/agents-manager && yarn dev --sync` — only `widgets.wp.com` needs sandboxing)
3. Ensure that the unified AI experience is enabled
4. On the sandboxed dev site, reset (ctrl-d, reset) to get back into site spec, and refresh the page after it has reset
5. On the site-spec screen, verify the AI chat is available (no longer hidden — see the expected behavior change above)
6. Confirm the build, and verify the unified chat opens docked at build start and behaves normally through the build
7. On a regular (non-onboarding) editor screen, verify the chat visuals are unchanged — the removed `.big-sky-onboarding__chat-view` rules could never match, so no visual diff is expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


