### PR TITLE
Reader post cache - fix bug with feeds having 0 post ID values.

### DIFF
--- a/client/reader/data/post/cache/index.ts
+++ b/client/reader/data/post/cache/index.ts
@@ -40,6 +40,14 @@ const valueToString = ( value: unknown ): string | null => {
 	return String( value );
 };
 
+// External and shadow-blog feed items often carry `ID: 0`. Treating that as a
+// real blog post id creates a shared `blog-0-{site_ID}` alias that collapses
+// every item on the feed into one cache entry.
+const isValidReaderPostId = ( value: unknown ): boolean => {
+	const stringValue = valueToString( value );
+	return Boolean( stringValue && stringValue !== '0' );
+};
+
 const postKeyStringFromKey = ( postKey: PostCacheKey ): string | null => {
 	return keyToString( postKey );
 };
@@ -67,14 +75,14 @@ const postKeyStringsFromPost = ( post: Post ): string[] => {
 		} );
 	}
 
-	if ( Boolean( post.is_external ) && postId ) {
+	if ( Boolean( post.is_external ) && isValidReaderPostId( post.ID ) ) {
 		const externalFeedId = feedId ?? siteId;
 		if ( externalFeedId ) {
 			keyStrings.add( `feed-${ postId }-${ externalFeedId }` );
 		}
 	}
 
-	if ( siteId && postId && ! post.is_external ) {
+	if ( siteId && isValidReaderPostId( post.ID ) && ! post.is_external ) {
 		keyStrings.add( `blog-${ postId }-${ siteId }` );
 	}
 
@@ -164,7 +172,12 @@ const arraysShareMatchingValue = ( left: unknown, right: unknown ): boolean => {
 
 const postMatchesKey = ( post: Post, key: PostCacheKey ): boolean => {
 	if ( key.blogId && key.postId ) {
-		return valuesMatch( post.site_ID, key.blogId ) && valuesMatch( post.ID, key.postId );
+		return (
+			isValidReaderPostId( key.postId ) &&
+			isValidReaderPostId( post.ID ) &&
+			valuesMatch( post.site_ID, key.blogId ) &&
+			valuesMatch( post.ID, key.postId )
+		);
 	}
 
 	if ( key.feedId && key.postId ) {
@@ -186,7 +199,12 @@ const postsShareIdentity = ( left: Post, right: Post ): boolean => {
 	if ( valuesMatch( left.global_ID, right.global_ID ) ) {
 		return true;
 	}
-	if ( valuesMatch( left.site_ID, right.site_ID ) && valuesMatch( left.ID, right.ID ) ) {
+	if (
+		isValidReaderPostId( left.ID ) &&
+		isValidReaderPostId( right.ID ) &&
+		valuesMatch( left.site_ID, right.site_ID ) &&
+		valuesMatch( left.ID, right.ID )
+	) {
 		return true;
 	}
 	if (
@@ -550,12 +568,10 @@ export const useCachedPosts = ( targets: PostCacheTarget[] ): Array< Post | null
 		} ) ),
 	} );
 
-	return useMemo(
-		() =>
-			queries.map( ( query ) =>
-				mergePostCacheData( query.data as PostCacheData | null | undefined )
-			),
-		[ queries ]
+	// Derived inline: `useQueries` returns a fresh array each render, so memoizing
+	// on it trips @tanstack/query/no-unstable-deps without buying anything.
+	return queries.map( ( query ) =>
+		mergePostCacheData( query.data as PostCacheData | null | undefined )
 	);
 };
 

--- a/client/reader/data/post/cache/test/index.test.tsx
+++ b/client/reader/data/post/cache/test/index.test.tsx
@@ -195,6 +195,59 @@ describe( 'reader post cache', () => {
 		} );
 	} );
 
+	it( 'keeps feed stream posts distinct when blog post IDs are zero', async () => {
+		const queryClient = makeQueryClient();
+		const feedId = 101852522;
+		const siteId = 162509141;
+		const posts = [
+			{
+				ID: 0,
+				site_ID: siteId,
+				feed_ID: feedId,
+				feed_item_ID: 6110855097,
+				global_ID: 'global-feed-item-1',
+				title: 'First TIME post',
+				is_external: false,
+			},
+			{
+				ID: 0,
+				site_ID: siteId,
+				feed_ID: feedId,
+				feed_item_ID: 6110855098,
+				global_ID: 'global-feed-item-2',
+				title: 'Second TIME post',
+				is_external: false,
+			},
+		];
+
+		upsertPostCache( queryClient, posts );
+
+		expect( getCachedPost( queryClient, { feedId, postId: 6110855097 } ) ).toMatchObject( {
+			title: 'First TIME post',
+			feed_item_ID: 6110855097,
+		} );
+		expect( getCachedPost( queryClient, { feedId, postId: 6110855098 } ) ).toMatchObject( {
+			title: 'Second TIME post',
+			feed_item_ID: 6110855098,
+		} );
+		expect( getCachedPost( queryClient, { blogId: siteId, postId: 0 } ) ).toBeNull();
+
+		const postKeys = [
+			{ feedId, postId: 6110855097 },
+			{ feedId, postId: 6110855098 },
+		];
+		const { result } = renderHook( () => useCachedPosts( postKeys ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => {
+			expect( result.current ).toEqual( [
+				expect.objectContaining( { title: 'First TIME post' } ),
+				expect.objectContaining( { title: 'Second TIME post' } ),
+			] );
+		} );
+	} );
+
 	it( 'exposes dynamic cached post lists through useCachedPosts', async () => {
 		const queryClient = makeQueryClient();
 		const postKeys = [


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # https://linear.app/a8c/issue/READ-585/reader-feed-page-shows-duplicated-post-cards 

## Proposed Changes

Prevents some feeds from showing massive amounts of duplicated items and being unusable:
* Adds minor `isValidReaderPostId` helper that also checks for the "0" string.
* Consumes the helper in logic for cache key assignment and matching.
Changes only impact feeds whose items resolve with `ID: 0`


BEFORE
<img width="640" height="536" alt="repeated-posts-stream" src="https://github.com/user-attachments/assets/8b9450dd-3b02-447e-b6d6-4d2d87834688" />


AFTER
<img width="745" height="681" alt="Screenshot 2026-07-07 at 10 40 53 AM" src="https://github.com/user-attachments/assets/409d9c08-6f25-4644-8b85-9e71eb750987" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* broken feed regressions from using this new query cache - the collision came from postsShareIdentity matching on site_ID + ID when both posts had ID: 0 (and from blog-0-{site_ID} alias creation)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit `*/reader/feeds/101852522`
* verify there are no mass duplications overwhelming the feed, you can compare to production for example. the feed now reflects the post order from the feed endpoint.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
