### PR TITLE
Agents Manager: externalize react-dom/client to the host's ReactDOM

### DIFF
--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -1,6 +1,9 @@
 const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const {
+	defaultRequestToHandle,
+} = require( '@wordpress/dependency-extraction-webpack-plugin/lib/util' );
 const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
 const CopyPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
@@ -105,6 +108,26 @@ function getIndividualConfig( options = {} ) {
 					if ( request === '@wordpress/ui' ) {
 						return null;
 					}
+					// Externalize react-dom/client so `createRoot` resolves to WordPress's
+					// ReactDOM instead of bundling a copy of react-dom. The plugin default
+					// externalizes react / react-dom / react-jsx-runtime but NOT this subpath,
+					// so react-dom gets bundled — and a bundled react-dom carries its own React
+					// runtime that mismatches the host's React (React 18 and 19 runtimes are
+					// incompatible). Same rationale as odyssey-stats and blaze-dashboard, which
+					// externalize the React runtime to the host; this config additionally maps the
+					// react-dom/client subpath. See apps/odyssey-stats/webpack.config.js and
+					// apps/blaze-dashboard/webpack.config.js.
+					if ( request === 'react-dom/client' ) {
+						return 'ReactDOM';
+					}
+				},
+				requestToHandle( request ) {
+					// react-dom/client resolves to the `react-dom` script handle; WordPress
+					// registers no separate handle for the subpath.
+					if ( request === 'react-dom/client' ) {
+						return 'react-dom';
+					}
+					return defaultRequestToHandle( request );
 				},
 			} ),
 			new ReadableJsAssetsWebpackPlugin(),


### PR DESCRIPTION
## Proposed Changes

* Externalize `react-dom/client` in the Agents Manager widget build so `createRoot` resolves to WordPress's `ReactDOM` instead of bundling a copy of `react-dom`, and map the subpath to the `react-dom` script handle so it is declared as a dependency.

## Why are these changes being made?

The Agents Manager widgets externalize `react` and `react-dom` to the React that WordPress provides, but the dependency-extraction plugin does not externalize the `react-dom/client` subpath — so `createRoot` pulls a bundled copy of `react-dom` into the widget. A bundled react-dom ships its own React runtime, which is incompatible with the host's React whenever the versions differ.

Now that calypso builds against React 19 (#112339), a widget rebuilt from trunk bundles react-dom 19 while the block-editor host still runs React 18, which crashes the sidebar at mount (`Cannot read properties of undefined (reading 'S')` / minified React error 525). Externalizing `react-dom/client` makes the widget use the host's react-dom, so it always matches the host — React 18 today and React 19 automatically once the host migrates.

Same rationale as `odyssey-stats` and `blaze-dashboard`, which externalize the React runtime to the host; this change additionally maps the `react-dom/client` subpath.

## Testing Instructions

1. Sandbox `widgets.wp.com` and run `cd apps/agents-manager && yarn dev --sync`.
2. Open the post editor on a Simple or Atomic site and open the AI sidebar — the FAB should render with no React console errors.
3. Confirm the suggestions in the sidebar are working as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

