### PR TITLE
Reader: fix flash of stuff while loading

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -214,6 +214,10 @@ body.is-mobile-app-view {
 	// Related issue: https://github.com/Automattic/wp-calypso/issues/53504
 	z-index: z-index( 'root', '.layout__secondary' );
 
+	.is-section-reader & {
+		--color-sidebar-background: var( --color-main-background );
+	}
+
 	@include breakpoint-deprecated( '<960px' ) {
 		width: var( --sidebar-width-min );
 	}

--- a/client/reader/onboarding/gate.tsx
+++ b/client/reader/onboarding/gate.tsx
@@ -28,8 +28,8 @@ export default function ReaderOnboardingGate( props: ReaderOnboardingGateProps )
 	}
 
 	return isEnabled( 'reader/onboarding-rsm' ) ? (
-		<AsyncLoad require={ loadOnboardingRsm } { ...props } />
+		<AsyncLoad require={ loadOnboardingRsm } { ...props } placeholder={ null } />
 	) : (
-		<AsyncLoad require={ loadOnboarding } { ...props } />
+		<AsyncLoad require={ loadOnboarding } { ...props } placeholder={ null } />
 	);
 }


### PR DESCRIPTION
Fixes READ-163

## Proposed Changes

On slow connections the Reader load had two bits of jank. This fixes both:

* **Dark sidebar flash.** The sidebar briefly painted the dark admin color before the Reader's light style loaded. Set the light color up front so it starts light.
* **Throbbing bar above the feed.** A leftover loading placeholder for the onboarding gate (which usually shows nothing). Told it not to show a placeholder, like every other Reader `AsyncLoad` already does.

### Before
https://github.com/user-attachments/assets/91d39860-38fc-48d2-99b2-189eead71beb

### After
https://github.com/user-attachments/assets/8d87e1e2-59b9-4306-b858-d9d5777e54ca

## Testing Instructions

1. Open `/reader` in Chrome with network throttled to Fast 4G.
2. Reload.
3. **Before:** dark column flashes on the left, plus a pulsing bar at the top of the feed.
4. **After:** sidebar is light immediately, no bar.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?