### PR TITLE
Agents Manager: use a FAB on the Site Editor navigation view

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -138,8 +138,9 @@ jest.mock( '../../utils/is-plugin-compass-agent', () => ( {
 jest.mock( '../../utils/is-reader-chat-agent', () => ( {
 	isReaderChatHost: () => false,
 } ) );
-jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
-	hasAiChatEntryButton: () => mockHasAiChatEntry(),
+jest.mock( '../../hooks/use-has-ai-chat-entry-button', () => ( {
+	__esModule: true,
+	default: () => mockHasAiChatEntry(),
 } ) );
 
 import AgentChat from '../agent-chat';

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -9,6 +9,7 @@ import type { AgentsManagerContextType } from '../../contexts';
 const mockAbortCurrentRequest = jest.fn();
 const mockSetIsOpen = jest.fn();
 const mockSetIsDocked = jest.fn();
+const mockSetIsMinimized = jest.fn();
 const mockUseAgentLayoutManager = jest.fn();
 const mockResumeActiveChat = jest.fn();
 const mockCloseSidebar = jest.fn();
@@ -36,7 +37,7 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		setIsOpen: mockSetIsOpen,
 		setIsDocked: mockSetIsDocked,
-		setIsMinimized: jest.fn(),
+		setIsMinimized: mockSetIsMinimized,
 	} ),
 	useSelect: () => mockAgentsManagerState,
 } ) );
@@ -283,15 +284,47 @@ describe( 'AgentDock', () => {
 		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/support-guides' );
 	} );
 
