### PR TITLE
E2E: stabilize likes__post on mobile (cookie banners + slow popup login)

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -5,6 +5,7 @@ const selectors = {
 	continue: 'button:text("Continue"),a:text("Continue")',
 	loginWithAnotherAccount: ':text("another account")',
 	useUsernamePasswordInstead: 'button:text("Use username and password instead")',
+	cookieBannerAccept: '.a8c-cookie-banner__ok-button, .a8c-cookie-banner__accept-all-button',
 };
 
 /**
@@ -59,6 +60,24 @@ export class LoginPage {
 	async submitVerificationCode( code: string ): Promise< void > {
 		await this.fillVerificationCode( code );
 		await Promise.all( [ this.page.waitForNavigation(), this.clickSubmit() ] );
+	}
+
+	/**
+	 * Dismisses the cookie consent banner if it is present.
+	 *
+	 * The banner is shown on logged-out WordPress.com pages and, on mobile
+	 * viewports, can overlay the login form's submit button, blocking the click.
+	 * Its appearance is not deterministic, so a missing banner is not an error.
+	 */
+	async dismissCookieBanner(): Promise< void > {
+		const locator = this.page.locator( selectors.cookieBannerAccept ).first();
+		try {
+			await locator.waitFor( { timeout: 5 * 1000 } );
+		} catch {
+			// Banner did not appear; nothing to dismiss.
+			return;
+		}
+		await locator.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -62,12 +62,12 @@ export class PublishedPostPage {
 	}
 
 	/**
-	 * Clicks the Like button on the post.
+	 * Clicks the Like button on the post, without asserting the outcome.
 	 *
-	 * This method will also confirm that click action on the Like button
-	 * had the intended effect.
+	 * For a logged-out visitor this click opens the WordPress.com login popup
+	 * instead of registering the like.
 	 */
-	async likePost(): Promise< void > {
+	async clickLikeButton(): Promise< void > {
 		await this.dismissCookieConsent();
 
 		const iframeLocator = this.page.locator( 'iframe[title="Like or Reblog"]' );
@@ -87,9 +87,37 @@ export class PublishedPostPage {
 		await likeLocator.evaluate( ( element ) => element.scrollIntoView() );
 
 		await likeLocator.click();
+	}
 
-		// The button should now read "Liked".
-		await iframe.getByRole( 'link', { name: 'Liked', exact: true } ).waitFor();
+	/**
+	 * Clicks the Like button on the post and confirms the "Liked" state.
+	 *
+	 * For a logged-out visitor, pass `handleLoginPopup` to complete the
+	 * WordPress.com login that the first click opens. The widget registers the
+	 * like on its own once that login handshake finishes, so the "Liked"
+	 * confirmation is given extra time in that case.
+	 *
+	 * @param {Object} [options] Keyed options.
+	 * @param {Function} [options.handleLoginPopup] Handler that authenticates
+	 * the login popup opened by the initial, logged-out Like click.
+	 */
+	async likePost( {
+		handleLoginPopup,
+	}: { handleLoginPopup?: ( popup: Page ) => Promise< void > } = {} ): Promise< void > {
+		if ( handleLoginPopup ) {
+			const popupPromise = this.page.waitForEvent( 'popup' );
+			await this.clickLikeButton();
+			await handleLoginPopup( await popupPromise );
+		} else {
+			await this.clickLikeButton();
+		}
+
+		// The button should now read "Liked". The popup login handshake can run
+		// long, so allow extra time before the widget reflects the like.
+		const iframe = this.page.frameLocator( 'iframe[title="Like or Reblog"]' );
+		await iframe
+			.getByRole( 'link', { name: 'Liked', exact: true } )
+			.waitFor( { timeout: handleLoginPopup ? 30 * 1000 : undefined } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -7,6 +7,12 @@ const selectors = {
 
 	// Published content
 	socialShareSection: '.sharedaddy',
+
+	// WordPress.com EU cookie-law consent notice. On mobile viewports it is
+	// pinned to the bottom of the screen and overlays the Like widget, so it
+	// must be dismissed before interacting with the widget. Targeted by CSS
+	// rather than button text because the label is localized.
+	cookieConsentAccept: '#eu-cookie-law .accept',
 };
 
 /**
@@ -37,12 +43,33 @@ export class PublishedPostPage {
 	}
 
 	/**
+	 * Dismisses the site's cookie consent notice if it is present.
+	 *
+	 * On mobile viewports the notice is pinned to the bottom of the screen and
+	 * can overlay the Like widget, intercepting clicks. It auto-hides after a
+	 * timeout and only shows before consent is given, so a missing notice is
+	 * not an error.
+	 */
+	async dismissCookieConsent(): Promise< void > {
+		const locator = this.page.locator( selectors.cookieConsentAccept );
+		try {
+			await locator.waitFor( { state: 'visible', timeout: 3 * 1000 } );
+		} catch {
+			// Notice did not appear; nothing to dismiss.
+			return;
+		}
+		await locator.click();
+	}
+
+	/**
 	 * Clicks the Like button on the post.
 	 *
 	 * This method will also confirm that click action on the Like button
 	 * had the intended effect.
 	 */
 	async likePost(): Promise< void > {
+		await this.dismissCookieConsent();
+
 		const iframeLocator = this.page.locator( 'iframe[title="Like or Reblog"]' );
 		await iframeLocator.waitFor();
 
@@ -72,6 +99,8 @@ export class PublishedPostPage {
 	 * had the intended effect.
 	 */
 	async unlikePost(): Promise< void > {
+		await this.dismissCookieConsent();
+
 		const iframeLocator = this.page.locator( 'iframe[title="Like or Reblog"]' );
 		await iframeLocator.waitFor();
 

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -112,8 +112,14 @@ export class TestAccount {
 		await loginPage.clickSubmit();
 		await loginPage.fillPassword( password );
 
-		// Popup pages close once authentication is successful.
-		await Promise.all( [ page.waitForEvent( 'close' ), loginPage.clickSubmit() ] );
+		// Popup pages close once authentication is successful. The like/comment
+		// login runs a cross-domain "highlander" handshake (via r-login.wordpress.com)
+		// after submitting, which can take well over the default 10s before the
+		// popup closes, so wait longer.
+		await Promise.all( [
+			page.waitForEvent( 'close', { timeout: 30 * 1000 } ),
+			loginPage.clickSubmit(),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -103,6 +103,11 @@ export class TestAccount {
 		const loginPage = new LoginPage( page );
 
 		const { username, password } = this.credentials;
+
+		// On mobile viewports the cookie consent banner can overlay the login
+		// form's submit button, blocking the click and leaving the popup open.
+		await loginPage.dismissCookieBanner();
+
 		await loginPage.fillUsername( username );
 		await loginPage.clickSubmit();
 		await loginPage.fillPassword( password );

--- a/test/e2e/specs/published-content/likes__post.spec.ts
+++ b/test/e2e/specs/published-content/likes__post.spec.ts
@@ -104,12 +104,10 @@ test.describe(
 			} );
 
 			await test.step( 'Login via popup to like the post', async () => {
-				newPage.on( 'popup', async ( popup ) => {
-					await otherUser.logInViaPopupPage( popup );
-				} );
-
 				const loggedOutPostPage = new PublishedPostPage( newPage );
-				await loggedOutPostPage.likePost();
+				await loggedOutPostPage.likePost( {
+					handleLoginPopup: ( popup ) => otherUser.logInViaPopupPage( popup ),
+				} );
 			} );
 
 			await newContext.close();


### PR DESCRIPTION
## Proposed Changes

* **Dismiss cookie-consent banners** that block the flow on mobile: the WordPress.com banner overlapping the login popup's submit button, and the published site's EU cookie-law notice overlapping the Like widget.
* **Wait for the slow popup-login handshake** before confirming the like: extend the popup wait-for-close to 30s, and await the login fully before checking for "Liked" (via a `likePost` login-popup handler) instead of firing it in a background handler and giving up after 10s.

## Why are these changes being made?

`likes__post` has been intermittently failing on the `pixel` (mobile) project. Investigation against production surfaced two independent causes:

1. **Consent banners.** On mobile, two different banners are pinned to the bottom of the viewport and overlap the controls the spec clicks — the login banner covers the popup's submit button (so popup login never completes), and the site's "Close and accept" notice overlaps the Like widget.

2. **Slow popup login.** The logged-out "like via popup" step authenticates through WordPress.com's cross-domain "highlander" handshake (via `r-login.wordpress.com`). After submitting credentials it routinely takes well over 10 seconds to complete the redirect, close the popup, and register the like. The spec fired the login in a background `on('popup')` handler and then waited only 10s for "Liked", so it gave up mid-handshake. Given enough time the login completes as the correct user and the widget registers the like on its own — no reload needed.

## Testing Instructions

* Run on the mobile project against a target:
  * `cd test/e2e && yarn playwright test specs/published-content/likes__post.spec.ts --project=pixel --reporter=list`
* Verified green 3× consecutively against production with these changes.
* The banner-dismissal helpers are safe no-ops when a banner is absent, so other projects are unaffected.

## Considerations

* The site consent notice is targeted by CSS (`#eu-cookie-law .accept`) rather than its button label, since the label is localized.
* Reload-after-login was considered for the popup step but rejected: reloading intermittently leaves the Like widget blank, and it is unnecessary because the widget registers the like once the login handshake finishes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
