### PR TITLE
SHILL-2211: Show volume-adjusted totals on multi-unit cost-override receipts

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -59,6 +59,13 @@ export interface LineItemCostOverrideForDisplay {
 	 * If not set, a number will not be displayed.
 	 */
 	discountAmount?: number;
+	/**
+	 * The volume-adjusted line totals before/after the override, in the
+	 * currency's smallest unit (fall back to the per-unit price when no
+	 * volume-adjusted subtotal was stored). Rendered as `<s>old</s> new`.
+	 */
+	oldSubtotalInteger?: number;
+	newSubtotalInteger?: number;
 }
 
 export default function Receipt() {
@@ -569,19 +576,35 @@ function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Recei
 	);
 }
 
-function ReceiptItemDiscounts( { item, receiptDate }: { item: ReceiptItem; receiptDate: string } ) {
+export function ReceiptItemDiscounts( {
+	item,
+	receiptDate,
+}: {
+	item: ReceiptItem;
+	receiptDate: string;
+} ) {
 	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receiptDate );
 
 	return (
 		<ul className="receipt-discount-list">
 			{ filterCostOverridesForReceiptItem( item ).map( ( costOverride ) => {
+				const formatAmount = ( amount: number ) =>
+					formatCurrency( amount, item.currency, { isSmallestUnit: true, stripZeros: true } );
+				// Single-unit overrides render the plain discount-amount line;
+				// volume-adjusted (multi-unit) overrides render the struck totals.
 				const formattedDiscountAmount =
 					shouldShowDiscount && costOverride.discountAmount
-						? formatCurrency( -costOverride.discountAmount, item.currency, {
-								isSmallestUnit: true,
-								stripZeros: true,
-						  } )
+						? formatAmount( -costOverride.discountAmount )
 						: '';
+				const subtotalsDisplay =
+					shouldShowDiscount &&
+					costOverride.oldSubtotalInteger !== undefined &&
+					costOverride.newSubtotalInteger !== undefined ? (
+						<>
+							<s>{ formatAmount( costOverride.oldSubtotalInteger ) }</s>{ ' ' }
+							{ formatAmount( costOverride.newSubtotalInteger ) }
+						</>
+					) : null;
 
 				if (
 					doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
@@ -615,7 +638,7 @@ function ReceiptItemDiscounts( { item, receiptDate }: { item: ReceiptItem; recei
 					<li key={ costOverride.humanReadableReason }>
 						<Flex justify="space-between">
 							<Text>{ costOverride.humanReadableReason }</Text>
-							<Text>{ formattedDiscountAmount }</Text>
+							<Text>{ subtotalsDisplay ?? formattedDiscountAmount }</Text>
 						</Flex>
 					</li>
 				);
@@ -645,6 +668,8 @@ function filterCostOverridesForReceiptItem( item: ReceiptItem ): LineItemCostOve
 				humanReadableReason: costOverride.human_readable_reason,
 				overrideCode: costOverride.override_code,
 				discountAmount: costOverride.old_price_integer - costOverride.new_price_integer,
+				oldSubtotalInteger: costOverride.old_subtotal_integer ?? undefined,
+				newSubtotalInteger: costOverride.new_subtotal_integer ?? undefined,
 			};
 		} );
 }

--- a/client/dashboard/me/billing-history/test/receipt.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, within } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { ReceiptItemDiscounts } from '../receipt';
+import type { ReceiptItem, ReceiptItemCostOverride, User } from '@automattic/api-core';
+
+// Recent receipt date so the discount rows render.
+const RECEIPT_DATE = '2026-05-21T00:00:00+00:00';
+const testUser = { ID: 1, username: 'testuser', language: 'en' } as User;
+
+function makeItem( costOverride: Partial< ReceiptItemCostOverride > ): ReceiptItem {
+	return {
+		currency: 'USD',
+		introductory_offer_terms: null,
+		months_per_renewal_interval: 24,
+		amount_integer: 0,
+		cost_overrides: [
+			{
+				human_readable_reason: 'Free domain for first year',
+				override_code: 'coupon-discount',
+				does_override_original_cost: false,
+				...costOverride,
+			},
+		],
+	} as unknown as ReceiptItem;
+}
+
+describe( '<ReceiptItemDiscounts>', () => {
+	test( 'shows the volume-adjusted subtotals changing from struck old total to new total', () => {
+		// Real receipt 118392995: unit 15.00 -> 7.50, volume 2, subtotal 30.00 -> 15.00.
+		const item = makeItem( {
+			old_price_integer: 1500,
+			new_price_integer: 750,
+			old_subtotal_integer: 3000,
+			new_subtotal_integer: 1500,
+		} );
+
+		render( <ReceiptItemDiscounts item={ item } receiptDate={ RECEIPT_DATE } />, {
+			user: testUser,
+		} );
+
+		const row = screen.getByRole( 'listitem' );
+		expect( within( row ).getByText( '$30' ).tagName ).toBe( 'S' ); // struck old total
+		expect( row ).toHaveTextContent( '$15' ); // new total
+	} );
+
+	test( 'shows the stored subtotal, never price * volume', () => {
+		// First-unit-only discount where the subtotal is not price * volume: unit
+		// 20.00 -> 12.00, volume 3, subtotal 60.00 -> 52.00 (price * volume would be $36).
+		const item = makeItem( {
+			old_price_integer: 2000,
+			new_price_integer: 1200,
+			old_subtotal_integer: 6000,
+			new_subtotal_integer: 5200,
+		} );
+
+		render( <ReceiptItemDiscounts item={ item } receiptDate={ RECEIPT_DATE } />, {
+			user: testUser,
+		} );
+
+		const row = screen.getByRole( 'listitem' );
+		expect( within( row ).getByText( '$60' ).tagName ).toBe( 'S' );
+		expect( row ).toHaveTextContent( '$52' );
+	} );
+
+	test( 'renders the plain discount-amount line for a single-unit override (no struck totals)', () => {
+		// Volume-1 / legacy case: no volume-adjusted subtotals, so the display is
+		// unchanged - the signed savings amount (15.00 - 7.50 = -7.50),
+		// not the struck old/new totals.
+		const item = makeItem( {
+			old_price_integer: 1500,
+			new_price_integer: 750,
+		} );
+
+		render( <ReceiptItemDiscounts item={ item } receiptDate={ RECEIPT_DATE } />, {
+			user: testUser,
+		} );
+
+		const row = screen.getByRole( 'listitem' );
+		expect( row ).toHaveTextContent( '-$7.50' );
+		expect( row ).not.toHaveTextContent( '$15' ); // no struck old total
+	} );
+} );

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -417,6 +417,8 @@ function filterCostOverridesForReceiptItem(
 				humanReadableReason: costOverride.human_readable_reason,
 				overrideCode: costOverride.override_code,
 				discountAmount: costOverride.old_price_integer - costOverride.new_price_integer,
+				oldSubtotalInteger: costOverride.old_subtotal_integer ?? undefined,
+				newSubtotalInteger: costOverride.new_subtotal_integer ?? undefined,
 			};
 		} );
 }
