### PR TITLE
Agents Manager: externalize react-dom/client in the app bundles

### DIFF
--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -105,6 +105,18 @@ function getIndividualConfig( options = {} ) {
 					if ( request === '@wordpress/ui' ) {
 						return null;
 					}
+					// The plugin maps `react`/`react-dom` but not this deep import,
+					// so it would get bundled — a second react-dom copy (v19) that
+					// crashes against the page's external React. WordPress's
+					// `ReactDOM` global has included `createRoot` since WP 6.2.
+					if ( request === 'react-dom/client' ) {
+						return 'ReactDOM';
+					}
+				},
+				requestToHandle( request ) {
+					if ( request === 'react-dom/client' ) {
+						return 'react-dom';
+					}
 				},
 			} ),
 			new ReadableJsAssetsWebpackPlugin(),


### PR DESCRIPTION
## Proposed Changes

* Externalize the `react-dom/client` deep import in the Agents Manager app bundles: map it to the `ReactDOM` global (WordPress's `react-dom` script has included `createRoot` since WP 6.2) and to the `react-dom` script handle, so the generated `.asset.json` declares the dependency.

## Why are these changes being made?

* `DependencyExtractionWebpackPlugin` maps `react` and `react-dom` but not the `react-dom/client` deep import, so webpack bundled a second copy of react-dom into the Agents Manager bundles. The import is reached via `@automattic/components`' `embed-container` (`support-guide` → `@automattic/support-articles` → `embed-container` → `react-dom/client`).
* This was latent while `node_modules` react-dom matched the page's React. After the React 19 upgrade (#111721) the bundled copy is v19, and it crashes at module evaluation against the page's external React:

  ```
  Uncaught TypeError: Cannot read properties of undefined (reading 'S')
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js
  ```

  This breaks the whole bundle on load (e.g. `agents-manager-gutenberg` on the Site Editor).
* Verified on a dev build: the rebuilt `agents-manager-gutenberg.js` contains zero `react-dom-client` modules, and `agents-manager-gutenberg.asset.json` now lists `react-dom` in its dependencies.
* Note: the `.asset.json` dependency change only reaches Atomic sites after a production deploy (Jetpack fetches asset files from production, not the sandbox).
* Follow-up candidate (intentionally out of scope): `apps/help-center` has the same latent exposure through the same import chain.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/agents-manager && yarn dev --sync`.
3. Visit a Simple site's Site Editor (`/wp-admin/site-editor.php`).
4. Verify the Agents Manager loads without the `Cannot read properties of undefined (reading 'S')` console error, and the chat opens.
5. Check `dist/agents-manager-gutenberg.asset.json` includes `react-dom` in `dependencies`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
