### PR TITLE
E2E: cancel purchases via API in new-hosted-site teardown to prevent Atomic leaks

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -19,6 +19,8 @@ import type {
 	BearerTokenResponse,
 	MyAccountInformationResponse,
 	AccountClosureResponse,
+	PurchaseDetails,
+	PurchaseCancelResponse,
 	SiteDeletionResponse,
 	CalypsoPreferences,
 	CalypsoPreferencesResponse,
@@ -346,6 +348,70 @@ export class RestAPIClient {
 
 		console.log( `Successfully deleted site ID ${ targetSite.domain }` );
 		return response;
+	}
+
+	/* Purchases */
+
+	/**
+	 * Returns the list of purchases (plans, add-ons, domains) owned by the user.
+	 *
+	 * @returns {Promise< PurchaseDetails[] >} Array of the user's purchases.
+	 * @throws {Error} If the API responded with an error.
+	 */
+	async getAllPurchases(): Promise< PurchaseDetails[] > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const response = await this.sendRequest( this.getRequestURL( '1.2', '/me/purchases' ), params );
+
+		// A successful response is an array of purchases; an error is an object.
+		if ( ! Array.isArray( response ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
+	/**
+	 * Cancels and refunds a purchase, removing it from the account.
+	 *
+	 * Mirrors the request the cancel-purchase UI fires
+	 * (`wpcom/v2/purchases/<id>/cancel`). For a plan on an Atomic site this
+	 * begins the site's asynchronous deprovisioning, which is a prerequisite
+	 * for closing the owning account (see `closeAccountAndRecordLeak`).
+	 *
+	 * @param {number} purchaseId ID of the purchase to cancel.
+	 * @param {number} productId Product ID of the purchase, required by the endpoint.
+	 * @returns {Promise< PurchaseCancelResponse >} The API response.
+	 */
+	async cancelAndRefundPurchase(
+		purchaseId: number,
+		productId: number
+	): Promise< PurchaseCancelResponse > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( {
+				product_id: productId,
+				cancel_bundled_domain: 0,
+				email_variant: 'control',
+			} ),
+		};
+
+		return await this.sendRequest(
+			this.getRequestURL( '2', `/purchases/${ purchaseId }/cancel`, 'wpcom' ),
+			params
+		);
 	}
 
 	/* Invites */

--- a/packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for RestAPIClient.getAllPurchases and RestAPIClient.cancelAndRefundPurchase.
+ *
+ * These back the Atomic-site teardown self-heal: when a hosted-site test fails
+ * before its in-flow plan cancellation, teardown lists the account's purchases
+ * and cancels them via API so the Atomic site deprovisions and the account can
+ * be closed. The tests pin the endpoint contract (path, version, namespace and
+ * request body) each method relies on.
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import nock from 'nock';
+import { RestAPIClient, BEARER_TOKEN_URL } from '../rest-api-client';
+import { SecretsManager } from '../secrets';
+import type { Secrets } from '../secrets';
+
+const fakeSecrets = {
+	calypsoOauthApplication: {
+		client_id: 'some_value',
+		client_secret: 'some_value',
+	},
+} as unknown as Secrets;
+
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
+
+/**
+ * Persists a stub bearer-token endpoint so authenticated calls resolve.
+ */
+function persistBearerToken() {
+	nock( BEARER_TOKEN_URL )
+		.persist()
+		.post( /.*/ )
+		.reply( 200, {
+			success: true,
+			data: { bearer_token: 'abcdefghijklmn', token_links: [] },
+		} );
+}
+
+persistBearerToken();
+
+describe( 'RestAPIClient: purchases', function () {
+	const restAPIClient = new RestAPIClient( {
+		username: 'fake_user',
+		password: 'fake_password',
+	} );
+
+	const purchasesURL = restAPIClient.getRequestURL( '1.2', '/me/purchases' );
+
+	beforeEach( function () {
+		nock.cleanAll();
+		persistBearerToken();
+	} );
+
+	describe( 'getAllPurchases', function () {
+		test( 'returns the array of purchases from /me/purchases', async function () {
+			const purchases = [
+				{ ID: '111', product_id: '1008', product_slug: 'business-bundle' },
+				{ ID: '222', product_id: '1153', product_slug: 'wordpress_com_1gb_space_addon' },
+			];
+			nock( purchasesURL.origin ).get( purchasesURL.pathname ).reply( 200, purchases );
+
+			const response = await restAPIClient.getAllPurchases();
+
+			expect( response ).toEqual( purchases );
+		} );
+
+		test( 'throws when the API returns an error object', async function () {
+			nock( purchasesURL.origin )
+				.get( purchasesURL.pathname )
+				.reply( 200, { error: 'unauthorized', message: 'Denied.' } );
+
+			await expect( restAPIClient.getAllPurchases() ).rejects.toThrow( 'unauthorized: Denied.' );
+		} );
+	} );
+
+	describe( 'cancelAndRefundPurchase', function () {
+		test( 'posts to wpcom/v2/purchases/<id>/cancel with the cancel-and-refund body', async function () {
+			const purchaseId = 111;
+			const productId = 1008;
+			const cancelURL = restAPIClient.getRequestURL(
+				'2',
+				`/purchases/${ purchaseId }/cancel`,
+				'wpcom'
+			);
+
+			let capturedBody: Record< string, unknown > | undefined;
+			const cancelScope = nock( cancelURL.origin )
+				.post( cancelURL.pathname, ( body ) => {
+					capturedBody = body;
+					return true;
+				} )
+				.reply( 200, { status: 'completed' } );
+
+			const response = await restAPIClient.cancelAndRefundPurchase( purchaseId, productId );
+
+			expect( cancelScope.isDone() ).toBe( true );
+			expect( capturedBody ).toEqual( {
+				product_id: productId,
+				cancel_bundled_domain: 0,
+				email_variant: 'control',
+			} );
+			expect( response.status ).toBe( 'completed' );
+		} );
+	} );
+} );

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -107,6 +107,24 @@ export interface AccountClosureResponse {
 	success: boolean;
 }
 
+/**
+ * A single purchase (plan, add-on or domain) as returned by `/me/purchases`.
+ * Fields mirror the raw REST response, which keys IDs as strings.
+ */
+export interface PurchaseDetails {
+	ID: string | number;
+	product_id: string | number;
+	product_slug: string;
+	product_name: string;
+	blog_id: string | number;
+	is_refundable: boolean;
+}
+
+export interface PurchaseCancelResponse {
+	status?: string;
+	message?: string;
+}
+
 export interface NewInviteResponse {
 	sent: string[];
 	errors: string[];

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -29,17 +29,39 @@ test.describe(
 			if ( ! newUserDetails ) {
 				return;
 			}
-			// An account with an active Atomic site cannot be closed ("atomic-site").
-			// The Atomic site cannot be deleted via API either ("cannot delete jetpack
-			// site via API"), so the only lever is time: cancelling the Business plan
-			// (done in the test) is expected to deprovision the site asynchronously.
-			// apiCloseAccount polls the close past that wait; allow generous time.
+			// An account with an active Atomic site cannot be closed ("atomic-site"),
+			// and the Atomic site itself cannot be deleted via API ("cannot delete
+			// jetpack site via API"). The only lever is cancelling the Business plan,
+			// which deprovisions the site asynchronously. The in-flow UI cancellation
+			// does this on the happy path, but a test that fails earlier never reaches
+			// it, leaving an account that can never be closed. So we cancel any
+			// remaining purchases via API here first, then apiCloseAccount polls the
+			// close past the ~80s deprovision wait. Allow generous time for both.
 			test.setTimeout( 240 * 1000 );
 
 			const restAPIClient = new RestAPIClient(
 				{ username: testUser.username, password: testUser.password },
 				newUserDetails.body.bearer_token
 			);
+
+			// Best-effort: cancelling here is a teardown safety net, so never let a
+			// failure abort the close that follows. Each purchase is cancelled
+			// independently so one failure does not skip the rest.
+			try {
+				const purchases = await restAPIClient.getAllPurchases();
+				for ( const purchase of purchases ) {
+					try {
+						await restAPIClient.cancelAndRefundPurchase(
+							Number( purchase.ID ),
+							Number( purchase.product_id )
+						);
+					} catch ( error ) {
+						console.warn( `Failed to cancel purchase ${ purchase.ID }: ${ error }` );
+					}
+				}
+			} catch ( error ) {
+				console.warn( `Failed to list purchases during teardown: ${ error }` );
+			}
 
 			await apiCloseAccount( restAPIClient, {
 				userID: newUserDetails.body.user_id,


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Add `getAllPurchases` and `cancelAndRefundPurchase` to the e2e `RestAPIClient`, mirroring the request the cancel-purchase UI fires.
* In the new-hosted-site test's `afterAll`, cancel any remaining purchases via API before closing the account. Best-effort: it never throws, and each purchase is cancelled independently.
* Add unit tests pinning the endpoint contract (path, version, namespace, body) for the two new methods.

## Why are these changes being made?

The new-hosted-site test buys a Business plan (which triggers an Atomic transfer), then relies on its in-flow UI cancellation to deprovision the site so the account can be closed in teardown. An account with an active Atomic site cannot be closed, and the Atomic site itself cannot be deleted via API — the only lever is cancelling the plan, which deprovisions the site asynchronously.

When the test fails **before** reaching its cancel-plan step, the plan stays active, the site never deprovisions, and the account can never be closed. That produces a permanent teardown leak that fails the leak-check CI step — even when the retry passes. A recent run showed exactly this: attempt 1 failed (its account leaked after the full ~180s deprovision wait), while the retry passed and closed cleanly in ~80s.

Cancelling remaining purchases via API in teardown makes deprovisioning happen regardless of how far the test got, so the leak can no longer occur. On the happy path there is nothing left to cancel, so it is a no-op.

## Testing Instructions

* This exercises a live purchase/transfer/cancel round-trip against WordPress.com, so it can only be fully verified on CI. Run the `onboarding__new-hosted-site` spec; confirm it passes and that no teardown leak is reported.
* Unit tests: `yarn jest --config packages/calypso-e2e/jest.config.js packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts`.

## Considerations

This fixes the build-failing leak, not the underlying flake that made the first attempt fail. It removes the leak regardless of the flake; fixing the specific flaky step is a separate follow-up.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)