### PR TITLE
Pricing grid redesign: implement variant1

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -32,10 +32,22 @@ const INELIGIBLE_RESULT = {
 const mockUseExperiment = useExperiment as jest.Mock;
 const mockUseSelector = useSelector as jest.Mock;
 
-function mockSite( isGatingBusinessQ1: boolean | undefined ) {
+function mockSite( {
+	isGatingBusinessQ1,
+	siteCreationFlow = 'onboarding',
+}: {
+	isGatingBusinessQ1?: boolean;
+	siteCreationFlow?: string | null;
+} = {} ) {
 	mockUseSelector.mockImplementation( () =>
 		isGatingBusinessQ1 !== undefined
-			? { ID: 123, options: { is_gating_business_q1: isGatingBusinessQ1 } }
+			? {
+					ID: 123,
+					options: {
+						is_gating_business_q1: isGatingBusinessQ1,
+						site_creation_flow: siteCreationFlow,
+					},
+			  }
 			: null
 	);
 }
@@ -43,7 +55,7 @@ function mockSite( isGatingBusinessQ1: boolean | undefined ) {
 describe( 'usePlansGridRedesignExperiment', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockSite( undefined );
+		mockSite();
 		mockUseExperiment.mockReturnValue( [ false, { variationName: 'control' } ] );
 	} );
 
@@ -61,12 +73,12 @@ describe( 'usePlansGridRedesignExperiment', () => {
 		} );
 	} );
 
-	test( 'is eligible for existing sites with the gating flag', () => {
-		mockSite( true );
+	test( 'is eligible for logged-in plans pages when the site has the gating flag and was created by onboarding', () => {
+		mockSite( { isGatingBusinessQ1: true, siteCreationFlow: 'onboarding' } );
 
 		renderHook( () =>
 			usePlansGridRedesignExperiment( {
-				flowName: 'not-onboarding',
+				flowName: null,
 				isInSignup: false,
 				siteId: 123,
 			} )
@@ -77,8 +89,25 @@ describe( 'usePlansGridRedesignExperiment', () => {
 		} );
 	} );
 
+	test( 'is not eligible for logged-in plans pages when the site has the gating flag but was not created by onboarding', () => {
+		mockSite( { isGatingBusinessQ1: true, siteCreationFlow: 'newsletter' } );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: null,
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202607', {
+			isEligible: false,
+		} );
+		expect( result.current ).toEqual( INELIGIBLE_RESULT );
+	} );
+
 	test( 'is not eligible for onboarding flows with an existing site and no gating flag', () => {
-		mockSite( false );
+		mockSite( { isGatingBusinessQ1: false, siteCreationFlow: 'onboarding' } );
 
 		const { result } = renderHook( () =>
 			usePlansGridRedesignExperiment( {

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -64,11 +64,13 @@ function usePlansGridRedesignExperiment( {
 	const site = useSelector( ( state: IAppState ) => getSite( state, siteId ) );
 
 	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
+	const wasCreatedWithOnboardingFlow = site?.options?.site_creation_flow === 'onboarding';
 
-	// Onboarding flow is eligible
-	// Flows operating on an existing site are eligible only when the gating flag is set.
+	// New-site onboarding signups are eligible before a site exists.
+	// Existing sites are eligible only when they were created by onboarding and have the gating flag.
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
-	const isEligible = ( isEligibleSignupFlow && ! siteId ) || hasGatingFlag;
+	const isEligible =
+		( isEligibleSignupFlow && ! siteId ) || ( hasGatingFlag && wasCreatedWithOnboardingFlow );
 
 	const [ isLoading, assignment ] = useExperiment( PLANS_GRID_REDESIGN_EXPERIMENT_NAME, {
 		isEligible,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -965,7 +965,12 @@ const PlansFeaturesMain = ( {
 	let enableTermSavingsPriceDisplay = true;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
-	if ( redirectToAddDomainFlow !== undefined || hidePlanTypeSelector || isVisualSplitEnabled ) {
+	if (
+		redirectToAddDomainFlow !== undefined ||
+		hidePlanTypeSelector ||
+		isVisualSplitEnabled ||
+		( usePlansGridRedesign && isInSignup )
+	) {
 		hidePlanSelector = true;
 	}
 	if ( ! isInSignup ) {

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -78,6 +78,7 @@ import {
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { screen } from '@testing-library/react';
+import usePlansGridRedesignExperiment from 'calypso/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import useIntentFromSiteMeta from '../hooks/use-plan-intent-from-site-meta';
@@ -112,6 +113,15 @@ describe( 'PlansFeaturesMain', () => {
 			data: emptyPlansIndexForMockedFeatures,
 		} ) );
 		Plans.usePricingMetaForGridPlans.mockImplementation( () => emptyPlansIndexForMockedFeatures );
+		usePlansGridRedesignExperiment.mockImplementation( () => ( {
+			isLoading: false,
+			variant: 'control',
+			usePlansGridRedesign: false,
+			showDifferentiatorHeader: false,
+			showEnterpriseBottomCard: false,
+			showWooCommerceBottomCard: false,
+			isExperimentEligible: false,
+		} ) );
 	} );
 
 	describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
@@ -286,6 +296,38 @@ describe( 'PlansFeaturesMain', () => {
 		} );
 
 		test( 'Should render <PlanFeatures /> with tab picker when requested', () => {
+			renderWithProvider( <PlansFeaturesMain { ...myProps } /> );
+
+			expect( screen.getByText( 'PlanTypeSelector' ) ).toBeVisible();
+		} );
+
+		test( 'Should hide the plan type selector for redesign variants in signup', () => {
+			usePlansGridRedesignExperiment.mockImplementation( () => ( {
+				isLoading: false,
+				variant: 'six_plan_new_design',
+				usePlansGridRedesign: true,
+				showDifferentiatorHeader: false,
+				showEnterpriseBottomCard: false,
+				showWooCommerceBottomCard: false,
+				isExperimentEligible: true,
+			} ) );
+
+			renderWithProvider( <PlansFeaturesMain { ...myProps } flowName="onboarding" isInSignup /> );
+
+			expect( screen.queryByText( 'PlanTypeSelector' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'Should keep the plan type selector visible for redesign variants outside signup', () => {
+			usePlansGridRedesignExperiment.mockImplementation( () => ( {
+				isLoading: false,
+				variant: 'six_plan_new_design',
+				usePlansGridRedesign: true,
+				showDifferentiatorHeader: false,
+				showEnterpriseBottomCard: false,
+				showWooCommerceBottomCard: false,
+				isExperimentEligible: true,
+			} ) );
+
 			renderWithProvider( <PlansFeaturesMain { ...myProps } /> );
 
 			expect( screen.getByText( 'PlanTypeSelector' ) ).toBeVisible();


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17769

## Proposed Changes

* Show the new design in onboarding and /plans page for `six_plan_new_design` variant.

**Onboarding flow**
<img width="1410" height="871" alt="Screenshot 2026-07-07 at 13 38 01" src="https://github.com/user-attachments/assets/8e17628e-a660-43fa-9418-44bdf25235b7" />

**Ineligible flow**
<img width="1410" height="871" alt="Screenshot 2026-07-07 at 13 39 20" src="https://github.com/user-attachments/assets/b9d02db9-35ad-4874-b098-828c97d1acf0" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to `six_plan_new_design` variant and navigate to /setup/onboarding.
* Create a new site and confirm that the new design is shown during onboarding (without interval selector) and on /plans.
* Create a new site from /setup/reblogging flow and confirm that the old design is shown in onboarding and on /plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
