### PR TITLE
Odyssey Stats: Align React DOM client with host runtime

### DIFF
--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -1,8 +1,7 @@
 import '@automattic/calypso-polyfills';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createRoot } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
-import { createRoot } from 'react-dom/client';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import config from '../lib/config-api';
 import getSiteAdminUrl from '../lib/selectors/get-site-admin-url';
@@ -11,6 +10,7 @@ import setLocale from '../lib/set-locale';
 import Highlights from './highlights';
 import MiniChart from './mini-chart';
 import Modules from './modules';
+import type { FunctionComponent } from 'react';
 
 import './index.scss';
 

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -132,8 +132,18 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			injectPolyfill: true,
 			useDefaults: false,
-			requestToHandle: defaultRequestToHandle,
+			requestToHandle: ( request ) => {
+				if ( request === 'react-dom/client' ) {
+					return 'wp-element';
+				}
+
+				return defaultRequestToHandle( request );
+			},
 			requestToExternal: ( request ) => {
+				if ( request === 'react-dom/client' ) {
+					return [ 'wp', 'element' ];
+				}
+
 				if (
 					! [
 						'lodash',


### PR DESCRIPTION
<img width="1468" height="492" alt="截圖 2026-07-08 晚上8 42 30" src="https://github.com/user-attachments/assets/27664a78-2542-4f96-a238-88242a45ceaa" />

## Proposed Changes

* Externalize `react-dom/client` to `wp-element` in the Odyssey Stats webpack dependency extraction config.
* Update the Odyssey dashboard widget entry to import `createRoot` from `@wordpress/element` instead of `react-dom/client`.
* Keep Odyssey Stats aligned with the React runtime provided by the wp-admin host page.

## Why are these changes being made?

* A freshly deployed Odyssey Stats bundle can run inside a wp-admin host page that still provides React 18 via Gutenberg scripts.
* Calypso currently builds with React 19, and importing `react-dom/client` directly can bundle ReactDOM client runtime code that expects React 19 internals.
* When that runtime executes against a React 18 host, the dashboard can fail with `Cannot read properties of undefined (reading 'S')`.
* Mapping `react-dom/client` to `wp.element` ensures `createRoot` comes from the same WordPress-provided runtime as the rest of the externalized React dependencies.

## Testing Instructions

* Build Odyssey Stats:
  * `NODE_ENV=production yarn workspace @automattic/odyssey-stats dev`
* Confirm the built Odyssey bundle no longer contains React 19 internals or a bundled `react-dom/client` runtime:
  * `rg "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE|ReactSharedInternals\\.S|react-dom/client" apps/odyssey-stats/dist`
  * The command should return no matches.
* Confirm bundle size remains within the configured limits:
  * `yarn workspace @automattic/odyssey-stats test:size`
* Confirm Odyssey unit tests pass:
  * `yarn workspace @automattic/odyssey-stats test:js`
* Deploy Odyssey Stats to a Jetpack wp-admin test site where the host page provides React 18.
* In the browser console, confirm the host runtime is still React 18:
  * `window.React?.version`
* Open the Stats dashboard/widget and confirm the page no longer throws `Cannot read properties of undefined (reading 'S')`.

### Test results (verified on this branch)

Build-level checks, run locally:

* ✅ `NODE_ENV=production yarn workspace @automattic/odyssey-stats dev` — compiles cleanly.
* ✅ `rg "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE|ReactSharedInternals\.S|react-dom/client" apps/odyssey-stats/dist` — no matches; React 19's react-dom client runtime is no longer bundled.
* ✅ `build.min.asset.php` / `widget-loader.min.asset.php` dependency handles are unchanged from trunk (`wp-element` was already listed), so no new script handles are introduced.
* ✅ The built bundle references `window["wp"]["element"]` for `createRoot`, confirming the externalization took effect.
* ✅ `yarn workspace @automattic/odyssey-stats test:size` — `build.min.js` 488.86 kB gzipped (limit 558.08 kB), `widget-loader.min.js` 7.91 kB gzipped (limit 8.19 kB).
* ✅ `yarn workspace @automattic/odyssey-stats test:js` — 16/16 tests pass.

Runtime checks, on a self-hosted Jetpack site (local Docker) whose host page provides React 18:

* ✅ Deployed the build into the local Jetpack `stats-admin` package via `STATS_PACKAGE_PATH` and confirmed the site serves the local `dist/build.min.js` (the `ver` query param matches the freshly built `*.asset.php` version hash).
* ✅ `window.React?.version` → `18.3.1` (host runtime is React 18).
* ✅ Fetching the served `build.min.js` in the console confirms it contains no React 19 internals marker.
* ✅ The Stats dashboard mounts and renders normally — no `Cannot read properties of undefined (reading 'S')` and no other console errors.
* ✅ The wp-admin Dashboard widget (the `widget/index.tsx` entry changed in this PR) renders its mini chart and highlights normally.

<img width="1003" height="716" alt="截圖 2026-07-09 中午12 08 26" src="https://github.com/user-attachments/assets/ff8706d7-a032-4f04-a2ef-fb362cec328b" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

