### PR TITLE
Add Ecommerce link to universal footer navigation

### DIFF
--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -90,6 +90,11 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/ecommerce/' ) } target="_self">
+										{ __( 'Ecommerce', __i18n_text_domain__ ) }
+									</a>
+								</li>
+								<li>
 									<a href={ localizeUrl( 'https://wordpress.com/affiliates/' ) } target="_self">
 										{ __( 'Become an Affiliate', __i18n_text_domain__ ) }
 									</a>


### PR DESCRIPTION
Part of DOTCOM-17795

## Proposed Changes

* Add an "Ecommerce" link to the universal footer navigation, pointing to `https://wordpress.com/ecommerce/` (localized via `localizeUrl`).

## Why are these changes being made?

* Surface the Ecommerce offering in the footer navigation alongside the other WordPress.com product links.

## Testing Instructions

* Load a page rendering the universal footer navigation.
  * For example: `/patterns` or `/themes`
* Verify the new "Ecommerce" link appears in the products column and navigates to the localized `/ecommerce/` URL.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?