@@ -462,7 +464,7 @@ function ReceiptItemDiscountIntroductoryOfferDate( { item }: { item: BillingTran
 	);
 }
 
-function ReceiptItemDiscounts( {
+export function ReceiptItemDiscounts( {
 	item,
 	receiptDate,
 }: {
@@ -474,13 +476,23 @@ function ReceiptItemDiscounts( {
 	return (
 		<ul className="billing-history__receipt-item-discounts-list">
 			{ filterCostOverridesForReceiptItem( item, translate ).map( ( costOverride ) => {
+				const formatAmount = ( amount: number ) =>
+					formatCurrency( amount, item.currency, { isSmallestUnit: true, stripZeros: true } );
+				// Single-unit overrides render the plain discount-amount line;
+				// volume-adjusted (multi-unit) overrides render the struck totals.
 				const formattedDiscountAmount =
 					shouldShowDiscount && costOverride.discountAmount
-						? formatCurrency( -costOverride.discountAmount, item.currency, {
-								isSmallestUnit: true,
-								stripZeros: true,
-						  } )
+						? formatAmount( -costOverride.discountAmount )
 						: '';
+				const subtotalsDisplay =
+					shouldShowDiscount &&
+					costOverride.oldSubtotalInteger !== undefined &&
+					costOverride.newSubtotalInteger !== undefined ? (
+						<>
+							<s>{ formatAmount( costOverride.oldSubtotalInteger ) }</s>{ ' ' }
+							{ formatAmount( costOverride.newSubtotalInteger ) }
+						</>
+					) : null;
 				if (
 					doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 						item.cost_overrides,
@@ -504,7 +516,7 @@ function ReceiptItemDiscounts( {
 						className="billing-history__receipt-item-discount"
 					>
 						<span>{ costOverride.humanReadableReason }</span>
-						<span>{ formattedDiscountAmount }</span>
+						<span>{ subtotalsDisplay ?? formattedDiscountAmount }</span>
 					</li>
 				);
 			} ) }

--- a/client/me/purchases/billing-history/test/receipt.test.tsx
+++ b/client/me/purchases/billing-history/test/receipt.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, within } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createTestReduxStore } from 'calypso/my-sites/checkout/src/test/util';
+import { ReceiptItemDiscounts } from '../receipt';
+import type { BillingTransactionItem } from 'calypso/state/billing-transactions/types';
+
+// Recent receipt date so the discount rows render.
+const RECEIPT_DATE = '2026-05-21T00:00:00+00:00';
+
+function makeItem( costOverride: Record< string, unknown > ): BillingTransactionItem {
+	return {
+		currency: 'USD',
+		introductory_offer_terms: null,
+		months_per_renewal_interval: 24,
+		amount_integer: 0,
+		cost_overrides: [
+			{
+				human_readable_reason: 'Free domain for first year',
+				override_code: 'coupon-discount',
+				does_override_original_cost: false,
+				...costOverride,
+			},
+		],
+	} as unknown as BillingTransactionItem;
+}
+
+function renderDiscounts( item: BillingTransactionItem ) {
+	const store = createTestReduxStore();
+	const queryClient = new QueryClient();
+	return render(
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<ReceiptItemDiscounts item={ item } receiptDate={ RECEIPT_DATE } />
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+describe( '<ReceiptItemDiscounts>', () => {
+	test( 'shows the volume-adjusted subtotals changing from struck old total to new total', () => {
+		// Real receipt 118392995: unit 15.00 -> 7.50, volume 2, subtotal 30.00 -> 15.00.
+		renderDiscounts(
+			makeItem( {
+				old_price_integer: 1500,
+				new_price_integer: 750,
+				old_subtotal_integer: 3000,
+				new_subtotal_integer: 1500,
+			} )
+		);
+
+		const row = screen.getByRole( 'listitem' );
+		expect( within( row ).getByText( '$30' ).tagName ).toBe( 'S' ); // struck old total
+		expect( row ).toHaveTextContent( '$15' ); // new total
+	} );
+
+	test( 'shows the stored subtotal, never price * volume', () => {
+		// First-unit-only discount where the subtotal is not price * volume: unit
+		// 20.00 -> 12.00, volume 3, subtotal 60.00 -> 52.00 (price * volume would be $36).
+		renderDiscounts(
+			makeItem( {
+				old_price_integer: 2000,
+				new_price_integer: 1200,
+				old_subtotal_integer: 6000,
+				new_subtotal_integer: 5200,
+			} )
+		);
+
+		const row = screen.getByRole( 'listitem' );
+		expect( within( row ).getByText( '$60' ).tagName ).toBe( 'S' );
+		expect( row ).toHaveTextContent( '$52' );
+	} );
+
+	test( 'renders the plain discount-amount line for a single-unit override (no struck totals)', () => {
+		// Volume-1 / legacy case: no volume-adjusted subtotals, so the display is
+		// unchanged - the signed savings amount (15.00 - 7.50 = -7.50),
+		// not the struck old/new totals.
+		renderDiscounts(
+			makeItem( {
+				old_price_integer: 1500,
+				new_price_integer: 750,
+			} )
+		);
+
+		const row = screen.getByRole( 'listitem' );
+		expect( row ).toHaveTextContent( '-$7.50' );
+		expect( row ).not.toHaveTextContent( '$15' ); // no struck old total
+	} );
+} );

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -187,6 +187,14 @@ export interface ReceiptCostOverride {
 	 * in the currency's smallest unit.
 	 */
 	new_price_integer: number;
+
+	/**
+	 * Volume-adjusted line totals. Optional because receipts cached before this
+	 * shipped (or written without volume-adjusted data, e.g. auto-renewals) omit
+	 * them; consumers fall back to the per-unit price.
+	 */
+	old_subtotal_integer?: number | null;
+	new_subtotal_integer?: number | null;
 }
 
 export interface UpcomingCharge {

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -45,6 +45,14 @@ export interface ReceiptItemCostOverride {
 	does_override_original_cost: boolean;
 	old_price_integer: number;
 	new_price_integer: number;
+
+	/**
+	 * Volume-adjusted line totals. Optional because receipts cached before this
+	 * shipped (or written without volume-adjusted data, e.g. auto-renewals) omit
+	 * them; consumers fall back to the per-unit price.
+	 */
+	old_subtotal_integer?: number | null;
+	new_subtotal_integer?: number | null;
 }
 
 export interface ReceiptItem {

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -242,6 +242,14 @@ export interface LineItemCostOverrideForDisplay {
 	 * manner.
 	 */
 	discountAmount?: number;
+
+	/**
+	 * The volume-adjusted line totals before/after the override, in the
+	 * currency's smallest unit. Fall back to the per-unit price when the
+	 * volume-adjusted subtotal was not stored (volume 1, auto-renewals, legacy).
+	 */
+	oldSubtotalInteger?: number;
+	newSubtotalInteger?: number;
 }
 
 export function isUserVisibleCostOverride( costOverride: {


### PR DESCRIPTION
Resolves SHILL-2211

3-PR set (needs wpcom's API fields deployed/synced first):
- wp-calypso (this PR) - classic + dashboard receipt views
- wpcom - 227075-ghe-Automattic/wpcom
- missioncontrol - 163377-ghe-Automattic/missioncontrol

## Proposed Changes

* `client/me/purchases/billing-history/receipt.tsx` (classic) and `client/dashboard/me/billing-history/receipt.tsx` (dashboard) - multi-unit cost-override rows now show the volume-adjusted totals as a struck-out old subtotal then new subtotal (`~~$44~~ $22`). Single-unit rows are unchanged (the existing `-$X` savings line).
* `packages/wpcom-checkout/src/transformations.ts`, `packages/api-core/src/me-billing-history/types.ts`, `client/state/billing-transactions/types.ts` - carry the `old_subtotal_integer`/`new_subtotal_integer` fields to the receipt views.
* Tests for both receipt views (multi-unit struck totals; single-unit unchanged).

## Why are these changes being made?

Cost-override rows on multi-unit/multi-year receipts showed the wrong per-unit before/after (e.g. `$22 → $11`) instead of the real volume-adjusted totals (`$44 → $22`). Checkout already stores the volume-adjusted subtotals; the wpcom read path now sends them to Calypso and these views render them. Display-only.

Only multi-unit rows change. The backend sends the subtotal fields only when the override is actually volume-adjusted, so single-unit rows still look like trunk.

| Scenario | Before | After |
|----------|--------|-------|
| Multi-unit override (volume 2) | `$22 → $11` (per-unit) | `~~$44~~ $22` (totals) |
| Single-unit override | `-$X` savings line | `-$X` savings line (unchanged) |

Depends on the wpcom PR - its API fields must be deployed or synced to your sandbox before these values show up.

## Testing Instructions

**Setup:**
1. Check out this branch and start Calypso (`yarn start`, then open `http://calypso.localhost:3000`).
2. Sync the wpcom PR branch to your wpcom sandbox - without it the API won't return the new fields and nothing changes.
3. Sandbox `public-api.wordpress.com` (point it at that wpcom sandbox) and turn on Store Sandbox mode.

**Steps** (test receipt `20748696` - a 2-year domain with a bundled free-first-year credit, volume 2):
1. Go to `/me/purchases/billing-history/receipt/20748696` (classic).
2. Verify the "Free domain for first year" line shows `~~$44~~ $22` (struck $44, then $22), not the per-unit `-$11`.
3. Go to `/me/billing/history/20748696` (dashboard).
4. Verify the same line shows `~~$44~~ $22`.

If a receipt still shows the old per-unit value, Calypso cached it - clear localStorage + IndexedDB and reload to refetch.

## Screenshots

Test receipt 20748696, "Free domain for first year" now `~~$44~~ $22`.

**Classic receipt, after:**
<img width="1176" height="1018" alt="classic-receipt-after" src="https://github.com/user-attachments/assets/f699afc2-4ad0-49c6-bde7-dcc13fb6cb82" />

**Dashboard receipt, after:**
<img width="1307" height="1131" alt="dashboard-receipt-after" src="https://github.com/user-attachments/assets/4e5bf083-c90b-4db8-92a9-ed4ed6be998b" />
