### PR TITLE
Pricing grid redesign: update eligibility for existing sites to be based on the launch date

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -37,7 +37,7 @@ const mockUseSelector = useSelector as jest.Mock;
 function mockSite( {
 	isGatingBusinessQ1,
 	siteCreationFlow = 'onboarding',
-	createdAt = '2026-07-17 00:00:01',
+	createdAt = '2026-07-13 16:07:02',
 }: {
 	isGatingBusinessQ1?: boolean;
 	siteCreationFlow?: string | null;
@@ -111,11 +111,11 @@ describe( 'usePlansGridRedesignExperiment', () => {
 		expect( result.current ).toEqual( INELIGIBLE_RESULT );
 	} );
 
-	test( 'is not eligible for logged-in plans pages when the onboarding-created site predates the experiment launch', () => {
+	test( 'is not eligible for logged-in plans pages when the onboarding-created site is not after the experiment launch', () => {
 		mockSite( {
 			isGatingBusinessQ1: true,
 			siteCreationFlow: 'onboarding',
-			createdAt: '2026-07-06 23:59:59',
+			createdAt: '2026-07-09 16:00:00',
 		} );
 
 		const { result } = renderHook( () =>

--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -37,9 +37,11 @@ const mockUseSelector = useSelector as jest.Mock;
 function mockSite( {
 	isGatingBusinessQ1,
 	siteCreationFlow = 'onboarding',
+	createdAt = '2026-07-17 00:00:01',
 }: {
 	isGatingBusinessQ1?: boolean;
 	siteCreationFlow?: string | null;
+	createdAt?: string;
 } = {} ) {
 	mockUseSelector.mockImplementation( () =>
 		isGatingBusinessQ1 !== undefined
@@ -48,6 +50,7 @@ function mockSite( {
 					options: {
 						is_gating_business_q1: isGatingBusinessQ1,
 						site_creation_flow: siteCreationFlow,
+						...( createdAt && { created_at: createdAt } ),
 					},
 			  }
 			: null
@@ -93,6 +96,48 @@ describe( 'usePlansGridRedesignExperiment', () => {
 
 	test( 'is not eligible for logged-in plans pages when the site has the gating flag but was not created by onboarding', () => {
 		mockSite( { isGatingBusinessQ1: true, siteCreationFlow: 'newsletter' } );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: null,
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202607', {
+			isEligible: false,
+		} );
+		expect( result.current ).toEqual( INELIGIBLE_RESULT );
+	} );
+
+	test( 'is not eligible for logged-in plans pages when the onboarding-created site predates the experiment launch', () => {
+		mockSite( {
+			isGatingBusinessQ1: true,
+			siteCreationFlow: 'onboarding',
+			createdAt: '2026-07-06 23:59:59',
+		} );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: null,
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_pricing_differentiation_202607', {
+			isEligible: false,
+		} );
+		expect( result.current ).toEqual( INELIGIBLE_RESULT );
+	} );
+
+	test( 'is not eligible for logged-in plans pages when the site has no creation date', () => {
+		mockSite( {
+			isGatingBusinessQ1: true,
+			siteCreationFlow: 'onboarding',
+			createdAt: '',
+		} );
 
 		const { result } = renderHook( () =>
 			usePlansGridRedesignExperiment( {

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -4,6 +4,7 @@ import getSite from 'calypso/state/sites/selectors/get-site';
 import type { IAppState } from 'calypso/state/types';
 
 const PLANS_GRID_REDESIGN_EXPERIMENT_NAME = 'calypso_pricing_differentiation_202607';
+const PLANS_GRID_REDESIGN_EXPERIMENT_LAUNCH_DATE = '2026-07-09 00:00:00';
 
 const PLANS_GRID_REDESIGN_EXPERIMENT_VARIANTS = [
 	'control',
@@ -73,12 +74,16 @@ function usePlansGridRedesignExperiment( {
 
 	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
 	const wasCreatedWithOnboardingFlow = site?.options?.site_creation_flow === 'onboarding';
+	const siteCreatedAt = site?.options?.created_at;
+	const wasCreatedAfterExperimentLaunch =
+		!! siteCreatedAt && siteCreatedAt > PLANS_GRID_REDESIGN_EXPERIMENT_LAUNCH_DATE;
 
 	// New-site onboarding signups are eligible before a site exists.
-	// Existing sites are eligible only when they were created by onboarding and have the gating flag.
+	// Existing sites are eligible only when they were created by onboarding after launch and have the gating flag.
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
 	const isEligible =
-		( isEligibleSignupFlow && ! siteId ) || ( hasGatingFlag && wasCreatedWithOnboardingFlow );
+		( isEligibleSignupFlow && ! siteId ) ||
+		( hasGatingFlag && wasCreatedWithOnboardingFlow && wasCreatedAfterExperimentLaunch );
 
 	const [ isLoading, assignment ] = useExperiment( PLANS_GRID_REDESIGN_EXPERIMENT_NAME, {
 		isEligible,

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -4,7 +4,7 @@ import getSite from 'calypso/state/sites/selectors/get-site';
 import type { IAppState } from 'calypso/state/types';
 
 const PLANS_GRID_REDESIGN_EXPERIMENT_NAME = 'calypso_pricing_differentiation_202607';
-const PLANS_GRID_REDESIGN_EXPERIMENT_LAUNCH_DATE = '2026-07-09 00:00:00';
+const PLANS_GRID_REDESIGN_EXPERIMENT_LAUNCH_DATE = '2026-07-13 16:07:00';
 
 const PLANS_GRID_REDESIGN_EXPERIMENT_VARIANTS = [
 	'control',


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Add an eligibility check to prevent older sites from seeing the experiment on /plans page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
