### PR TITLE
Calypso Purchases: fix missing payment method warning styling

### DIFF
--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PaymentLogo from 'calypso/components/payment-logo';
@@ -158,11 +157,8 @@ function NoPaymentMethodWarning( {
 } ) {
 	const translate = useTranslate();
 	return (
-		<>
-			<div className="manage-purchase__no-payment-method">
-				<Icon icon={ warning } />
-				{ translate( 'You don’t have a payment method to renew this subscription' ) }
-			</div>
+		<div className="manage-purchase__no-payment-method">
+			{ translate( 'You don’t have a payment method to renew this subscription' ) }
 			{ addPaymentMethodUrl && (
 				<Button
 					className="manage-purchase__add-payment-method-link"
@@ -173,7 +169,7 @@ function NoPaymentMethodWarning( {
 					{ translate( 'Add payment method' ) }
 				</Button>
 			) }
-		</>
+		</div>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -373,6 +373,7 @@
 	.manage-purchase__no-payment-method {
 		display: flex;
 		align-items: flex-start;
+		flex-direction: column;
 		gap: 4px;
 
 		@include breakpoint-deprecated( '<660px' ) {
@@ -383,10 +384,6 @@
 		svg {
 			flex-shrink: 0;
 			fill: var( --color-warning-30 );
-		}
-
-		a {
-			display: inline-block;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-500/

## Proposed Changes

This cleans up the styling and markup for the `Add payment method` link added in https://github.com/Automattic/wp-calypso/pull/112389/. It also removes the redundant warning icon, per the request in https://linear.app/a8c/issue/CHE-500/#comment-bc3444e5

| Before | After |
| ----------- | ----------- |
| <img width="626" height="354" alt="CleanShot 2026-07-08 at 11 41 41@2x" src="https://github.com/user-attachments/assets/bfc3bc7e-85c6-4476-8ea5-1b7df78b3f03" /> | <img width="598" height="314" alt="CleanShot 2026-07-08 at 11 51 01@2x" src="https://github.com/user-attachments/assets/ce2079b4-6e79-449d-9709-0dde7eeb24c9" /> |

## Testing Instructions

- On a Simple site, open a subscription's manage page: /purchases/subscriptions/{siteSlug}/{purchaseId} for a subscription that has auto-renew enabled and no payment method assigned.
- Confirm an "Add payment method" link now appears directly under the "You don’t have a payment method to renew this subscription" warning, and that clicking it navigates to the add-payment-method flow.
- Confirm the Tracks event calypso_purchases_add_payment_method_from_warning fires on click.
- Confirm an expired / one-time / included-with-plan purchase still shows the warning without the link.
