### PR TITLE
MSD Survicate: publish per-area visit-count visitor traits

### DIFF
--- a/client/dashboard/app/hooks/test/use-visit-counter.test.tsx
+++ b/client/dashboard/app/hooks/test/use-visit-counter.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { isSameDay, usePersistentVisitCounter } from '../use-visit-counter';
+
+const DAY_IN_MS = 86400000;
+
+function createWrapper() {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+}
+
+function mockGetPreferences( preferences: Record< string, unknown > ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: preferences } );
+}
+
+function mockUpdatePreferences( matchCount: number ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/me/preferences', ( body ) => {
+			const counter = body?.calypso_preferences?.[ 'hosting-dashboard-visit-count-deployments' ];
+			return counter?.count === matchCount && typeof counter?.lastUpdated === 'number';
+		} )
+		.reply( 200, { calypso_preferences: {} } );
+}
+
+describe( 'isSameDay', () => {
+	test( 'is true for two timestamps in the same UTC day', () => {
+		const base = 5 * DAY_IN_MS;
+		expect( isSameDay( base, base + 1000 ) ).toBe( true );
+	} );
+
+	test( 'is false for timestamps on different days', () => {
+		const base = 5 * DAY_IN_MS;
+		expect( isSameDay( base, base + DAY_IN_MS ) ).toBe( false );
+	} );
+} );
+
+describe( 'usePersistentVisitCounter', () => {
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'increments to 1 on the first visit of a fresh day', async () => {
+		mockGetPreferences( {} );
+		const update = mockUpdatePreferences( 1 );
+
+		renderHook( () => usePersistentVisitCounter( 'deployments' ), { wrapper: createWrapper() } );
+
+		await waitFor( () => expect( update.isDone() ).toBe( true ) );
+	} );
+
+	test( 'increments from an existing count when last visit was a previous day', async () => {
+		mockGetPreferences( {
+			'hosting-dashboard-visit-count-deployments': {
+				count: 3,
+				lastUpdated: Date.now() - 2 * DAY_IN_MS,
+			},
+		} );
+		const update = mockUpdatePreferences( 4 );
+
+		renderHook( () => usePersistentVisitCounter( 'deployments' ), { wrapper: createWrapper() } );
+
+		await waitFor( () => expect( update.isDone() ).toBe( true ) );
+	} );
+
+	test( 'does not increment when already counted today', async () => {
+		const get = mockGetPreferences( {
+			'hosting-dashboard-visit-count-deployments': {
+				count: 3,
+				lastUpdated: Date.now(),
+			},
+		} );
+		// Any POST at all would count as a wrongful increment.
+		const update = nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/preferences' )
+			.reply( 200, { calypso_preferences: {} } );
+
+		renderHook( () => usePersistentVisitCounter( 'deployments' ), { wrapper: createWrapper() } );
+
+		await waitFor( () => expect( get.isDone() ).toBe( true ) );
+		await act( () => new Promise( ( resolve ) => setTimeout( resolve, 20 ) ) );
+
+		expect( update.isDone() ).toBe( false );
+	} );
+
+	test( 'does nothing when area is null', async () => {
+		const update = nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/preferences' )
+			.reply( 200, { calypso_preferences: {} } );
+
+		renderHook( () => usePersistentVisitCounter( null ), { wrapper: createWrapper() } );
+
+		await act( () => new Promise( ( resolve ) => setTimeout( resolve, 20 ) ) );
+
+		expect( update.isDone() ).toBe( false );
+	} );
+} );

