### PR TITLE
Reader Spaces: Use normalized posts in feed cards

### DIFF
--- a/client/reader/color-scheme/dark-mode.scss
+++ b/client/reader/color-scheme/dark-mode.scss
@@ -6,6 +6,12 @@
 	--color-sidebar-menu-hover-background: var( --dashboard-item-selected-hover__background-color );
 	--color-sidebar-menu-hover-text: var( --color-text );
 	--color-sidebar-menu-selected-text: var( --wp-components-color-accent-darker-20 );
+	--color-sidebar-tooltip-background: color-mix(
+		in srgb,
+		var( --wp-admin-theme-color ) 24%,
+		var( --dashboard__background-color )
+	);
+	--color-sidebar-tooltip-text: var( --color-text );
 	--color-sidebar-text-alternative: var( --dashboard__text-muted-color );
 	--color-sidebar-gridicon-fill: var( --dashboard__text-muted-color );
 	--color-sidebar-gridicon-hover-fill: currentColor;
@@ -50,6 +56,12 @@
 		--color-sidebar-menu-hover-background: var( --dashboard-item-selected-hover__background-color );
 		--color-sidebar-menu-hover-text: var( --color-text );
 		--color-sidebar-menu-selected-text: var( --wp-components-color-accent-darker-20 );
+		--color-sidebar-tooltip-background: color-mix(
+			in srgb,
+			var( --wp-admin-theme-color ) 24%,
+			var( --dashboard__background-color )
+		);
+		--color-sidebar-tooltip-text: var( --color-text );
 		--color-sidebar-submenu-selected-text: var( --color-sidebar-menu-selected-text );
 		--color-sidebar-submenu-hover-text: var( --color-sidebar-menu-selected-text );
 		--color-sidebar-submenu-selected-hover-text: var( --color-sidebar-menu-selected-text );

--- a/client/reader/data/stream/hooks/use-infinite-stream/index.ts
+++ b/client/reader/data/stream/hooks/use-infinite-stream/index.ts
@@ -17,11 +17,16 @@ import { buildStreamQueryParams } from '../../build-query-params';
 import { extractPageHandle, normalizeStreamPage } from '../../normalization';
 import { combineXPosts } from '../../utils';
 import type { StreamItem } from '../../types';
