### PR TITLE
Odyssey Stats: externalize react-dom/client to avoid bundling a mismatched React

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -140,6 +140,7 @@ module.exports = {
 						'lodash-es',
 						'react',
 						'react-dom',
+						'react-dom/client',
 						// Externalize the JSX runtime alongside react/react-dom so it matches the
 						// React that WordPress provides. Bundling it (the default here, since it is
 						// absent from this allow list) ships an older React's runtime, whose elements
@@ -166,6 +167,12 @@ module.exports = {
 				// moment locales requires moment.js main file, so we need to handle it as an external as well.
 				if ( request === '../moment' ) {
 					request = 'moment';
+				}
+				// `react-dom/client` (createRoot/hydrateRoot) has no mapping in
+				// `defaultRequestToExternal`, so alias it to `react-dom` — otherwise React 19's
+				// react-dom is bundled and clashes with the externalized React the site provides.
+				if ( request === 'react-dom/client' ) {
+					request = 'react-dom';
 				}
 				return defaultRequestToExternal( request );
 			},


### PR DESCRIPTION
## Proposed Changes

* Add `react-dom/client` to the Odyssey Stats build's externalization allow-list (`apps/odyssey-stats/webpack.config.js`) and alias it to `react-dom`, so it resolves to the site-provided `window.ReactDOM` instead of being bundled.

## Why are these changes being made?

The build externalizes `react` and `react-dom` to the React that WordPress provides, but **not** the `react-dom/client` subpath — which is how the app actually mounts (`client/controller/web-util.js` uses `createRoot`/`hydrateRoot` from `react-dom/client`). `defaultRequestToExternal` has no mapping for that subpath, so it was bundled from wp-calypso's React 19 `react-dom`.

On a site running React 18 (e.g. current WordPress core), the bundled React 19 `react-dom` initializes against the externalized React 18 and throws immediately — `Uncaught TypeError: Cannot read properties of undefined (reading 'S')` (React 19's react-dom reaches for `ReactSharedInternals`, which React 18 doesn't expose). The app is stuck on the loading spinner. This reproduces with local dev/sandbox builds; the deployed production build isn't affected.

Aliasing `react-dom/client` to the `react-dom` external makes the whole react-dom surface resolve to `window.ReactDOM`, matching `window.React`. The crash is gone and the bundle is ~180 KB smaller (no duplicated react-dom).

## Testing Instructions

* Build Odyssey Stats locally and load it in wp-admin on a site whose `window.React` is 18.x.
* **Before:** Stats is stuck on the loading spinner; console shows `Cannot read properties of undefined (reading 'S')`.
* **After:** Stats mounts and renders normally, no console error.
* Confirm the built `build.min.js` no longer bundles react-dom (no `checkDCE`) and that `window.React` / `window.ReactDOM` are used for mounting.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
