### PR TITLE
A4A: Wire up agencies-beta.automattic.com dashboard domain

### DIFF
--- a/client/dashboard/app-a4a/routing.ts
+++ b/client/dashboard/app-a4a/routing.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 
-const A4A_DASHBOARD_ALLOWED_HOSTNAMES = [ 'my.a4a.localhost' ];
+const A4A_DASHBOARD_ALLOWED_HOSTNAMES = [ 'my.a4a.localhost', 'agencies-beta.automattic.com' ];
 
 export function isAllowedA4ADashboardHostname( hostname?: string ): boolean {
 	// Calypso Live links
@@ -16,6 +16,5 @@ export function buildA4ADashboardLink( path: string = '' ) {
 		const port = config( 'port' ) ?? 3000;
 		return new URL( path, `http://my.a4a.localhost:${ port }` ).href;
 	}
-	// TODO: Add the A4A domain once it's ready.
-	return path;
+	return new URL( path, 'https://agencies-beta.automattic.com' ).href;
 }


### PR DESCRIPTION
## Proposed Changes

* Register `agencies-beta.automattic.com` as an allowed A4A dashboard hostname in `isAllowedA4ADashboardHostname`.
* Replace the `// TODO: Add the A4A domain once it's ready.` placeholder in `buildA4ADashboardLink` so non-development environments resolve links against `https://agencies-beta.automattic.com` instead of returning the bare path.

## Why are these changes being made?

The A4A dashboard now has a production domain. This wires it up so the dashboard both renders when served from that host and generates correct outbound links. The pattern mirrors the existing `buildDotcomDashboardLink` and `buildCiabDashboardLink` builders (development → localhost, otherwise → hardcoded production domain), keeping the three dashboard variants consistent.

## Testing Instructions

* In development, confirm `buildA4ADashboardLink( '/sites' )` still returns `http://my.a4a.localhost:<port>/sites`.
* In a non-development build, confirm `buildA4ADashboardLink( '/sites' )` returns `https://agencies-beta.automattic.com/sites` and `buildA4ADashboardLink()` returns `https://agencies-beta.automattic.com/`.
* Confirm the dashboard loads when served from `agencies-beta.automattic.com`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