-import type { ReadStreamQueryParams, ReadStreamResponse } from '@automattic/api-core';
+import type {
+	ReadStreamPost,
+	ReadStreamQueryParams,
+	ReadStreamResponse,
+} from '@automattic/api-core';
 import type { Dispatch } from 'redux';
 
 export interface UseInfiniteStreamResult {
 	items: StreamItem[];
+	posts: ReadStreamPost[];
 	pages: ReadStreamResponse[];
 	isLoading: boolean;
 	isFetching: boolean;
@@ -185,6 +190,18 @@ export const useInfiniteStream = ( {
 		return combineXPosts( collected ) as StreamItem[];
 	}, [ query.data, streamType ] );
 
+	// The stream's posts, parsed once from the same `normalizeStreamPage` that feeds
+	// `syncStreamPage` — so consumers don't re-parse the raw pages themselves.
+	const posts: ReadStreamPost[] = useMemo( () => {
+		const pages = query.data?.pages ?? [];
+		const collected: ReadStreamPost[] = [];
+		for ( const page of pages ) {
+			const { streamPosts } = normalizeStreamPage( page as ReadStreamResponse, streamType );
+			collected.push( ...( streamPosts as unknown as ReadStreamPost[] ) );
+		}
+		return collected;
+	}, [ query.data, streamType ] );
+
 	const queryKey = queryOptions.queryKey;
 	const invalidate = useCallback( () => {
 		queryClient.invalidateQueries( { queryKey, refetchType: 'none' } );
@@ -192,6 +209,7 @@ export const useInfiniteStream = ( {
 
 	return {
 		items,
+		posts,
 		pages: ( query.data?.pages ?? [] ) as ReadStreamResponse[],
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,

--- a/client/reader/spaces/feed/index.tsx
+++ b/client/reader/spaces/feed/index.tsx
@@ -1,7 +1,7 @@
 import { isDefaultLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useSpace } from 'calypso/reader/data/spaces';
 import { useInfiniteStream } from 'calypso/reader/data/stream';
@@ -28,7 +28,7 @@ import {
 	getLayoutPageSize,
 	getLayoutSkeleton,
 } from './layouts/registry';
-import type { ReadStreamPost, ReadStreamResponse, SpaceFeedLayout } from '@automattic/api-core';
+import type { ReadStreamPost, SpaceFeedLayout } from '@automattic/api-core';
 
 import './style.scss';
 
@@ -41,22 +41,6 @@ interface Props {
 	variant?: 'feed' | 'discover';
 	// Opens the Customize modal's Sources tab; wired to the Feed empty-state CTA.
 	onAddSources?: () => void;
-}
-
-export function collectPosts( pages: ReadStreamResponse[] ): ReadStreamPost[] {
-	const posts: ReadStreamPost[] = [];
-	for ( const page of pages ) {
-		if ( page.cards?.length ) {
-			for ( const card of page.cards ) {
-				if ( card.type === 'post' ) {
-					posts.push( card.data );
-				}
-			}
-		} else if ( page.posts?.length ) {
-			posts.push( ...page.posts );
-		}
-	}
-	return posts;
 }
 
 /**
@@ -93,7 +77,10 @@ export function SpaceFeed( { spaceId, layoutView, variant = 'feed', onAddSources
 		perPage: getLayoutPageSize( layout ),
 		options: { enabled: ! isLegacy },
 	} );
-	const posts = useMemo( () => collectPosts( stream.pages ), [ stream.pages ] );
+	// The shell only needs the stream's posts for the list's structure and ordering
+	// (parsed by the stream hook); each card reads its own normalized post from the
+	// cache (see the card components).
+	const posts = stream.posts;
 
 	const { selectedPostKey, selectPostKey, selectNextPost, selectPreviousPost } =
 		useStreamPostKeySelection( { streamKey, localeSlug, items: stream.items } );

--- a/client/reader/spaces/feed/layouts/board/index.tsx
+++ b/client/reader/spaces/feed/layouts/board/index.tsx
@@ -2,29 +2,49 @@ import page from '@automattic/calypso-router';
 import { useMemo } from 'react';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useCachedPost } from 'calypso/reader/data/post/cache';
+import { type StreamPostKey } from 'calypso/reader/data/stream';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { keyForPost } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
 import { Shimmer } from '../../components/skeleton';
 import { SpaceFeedTimeSince } from '../../components/time-since';
 import { getPostFieldKey, getPostFields } from '../../post-fields';
 import { useScrollSelectedIntoView } from '../use-scroll-selected-into-view';
 import type { SpaceFeedLayoutProps, SpaceFeedSkeletonProps } from '../types';
-import type { ReadStreamPost } from '@automattic/api-core';
 
 import './style.scss';
 
 const LANES = 2;
 const ESTIMATED_SIZE = 260;
 
+/** A single card-shaped shimmer, shown while a post loads from the cache. */
+function BoardSkeletonCard() {
+	return (
+		<div className="space-feed-board__card">
+			<Shimmer className="space-feed-board__skeleton-hero" />
+			<div className="space-feed-board__body">
+				<Shimmer className="space-feed-board__skeleton-line is-title" />
+				<Shimmer className="space-feed-board__skeleton-line" />
+				<Shimmer className="space-feed-board__skeleton-line is-short" />
+			</div>
+		</div>
+	);
+}
+
 function BoardCard( {
-	post,
+	postKey,
 	onOpen,
 	showTimestamp,
 }: {
-	post: ReadStreamPost;
+	postKey: StreamPostKey | undefined;
 	onOpen: () => void;
 	showTimestamp: boolean;
 } ) {
+	const post = useCachedPost( postKey );
+	if ( ! post ) {
+		return <BoardSkeletonCard />;
+	}
 	const fields = getPostFields( post );
 	return (
 		<div className="space-feed-board__card">
@@ -120,7 +140,7 @@ export function BoardLayout( {
 					} }
 				>
 					<BoardCard
-						post={ posts[ virtualItem.index ] }
+						postKey={ keyForPost( posts[ virtualItem.index ] ) }
 						onOpen={ () => selectPost( posts[ virtualItem.index ] ) }
 						showTimestamp={ showTimestamp }
 					/>
@@ -135,14 +155,7 @@ export function BoardSkeleton( { count }: SpaceFeedSkeletonProps ) {
 	return (
 		<div className="space-feed-board__skeleton" aria-hidden="true">
 			{ Array.from( { length: count }, ( _value, index ) => (
-				<div className="space-feed-board__card" key={ index }>
-					<Shimmer className="space-feed-board__skeleton-hero" />
-					<div className="space-feed-board__body">
-						<Shimmer className="space-feed-board__skeleton-line is-title" />
-						<Shimmer className="space-feed-board__skeleton-line" />
-						<Shimmer className="space-feed-board__skeleton-line is-short" />
-					</div>
-				</div>
+				<BoardSkeletonCard key={ index } />
 			) ) }
 		</div>
 	);

--- a/client/reader/spaces/feed/layouts/board/style.scss
+++ b/client/reader/spaces/feed/layouts/board/style.scss
@@ -86,7 +86,7 @@
 	margin: 8px 0 0;
 	font-size: 0.875rem;
 	line-height: 1.45;
-	color: var(--color-text-subtle);
+	color: var(--color-neutral-80);
 }
 
 .space-feed-board__excerpt p {

--- a/client/reader/spaces/feed/layouts/gallery/index.tsx
+++ b/client/reader/spaces/feed/layouts/gallery/index.tsx
@@ -7,7 +7,10 @@ import {
 import { useMemo } from 'react';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useCachedPost } from 'calypso/reader/data/post/cache';
+import { type StreamPostKey } from 'calypso/reader/data/stream';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { keyForPost } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
 import { Shimmer } from '../../components/skeleton';
 import { SpaceFeedTimeSince } from '../../components/time-since';
@@ -36,16 +39,20 @@ function useGalleryColumns(): number {
 }
 
 function GalleryCard( {
-	post,
+	postKey,
 	isSelected,
 	onOpen,
 	showTimestamp,
 }: {
-	post: ReadStreamPost;
+	postKey: StreamPostKey | undefined;
 	isSelected: boolean;
 	onOpen: () => void;
 	showTimestamp: boolean;
 } ) {
+	const post = useCachedPost( postKey );
+	if ( ! post ) {
+		return <GallerySkeletonCard />;
+	}
 	const fields = getPostFields( post );
 	return (
 		<VStack
@@ -206,7 +213,7 @@ export function GalleryLayout( {
 							cell ? (
 								<GalleryCard
 									key={ getPostFieldKey( cell ) }
-									post={ cell }
+									postKey={ keyForPost( cell ) }
 									isSelected={ isPostSelected( cell ) }
 									onOpen={ () => selectPost( cell ) }
 									showTimestamp={ showTimestamp }

--- a/client/reader/spaces/feed/layouts/standard-list/index.tsx
+++ b/client/reader/spaces/feed/layouts/standard-list/index.tsx
@@ -7,11 +7,19 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import { SiteIcon } from 'calypso/blocks/site-icon';
+import { useCachedPost } from 'calypso/reader/data/post/cache';
+import { type StreamPostKey } from 'calypso/reader/data/stream';
 import { useInfiniteList } from 'calypso/reader/hooks/use-infinite-list';
+import { keyForPost } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
 import { Shimmer } from '../../components/skeleton';
 import { SpaceFeedTimeSince } from '../../components/time-since';
-import { getPostFields, type SpaceFeedDayGroup, type SpaceFeedPostFields } from '../../post-fields';
+import {
+	getPostDayGroup,
+	getPostFieldKey,
+	getPostFields,
+	type SpaceFeedDayGroup,
+} from '../../post-fields';
 import { useScrollSelectedIntoView } from '../use-scroll-selected-into-view';
 import type { SpaceFeedLayoutProps, SpaceFeedSkeletonProps } from '../types';
 import type { ReadStreamPost } from '@automattic/api-core';
@@ -20,24 +28,38 @@ import './style.scss';
 
 type Row =
 	| { kind: 'header'; key: string; label: string }
-	| { kind: 'post'; key: string; fields: SpaceFeedPostFields; post: ReadStreamPost };
+	| { kind: 'post'; key: string; post: ReadStreamPost };
 
 const HEADER_SIZE = 44;
 const ROW_SIZE = 170;
 
+/** A single row-shaped shimmer, shown while a post loads from the cache. */
+function StandardListSkeletonRow() {
+	return (
+		<div className="space-feed-standard-list__skeleton-row">
+			<Shimmer className="space-feed-standard-list__skeleton-line is-title" />
+			<Shimmer className="space-feed-standard-list__skeleton-line" />
+			<Shimmer className="space-feed-standard-list__skeleton-line is-meta" />
+		</div>
+	);
+}
+
 function PostRow( {
-	fields,
-	post,
+	postKey,
 	isSelected,
 	onOpen,
 	showTimestamp,
 }: {
-	fields: SpaceFeedPostFields;
-	post: ReadStreamPost;
+	postKey: StreamPostKey | undefined;
 	isSelected: boolean;
 	onOpen: () => void;
 	showTimestamp: boolean;
 } ) {
+	const post = useCachedPost( postKey );
+	if ( ! post ) {
+		return <StandardListSkeletonRow />;
+	}
+	const fields = getPostFields( post );
 	return (
 		<HStack
 			className="space-feed-standard-list__row"
@@ -130,8 +152,9 @@ export function StandardListLayout( {
 		const out: Row[] = [];
 		let lastGroup: SpaceFeedDayGroup = '';
 		posts.forEach( ( post, index ) => {
-			const fields = getPostFields( post );
-			const { dayGroup, key } = fields;
+			// Day grouping and the row key read only the raw post's date/identity — each
+			// PostRow resolves its own normalized copy for display.
+			const dayGroup = getPostDayGroup( post );
 			// Discover is recommendation-ranked, not chronological: day grouping would
 			// bucket unrelated posts under misleading dates. Gate it like the timestamp.
 			if ( showTimestamp && dayGroup && dayGroup !== lastGroup ) {
@@ -142,7 +165,7 @@ export function StandardListLayout( {
 				} );
 				lastGroup = dayGroup;
 			}
-			out.push( { kind: 'post', key: `post-${ key }`, fields, post } );
+			out.push( { kind: 'post', key: `post-${ getPostFieldKey( post ) }`, post } );
 		} );
 		return out;
 	}, [ posts, translate, showTimestamp ] );
@@ -188,8 +211,7 @@ export function StandardListLayout( {
 							<h2 className="space-feed-standard-list__group">{ row.label }</h2>
 						) : (
 							<PostRow
-								fields={ row.fields }
-								post={ row.post }
+								postKey={ keyForPost( row.post ) }
 								isSelected={ isPostSelected( row.post ) }
 								onOpen={ () => selectPost( row.post ) }
 								showTimestamp={ showTimestamp }
@@ -207,11 +229,7 @@ export function StandardListSkeleton( { count }: SpaceFeedSkeletonProps ) {
 	return (
 		<div aria-hidden="true">
 			{ Array.from( { length: count }, ( _value, index ) => (
-				<div className="space-feed-standard-list__skeleton-row" key={ index }>
-					<Shimmer className="space-feed-standard-list__skeleton-line is-title" />
-					<Shimmer className="space-feed-standard-list__skeleton-line" />
-					<Shimmer className="space-feed-standard-list__skeleton-line is-meta" />
-				</div>
+				<StandardListSkeletonRow key={ index } />
 			) ) }
 		</div>
 	);

--- a/client/reader/spaces/feed/layouts/standard-list/style.scss
+++ b/client/reader/spaces/feed/layouts/standard-list/style.scss
@@ -73,7 +73,7 @@
 .space-feed-standard-list__excerpt {
 	font-size: 0.875rem;
 	line-height: 1.4;
-	color: var(--color-text-subtle);
+	color: var(--color-neutral-80);
 	overflow: hidden;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;

--- a/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
+++ b/client/reader/spaces/feed/layouts/test/standard-list.test.tsx
@@ -24,15 +24,20 @@ jest.mock( 'calypso/reader/hooks/use-infinite-list', () => ( {
 
 jest.mock( '../../post-fields', () => ( {
 	getPostFields: jest.fn( () => ( {
-		id: 1,
-		key: 'blog-1-2',
 		title: 'Test post',
 		excerptHtml: '',
 		sourceName: 'Test site',
-		dayGroup: 'today',
 		postHref: '/reader/blogs/2/posts/1',
 		isUnread: false,
 	} ) ),
+	getPostFieldKey: jest.fn( () => 'blog-1-2' ),
+	getPostDayGroup: jest.fn( () => 'today' ),
+} ) );
+
+// Stub the per-row cache read so this structural test needs no QueryClient; a truthy
+// post keeps the row out of its placeholder branch.
+jest.mock( 'calypso/reader/data/post/cache', () => ( {
+	useCachedPost: jest.fn( () => ( { ID: 1, site_ID: 2 } ) ),
 } ) );
 
 // ReaderPostActions is a Redux/React-Query-connected block tested on its own and
@@ -73,7 +78,7 @@ describe( 'StandardListLayout', () => {
 		);
 	} );
 
-	it( 'extracts post fields centrally and hands them to the row', () => {
+	it( 'extracts post fields from each post for its row', () => {
 		mockUseInfiniteList.mockReturnValueOnce( {
 			getListProps: ( props: ListProps = {} ) => ( { ...props, style: props.style ?? {} } ),
 			items: [ { index: 1, key: 'post-blog-1-2', start: 44 } ],
@@ -98,8 +103,6 @@ describe( 'StandardListLayout', () => {
 			/>
 		);
 
-		// Fields are extracted once per post while building the rows and passed to
-		// the row as props — the row never re-extracts them itself.
 		expect( mockGetPostFields ).toHaveBeenCalledWith( post );
 	} );
 

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -1,7 +1,13 @@
 import { keyForPost, keyToString } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
-import type { ReadStreamPost } from '@automattic/api-core';
-import type { Post } from 'calypso/reader/data/post/cache';
+import type { ReadPost, ReadStreamPost } from '@automattic/api-core';
+
+/**
+ * The card's input: a client-normalized post from the cache (`useCachedPost` returns
+ * `Post`, which is assignable to this). Typed as `Partial<ReadPost>` so the display
+ * fields read as their real types rather than `unknown`.
+ */
+type NormalizedPost = Partial< ReadPost >;
 
 /**
  * Day buckets the standard list groups by. The layout maps these to translated
@@ -33,9 +39,6 @@ export interface SpaceFeedPostFields {
 	isUnread: boolean;
 }
 
-const asString = ( value: unknown ): string | undefined =>
-	typeof value === 'string' && value ? value : undefined;
-
 const MS_PER_DAY = 86_400_000;
 
 const startOfDay = ( date: Date ): number =>
@@ -66,12 +69,12 @@ function dayGroupOf( dateIso?: string ): SpaceFeedDayGroup {
 
 /** The day bucket a stream post falls into, for the standard list's date headers. */
 export function getPostDayGroup( post: ReadStreamPost ): SpaceFeedDayGroup {
-	return dayGroupOf( asString( post.date ) );
+	return dayGroupOf( post.date );
 }
 
 /** The blog's domain from `feed_URL` (fallback the post URL), `www.` stripped. */
-function domainOf( post: Post ): string | undefined {
-	const url = asString( post.feed_URL ) ?? asString( post.URL );
+function domainOf( post: NormalizedPost ): string | undefined {
+	const url = post.feed_URL || post.URL;
 	if ( ! url ) {
 		return undefined;
 	}
@@ -82,23 +85,12 @@ function domainOf( post: Post ): string | undefined {
 	}
 }
 
-function imageOf( post: Post ): string | undefined {
+function imageOf( post: NormalizedPost ): string | undefined {
 	// The normalizer already folds the featured image into `canonical_media` (and
 	// drops non-image URLs), so this is the resolved image — no fallback needed.
 	const media = post.canonical_media;
-	if ( media && typeof media === 'object' ) {
-		const { src, mediaType } = media as { src?: unknown; mediaType?: unknown };
-		if ( typeof src === 'string' && src && ( mediaType === undefined || mediaType === 'image' ) ) {
-			return src;
-		}
-	}
-	return undefined;
-}
-
-function authorOf( post: Post ): string | undefined {
-	const author = post.author;
-	if ( author && typeof author === 'object' ) {
-		return asString( ( author as { name?: unknown } ).name );
+	if ( media?.src && ( media.mediaType === undefined || media.mediaType === 'image' ) ) {
+		return media.src;
 	}
 	return undefined;
 }
@@ -107,21 +99,21 @@ function authorOf( post: Post ): string | undefined {
 export function getPostFieldKey( post: ReadStreamPost ): string {
 	return (
 		keyToString( keyForPost( post ) ) ??
-		asString( post.global_ID ) ??
+		post.global_ID ??
 		`post-${ post.site_ID ?? '' }-${ post.feed_ID ?? '' }-${ post.feed_item_ID ?? '' }-${ post.ID }`
 	);
 }
 
-export function getPostFields( post: Post ): SpaceFeedPostFields {
+export function getPostFields( post: NormalizedPost ): SpaceFeedPostFields {
 	return {
-		title: asString( post.title ) ?? asString( post.site_name ) ?? '',
-		excerptHtml: asString( post.better_excerpt ) ?? '',
-		sourceName: asString( post.site_name ) ?? '',
-		authorName: authorOf( post ),
+		title: post.title || post.site_name || '',
+		excerptHtml: post.better_excerpt ?? '',
+		sourceName: post.site_name ?? '',
+		authorName: post.author?.name,
 		imageUrl: imageOf( post ),
-		siteIconUrl: asString( ( post.site_icon as { ico?: unknown } | undefined )?.ico ),
+		siteIconUrl: post.site_icon?.ico,
 		siteDomain: domainOf( post ),
-		publishedDate: asString( post.date ),
+		publishedDate: post.date,
 		postHref: getPostUrl( post ),
 		isUnread: post.is_seen === false,
 	};

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -1,8 +1,7 @@
-import { decodeEntities } from 'calypso/lib/formatting';
-import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
 import { keyForPost, keyToString } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
 import type { ReadStreamPost } from '@automattic/api-core';
+import type { Post } from 'calypso/reader/data/post/cache';
 
 /**
  * Day buckets the standard list groups by. The layout maps these to translated
@@ -11,19 +10,14 @@ import type { ReadStreamPost } from '@automattic/api-core';
 export type SpaceFeedDayGroup = 'today' | 'yesterday' | 'earlier' | 'older' | '';
 
 /**
- * Display fields the layouts read off a real `ReadStreamPost` (from the existing
- * Reader stream query). Most arrive through the type's index signature as
- * `unknown`; narrow them here once so the layout components stay cast-free.
+ * Display fields a card reads off its post. Cards feed the fully client-normalized
+ * post from the cache (`useCachedPost`), so these are taken as-is: entity decoding,
+ * the excerpt (`better_excerpt`) and the canonical image are already resolved by the
+ * Reader post normalizer — re-doing them here would just duplicate that work.
  */
 export interface SpaceFeedPostFields {
-	id: number;
-	key: string;
 	title: string;
-	/**
-	 * Sanitized excerpt HTML (Reader's `formatExcerpt` — same as PostLifecycle's
-	 * `better_excerpt`). Render with `dangerouslySetInnerHTML`, not as text, so
-	 * `<p>`/entities resolve instead of showing literally.
-	 */
+	/** Sanitized excerpt HTML (`post.better_excerpt`); render with `dangerouslySetInnerHTML`. */
 	excerptHtml: string;
 	sourceName: string;
 	authorName?: string;
@@ -34,7 +28,6 @@ export interface SpaceFeedPostFields {
 	siteDomain?: string;
 	/** Raw ISO publish date, for a relative `<TimeSince>` (e.g. "6h ago"). */
 	publishedDate?: string;
-	dayGroup: SpaceFeedDayGroup;
 	/** Reader full-post page path, e.g. `/reader/feeds/:feed/posts/:post`. */
 	postHref: string;
 	isUnread: boolean;
@@ -71,8 +64,13 @@ function dayGroupOf( dateIso?: string ): SpaceFeedDayGroup {
 	return 'older';
 }
 
+/** The day bucket a stream post falls into, for the standard list's date headers. */
+export function getPostDayGroup( post: ReadStreamPost ): SpaceFeedDayGroup {
+	return dayGroupOf( asString( post.date ) );
+}
+
 /** The blog's domain from `feed_URL` (fallback the post URL), `www.` stripped. */
-function domainOf( post: ReadStreamPost ): string | undefined {
+function domainOf( post: Post ): string | undefined {
 	const url = asString( post.feed_URL ) ?? asString( post.URL );
 	if ( ! url ) {
 		return undefined;
@@ -84,7 +82,9 @@ function domainOf( post: ReadStreamPost ): string | undefined {
 	}
 }
 
-function imageOf( post: ReadStreamPost ): string | undefined {
+function imageOf( post: Post ): string | undefined {
+	// The normalizer already folds the featured image into `canonical_media` (and
+	// drops non-image URLs), so this is the resolved image — no fallback needed.
 	const media = post.canonical_media;
 	if ( media && typeof media === 'object' ) {
 		const { src, mediaType } = media as { src?: unknown; mediaType?: unknown };
@@ -92,10 +92,10 @@ function imageOf( post: ReadStreamPost ): string | undefined {
 			return src;
 		}
 	}
-	return asString( post.featured_image );
+	return undefined;
 }
 
-function authorOf( post: ReadStreamPost ): string | undefined {
+function authorOf( post: Post ): string | undefined {
 	const author = post.author;
 	if ( author && typeof author === 'object' ) {
 		return asString( ( author as { name?: unknown } ).name );
@@ -103,6 +103,7 @@ function authorOf( post: ReadStreamPost ): string | undefined {
 	return undefined;
 }
 
+/** Stable identity key for a stream post — React keys and day-group boundaries. */
 export function getPostFieldKey( post: ReadStreamPost ): string {
 	return (
 		keyToString( keyForPost( post ) ) ??
@@ -111,29 +112,16 @@ export function getPostFieldKey( post: ReadStreamPost ): string {
 	);
 }
 
-export function getPostFields( post: ReadStreamPost ): SpaceFeedPostFields {
-	const date = asString( post.date );
-	const author = authorOf( post );
+export function getPostFields( post: Post ): SpaceFeedPostFields {
 	return {
-		id: post.ID,
-		key: getPostFieldKey( post ),
-		// Title, source and author render as plain text, so decode the HTML
-		// entities the raw API title carries (e.g. `&nbsp;`, `&#039;`) — the legacy
-		// card gets this for free from the normalized post. Titles are sometimes
-		// double-encoded, so decode twice, mirroring the Reader post normalizer
-		// (rule-decode-entities). The excerpt is rendered as HTML, so it doesn't
-		// need this.
-		title: decodeEntities(
-			decodeEntities( asString( post.title ) ?? asString( post.site_name ) ?? '' )
-		),
-		excerptHtml: formatExcerpt( asString( post.excerpt ) ?? post.description ?? '' ),
-		sourceName: decodeEntities( asString( post.site_name ) ?? '' ),
-		authorName: author ? decodeEntities( author ) : undefined,
+		title: asString( post.title ) ?? asString( post.site_name ) ?? '',
+		excerptHtml: asString( post.better_excerpt ) ?? '',
+		sourceName: asString( post.site_name ) ?? '',
+		authorName: authorOf( post ),
 		imageUrl: imageOf( post ),
-		siteIconUrl: asString( post.site_icon?.ico ),
+		siteIconUrl: asString( ( post.site_icon as { ico?: unknown } | undefined )?.ico ),
 		siteDomain: domainOf( post ),
-		publishedDate: date,
-		dayGroup: dayGroupOf( date ),
+		publishedDate: asString( post.date ),
 		postHref: getPostUrl( post ),
 		isUnread: post.is_seen === false,
 	};

--- a/client/reader/spaces/feed/post-fields.ts
+++ b/client/reader/spaces/feed/post-fields.ts
@@ -1,3 +1,4 @@
+import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
 import { keyForPost, keyToString } from 'calypso/reader/post-key';
 import { getPostUrl } from 'calypso/reader/route';
 import type { ReadPost, ReadStreamPost } from '@automattic/api-core';
@@ -17,13 +18,13 @@ export type SpaceFeedDayGroup = 'today' | 'yesterday' | 'earlier' | 'older' | ''
 
 /**
  * Display fields a card reads off its post. Cards feed the fully client-normalized
- * post from the cache (`useCachedPost`), so these are taken as-is: entity decoding,
- * the excerpt (`better_excerpt`) and the canonical image are already resolved by the
- * Reader post normalizer — re-doing them here would just duplicate that work.
+ * post from the cache (`useCachedPost`), so most fields are taken as-is: entity
+ * decoding and the canonical image are already resolved by the Reader post
+ * normalizer — re-doing them here would just duplicate that work.
  */
 export interface SpaceFeedPostFields {
 	title: string;
-	/** Sanitized excerpt HTML (`post.better_excerpt`); render with `dangerouslySetInnerHTML`. */
+	/** Sanitized excerpt HTML from the API excerpt; render with `dangerouslySetInnerHTML`. */
 	excerptHtml: string;
 	sourceName: string;
 	authorName?: string;
@@ -107,7 +108,10 @@ export function getPostFieldKey( post: ReadStreamPost ): string {
 export function getPostFields( post: NormalizedPost ): SpaceFeedPostFields {
 	return {
 		title: post.title || post.site_name || '',
-		excerptHtml: post.better_excerpt ?? '',
+		// The API excerpt (a short summary), sanitized to p/br/sup/sub. Not
+		// `better_excerpt` — that's built from the post content (first paragraphs) and
+		// runs much longer, closer to the whole post.
+		excerptHtml: formatExcerpt( post.excerpt || post.description || '' ),
 		sourceName: post.site_name ?? '',
 		authorName: post.author?.name,
 		imageUrl: imageOf( post ),

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -6,9 +6,10 @@ import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import { upsertPostCache } from 'calypso/reader/data/post/cache';
 import { useInfiniteStream } from 'calypso/reader/data/stream';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import { SpaceFeed, collectPosts } from '../index';
+import { SpaceFeed } from '../index';
 import type {
 	ReadSpaceDetails,
 	ReadStreamPost,
@@ -59,9 +60,18 @@ jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
 
 const mockUseInfiniteStream = useInfiniteStream as jest.Mock;
 
+function postsFromPages( pages: ReadStreamResponse[] ): ReadStreamPost[] {
+	return pages.flatMap( ( page ) =>
+		page.cards
+			? page.cards.filter( ( card ) => card.type === 'post' ).map( ( card ) => card.data )
+			: page.posts ?? []
+	);
+}
+
 function streamResult( overrides: Partial< ReturnType< typeof useInfiniteStream > > = {} ) {
-	return {
+	const result = {
 		items: [],
+		posts: [],
 		pages: [],
 		isLoading: false,
 		isFetching: false,
@@ -75,6 +85,12 @@ function streamResult( overrides: Partial< ReturnType< typeof useInfiniteStream 
 		invalidate: jest.fn(),
 		...overrides,
 	};
+	// The real hook parses `posts` from the pages; mirror that so tests can keep
+	// setting `pages` (or override `posts` directly).
+	if ( ! ( 'posts' in overrides ) ) {
+		result.posts = postsFromPages( result.pages ) as never;
+	}
+	return result;
 }
 
 function makeSpace( id: string, name: string, view: SpaceFeedLayout ): ReadSpaceDetails {
@@ -286,6 +302,8 @@ describe( 'SpaceFeed', () => {
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
 		const post = makePost();
+		// Cards render from the canonical cache; seed it so the row shows the post.
+		upsertPostCache( queryClient, [ post ] );
 		const streamItem = {
 			feedId: post.feed_ID,
 			postId: post.feed_item_ID,
@@ -318,6 +336,7 @@ describe( 'SpaceFeed', () => {
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 		queryClient.setQueryData( readSpaceQuery( WORK.id ).queryKey, WORK );
 		const post = makePost();
+		upsertPostCache( queryClient, [ post ] );
 		mockUseInfiniteStream.mockReturnValue(
 			streamResult( { pages: [ { posts: [ post ] } as unknown as ReadStreamResponse ] } )
 		);
@@ -432,29 +451,5 @@ describe( 'SpaceFeed', () => {
 		render( WORK );
 
 		expect( screen.queryByText( 'Loading more posts…' ) ).not.toBeInTheDocument();
-	} );
-} );
-
-describe( 'collectPosts', () => {
-	it( 'prefers post cards over the legacy posts field when both are present', () => {
-		const postFromPosts = {
-			ID: 1,
-			site_ID: 2,
-			title: 'posts field',
-		} as unknown as ReadStreamPost;
-		const postFromCard = {
-			ID: 2,
-			site_ID: 3,
-			title: 'card field',
-		} as unknown as ReadStreamPost;
-
-		expect(
-			collectPosts( [
-				{
-					posts: [ postFromPosts ],
-					cards: [ { type: 'post', data: postFromCard }, { type: 'recommendation' } ],
-				} as unknown as ReadStreamResponse,
-			] )
-		).toEqual( [ postFromCard ] );
 	} );
 } );

--- a/client/reader/spaces/feed/test/post-fields.test.ts
+++ b/client/reader/spaces/feed/test/post-fields.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { getPostFields } from '../post-fields';
+import { getPostFieldKey, getPostFields } from '../post-fields';
 import type { ReadStreamPost } from '@automattic/api-core';
 
 describe( 'getPostFields', () => {
@@ -47,8 +47,8 @@ describe( 'getPostFields', () => {
 			title: 'Second',
 		} as unknown as ReadStreamPost;
 
-		expect( getPostFields( first ).key ).toBe( 'blog-7-20' );
-		expect( getPostFields( second ).key ).toBe( 'blog-7-21' );
+		expect( getPostFieldKey( first ) ).toBe( 'blog-7-20' );
+		expect( getPostFieldKey( second ) ).toBe( 'blog-7-21' );
 	} );
 
 	it( 'reads the image from canonical_media and the author name', () => {
@@ -65,11 +65,11 @@ describe( 'getPostFields', () => {
 		expect( fields.authorName ).toBe( 'Ada' );
 	} );
 
-	it( 'returns sanitized excerpt HTML whose text decodes entities', () => {
+	it( 'passes through the normalized excerpt HTML (post.better_excerpt)', () => {
 		const post = {
 			ID: 1,
 			site_ID: 2,
-			excerpt: '<p>Latin, Asian Pop and R&amp;B genres, including the Best&hellip;</p>',
+			better_excerpt: '<p>Latin, Asian Pop and R&amp;B genres, including the Best&hellip;</p>',
 		} as unknown as ReadStreamPost;
 
 		const { excerptHtml } = getPostFields( post );
@@ -77,21 +77,6 @@ describe( 'getPostFields', () => {
 		const host = document.createElement( 'div' );
 		host.innerHTML = excerptHtml;
 		expect( host.textContent ).toBe( 'Latin, Asian Pop and R&B genres, including the Best…' );
-	} );
-
-	it( 'decodes HTML entities in the plain-text title, source and author', () => {
-		const post = {
-			ID: 1,
-			site_ID: 2,
-			title: 'Pre-Order Reveal&nbsp;: GTA&nbsp;6',
-			site_name: 'Kendall Lacey&#039;s Webworld',
-			author: { name: 'A &amp; B' },
-		} as unknown as ReadStreamPost;
-
-		const fields = getPostFields( post );
-		expect( fields.title ).toBe( 'Pre-Order Reveal : GTA 6' );
-		expect( fields.sourceName ).toBe( "Kendall Lacey's Webworld" );
-		expect( fields.authorName ).toBe( 'A & B' );
 	} );
 
 	it( 'reads the blog icon from site_icon.ico', () => {

--- a/client/reader/spaces/feed/test/post-fields.test.ts
+++ b/client/reader/spaces/feed/test/post-fields.test.ts
@@ -65,11 +65,11 @@ describe( 'getPostFields', () => {
 		expect( fields.authorName ).toBe( 'Ada' );
 	} );
 
-	it( 'passes through the normalized excerpt HTML (post.better_excerpt)', () => {
+	it( 'returns sanitized excerpt HTML from the API excerpt', () => {
 		const post = {
 			ID: 1,
 			site_ID: 2,
-			better_excerpt: '<p>Latin, Asian Pop and R&amp;B genres, including the Best&hellip;</p>',
+			excerpt: '<p>Latin, Asian Pop and R&amp;B genres, including the Best&hellip;</p>',
 		} as unknown as ReadStreamPost;
 
 		const { excerptHtml } = getPostFields( post );

--- a/packages/api-core/src/read-post/types.ts
+++ b/packages/api-core/src/read-post/types.ts
@@ -17,6 +17,16 @@ export interface ReadPost {
 	feed_ID?: number;
 	feed_item_ID?: number;
 	global_ID: string;
+	title?: string;
+	site_name?: string;
+	better_excerpt?: string;
+	date?: string;
+	URL?: string;
+	feed_URL?: string;
+	is_seen?: boolean;
+	site_icon?: { ico?: string; [ key: string ]: unknown };
+	author?: { name?: string; [ key: string ]: unknown };
+	canonical_media?: { src?: string; mediaType?: string; [ key: string ]: unknown };
 	[ key: string ]: unknown;
 }
 

--- a/packages/api-core/src/read-post/types.ts
+++ b/packages/api-core/src/read-post/types.ts
@@ -19,6 +19,8 @@ export interface ReadPost {
 	global_ID: string;
 	title?: string;
 	site_name?: string;
+	excerpt?: string;
+	description?: string;
 	better_excerpt?: string;
 	date?: string;
 	URL?: string;


### PR DESCRIPTION
## Proposed Changes

* Render Reader Spaces feed cards from the normalized Reader post cache across standard list, board, and gallery layouts.
* Keep stream responses responsible for ordering, selection, virtualization, and day grouping while each card reads its display fields from the cached normalized post.
* Tighten Reader Spaces post display-field typing and add the `ReadPost` display fields used by feed cards.
* Keep feed excerpts short by formatting the API excerpt/description instead of using the longer normalized `better_excerpt`.
* Add skeleton fallbacks for cards while their normalized post data is resolving from cache.
* Add Reader dark mode tooltip color tokens so action tooltips use an opaque background.

## Why are these changes being made?

Reader Spaces feed cards need to match the canonical Reader post presentation instead of re-normalizing raw stream data in each layout. Reading display data from the normalized post cache keeps titles, images, authors, and metadata aligned with the rest of Reader while preserving the stream order and layout behavior.

The card excerpt should remain a compact feed summary, not expand toward the full post content. The dark mode tooltip token also needed a Reader-specific opaque value because the inherited sidebar hover background is transparent in this surface.

## Testing Instructions

### Scenario 1 - Spaces standard list:
- Go to `/reader/spaces`
- Open a space that has feed posts
- Switch to the standard list layout
- Check if post cards show compact excerpts, source names, authors, timestamps, and unread state without rendering near-full post content

### Scenario 2 - Spaces board and gallery:
- Go to `/reader/spaces`
- Open a space that has feed posts with images
- Switch between board and gallery layouts
- Check if cards keep their images, metadata, actions, and selection/open behavior while loading more posts

### Scenario 3 - Reader action tooltip:
- Go to `/read/discover`
- Enable dark mode if it is not already enabled
- Hover the repost action on a Reader post
- Check if the tooltip has a solid background and the post text behind it is not visible through the tooltip

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
