### PR TITLE
Reader Spaces: rename to "Create a space", fix hover overflow, reorder sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -211,6 +211,8 @@ export class ReaderSidebar extends Component {
 						/>
 					</li>
 
+					{ isEnabled( 'reader/spaces' ) && <ReaderSidebarSpaces path={ path } /> }
+
 					{ this.props.organizations && (
 						<ReaderSidebarOrganizations organizations={ this.props.organizations } path={ path } />
 					) }
@@ -234,8 +236,6 @@ export class ReaderSidebar extends Component {
 						onFollowTag={ this.highlightNewTag }
 						currentTag={ this.state.currentTag }
 					/>
-
-					{ isEnabled( 'reader/spaces' ) && <ReaderSidebarSpaces path={ path } /> }
 
 					<li className="reader-sidebar__section-header" role="presentation">
 						<span role="heading" aria-level="3">

--- a/client/reader/sidebar/spaces/index.tsx
+++ b/client/reader/sidebar/spaces/index.tsx
@@ -174,7 +174,7 @@ export function ReaderSidebarSpaces( { path }: Props ) {
 						onPrefetch={ () => prefetchSpace( space.id ) }
 					/>
 				) ) }
-				<AddMenuItem label={ translate( 'Add a space' ) } onClick={ handleAddSpaceClick } />
+				<AddMenuItem label={ translate( 'Create a space' ) } onClick={ handleAddSpaceClick } />
 			</ExpandableSidebarMenu>
 			{ isOnboardingOpen && (
 				<AsyncLoad

--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -140,24 +140,24 @@ describe( 'ReaderSidebarSpaces', () => {
 		expect( container.querySelector( 'li.sidebar__menu-item.selected' ) ).toBeNull();
 	} );
 
-	it( 'opens the create-space modal from the "Add a space" button', async () => {
+	it( 'opens the create-space modal from the "Create a space" button', async () => {
 		const user = userEvent.setup();
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
 
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 
 		const dialog = await screen.findByRole( 'dialog' );
 		expect( dialog ).toBeVisible();
 		expect( screen.getByRole( 'heading', { name: 'Create a new space' } ) ).toBeVisible();
 	} );
 
-	it( 'shows the onboarding walkthrough on the first "Add a space" click', async () => {
+	it( 'shows the onboarding walkthrough on the first "Create a space" click', async () => {
 		const user = userEvent.setup();
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } />, { preferences: { remoteValues: {} } } );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 
 		// The walkthrough, not the create form.
 		expect( await screen.findByRole( 'heading', { name: 'Meet Spaces' } ) ).toBeVisible();
@@ -172,7 +172,7 @@ describe( 'ReaderSidebarSpaces', () => {
 			preferences: { remoteValues: { has_seen_reader_spaces_onboarding: true } },
 		} );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 
 		expect( await screen.findByRole( 'heading', { name: 'Create a new space' } ) ).toBeVisible();
 	} );
@@ -184,7 +184,7 @@ describe( 'ReaderSidebarSpaces', () => {
 			preferences: { remoteValues: { has_seen_reader_spaces_onboarding: true } },
 		} );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 
 		expect( await screen.findByRole( 'heading', { name: 'Meet Spaces' } ) ).toBeVisible();
 	} );
@@ -193,7 +193,7 @@ describe( 'ReaderSidebarSpaces', () => {
 		const user = userEvent.setup();
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } />, { preferences: { remoteValues: {} } } );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Show me how' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
@@ -201,11 +201,11 @@ describe( 'ReaderSidebarSpaces', () => {
 		expect( await screen.findByRole( 'heading', { name: 'Create a new space' } ) ).toBeVisible();
 	} );
 
-	it( 'marks the walkthrough seen when skipped before the next "Add a space" click', async () => {
+	it( 'marks the walkthrough seen when skipped before the next "Create a space" click', async () => {
 		const user = userEvent.setup();
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } />, { preferences: { remoteValues: {} } } );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 		await user.click( await screen.findByRole( 'button', { name: 'Skip' } ) );
 
 		expect( screen.queryByRole( 'heading', { name: 'Meet Spaces' } ) ).not.toBeInTheDocument();
@@ -213,7 +213,7 @@ describe( 'ReaderSidebarSpaces', () => {
 			screen.queryByRole( 'heading', { name: 'Create a new space' } )
 		).not.toBeInTheDocument();
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 
 		expect( await screen.findByRole( 'heading', { name: 'Create a new space' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'heading', { name: 'Meet Spaces' } ) ).not.toBeInTheDocument();
@@ -243,7 +243,7 @@ describe( 'ReaderSidebarSpaces', () => {
 			} );
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add a space' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -374,7 +374,7 @@ body.is-section-reader {
 			gap: 6px;
 			line-height: 1.5;
 			padding: 12px;
-			box-sizing: content-box;
+			box-sizing: border-box;
 
 			&.view-more-link {
 				color: var( --color-link );

--- a/client/reader/spaces/onboarding-modal/constants.ts
+++ b/client/reader/spaces/onboarding-modal/constants.ts
@@ -3,6 +3,6 @@ export const READER_SPACES_ONBOARDING_SEEN_PREFERENCE_KEY = 'has_seen_reader_spa
 export const READER_SPACES_ONBOARDING_TRACKS_EVENT_PREFIX = 'calypso_reader_spaces_onboarding_';
 
 // Debug override: set this key to '1' in localStorage (e.g. from the browser
-// console) to force the walkthrough to show on every "Add a space" click,
+// console) to force the walkthrough to show on every "Create a space" click,
 // regardless of the "seen" preference. Remove the key to restore normal gating.
 export const READER_SPACES_ONBOARDING_DEBUG_KEY = 'reader_spaces_onboarding_debug';


### PR DESCRIPTION
Closes RSM-4646

## Proposed Changes

* Rename the Reader **Spaces** sidebar footer row from "Add a space" to "Create a space" (label + tests + a debug comment).
* Fix the row's hover highlight overflowing the rounded Spaces container: the togglable `.sidebar__menu-link` now uses `box-sizing: border-box` instead of `content-box`, so its 12px padding no longer pushes the rendered width past the container.
* Move the **Spaces** section in the Reader sidebar to sit directly below **Recent** (previously it sat below Tags).

## Why are these changes being made?

"Create a space" reads as a clearer call to action than "Add a space". With `content-box` + `padding: 12px`, the full-width "Create a space" button rendered 24px wider than its container, so its hover background spilled past the section's rounded right edge (a square-cornered block poked out); `border-box` keeps the highlight clipped to the rounded corners. This reproduces in Chrome and Firefox since it's a box-model issue, not a browser quirk. Placing Spaces right under Recent gives it more prominence in the Feeds area.

## Testing Instructions

### Scenario 1 - Hover highlight stays inside the rounded container:
- Go to `/reader` and expand the **Spaces** section in the sidebar
- Hover the **Create a space** row
- Check that the highlight follows the rounded corners on the right edge with no rectangular block poking out (verify in both light and dark mode)

### Scenario 2 - Renamed row still opens the create flow:
- Go to `/reader`, expand **Spaces**, and click **Create a space**
- Check that the onboarding walkthrough (first time) or the "Create a new space" modal opens

### Scenario 3 - Sidebar order:
- Go to `/reader`
- Check that the sidebar lists **Spaces** immediately below **Recent**, above Organizations, Lists, and Tags

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?