### PR TITLE
E2E: run @calypso-pr plus changed spec files on PRs instead of the full suite

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -155,28 +155,6 @@ object CalypsoE2ETestsBuildTemplate : Template({
 			dockerImage = "%docker_image_e2e%"
 		}
 
-		bashNodeScript {
-			name = "Determine test group"
-			id = "determine_test_group"
-			scriptContent = """
-				# Check if IGNORE_TEST_GROUP_FOR_E2E_CHANGES param is "true"
-				if [[ "%IGNORE_TEST_GROUP_FOR_E2E_CHANGES%" == "true" ]]; then
-					echo "IGNORE_TEST_GROUP_FOR_E2E_CHANGES is true, checking for E2E changes..."
-
-					# Check if test/e2e or packages/calypso-e2e files have been changed
-					CHANGED_FILES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
-					if echo "${'$'}CHANGED_FILES" | grep -q -E "^(test/e2e/|packages/calypso-e2e/)"; then
-						echo "Changes detected in test/e2e/ or packages/calypso-e2e/, clearing TEST_GROUP"
-						echo "##teamcity[setParameter name='TEST_GROUP' value='']"
-					else
-						echo "No changes in test/e2e/ or packages/calypso-e2e/, keeping TEST_GROUP as is"
-					fi
-				else
-					echo "IGNORE_TEST_GROUP_FOR_E2E_CHANGES is false, keeping TEST_GROUP as is"
-				fi
-				"""
-			dockerImage = "%docker_image_e2e%"
-		}
 
 		bashNodeScript {
 			name = "Set extra environment variables"
@@ -200,14 +178,17 @@ object CalypsoE2ETestsBuildTemplate : Template({
 			id = "run_tests"
 			scriptContent = """
 
-				# Check TEST_GROUP param
-				if [[ -n "%TEST_GROUP%" ]]; then
-					echo "TEST_GROUP is set to: %TEST_GROUP%"
+				# Resolve the Playwright grep flag. When IGNORE_TEST_GROUP_FOR_E2E_CHANGES is
+				# "true", adapt TEST_GROUP to the changed E2E files (union with changed specs,
+				# or clear to run all on a non-spec change); otherwise use TEST_GROUP as is.
+				if [[ "%IGNORE_TEST_GROUP_FOR_E2E_CHANGES%" == "true" ]]; then
+					GREP_FLAG=${'$'}(TEST_GROUP="%TEST_GROUP%" ./bin/e2e-grep-flag.sh)
+				elif [[ -n "%TEST_GROUP%" ]]; then
 					GREP_FLAG="--grep=%TEST_GROUP%"
 				else
-					echo "TEST_GROUP is not set, running all tests"
 					GREP_FLAG=""
 				fi
+				echo "Playwright grep flag: ${'$'}{GREP_FLAG:-(none, running all tests)}"
 
 				cd test/e2e
 				# Clear any stale teardown-leak markers from a reused checkout before this run.

--- a/bin/e2e-grep-flag.sh
+++ b/bin/e2e-grep-flag.sh
@@ -63,7 +63,7 @@ compute_flag() {
 	while IFS= read -r file; do
 		[[ -z "$file" ]] && continue
 		rel="${file#test/e2e/specs/}"
-		grep_value+="|${rel//./\\.}"
+		grep_value+="|(^|\\s)${rel//./\\.}"
 	done <<<"$pw_specs"
 
 	printf -- '--grep=%s' "$grep_value"

--- a/bin/e2e-grep-flag.sh
+++ b/bin/e2e-grep-flag.sh
@@ -87,7 +87,7 @@ self_test() {
 	local PW2=test/e2e/specs/tools/import__sites-wordpress.spec.ts
 	local JEST=test/e2e/specs/blocks/blocks__core.ts
 	local POM=test/e2e/lib/pages/some-page.ts
-	local PW_GREP='--grep=@calypso-pr|tools/import__sites-squarespace\.spec\.ts'
+	local PW_GREP='--grep=@calypso-pr|(^|\s)tools/import__sites-squarespace\.spec\.ts'
 
 	# No relevant change: keep the group.
 	check "no e2e change keeps group"   "--grep=@calypso-pr" $'client/foo.ts\ndocs/bar.md'
@@ -100,7 +100,7 @@ self_test() {
 	check "two Jest specs keep group"    "--grep=@calypso-pr" $'test/e2e/specs/blocks/blocks__core.ts\ntest/e2e/specs/me/me__account.ts'
 	check "single PW spec unions path"  "$PW_GREP" "$PW"
 	check "two PW specs union all" \
-		'--grep=@calypso-pr|tools/import__sites-squarespace\.spec\.ts|tools/import__sites-wordpress\.spec\.ts' \
+		'--grep=@calypso-pr|(^|\s)tools/import__sites-squarespace\.spec\.ts|(^|\s)tools/import__sites-wordpress\.spec\.ts' \
 		$'test/e2e/specs/tools/import__sites-squarespace.spec.ts\ntest/e2e/specs/tools/import__sites-wordpress.spec.ts'
 
 	# Mix-and-match.
@@ -112,8 +112,14 @@ self_test() {
 	# Group edge cases.
 	check "PW spec, empty group runs all" "" "$PW" ""
 	check "release group unions" \
-		'--grep=@calypso-release|blocks/blocks__media\.spec\.ts' \
+		'--grep=@calypso-release|(^|\s)blocks/blocks__media\.spec\.ts' \
 		"test/e2e/specs/blocks/blocks__media.spec.ts" "@calypso-release"
+
+	# Each spec path is anchored with (^|\s) so a shorter path can't match a longer
+	# one by suffix, e.g. changed.spec.ts must not select unchanged.spec.ts.
+	check "spec path is anchored" \
+		'--grep=@calypso-pr|(^|\s)a/changed\.spec\.ts' \
+		"test/e2e/specs/a/changed.spec.ts"
 
 	return $fail
 }

--- a/bin/e2e-grep-flag.sh
+++ b/bin/e2e-grep-flag.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Compute the Playwright `--grep` flag for the E2E "Playwright Test" build, adapting the
+# group to the E2E files changed on this branch. The build only calls this when it wants
+# that adaptive behavior; otherwise it uses TEST_GROUP directly and never runs this script.
+#
+# Reads (as environment variables):
+#   TEST_GROUP        Default group tag, e.g. "@calypso-pr". May be empty.
+#   E2E_CHANGED_FILES Optional newline-separated changed-file list. Testing seam; when unset,
+#                     falls back to `git diff` against trunk.
+#
+# Prints the flag to stdout: "--grep=<value>", or "" to run every test.
+#
+#   - no test/e2e or packages/calypso-e2e change -> keep TEST_GROUP
+#   - a changed E2E file is neither a Playwright spec nor a legacy Jest spec (POM, util,
+#     config, fixtures, packages/calypso-e2e) -> clear the group, run all tests
+#   - only legacy Jest specs changed (test/e2e/specs/**/*.ts without .spec) -> keep TEST_GROUP;
+#     these run via the Jest runner, not test:pw, so they don't affect Playwright selection
+#   - Playwright specs changed (test/e2e/specs/**/*.spec.ts) -> run TEST_GROUP plus those specs
+#     in a single pass. Playwright's `--grep` matches the spec path relative to test/e2e/specs/,
+#     so a test selected by both the tag and a changed path runs once.
+#
+# Run the built-in checks with:  ./bin/e2e-grep-flag.sh --self-test
+
+compute_flag() {
+	local group="${TEST_GROUP:-}"
+	local changed e2e_changed pw_specs grep_value file rel
+
+	changed="${E2E_CHANGED_FILES-$(git diff --name-only refs/remotes/origin/trunk...HEAD)}"
+	e2e_changed="$(grep -E "^(test/e2e/|packages/calypso-e2e/)" <<<"$changed" || true)"
+
+	# No E2E changes: keep the group unchanged.
+	if [[ -z "$e2e_changed" ]]; then
+		[[ -n "$group" ]] && printf -- '--grep=%s' "$group"
+		return 0
+	fi
+
+	# Any changed E2E file that is not a spec .ts under test/e2e/specs/ (POM/util/config/
+	# fixtures/packages) can affect any test, so run everything by clearing the group.
+	if grep -qvE "^test/e2e/specs/.*\.ts$" <<<"$e2e_changed"; then
+		return 0
+	fi
+
+	# Only spec .ts files changed. Legacy Jest specs (no .spec) run under Jest, not test:pw,
+	# so keep the group and add just the changed Playwright specs (if any).
+	pw_specs="$(grep -E "^test/e2e/specs/.*\.spec\.ts$" <<<"$e2e_changed" || true)"
+	if [[ -z "$pw_specs" ]]; then
+		[[ -n "$group" ]] && printf -- '--grep=%s' "$group"
+		return 0
+	fi
+
+	# With no group set the build already runs everything, so keep clear.
+	if [[ -z "$group" ]]; then
+		return 0
+	fi
+
+	# Union the group tag with each changed Playwright spec, addressed by its path relative to
+	# test/e2e/specs/. Only "." is regex-special in these paths (verified against the spec tree).
+	grep_value="$group"
+	while IFS= read -r file; do
+		[[ -z "$file" ]] && continue
+		rel="${file#test/e2e/specs/}"
+		grep_value+="|${rel//./\\.}"
+	done <<<"$pw_specs"
+
+	printf -- '--grep=%s' "$grep_value"
+}
+
+# Assert compute_flag's output over controlled param states. No git, no TeamCity.
+self_test() {
+	local fail=0
+	check() { # name expected changed [group]
+		local group out
+		group="${4-@calypso-pr}"
+		out="$(TEST_GROUP="$group" E2E_CHANGED_FILES="$3" compute_flag)"
+		[[ "$out" == "$2" ]] && echo "ok   - $1" || { echo "FAIL - $1"; fail=1; }
+		echo "       group    [$group]"
+		echo "       changed  [${3//$'\n'/ | }]"
+		echo "       expected [$2]"
+		echo "       actual   [$out]"
+	}
+
+	local PW=test/e2e/specs/tools/import__sites-squarespace.spec.ts
+	local PW2=test/e2e/specs/tools/import__sites-wordpress.spec.ts
+	local JEST=test/e2e/specs/blocks/blocks__core.ts
+	local POM=test/e2e/lib/pages/some-page.ts
+	local PW_GREP='--grep=@calypso-pr|tools/import__sites-squarespace\.spec\.ts'
+
+	# No relevant change: keep the group.
+	check "no e2e change keeps group"   "--grep=@calypso-pr" $'client/foo.ts\ndocs/bar.md'
+	check "empty change keeps group"    "--grep=@calypso-pr" ""
+
+	# Single-kind changes.
+	check "POM/util clears group"       "" "$POM"
+	check "packages/calypso-e2e clears" "" "packages/calypso-e2e/src/lib/foo.ts"
+	check "single Jest spec keeps group" "--grep=@calypso-pr" "$JEST"
+	check "two Jest specs keep group"    "--grep=@calypso-pr" $'test/e2e/specs/blocks/blocks__core.ts\ntest/e2e/specs/me/me__account.ts'
+	check "single PW spec unions path"  "$PW_GREP" "$PW"
+	check "two PW specs union all" \
+		'--grep=@calypso-pr|tools/import__sites-squarespace\.spec\.ts|tools/import__sites-wordpress\.spec\.ts' \
+		$'test/e2e/specs/tools/import__sites-squarespace.spec.ts\ntest/e2e/specs/tools/import__sites-wordpress.spec.ts'
+
+	# Mix-and-match.
+	check "PW + Jest unions PW only"        "$PW_GREP" $'test/e2e/specs/tools/import__sites-squarespace.spec.ts\ntest/e2e/specs/blocks/blocks__core.ts'
+	check "PW + POM clears group"           "" $'test/e2e/specs/tools/import__sites-squarespace.spec.ts\ntest/e2e/lib/pages/some-page.ts'
+	check "Jest + POM clears group"         "" $'test/e2e/specs/blocks/blocks__core.ts\ntest/e2e/lib/pages/some-page.ts'
+	check "PW + Jest + POM clears group"    "" $'test/e2e/specs/tools/import__sites-squarespace.spec.ts\ntest/e2e/specs/blocks/blocks__core.ts\ntest/e2e/lib/pages/some-page.ts'
+
+	# Group edge cases.
+	check "PW spec, empty group runs all" "" "$PW" ""
+	check "release group unions" \
+		'--grep=@calypso-release|blocks/blocks__media\.spec\.ts' \
+		"test/e2e/specs/blocks/blocks__media.spec.ts" "@calypso-release"
+
+	return $fail
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+	self_test
+	exit
+fi
+
+compute_flag


### PR DESCRIPTION
Part of [TESTOPS-211](https://linear.app/a8c/issue/TESTOPS-211)

## Proposed Changes

- In the `.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt` file remove the portion of the code modifying the `TEST_GROUP` build parameter to modify the `GREP_FLAG` used to run Playwright tests later.
- move the logic building the `GREP_FLAG` to a dedicated bash script, `bin/e2e-grep-flag.sh` that takes the `TEST_GROUP` and `E2E_CHANGED_FILES` as an input to return the `--grep` option flag content that will be used to run the Playwright tests. The bash script contains a `--self-test` option to run the script self tests in place of emitting the `--grep` flag.

The logic changed to:
- if no files are modified in the `test/e2e` or `packages/calypso-e2e` directories, then do not touch the `TEST_GROUP` -> Playwright will run with `--grep @calypso-pr`
- if files are modified in the `test/e2e` or `packages/calypso-e2e` directories:
    - if the files are Jest test files (e.g. the `test/e2e/specs/blocks/blocks__core.ts` one) then leave the `TEST_GROUP` as is since Playwright would not run those tests in any case (since Playwright is using the default `*.spec.ts` or `*.test.ts` match to find test files)
    - if the files are Playwright test files (`*.spec.ts`) then run only those by adding them to the `--grep` flag. E.g. `--grep=@calypso-release|blocks/blocks__media\.spec\.ts`
    - if the files are neither, then assume they are POM/util/fixture/shared files -> rerun all tests.

The `bin/e2e-grep-flag.sh --self-test` run will show the different combinations.

**Notes**
* Playwright will deduplicate matches: a file that matches both the group `@calypso-pr` and is added to the --grep` flag will run once, not twice.
* I've though about adding some system to deal with the case where **all** the Playwright files are changed and would thus be added to the `--grep` flag and deemed that premature optimization. With a default single-argument limit of 128Kb on Linux that case would still not hit.

## Why these changes being made?

The previous logic would empty the `TEST_GROUP` build parameter, then used to build the `GREP_FLAG` appended to the `yarn test:pw:desktop` (or `yarn test:pw:mobile`) command.
In the context of a normal build running following a PR push the possibile values would be (using `desktop` as an example):
- `yarn test:pw:desktop --grep "@calypso-pr"` for the `@calypso-pr` subset of Playwright tests that can run in a PR without running the risk of running into throttling issues.
- `yarn test:pw:desktop` (empty `GREP_FLAG`) for the full suite of Playwright tests, **including the tests in the `@calypso-release` group that can run into throttling issues**, or affect them.

The `TEST_GROUP` parameter would be emptied when any file in the `test/e2e` or `packages/calypso-e2e` is modified. The measure was too broad and the purpose of this PR is to narrow it down.

## Revert of #112429 changes

PR https://github.com/Automattic/wp-calypso/pull/112429 added a `skipIfNotTrunk` function to work around the `TEST_GROUP` clearing and provide a stop-gap measure for a throttling cascade.
I've left that code in place to ship this measure, see how it would fare under real usage monitoring the output line in the build reporting the built `--grep` flag, and decide.