-	it( 'hides the support guides list without the WP admin bar trigger', () => {
-		// `mockHasAdminBar` stays false, so the list route is unavailable and
-		// unknown paths fall back to `/chat`.
+	it( 'keeps the support guides list without the WP admin bar trigger', () => {
+		// The route stays registered even without an entry button, so a
+		// mid-session entry-button change (Site Editor navigation) can't
+		// redirect a user off the list.
 		useWpAdminAgent();
+		mockShouldUseUnifiedAgent = true;
+
+		renderAgentDock( '/support-guides' );
+
+		expect( screen.getByTestId( 'support-guides' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/support-guides' );
+	} );
+
+	it( 'hides the support guides list without the unified agent', () => {
+		// Unknown paths fall back to `/chat`.
+		useWpAdminAgent();
+		mockHasAdminBar = true;
 
 		renderAgentDock( '/support-guides' );
 
 		expect( screen.queryByTestId( 'support-guides' ) ).toBeNull();
 		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/chat' );
+	} );
+
+	it( 'clears the minimized flag when the entry button disappears mid-session', () => {
+		useWpAdminAgent();
+		mockHasAdminBar = true;
+		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
+
+		const { rerender } = renderAgentDock();
+		expect( mockSetIsMinimized ).not.toHaveBeenCalled();
+
+		mockHasAdminBar = false;
+		rerender(
+			<MemoryRouter initialEntries={ [ '/chat' ] }>
+				<AgentDock />
+				<LocationProbe />
+			</MemoryRouter>
+		);
+
+		expect( mockSetIsMinimized ).toHaveBeenCalledWith( false );
 	} );
 
 	it( 'keeps the /post viewer available without the WP admin bar trigger', () => {

--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -43,8 +43,9 @@ jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
 } ) );
-jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
-	hasAiChatEntryButton: () =>
+jest.mock( '../../hooks/use-has-ai-chat-entry-button', () => ( {
+	__esModule: true,
+	default: () =>
 		!! globalThis.document.getElementById( 'wp-admin-bar-agents-manager-ai-chat' ) ||
 		!! globalThis.document.querySelector( '.masterbar__item-agents-manager-ai-chat' ),
 } ) );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -14,7 +14,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
+import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { getAgentsManagerInlineData } from '../../utils/get-agents-manager-inline-data';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
@@ -194,7 +194,7 @@ export default function AgentChat( {
 	);
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
-	let floatingChatState: ChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
+	let floatingChatState: ChatState = useHasAiChatEntryButton() ? 'minimized' : 'collapsed';
 	if ( isOpen ) {
 		floatingChatState = 'expanded';
 	} else if ( isCompactMode ) {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -5,7 +5,7 @@ import {
 	type Suggestion,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { columns, comment, drawerRight, login } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -173,16 +173,30 @@ export default function AgentDock( {
 	// WP admin bar integration. Returns whether the AI chat entry button is present.
 	const hasAiChatEntry = useAdminBarIntegration( { closeChat: handleClose, openChat } );
 
+	// `isMinimized` only matters next to an entry button — without one the chat
+	// shows regardless. When the button disappears mid-session (Site Editor
+	// canvas → navigation view), clear the stale flag so re-entering the canvas
+	// doesn't instantly re-minimize the chat the user is looking at.
+	const prevHasAiChatEntryRef = useRef( hasAiChatEntry );
+	useEffect( () => {
+		if ( prevHasAiChatEntryRef.current && ! hasAiChatEntry && isMinimized ) {
+			setIsMinimized( false );
+		}
+		prevHasAiChatEntryRef.current = hasAiChatEntry;
+	}, [ hasAiChatEntry, isMinimized, setIsMinimized ] );
+
 	// Route visibility. All are hidden in reader chat (public blog frontends);
 	// some add a further requirement, noted below. Ordered to match the routes.
 	//
-	// `/zendesk` also needs the unified agent or using Woo AI.
+	// `/zendesk` also needs the unified agent.
 	const showZendeskChat = shouldUseUnifiedAgent && ! isReaderChat;
-	// `/support-guides` (the list) also needs the unified agent, and is only
-	// reachable from the AI chat entry button (WP admin bar or Calypso masterbar).
-	const showSupportGuides = shouldUseUnifiedAgent && ! isReaderChat && hasAiChatEntry;
+	// `/support-guides` (the list) also needs the unified agent. Registered even
+	// without an entry button: unregistering it mid-session (Site Editor
+	// navigation) would yank the route from under a user viewing it, and the
+	// wildcard redirect would reset their chat.
+	const showSupportGuides = shouldUseUnifiedAgent && ! isReaderChat;
 	// `/post` (the viewer) opens a guide or link from in-chat links and sources,
-	// so unlike the list it isn't tied to the admin bar.
+	// so unlike the list it doesn't need the unified agent.
 	const showSupportGuide = ! isReaderChat;
 	// `/history` matches the chat header's history button.
 	const showChatHistory = ! isReaderChat;

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useAgentsManagerContext } from '../../contexts';
-import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
+import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -45,7 +45,7 @@ export default function AgentHistory( {
 	}, [] );
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
-	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
+	const closedChatState = useHasAiChatEntryButton() ? 'minimized' : 'collapsed';
 	const title = __( 'Past chats', __i18n_text_domain__ );
 
 	const handleBack = () => resumeActiveChat();

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -1,10 +1,9 @@
 import { Button, DropdownMenu } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close, lineSolid, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
-import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
+import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import { recordAgentsManagerTracksEvent } from '../../utils/tracks';
@@ -25,7 +24,7 @@ interface Props {
 export default function ChatHeader( { onClose, options, title, onBack, isDocked }: Props ) {
 	const navigate = useNavigate();
 	const { setIsMinimized } = useDispatch( AGENTS_MANAGER_STORE );
-	const [ hasAiChatEntry ] = useState( hasAiChatEntryButton );
+	const hasAiChatEntry = useHasAiChatEntryButton();
 
 	// Minimize only applies to the floating chat reachable from an AI chat entry button
 	// (wp-admin bar, Calypso masterbar, or editor toolbar).

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
-import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
+import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import './style.scss';
@@ -45,7 +45,7 @@ export default function SupportGuide( {
 	}, [] );
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
-	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
+	const closedChatState = useHasAiChatEntryButton() ? 'minimized' : 'collapsed';
 	const isFromChat = !! ( state?.sessionId || state?.conversationId );
 	const title = __( 'Support Guides', __i18n_text_domain__ );
 

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -13,7 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Link, useLocation } from 'react-router-dom';
-import { hasAiChatEntryButton } from '../../hooks/use-admin-bar-integration';
+import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import useHelpSearchQuery from '../../hooks/use-help-search-query';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -127,7 +127,7 @@ export default function SupportGuides( {
 	}, [] );
 
 	// Without the AI chat entry button, use `collapsed` (a FAB) instead of `minimized`.
-	const closedChatState = hasAiChatEntryButton() ? 'minimized' : 'collapsed';
+	const closedChatState = useHasAiChatEntryButton() ? 'minimized' : 'collapsed';
 	const title = __( 'Support Guides', __i18n_text_domain__ );
 
 	return (

--- a/packages/agents-manager/src/hooks/__tests__/use-has-ai-chat-entry-button.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-has-ai-chat-entry-button.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { renderHook, act } from '@testing-library/react';
+
+const mockIsEditorAiEntryEnabled = jest.fn( () => false );
+const mockIsAdminBarInEditor = jest.fn( () => false );
+
+// The real checks read `window.matchMedia` and Gutenberg globals; mock them
+// down to controllable flags.
+jest.mock( '../../utils/editor-entry-points', () => ( {
+	isEditorAiEntryEnabled: () => mockIsEditorAiEntryEnabled(),
+	isAdminBarInEditor: () => mockIsAdminBarInEditor(),
+} ) );
+
+import useHasAiChatEntryButton, { hasAiChatEntryButton } from '../use-has-ai-chat-entry-button';
+
+const AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
+const MASTERBAR_BUTTON_CLASS = 'masterbar__item-agents-manager-ai-chat';
+
+const setUrl = ( path: string ) => window.history.replaceState( {}, '', path );
+
+const installAdminBarButton = () => {
+	const button = document.createElement( 'div' );
+	button.id = AI_CHAT_BUTTON_ID;
+	document.body.appendChild( button );
+};
+
+const installMasterbarButton = () => {
+	const button = document.createElement( 'div' );
+	button.className = MASTERBAR_BUTTON_CLASS;
+	document.body.appendChild( button );
+};
+
+afterEach( () => {
+	// `replaceState` is patched to notify subscribers, so wrap the reset in
+	// `act()` to flush any hook still mounted during teardown.
+	act( () => setUrl( '/' ) );
+	document.body.innerHTML = '';
+	mockIsEditorAiEntryEnabled.mockReturnValue( false );
+	mockIsAdminBarInEditor.mockReturnValue( false );
+} );
+
+describe( 'hasAiChatEntryButton', () => {
+	describe( 'on the Site Editor navigation view', () => {
+		beforeEach( () => {
+			setUrl( '/wp-admin/site-editor.php' );
+			// Force the toolbar entry `true` — `isEditorAiEntryEnabled()` has no
+			// navigation-view exclusion, so the navigation-view branch must
+			// ignore it since the toolbar isn't rendered there.
+			mockIsEditorAiEntryEnabled.mockReturnValue( true );
+		} );
+
+		it.each( [
+			{
+				expected: false,
+				because: 'the admin-bar button markup is hidden without the omnibar',
+				omnibar: false,
+				buttonInDom: true,
+			},
+			{
+				expected: true,
+				because: 'the omnibar shows the admin-bar button',
+				omnibar: true,
+				buttonInDom: true,
+			},
+			{
+				expected: false,
+				because: 'the omnibar has no AI chat button',
+				omnibar: true,
+				buttonInDom: false,
+			},
+		] )( 'is $expected when $because', ( { omnibar, buttonInDom, expected } ) => {
+			mockIsAdminBarInEditor.mockReturnValue( omnibar );
+			if ( buttonInDom ) {
+				installAdminBarButton();
+			}
+
+			expect( hasAiChatEntryButton() ).toBe( expected );
+		} );
+	} );
+
+	describe( 'everywhere else', () => {
+		it( 'counts the editor toolbar entry in the Site Editor editing canvas', () => {
+			setUrl( '/wp-admin/site-editor.php?canvas=edit' );
+			mockIsEditorAiEntryEnabled.mockReturnValue( true );
+
+			expect( hasAiChatEntryButton() ).toBe( true );
+		} );
+
+		it( 'counts the wp-admin bar button', () => {
+			setUrl( '/wp-admin/index.php' );
+			installAdminBarButton();
+
+			expect( hasAiChatEntryButton() ).toBe( true );
+		} );
+
+		it( 'counts the Calypso masterbar button', () => {
+			installMasterbarButton();
+
+			expect( hasAiChatEntryButton() ).toBe( true );
+		} );
+
+		it( 'is false without any entry button', () => {
+			expect( hasAiChatEntryButton() ).toBe( false );
+		} );
+	} );
+} );
+
+describe( 'useHasAiChatEntryButton', () => {
+	it( "reacts to the Site Editor's client-side navigation between the canvas and the navigation view", () => {
+		setUrl( '/wp-admin/site-editor.php?canvas=edit' );
+		mockIsEditorAiEntryEnabled.mockReturnValue( true );
+
+		const { result } = renderHook( () => useHasAiChatEntryButton() );
+		expect( result.current ).toBe( true );
+
+		act( () => window.history.pushState( {}, '', '/wp-admin/site-editor.php' ) );
+		expect( result.current ).toBe( false );
+
+		act( () => window.history.pushState( {}, '', '/wp-admin/site-editor.php?canvas=edit' ) );
+		expect( result.current ).toBe( true );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -1,10 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
-import { isEditorAiEntryEnabled } from '../../utils/editor-entry-points';
+import useHasAiChatEntryButton, {
+	ADMIN_BAR_AI_CHAT_BUTTON_ID,
+} from '../use-has-ai-chat-entry-button';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 import './style.scss';
 
@@ -13,23 +15,6 @@ const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
 const ADMIN_BAR_CHAT_ITEM_ID = 'wp-admin-bar-agents-manager-chat-support';
 const ADMIN_BAR_HISTORY_ITEM_ID = 'wp-admin-bar-agents-manager-chat-history';
 const ADMIN_BAR_GUIDES_ITEM_ID = 'wp-admin-bar-agents-manager-support-guides';
-
-// The standalone AI chat button — the chat's entry point, separate from the Help
-// menu. The wp-admin bar exposes it by ID; Calypso's masterbar by class.
-const ADMIN_BAR_AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
-const MASTERBAR_AI_CHAT_BUTTON_SELECTOR = '.masterbar__item-agents-manager-ai-chat';
-
-/**
- * Whether an AI chat entry button (wp-admin bar, Calypso masterbar, or editor toolbar) is
- * present. If so, the chat hides on close and reopens from it instead of a floating bubble.
- */
-export function hasAiChatEntryButton(): boolean {
-	return (
-		isEditorAiEntryEnabled() ||
-		!! document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID ) ||
-		!! document.querySelector( MASTERBAR_AI_CHAT_BUTTON_SELECTOR )
-	);
-}
 
 // CSS class name
 const OPEN_CLICK_CLASS = 'open-click';
@@ -74,8 +59,7 @@ export default function useAdminBarIntegration( {
 	const resumeActiveChatRef = useRef( resumeActiveChat );
 	resumeActiveChatRef.current = resumeActiveChat;
 
-	// Whether the AI chat entry button is present (captured once on mount).
-	const [ hasAiChatEntry ] = useState( hasAiChatEntryButton );
+	const hasAiChatEntry = useHasAiChatEntryButton();
 
 	// Whether the chat is visible (open and not minimized), read inside the
 	// one-time DOM click handlers below to decide whether a click opens or closes.

--- a/packages/agents-manager/src/hooks/use-has-ai-chat-entry-button.ts
+++ b/packages/agents-manager/src/hooks/use-has-ai-chat-entry-button.ts
@@ -1,0 +1,80 @@
+import { useSyncExternalStore } from '@wordpress/element';
+import { isAdminBarInEditor, isEditorAiEntryEnabled } from '../utils/editor-entry-points';
+import { isSiteEditorContext, isSiteEditorNavigationView } from '../utils/site-editor-context';
+
+// The standalone AI chat button — the chat's entry point, separate from the Help
+// menu. The wp-admin bar exposes it by ID; Calypso's masterbar by class.
+export const ADMIN_BAR_AI_CHAT_BUTTON_ID = 'wp-admin-bar-agents-manager-ai-chat';
+const MASTERBAR_AI_CHAT_BUTTON_SELECTOR = '.masterbar__item-agents-manager-ai-chat';
+
+/**
+ * Whether an AI chat entry button (wp-admin bar, Calypso masterbar, or editor toolbar) is
+ * present. If so, the chat hides on close and reopens from it instead of a floating bubble.
+ */
+export function hasAiChatEntryButton(): boolean {
+	// The Site Editor navigation view hides the editor toolbar and — unless the
+	// omnibar experiment shows it — the admin bar, whose markup can still sit
+	// hidden in the DOM. Only the omnibar's admin-bar button counts as an entry.
+	// (`isEditorAiEntryEnabled()` stays `true` here on purpose: it keeps the
+	// toolbar `Fill` registered for the canvas.)
+	if ( isSiteEditorNavigationView() ) {
+		return isAdminBarInEditor() && !! document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID );
+	}
+
+	return (
+		isEditorAiEntryEnabled() ||
+		!! document.getElementById( ADMIN_BAR_AI_CHAT_BUTTON_ID ) ||
+		!! document.querySelector( MASTERBAR_AI_CHAT_BUTTON_SELECTOR )
+	);
+}
+
+const LOCATION_CHANGE_EVENT = 'agentsManagerLocationChange';
+
+// `pushState`/`replaceState` fire no event, so Site Editor navigation would
+// otherwise go unnoticed. Patch them once to also dispatch
+// `LOCATION_CHANGE_EVENT`; never restored, to avoid clobbering another
+// library's patch.
+let historyPatched = false;
+function patchHistoryOnce(): void {
+	if ( historyPatched ) {
+		return;
+	}
+	historyPatched = true;
+
+	( [ 'pushState', 'replaceState' ] as const ).forEach( ( method ) => {
+		const original = window.history[ method ];
+		window.history[ method ] = function ( ...args ) {
+			const result = original.apply( this, args );
+			window.dispatchEvent( new Event( LOCATION_CHANGE_EVENT ) );
+			return result;
+		};
+	} );
+}
+
+/**
+ * Subscribes `notify` to the Site Editor's client-side navigation (`pushState`,
+ * `replaceState`, and `popstate`). No-op off the Site Editor — the only surface
+ * where an entry button appears or disappears without a full page load.
+ */
+function subscribeToSiteEditorLocation( notify: () => void ): () => void {
+	if ( ! isSiteEditorContext() ) {
+		return () => {};
+	}
+
+	patchHistoryOnce();
+	window.addEventListener( 'popstate', notify );
+	window.addEventListener( LOCATION_CHANGE_EVENT, notify );
+
+	return () => {
+		window.removeEventListener( 'popstate', notify );
+		window.removeEventListener( LOCATION_CHANGE_EVENT, notify );
+	};
+}
+
+/**
+ * Reactive `hasAiChatEntryButton()` — re-evaluates on the Site Editor's client-side
+ * navigation, where the toolbar entry appears and disappears without a page load.
+ */
+export default function useHasAiChatEntryButton(): boolean {
+	return useSyncExternalStore( subscribeToSiteEditorLocation, hasAiChatEntryButton );
+}

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -23,6 +23,10 @@ export function isAdminBarInEditor(): boolean {
  * Whether an editor toolbar entry point can show at all: on a block editor page, on desktop, and
  * with the omnibar off (when it's on, the entries live in the editor admin bar instead). All
  * checks are synchronous, so it's safe to read during render — e.g. from `hasAiChatEntryButton()`.
+ *
+ * Intentionally stays `true` on the Site Editor navigation view, where the toolbar is hidden:
+ * the entry `Fill`s must stay registered so the buttons appear once the canvas toolbar mounts.
+ * `hasAiChatEntryButton()` excludes that view on its own.
  */
 function isEditorEntryVisible(): boolean {
 	return (

--- a/packages/agents-manager/src/utils/site-editor-context.ts
+++ b/packages/agents-manager/src/utils/site-editor-context.ts
@@ -11,6 +11,18 @@ export function isSiteEditorContext( environment?: string, currentRoute?: string
 	);
 }
 
+/**
+ * True on the Site Editor navigation view (`site-editor.php` without
+ * `?canvas=edit`) — the screen with the left nav menu, where the editor toolbar
+ * is hidden. False in the editing canvas and on all other pages.
+ */
+export function isSiteEditorNavigationView(): boolean {
+	return (
+		isSiteEditorContext() &&
+		new URLSearchParams( window.location.search ).get( 'canvas' ) !== 'edit'
+	);
+}
+
 export function getClientConstructorArguments(
 	environment?: string,
 	currentRoute?: string


### PR DESCRIPTION
Part of AI-1066. Built on top of #112372.

## Proposed Changes

* On the Site Editor navigation view (`site-editor.php` without `canvas=edit`) with the omnibar off, the closed chat now collapses to a floating action button (FAB) instead of hiding behind a `minimized` state with no visible entry point, and the undocked chat header hides its Minimize option there. With the omnibar enabled, behavior is unchanged — the chat still reopens from the omnibar's AI button.
* Move `hasAiChatEntryButton()` into a new `use-has-ai-chat-entry-button` hook module with a navigation-view branch (only the omnibar's admin-bar button counts as an entry there), plus a reactive `useHasAiChatEntryButton()` built on `useSyncExternalStore` over the Site Editor's client-side navigation (patched `pushState`/`replaceState` and `popstate`; no-op on other surfaces). All consumers now use the hook, so the value tracks canvas ↔ navigation transitions without a page reload.
* Register `/support-guides` without the entry-button gate: unregistering the route mid-session would yank it from under a user viewing it, and the wildcard redirect (`isNewChat: true`) would reset their conversation.
* Clear the persisted `isMinimized` flag when the entry button disappears mid-session, so re-entering the canvas doesn't instantly re-minimize a chat the user is looking at.
* Document the enabled-while-unrendered contract on the editor entry checks (the toolbar `Fill` must stay registered on the navigation view) and remove stale comments (a leftover Woo AI condition, the `/post` route contrast).

## Why are these changes being made?

* On the Site Editor navigation view the editor toolbar — and its Ask AI entry button — is not rendered, but `hasAiChatEntryButton()` still counted it. Closing the chat there put it into the `minimized` state: fully hidden, reopenable only from an entry button that doesn't exist on the page (unless the omnibar is enabled). The undocked header's Minimize option stranded users the same way. The FAB (`collapsed` state) is the existing pattern for surfaces without an entry button, so this brings the navigation view in line with it.
* The Site Editor navigates between the navigation view and the canvas client-side, so the detection must react to `pushState`/`popstate` rather than being computed once per page load — the one-time capture is also what previously made the entry-button state unable to strand or surprise users mid-session, hence the `/support-guides` and `isMinimized` guards.

## Testing Instructions

* Ensure the site editor's omnibar is disabled
* Go to: `https://<YOUR_SITE_URL>/wp-admin/site-editor.php`, and the chat can be reopened on the page:

https://github.com/user-attachments/assets/5f493a31-fde4-4575-aae7-0ba67b16e118

* Enable the site editor's omnibar, from the `/wp-admin/admin.php?page=gutenberg-experiments` > Toolbar in editor
* The open / close behavior still works the same

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
