### PR TITLE
E2E: scope stats loading-placeholder wait to the main region

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -136,7 +136,10 @@ export class StatsPage {
 		// for this element.
 		// A loop is used here because multiple locators can match the CSS locator
 		// and to be safe, it's best to wait for all placeholders to be detached.
-		const locators = await this.page.locator( '.is-loading' ).all();
+		// Scope to the main content region: a page-wide `.is-loading` also matches
+		// unrelated chrome (e.g. the masterbar language picker) that stays hidden
+		// with the class instead of detaching, which would hang this wait.
+		const locators = await this.anchor.locator( '.is-loading' ).all();
 		for ( const locator of locators ) {
 			await locator.waitFor( { state: 'detached' } );
 		}


### PR DESCRIPTION
## Proposed Changes

* Scope the `.is-loading` placeholder wait in `StatsPage.showStatsOfType` to the main content region (`this.anchor`) instead of the whole page.

## Why are these changes being made?

`StatsPage.showStatsOfType` waited for **every** `.is-loading` element on the page to detach. That page-wide selector also matched unrelated chrome outside the stats content — notably the masterbar language picker, which stays in the DOM *hidden* with the `is-loading` class rather than detaching. The `waitFor( { state: 'detached' } )` loop therefore hung on it until the 10s timeout, flaking `stats/stats.spec.ts` (`As a user, I can browse the Traffic, Insights and Subscribers stats`) on the Desktop project:

```
TimeoutError: locator.waitFor: Timeout 10000ms exceeded.
  - waiting for locator('.is-loading').first() to be detached
    22 × locator resolved to hidden <div class="language-picker is-loading">…</div>
```

The failure was intermittent — the same commit both passed and failed — because it depended on whether the language picker happened to still be loading when the helper snapshotted `.is-loading`. Scoping the wait to `this.anchor` (the `main` region) keeps the legitimate stats-chart placeholder wait while excluding the unrelated chrome, making it deterministic.

## Testing Instructions

* Run `yarn playwright test specs/stats/stats.spec.ts --project=chrome --reporter=list --repeat-each=5` against a local Calypso instance; all runs should pass. Verified locally: 6/6 runs green, including the previously-failing "Filter traffic activity to Likes" step.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?