### PR TITLE
Cancellation flow: open chat with "contact us" button

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -14,7 +14,6 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Card } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
@@ -1261,7 +1260,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					<p className="cancel-purchase__support-text">
 						{ translate( 'Our support team is here for you. {{a}}Contact us{{/a}}', {
 							components: {
-								a: isSplitCancelRemoveEnabled ? (
+								a: (
 									<ContactSupportButton
 										purchase={ {
 											siteId: purchase.siteId,
@@ -1269,12 +1268,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 											productName: purchase.productName,
 										} }
 										displayVariant={ displayVariant }
-									/>
-								) : (
-									<a
-										href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
-										target="_blank"
-										rel="noopener noreferrer"
 									/>
 								),
 							},


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/SHILL-2232/

## Proposed Changes

This removes the feature flag gating for opening a support chat when the user clicks "Contact Us" inside the cancellation flow. This is the Calypso half of the change made in https://github.com/Automattic/wp-calypso/pull/112309. The original gating was added in https://github.com/Automattic/wp-calypso/pull/110344/ and at one point was running for 90% of users in the cancellation flow.

## Testing Instructions

* Visit Me > Purchases and select an active plan
* Click "Cancel plan"
* Click "Contact us" on the cancel-purchase confirm screen. Help Center opens with a pre-filled message reflecting the intent + product name.