### PR TITLE
Reader onboarding - fix logged out discover

### DIFF
--- a/client/reader/onboarding/gate.tsx
+++ b/client/reader/onboarding/gate.tsx
@@ -1,5 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const loadOnboardingRsm = () =>
 	import(
@@ -16,6 +18,15 @@ type ReaderOnboardingGateProps = {
 };
 
 export default function ReaderOnboardingGate( props: ReaderOnboardingGateProps ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	// Reader onboarding is a logged-in-only experience (it reads/writes user
+	// preferences and follow state). Surfaces like Discover render this gate
+	// while logged out, so guard here rather than relying on the host route.
+	if ( ! isLoggedIn ) {
+		return null;
+	}
+
 	return isEnabled( 'reader/onboarding-rsm' ) ? (
 		<AsyncLoad require={ loadOnboardingRsm } { ...props } />
 	) : (

--- a/client/reader/onboarding/test/gate.test.tsx
+++ b/client/reader/onboarding/test/gate.test.tsx
@@ -2,18 +2,30 @@
  * @jest-environment jsdom
  */
 import { isEnabled } from '@automattic/calypso-config';
-import { render } from '@testing-library/react';
 import AsyncLoad from 'calypso/components/async-load';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import ReaderOnboardingGate from '../gate';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn();
+	const isEnabledMock = jest.fn();
+	return {
+		__esModule: true,
+		default: Object.assign( config, { isEnabled: isEnabledMock } ),
+		isEnabled: isEnabledMock,
+	};
+} );
 
 jest.mock( 'calypso/components/async-load', () => ( {
 	__esModule: true,
 	default: jest.fn( () => null ),
 } ) );
+
+const loggedInState = { currentUser: { id: 12345 } };
+const loggedOutState = { currentUser: { id: null } };
+
+const render = ( ui: React.ReactElement, initialState = loggedInState ) =>
+	renderWithProvider( ui, { initialState } );
 
 describe( 'ReaderOnboardingGate', () => {
 	beforeEach( () => {
@@ -50,5 +62,13 @@ describe( 'ReaderOnboardingGate', () => {
 			onRender,
 			isSuppressed: true,
 		} );
+	} );
+
+	it( 'renders nothing when the user is logged out', () => {
+		( isEnabled as jest.Mock ).mockReturnValue( true );
+
+		render( <ReaderOnboardingGate />, loggedOutState );
+
+		expect( AsyncLoad as jest.Mock ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/reader/onboarding/test/gate.test.tsx
+++ b/client/reader/onboarding/test/gate.test.tsx
@@ -5,6 +5,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import ReaderOnboardingGate from '../gate';
+import type { ReactElement } from 'react';
 
 jest.mock( '@automattic/calypso-config', () => {
 	const config = jest.fn();
@@ -21,10 +22,12 @@ jest.mock( 'calypso/components/async-load', () => ( {
 	default: jest.fn( () => null ),
 } ) );
 
-const loggedInState = { currentUser: { id: 12345 } };
-const loggedOutState = { currentUser: { id: null } };
+type TestState = { currentUser: { id: number | null } };
 
-const render = ( ui: React.ReactElement, initialState = loggedInState ) =>
+const loggedInState: TestState = { currentUser: { id: 12345 } };
+const loggedOutState: TestState = { currentUser: { id: null } };
+
+const render = ( ui: ReactElement, initialState: TestState = loggedInState ) =>
 	renderWithProvider( ui, { initialState } );
 
 describe( 'ReaderOnboardingGate', () => {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # logged out discover showing onboarding checklist.

## Proposed Changes

adds an isLoggedIn check to the onboarding gate.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* some recent change caused this regression where onboarding checklist shows up in logged out discover...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to /discover in incognito/logged-out tab. verify checklist isnt present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
