### PR TITLE
Account recovery notice: only show when no backup is set, drop Gmail/Outlook suggestion

### DIFF
--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -1,5 +1,6 @@
-import { cancelPendingEmailChangeMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import { accountRecoveryQuery, cancelPendingEmailChangeMutation } from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import { __experimentalInputControl as InputControl, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -97,11 +98,17 @@ export default function EmailSection( {
 		validateEmail( value );
 	}, [ value, validateEmail ] );
 
+	const { data: accountRecovery } = useQuery( accountRecoveryQuery() );
+	const isAccountRecoveryReady = accountRecovery !== undefined;
+	const hasRecoveryMethod = !! accountRecovery?.email || !! accountRecovery?.phone;
+
 	const showCustomDomainWarning =
 		! isEmailPending &&
 		!! value &&
 		emailValidator.validate( value ) &&
-		isCustomDomainEmail( value );
+		isCustomDomainEmail( value ) &&
+		isAccountRecoveryReady &&
+		! hasRecoveryMethod;
 
 	const getValidationClass = () => {
 		if ( isEmailPending ) {
@@ -151,8 +158,13 @@ export default function EmailSection( {
 			return (
 				<>
 					<Icon icon={ info } size={ 16 } />
-					{ __(
-						'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. Consider an email from a service like Gmail or Outlook instead.'
+					{ createInterpolateElement(
+						__(
+							'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. <a>Set up a recovery email or phone number</a> to keep access to your account.'
+						),
+						{
+							a: <Link to="/me/security/account-recovery" />,
+						}
 					) }
 				</>
 			);

--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -158,14 +158,16 @@ export default function EmailSection( {
 			return (
 				<>
 					<Icon icon={ info } size={ 16 } />
-					{ createInterpolateElement(
-						__(
-							'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. <a>Set up a recovery email or phone number</a> to keep access to your account.'
-						),
-						{
-							a: <Link to="/me/security/account-recovery" />,
-						}
-					) }
+					<span>
+						{ createInterpolateElement(
+							__(
+								'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. <a>Set up a recovery email or phone number</a> to keep access to your account.'
+							),
+							{
+								a: <Link to="/me/security/account-recovery" />,
+							}
+						) }
+					</span>
 				</>
 			);
 		}

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -41,6 +41,20 @@ function mockIsAutomattician( isAutomattician: boolean ) {
 		} );
 }
 
+function mockAccountRecovery( {
+	email = '',
+	phone = null,
+}: { email?: string; phone?: object | null } = {} ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/account-recovery' )
+		.reply( 200, {
+			email,
+			email_validated: false,
+			phone,
+			phone_validated: false,
+		} );
+}
+
 describe( '<PersonalDetailsSection>', () => {
 	test( 'renders the form and saves the form', async () => {
 		const user = userEvent.setup();
@@ -220,16 +234,67 @@ describe( '<PersonalDetailsSection>', () => {
 			} );
 		} );
 
-		test( 'warns when the account email uses a custom domain', async () => {
+		test( 'warns when the account email uses a custom domain and no recovery method is set', async () => {
 			mockUserSettings( {
 				...settings,
 				user_email: 'jane@mycustomdomain.com',
 			} as unknown as UserSettings );
 			mockIsAutomattician( false );
+			mockAccountRecovery();
 
 			render( <PersonalDetailsSection /> );
 
 			expect( await screen.findByText( /lose access to account recovery/i ) ).toBeVisible();
+		} );
+
+		test( 'links to the account recovery settings page', async () => {
+			mockUserSettings( {
+				...settings,
+				user_email: 'jane@mycustomdomain.com',
+			} as unknown as UserSettings );
+			mockIsAutomattician( false );
+			mockAccountRecovery();
+
+			render( <PersonalDetailsSection /> );
+
+			expect(
+				await screen.findByRole( 'link', { name: /set up a recovery email or phone number/i } )
+			).toHaveAttribute( 'href', '/me/security/account-recovery' );
+		} );
+
+		test( 'does not warn when a recovery email is already set', async () => {
+			mockUserSettings( {
+				...settings,
+				user_email: 'jane@mycustomdomain.com',
+			} as unknown as UserSettings );
+			mockIsAutomattician( false );
+			mockAccountRecovery( { email: 'backup@gmail.com' } );
+
+			render( <PersonalDetailsSection /> );
+
+			await screen.findByRole( 'textbox', { name: 'Email address' } );
+			expect( screen.queryByText( /lose access to account recovery/i ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'does not warn when a recovery phone is already set', async () => {
+			mockUserSettings( {
+				...settings,
+				user_email: 'jane@mycustomdomain.com',
+			} as unknown as UserSettings );
+			mockIsAutomattician( false );
+			mockAccountRecovery( {
+				phone: {
+					country_code: 'US',
+					country_numeric_code: '+1',
+					number: '5551234',
+					number_full: '+15551234',
+				},
+			} );
+
+			render( <PersonalDetailsSection /> );
+
+			await screen.findByRole( 'textbox', { name: 'Email address' } );
+			expect( screen.queryByText( /lose access to account recovery/i ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'does not warn for a free email provider', async () => {
@@ -238,6 +303,7 @@ describe( '<PersonalDetailsSection>', () => {
 				user_email: 'jane@gmail.com',
 			} as unknown as UserSettings );
 			mockIsAutomattician( false );
+			mockAccountRecovery();
 
 			render( <PersonalDetailsSection /> );
 
@@ -251,6 +317,7 @@ describe( '<PersonalDetailsSection>', () => {
 				user_email: 'jane@mail.gmail.com',
 			} as unknown as UserSettings );
 			mockIsAutomattician( false );
+			mockAccountRecovery();
 
 			render( <PersonalDetailsSection /> );
 

--- a/client/me/account/account-email-field.tsx
+++ b/client/me/account/account-email-field.tsx
@@ -4,10 +4,16 @@ import { removeQueryArgs } from '@wordpress/url';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useDispatch, useSelector } from 'calypso/state';
+import {
+	getAccountRecoveryEmail,
+	getAccountRecoveryPhone,
+	isAccountRecoverySettingsReady,
+} from 'calypso/state/account-recovery/settings/selectors';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
@@ -165,19 +171,34 @@ const isCustomDomainEmail = ( email: string ): boolean => {
 
 const AccountEmailCustomDomainNotice = ( { email }: { email: string } ) => {
 	const translate = useTranslate();
+	const isSettingsReady = useSelector( isAccountRecoverySettingsReady );
+	const recoveryEmail = useSelector( getAccountRecoveryEmail );
+	const recoveryPhone = useSelector( getAccountRecoveryPhone );
 
 	if ( ! isCustomDomainEmail( email ) ) {
 		return null;
 	}
 
+	const hasRecoveryMethod = !! recoveryEmail || !! recoveryPhone;
+
 	return (
-		<FormInputValidation
-			isError={ false }
-			isWarning
-			text={ translate(
-				"This email uses a custom domain. If your domain expires, you'd lose access to account recovery. Consider an email from a service like Gmail or Outlook instead."
+		<>
+			<QueryAccountRecoverySettings />
+			{ isSettingsReady && ! hasRecoveryMethod && (
+				<FormInputValidation
+					isError={ false }
+					isWarning
+					text={ translate(
+						"This email uses a custom domain. If your domain expires, you'd lose access to account recovery. {{a}}Set up a recovery email or phone number{{/a}} to keep access to your account.",
+						{
+							components: {
+								a: <a href="/me/security/account-recovery" />,
+							},
+						}
+					) }
+				/>
 			) }
-		/>
+		</>
 	);
 };
 

--- a/client/me/account/test/account-email-field.tsx
+++ b/client/me/account/test/account-email-field.tsx
@@ -3,11 +3,24 @@
  */
 import { screen } from '@testing-library/react';
 import nock from 'nock';
+import accountRecoveryReducer from 'calypso/state/account-recovery/reducer';
 import userSettingsReducer from 'calypso/state/user-settings/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import AccountEmailField from '../account-email-field';
 
-const buildInitialState = () => ( {
+jest.mock( 'calypso/components/data/query-account-recovery-settings', () => () => null );
+
+type RecoveryState = {
+	isReady?: boolean;
+	recoveryEmail?: string;
+	recoveryPhone?: object | null;
+};
+
+const buildInitialState = ( {
+	isReady = true,
+	recoveryEmail = '',
+	recoveryPhone = null,
+}: RecoveryState = {} ) => ( {
 	currentUser: {
 		id: 1,
 		user: { ID: 1, email: 'user@gmail.com', email_verified: true },
@@ -18,17 +31,33 @@ const buildInitialState = () => ( {
 		updating: {},
 		failed: {},
 	},
+	accountRecovery: {
+		isFetchingSettings: false,
+		settings: {
+			data: {
+				email: recoveryEmail,
+				emailValidated: false,
+				phone: recoveryPhone,
+				phoneValidated: false,
+			},
+			isReady,
+			isUpdating: {},
+			isDeleting: {},
+			isValidatingPhone: false,
+			hasSentValidation: {},
+		},
+	},
 } );
 
-const renderFieldWithEmail = ( email: string ) =>
+const renderFieldWithEmail = ( email: string, recoveryState: RecoveryState = {} ) =>
 	renderWithProvider(
 		<AccountEmailField
 			userSettings={ { user_email: 'user@gmail.com' } }
 			unsavedUserSettings={ { user_email: email } }
 		/>,
 		{
-			initialState: buildInitialState(),
-			reducers: { userSettings: userSettingsReducer },
+			initialState: buildInitialState( recoveryState ),
+			reducers: { userSettings: userSettingsReducer, accountRecovery: accountRecoveryReducer },
 		}
 	);
 
@@ -59,7 +88,7 @@ describe( 'AccountEmailField — custom domain warning', () => {
 		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
 	} );
 
-	it( 'shows the warning for a custom domain', () => {
+	it( 'shows the warning for a custom domain when no recovery method is set', () => {
 		renderFieldWithEmail( 'me@my-custom-domain.com' );
 		expect( screen.getByText( WARNING_MATCHER ) ).toBeVisible();
 	} );
@@ -67,6 +96,30 @@ describe( 'AccountEmailField — custom domain warning', () => {
 	it( 'shows the warning for a custom domain case-insensitively', () => {
 		renderFieldWithEmail( 'me@MY-CUSTOM-DOMAIN.COM' );
 		expect( screen.getByText( WARNING_MATCHER ) ).toBeVisible();
+	} );
+
+	it( 'links to the account recovery settings page', () => {
+		renderFieldWithEmail( 'me@my-custom-domain.com' );
+		expect(
+			screen.getByRole( 'link', { name: /set up a recovery email or phone number/i } )
+		).toHaveAttribute( 'href', '/me/security/account-recovery' );
+	} );
+
+	it( 'does not show the warning when a recovery email is already set', () => {
+		renderFieldWithEmail( 'me@my-custom-domain.com', { recoveryEmail: 'backup@gmail.com' } );
+		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
+	} );
+
+	it( 'does not show the warning when a recovery phone is already set', () => {
+		renderFieldWithEmail( 'me@my-custom-domain.com', {
+			recoveryPhone: { countryCode: 'US', number: '5551234' },
+		} );
+		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
+	} );
+
+	it( 'does not show the warning before account recovery settings are ready', () => {
+		renderFieldWithEmail( 'me@my-custom-domain.com', { isReady: false } );
+		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
 	} );
 
 	it( 'does not show the warning for an empty email', () => {


### PR DESCRIPTION
Closes DOTOBRD-486

## Proposed Changes

The account-recovery notice (shown when the account email is on a custom domain) was updated in both the classic Calypso account page and the new Multi-site Dashboard (MSD) so the two surfaces behave the same:

* The notice now appears **only when the user has no recovery email or phone set**. Users who already have a backup method configured are no longer nudged.
* Removed the recommendation to use a third-party provider (Gmail/Outlook). The notice now links to the recovery setup page (`/me/security/account-recovery`) so the user can add a recovery method directly.
* Both surfaces load the recovery state before showing the notice and wait for it to be ready so the notice does not flash before the data arrives. Calypso mounts `QueryAccountRecoverySettings`; MSD fetches it through the `accountRecoveryQuery` TanStack query.

Files:

* Calypso: `client/me/account/account-email-field.tsx`
* MSD: `client/dashboard/me/profile-personal-details/email-section.tsx`

In MSD the notice text is rendered inside a single `<span>` so the interpolated link flows inline within the flex help row instead of splitting into separate columns.

New copy:

> This email uses a custom domain. If your domain expires, you'd lose access to account recovery. **Set up a recovery email or phone number** to keep access to your account.

### Screenshots

| Before | After |
| --- | --- |
| <img width="689" height="595" alt="Screenshot 2026-07-08 at 11 59 19" src="https://github.com/user-attachments/assets/59f5e4cc-6da0-43a6-87df-1cc599b0ee20" /> | <img width="691" height="567" alt="Screenshot 2026-07-08 at 11 59 39" src="https://github.com/user-attachments/assets/7754cf5e-50e7-40fb-926e-518b15ca4011" /> |

## Why are these changes being made?

* Recommending third-party email providers is off-message given we sell custom-domain email ourselves.
* The notice is only relevant when the user has no other way back into their account, so it should not nag users who already have a backup recovery method.
* Flagged on the Phase 1 account-recovery design discussion; tracked as DOTOBRD-486.

## Testing Instructions

* Run the Calypso unit tests: `yarn test-client client/me/account/test/account-email-field.tsx` (12 cases, covering free providers, custom domains, recovery email/phone set, settings-not-ready, and the link target).
* Run the MSD unit tests: `yarn test-client client/dashboard/me/profile-personal-details/test/index.test.tsx` (13 cases, covering the same recovery-notice scenarios plus the existing personal-details form behavior).
* Manual (Calypso): go to `/me/account` while signed in as a user whose account email is on a custom domain.
  * With **no** recovery email/phone set (`/me/security/account-recovery`): the warning appears and its link points to `/me/security/account-recovery`.
  * With a recovery email **or** phone set: the warning does not appear.
  * With a free-provider account email (gmail/outlook/etc.): the warning does not appear.
* Manual (MSD): open the Dashboard Profile → Personal details screen and repeat the same three cases against the Email address field.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
