### PR TITLE
Masterbar: hide broken Edit Profile link for accounts without sites

### DIFF
--- a/client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { InterimOmnibar } from '../interim-omnibar';
+import type { Site, User } from '@automattic/api-core';
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const userWithSite = {
+	ID: 1,
+	username: 'testuser',
+	display_name: 'Test User',
+	site_count: 1,
+	primary_blog: 1,
+} as User;
+
+const userWithoutSites = {
+	ID: 1,
+	username: 'testuser',
+	display_name: 'Test User',
+	site_count: 0,
+	primary_blog: 0,
+} as User;
+
+const site = {
+	ID: 1,
+	name: 'Test Site',
+	slug: 'test-site.wordpress.com',
+	URL: 'https://test-site.wordpress.com',
+	launch_status: 'launched',
+	is_a4a_dev_site: false,
+	is_wpcom_staging_site: false,
+	is_wpcom_atomic: false,
+	is_deleted: false,
+	jetpack: false,
+	site_migration: {
+		migration_status: undefined,
+	},
+	capabilities: {
+		manage_options: true,
+	},
+	options: {
+		admin_url: 'https://test-site.wordpress.com/wp-admin/',
+	},
+	plan: {
+		product_slug: 'free_plan',
+		product_name_short: 'Free',
+		is_free: true,
+	},
+} as Site;
+
+describe( '<InterimOmnibar /> profile menu', () => {
+	const originalScrollTo = window.scrollTo;
+
+	beforeEach( () => {
+		window.history.pushState( {}, '', '/me' );
+		window.scrollTo = jest.fn();
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/all-domains' )
+			.query( true )
+			.reply( 200, { domains: [] } );
+	} );
+
+	afterEach( () => {
+		window.scrollTo = originalScrollTo;
+		nock.cleanAll();
+	} );
+
+	test( 'does not render a broken Edit Profile link for accounts without sites', async () => {
+		render( <InterimOmnibar user={ userWithoutSites } site={ null } currentRoute="/me" /> );
+
+		// The "My WordPress.com Account" link is the anchor that is always present;
+		// wait for it so the masterbar has finished rendering the profile menu.
+		expect(
+			await screen.findByRole( 'link', { name: /WordPress\.com Account/i } )
+		).toHaveAttribute( 'href', '/me/account' );
+
+		// No "Edit Profile" link should exist, and crucially none pointing at the
+		// broken `nullprofile.php` URL.
+		expect( screen.queryByRole( 'link', { name: /edit profile/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /profile\.php/i } ) ).not.toBeInTheDocument();
+
+		// The user's identity is still shown in the menu.
+		expect( screen.getAllByText( 'Test User' ).length ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'renders the site Edit Profile link when a site is selected', async () => {
+		render( <InterimOmnibar user={ userWithSite } site={ site } currentRoute="/me" /> );
+
+		const editProfile = await screen.findByRole( 'link', { name: /edit profile/i } );
+		expect( editProfile ).toHaveAttribute(
+			'href',
+			'https://test-site.wordpress.com/wp-admin/profile.php'
+		);
+	} );
+
+	test( 'does not render a broken Edit Profile link when the selected site has no admin URL', async () => {
+		const siteWithoutAdminUrl = { ...site, options: {} } as Site;
+		render(
+			<InterimOmnibar user={ userWithSite } site={ siteWithoutAdminUrl } currentRoute="/me" />
+		);
+
+		expect(
+			await screen.findByRole( 'link', { name: /WordPress\.com Account/i } )
+		).toHaveAttribute( 'href', '/me/account' );
+		expect( screen.queryByRole( 'link', { name: /profile\.php/i } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx
@@ -3,14 +3,9 @@
  */
 
 import { screen } from '@testing-library/react';
-import nock from 'nock';
 import { render } from '../../../test-utils';
 import { InterimOmnibar } from '../interim-omnibar';
 import type { Site, User } from '@automattic/api-core';
-
-jest.mock( 'calypso/lib/analytics/tracks', () => ( {
-	recordTracksEvent: jest.fn(),
-} ) );
 
 const userWithSite = {
 	ID: 1,
@@ -56,22 +51,6 @@ const site = {
 } as Site;
 
 describe( '<InterimOmnibar /> profile menu', () => {
-	const originalScrollTo = window.scrollTo;
-
-	beforeEach( () => {
-		window.history.pushState( {}, '', '/me' );
-		window.scrollTo = jest.fn();
-
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.2/all-domains' )
-			.query( true )
-			.reply( 200, { domains: [] } );
-	} );
-
-	afterEach( () => {
-		window.scrollTo = originalScrollTo;
-	} );
-
 	test( 'does not render a broken Edit Profile link for accounts without sites', async () => {
 		render( <InterimOmnibar user={ userWithoutSites } site={ null } currentRoute="/me" /> );
 

--- a/client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx
@@ -70,7 +70,6 @@ describe( '<InterimOmnibar /> profile menu', () => {
 
 	afterEach( () => {
 		window.scrollTo = originalScrollTo;
-		nock.cleanAll();
 	} );
 
 	test( 'does not render a broken Edit Profile link for accounts without sites', async () => {
@@ -82,10 +81,8 @@ describe( '<InterimOmnibar /> profile menu', () => {
 			await screen.findByRole( 'link', { name: /WordPress\.com Account/i } )
 		).toHaveAttribute( 'href', '/me/account' );
 
-		// No "Edit Profile" link should exist, and crucially none pointing at the
-		// broken `nullprofile.php` URL.
+		// No "Edit Profile" link should exist, so there is no broken `nullprofile.php` URL.
 		expect( screen.queryByRole( 'link', { name: /edit profile/i } ) ).not.toBeInTheDocument();
-		expect( screen.queryByRole( 'link', { name: /profile\.php/i } ) ).not.toBeInTheDocument();
 
 		// The user's identity is still shown in the menu.
 		expect( screen.getAllByText( 'Test User' ).length ).toBeGreaterThan( 0 );
@@ -110,6 +107,6 @@ describe( '<InterimOmnibar /> profile menu', () => {
 		expect(
 			await screen.findByRole( 'link', { name: /WordPress\.com Account/i } )
 		).toHaveAttribute( 'href', '/me/account' );
-		expect( screen.queryByRole( 'link', { name: /profile\.php/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /edit profile/i } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -760,6 +760,8 @@ class MasterbarLoggedIn extends Component {
 
 	renderProfileMenu() {
 		const { translate, user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
+		// No site admin URL (e.g. an account with no sites) means no profile.php to link to.
+		const canEditProfile = isGlobalSidebarVisible || !! siteAdminUrl;
 		const editProfileUrl = isGlobalSidebarVisible ? '/me' : `${ siteAdminUrl }profile.php`;
 		const profileActions = [
 			{
@@ -778,14 +780,20 @@ class MasterbarLoggedIn extends Component {
 							<span className="username" title={ user.username }>
 								{ user.username }
 							</span>
-							<span className="display-name edit-profile">
-								{ isGlobalSidebarVisible ? translate( 'My Profile' ) : translate( 'Edit Profile' ) }
-							</span>
+							{ canEditProfile && (
+								<span className="display-name edit-profile">
+									{ isGlobalSidebarVisible
+										? translate( 'My Profile' )
+										: translate( 'Edit Profile' ) }
+								</span>
+							) }
 						</div>
 					</div>
 				),
-				url: editProfileUrl,
-				onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_edit_profile_clicked' ),
+				url: canEditProfile ? editProfileUrl : undefined,
+				onClick: canEditProfile
+					? () => this.props.recordTracksEvent( 'calypso_masterbar_edit_profile_clicked' )
+					: undefined,
 			},
 			{
 				label: translate( 'Log Out' ),


### PR DESCRIPTION
Fixes DOTCOM-17802

## Proposed Changes

* In the multi-site Dashboard's top-right user menu, the "Edit Profile" link is now hidden for accounts that have no sites. The gravatar/identity header, "Log Out", and "My WordPress.com Account" remain.
* Previously that link resolved to a broken `my.wordpress.com/nullprofile.php`.

## Why are these changes being made?

The masterbar builds the Edit Profile URL by appending `profile.php` to the selected site's wp-admin URL. An account with no sites has no such URL, so the value was `null` and the link pointed at `nullprofile.php`. There is no per-site profile to edit in this case, and the Dashboard has no standalone profile page (`/me` redirects to `/me/account`, where profile fields already live), so the link is omitted rather than pointed at a duplicate destination.

## Testing Instructions

* Sign in to the multi-site Dashboard with an account that has **no sites**.
* Open the top-right user menu.
* Confirm there is no "Edit Profile" entry, and that "My WordPress.com Account" (→ `/me/account`) and "Log Out" still work.
* With an account that **has a site selected**, confirm "Edit Profile" still links to that site's `wp-admin/profile.php`.
* Automated coverage: `yarn test-client client/dashboard/app/interim-omnibar/test/interim-omnibar.test.tsx`

## Considerations

The fix gates on `siteAdminUrl` — the value that was being interpolated — so it can never produce `nullprofile.php`, including the edge case of a selected site whose admin URL hasn't loaded. Gating instead on `hasNoSites` was considered but is a weaker proxy: it would still render the broken link if a site were selected without an admin URL.

An alternative was to keep the entry as "My Profile" pointing at `/me`. However, in the multi-site Dashboard `/me` redirects to `/me/account` — the same destination as the existing "My WordPress.com Account" link — so it would just be a duplicate entry rather than a distinct profile page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
