### PR TITLE
Stats: Allow docs tooltip links to wrap

### DIFF
--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -199,7 +199,11 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 											comment: '{{link}} links to support documentation.',
 											components: {
 												link: (
-													<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+													<InlineSupportLink
+														supportContext={ supportContext }
+														showIcon={ false }
+														noWrap={ false }
+													/>
 												),
 											},
 											context:
@@ -212,7 +216,11 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 											comment: '{{link}} links to support documentation.',
 											components: {
 												link: (
-													<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+													<InlineSupportLink
+														supportContext={ supportContext }
+														showIcon={ false }
+														noWrap={ false }
+													/>
 												),
 											},
 											context:
@@ -263,7 +271,11 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 									comment: '{{link}} links to support documentation.',
 									components: {
 										link: (
-											<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+											<InlineSupportLink
+												supportContext={ supportContext }
+												showIcon={ false }
+												noWrap={ false }
+											/>
 										),
 									},
 									context: 'Stats: Info box label when the Posts & Pages module is empty',

--- a/client/my-sites/stats/sections/all-time-views-section/all-time-views-section.tsx
+++ b/client/my-sites/stats/sections/all-time-views-section/all-time-views-section.tsx
@@ -136,6 +136,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 														<InlineSupportLink
 															supportContext={ supportContext }
 															showIcon={ false }
+															noWrap={ false }
 														/>
 													),
 												},


### PR DESCRIPTION
Follow-up to #112391.

## Proposed Changes

* Pass `noWrap={ false }` to the Stats docs tooltip `InlineSupportLink` instances added in #112391.
* Keep the shared `InlineSupportLink` default behavior unchanged for existing callers.

## Why are these changes being made?

* These links render inside tooltip copy, where forcing the support link text to `nowrap` can make the tooltip copy overflow instead of wrapping naturally.

## Testing Instructions

* Open the Stats Top Posts / Posts & Pages tooltip and confirm the support documentation link can wrap with the surrounding tooltip copy.
* Open the Stats Total Views tooltip and confirm the support documentation link can wrap with the surrounding tooltip copy.
* Local checks:
  * `prettier --write` on the touched files.
  * `eslint` on the touched files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
