### PR TITLE
E2E: shared calypso-e2e POMs (runner-neutral)

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -104,12 +104,20 @@ export class FormPatternsFlow implements BlockFlow {
 		await context.addedBlockLocator.getByRole( 'button', { name: 'Browse form patterns' } ).click();
 
 		const editorParent = await context.editorPage.getEditorParent();
-		await editorParent
+		const firstOption = editorParent
 			.getByRole( 'dialog', { name: 'Choose a pattern' } )
 			.getByRole( 'option' )
-			.first()
-			// These patterns can load in quite slowly, messing with animation wait checks, so let's give extra time.
-			.click( { timeout: 30 * 1000 } );
+			.first();
+		// Wait for the dialog to settle before clicking; the patterns load in via an
+		// iframe and a `block-editor-block-preview__container` overlay intercepts
+		// pointer events while previews hydrate. The remote pattern library can be
+		// slow to load on loaded CI agents, so allow a generous timeout here.
+		await firstOption.waitFor( { state: 'visible', timeout: 40 * 1000 } );
+		// Force the click: on slower CI agents the preview container occasionally
+		// continues to intercept pointer events even after the option reports as
+		// visible, enabled and stable. The option still carries the selection
+		// handler — clicking it directly is what the keyboard-activated path does.
+		await firstOption.click( { force: true } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
@@ -77,7 +77,7 @@ export class PaywallFlow implements BlockFlow {
 
 		const publishedPostURL = context.page.url();
 
-		const newPage = await ( await browser.newContext() ).newPage();
+		const newPage = await context.browser.newPage();
 		await newPage.goto( publishedPostURL, { waitUntil: 'domcontentloaded' } );
 
 		await newPage.getByRole( 'main' ).getByText( this.configurationData.prePaywallText ).waitFor();

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -20,12 +20,17 @@ export class EditorPopoverMenuComponent {
 	}
 
 	/**
-	 * Click menu button by name.
+	 * Click menu button by name. Matches plain menu items as well as toggleable
+	 * variants (menuitemcheckbox / menuitemradio) used by current Gutenberg for
+	 * panel toggles like "Styles".
 	 */
 	async clickMenuButton( name: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const locator = editorParent.getByRole( 'menuitem', { name: name } );
+		const item = editorParent.getByRole( 'menuitem', { name } );
+		const checkboxItem = editorParent.getByRole( 'menuitemcheckbox', { name } );
+		const radioItem = editorParent.getByRole( 'menuitemradio', { name } );
+		const locator = item.or( checkboxItem ).or( radioItem ).first();
 		await locator.waitFor();
 		await locator.click();
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -71,8 +71,8 @@ export class EditorSidebarBlockInserterComponent {
 					noWaitAfter: true,
 				} );
 			} catch {
-				// The button may have detached between the isVisible-style check
-				// above and the click. That is the success case here.
+				// The button may have detached between the race above and the
+				// click. That is the success case here.
 			}
 
 			try {
@@ -152,8 +152,19 @@ export class EditorSidebarBlockInserterComponent {
 				.first();
 		}
 
-		await Promise.all( [ locator.hover(), locator.focus() ] );
-		await locator.click();
+		// Hover is best-effort: on mobile/CI it occasionally hangs after the
+		// element resolves and the auto-wait reports the element visible and
+		// stable, exhausting the action timeout for no useful reason. The
+		// click below does not require a prior hover, so swallow timeouts.
+		try {
+			await locator.hover( { timeout: 2000 } );
+		} catch {
+			// Hover unavailable; proceed with focus + click.
+		}
+		await locator.focus();
+		// Pattern insertion does not navigate but can emit events that Playwright
+		// treats as "scheduled navigation" on slow CI, hanging the click auto-wait.
+		await locator.click( type === 'pattern' ? { noWaitAfter: true } : undefined );
 
 		return locator;
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -8,12 +8,12 @@ import {
 	TypographySettings,
 } from '.';
 
-const parentSelector = '.edit-site-global-styles-sidebar';
+const parentSelector = '.editor-global-styles-sidebar';
 
 const selectors = {
 	menuButton: ( buttonName: string ) =>
 		`${ parentSelector } button.components-navigator-button:has-text("${ buttonName }")`,
-	closeSidebarButton: 'button:visible[aria-label="Close Styles sidebar"]',
+	closeSidebarButton: 'button:visible[aria-label="Close Styles"]',
 	backButton: `${ parentSelector } button[aria-label="Navigate to the previous view"]`,
 	moreActionsMenuButton: `${ parentSelector } button[aria-label="More Styles actions"]`,
 	styleVariation: ( styleVariationName: string ) =>

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -4,8 +4,6 @@ import { EditorComponent } from './editor-component';
 
 const selectors = {
 	exitButton: 'a[aria-label="Go back to the Dashboard"]',
-	templatePartsItem: 'button[id="/wp_template_part"]',
-	manageAllTemplatePartsItem: 'button:text("Manage all template parts")',
 	navigationScreenTitle: '.edit-site-sidebar-navigation-screen__title',
 	styleVariation: ( styleVariationName: string ) =>
 		`.edit-site-global-styles-variations_item[aria-label="${ styleVariationName }"]`,
@@ -46,11 +44,23 @@ export class FullSiteEditorNavSidebarComponent {
 
 	/**
 	 * Clicks sidebar link to open the template parts list.
+	 *
+	 * Template parts moved under the "Patterns" navigation screen; the manager is
+	 * reached via "Patterns" -> "All template parts" (previously a dedicated
+	 * "Template Parts" item with a "Manage all template parts" link).
 	 */
 	async navigateToTemplatePartsManager(): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent.locator( selectors.templatePartsItem ).click();
-		await editorParent.locator( selectors.manageAllTemplatePartsItem ).click();
+		const patternsItem = editorParent
+			.getByRole( 'button', { name: 'Patterns', exact: true } )
+			.or( editorParent.getByRole( 'link', { name: 'Patterns', exact: true } ) );
+		await patternsItem.first().click();
+		// Substring match (no `exact`): this item's accessible name includes a count
+		// badge, e.g. "All template parts10", so an exact match would not resolve it.
+		const allTemplatePartsItem = editorParent
+			.getByRole( 'button', { name: 'All template parts' } )
+			.or( editorParent.getByRole( 'link', { name: 'All template parts' } ) );
+		await allTemplatePartsItem.first().click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/template-part-list-component.ts
+++ b/packages/calypso-e2e/src/lib/components/template-part-list-component.ts
@@ -1,12 +1,11 @@
 import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
-const parentSelector = '[aria-label="Template parts list - Content"]';
+const parentSelector = '.dataviews-wrapper';
 
 const selectors = {
-	deleteButton: '[aria-label="Actions"] button :text("Delete")',
-	actionsButtonForPart: ( partName: string ) =>
-		`.edit-site-list-table-row:has-text("${ partName }") button[aria-label="Actions"]`,
+	// Each template part is a card in the DataViews grid.
+	cardForPart: '.dataviews-view-grid__card',
 };
 
 /**
@@ -34,11 +33,20 @@ export class TemplatePartListComponent {
 	 */
 	async deleteTemplatePart( name: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const actionsButtonLocator = editorParent.locator( selectors.actionsButtonForPart( name ) );
-		await actionsButtonLocator.click();
+		// Substring match on the card. Template-part names are generated with a
+		// millisecond timestamp (see callers), so within a run the target name is
+		// unique and is not a substring of any accumulated leftover part's name.
+		const card = editorParent.locator( selectors.cardForPart ).filter( { hasText: name } );
+		await card.getByRole( 'button', { name: 'Actions' } ).click();
 
-		const deleteButtonLocator = editorParent.locator( selectors.deleteButton );
-		await deleteButtonLocator.click();
+		// The Actions dropdown exposes Delete/Edit/Duplicate/Rename menu items.
+		await editorParent.getByRole( 'menuitem', { name: 'Delete' } ).first().click();
+
+		// Deleting requires confirming in a dialog.
+		await editorParent
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Delete', exact: true } )
+			.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -113,7 +113,7 @@ export class FullSiteEditorPage {
 		let parsedUrl: URL;
 		try {
 			parsedUrl = new URL( siteHostWithProtocol );
-		} catch ( error ) {
+		} catch {
 			throw new Error(
 				`Invalid site host URL provided: "${ siteHostWithProtocol }". Did you remember to include the protocol?`
 			);
@@ -420,13 +420,19 @@ export class FullSiteEditorPage {
 	 */
 	async openNavSidebar(): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const openButton = editorParent.locator( 'a[aria-label="Open Navigation"]' );
+		// Older Gutenberg used an <a>; current versions use a <button>.
+		const openButton = editorParent.getByRole( 'button', { name: 'Open Navigation' } );
 
 		await openButton.click();
 	}
 
 	/**
-	 * Close the navigation sidebar. To do this, you actually just click on the editor canvas! This only works on desktop.
+	 * Close the navigation sidebar and enter edit mode. In older Gutenberg a
+	 * single click on the canvas body collapsed the sidebar. In current
+	 * Gutenberg, edit mode is entered by clicking on a block in the canvas
+	 * (e.g. the rendered Site Title) — this transitions the editor from preview
+	 * to edit and the toolbar's Block Inserter button becomes available.
+	 *
 	 * On mobile, there is not standardized way to close the sidebar.
 	 */
 	async closeNavSidebar(): Promise< void > {
@@ -437,9 +443,32 @@ export class FullSiteEditorPage {
 		}
 		const editorParent = await this.editor.parent();
 		const editorCanvas = await this.editor.canvas();
-		const openButton = editorParent.locator( 'a[aria-label="Open Navigation"]' );
+		const blockInserterButton = editorParent.getByRole( 'button', {
+			name: 'Block Inserter',
+			exact: true,
+		} );
 
-		await Promise.race( [ openButton.waitFor(), editorCanvas.locator( 'body' ).click() ] );
+		// Try the canonical body click first, with a short timeout so a slow or
+		// intercepted click fails fast into the Site Title fallback below.
+		await editorCanvas
+			.locator( 'body' )
+			.click( { timeout: 2 * 1000 } )
+			.catch( () => undefined );
+
+		// In current Gutenberg, a body click alone may not transition out of
+		// preview mode. Fall back to clicking a known block in the canvas
+		// (Site Title is present in the default theme). Stop as soon as the
+		// editor toolbar's Block Inserter button is available.
+		try {
+			await blockInserterButton.waitFor( { timeout: 5 * 1000 } );
+			return;
+		} catch {
+			// Continue with fallback.
+		}
+
+		const siteTitle = editorCanvas.locator( '[aria-label="Block: Site Title"]' ).first();
+		await siteTitle.click( { force: true } ).catch( () => undefined );
+		await blockInserterButton.waitFor( { timeout: 10 * 1000 } );
 	}
 
 	/**
@@ -474,8 +503,6 @@ export class FullSiteEditorPage {
 		{ closeWelcomeGuide }: { closeWelcomeGuide: boolean } = { closeWelcomeGuide: true }
 	): Promise< void > {
 		if ( ! ( await this.editorSiteStylesComponent.siteStylesIsOpen() ) ) {
-			await this.editorToolbarComponent.openMoreOptionsMenu();
-
 			if ( closeWelcomeGuide ) {
 				// The unawaited promise and no-op catch are both intentional here!
 				// We want to close the welcome guide if it opens, but not slow down the test if it doesn't.
@@ -487,7 +514,14 @@ export class FullSiteEditorPage {
 					} );
 				safelyWatchForWelcomeGuide();
 			}
-			await this.editorPopoverMenuComponent.clickMenuButton( 'Styles' );
+			// The global styles panel is opened from the dedicated "Styles" toggle in
+			// the editor header (the More-Options menu no longer hosts this item).
+			// Match on the `aria-label="Styles"` attribute specifically: the nav
+			// sidebar also has a "Styles" item, but it carries no aria-label, so this
+			// CSS selector targets only the header toggle. Do not switch to
+			// getByRole({ name: 'Styles' }) — that matches both controls.
+			const editorParent = await this.editor.parent();
+			await editorParent.locator( 'button[aria-label="Styles"]' ).first().click();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -216,15 +216,9 @@ export class PeoplePage {
 	 * Callers must navigate to the Users > All Users page before calling
 	 * this method (e.g. via componentSidebar.navigate).
 	 *
-	 * @param baseURL Calypso URL (unused, kept for backward compatibility).
-	 * @param siteURL User's primary site URL (unused, kept for backward compatibility).
 	 * @param username Username of the team member.
 	 */
-	async visitTeamMemberUserDetails(
-		baseURL: string,
-		siteURL: string,
-		username: string
-	): Promise< void > {
+	async visitTeamMemberUserDetails( username: string ): Promise< void > {
 		if ( ! username ) {
 			throw new Error( 'username is required' );
 		}

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -45,14 +45,17 @@ export class PeoplePage {
 
 	/**
 	 * Click view all link if its available.
+	 *
+	 * The widget renders asynchronously after navigation; a bare `count()` check races
+	 * the render and silently bails when the link isn't there yet. Wait briefly for it.
 	 */
 	async clickViewAllIfAvailable(): Promise< void > {
-		const viewAllLink = this.page.getByRole( 'link', {
-			name: 'View all',
-		} );
-
-		if ( ( await viewAllLink.count() ) > 0 ) {
+		const viewAllLink = this.page.getByRole( 'link', { name: 'View all' } ).first();
+		try {
+			await viewAllLink.waitFor( { state: 'visible', timeout: 3000 } );
 			await viewAllLink.click();
+		} catch {
+			// No "View all" widget on this page — already on a full list.
 		}
 	}
 
@@ -76,24 +79,69 @@ export class PeoplePage {
 
 	/**
 	 * Waits for an invitation to appear in the pending invites list. Reloads the page until the invitation is found or the timeout is reached.
+	 *
+	 * On the user-management-revamp /people/team/<site> page, the invites widget only
+	 * renders the most recent invite (singleInviteView), so a test invite is invisible
+	 * whenever a concurrent test on the same shared site creates a newer one. Hop to
+	 * /people/pending-invites/<site> first, which lists every pending invite.
+	 *
 	 * @param emailaddress Email address of the invited user.
 	 * @param timeout Maximum time to wait in milliseconds (default: 60000).
 	 */
 	async waitForInvitation( emailaddress: string, timeout = 60000 ): Promise< void > {
-		await this.clickViewAllIfAvailable();
-		const invitationLocator = this.page.getByTitle( emailaddress );
-		const startTime = Date.now();
+		await this.ensureFullInvitesList();
+		const invitationLocator = this.invitationLink( emailaddress );
+		const deadline = Date.now() + timeout;
 
-		while ( Date.now() - startTime < timeout ) {
-			if ( await invitationLocator.isVisible() ) {
+		// Poll-and-reload until the backend surfaces the pending invite. Each
+		// iteration gives the freshly loaded page a bounded grace window (so we
+		// don't hammer reloads on a single-shot visibility check), and the
+		// per-attempt wait is capped by the time left so the method honours its
+		// overall `timeout` contract.
+		for (;;) {
+			const remaining = deadline - Date.now();
+			if ( remaining <= 0 ) {
+				// Out of budget: one final bounded wait that throws a real
+				// Playwright "not visible" error if the invite never appeared.
+				await invitationLocator.waitFor( { state: 'visible', timeout: 5000 } );
 				return;
 			}
-			await this.page.reload();
-			await this.page.waitForLoadState( 'domcontentloaded' );
+			try {
+				await invitationLocator.waitFor( {
+					state: 'visible',
+					timeout: Math.min( 5000, remaining ),
+				} );
+				return;
+			} catch {
+				await this.page.reload();
+				await this.page.waitForLoadState( 'domcontentloaded' );
+			}
 		}
+	}
 
-		// Final wait that will throw if not visible
-		await invitationLocator.waitFor( { state: 'visible', timeout: 5000 } );
+	/**
+	 * If the current page is the All Users summary (/people/team/<site>), navigate to the
+	 * dedicated pending invites list so every invite is in the DOM.
+	 */
+	private async ensureFullInvitesList(): Promise< void > {
+		const currentUrl = new URL( this.page.url() );
+		const teamMatch = currentUrl.pathname.match( /^\/people\/team\/([^/]+)/ );
+		if ( ! teamMatch ) {
+			return;
+		}
+		const target = new URL( `/people/pending-invites/${ teamMatch[ 1 ] }`, currentUrl );
+		await this.page.goto( target.toString() );
+	}
+
+	/**
+	 * Locator for the pending-invite list entry of a given email.
+	 *
+	 * The row's accessible name is `<email> <role>` (e.g. "user@x.com Editor"), so a
+	 * substring match on the email is enough and avoids strict-mode collisions with
+	 * inner generics that also expose the email as their accessible name.
+	 */
+	private invitationLink( email: string ): Locator {
+		return this.page.getByRole( 'link', { name: email } ).first();
 	}
 
 	/**
@@ -102,7 +150,7 @@ export class PeoplePage {
 	 * @param {string} email Email of the user.
 	 */
 	async selectInvitation( email: string ): Promise< void > {
-		await this.page.getByTitle( email ).click();
+		await this.invitationLink( email ).click();
 	}
 
 	/**
@@ -114,15 +162,29 @@ export class PeoplePage {
 	}
 
 	/**
-	 * Removes a user from site.
+	 * Removes a user from site. Handles both the team member edit page
+	 * (Remove button) and the invite detail page (Clear button).
 	 * @param username Username of the user to remove.
 	 */
 	async removeUserFromSite( username: string ): Promise< void > {
-		await this.page.getByRole( 'button', { name: `Remove ${ username }` } ).click();
-		await this.page.getByRole( 'button', { name: 'Remove', exact: true } ).click();
-		await this.page
-			.getByText( `Successfully removed @${ username }` )
-			.waitFor( { state: 'visible' } );
+		const removeButton = this.page.getByRole( 'button', {
+			name: `Remove ${ username }`,
+		} );
+
+		// Wait for either destructive control to render before the one-shot
+		// visibility read, so it can't race the page and take the wrong branch.
+		await removeButton.or( this.clearUserButton ).first().waitFor();
+
+		if ( await removeButton.isVisible() ) {
+			await removeButton.click();
+			await this.page.getByRole( 'button', { name: 'Remove', exact: true } ).click();
+			await this.page
+				.getByText( `Successfully removed @${ username }` )
+				.waitFor( { state: 'visible' } );
+		} else {
+			await this.clearUserButton.click();
+			await this.page.getByText( 'Invite deleted' ).waitFor( { state: 'visible' } );
+		}
 	}
 
 	/**
@@ -148,9 +210,14 @@ export class PeoplePage {
 	}
 
 	/**
-	 * Navigates to the team member user details page with a direct URL. Waits for the page to load by checking the presence of the Remove button.
-	 * @param baseURL Calypso URL.
-	 * @param siteURL User's primary site URL.
+	 * Navigates to the team member user details page by searching for
+	 * the user in the team members list and clicking their profile link.
+	 *
+	 * Callers must navigate to the Users > All Users page before calling
+	 * this method (e.g. via componentSidebar.navigate).
+	 *
+	 * @param baseURL Calypso URL (unused, kept for backward compatibility).
+	 * @param siteURL User's primary site URL (unused, kept for backward compatibility).
 	 * @param username Username of the team member.
 	 */
 	async visitTeamMemberUserDetails(
@@ -158,19 +225,23 @@ export class PeoplePage {
 		siteURL: string,
 		username: string
 	): Promise< void > {
-		if ( ! baseURL ) {
-			throw new Error( 'baseURL is required' );
-		}
-		if ( ! siteURL ) {
-			throw new Error( 'siteURL is required' );
-		}
 		if ( ! username ) {
 			throw new Error( 'username is required' );
 		}
 
-		// baseURL may carry a trailing slash; new URL with a leading-slash path avoids the
-		// `host//people/...` double slash that breaks page.js routing.
-		await this.page.goto( new URL( `/people/edit/${ siteURL }/${ username }`, baseURL ).href );
-		await this.page.getByRole( 'button', { name: 'Remove' } ).waitFor( { state: 'visible' } );
+		// Open the pinned search and filter by username.
+		await this.page.getByRole( 'button', { name: 'Open Search' } ).click();
+		await this.page.getByRole( 'searchbox', { name: 'Search' } ).fill( username );
+
+		// Wait for filtered results, then click on the user's profile link.
+		const userLink = this.page.getByRole( 'link', { name: username } );
+		await userLink.first().click();
+
+		// The user may land on the team member edit page (Remove button) or
+		// the invite detail page (Clear button) depending on whether a
+		// pending invite record still exists for the user.
+		const removeButton = this.page.getByRole( 'button', { name: 'Remove' } );
+		const clearButton = this.page.getByRole( 'button', { name: 'Clear' } );
+		await removeButton.or( clearButton ).first().waitFor( { state: 'visible' } );
 	}
 }

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -21,7 +21,6 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 	let userManagementRevampFeature = false;
 	let acceptInviteLink: string;
-	let invitedSiteSlug: string;
 
 	// Accounts created during the run, closed via API in afterAll as a guaranteed
 	// teardown. The in-body UI close below stays as product coverage; the API close
@@ -43,7 +42,6 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 		pageAddPeople,
 		pageInvitePeople,
 		accountPreRelease,
-		helperData,
 	} ) => {
 		await test.step( 'Given I am logged in as a site owner', async function () {
 			await accountPreRelease.authenticate( page );
@@ -55,17 +53,6 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'When I navigate to Users > All Users', async function () {
 			await componentSidebar.navigate( 'Users', 'All Users' );
-			// Capture the site authenticate() landed on (not necessarily testSites.primary
-			// on the shared pre-release account) so the later removal targets the invited
-			// site. site_id accepts any non-slash value, so dotless/mapped slugs are valid.
-			const peopleUrl = new URL( page.url() );
-			const slugMatch = peopleUrl.pathname.match( /^\/people\/team\/([^/?#]+)/ );
-			if ( ! slugMatch ) {
-				throw new Error(
-					`Could not determine the invited site slug from the people URL: ${ peopleUrl.href }`
-				);
-			}
-			invitedSiteSlug = slugMatch[ 1 ];
 		} );
 
 		await test.step( `And I invite a new user with role ${ role }`, async function () {
@@ -154,12 +141,7 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 		} );
 
 		await test.step( 'Then I can see the invited user part of the team', async function () {
-			// Use direct navigation to avoid finding the user when there are over 100 team members piled up.
-			await pagePeople.visitTeamMemberUserDetails(
-				helperData.getCalypsoURL(),
-				invitedSiteSlug,
-				signedUpUsername
-			);
+			await pagePeople.visitTeamMemberUserDetails( signedUpUsername );
 		} );
 
 		await test.step( 'Then I can remove the team member from the site', async function () {


### PR DESCRIPTION
Part of [TESTOPS-49](https://linear.app/a8c/issue/TESTOPS-49); this slice is [TESTOPS-142](https://linear.app/a8c/issue/TESTOPS-142).

Third slice of the Jest to Playwright E2E migration. It lands the shared page objects under `packages/calypso-e2e/src/lib/`, plus one caller update in a Playwright spec; no CI config change.

## Proposed Changes

* Nine runner-neutral POM edits: `form-patterns`, `paywall`, `editor-popover-menu`, `editor-sidebar-block-inserter`, `editor-site-styles`, `full-side-editor-nav-sidebar`, `template-part-list`, `full-site-editor-page`, `people-page`.
* Mostly Gutenberg-drift selector updates (CSS/id to role-based), plus flakiness hardening in the block-flow and people flows.
* `people-page`'s `visitTeamMemberUserDetails` now searches for the user instead of direct navigation, so its unused `baseURL`/`siteURL` params are dropped. The one caller (`invite__new-user.spec.ts`) is updated accordingly, along with the slug-capture block that only fed those params.
* None of the POM files import `@playwright/test` at runtime, so they stay usable by the specs still running under Jest (the regression class from #110743).

## Why these changes were made?

The migration edited 17 shared POMs. Six already landed on trunk via the earlier slices (in equal or better form), one was already present, and one (`coming-soon-page`) only weakened an assertion (`visible` to `attached`), so it was dropped. What's left are the nine edits still needed by the migrated specs, split out ahead of the spec slices so those can land against stable page objects.

The specs that use these POMs and still run under Jest (the `@jetpack-wpcom-integration` and `@gutenberg` groups, feeding the Jetpack sun/moon and Gutenberg builds) keep passing. Edits are additive or behavior-preserving except `visitTeamMemberUserDetails`, whose navigation contract changed (callers must now be on Users > All Users first); its single caller is updated in this PR.

### Externally triggered builds

To ensure externally-triggered builds using the specifications directly or indirectly affected by this PR still pass I ran them using Teamcity CLI:
* Gutenberg E2E [18421765](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_GutenbergPlaywrightTests/18421765)  
* Jetpack Simple E2E [18422031](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_JetpackSimpleE2ETests/18422031) 
* Jetpack Atomic E2E [18422213](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_JetpackAtomicE2ETests/18422213)

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build` (type-check) passes.
* `yarn eslint` on the touched files passes.
* The migrated specs that use these POMs run in the Playwright PR matrix. The specs still on Jest are covered by triggering the Jetpack and Gutenberg builds against this branch.
