### PR TITLE
Account recovery interstitial: hide it during HE support sessions

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -4,6 +4,7 @@ import {
 	userPreferenceQuery,
 	userPreferenceMutation,
 } from '@automattic/api-queries';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
@@ -107,12 +108,14 @@ export default function AccountRecoveryInterstitial() {
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
 
-	// Eligible once the data has loaded and the snooze (if any) has elapsed.
+	// Eligible once the data has loaded and the snooze (if any) has elapsed. Support sessions are
+	// skipped.
 	const isEligible =
 		isAccountRecoveryLoaded &&
 		isUserSettingsLoaded &&
 		isSnoozeLoaded &&
 		! isSnoozed &&
+		! isSupportSession() &&
 		securityLevel !== 'strong';
 
 	// Gate the interstitial behind an A/B experiment. Mark the user eligible only once they would

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -79,6 +79,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 
 	afterEach( () => {
 		window.localStorage.clear();
+		delete window.isSupportSession;
 	} );
 
 	test( 'shows the modal and records an impression for a user with no recovery method', async () => {
@@ -247,6 +248,22 @@ describe( '<AccountRecoveryInterstitial>', () => {
 				snooze_period: 14,
 			}
 		);
+	} );
+
+	test( 'does not show (and records nothing) for a Happiness Engineer in a support session', async () => {
+		// An otherwise-eligible user (no recovery method, not snoozed), viewed through a support
+		// session. The nudge targets the account owner, not the HE acting on their behalf.
+		window.isSupportSession = true;
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences();
+
+		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not show for a user in the experiment treatment group, even when eligible', async () => {


### PR DESCRIPTION
## Proposed Changes

* Hide the account recovery interstitial in the hosting dashboard when the user is being viewed through a Happiness Engineer support session.
* Fold `! isSupportSession()` into the interstitial's eligibility check, so it is suppressed for both support-user impersonation and "support next" sessions.
* Add a test covering the support-session case (no modal, no Tracks events).

## Why are these changes being made?

The account recovery nudge is meant for the account owner, prompting them to add a recovery method, 2FA, or backup codes. It was also showing to Happiness Engineers acting on a user's behalf during a support session, which is not the intended audience. This was raised in HE feedback on the interstitial.

Because the eligibility check also gates the A/B experiment exposure, excluding support sessions additionally keeps them from firing the exposure event and diluting the experiment population.

## Testing Instructions

* Run `yarn test-client client/dashboard/app/account-recovery-interstitial` — all cases pass, including the new "does not show ... for a Happiness Engineer in a support session" test.
* Manually: as an otherwise-eligible user (no recovery method set up, not snoozed), open the hosting dashboard in a support session. Confirm the account recovery modal does not appear. In a normal session the modal still appears as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
