### PR TITLE
Revert "Account recovery notice: only show when no backup is set, drop Gmail/Outlook suggestion"

### DIFF
--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -1,6 +1,5 @@
-import { accountRecoveryQuery, cancelPendingEmailChangeMutation } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { cancelPendingEmailChangeMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
 import { __experimentalInputControl as InputControl, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -98,17 +97,11 @@ export default function EmailSection( {
 		validateEmail( value );
 	}, [ value, validateEmail ] );
 
-	const { data: accountRecovery } = useQuery( accountRecoveryQuery() );
-	const isAccountRecoveryReady = accountRecovery !== undefined;
-	const hasRecoveryMethod = !! accountRecovery?.email || !! accountRecovery?.phone;
-
 	const showCustomDomainWarning =
 		! isEmailPending &&
 		!! value &&
 		emailValidator.validate( value ) &&
-		isCustomDomainEmail( value ) &&
-		isAccountRecoveryReady &&
-		! hasRecoveryMethod;
+		isCustomDomainEmail( value );
 
 	const getValidationClass = () => {
 		if ( isEmailPending ) {
@@ -158,16 +151,9 @@ export default function EmailSection( {
 			return (
 				<>
 					<Icon icon={ info } size={ 16 } />
-					<span>
-						{ createInterpolateElement(
-							__(
-								'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. <a>Set up a recovery email or phone number</a> to keep access to your account.'
-							),
-							{
-								a: <Link to="/me/security/account-recovery" />,
-							}
-						) }
-					</span>
+					{ __(
+						'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. Consider an email from a service like Gmail or Outlook instead.'
+					) }
 				</>
 			);
 		}

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -41,20 +41,6 @@ function mockIsAutomattician( isAutomattician: boolean ) {
 		} );
 }
 
-function mockAccountRecovery( {
-	email = '',
-	phone = null,
-}: { email?: string; phone?: object | null } = {} ) {
-	return nock( 'https://public-api.wordpress.com' )
-		.get( '/rest/v1.1/me/account-recovery' )
-		.reply( 200, {
-			email,
-			email_validated: false,
-			phone,
-			phone_validated: false,
-		} );
-}
-
 describe( '<PersonalDetailsSection>', () => {
 	test( 'renders the form and saves the form', async () => {
 		const user = userEvent.setup();
@@ -234,67 +220,16 @@ describe( '<PersonalDetailsSection>', () => {
 			} );
 		} );
 
-		test( 'warns when the account email uses a custom domain and no recovery method is set', async () => {
+		test( 'warns when the account email uses a custom domain', async () => {
 			mockUserSettings( {
 				...settings,
 				user_email: 'jane@mycustomdomain.com',
 			} as unknown as UserSettings );
 			mockIsAutomattician( false );
-			mockAccountRecovery();
 
 			render( <PersonalDetailsSection /> );
 
 			expect( await screen.findByText( /lose access to account recovery/i ) ).toBeVisible();
-		} );
-
-		test( 'links to the account recovery settings page', async () => {
-			mockUserSettings( {
-				...settings,
-				user_email: 'jane@mycustomdomain.com',
-			} as unknown as UserSettings );
-			mockIsAutomattician( false );
-			mockAccountRecovery();
-
-			render( <PersonalDetailsSection /> );
-
-			expect(
-				await screen.findByRole( 'link', { name: /set up a recovery email or phone number/i } )
-			).toHaveAttribute( 'href', '/me/security/account-recovery' );
-		} );
-
-		test( 'does not warn when a recovery email is already set', async () => {
-			mockUserSettings( {
-				...settings,
-				user_email: 'jane@mycustomdomain.com',
-			} as unknown as UserSettings );
-			mockIsAutomattician( false );
-			mockAccountRecovery( { email: 'backup@gmail.com' } );
-
-			render( <PersonalDetailsSection /> );
-
-			await screen.findByRole( 'textbox', { name: 'Email address' } );
-			expect( screen.queryByText( /lose access to account recovery/i ) ).not.toBeInTheDocument();
-		} );
-
-		test( 'does not warn when a recovery phone is already set', async () => {
-			mockUserSettings( {
-				...settings,
-				user_email: 'jane@mycustomdomain.com',
-			} as unknown as UserSettings );
-			mockIsAutomattician( false );
-			mockAccountRecovery( {
-				phone: {
-					country_code: 'US',
-					country_numeric_code: '+1',
-					number: '5551234',
-					number_full: '+15551234',
-				},
-			} );
-
-			render( <PersonalDetailsSection /> );
-
-			await screen.findByRole( 'textbox', { name: 'Email address' } );
-			expect( screen.queryByText( /lose access to account recovery/i ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'does not warn for a free email provider', async () => {
@@ -303,7 +238,6 @@ describe( '<PersonalDetailsSection>', () => {
 				user_email: 'jane@gmail.com',
 			} as unknown as UserSettings );
 			mockIsAutomattician( false );
-			mockAccountRecovery();
 
 			render( <PersonalDetailsSection /> );
 
@@ -317,7 +251,6 @@ describe( '<PersonalDetailsSection>', () => {
 				user_email: 'jane@mail.gmail.com',
 			} as unknown as UserSettings );
 			mockIsAutomattician( false );
-			mockAccountRecovery();
 
 			render( <PersonalDetailsSection /> );
 

--- a/client/me/account/account-email-field.tsx
+++ b/client/me/account/account-email-field.tsx
@@ -4,16 +4,10 @@ import { removeQueryArgs } from '@wordpress/url';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useDispatch, useSelector } from 'calypso/state';
-import {
-	getAccountRecoveryEmail,
-	getAccountRecoveryPhone,
-	isAccountRecoverySettingsReady,
-} from 'calypso/state/account-recovery/settings/selectors';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
@@ -171,34 +165,19 @@ const isCustomDomainEmail = ( email: string ): boolean => {
 
 const AccountEmailCustomDomainNotice = ( { email }: { email: string } ) => {
 	const translate = useTranslate();
-	const isSettingsReady = useSelector( isAccountRecoverySettingsReady );
-	const recoveryEmail = useSelector( getAccountRecoveryEmail );
-	const recoveryPhone = useSelector( getAccountRecoveryPhone );
 
 	if ( ! isCustomDomainEmail( email ) ) {
 		return null;
 	}
 
-	const hasRecoveryMethod = !! recoveryEmail || !! recoveryPhone;
-
 	return (
-		<>
-			<QueryAccountRecoverySettings />
-			{ isSettingsReady && ! hasRecoveryMethod && (
-				<FormInputValidation
-					isError={ false }
-					isWarning
-					text={ translate(
-						"This email uses a custom domain. If your domain expires, you'd lose access to account recovery. {{a}}Set up a recovery email or phone number{{/a}} to keep access to your account.",
-						{
-							components: {
-								a: <a href="/me/security/account-recovery" />,
-							},
-						}
-					) }
-				/>
+		<FormInputValidation
+			isError={ false }
+			isWarning
+			text={ translate(
+				"This email uses a custom domain. If your domain expires, you'd lose access to account recovery. Consider an email from a service like Gmail or Outlook instead."
 			) }
-		</>
+		/>
 	);
 };
 

--- a/client/me/account/test/account-email-field.tsx
+++ b/client/me/account/test/account-email-field.tsx
@@ -3,24 +3,11 @@
  */
 import { screen } from '@testing-library/react';
 import nock from 'nock';
-import accountRecoveryReducer from 'calypso/state/account-recovery/reducer';
 import userSettingsReducer from 'calypso/state/user-settings/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import AccountEmailField from '../account-email-field';
 
-jest.mock( 'calypso/components/data/query-account-recovery-settings', () => () => null );
-
-type RecoveryState = {
-	isReady?: boolean;
-	recoveryEmail?: string;
-	recoveryPhone?: object | null;
-};
-
-const buildInitialState = ( {
-	isReady = true,
-	recoveryEmail = '',
-	recoveryPhone = null,
-}: RecoveryState = {} ) => ( {
+const buildInitialState = () => ( {
 	currentUser: {
 		id: 1,
 		user: { ID: 1, email: 'user@gmail.com', email_verified: true },
@@ -31,33 +18,17 @@ const buildInitialState = ( {
 		updating: {},
 		failed: {},
 	},
-	accountRecovery: {
-		isFetchingSettings: false,
-		settings: {
-			data: {
-				email: recoveryEmail,
-				emailValidated: false,
-				phone: recoveryPhone,
-				phoneValidated: false,
-			},
-			isReady,
-			isUpdating: {},
-			isDeleting: {},
-			isValidatingPhone: false,
-			hasSentValidation: {},
-		},
-	},
 } );
 
-const renderFieldWithEmail = ( email: string, recoveryState: RecoveryState = {} ) =>
+const renderFieldWithEmail = ( email: string ) =>
 	renderWithProvider(
 		<AccountEmailField
 			userSettings={ { user_email: 'user@gmail.com' } }
 			unsavedUserSettings={ { user_email: email } }
 		/>,
 		{
-			initialState: buildInitialState( recoveryState ),
-			reducers: { userSettings: userSettingsReducer, accountRecovery: accountRecoveryReducer },
+			initialState: buildInitialState(),
+			reducers: { userSettings: userSettingsReducer },
 		}
 	);
 
@@ -88,7 +59,7 @@ describe( 'AccountEmailField — custom domain warning', () => {
 		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
 	} );
 
-	it( 'shows the warning for a custom domain when no recovery method is set', () => {
+	it( 'shows the warning for a custom domain', () => {
 		renderFieldWithEmail( 'me@my-custom-domain.com' );
 		expect( screen.getByText( WARNING_MATCHER ) ).toBeVisible();
 	} );
@@ -96,30 +67,6 @@ describe( 'AccountEmailField — custom domain warning', () => {
 	it( 'shows the warning for a custom domain case-insensitively', () => {
 		renderFieldWithEmail( 'me@MY-CUSTOM-DOMAIN.COM' );
 		expect( screen.getByText( WARNING_MATCHER ) ).toBeVisible();
-	} );
-
-	it( 'links to the account recovery settings page', () => {
-		renderFieldWithEmail( 'me@my-custom-domain.com' );
-		expect(
-			screen.getByRole( 'link', { name: /set up a recovery email or phone number/i } )
-		).toHaveAttribute( 'href', '/me/security/account-recovery' );
-	} );
-
-	it( 'does not show the warning when a recovery email is already set', () => {
-		renderFieldWithEmail( 'me@my-custom-domain.com', { recoveryEmail: 'backup@gmail.com' } );
-		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
-	} );
-
-	it( 'does not show the warning when a recovery phone is already set', () => {
-		renderFieldWithEmail( 'me@my-custom-domain.com', {
-			recoveryPhone: { countryCode: 'US', number: '5551234' },
-		} );
-		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
-	} );
-
-	it( 'does not show the warning before account recovery settings are ready', () => {
-		renderFieldWithEmail( 'me@my-custom-domain.com', { isReady: false } );
-		expect( screen.queryByText( WARNING_MATCHER ) ).toBeNull();
 	} );
 
 	it( 'does not show the warning for an empty email', () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112397 (if needed)