### PR TITLE
Revert "Account recovery interstitial: hide it during HE support sessions"

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -4,7 +4,6 @@ import {
 	userPreferenceQuery,
 	userPreferenceMutation,
 } from '@automattic/api-queries';
-import { isSupportSession } from '@automattic/calypso-support-session';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
@@ -108,14 +107,12 @@ export default function AccountRecoveryInterstitial() {
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
 
-	// Eligible once the data has loaded and the snooze (if any) has elapsed. Support sessions are
-	// skipped.
+	// Eligible once the data has loaded and the snooze (if any) has elapsed.
 	const isEligible =
 		isAccountRecoveryLoaded &&
 		isUserSettingsLoaded &&
 		isSnoozeLoaded &&
 		! isSnoozed &&
-		! isSupportSession() &&
 		securityLevel !== 'strong';
 
 	// Gate the interstitial behind an A/B experiment. Mark the user eligible only once they would

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -79,7 +79,6 @@ describe( '<AccountRecoveryInterstitial>', () => {
 
 	afterEach( () => {
 		window.localStorage.clear();
-		delete window.isSupportSession;
 	} );
 
 	test( 'shows the modal and records an impression for a user with no recovery method', async () => {
@@ -248,22 +247,6 @@ describe( '<AccountRecoveryInterstitial>', () => {
 				snooze_period: 14,
 			}
 		);
-	} );
-
-	test( 'does not show (and records nothing) for a Happiness Engineer in a support session', async () => {
-		// An otherwise-eligible user (no recovery method, not snoozed), viewed through a support
-		// session. The nudge targets the account owner, not the HE acting on their behalf.
-		window.isSupportSession = true;
-		mockAccountRecovery( NONE_RECOVERY );
-		mockUserSettings( { two_step_enabled: false } );
-		mockPreferences();
-
-		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
-
-		await waitFor( () => {
-			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
-		} );
-		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not show for a user in the experiment treatment group, even when eligible', async () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112398 (if needed)