### PR TITLE
E2E: cancel Atomic Business plan in teardown to stop account/site leaks

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -44,6 +44,8 @@ import type {
 	JetpackSearchParams,
 	Subscriber,
 	SitePostState,
+	AllPurchasesResponse,
+	PurchaseCancelParams,
 } from './types';
 
 /* Internal types and interfaces */
@@ -625,6 +627,103 @@ export class RestAPIClient {
 		};
 
 		return await this.sendRequest( this.getRequestURL( '1.1', '/me/account/close' ), params );
+	}
+
+	/* Purchases */
+
+	/**
+	 * Returns all purchases belonging to the authenticated user.
+	 *
+	 * Discovery is bearer-scoped and needs no site ID, so it works even when the
+	 * test failed before a site slug/ID was known.
+	 *
+	 * @returns {Promise<AllPurchasesResponse>} Array of the user's purchases.
+	 * @throws {Error} If the API responded with an error.
+	 */
+	async getAllPurchases(): Promise< AllPurchasesResponse > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const response = await this.sendRequest( this.getRequestURL( '1.2', '/me/purchases' ), params );
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
+	/**
+	 * Cancels and refunds a purchase. Cancelling a Business-plan purchase on an
+	 * Atomic site triggers asynchronous deprovision of the site, the only lever
+	 * that later allows the account to be closed.
+	 *
+	 * Mirrors Calypso's cancel-and-refund call (POST wpcom/v2 /purchases/{id}/cancel).
+	 *
+	 * @param {string|number} purchaseId ID of the purchase to cancel.
+	 * @param {PurchaseCancelParams} body Cancellation parameters.
+	 * @returns {Promise<any>} Decoded JSON response.
+	 */
+	async cancelPurchase( purchaseId: string | number, body: PurchaseCancelParams ): Promise< any > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( body ),
+		};
+
+		return await this.sendRequest(
+			this.getRequestURL( '2', `/purchases/${ purchaseId }/cancel`, 'wpcom' ),
+			params
+		);
+	}
+
+	/**
+	 * Cancels the Business-plan purchase, triggering asynchronous Atomic-site
+	 * deprovision (the only lever that later allows the account to be closed).
+	 *
+	 * The purchase is discovered bearer-scoped via `getAllPurchases`, so no site
+	 * slug/ID is required. When `siteId` is omitted the first Business plan found
+	 * is cancelled; pass `siteId` to restrict to that site's Business plan.
+	 *
+	 * @param {number|string} [siteId] Restrict cancellation to this site's Business plan.
+	 * @returns {Promise<any | null>} The cancel response, or null if no Business plan was found.
+	 * @throws {Error} If listing purchases responded with an error.
+	 */
+	async cancelAtomicPlan( siteId?: number | string ): Promise< any | null > {
+		const purchases = await this.getAllPurchases();
+
+		const plan = purchases.find(
+			( purchase ) =>
+				purchase.product_slug === 'business-bundle' &&
+				( siteId === undefined || Number( purchase.blog_id ) === Number( siteId ) )
+		);
+
+		if ( ! plan ) {
+			console.info(
+				siteId !== undefined
+					? `No Business plan purchase found for site ${ siteId }; skipping Atomic deprovision.`
+					: 'No Business plan purchase found; skipping Atomic deprovision.'
+			);
+			return null;
+		}
+
+		console.log( `Cancelling Business plan purchase ${ plan.ID } to deprovision Atomic site.` );
+
+		return await this.cancelPurchase( plan.ID, {
+			product_id: plan.product_id,
+			cancel_bundled_domain: 0,
+			email_variant: 'control',
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for RestAPIClient purchase methods, the bearer-scoped lever used to
+ * deprovision an Atomic site during teardown: the getAllPurchases/cancelPurchase
+ * primitives and the cancelAtomicPlan orchestration (Business-plan selection).
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import nock from 'nock';
+import { RestAPIClient, BEARER_TOKEN_URL } from '../rest-api-client';
+import { SecretsManager } from '../secrets';
+import type { Secrets } from '../secrets';
+
+const fakeSecrets = {
+	calypsoOauthApplication: {
+		client_id: 'some_value',
+		client_secret: 'some_value',
+	},
+} as unknown as Secrets;
+
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
+
+describe( 'RestAPIClient: purchases', function () {
+	const restAPIClient = new RestAPIClient( {
+		username: 'fake_user',
+		password: 'fake_password',
+	} );
+
+	const purchasesURL = restAPIClient.getRequestURL( '1.2', '/me/purchases' );
+
+	beforeEach( function () {
+		nock.cleanAll();
+		nock( BEARER_TOKEN_URL )
+			.persist()
+			.post( /.*/ )
+			.reply( 200, {
+				success: true,
+				data: { bearer_token: 'abcdefghijklmn', token_links: [] },
+			} );
+	} );
+
+	test( 'getAllPurchases returns the purchases array', async function () {
+		const purchases = [
+			{ ID: '111', product_id: '1008', product_slug: 'business-bundle', blog_id: '5' },
+			{
+				ID: '222',
+				product_id: '1200',
+				product_slug: 'wordpress_com_1gb_space_upgrade',
+				blog_id: '5',
+			},
+		];
+		nock( purchasesURL.origin ).get( purchasesURL.pathname ).reply( 200, purchases );
+
+		const response = await restAPIClient.getAllPurchases();
+
+		expect( response ).toHaveLength( 2 );
+		expect( response[ 0 ].product_slug ).toBe( 'business-bundle' );
+	} );
+
+	test( 'getAllPurchases throws when the API returns an error', async function () {
+		nock( purchasesURL.origin )
+			.get( purchasesURL.pathname )
+			.reply( 200, { error: 'unauthorized', message: 'nope' } );
+
+		await expect( restAPIClient.getAllPurchases() ).rejects.toThrow( 'unauthorized: nope' );
+	} );
+
+	test( 'cancelPurchase posts to the wpcom/v2 cancel endpoint with the given body', async function () {
+		const cancelURL = restAPIClient.getRequestURL( '2', '/purchases/111/cancel', 'wpcom' );
+		const body = {
+			product_id: '1008',
+			cancel_bundled_domain: 0,
+			email_variant: 'control',
+		} as const;
+
+		const cancelScope = nock( cancelURL.origin )
+			.post( cancelURL.pathname, body )
+			.reply( 200, { status: 'completed' } );
+
+		const response = await restAPIClient.cancelPurchase( '111', body );
+
+		expect( cancelScope.isDone() ).toBe( true );
+		expect( response.status ).toBe( 'completed' );
+	} );
+
+	describe( 'cancelAtomicPlan', function () {
+		const businessPlan = {
+			ID: '111',
+			product_id: '1008',
+			product_slug: 'business-bundle',
+			blog_id: '5',
+		};
+		const otherSitePlan = {
+			ID: '333',
+			product_id: '1008',
+			product_slug: 'business-bundle',
+			blog_id: '9',
+		};
+		const addOn = {
+			ID: '222',
+			product_id: '1200',
+			product_slug: 'wordpress_com_1gb_space_upgrade',
+			blog_id: '5',
+		};
+
+		/**
+		 * Stubs GET /me/purchases with the given list.
+		 *
+		 * @param {unknown[]} purchases Raw purchase objects to return.
+		 */
+		function mockPurchases( purchases: unknown[] ) {
+			nock( purchasesURL.origin ).get( purchasesURL.pathname ).reply( 200, purchases );
+		}
+
+		test( 'cancels the first Business plan when no siteId is given', async function () {
+			mockPurchases( [ addOn, businessPlan ] );
+			const cancelURL = restAPIClient.getRequestURL( '2', '/purchases/111/cancel', 'wpcom' );
+			const cancelScope = nock( cancelURL.origin )
+				.post( cancelURL.pathname, {
+					product_id: '1008',
+					cancel_bundled_domain: 0,
+					email_variant: 'control',
+				} )
+				.reply( 200, { status: 'completed' } );
+
+			const response = await restAPIClient.cancelAtomicPlan();
+
+			expect( cancelScope.isDone() ).toBe( true );
+			expect( response.status ).toBe( 'completed' );
+		} );
+
+		test( 'returns null and cancels nothing when there is no Business plan', async function () {
+			mockPurchases( [ addOn ] );
+
+			const response = await restAPIClient.cancelAtomicPlan();
+
+			expect( response ).toBeNull();
+		} );
+
+		test( 'cancels only the Business plan matching the given siteId', async function () {
+			mockPurchases( [ otherSitePlan, businessPlan ] );
+			const cancelURL = restAPIClient.getRequestURL( '2', '/purchases/111/cancel', 'wpcom' );
+			const cancelScope = nock( cancelURL.origin )
+				.post( cancelURL.pathname )
+				.reply( 200, { status: 'completed' } );
+
+			await restAPIClient.cancelAtomicPlan( 5 );
+
+			expect( cancelScope.isDone() ).toBe( true );
+		} );
+
+		test( 'returns null when no Business plan matches the given siteId', async function () {
+			mockPurchases( [ businessPlan ] );
+
+			const response = await restAPIClient.cancelAtomicPlan( 999 );
+
+			expect( response ).toBeNull();
+		} );
+	} );
+} );

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -107,6 +107,23 @@ export interface AccountClosureResponse {
 	success: boolean;
 }
 
+// Raw `/me/purchases` (v1.2) items. `ID`/`product_id` come back as either
+// strings or numbers depending on the endpoint, so both are accepted.
+export interface Purchase {
+	ID: string | number;
+	product_id: string | number;
+	product_slug: string;
+	blog_id: string | number;
+}
+
+export type AllPurchasesResponse = Array< Purchase >;
+
+export interface PurchaseCancelParams {
+	product_id: string | number;
+	cancel_bundled_domain: 0 | 1;
+	email_variant: 'control';
+}
+
 export interface NewInviteResponse {
 	sent: string[];
 	errors: string[];

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -14,7 +14,7 @@ import {
 	cancelSubscriptionFlow,
 } from '@automattic/calypso-e2e';
 import { tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCancelAtomicPlan, apiCloseAccount } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
@@ -31,15 +31,18 @@ test.describe(
 			}
 			// An account with an active Atomic site cannot be closed ("atomic-site").
 			// The Atomic site cannot be deleted via API either ("cannot delete jetpack
-			// site via API"), so the only lever is time: cancelling the Business plan
-			// (done in the test) is expected to deprovision the site asynchronously.
-			// apiCloseAccount polls the close past that wait; allow generous time.
-			test.setTimeout( 240 * 1000 );
+			// site via API"), so the only lever is cancelling the Business plan, which
+			// deprovisions the site asynchronously. The in-test cancellation only runs
+			// on the happy path; cancel here too (bearer-scoped) so a mid-test failure
+			// still deprovisions. apiCloseAccount then polls the close past that wait.
+			test.setTimeout( 300 * 1000 );
 
 			const restAPIClient = new RestAPIClient(
 				{ username: testUser.username, password: testUser.password },
 				newUserDetails.body.bearer_token
 			);
+
+			await apiCancelAtomicPlan( restAPIClient );
 
 			await apiCloseAccount( restAPIClient, {
 				userID: newUserDetails.body.user_id,

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -1,6 +1,6 @@
 import { BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiDeleteSite } from '../shared';
+import { apiCancelAtomicPlan, apiDeleteSite } from '../shared';
 import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
 
 test.describe(
@@ -84,6 +84,13 @@ test.describe(
 				username: accountUsed.credentials.username,
 				password: accountUsed.credentials.password,
 			} );
+
+			// Business is an Atomic plan: the site can't be deleted via API while the
+			// subscription is active, and this shared pre-release account must not be
+			// closed. Cancel this site's plan first (scoped by blog ID so a concurrent
+			// test's plan is untouched) to stop billing and trigger deprovision. The
+			// delete below is best-effort until that async deprovision completes.
+			await apiCancelAtomicPlan( restAPIClient, newSiteDetails.blog_details.blogid );
 
 			await apiDeleteSite( restAPIClient, {
 				url: newSiteDetails.blog_details.url,

--- a/test/e2e/specs/shared/api-cancel-atomic-plan.ts
+++ b/test/e2e/specs/shared/api-cancel-atomic-plan.ts
@@ -1,0 +1,23 @@
+import type { RestAPIClient } from '@automattic/calypso-e2e';
+
+/**
+ * Cancels the Business-plan purchase for the authenticated test user (see
+ * `RestAPIClient.cancelAtomicPlan`), triggering Atomic-site deprovision so
+ * `apiCloseAccount` can later close the account.
+ *
+ * Runs in `afterAll`, so it never throws: on any failure it warns and returns,
+ * degrading to the prior leak-marker behavior.
+ *
+ * @param {RestAPIClient} client Client to interact with the WP REST API.
+ * @param {number|string} [siteId] Restrict cancellation to this site's Business plan.
+ */
+export async function apiCancelAtomicPlan(
+	client: RestAPIClient,
+	siteId?: number | string
+): Promise< void > {
+	try {
+		await client.cancelAtomicPlan( siteId );
+	} catch ( error ) {
+		console.warn( `Error cancelling Atomic plan (continuing to account close): ${ error }` );
+	}
+}

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,3 +1,4 @@
+export * from './api-cancel-atomic-plan';
 export * from './api-close-account';
 export * from './api-create-free-site';
 export * from './api-delete-site';


### PR DESCRIPTION
p1783484821930459-slack-C02DQP0FP

Builds:
- [18435285](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix/18435285)
- [18434265](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix/18434265)

## The issue

In the `onboarding__new-hosted-site.spec.ts` creates a user, a site and purchases a Business plan for it. The `afterAll` function would try to close the user account after the test and fail as users with Atomic accounts cannot be closed. The Business plan created in the context of the tests needs to be deprovisioned first for the account to be closeable.

The messages in the builds confirmed this with messages like:
```json
Failed to delete user ID 282552574
{
  error:'atomic-site',
  message:'This user account cannot be closed while it has active atomic sites.'
}
```

## The fix

Add a step in the `afterAll` function of the test to cancel the plan, wait a bit for the deprovision to take effect and then close the user account.

Added:
- `getAllPurchases`, `cancelPurchase`, and `cancelAtomicPlan` methods in the `rest-api-client.ts` file, together with related types and tests. The Atomic plan cancellation supports an optional site ID parameter to be more selective about the plan to cancel. The function is not used by the test since it might fail before reaching the site creation process and never be able to provide a site ID and the user, a new one, will always have only one Atomic plan to cancel.
- `api-cancel-atomic-plan.ts` using the method above to find and cancel the Atomic plan for a user and cancel it in the tests' `afterAll`
- Update the spec file `plans__signup-business.spec.ts` file as it's bound to have the same issue.

## Testing Instructions

Atomic provisioning is not drivable locally, so full verification needs a CI Pre-Release Playwright matrix run. Unit tests for the new REST methods run in the `test-packages` lane:

```
yarn test-packages rest-api-client.purchases
```

Notes:
- The cancel endpoint is not verified against a still-pending Atomic transfer. If it rejects, behavior degrades to the prior leak-marker rather than throwing, so it cannot regress current behavior.
- For `plans__signup-business.spec.ts` the site delete stays best-effort: cancelling stops the recurring billing and triggers deprovision, but the delete only succeeds once that async deprovision completes.

