### PR TITLE
E2E: skip domain tests on non-trunk branches (throttling workaround)

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -744,6 +744,21 @@ export function skipIfMailosaurLimitReached(): void {
 }
 
 /**
+ * Skips the current test suite when not running on trunk.
+ *
+ * @example
+ * ```typescript
+ * test.describe( 'My Test Suite', () => {
+ *   skipIfNotTrunk();
+ *   test( 'my test', async () => { ... });
+ * });
+ * ```
+ */
+export function skipIfNotTrunk(): void {
+	test.skip( ( process.env.BRANCH_NAME || '' ) !== 'trunk', 'Skipping: run only on trunk' );
+}
+
+/**
  * Deletes an ephemeral test site. Retries transient failures and never throws:
  * it runs from fixture teardown, which Playwright executes even when the test
  * fails or times out, so a cleanup hiccup must not redden a passing test. On

--- a/test/e2e/specs/blocks/blocks__media.spec.ts
+++ b/test/e2e/specs/blocks/blocks__media.spec.ts
@@ -11,7 +11,7 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { TEST_IMAGE_PATH, TEST_AUDIO_PATH } from '../constants';
 
 /**
@@ -23,6 +23,8 @@ test.describe(
 	'Blocks: Media (Upload)',
 	{ tag: [ tags.CALYPSO_PR, tags.GUTENBERG, tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
+		skipIfNotTrunk();
+
 		const features = envToFeatureKey( envVariables );
 
 		// Default to `defaultUser` as it has WordPress.com Premium enabled, which is required

--- a/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
@@ -1,6 +1,7 @@
-import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.DASHBOARD_PR ] }, () => {
+	skipIfNotTrunk();
 	skipIfMailosaurLimitReached();
 
 	test( 'As a new simple site user, I can set my site visibility to Private, so that only I can see my site', async ( {

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -1,4 +1,4 @@
-import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Domain: Upsell (Home)',
@@ -6,6 +6,7 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		skipIfNotTrunk();
 		skipIfMailosaurLimitReached();
 
 		test( 'As a user, I can see domain upsell on Home dashboard and proceed to checkout', async ( {

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
@@ -1,6 +1,7 @@
-import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
+	skipIfNotTrunk();
 	skipIfMailosaurLimitReached();
 
 	const planName = 'Premium';

--- a/test/e2e/specs/domains/domains__add.spec.ts
+++ b/test/e2e/specs/domains/domains__add.spec.ts
@@ -1,5 +1,5 @@
 import { DomainsPage } from '@automattic/calypso-e2e';
-import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Domains: Add to current site',
@@ -7,6 +7,7 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		skipIfNotTrunk();
 		skipIfMailosaurLimitReached();
 
 		test( 'As a user, I can add a domain to my existing site', async ( {

--- a/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
@@ -10,9 +10,11 @@ import {
 	envToFeatureKey,
 	ElementHelper,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Editor: Advanced Post Flow', { tag: [ tags.GUTENBERG, tags.CALYPSO_PR ] }, () => {
+	skipIfNotTrunk();
+
 	// Authentication setup.
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [

--- a/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
+++ b/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
@@ -1,6 +1,8 @@
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
+	skipIfNotTrunk();
+
 	test( 'As a user with a qualifying yearly plan, I skip plan selection and go directly to checkout', async ( {
 		accountAtomic,
 		componentDomainSearch,

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -6,7 +6,7 @@ import {
 	NewUserResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { tags, test, expect } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test, expect } from '../../lib/pw-base';
 import { apiCloseAccount, apiCreateFreeSiteForUser, apiDeleteSite } from '../shared';
 
 test.describe(
@@ -15,6 +15,8 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		skipIfNotTrunk();
+
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;
 			newUserDetails: NewUserResponse;

--- a/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
+++ b/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
@@ -4,7 +4,7 @@ import {
 	NewUserResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { tags, test, expect } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test, expect } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 
 test.describe(
@@ -13,6 +13,8 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		skipIfNotTrunk();
+
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;
 			newUserDetails: NewUserResponse;

--- a/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
@@ -5,7 +5,7 @@ import {
 	NewSiteResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
@@ -14,6 +14,8 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		skipIfNotTrunk();
+
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;
 			newUserDetails: NewUserResponse;

--- a/test/e2e/specs/help-center/help-center__calypso.spec.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.spec.ts
@@ -5,9 +5,11 @@ import {
 	envVariables,
 } from '@automattic/calypso-e2e';
 import { Locator } from 'playwright';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
+	skipIfNotTrunk();
+
 	const normalizeString = ( str: string | null ) => str?.replace( /\s+/g, ' ' ).trim();
 
 	test( 'As a user, I can interact with the Help Center in Calypso', async ( { page } ) => {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.spec.ts
@@ -7,13 +7,15 @@ import {
 	RestAPIClient,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain selection' ),
 	{ tag: [ tags.CALYPSO_RELEASE ] },
 	() => {
+		skipIfNotTrunk();
+
 		const planName = 'Business';
 		const blogName = DataHelper.getBlogName();
 		const testUser = DataHelper.getNewTestUser();

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.spec.ts
@@ -6,7 +6,7 @@ import {
 	RestAPIClient,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 
 /**
@@ -19,6 +19,8 @@ test.describe(
 	),
 	{ tag: [ tags.CALYPSO_RELEASE ] },
 	() => {
+		skipIfNotTrunk();
+
 		const planSlug = 'business-bundle';
 		const planName = 'Business';
 		const blogName = DataHelper.getBlogName();

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__pre-selected-plan.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__pre-selected-plan.spec.ts
@@ -5,13 +5,15 @@ import {
 	RestAPIClient,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With pre-selected plan' ),
 	{ tag: [ tags.CALYPSO_RELEASE ] },
 	() => {
+		skipIfNotTrunk();
+
 		const planSlug = 'business-bundle';
 		const planName = 'Business';
 		const testUser = DataHelper.getNewTestUser();

--- a/test/e2e/specs/plugins/plugins__browse.spec.ts
+++ b/test/e2e/specs/plugins/plugins__browse.spec.ts
@@ -6,12 +6,14 @@ import {
 	envToFeatureKey,
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Plugins: Browse' ),
 	{ tag: [ tags.CALYPSO_PR, tags.JETPACK_REMOTE_SITE ] },
 	() => {
+		skipIfNotTrunk();
+
 		test( 'As a user, I can browse plugins on the plugins page', async ( { page } ) => {
 			let pluginsPage: PluginsPage;
 			let siteUrl: string;

--- a/test/e2e/specs/plugins/plugins__search.spec.ts
+++ b/test/e2e/specs/plugins/plugins__search.spec.ts
@@ -5,12 +5,14 @@ import {
 	TestAccount,
 	envVariables,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Plugins search' ),
 	{ tag: [ tags.CALYPSO_PR ] },
 	() => {
+		skipIfNotTrunk();
+
 		test( 'As a user, I can search for plugins and navigate search results', async ( { page } ) => {
 			let pluginsPage: PluginsPage;
 			let siteUrl: string;

--- a/test/e2e/specs/stats/stats.spec.ts
+++ b/test/e2e/specs/stats/stats.spec.ts
@@ -7,7 +7,7 @@ import {
 	envToFeatureKey,
 	envVariables,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 /**
  * Shallowly tests the Stats feature, including Jetpack/Odyssey stats.
@@ -15,6 +15,8 @@ import { tags, test } from '../../lib/pw-base';
  * Keywords: Stats, Jetpack, Odyssey Stats
  */
 test.describe( 'Stats', { tag: [ tags.CALYPSO_PR, tags.JETPACK_WPCOM_INTEGRATION ] }, () => {
+	skipIfNotTrunk();
+
 	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'defaultUser' },
 	] );

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -6,11 +6,12 @@ import {
 	Roles,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
-import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount, recordAccountLeakMarker } from '../shared';
 import type { NewUserResponse } from '@automattic/calypso-e2e';
 
 test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
