### PR TITLE
Pricing grid redesign: implement variant2

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -182,7 +182,7 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			...CONTROL_RESULT,
 			variant: 'six_plan_new_features',
 			usePlansGridRedesign: true,
-			usePlansGridRedesignNewDescription: true,
+			usePlansGridRedesignNewDescription: false,
 			showDifferentiatorHeader: true,
 		} );
 	} );

--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -18,6 +18,7 @@ const CONTROL_RESULT = {
 	isLoading: false,
 	variant: 'control',
 	usePlansGridRedesign: false,
+	usePlansGridRedesignNewDescription: false,
 	showDifferentiatorHeader: false,
 	showEnterpriseBottomCard: false,
 	showWooCommerceBottomCard: false,
@@ -181,7 +182,45 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			...CONTROL_RESULT,
 			variant: 'six_plan_new_features',
 			usePlansGridRedesign: true,
+			usePlansGridRedesignNewDescription: true,
 			showDifferentiatorHeader: true,
+		} );
+	} );
+
+	test( 'enables the redesigned plan descriptions for six_plan_new_description', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'six_plan_new_description' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'six_plan_new_description',
+			usePlansGridRedesign: true,
+			usePlansGridRedesignNewDescription: true,
+		} );
+	} );
+
+	test( 'does not enable the redesigned plan descriptions for six_plan_new_design', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'six_plan_new_design' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: 'onboarding',
+				isInSignup: true,
+				siteId: null,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'six_plan_new_design',
+			usePlansGridRedesign: true,
 		} );
 	} );
 
@@ -200,6 +239,7 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			...CONTROL_RESULT,
 			variant: 'five_plan_new_description',
 			usePlansGridRedesign: true,
+			usePlansGridRedesignNewDescription: true,
 			showEnterpriseBottomCard: true,
 		} );
 	} );
@@ -219,6 +259,7 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			...CONTROL_RESULT,
 			variant: 'four_plan_new_description',
 			usePlansGridRedesign: true,