--- a/client/dashboard/app/hooks/use-visit-counter.ts
+++ b/client/dashboard/app/hooks/use-visit-counter.ts
@@ -1,0 +1,72 @@
+import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useRouterState } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+import { resolveVisitAreaSlug } from '../survicate/visit-areas';
+
+const DAY_IN_MS = 86400000;
+
+/**
+ * Whether two `Date.now()`-style timestamps fall on the same calendar day
+ * (UTC-day boundaries, matching `client/state/persistent-counter`).
+ */
+export function isSameDay( a: number, b: number ): boolean {
+	return Math.floor( a / DAY_IN_MS ) === Math.floor( b / DAY_IN_MS );
+}
+
+/**
+ * Marks a visit to a dashboard area, incrementing its backend-persisted counter
+ * at most once per calendar day. The count is published to Survicate as a
+ * visitor trait by `useSurvicateVisitTraits`; see `app/survicate/visit-areas.ts`.
+ * @param area Slug from the `VISIT_AREAS` registry, or `null` for no tracked area.
+ */
+export function usePersistentVisitCounter( area: string | null ): void {
+	// Shares the `[ 'me', 'preferences' ]` query cache with every other
+	// preference consumer, so this never triggers an extra fetch. Disabled when
+	// there is no tracked area, so the placeholder key is never queried.
+	const preferenceName = `hosting-dashboard-visit-count-${ area ?? '' }` as const;
+	const { data: counter, isSuccess } = useQuery( {
+		...userPreferenceQuery( preferenceName ),
+		enabled: !! area,
+	} );
+	const { mutate } = useMutation( userPreferenceOptimisticMutation( preferenceName ) );
+
+	// Tracks the area value we last evaluated, so a given area is counted at most
+	// once per navigation to it — even when the optimistic update re-runs the
+	// effect or React StrictMode double-mounts.
+	const evaluatedFor = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( ! area || ! isSuccess ) {
+			return;
+		}
+		if ( evaluatedFor.current === area ) {
+			return;
+		}
+		evaluatedFor.current = area;
+
+		const now = Date.now();
+		const lastUpdated = counter?.lastUpdated ?? null;
+		if ( lastUpdated !== null && isSameDay( lastUpdated, now ) ) {
+			return;
+		}
+
+		mutate( {
+			count: ( counter?.count ?? 0 ) + 1,
+			lastUpdated: now,
+		} );
+	}, [ area, isSuccess, counter, mutate ] );
+}
+
+/**
+ * Resolves the current dashboard route to a visit-area and marks a visit to it.
+ * Mounted once inside the router tree (the root route component).
+ */
+export function useTrackVisitedAreas(): void {
+	const enabled = config( 'survicate_enabled' );
+	const area = useRouterState( {
+		select: ( state ) => resolveVisitAreaSlug( state.location.pathname ),
+	} );
+	usePersistentVisitCounter( enabled ? area : null );
+}

--- a/client/dashboard/app/hooks/use-visit-counter.ts
+++ b/client/dashboard/app/hooks/use-visit-counter.ts
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouterState } from '@tanstack/react-router';
 import { useEffect, useRef } from 'react';
+import { useAppContext } from '../context';
 import { resolveVisitAreaSlug } from '../survicate/visit-areas';
 
 const DAY_IN_MS = 86400000;