+	skipIfNotTrunk();
 	skipIfMailosaurLimitReached();
 	const role = 'Editor';
 	const testUser = DataHelper.getNewTestUser( {


### PR DESCRIPTION
## Proposed Changes

Temporarily skip domain-related E2E suites on every branch except `trunk`.

Adds a `skipIfNotTrunk()` helper in `test/e2e/lib/pw-base.ts` that calls `test.skip()` when `process.env.BRANCH_NAME !== 'trunk'`, and wires it into the suites currently affected by the throttling.

`BRANCH_NAME` is set per build by TeamCity (`env.BRANCH_NAME` = `%teamcity.build.branch%` in `CalypsoE2ETestsBuildTemplate.kt`) and resolves to `trunk` on the default branch, so these suites still run on trunk and are skipped on per-PR runs.

## Why these changes being made?

Domain registration APIs throttle these suites in per-PR CI, causing consistent failures unrelated to the code under test. This is a temporary measure to stop the noise while the underlying rate limit is addressed. The helper and its callers should be removed once throttling is resolved.

## Testing Instructions

* On a non-trunk branch (any PR): the 9 domain suites report as skipped in the E2E run.
* On trunk: the suites run as before.
* Locally: `BRANCH_NAME=trunk yarn playwright test specs/domains/domains__add.spec.ts --reporter=list` runs the suite; without `BRANCH_NAME=trunk` it is skipped.