+			usePlansGridRedesignNewDescription: true,
 			showWooCommerceBottomCard: true,
 		} );
 	} );

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -25,6 +25,10 @@ type PlansGridRedesignExperimentResult = {
 	 */
 	usePlansGridRedesign: boolean;
 	/**
+	 * When true, use the redesigned plan tagline copy.
+	 */
+	usePlansGridRedesignNewDescription: boolean;
+	/**
 	 * When true, show the differentiator header (4 bullet points).
 	 */
 	showDifferentiatorHeader: boolean;
@@ -84,11 +88,19 @@ function usePlansGridRedesignExperiment( {
 			: 'control';
 
 	const usePlansGridRedesign = isEligible && ! isLoading && variant !== 'control';
+	const usePlansGridRedesignNewDescription =
+		usePlansGridRedesign &&
+		[
+			'five_plan_new_description',
+			'four_plan_new_description',
+			'six_plan_new_description',
+		].includes( variant );
 
 	return {
 		isLoading,
 		variant,
 		usePlansGridRedesign,
+		usePlansGridRedesignNewDescription,
 		showDifferentiatorHeader: usePlansGridRedesign && variant === 'six_plan_new_features',
 		showEnterpriseBottomCard: usePlansGridRedesign && variant === 'five_plan_new_description',
 		showWooCommerceBottomCard: usePlansGridRedesign && variant === 'four_plan_new_description',

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -691,6 +691,7 @@ const PlansFeaturesMain = ( {
 		isLoading: isPlansGridRedesignExperimentLoading,
 		showDifferentiatorHeader: showPlansGridRedesignDifferentiatorHeader,
 		usePlansGridRedesign,
+		usePlansGridRedesignNewDescription,
 	} = usePlansGridRedesignExperiment( { flowName, isInSignup, siteId } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
@@ -878,6 +879,7 @@ const PlansFeaturesMain = ( {
 		useVar42NoAiFeatures,
 		showPricingDifferentiationFeaturePills,
 		useFocusedNewCopyTaglines,
+		usePlansGridRedesignNewDescription,
 		isExperimentVariant,
 		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
 	} );
@@ -907,6 +909,7 @@ const PlansFeaturesMain = ( {
 		useVar42NoAiFeatures,
 		showPricingDifferentiationFeaturePills,
 		useFocusedNewCopyTaglines,
+		usePlansGridRedesignNewDescription,
 		isExperimentVariant,
 		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
 	} );

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -48,6 +48,10 @@ export interface UseGridPlansParams {
 	 */
 	useFocusedNewCopyTaglines?: boolean;
 	/**
+	 * When true, use the pricing grid redesign taglines for plan headers.
+	 */
+	usePlansGridRedesignNewDescription?: boolean;
+	/**
 	 * When true, use cohort feature lists and comparison grid copy.
 	 */
 	isExperimentVariant?: boolean;

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -31,6 +31,7 @@ const useGridPlansForComparisonGrid = ( {
 	useVar42NoAiFeatures,
 	showPricingDifferentiationFeaturePills,
 	useFocusedNewCopyTaglines,
+	usePlansGridRedesignNewDescription,
 	isExperimentVariant,
 	showBillingDescriptionForIncreasedRenewalPrice,
 }: UseGridPlansParams ): GridPlan[] | null => {
@@ -52,6 +53,7 @@ const useGridPlansForComparisonGrid = ( {
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
 		useFocusedNewCopyTaglines,
+		usePlansGridRedesignNewDescription,
 		showBillingDescriptionForIncreasedRenewalPrice,
 	} );
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -28,6 +28,7 @@ const useGridPlansForFeaturesGrid = ( {
 	useVar42NoAiFeatures,
 	showPricingDifferentiationFeaturePills,
 	useFocusedNewCopyTaglines,
+	usePlansGridRedesignNewDescription,
 	isExperimentVariant,
 	showBillingDescriptionForIncreasedRenewalPrice,
 }: UseGridPlansParams ): GridPlan[] | null => {
@@ -51,6 +52,7 @@ const useGridPlansForFeaturesGrid = ( {
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
 		useFocusedNewCopyTaglines,
+		usePlansGridRedesignNewDescription,
 		showBillingDescriptionForIncreasedRenewalPrice,
 	} );
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -329,6 +329,7 @@ const useGridPlans: UseGridPlansType = ( {
 	isDomainOnlySite,
 	reflectStorageSelectionInPlanPrices,
 	useFocusedNewCopyTaglines,
+	usePlansGridRedesignNewDescription,
 	showBillingDescriptionForIncreasedRenewalPrice,
 } ) => {
 	const translate = useTranslate();
@@ -472,6 +473,51 @@ const useGridPlans: UseGridPlansType = ( {
 					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
 					i18n.hasTranslation( 'Run an online store and keep more of what you earn.' )
 						? translate( 'Run an online store and keep more of what you earn.' )
+						: existingTagline;
+			} else if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Publish securely at enterprise scale.' )
+						? translate( 'Publish securely at enterprise scale.' )
+						: existingTagline;
+			}
+		}
+
+		if ( usePlansGridRedesignNewDescription ) {
+			const existingTagline = tagline;
+			if ( isFreePlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'For exploring WordPress.' )
+						? translate( 'For exploring WordPress.' )
+						: existingTagline;
+			} else if ( isPersonalPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'For making a personal site or blog truly yours.' )
+						? translate( 'For making a personal site or blog truly yours.' )
+						: existingTagline;
+			} else if ( isPremiumPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'For creators and professionals building a credible presence.' )
+						? translate( 'For creators and professionals building a credible presence.' )
+						: existingTagline;
+			} else if ( isBusinessPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation(
+						'For businesses and developers who need powerful tools and priority support.'
+					)
+						? translate(
+								'For businesses and developers who need powerful tools and priority support.'
+						  )
+						: existingTagline;
+			} else if ( isEcommercePlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'For merchants growing an online store.' )
+						? translate( 'For merchants growing an online store.' )
 						: existingTagline;
 			} else if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
 				tagline =


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17770

## Proposed Changes

* Show the new design in onboarding and /plans page for six_plan_new_description variant.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the `six_plan_new_description` variant and navigate to /setup/onboarding.
* Confirm that new taglines for plans are visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