@@ -65,8 +66,9 @@ export function usePersistentVisitCounter( area: string | null ): void {
  */
 export function useTrackVisitedAreas(): void {
 	const enabled = config( 'survicate_enabled' );
+	const { basePath } = useAppContext();
 	const area = useRouterState( {
-		select: ( state ) => resolveVisitAreaSlug( state.location.pathname ),
+		select: ( state ) => resolveVisitAreaSlug( state.location.pathname, basePath ),
 	} );
 	usePersistentVisitCounter( enabled ? area : null );
 }

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -18,7 +18,7 @@ import { dashboardChartTheme } from './chart-theme';
 import { AppProvider, useAppContext } from './context';
 import { I18nProvider } from './i18n';
 import { getRouter } from './router';
-import { useSurvicate } from './survicate';
+import { useSurvicate, useSurvicateVisitTraits } from './survicate';
 import type { AppConfig } from './context';
 
 function AnalyticsProviderWithClient( {
@@ -68,6 +68,7 @@ function AnalyticsProviderWithClient( {
 	);
 
 	useSurvicate();
+	useSurvicateVisitTraits();
 
 	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;
 }

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -19,6 +19,7 @@ import AccountRecoveryInterstitial from '../account-recovery-interstitial';
 import { bumpStat } from '../analytics';
 import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
+import { useTrackVisitedAreas } from '../hooks/use-visit-counter';
 import OmnibarAgentsManager from '../interim-omnibar/omnibar-agents-manager';
 import OmnibarHelpCenter from '../interim-omnibar/omnibar-help-center';
 import { NavigationBlockerRegistry } from '../navigation-blocker';
@@ -57,6 +58,7 @@ function Root() {
 	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
 
 	useInitializeOmnibarSite();
+	useTrackVisitedAreas();
 	useOmnibarEvent( 'mobileMenu', () => setIsSidebarOpen( ( v ) => ! v ) );
 	useOmnibarEvent( 'linkClick', ( { href, event } ) => {
 		const url = new URL( href, window.location.origin );

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -1,3 +1,4 @@
+import { rawUserPreferencesQuery } from '@automattic/api-queries';
 // eslint-disable-next-line no-restricted-imports
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
@@ -8,10 +9,12 @@ import {
 	getAccountAgeInDays,
 	SURVICATE_WORKSPACE_ID,
 } from '@automattic/survicate';
+import { useQuery } from '@tanstack/react-query';
 import { useViewportMatch } from '@wordpress/compose';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAuth } from '../auth';
 import { useLocale } from '../locale';
+import { VISIT_AREAS } from './visit-areas';
 
 export function useSurvicate() {
 	const { user } = useAuth();
@@ -60,4 +63,54 @@ export function useSurvicate() {
 			controller.abort();
 		};
 	}, [ user, locale, isMobile ] );
+}
+
+/**
+ * Publishes per-area visit counts to Survicate as visitor traits, so surveys
+ * can target users who have visited an area at least X times (the threshold is
+ * configured per survey in the Survicate dashboard). Counts are maintained by
+ * `usePersistentVisitCounter`; the trait mapping lives in `visit-areas.ts`.
+ *
+ * Decoupled from incrementing: this reads the visit-count preferences and
+ * re-pushes whenever they change. Relies on `useSurvicate` to load the script;
+ * `setSurvicateVisitorTraits` defers until `SurvicateReady` if needed.
+ */
+export function useSurvicateVisitTraits() {
+	const locale = useLocale();
+	const isMobile = useViewportMatch( 'mobile', '<' );
+	const { data: preferences } = useQuery( rawUserPreferencesQuery() );
+
+	const traits = useMemo( () => {
+		const result: Record< string, number > = {};
+		if ( preferences ) {
+			for ( const area of VISIT_AREAS ) {
+				const counter = preferences[ `hosting-dashboard-visit-count-${ area.slug }` ];
+				if ( counter && counter.count > 0 ) {
+					result[ area.trait ] = counter.count;
+				}
+			}
+		}
+		return result;
+	}, [ preferences ] );
+
+	const traitsKey = JSON.stringify( traits );
+
+	useEffect( () => {
+		if ( ! config( 'survicate_enabled' ) ) {
+			return;
+		}
+
+		if ( ! shouldLoadSurvicate( { locale, isMobile } ) ) {
+			return;
+		}
+
+		if ( Object.keys( traits ).length === 0 ) {
+			return;
+		}
+
+		return setSurvicateVisitorTraits( traits );
+		// `traits` is captured via its serialized `traitsKey` to avoid re-pushing
+		// on unrelated preference changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ traitsKey, locale, isMobile ] );
 }

--- a/client/dashboard/app/survicate/test/visit-areas.test.ts
+++ b/client/dashboard/app/survicate/test/visit-areas.test.ts
@@ -1,0 +1,52 @@
+import { resolveVisitAreaSlug } from '../visit-areas';
+
+describe( 'resolveVisitAreaSlug', () => {
+	test.each( [
+		[ '/sites', 'sites-list' ],
+		[ '/sites/', 'sites-list' ],
+		[ '/sites/example.com', 'site-overview' ],
+		[ '/sites/example.com/', 'site-overview' ],
+		[ '/sites/example.com/deployments', 'deployments' ],
+		[ '/sites/example.com/deployments/manage/123', 'deployments' ],
+		[ '/sites/example.com/monitoring', 'logs-monitoring' ],
+		[ '/sites/example.com/logs', 'logs-monitoring' ],
+		[ '/sites/example.com/logs/php', 'logs-monitoring' ],
+		[ '/sites/example.com/logs/server', 'logs-monitoring' ],
+		[ '/sites/example.com/backups', 'backups-activity' ],
+		[ '/sites/example.com/backups/123/restore', 'backups-activity' ],
+		[ '/sites/example.com/performance', 'performance' ],
+		[ '/sites/example.com/performance/backend/database', 'performance' ],
+		[ '/domains', 'domains' ],
+		[ '/domains/example.com/dns', 'domains' ],
+		[ '/emails', 'emails' ],
+		[ '/emails/choose-domain', 'emails' ],
+		[ '/me', 'account' ],
+		[ '/me/billing/purchases', 'account' ],
+	] )( 'maps %s to %s', ( pathname, expected ) => {
+		expect( resolveVisitAreaSlug( pathname ) ).toBe( expected );
+	} );
+
+	test( 'resolves logs/activity to backups-activity, not logs-monitoring', () => {
+		expect( resolveVisitAreaSlug( '/sites/example.com/logs/activity' ) ).toBe( 'backups-activity' );
+	} );
+
+	test.each( [
+		[ '/sites/example.com/settings/sftp-ssh' ],
+		[ '/sites/example.com/settings/php' ],
+		[ '/sites/example.com/settings/database' ],
+		[ '/sites/example.com/settings/caching' ],
+	] )( 'maps hosting setting %s to server-config', ( pathname ) => {
+		expect( resolveVisitAreaSlug( pathname ) ).toBe( 'server-config' );
+	} );
+
+	test.each( [
+		[ '/sites/example.com/settings' ],
+		[ '/sites/example.com/settings/wordpress' ],
+		[ '/sites/example.com/scan' ],
+		[ '/sites/example.com/plans' ],
+		[ '/' ],
+		[ '/reader' ],
+	] )( 'returns null for untracked path %s', ( pathname ) => {
+		expect( resolveVisitAreaSlug( pathname ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/app/survicate/test/visit-areas.test.ts
+++ b/client/dashboard/app/survicate/test/visit-areas.test.ts
@@ -31,6 +31,15 @@ describe( 'resolveVisitAreaSlug', () => {
 	} );
 
 	test.each( [
+		[ '/newproduct/sites', '/newproduct', 'sites-list' ],
+		[ '/newproduct/sites/example.com/deployments', '/newproduct', 'deployments' ],
+		[ '/newproduct/domains', 'newproduct', 'domains' ],
+		[ '/sites', '/', 'sites-list' ],
+	] )( 'strips basePath %s (%s)', ( pathname, basePath, expected ) => {
+		expect( resolveVisitAreaSlug( pathname, basePath ) ).toBe( expected );
+	} );
+
+	test.each( [
 		[ '/sites/example.com/settings/sftp-ssh' ],
 		[ '/sites/example.com/settings/php' ],
 		[ '/sites/example.com/settings/database' ],

--- a/client/dashboard/app/survicate/test/visit-traits.test.tsx
+++ b/client/dashboard/app/survicate/test/visit-traits.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import config from '@automattic/calypso-config';
+import { shouldLoadSurvicate, setSurvicateVisitorTraits } from '@automattic/survicate';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
+import nock from 'nock';
+import { AuthContext } from '../../auth';
+import { useSurvicateVisitTraits } from '../index';
+import type { User } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const fn = jest.fn();
+	return Object.assign( fn, { __esModule: true, default: fn, isEnabled: jest.fn() } );
+} );
+
+jest.mock( '@automattic/survicate', () => ( {
+	shouldLoadSurvicate: jest.fn(),
+	setSurvicateVisitorTraits: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
+
+const mockedConfig = jest.mocked( config );
+const mockedShouldLoad = jest.mocked( shouldLoadSurvicate );
+const mockedSetTraits = jest.mocked( setSurvicateVisitorTraits );
+const mockedUseViewportMatch = jest.mocked( useViewportMatch );
+
+const user = { ID: 1, email: 'test@example.com', language: 'en' } as User;
+
+function mockGetPreferences( preferences: Record< string, unknown > ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: preferences } );
+}
+
+function renderTraitsHook() {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return renderHook( () => useSurvicateVisitTraits(), {
+		wrapper: ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>
+				<AuthContext.Provider value={ { user, logout: jest.fn() } }>
+					{ children }
+				</AuthContext.Provider>
+			</QueryClientProvider>
+		),
+	} );
+}
+
+describe( 'useSurvicateVisitTraits', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedSetTraits.mockReturnValue( jest.fn() );
+		mockedConfig.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( true );
+		mockedUseViewportMatch.mockReturnValue( false );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'pushes a trait per area with a positive count', async () => {
+		mockGetPreferences( {
+			'hosting-dashboard-visit-count-deployments': { count: 5, lastUpdated: 1 },
+			'hosting-dashboard-visit-count-domains': { count: 2, lastUpdated: 1 },
+		} );
+
+		renderTraitsHook();
+
+		await waitFor( () =>
+			expect( mockedSetTraits ).toHaveBeenCalledWith( {
+				msd_visits_deployments: 5,
+				msd_visits_domains: 2,
+			} )
+		);
+	} );
+
+	test( 'skips areas with a zero count', async () => {
+		mockGetPreferences( {
+			'hosting-dashboard-visit-count-deployments': { count: 0, lastUpdated: 1 },
+			'hosting-dashboard-visit-count-domains': { count: 3, lastUpdated: 1 },
+		} );
+
+		renderTraitsHook();
+
+		await waitFor( () =>
+			expect( mockedSetTraits ).toHaveBeenCalledWith( { msd_visits_domains: 3 } )
+		);
+		expect( mockedSetTraits ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { msd_visits_deployments: expect.anything() } )
+		);
+	} );
+
+	test( 'does not push when there are no visited areas', async () => {
+		mockGetPreferences( {} );
+
+		renderTraitsHook();
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		expect( mockedSetTraits ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not push when Survicate is disabled', async () => {
+		mockedConfig.mockReturnValue( false );
+		mockGetPreferences( {
+			'hosting-dashboard-visit-count-deployments': { count: 5, lastUpdated: 1 },
+		} );
+
+		renderTraitsHook();
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		expect( mockedSetTraits ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not push when the locale/mobile gate fails', async () => {
+		mockedShouldLoad.mockReturnValue( false );
+		mockGetPreferences( {
+			'hosting-dashboard-visit-count-deployments': { count: 5, lastUpdated: 1 },
+		} );
+
+		renderTraitsHook();
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		expect( mockedSetTraits ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/app/survicate/visit-areas.ts
+++ b/client/dashboard/app/survicate/visit-areas.ts
@@ -4,8 +4,9 @@
  * X times. The "≥ X" threshold is configured per survey in the Survicate
  * dashboard, not here.
  *
- * To track a new area: add an entry here and call
- * `usePersistentVisitCounter( '<slug>' )` from that area's route component.
+ * To track a new area: add an entry here and a matching case in
+ * `resolveVisitAreaSlug` below. Counting is route-driven via
+ * `useTrackVisitedAreas`; no per-route wiring is needed.
  */
 
 export interface VisitArea {
@@ -36,9 +37,16 @@ const SERVER_CONFIG_SETTINGS = new Set( [ 'sftp-ssh', 'php', 'database', 'cachin
  * the pathname is not a tracked area. Resolution is by the deepest meaningful
  * path segment, so overlapping routes (e.g. `logs/activity` sitting under the
  * logs route) resolve to the most specific area.
+ *
+ * `pathname` is the router's `location.pathname`, which includes the entry
+ * point's `basePath` — strip it so matching is relative to the app root.
  */
-export function resolveVisitAreaSlug( pathname: string ): string | null {
+export function resolveVisitAreaSlug( pathname: string, basePath = '' ): string | null {
 	const parts = pathname.split( '/' ).filter( Boolean );
+	const baseParts = basePath.split( '/' ).filter( Boolean );
+	if ( baseParts.every( ( segment, i ) => parts[ i ] === segment ) ) {
+		parts.splice( 0, baseParts.length );
+	}
 
 	if ( parts[ 0 ] === 'sites' ) {
 		if ( parts.length === 1 ) {

--- a/client/dashboard/app/survicate/visit-areas.ts
+++ b/client/dashboard/app/survicate/visit-areas.ts
@@ -1,0 +1,79 @@
+/**
+ * Registry of dashboard areas whose visit counts are published to Survicate as
+ * visitor traits, so surveys can target users who have visited an area at least
+ * X times. The "≥ X" threshold is configured per survey in the Survicate
+ * dashboard, not here.
+ *
+ * To track a new area: add an entry here and call
+ * `usePersistentVisitCounter( '<slug>' )` from that area's route component.
+ */
+
+export interface VisitArea {
+	/** Suffix of the `hosting-dashboard-visit-count-<slug>` preference key. */
+	slug: string;
+	/** Survicate visitor trait that receives the area's visit count. */
+	trait: string;
+}
+
+export const VISIT_AREAS: VisitArea[] = [
+	{ slug: 'sites-list', trait: 'msd_visits_sites_list' },
+	{ slug: 'site-overview', trait: 'msd_visits_site_overview' },
+	{ slug: 'deployments', trait: 'msd_visits_deployments' },
+	{ slug: 'logs-monitoring', trait: 'msd_visits_logs_monitoring' },
+	{ slug: 'backups-activity', trait: 'msd_visits_backups_activity' },
+	{ slug: 'performance', trait: 'msd_visits_performance' },
+	{ slug: 'server-config', trait: 'msd_visits_server_config' },
+	{ slug: 'domains', trait: 'msd_visits_domains' },
+	{ slug: 'emails', trait: 'msd_visits_emails' },
+	{ slug: 'account', trait: 'msd_visits_account' },
+];
+
+// Site-settings children counted as the "server-config" (hosting config) area.
+const SERVER_CONFIG_SETTINGS = new Set( [ 'sftp-ssh', 'php', 'database', 'caching' ] );
+
+/**
+ * Maps a dashboard pathname to the visit-area slug it belongs to, or `null` if
+ * the pathname is not a tracked area. Resolution is by the deepest meaningful
+ * path segment, so overlapping routes (e.g. `logs/activity` sitting under the
+ * logs route) resolve to the most specific area.
+ */
+export function resolveVisitAreaSlug( pathname: string ): string | null {
+	const parts = pathname.split( '/' ).filter( Boolean );
+
+	if ( parts[ 0 ] === 'sites' ) {
+		if ( parts.length === 1 ) {
+			return 'sites-list';
+		}
+		if ( parts.length === 2 ) {
+			return 'site-overview';
+		}
+		switch ( parts[ 2 ] ) {
+			case 'deployments':
+				return 'deployments';
+			case 'monitoring':
+				return 'logs-monitoring';
+			case 'logs':
+				return parts[ 3 ] === 'activity' ? 'backups-activity' : 'logs-monitoring';
+			case 'backups':
+				return 'backups-activity';
+			case 'performance':
+				return 'performance';
+			case 'settings':
+				return SERVER_CONFIG_SETTINGS.has( parts[ 3 ] ) ? 'server-config' : null;
+			default:
+				return null;
+		}
+	}
+
+	if ( parts[ 0 ] === 'domains' ) {
+		return 'domains';
+	}
+	if ( parts[ 0 ] === 'emails' ) {
+		return 'emails';
+	}
+	if ( parts[ 0 ] === 'me' ) {
+		return 'account';
+	}
+
+	return null;
+}

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -17,6 +17,11 @@ export interface ReaderLandingPage extends LandingPagePreference {
 	useReaderAsLandingPage: boolean;
 }
 
+export interface VisitCounter {
+	count: number;
+	lastUpdated: number | null; // Result of Date.now(), or null before the first visit
+}
+
 export interface UserPreferences {
 	recentSites?: number[];
 	'hosting-dashboard-color-scheme'?: 'light' | 'dark' | 'system';
@@ -24,6 +29,7 @@ export interface UserPreferences {
 	'hosting-dashboard-dark-mode-announcement-dismissed'?: string; // Timestamp when the user dismissed the notice
 	'hosting-dashboard-opt-in-welcome-modal-dismissed'?: string; // Timestamp when the user dismissed the modal
 	[ key: `hosting-dashboard-dataviews-view-${ string }` ]: View | undefined;
+	[ key: `hosting-dashboard-visit-count-${ string }` ]: VisitCounter | undefined;
 	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
 	[ key: `hosting-dashboard-tours-${ string }` ]: string; // ISO date string when the user completed the tours
 	[ key: `hosting-dashboard-time-mismatch-warning-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice

--- a/packages/survicate/AGENTS.md
+++ b/packages/survicate/AGENTS.md
@@ -42,6 +42,35 @@ and each needs its own guard:
    "show after N seconds", etc.). This **never touches our code**, so an invoke-time
    guard can't catch it. The only universal hook is the SDK's `survey_displayed` event.
 
+## Visit-count traits (area-based survey targeting)
+
+To show a survey only after a user has visited a dashboard area at least X times
+(reducing survey overload and giving users enough exposure to answer), the MSD
+publishes a per-area visit count as a numeric visitor trait. The "≥ X" threshold
+is configured **per survey in the Survicate dashboard**, not in code — so it's
+tunable without a deploy, and multi-area audiences (`msd_visits_a >= 3 AND
+msd_visits_b >= 3`) need no code change.
+
+- **Registry / resolver**: `client/dashboard/app/survicate/visit-areas.ts` —
+  `VISIT_AREAS` maps each area slug to its `msd_visits_<slug>` trait;
+  `resolveVisitAreaSlug( pathname )` maps a route to its area (deepest match
+  wins, so overlaps like `logs/activity` resolve correctly). Add an area by
+  adding a registry entry and a resolver case — nothing else changes.
+- **Counting**: `client/dashboard/app/hooks/use-visit-counter.ts` —
+  `useTrackVisitedAreas()` (mounted once in the root route component) increments
+  the current area's counter at most once per calendar day, persisted to the
+  `hosting-dashboard-visit-count-<slug>` user preference. Gated on
+  `survicate_enabled`.
+- **Publishing**: `useSurvicateVisitTraits()` in
+  `client/dashboard/app/survicate/index.tsx` (mounted in the layout) reads those
+  preferences and pushes `{ msd_visits_<slug>: count }` via
+  `setSurvicateVisitorTraits`, re-pushing when counts change. Incrementing and
+  publishing are deliberately decoupled — they share only the preference store.
+
+`setSurvicateVisitorTraits` accepts an arbitrary `Record<string, string | number>`,
+so any trait (email, account age, visit counts) flows through the same
+deferred-until-`SurvicateReady` path.
+
 ## Help Center coordination (defense-in-depth)
 
 Surveys must not cover the Help Center while a user is actively seeking support. Three

--- a/packages/survicate/AGENTS.md
+++ b/packages/survicate/AGENTS.md
@@ -71,6 +71,24 @@ msd_visits_b >= 3`) need no code change.
 so any trait (email, account age, visit counts) flows through the same
 deferred-until-`SurvicateReady` path.
 
+### Two separate trait pushes are expected
+
+Visitor traits are published from **two** independent `setSurvicateVisitorTraits`
+call sites, and this is intentional — don't consolidate them into one:
+
+- `useSurvicate` pushes **identity** traits (`email`, `account_age_in_days`) once
+  from the authenticated user, right after the script loads, next to the
+  `calypso_survicate_user_not_available_error` tracks event that fires when the
+  email is missing at load time.
+- `useSurvicateVisitTraits` pushes **behavioral** traits (`msd_visits_<slug>`)
+  reactively, re-pushing whenever a preference-backed visit count changes.
+
+They have different sources and lifecycles (set-once identity vs. reactive
+counts), so keeping them apart keeps each concern where it belongs. This is safe
+because `_sva.setVisitorTraits` **merges** traits across calls (upsert), rather
+than replacing the whole set — so the visit-count push does not clobber the
+email/account-age traits, and vice versa.
+
 ## Help Center coordination (defense-in-depth)
 
 Surveys must not cover the Help Center while a user is actively seeking support. Three

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -28,10 +28,7 @@ export function getAccountAgeInDays( registrationDate: string ): number {
  * Otherwise, waits for the `SurvicateReady` window event before setting traits.
  * @returns A cleanup function that removes the event listener.
  */
-export function setSurvicateVisitorTraits( traits: {
-	email: string;
-	account_age_in_days?: number;
-} ): () => void {
+export function setSurvicateVisitorTraits( traits: Record< string, string | number > ): () => void {
 	const setTraits = function () {
 		if ( typeof window._sva !== 'undefined' && window._sva.setVisitorTraits ) {
 			window._sva.setVisitorTraits( traits );


### PR DESCRIPTION
Task-related: DOTOBRD-511


## Proposed Changes

Add **area-based Survicate survey targeting** to the Multi-site Dashboard (MSD).

- Track how many distinct **days** a user has visited each product area (once-per-day, backend-persisted under a per-area `hosting-dashboard-visit-count-<slug>` preference).
- Publish the counts to Survicate as numeric `msd_visits_<area>` visitor traits.
- Surveys target users with a per-survey **"at least X visits"** threshold configured in the Survicate dashboard — tunable without a deploy, and multi-area audiences (`msd_visits_a >= 3 AND msd_visits_b >= 3`) need no code change.

Two responsibilities, deliberately decoupled (they share only the preference store):
1. **Counting** — `useTrackVisitedAreas()` mounted once in the root route component; resolves the current route to an area via `resolveVisitAreaSlug()` and increments at most once per day.
2. **Publishing** — `useSurvicateVisitTraits()` mounted in the layout; reads the visit-count preferences and re-pushes traits when counts change.

`setSurvicateVisitorTraits` is generalized to accept `Record<string, string | number>` so the existing `email`/`account_age_in_days` caller and the new visit-count caller share one deferred-until-`SurvicateReady` path.

Adding an area is one `VISIT_AREAS` registry entry plus a resolver case — nothing else changes.

## Why are these changes being made?

To reduce survey overload: don't ask on a user's first visit, and give users enough exposure to an area to answer meaningfully. Keeping the threshold in Survicate (not code) lets it be tuned per survey without a deploy.

## Testing Instructions

- Enable Survicate debug with `localStorage.setItem('debug', 'survicate')`
- Navigate between MSD areas on separate days and confirm `msd_visits_<area>` traits appear on the visitor in Survicate; visiting the same area twice in one day does not double-count.
     <img width="587" height="201" alt="image" src="https://github.com/user-attachments/assets/c3d9c4c2-2d59-461b-be67-ff6e4bf4777c" />

     **Note**: It's okay to have two calls as Survicate merges them. This is needed to simplify the code, since they occur at two different times.

- Check if the division logic makes sense
- Check if we're not making too many backend requests to save the state

- Inside Survicate, we should see the user's data:
     <img width="328" height="270" alt="image" src="https://github.com/user-attachments/assets/87c9144c-944d-436c-b99b-e4ae0c153127" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode? <!-- no UI changes -->
- [ ] Have you tested accessibility for your changes? <!-- no UI changes -->
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label? <!-- no new user-facing strings -->
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

---

_Draft opened by an automated review-and-fix loop._ Two working-tree changes were **intentionally excluded** as out-of-scope for this feature: a `.gitignore` addition for `.claude/settings.local.json` (local Claude tooling) and `docs/plans/…-design.md` (internal design doc; `docs/plans/` is not a tracked path in trunk). Say the word to fold either in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
