### PR TITLE
Purchases: add inline Add payment method link to payment-method warning

### DIFF
--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -19,9 +20,13 @@ import type { ReactNode } from 'react';
 export default function PaymentInfoBlock( {
 	purchase,
 	cards,
+	addPaymentMethodUrl,
+	onAddPaymentMethodClick,
 }: {
 	purchase: Purchase;
 	cards: StoredPaymentMethod[];
+	addPaymentMethodUrl?: string;
+	onAddPaymentMethodClick?: () => void;
 } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -40,10 +45,10 @@ export default function PaymentInfoBlock( {
 	if ( hasPaymentMethod( purchase ) && isPaidWithCredits( purchase ) ) {
 		return (
 			<PaymentInfoBlockWrapper>
-				<div className="manage-purchase__no-payment-method">
-					<Icon icon={ warning } />
-					{ translate( 'You don’t have a payment method to renew this subscription' ) }
-				</div>
+				<NoPaymentMethodWarning
+					addPaymentMethodUrl={ addPaymentMethodUrl }
+					onAddPaymentMethodClick={ onAddPaymentMethodClick }
+				/>
 			</PaymentInfoBlockWrapper>
 		);
 	}
@@ -109,10 +114,10 @@ export default function PaymentInfoBlock( {
 	if ( purchase.isAutoRenewEnabled && ! hasPaymentMethod( purchase ) ) {
 		return (
 			<PaymentInfoBlockWrapper>
-				<div className="manage-purchase__no-payment-method">
-					<Icon icon={ warning } />
-					{ translate( 'You don’t have a payment method to renew this subscription' ) }
-				</div>
+				<NoPaymentMethodWarning
+					addPaymentMethodUrl={ addPaymentMethodUrl }
+					onAddPaymentMethodClick={ onAddPaymentMethodClick }
+				/>
 			</PaymentInfoBlockWrapper>
 		);
 	}
@@ -124,10 +129,10 @@ export default function PaymentInfoBlock( {
 	) {
 		return (
 			<PaymentInfoBlockWrapper>
-				<div className="manage-purchase__no-payment-method">
-					<Icon icon={ warning } />
-					{ translate( 'You don’t have a payment method to renew this subscription' ) }
-				</div>
+				<NoPaymentMethodWarning
+					addPaymentMethodUrl={ addPaymentMethodUrl }
+					onAddPaymentMethodClick={ onAddPaymentMethodClick }
+				/>
 			</PaymentInfoBlockWrapper>
 		);
 	}
@@ -141,6 +146,34 @@ function PaymentInfoBlockWrapper( { children }: { children: ReactNode } ) {
 			<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
 			<span className="manage-purchase__detail">{ children }</span>
 		</aside>
+	);
+}
+
+function NoPaymentMethodWarning( {
+	addPaymentMethodUrl,
+	onAddPaymentMethodClick,
+}: {
+	addPaymentMethodUrl?: string;
+	onAddPaymentMethodClick?: () => void;
+} ) {
+	const translate = useTranslate();
+	return (
+		<>
+			<div className="manage-purchase__no-payment-method">
+				<Icon icon={ warning } />
+				{ translate( 'You don’t have a payment method to renew this subscription' ) }
+			</div>
+			{ addPaymentMethodUrl && (
+				<Button
+					className="manage-purchase__add-payment-method-link"
+					variant="link"
+					href={ addPaymentMethodUrl }
+					onClick={ onAddPaymentMethodClick }
+				>
+					{ translate( 'Add payment method' ) }
+				</Button>
+			) }
+		</>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -161,18 +161,20 @@ function NoPaymentMethodWarning( {
 		<>
 			<div className="manage-purchase__no-payment-method">
 				<Icon icon={ warning } />
-				{ translate( 'You don’t have a payment method to renew this subscription' ) }
+				<span>
+					{ translate( 'You don’t have a payment method to renew this subscription' ) }
+					{ addPaymentMethodUrl && (
+						<Button
+							className="manage-purchase__add-payment-method-link"
+							variant="secondary"
+							href={ addPaymentMethodUrl }
+							onClick={ onAddPaymentMethodClick }
+						>
+							{ translate( 'Add payment method' ) }
+						</Button>
+					) }
+				</span>
 			</div>
-			{ addPaymentMethodUrl && (
-				<Button
-					className="manage-purchase__add-payment-method-link"
-					variant="link"
-					href={ addPaymentMethodUrl }
-					onClick={ onAddPaymentMethodClick }
-				>
-					{ translate( 'Add payment method' ) }
-				</Button>
-			) }
 		</>
 	);
 }

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -161,20 +161,18 @@ function NoPaymentMethodWarning( {
 		<>
 			<div className="manage-purchase__no-payment-method">
 				<Icon icon={ warning } />
-				<span>
-					{ translate( 'You don’t have a payment method to renew this subscription' ) }
-					{ addPaymentMethodUrl && (
-						<Button
-							className="manage-purchase__add-payment-method-link"
-							variant="secondary"
-							href={ addPaymentMethodUrl }
-							onClick={ onAddPaymentMethodClick }
-						>
-							{ translate( 'Add payment method' ) }
-						</Button>
-					) }
-				</span>
+				{ translate( 'You don’t have a payment method to renew this subscription' ) }
 			</div>
+			{ addPaymentMethodUrl && (
+				<Button
+					className="manage-purchase__add-payment-method-link"
+					variant="link"
+					href={ addPaymentMethodUrl }
+					onClick={ onAddPaymentMethodClick }
+				>
+					{ translate( 'Add payment method' ) }
+				</Button>
+			) }
 		</>
 	);
 }

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -1,8 +1,12 @@
 import { isAkismetFreeProduct, isDomainTransfer } from '@automattic/calypso-products';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { isOneTimePurchase, isPaidWithCreditCard } from 'calypso/lib/purchases';
+import { isOneTimePurchase, isPaidWithCreditCard, isPartnerPurchase } from 'calypso/lib/purchases';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
-import { canEditPaymentDetails } from '../utils';
+import {
+	canEditPaymentDetails,
+	isAkismetHoldingSitePurchase,
+	isMarketplaceHoldingSitePurchase,
+} from '../utils';
 import PaymentInfoBlock from './payment-info-block';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { Purchase, GetChangePaymentMethodUrlFor } from 'calypso/lib/purchases/types';
@@ -29,6 +33,27 @@ function PurchaseMetaPaymentDetails( {
 		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
 	};
 
+	const isHoldingSitePurchase =
+		isAkismetHoldingSitePurchase( purchase ) || isMarketplaceHoldingSitePurchase( purchase );
+
+	const canAddPaymentMethod =
+		canEditPaymentDetails( purchase ) &&
+		! isPaidWithCreditCard( purchase ) &&
+		!! siteSlug &&
+		! ( isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase ) &&
+		( !! site || isAkismetPurchase || !! isA4ABillingDragonPurchase || isHoldingSitePurchase );
+
+	const addPaymentMethodUrl =
+		canAddPaymentMethod && siteSlug
+			? getChangePaymentMethodUrlFor( siteSlug, purchase )
+			: undefined;
+
+	const handleAddPaymentMethodClick = () => {
+		recordTracksEvent( 'calypso_purchases_add_payment_method_from_warning', {
+			product_slug: purchase.productSlug,
+		} );
+	};
+
 	if (
 		isOneTimePurchase( purchase ) ||
 		isDomainTransfer( purchase ) ||
@@ -37,7 +62,14 @@ function PurchaseMetaPaymentDetails( {
 		return null;
 	}
 
-	const paymentDetails = <PaymentInfoBlock purchase={ purchase } cards={ cards } />;
+	const paymentDetails = (
+		<PaymentInfoBlock
+			purchase={ purchase }
+			cards={ cards }
+			addPaymentMethodUrl={ addPaymentMethodUrl }
+			onAddPaymentMethodClick={ handleAddPaymentMethodClick }
+		/>
+	);
 
 	if (
 		! canEditPaymentDetails( purchase ) ||

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -386,6 +386,11 @@
 		}
 	}
 
+	.manage-purchase__add-payment-method-link {
+		margin-block-start: 4px;
+		height: auto;
+	}
+
 	.payment-logo {
 		margin-right: 5px;
 		border-radius: 2px;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -372,7 +372,7 @@
 
 	.manage-purchase__no-payment-method {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 4px;
 
 		@include breakpoint-deprecated( '<660px' ) {
@@ -383,6 +383,10 @@
 		svg {
 			flex-shrink: 0;
 			fill: var( --color-warning-30 );
+		}
+
+		a {
+			display: inline-block;
 		}
 	}
 

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -6,6 +6,7 @@
 /* eslint-disable jest/valid-title */
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import PaymentInfoBlock from '../payment-info-block';
 
 describe( 'PaymentInfoBlock', () => {
@@ -374,5 +375,48 @@ describe( 'PaymentInfoBlock', () => {
 		expect(
 			screen.getByText( 'You don’t have a payment method to renew this subscription' )
 		).toBeInTheDocument();
+	} );
+
+	describe( 'the inline "Add payment method" link', () => {
+		const noMethodPurchase = {
+			expiryStatus: undefined,
+			payment: { type: 'none' },
+			isRechargeable: false,
+			isAutoRenewEnabled: true,
+		};
+
+		it( 'renders a link with the given href when addPaymentMethodUrl is provided', () => {
+			render(
+				<PaymentInfoBlock
+					purchase={ noMethodPurchase }
+					cards={ [] }
+					addPaymentMethodUrl="/me/purchases/add-payment-method/example.com/123"
+				/>
+			);
+			const link = screen.getByRole( 'link', { name: 'Add payment method' } );
+			expect( link ).toBeVisible();
+			expect( link ).toHaveAttribute( 'href', '/me/purchases/add-payment-method/example.com/123' );
+		} );
+
+		it( 'does not render the link when addPaymentMethodUrl is absent', () => {
+			render( <PaymentInfoBlock purchase={ noMethodPurchase } cards={ [] } /> );
+			expect(
+				screen.queryByRole( 'link', { name: 'Add payment method' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'calls onAddPaymentMethodClick when the link is clicked', async () => {
+			const onClick = jest.fn();
+			render(
+				<PaymentInfoBlock
+					purchase={ noMethodPurchase }
+					cards={ [] }
+					addPaymentMethodUrl="/me/purchases/add-payment-method/example.com/123"
+					onAddPaymentMethodClick={ onClick }
+				/>
+			);
+			await userEvent.click( screen.getByRole( 'link', { name: 'Add payment method' } ) );
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -130,6 +130,18 @@ function createMockReduxStoreForPurchase( purchaseForRedux, domains_items = {} )
 	);
 }
 
+// The manage-purchase page renders two "Add/Change payment method" links: the
+// management nav item, and an inline link inside the "Payment method" detail
+// (the complementary region) that connects the no-payment-method warning to an
+// action. This returns the nav item, which lives outside that region.
+async function findPaymentMethodNavItem() {
+	const links = await screen.findAllByRole( 'link', {
+		name: /(?:Add|Change) payment method/,
+	} );
+	const paymentMethodDetail = screen.getByRole( 'complementary', { name: 'Payment method' } );
+	return links.find( ( link ) => ! paymentMethodDetail.contains( link ) );
+}
+
 describe( 'Purchase Management Buttons', () => {
 	const queryClient = new QueryClient();
 
@@ -359,7 +371,7 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( /(?:Add|Change) payment method/ ) ).toBeInTheDocument();
+		expect( await findPaymentMethodNavItem() ).toBeInTheDocument();
 	} );
 
 	it( 'renders payment method nav item for A4A billingdragon purchase on a siteless holding site', async () => {
@@ -410,7 +422,7 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( /(?:Add|Change) payment method/ ) ).toBeInTheDocument();
+		expect( await findPaymentMethodNavItem() ).toBeInTheDocument();
 	} );
 
 	it( 'renders renew button for A4A billingdragon purchase', async () => {
@@ -491,7 +503,7 @@ describe( 'Purchase Management Buttons', () => {
 		);
 
 		// Wait for component to fully render
-		await screen.findByText( /(?:Add|Change) payment method/ );
+		await findPaymentMethodNavItem();
 		expect( screen.queryByText( /Upgrade/ ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-500/

## Proposed Changes

Adds an inline "Add payment method" link directly beneath the "You don’t have a payment method to renew this subscription" warning on the classic manage-purchase page, so the action lives with the warning instead of only as a disconnected nav item further down the list. This mirrors the fix already shipped for the Multi-site Dashboard (CHE-274).

| Before | After |
| ----------- | ----------- |
| <img width="2154" height="1132" alt="CleanShot 2026-07-07 at 15 26 09@2x" src="https://github.com/user-attachments/assets/4f1be800-9984-43c9-b67b-e356443fab26" /> | <img width="2176" height="1468" alt="CleanShot 2026-07-07 at 15 25 50@2x" src="https://github.com/user-attachments/assets/6eebfcd7-ef9f-4362-99d8-8487ad47e6ee" /> |

* Extract the duplicated warning markup in `PaymentInfoBlock` into a `NoPaymentMethodWarning` component and give the block two optional props (`addPaymentMethodUrl`, `onAddPaymentMethodClick`); when a URL is provided it renders an "Add payment method" link-style button (`Button variant="link"`) under the warning.
* Compute eligibility in `PurchaseMetaPaymentDetails`, matching the existing nav item's gate and the Dashboard's `! is_rechargeable` intent, and resolve the URL via `getChangePaymentMethodUrlFor` (which points at the add-payment-method flow when there's no card).
* Fire a distinct Tracks event `calypso_purchases_add_payment_method_from_warning` on click.

## Why are these changes being made?

The Payment method cell warned users that they had no payment method to renew, but offered no way to act on it — the "Add payment method" action sat lower in the list, visually disconnected from the warning, so the relationship wasn't obvious. Placing the action inline with the warning lets people fix the problem where they encounter it.

The eligibility gate deliberately includes `! isPaidWithCreditCard( purchase )`: `PurchaseMetaPaymentDetails` already wraps the whole cell in an anchor for credit-card purchases, so excluding that case prevents nesting an anchor inside an anchor and matches the Dashboard behavior (card purchases show the card + update affordance; only the no-usable-method cases get the inline "Add payment method" link).

Note: unlike the existing nav item, the inline gate does not replicate the `isHundredYearDomain` domain-details exclusion (which would require plumbing Redux domain details into this functional component). This edge case is only reachable for a near-expiry hundred-year domain in a no-rechargeable-method state, where offering "Add payment method" is harmless; it was left out intentionally.

## Testing Instructions

Manual testing:
* On a Simple site, open a subscription's manage page: `/purchases/subscriptions/{siteSlug}/{purchaseId}` for a subscription that has auto-renew enabled and no payment method assigned.
* Confirm an "Add payment method" link now appears directly under the "You don’t have a payment method to renew this subscription" warning, and that clicking it navigates to the add-payment-method flow.
* Confirm the Tracks event `calypso_purchases_add_payment_method_from_warning` fires on click.
* Confirm an expired / one-time / included-with-plan purchase still shows the warning without the link.
