### PR TITLE
Plans: increase top padding on plan comparison grid

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -32,7 +32,7 @@
 		}
 
 		@include plans-grid-medium-large {
-			padding-top: 34px;
+			padding-top: 40px;
 
 			&.popular-plan-parent-class {
 				justify-content: space-between;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-503/

## Proposed Changes

This increases the top padding of the plans grid at desktop widths, per design audit request.

| Before  | Description |
| ----------- | ----------- |
| <img width="2510" height="804" alt="CleanShot 2026-07-07 at 10 53 52@2x" src="https://github.com/user-attachments/assets/b2876bcd-a81c-4fc5-963d-9591716c5b72" /> | <img width="2522" height="802" alt="CleanShot 2026-07-07 at 10 53 37@2x" src="https://github.com/user-attachments/assets/56e33698-5402-41b6-b09a-cea460e31193" /> |

## Testing Instructions

- On desktop
- Visit Upgrades > Plans
- Click "Compare plans" button at the bottom
- Verify that the top padding of the header element is increased