### PR TITLE
Domain search: stop rendering "Exact match" twice on the exact-match card

### DIFF
--- a/packages/domain-search/src/components/featured-search-results/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/item.tsx
@@ -28,19 +28,32 @@ export const FeaturedSearchResultsItem = ( {
 
 	const suggestion = useSuggestion( domainName );
 
+	const showsExactMatchBadge =
+		reason === 'exact-match' && suggestion.price_rule !== DomainPriceRule.DOMAIN_MOVE_PRICE;
+
 	const matchReasons = useMemo( () => {
 		if ( ! suggestion.match_reasons || query !== domainName ) {
 			return;
 		}
 
-		return parseMatchReasons( domainName, suggestion.match_reasons );
-	}, [ domainName, suggestion.match_reasons, query ] );
+		// The exact-match badge already surfaces "Exact match", so drop the redundant
+		// 'exact-match' footer reason to avoid rendering the same label twice on the
+		// card (the backend sends it for an available FQDN search). The remaining
+		// per-TLD reasons still render.
+		const reasons = showsExactMatchBadge
+			? suggestion.match_reasons.filter( ( matchReason ) => matchReason !== 'exact-match' )
+			: suggestion.match_reasons;
+
+		const parsed = parseMatchReasons( domainName, reasons );
+
+		return parsed.length > 0 ? parsed : undefined;
+	}, [ domainName, suggestion.match_reasons, query, showsExactMatchBadge ] );
 
 	const suggestionBadges = useDomainSuggestionBadges( domainName );
 	const policyBadges = usePolicyBadges( domainName );
 
 	const badges = useMemo( () => {
-		if ( reason === 'exact-match' && suggestion.price_rule !== DomainPriceRule.DOMAIN_MOVE_PRICE ) {
+		if ( showsExactMatchBadge ) {
 			return [
 				<DomainSuggestionBadge key="exact-match">
 					{ bullseyeIcon }
@@ -69,7 +82,7 @@ export const FeaturedSearchResultsItem = ( {
 			);
 		}
 		return existingBadges;
-	}, [ reason, suggestionBadges, policyBadges, suggestion.price_rule ] );
+	}, [ reason, suggestionBadges, policyBadges, showsExactMatchBadge ] );
 
 	const { events } = useDomainSearch();
 

--- a/packages/domain-search/src/components/featured-search-results/test/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/test/item.tsx
@@ -167,6 +167,40 @@ describe( 'FeaturedSearchResultsItem', () => {
 			expect( screen.getByText( "It's available!" ) ).toBeInTheDocument();
 		} );
 
+		it( 'renders "Exact match" only in the badge, not also in the match-reasons footer', async () => {
+			// An available FQDN search returns match_reasons including 'exact-match'
+			// (see the backend availability endpoint). Since query === domainName, the
+			// footer renders too — but "Exact match" must not appear twice: the badge
+			// owns it, and the footer keeps only the remaining per-TLD reason.
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-exact-match.com' },
+				suggestions: [
+					buildSuggestion( {
+						domain_name: 'test-exact-match.com',
+						match_reasons: [ 'exact-match', 'tld-exact' ],
+					} ),
+				],
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestions query="test-exact-match.com">
+					<FeaturedSearchResultsItem
+						reason="exact-match"
+						domainName="test-exact-match.com"
+						isSingleFeaturedSuggestion={ false }
+					/>
+				</TestDomainSearchWithSuggestions>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-exact-match.com' ) );
+
+			// Exactly one "Exact match" on the card (the badge), never duplicated.
+			expect( screen.getAllByText( 'Exact match' ) ).toHaveLength( 1 );
+			// The footer still renders, showing the remaining per-TLD reason.
+			expect( screen.getByTestId( 'domain-suggestion-match-reasons' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Extension ".com" matches your query' ) ).toBeInTheDocument();
+		} );
+
 		it( 'does not render the exact match badge if it is a move suggestion even if the reason is exact-match', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-move-suggestion.com' },


### PR DESCRIPTION
Related to #DOMAINS-2207
Follow-up to #112337.

## Problem

#112337 added an "Exact match" badge to the exact-match featured card. But when a user searches an available **FQDN** (`query === domainName`), the backend returns `match_reasons` including `exact-match`, which the match-reasons footer also renders as "Exact match". Result: the same label appears **twice** on one card — once in the badge, once as the first footer line.

This only happens on FQDN searches (e.g. typing `example.com`), since the footer is gated on `query === domainName`; bare-term searches show only the badge.

## Fix

When the exact-match badge is shown, drop the redundant `exact-match` reason from the footer, keeping the remaining per-TLD reason (e.g. `Extension ".com" matches your query`). This matches the design (the `ExactMatch` story shows badge + per-TLD tagline, not a repeated label).

## Testing

- New regression test populates `match_reasons: ['exact-match', 'tld-exact']` the way the FQDN availability path does, and asserts "Exact match" appears exactly once while the footer still renders the per-TLD reason.
- `yarn jest -c=test/packages/jest.config.js packages/domain-search/src/components/featured-search-results/test/item.tsx` → **23 passed**.

Co-Authored-By: Claude <noreply@anthropic.com>
