### PR TITLE
Login: brand OAuth2 login screen as Jetpack for the Jetpack app

### DIFF
--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -1,13 +1,27 @@
+import { getQueryArg } from '@wordpress/url';
+
+// The WordPress and Jetpack mobile apps share the same OAuth2 client IDs; the app
+// identity is not encoded in the client_id. Distinguish the Jetpack app from the
+// WordPress app by the redirect_uri scheme (jetpack:// vs wordpress://).
+// Keep these in sync with wpcom `.config/constants.php`.
+const IOS_APP_OAUTH2_CLIENT_IDS = [ 11, 29217, 36118, 55461 ];
+const ANDROID_APP_OAUTH2_CLIENT_IDS = [ 2697, 55462 ];
+
 export const isAkismetOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 973;
 };
 
 export const isAndroidOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client?.id === 2697;
+	return !! oauth2Client && ANDROID_APP_OAUTH2_CLIENT_IDS.includes( oauth2Client.id );
 };
 
 export const isIosOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client?.id === 11;
+	return !! oauth2Client && IOS_APP_OAUTH2_CLIENT_IDS.includes( oauth2Client.id );
+};
+
+// True for either mobile app (WordPress or Jetpack) on either platform.
+export const isSharedMobileAppOAuth2Client = ( oauth2Client ) => {
+	return isIosOAuth2Client( oauth2Client ) || isAndroidOAuth2Client( oauth2Client );
 };
 
 export const isCrowdsignalOAuth2Client = ( oauth2Client ) => {
@@ -77,4 +91,49 @@ export const isVIPOAuth2Client = ( oauth2Client ) => {
 export const isCiabOAuth2Client = ( oauth2Client ) => {
 	// 134404 => CIAB Dev, 134405 => CIAB Staging/Production.
 	return oauth2Client && [ 134404, 134405 ].includes( oauth2Client.id );
+};
+
+const JETPACK_APP_URI_SCHEME = 'jetpack://';
+
+// The redirect_uri reaches the login page nested inside redirect_to, where it is
+// often multiply percent-encoded (e.g. `jetpack%253A%252F%252F...`). Decode until
+// the value stops changing so the scheme is legible.
+const fullyDecode = ( value ) => {
+	let decoded = String( value );
+	for ( let i = 0; i < 5; i++ ) {
+		let next;
+		try {
+			next = decodeURIComponent( decoded );
+		} catch {
+			return decoded;
+		}
+		if ( next === decoded ) {
+			break;
+		}
+		decoded = next;
+	}
+	return decoded;
+};
+
+// Reads the app's OAuth2 callback (redirect_uri) out of a login query. It is
+// nested inside redirect_to, but may also appear as a direct query param.
+export const getOAuth2RedirectUri = ( query ) => {
+	if ( ! query ) {
+		return null;
+	}
+	if ( typeof query.redirect_uri === 'string' ) {
+		return query.redirect_uri;
+	}
+	if ( typeof query.redirect_to !== 'string' ) {
+		return null;
+	}
+	const redirectUri = getQueryArg( query.redirect_to, 'redirect_uri' );
+	return typeof redirectUri === 'string' ? redirectUri : null;
+};
+
+export const isJetpackAppRedirectUri = ( redirectUri ) => {
+	return (
+		typeof redirectUri === 'string' &&
+		fullyDecode( redirectUri ).toLowerCase().startsWith( JETPACK_APP_URI_SCHEME )
+	);
 };

--- a/client/lib/test/oauth2-clients.js
+++ b/client/lib/test/oauth2-clients.js
@@ -1,0 +1,93 @@
+import {
+	isIosOAuth2Client,
+	isAndroidOAuth2Client,
+	isSharedMobileAppOAuth2Client,
+	getOAuth2RedirectUri,
+	isJetpackAppRedirectUri,
+} from 'calypso/lib/oauth2-clients';
+
+describe( 'oauth2-clients mobile app helpers', () => {
+	describe( 'isIosOAuth2Client', () => {
+		test( 'matches the production and beta/alpha/trial iOS client IDs', () => {
+			expect( isIosOAuth2Client( { id: 11 } ) ).toBe( true );
+			expect( isIosOAuth2Client( { id: 29217 } ) ).toBe( true );
+			expect( isIosOAuth2Client( { id: 36118 } ) ).toBe( true );
+			expect( isIosOAuth2Client( { id: 55461 } ) ).toBe( true );
+		} );
+
+		test( 'does not match Android or unrelated clients', () => {
+			expect( isIosOAuth2Client( { id: 2697 } ) ).toBe( false );
+			expect( isIosOAuth2Client( { id: 1854 } ) ).toBe( false );
+			expect( isIosOAuth2Client( null ) ).toBe( false );
+			expect( isIosOAuth2Client( undefined ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isAndroidOAuth2Client', () => {
+		test( 'matches the production and trial Android client IDs', () => {
+			expect( isAndroidOAuth2Client( { id: 2697 } ) ).toBe( true );
+			expect( isAndroidOAuth2Client( { id: 55462 } ) ).toBe( true );
+		} );
+
+		test( 'does not match iOS or unrelated clients', () => {
+			expect( isAndroidOAuth2Client( { id: 11 } ) ).toBe( false );
+			expect( isAndroidOAuth2Client( { id: 1854 } ) ).toBe( false );
+			expect( isAndroidOAuth2Client( null ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isSharedMobileAppOAuth2Client', () => {
+		test( 'matches any shared mobile app client on either platform', () => {
+			expect( isSharedMobileAppOAuth2Client( { id: 11 } ) ).toBe( true );
+			expect( isSharedMobileAppOAuth2Client( { id: 2697 } ) ).toBe( true );
+			expect( isSharedMobileAppOAuth2Client( { id: 29217 } ) ).toBe( true );
+			expect( isSharedMobileAppOAuth2Client( { id: 55462 } ) ).toBe( true );
+		} );
+
+		test( 'does not match non-mobile clients', () => {
+			expect( isSharedMobileAppOAuth2Client( { id: 1854 } ) ).toBe( false );
+			expect( isSharedMobileAppOAuth2Client( { id: 68663 } ) ).toBe( false );
+			expect( isSharedMobileAppOAuth2Client( null ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getOAuth2RedirectUri', () => {
+		test( 'extracts redirect_uri nested inside redirect_to', () => {
+			const query = {
+				redirect_to:
+					'https://public-api.wordpress.com/oauth2/authorize?client_id=11&response_type=code&redirect_uri=jetpack%3A%2F%2Foauth2-callback',
+			};
+			expect( getOAuth2RedirectUri( query ) ).toBe( 'jetpack://oauth2-callback' );
+		} );
+
+		test( 'prefers a direct redirect_uri query param when present', () => {
+			const query = { redirect_uri: 'wordpress://oauth2-callback', redirect_to: 'https://x/?y=1' };
+			expect( getOAuth2RedirectUri( query ) ).toBe( 'wordpress://oauth2-callback' );
+		} );
+
+		test( 'returns null when neither is present', () => {
+			expect( getOAuth2RedirectUri( { from: 'jetpack' } ) ).toBeNull();
+			expect( getOAuth2RedirectUri( null ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'isJetpackAppRedirectUri', () => {
+		test( 'is true for the jetpack:// scheme, case-insensitively', () => {
+			expect( isJetpackAppRedirectUri( 'jetpack://oauth2-callback' ) ).toBe( true );
+			expect( isJetpackAppRedirectUri( 'jetpack://wpcom-authorize' ) ).toBe( true );
+			expect( isJetpackAppRedirectUri( 'JETPACK://oauth2-callback' ) ).toBe( true );
+		} );
+
+		test( 'is true even when singly or multiply percent-encoded', () => {
+			expect( isJetpackAppRedirectUri( 'jetpack%3A%2F%2Foauth2-callback' ) ).toBe( true );
+			expect( isJetpackAppRedirectUri( 'jetpack%253A%252F%252Foauth2-callback' ) ).toBe( true );
+		} );
+
+		test( 'is false for the wordpress:// scheme and empty values', () => {
+			expect( isJetpackAppRedirectUri( 'wordpress://oauth2-callback' ) ).toBe( false );
+			expect( isJetpackAppRedirectUri( '' ) ).toBe( false );
+			expect( isJetpackAppRedirectUri( null ) ).toBe( false );
+			expect( isJetpackAppRedirectUri( undefined ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -1,4 +1,3 @@
-import { WordPressLogo } from '@automattic/components';
 import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
 import blazeProLogo from 'calypso/assets/images/blaze/blaze-pro-logo.webp';
 import WooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
@@ -23,6 +22,7 @@ import {
 	isJetpackCloudOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isSharedMobileAppOAuth2Client,
+	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useSelector } from 'calypso/state';
@@ -31,6 +31,18 @@ import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 import getIsPassport from 'calypso/state/selectors/get-is-passport';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
+
+// The WordPress and Jetpack mobile apps are branded with their store icons, hosted
+// on WordPress.com. `?w=128` requests the 2x asset for the 64px logo slot.
+const MOBILE_APP_LOGO_URLS = {
+	jetpackIos:
+		'https://i0.wp.com/developer.files.wordpress.com/2026/07/jetpack-composited.png?w=128',
+	jetpackAndroid: 'https://i0.wp.com/developer.files.wordpress.com/2026/07/app_icon.png?w=128',
+	wordpressIos:
+		'https://i0.wp.com/developer.files.wordpress.com/2026/07/wordpress-composited.png?w=128',
+	wordpressAndroid:
+		'https://i0.wp.com/developer.files.wordpress.com/2026/07/wordpress_app_icon.png?w=128',
+};
 
 interface Props {
 	isJetpack?: boolean;
@@ -87,10 +99,28 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 			/>
 		);
 	} else if ( isJetpackApp ) {
-		logo = <JetpackPlusWpComLogo size={ 32 } />;
+		logo = (
+			<img
+				src={
+					isIosOAuth2Client( oauth2Client )
+						? MOBILE_APP_LOGO_URLS.jetpackIos
+						: MOBILE_APP_LOGO_URLS.jetpackAndroid
+				}
+				alt="Jetpack"
+			/>
+		);
 	} else if ( isSharedMobileAppOAuth2Client( oauth2Client ) ) {
 		// WordPress mobile app — the Jetpack app already matched `isJetpackApp` above.
-		logo = <WordPressLogo size={ 32 } />;
+		logo = (
+			<img
+				src={
+					isIosOAuth2Client( oauth2Client )
+						? MOBILE_APP_LOGO_URLS.wordpressIos
+						: MOBILE_APP_LOGO_URLS.wordpressAndroid
+				}
+				alt="WordPress"
+			/>
+		);
 	} else if ( isJetpack ) {
 		logo = <JetpackLogo size={ 64 } />;
 	} else if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -26,6 +26,7 @@ import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
+import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 import getIsPassport from 'calypso/state/selectors/get-is-passport';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
@@ -40,6 +41,7 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 	const isWoo = useSelector( getIsWoo );
 	const isAkismet = useSelector( getIsAkismet );
 	const isPassport = useSelector( getIsPassport );
+	const isJetpackApp = useSelector( getIsJetpackApp );
 	const { hasCustomBranding } = usePartnerBranding();
 
 	// If partner has custom top-left branding, don't show center logo
@@ -82,6 +84,8 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 				className="wp-login__connector-logo"
 			/>
 		);
+	} else if ( isJetpackApp ) {
+		logo = <JetpackPlusWpComLogo size={ 32 } />;
 	} else if ( isJetpack ) {
 		logo = <JetpackLogo size={ 64 } />;
 	} else if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -1,3 +1,4 @@
+import { WordPressLogo } from '@automattic/components';
 import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
 import blazeProLogo from 'calypso/assets/images/blaze/blaze-pro-logo.webp';
 import WooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
@@ -21,6 +22,7 @@ import {
 	isA4AOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isPartnerPortalOAuth2Client,
+	isSharedMobileAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useSelector } from 'calypso/state';
@@ -86,6 +88,9 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 		);
 	} else if ( isJetpackApp ) {
 		logo = <JetpackPlusWpComLogo size={ 32 } />;
+	} else if ( isSharedMobileAppOAuth2Client( oauth2Client ) ) {
+		// WordPress mobile app — the Jetpack app already matched `isJetpackApp` above.
+		logo = <WordPressLogo size={ 32 } />;
 	} else if ( isJetpack ) {
 		logo = <JetpackLogo size={ 64 } />;
 	} else if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -78,4 +78,10 @@
 
 .wp-login__one-login-header-client-name {
 	text-transform: capitalize;
+
+	// Pre-branded, exact-case names (e.g. "Jetpack for iOS") must not be
+	// title-cased, which would render "iOS" as "IOS" and "for" as "For".
+	&.is-exact-case {
+		text-transform: none;
+	}
 }

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -21,12 +21,6 @@
 		width: 64px;
 		height: 64px;
 	}
-
-	// `WordPressLogo` defaults to a white fill (it targets dark backgrounds);
-	// follow the heading text color so it stays visible in light and dark mode.
-	.wordpress-logo {
-		fill: currentColor;
-	}
 }
 
 .wp-login__one-login-layout-top-right {

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -21,6 +21,12 @@
 		width: 64px;
 		height: 64px;
 	}
+
+	// `WordPressLogo` defaults to a white fill (it targets dark backgrounds);
+	// follow the heading text color so it stays visible in light and dark mode.
+	.wordpress-logo {
+		fill: currentColor;
+	}
 }
 
 .wp-login__one-login-layout-top-right {

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -149,7 +149,9 @@ export function getHeaderText( {
 				args: { partner: partnerConfig.displayName },
 			} );
 		} else {
-			let clientName: TranslateResult | undefined = oauth2Client?.name;
+			// Resolve a known brand name. These are authoritative and rendered
+			// verbatim; only the raw client slug fallback below is title-cased.
+			let clientName: TranslateResult | undefined;
 			const mobileAppClientName = getMobileAppClientName( {
 				oauth2Client,
 				isJetpackApp,
@@ -183,6 +185,14 @@ export function getHeaderText( {
 				clientName = 'Woo';
 			}
 
+			// A resolved brand name is authoritative and rendered verbatim. Fall back
+			// to the raw client slug otherwise, which `text-transform: capitalize`
+			// prettifies (e.g. "crowdsignal" -> "Crowdsignal").
+			const isBrandedName = clientName !== undefined;
+			if ( ! isBrandedName ) {
+				clientName = oauth2Client?.name;
+			}
+
 			headerText = clientName
 				? ( fixMe( {
 						text: 'Log in to {{span}}%(client)s{{/span}} with WordPress.com',
@@ -192,7 +202,7 @@ export function getHeaderText( {
 								span: (
 									<span
 										className={ clsx( 'wp-login__one-login-header-client-name', {
-											'is-exact-case': !! mobileAppClientName,
+											'is-exact-case': isBrandedName,
 										} ) }
 									/>
 								),

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -7,6 +7,8 @@ import {
 	isBlazeProOAuth2Client,
 	isPartnerPortalOAuth2Client,
 	isVIPOAuth2Client,
+	isSharedMobileAppOAuth2Client,
+	isIosOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -22,6 +24,7 @@ interface Props {
 	currentQuery: ReturnType< typeof getCurrentQueryArguments >;
 	translate: ( arg0: string, arg1?: object ) => TranslateResult;
 	isJetpack?: boolean;
+	isJetpackApp?: boolean;
 	twoStepNonce?: string | null;
 	isSocialFirst?: boolean;
 	isWooJPC?: boolean;
@@ -57,6 +60,38 @@ const getLoggedInUserHeaderText = ( {
 };
 
 /**
+ * Branded title for the shared WordPress/Jetpack mobile app OAuth2 clients.
+ *
+ * Both apps share the same client IDs, so the stored client title/name is not a
+ * reliable brand (production has shown values like `wordpress-app-ios`). The
+ * Jetpack app is identified by its `jetpack://` redirect_uri. Returns null when
+ * the client is not one of the shared mobile app clients.
+ */
+export function getMobileAppClientName( {
+	oauth2Client,
+	isJetpackApp,
+	translate,
+}: {
+	oauth2Client: { id: number } | null | undefined;
+	isJetpackApp?: boolean;
+	translate: Props[ 'translate' ];
+} ): TranslateResult | null {
+	if ( ! isSharedMobileAppOAuth2Client( oauth2Client ) ) {
+		return null;
+	}
+
+	if ( isJetpackApp ) {
+		return isIosOAuth2Client( oauth2Client )
+			? translate( 'Jetpack for iOS' )
+			: translate( 'Jetpack for Android' );
+	}
+
+	return isIosOAuth2Client( oauth2Client )
+		? translate( 'WordPress for iOS' )
+		: translate( 'WordPress for Android' );
+}
+
+/**
  * This function is used to get the header text for the login page.
  * TODO: We'll convert this to hook form in the future.
  */
@@ -70,6 +105,7 @@ export function getHeaderText( {
 	oauth2Client,
 	isWooJPC,
 	isJetpack,
+	isJetpackApp,
 	isWCCOM,
 	isBlazePro,
 	isFromAkismet,
@@ -112,11 +148,18 @@ export function getHeaderText( {
 				args: { partner: partnerConfig.displayName },
 			} );
 		} else {
-			let clientName = oauth2Client?.name;
+			let clientName: TranslateResult | undefined = oauth2Client?.name;
+			const mobileAppClientName = getMobileAppClientName( {
+				oauth2Client,
+				isJetpackApp,
+				translate,
+			} );
 			if ( isFromAkismet ) {
 				clientName = 'Akismet';
 			} else if ( isFromPassport ) {
 				clientName = 'Passport';
+			} else if ( mobileAppClientName ) {
+				clientName = mobileAppClientName;
 			} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 				clientName = 'Blaze Pro';
 			} else if ( isA4AOAuth2Client( oauth2Client ) ) {

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -1,4 +1,5 @@
 import { capitalize } from '@automattic/js-utils';
+import clsx from 'clsx';
 import { TranslateResult, fixMe } from 'i18n-calypso';
 import { getLoginCopy } from 'calypso/jetpack-connect/connection-content';
 import {
@@ -187,7 +188,15 @@ export function getHeaderText( {
 						text: 'Log in to {{span}}%(client)s{{/span}} with WordPress.com',
 						newCopy: translate( 'Log in to {{span}}%(client)s{{/span}} with WordPress.com', {
 							args: { client: clientName },
-							components: { span: <span className="wp-login__one-login-header-client-name" /> },
+							components: {
+								span: (
+									<span
+										className={ clsx( 'wp-login__one-login-header-client-name', {
+											'is-exact-case': !! mobileAppClientName,
+										} ) }
+									/>
+								),
+							},
 						} ),
 						oldCopy: translate( 'Log in to WordPress.com' ),
 				  } ) as TranslateResult )

--- a/client/login/wp-login/hooks/test/get-header-text.test.tsx
+++ b/client/login/wp-login/hooks/test/get-header-text.test.tsx
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { useTranslate } from 'i18n-calypso';
-import { getMobileAppClientName } from '../get-header-text';
+import { render } from '@testing-library/react';
+import { useTranslate, translate, type TranslateResult } from 'i18n-calypso';
+import { getHeaderText, getMobileAppClientName } from '../get-header-text';
 
 describe( 'getMobileAppClientName', () => {
 	const translate = ( ( text: string ) => text ) as ReturnType< typeof useTranslate >;
@@ -43,5 +44,41 @@ describe( 'getMobileAppClientName', () => {
 		expect(
 			getMobileAppClientName( { oauth2Client: null, isJetpackApp: false, translate } )
 		).toBeNull();
+	} );
+} );
+
+describe( 'getHeaderText client-name casing', () => {
+	// The client-name span is `text-transform: capitalize`. Pre-branded mobile app
+	// titles opt out via `is-exact-case`; every other client must keep the default.
+	const renderClientName = ( oauth2Client: { id: number }, isJetpackApp?: boolean ) => {
+		const headerText = getHeaderText( {
+			isSocialFirst: true,
+			twoFactorAuthType: null,
+			isManualRenewalImmediateLoginAttempt: false,
+			socialConnect: false,
+			linkingSocialService: '',
+			action: 'login',
+			currentQuery: {},
+			oauth2Client,
+			isJetpackApp,
+			translate: translate as unknown as ( arg0: string, arg1?: object ) => TranslateResult,
+		} as Parameters< typeof getHeaderText >[ 0 ] );
+		const { container } = render( <div>{ headerText }</div> );
+		return container.querySelector( '.wp-login__one-login-header-client-name' );
+	};
+
+	test( 'opts the mobile app title out of title-casing via is-exact-case', () => {
+		const clientName = renderClientName( { id: 11 }, true );
+		expect( clientName ).toBeVisible();
+		expect( clientName ).toHaveClass( 'is-exact-case' );
+		expect( clientName ).toHaveTextContent( 'Jetpack for iOS' );
+	} );
+
+	test( 'keeps title-casing (no is-exact-case) for a non-mobile client', () => {
+		// 68663 => Jetpack Cloud.
+		const clientName = renderClientName( { id: 68663 } );
+		expect( clientName ).toBeVisible();
+		expect( clientName ).not.toHaveClass( 'is-exact-case' );
+		expect( clientName ).toHaveTextContent( 'Jetpack Cloud' );
 	} );
 } );

--- a/client/login/wp-login/hooks/test/get-header-text.test.tsx
+++ b/client/login/wp-login/hooks/test/get-header-text.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { useTranslate } from 'i18n-calypso';
+import { getMobileAppClientName } from '../get-header-text';
+
+describe( 'getMobileAppClientName', () => {
+	const translate = ( ( text: string ) => text ) as ReturnType< typeof useTranslate >;
+
+	test( 'brands the Jetpack app per platform', () => {
+		expect(
+			getMobileAppClientName( { oauth2Client: { id: 11 }, isJetpackApp: true, translate } )
+		).toBe( 'Jetpack for iOS' );
+		expect(
+			getMobileAppClientName( { oauth2Client: { id: 2697 }, isJetpackApp: true, translate } )
+		).toBe( 'Jetpack for Android' );
+		// Beta/alpha/trial clients share the platform.
+		expect(
+			getMobileAppClientName( { oauth2Client: { id: 29217 }, isJetpackApp: true, translate } )
+		).toBe( 'Jetpack for iOS' );
+	} );
+
+	test( 'brands the WordPress app per platform when it is not a jetpack:// request', () => {
+		expect(
+			getMobileAppClientName( { oauth2Client: { id: 11 }, isJetpackApp: false, translate } )
+		).toBe( 'WordPress for iOS' );
+		expect(
+			getMobileAppClientName( { oauth2Client: { id: 2697 }, isJetpackApp: false, translate } )
+		).toBe( 'WordPress for Android' );
+	} );
+
+	test( 'defaults to WordPress branding when the app is unknown (no redirect_uri)', () => {
+		expect( getMobileAppClientName( { oauth2Client: { id: 11 }, translate } ) ).toBe(
+			'WordPress for iOS'
+		);
+	} );
+
+	test( 'returns null for non-mobile clients so their own title is used', () => {
+		expect(
+			getMobileAppClientName( { oauth2Client: { id: 1854 }, isJetpackApp: true, translate } )
+		).toBeNull();
+		expect(
+			getMobileAppClientName( { oauth2Client: null, isJetpackApp: false, translate } )
+		).toBeNull();
+	} );
+} );

--- a/client/login/wp-login/hooks/test/get-header-text.test.tsx
+++ b/client/login/wp-login/hooks/test/get-header-text.test.tsx
@@ -48,9 +48,13 @@ describe( 'getMobileAppClientName', () => {
 } );
 
 describe( 'getHeaderText client-name casing', () => {
-	// The client-name span is `text-transform: capitalize`. Pre-branded mobile app
-	// titles opt out via `is-exact-case`; every other client must keep the default.
-	const renderClientName = ( oauth2Client: { id: number }, isJetpackApp?: boolean ) => {
+	// The client-name span is `text-transform: capitalize`. Resolved brand names are
+	// authoritative and opt out via `is-exact-case`; only the raw client slug keeps
+	// the default title-casing.
+	const renderClientName = (
+		oauth2Client: { id: number; name?: string },
+		isJetpackApp?: boolean
+	) => {
 		const headerText = getHeaderText( {
 			isSocialFirst: true,
 			twoFactorAuthType: null,
@@ -67,18 +71,30 @@ describe( 'getHeaderText client-name casing', () => {
 		return container.querySelector( '.wp-login__one-login-header-client-name' );
 	};
 
-	test( 'opts the mobile app title out of title-casing via is-exact-case', () => {
+	test( 'renders the mobile app title verbatim (is-exact-case)', () => {
 		const clientName = renderClientName( { id: 11 }, true );
 		expect( clientName ).toBeVisible();
 		expect( clientName ).toHaveClass( 'is-exact-case' );
 		expect( clientName ).toHaveTextContent( 'Jetpack for iOS' );
 	} );
 
-	test( 'keeps title-casing (no is-exact-case) for a non-mobile client', () => {
+	test( 'renders other known brand names verbatim (is-exact-case)', () => {
 		// 68663 => Jetpack Cloud.
-		const clientName = renderClientName( { id: 68663 } );
+		const jetpackCloud = renderClientName( { id: 68663 } );
+		expect( jetpackCloud ).toHaveClass( 'is-exact-case' );
+		expect( jetpackCloud ).toHaveTextContent( 'Jetpack Cloud' );
+
+		// 95928 => Automattic for Agencies — the lowercase "for" must survive.
+		const a4a = renderClientName( { id: 95928 } );
+		expect( a4a ).toHaveClass( 'is-exact-case' );
+		expect( a4a ).toHaveTextContent( 'Automattic for Agencies' );
+	} );
+
+	test( 'keeps title-casing (no is-exact-case) for an unbranded client slug', () => {
+		// 978 => Crowdsignal, which falls through to the raw `name` slug.
+		const clientName = renderClientName( { id: 978, name: 'crowdsignal' } );
 		expect( clientName ).toBeVisible();
 		expect( clientName ).not.toHaveClass( 'is-exact-case' );
-		expect( clientName ).toHaveTextContent( 'Jetpack Cloud' );
+		expect( clientName ).toHaveTextContent( 'crowdsignal' );
 	} );
 } );

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -39,6 +39,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
+import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 import getIsWCCOM from 'calypso/state/selectors/get-is-wccom';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import isWooJPCFlow, {
@@ -109,6 +110,7 @@ export class Login extends Component {
 			'oauth2Client',
 			'isWooJPC',
 			'isJetpack',
+			'isJetpackApp',
 			'isWCCOM',
 			'isBlazePro',
 			'isFromAkismet',
@@ -398,6 +400,7 @@ function getInitialHeadingState( props, translate ) {
 		oauth2Client,
 		isWooJPC,
 		isJetpack,
+		isJetpackApp,
 		isWCCOM,
 		isBlazePro,
 		isFromAkismet,
@@ -423,6 +426,7 @@ function getInitialHeadingState( props, translate ) {
 		oauth2Client,
 		isWooJPC,
 		isJetpack,
+		isJetpackApp,
 		isWCCOM,
 		isBlazePro,
 		isFromAkismet,
@@ -512,6 +516,7 @@ export default connect(
 			isWCCOM: getIsWCCOM( state ),
 			isWoo: getIsWoo( state ),
 			isBlazePro: getIsBlazePro( state ),
+			isJetpackApp: getIsJetpackApp( state ),
 			// This applies to all oauth screens except for A4A, Blaze Pro, Jetpack, Woo.
 			isGenericOauth:
 				oauth2Client &&

--- a/client/state/selectors/get-is-jetpack-app.ts
+++ b/client/state/selectors/get-is-jetpack-app.ts
@@ -1,0 +1,28 @@
+import 'calypso/state/route/init';
+import {
+	isSharedMobileAppOAuth2Client,
+	isJetpackAppRedirectUri,
+	getOAuth2RedirectUri,
+} from 'calypso/lib/oauth2-clients';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from './get-current-query-arguments';
+import getInitialQueryArguments from './get-initial-query-arguments';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Whether the current OAuth2 request is from the Jetpack mobile app.
+ *
+ * The WordPress and Jetpack apps share the same OAuth2 client IDs, so the app is
+ * identified by the redirect_uri scheme (`jetpack://`) rather than the client_id.
+ */
+export default function getIsJetpackApp( state: AppState ): boolean {
+	const oauth2Client = getCurrentOAuth2Client( state );
+
+	if ( ! isSharedMobileAppOAuth2Client( oauth2Client ) ) {
+		return false;
+	}
+
+	const query = getCurrentQueryArguments( state ) ?? getInitialQueryArguments( state );
+
+	return isJetpackAppRedirectUri( getOAuth2RedirectUri( query ) );
+}

--- a/client/state/selectors/test/get-is-jetpack-app.js
+++ b/client/state/selectors/test/get-is-jetpack-app.js
@@ -1,0 +1,70 @@
+import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
+
+const buildState = ( { clientId, redirectTo } ) => ( {
+	oauth2Clients: {
+		ui: { currentClientId: clientId ?? null },
+		clients: clientId ? { [ clientId ]: { id: clientId } } : {},
+	},
+	route: {
+		query: {
+			current: {
+				...( clientId ? { client_id: String( clientId ) } : {} ),
+				...( redirectTo ? { redirect_to: redirectTo } : {} ),
+			},
+		},
+	},
+} );
+
+const authorizeUrl = ( { clientId, redirectUri } ) =>
+	`https://public-api.wordpress.com/oauth2/authorize?client_id=${ clientId }&response_type=code&redirect_uri=${ redirectUri }`;
+
+describe( 'getIsJetpackApp', () => {
+	test( 'is true for an iOS shared mobile client with a jetpack:// redirect_uri', () => {
+		const state = buildState( {
+			clientId: 11,
+			redirectTo: authorizeUrl( { clientId: 11, redirectUri: 'jetpack%3A%2F%2Foauth2-callback' } ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( true );
+	} );
+
+	test( 'is false for an iOS shared mobile client with a wordpress:// redirect_uri', () => {
+		const state = buildState( {
+			clientId: 11,
+			redirectTo: authorizeUrl( {
+				clientId: 11,
+				redirectUri: 'wordpress%3A%2F%2Foauth2-callback',
+			} ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( false );
+	} );
+
+	test( 'is true for an Android shared mobile client with a double-encoded jetpack:// redirect_uri', () => {
+		const state = buildState( {
+			clientId: 2697,
+			redirectTo: authorizeUrl( {
+				clientId: 2697,
+				redirectUri: 'jetpack%253A%252F%252Fwpcom-authorize',
+			} ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( true );
+	} );
+
+	test( 'is false for a non-mobile client even with a jetpack:// redirect_uri', () => {
+		const state = buildState( {
+			clientId: 1854,
+			redirectTo: authorizeUrl( {
+				clientId: 1854,
+				redirectUri: 'jetpack%3A%2F%2Foauth2-callback',
+			} ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( false );
+	} );
+
+	test( 'is false for a shared mobile client with no redirect', () => {
+		expect( getIsJetpackApp( buildState( { clientId: 11 } ) ) ).toBe( false );
+	} );
+
+	test( 'is false when there is no current OAuth2 client', () => {
+		expect( getIsJetpackApp( buildState( {} ) ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

Brand the logged-out `wordpress.com/log-in` screen as **Jetpack** (name + cobrand logo) when an OAuth2 authorize request comes from the **Jetpack mobile app**, and **WordPress** when it comes from the **WordPress mobile app**. Both apps share the same OAuth2 client IDs, so the app is identified by the `redirect_uri` scheme (`jetpack://` vs `wordpress://`), not the `client_id`.

- **`client/lib/oauth2-clients.js`**: Add shared iOS/Android mobile-app client-ID sets (single source of truth, kept in sync with wpcom `.config/constants.php`) and widen `isIosOAuth2Client`/`isAndroidOAuth2Client` to cover the beta/alpha/trial IDs. Add `isSharedMobileAppOAuth2Client`, `getOAuth2RedirectUri` (extracts the nested, multiply-encoded `redirect_uri`), and `isJetpackAppRedirectUri`.
- **`client/state/selectors/get-is-jetpack-app.ts`**: New selector — a shared-mobile client **and** a `jetpack://` redirect.
- **`client/login/wp-login/hooks/get-header-text.tsx`**: New exported `getMobileAppClientName` returns one of four translatable titles (`Jetpack for iOS`, `Jetpack for Android`, `WordPress for iOS`, `WordPress for Android`) for shared mobile clients instead of the raw client name. Threaded in via a new `isJetpackApp` prop.
- **`client/login/wp-login/components/heading-logo.tsx`**: Render the `JetpackPlusWpComLogo` cobrand mark (the same asset Jetpack Cloud uses) for the Jetpack app; the WordPress app keeps the default WordPress chrome.
- **`client/login/wp-login/index.jsx`**: Wire `isJetpackApp` from the selector into the heading.
- **`get-header-text.tsx` + `one-login-layout.scss`**: The client-name span is `text-transform: capitalize` (added to prettify raw client slugs such as `crowdsignal` → "Crowdsignal"). That mangles hand-cased brand names — most visibly the new mobile titles (`iOS` → `IOS`) and A4A (`for` → `For`). Resolved brand names now render verbatim via an `is-exact-case` modifier; only the raw-slug fallback stays title-cased.
  - **Behavioral note for reviewers:** besides the mobile titles, the only other client whose header changes is **Automattic for Agencies** — "Automattic **For** Agencies" → "Automattic **for** Agencies". Every other client renders identically to trunk.

Introduces **4 new translatable strings** — the "[Status] String Freeze" label should be added.

## Why are these changes being made?

For a logged-out authorize request, wpcom hard-redirects to Calypso's `/log-in`, so it is the **first screen the app shows**. That screen was rendering the raw stored client `name` — literally `wordpress-app-ios` — because both apps share client IDs and the stored title/name is not a reliable brand (production has shown values like `Wordpress-App-Ios`). This is the Calypso side of the app-branding work; it mirrors the branding already applied to the screens wpcom itself renders (the post-login consent/approve screen).

Detection is done entirely client-side from `client_id` + `redirect_uri`, so it does not depend on a wpcom endpoint change. Two encoding details the implementation handles:

- The `redirect_uri` arrives nested inside `redirect_to` and is often **multiply percent-encoded** (`jetpack%253A%252F%252F…`); it is fully decoded before the scheme is compared, case-insensitively.
- Detection matches on the `jetpack://` **scheme, not the callback path** — iOS uses `oauth2-callback` and Android uses `wpcom-authorize`.

Note: widening `isIosOAuth2Client`/`isAndroidOAuth2Client` to the full ID sets also improves the two existing "is a mobile app" call sites (`client/layout/logged-out.jsx`, `client/login/magic-login/index.jsx`) so beta/alpha/trial app builds are recognized as mobile — a strict improvement with no test changes.

Out of scope (matching the parity work): the newer `client/oauth2/` authorize renderer served at `/oauth2/authorize`, and the magic-link login screen.

## Testing Instructions

Unit tests (22, all passing):

```
yarn test-client client/lib/test/oauth2-clients.js client/state/selectors/test/get-is-jetpack-app.js client/login/wp-login/hooks/test/get-header-text.test.tsx
```

Manual — while **logged out**, and after **revoking any prior app authorization** (Me → Security → Connected Applications). Hit the OAuth2 authorize endpoint with:

- **iOS Jetpack**: `client_id=11` + `redirect_uri=jetpack://oauth2-callback` → heading reads **"Log in to Jetpack for iOS"**, center shows the Jetpack + WordPress cobrand logo.
- **iOS WordPress**: `client_id=11` + `redirect_uri=wordpress://oauth2-callback` → **"WordPress for iOS"**, default WordPress chrome (no cobrand logo).
- **Android Jetpack**: `client_id=2697` + `redirect_uri=jetpack://wpcom-authorize` → **"Jetpack for Android"**.
- **Non-mobile OAuth client** (e.g. Jetpack Cloud) → unchanged.

If testing against a sandbox: disable Firefox DNS-over-HTTPS so the browser honors `/etc/hosts` (otherwise it silently hits production), and hard-reload to bust cached CSS/JS.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

Logged-out `/log-in` header for each OAuth `client_id` — **Production** (`wordpress.com`, pre-PR baseline) on the left, **this PR** on the right. Per the reviewer note above, only the mobile clients (§1) and **Automattic for Agencies** (§2) change; every other row is a regression check and should read identically in both columns.

<sub>The corner environment badge differs by capture source only — production shows `STAGING`, the PR-branch container shows `WPCALYPSO`. Not part of the change.</sub>

| Scenario | Production (current) | This PR |
|---|---|---|
| **1 · Mobile app — the feature (both redirect schemes)** | | |
| **11** — Jetpack/WP iOS · `jetpack://` → **Jetpack for iOS** | <img width="420" alt="01-11-wp-jp-ios-jetpack-scheme__production" src="https://github.com/user-attachments/assets/cc68297e-6c58-4f9f-9bff-d77bb609b2e7" /> | <img width="420" alt="01-11-wp-jp-ios-jetpack-scheme__pr" src="https://github.com/user-attachments/assets/25c18a01-ec6c-44ee-95ec-4cfd684b51d5" /> |
| **11** — Jetpack/WP iOS · `wordpress://` → **WordPress for iOS** | <img width="420" alt="02-11-wp-jp-ios-wordpress-scheme__production" src="https://github.com/user-attachments/assets/498c0cd5-146f-4a97-961a-e8022c41ef9d" /> | <img width="420" alt="02-11-wp-jp-ios-wordpress-scheme__pr" src="https://github.com/user-attachments/assets/91c191cc-e0f7-44e8-99dd-a240030a5293" /> |
| **2697** — Jetpack/WP Android · `jetpack://` → **Jetpack for Android** | <img width="420" alt="03-2697-wp-jp-android-jetpack-scheme__production" src="https://github.com/user-attachments/assets/facdd13f-a869-4dda-8058-606f1e987eae" /> | <img width="420" alt="03-2697-wp-jp-android-jetpack-scheme__pr" src="https://github.com/user-attachments/assets/9492596f-2787-423b-b931-de843681f043" /> |
| **2697** — Jetpack/WP Android · `wordpress://` → **WordPress for Android** | <img width="420" alt="04-2697-wp-jp-android-wordpress-scheme__production" src="https://github.com/user-attachments/assets/e1dd79fd-09d9-48ad-a882-a7906681f45d" /> | <img width="420" alt="04-2697-wp-jp-android-wordpress-scheme__pr" src="https://github.com/user-attachments/assets/70a622cd-62cd-4503-8991-9739e3327d83" /> |
| **2 · Branded names** | | |
| **95928** — Automattic for Agencies (Development) | <img width="420" alt="05-95928-automattic-for-agencies-dev__production" src="https://github.com/user-attachments/assets/6a4dddb1-1a96-413c-bbca-aebfa54b7d4a" /> | <img width="420" alt="05-95928-automattic-for-agencies-dev__pr" src="https://github.com/user-attachments/assets/aa857d9e-02d7-444b-9d3f-ee155ade71d1" /> |
| **92099** — Blaze Pro | <img width="420" alt="06-92099-blaze-pro__production" src="https://github.com/user-attachments/assets/7ddbada3-9d23-496f-a0d5-c0fdb9d73251" /> | <img width="420" alt="06-92099-blaze-pro__pr" src="https://github.com/user-attachments/assets/b80ec9dc-96b1-4edf-9d2b-f12e459c399e" /> |
| **99370** — Blaze Pro | <img width="420" alt="07-99370-blaze-pro__production" src="https://github.com/user-attachments/assets/5fa871e1-600d-4833-8b6e-c4fd7b3e9a36" /> | <img width="420" alt="07-99370-blaze-pro__pr" src="https://github.com/user-attachments/assets/d1d5ea69-002a-442b-b16f-c3d34f76915e" /> |
| **76596** — VIP (Authentication) | <img width="420" alt="08-76596-vip-authentication__production" src="https://github.com/user-attachments/assets/f21c0709-4321-46f9-a315-c33f072c857e" /> | <img width="420" alt="08-76596-vip-authentication__pr" src="https://github.com/user-attachments/assets/1bc3323c-3df8-403a-987e-4480fe7900b6" /> |
| **50019** — WooCommerce.com (dev) | <img width="420" alt="09-50019-woocommerce-dev__production" src="https://github.com/user-attachments/assets/e36ddb3d-1e56-49d6-a630-44cc857fba89" /> | <img width="420" alt="09-50019-woocommerce-dev__pr" src="https://github.com/user-attachments/assets/deab0c98-66cd-4081-ac39-9bca92995918" /> |
| **50915** — WooCommerce.com (staging) | <img width="420" alt="10-50915-woocommerce-staging__production" src="https://github.com/user-attachments/assets/d46a3b58-8f9c-419b-bd97-64644f10ddba" /> | <img width="420" alt="10-50915-woocommerce-staging__pr" src="https://github.com/user-attachments/assets/74774a8f-c53b-4542-ae32-4c8032e5e3cf" /> |
| **50916** — WooCommerce.com | <img width="420" alt="11-50916-woocommerce__production" src="https://github.com/user-attachments/assets/50e65141-1087-40c8-b630-38579dddb1e1" /> | <img width="420" alt="11-50916-woocommerce__pr" src="https://github.com/user-attachments/assets/92c65531-ef05-4941-8a87-7ceb8957ce4c" /> |
| **3 · Slug fallback (title-cased)** | | |
| **978** — Crowdsignal | <img width="420" alt="12-978-crowdsignal__production" src="https://github.com/user-attachments/assets/ad638fa6-faf5-4625-9c90-60c66210c777" /> | <img width="420" alt="12-978-crowdsignal__pr" src="https://github.com/user-attachments/assets/78ef6321-da7b-431e-8d6a-34acd3b4583a" /> |
| **930** — VaultPress | <img width="420" alt="13-930-vaultpress__production" src="https://github.com/user-attachments/assets/faf12e73-4f67-4db9-a701-1b767144531b" /> | <img width="420" alt="13-930-vaultpress__pr" src="https://github.com/user-attachments/assets/b7d5bf40-6766-4ab7-b669-fb3c47728c8d" /> |
| **2665** — IntenseDebate | <img width="420" alt="14-2665-intensedebate__production" src="https://github.com/user-attachments/assets/e3622b76-d01a-43eb-b434-1b30df3d847d" /> | <img width="420" alt="14-2665-intensedebate__pr" src="https://github.com/user-attachments/assets/bedba8f1-9272-42c4-8874-759db8e046bf" /> |
| **95109** — WordPress Studio | <img width="420" alt="15-95109-wordpress-studio__production" src="https://github.com/user-attachments/assets/ecc28400-2c5c-472f-9cdd-bf37334f590b" /> | <img width="420" alt="15-95109-wordpress-studio__pr" src="https://github.com/user-attachments/assets/f45104e9-62a6-4d12-bd76-9e945b6591f7" /> |
| **973** — Akismet | <img width="420" alt="16-973-akismet__production" src="https://github.com/user-attachments/assets/383d5540-c3ac-4b39-a85f-9933814c2381" /> | <img width="420" alt="16-973-akismet__pr" src="https://github.com/user-attachments/assets/ec8e02fa-e5a1-4422-8a6e-efe33715d6ea" /> |
| **4 · Other header paths** | | |
| **1854** — Gravatar | <img width="420" alt="17-1854-gravatar__production" src="https://github.com/user-attachments/assets/840855c1-0cad-4a2b-8a9f-a412a527057d" /> | <img width="420" alt="17-1854-gravatar__pr" src="https://github.com/user-attachments/assets/61b6f5d7-1d1f-430e-a712-7b6111cc6a67" /> |
| **90057** — WP Job Manager | <img width="420" alt="18-90057-wp-job-manager__production" src="https://github.com/user-attachments/assets/4ddbe2e9-ec9f-44d9-ba23-552b34998dd1" /> | <img width="420" alt="18-90057-wp-job-manager__pr" src="https://github.com/user-attachments/assets/2c252db4-c8b6-4a9e-b5c5-c0f045d3db9a" /> |
| **102832** — Automattic Partner Portal (Development) | <img width="420" alt="19-102832-automattic-partner-portal-dev__production" src="https://github.com/user-attachments/assets/e78d7819-4c30-4942-8873-82945338cf67" /> | <img width="420" alt="19-102832-automattic-partner-portal-dev__pr" src="https://github.com/user-attachments/assets/42d4c0ff-f79b-4d07-858f-403fbb849783" /> |
| **103914** — Automattic Partner Portal | <img width="420" alt="20-103914-automattic-partner-portal__production" src="https://github.com/user-attachments/assets/7cfc5850-1177-4e51-a942-2338ff0b5669" /> | <img width="420" alt="20-103914-automattic-partner-portal__pr" src="https://github.com/user-attachments/assets/85c56dfd-c719-40a4-9f78-b6539c7ba438" /> |
| **134404** — CIAB by Woo (Development) | <img width="420" alt="21-134404-ciab-by-woo-dev__production" src="https://github.com/user-attachments/assets/7e4c7575-e66c-4001-a38d-746f585aafff" /> | <img width="420" alt="21-134404-ciab-by-woo-dev__pr" src="https://github.com/user-attachments/assets/9b87036f-cdc9-4e5f-8475-01dd1faf9629" /> |
| **134405** — CIAB by Woo | <img width="420" alt="22-134405-ciab-by-woo__production" src="https://github.com/user-attachments/assets/7b694228-e8ac-44a4-8848-ef326b56a7e6" /> | <img width="420" alt="22-134405-ciab-by-woo__pr" src="https://github.com/user-attachments/assets/4d6f5bdc-8d7c-410d-a47a-2addaa781478" /> |
