### PR TITLE
Stats: Add Subscribers card info tooltip

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -432,6 +432,13 @@ const contextLinks = {
 	'stats-emails-jetpack': {
 		link: 'https://jetpack.com/support/jetpack-stats/subscribers-stats/#emails-section',
 	},
+	'stats-subscribers': {
+		link: 'https://wordpress.com/support/stats/view-subscriber-stats/#view-subscriber-stats',
+		post_id: 404454,
+	},
+	'stats-subscribers-jetpack': {
+		link: 'https://jetpack.com/support/jetpack-stats/subscribers-stats/#view-your-subscribers',
+	},
 	'stats-search-terms': {
 		link: 'https://wordpress.com/support/stats/understand-traffic-sources/#analyze-search-terms',
 		post_id: 404387,

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -4,6 +4,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -23,6 +25,9 @@ const StatModuleFollowers = ( { className } ) => {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 
 	const { data: subTotals, isLoading, isError: hasError } = useSubscribersTotalsQueries( siteId );
 
@@ -68,6 +73,7 @@ const StatModuleFollowers = ( { className } ) => {
 	const subscriberManagementUrl = useJetpackCloudLinks
 		? `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`
 		: `https://wordpress.com/subscribers/${ summaryPageSlug }`;
+	const supportContext = isSiteJetpackNotAtomic ? 'stats-subscribers-jetpack' : 'stats-subscribers';
 
 	return (
 		<StatsListCard
@@ -92,6 +98,17 @@ const StatModuleFollowers = ( { className } ) => {
 			usePlainCard
 			hasNoBackground
 			title={ translate( 'Subscribers' ) }
+			titleNodes={
+				<StatsInfoArea>
+					{ translate( '{{link}}Latest subscribers{{/link}} and when they subscribed.', {
+						comment: '{{link}} links to support documentation.',
+						components: {
+							link: <InlineSupportLink supportContext={ supportContext } showIcon={ false } />,
+						},
+						context: 'Stats: Header popover information when the Subscribers module has data.',
+					} ) }
+				</StatsInfoArea>
+			}
 			emptyMessage={ translate(
 				'Once you get a few, {{link}}your subscribers{{/link}} will appear here.',
 				{


### PR DESCRIPTION
Fixes STATS-281

## Proposed Changes

* Add a Subscribers card header info tooltip that matches the Emails card pattern.
* Add WordPress.com and Jetpack inline support contexts for the subscriber stats guide.
* Link the tooltip copy through `InlineSupportLink` so it opens the existing support doc flow.

## Why are these changes being made?

* The Subscribers card sits next to Emails on the Stats Subscribers page, but Emails had a docs tooltip while Subscribers did not.

## Testing Instructions

* Open `/stats/subscribers/:site` on a site with subscribers.
* Confirm the Subscribers card header shows the info icon.
* Open the tooltip and confirm the "Latest subscribers" link opens the support doc/help flow.
* Confirm the tooltip opens the WordPress.com support doc for WordPress.com/Atomic sites and the Jetpack support doc for non-Atomic Jetpack sites.
* Confirm the Emails card remains unchanged.

|WPCOM sites|Self-hosted sites|
|-|-|
|<img width="328" height="181" alt="截圖 2026-07-08 凌晨12 42 53" src="https://github.com/user-attachments/assets/83e59d2b-3c71-4df4-a2e5-8bdc56d54633" />|<img width="325" height="183" alt="截圖 2026-07-08 凌晨12 43 44" src="https://github.com/user-attachments/assets/2bf41462-878e-4e13-9e1b-2d14b77bd4e5" />|

Checks run locally:

* `git diff --check`
* `prettier --write client/my-sites/stats/stats-followers/index.jsx client/components/inline-support-link/context-links.js`
* `NODE_PATH=/Users/dognose/Sites/calypso/node_modules ESLINT_USE_FLAT_CONFIG=false /Users/dognose/Sites/calypso/node_modules/.bin/eslint client/my-sites/stats/stats-followers/index.jsx client/components/inline-support-link/context-links.js`

Not run:

* `yarn typecheck-client` (temporary worktree does not have full dependencies installed).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
