### PR TITLE
Login: brand the push two-step screen as the Jetpack app

### DIFF
--- a/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
+++ b/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
@@ -14,9 +14,7 @@ export default function WaitingTwoFactorNotificationApproval( { switchTwoFactorA
 		<Fragment>
 			<Card className="two-factor-authentication__push-notification-approval">
 				<p className="two-factor-authentication__info">
-					{ translate(
-						'Check your device. Approve your login with the Jetpack or WordPress mobile app.'
-					) }
+					{ translate( 'Check your device. Approve your login with the Jetpack mobile app.' ) }
 				</p>
 				<PushNotificationIllustration />
 				<FormDivider isHorizontal />

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -27,6 +27,7 @@ import {
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 import getIsPassport from 'calypso/state/selectors/get-is-passport';
@@ -44,6 +45,11 @@ const MOBILE_APP_LOGO_URLS = {
 		'https://i0.wp.com/developer.files.wordpress.com/2026/07/wordpress_app_icon.png?w=128',
 };
 
+// The push 2FA screen is approved from the Jetpack mobile app on another device,
+// so it is always branded as Jetpack, regardless of which client began the login.
+const JETPACK_PUSH_LOGO_URL =
+	'https://i0.wp.com/developer.files.wordpress.com/2026/07/appicon-ios-default-1024401x-1.png?w=128';
+
 interface Props {
 	isJetpack?: boolean;
 	isFromJetpackConnector?: boolean;
@@ -56,7 +62,11 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 	const isAkismet = useSelector( getIsAkismet );
 	const isPassport = useSelector( getIsPassport );
 	const isJetpackApp = useSelector( getIsJetpackApp );
+	const currentRoute = useSelector( getCurrentRoute );
 	const { hasCustomBranding } = usePartnerBranding();
+
+	// The push 2FA screen (`/log-in/push`) is authorized from the Jetpack mobile app.
+	const isPushTwoFactor = currentRoute?.split( '/' ).includes( 'push' ) ?? false;
 
 	// If partner has custom top-left branding, don't show center logo
 	if ( hasCustomBranding ) {
@@ -64,7 +74,9 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 	}
 
 	let logo = null;
-	if ( isStudioAppOAuth2Client( oauth2Client ) ) {
+	if ( isPushTwoFactor ) {
+		logo = <img src={ JETPACK_PUSH_LOGO_URL } alt="Jetpack" />;
+	} else if ( isStudioAppOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ studioAppLogo } alt="Studio App Logo" />;
 	} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ crowdsignalLogo } alt="Crowdsignal Logo" />;


### PR DESCRIPTION
## Proposed Changes

Two commits — brand the push two-step screen (`/log-in/push`) for the Jetpack app:

- **Logo** (`client/login/wp-login/components/heading-logo.tsx`): render the Jetpack app icon as the centered heading logo on the push screen, overriding the per-initiating-client logo. Keyed off the `/log-in/push` route, so it applies however the screen is reached — including a plain browser login, which previously showed no centered logo at all.
- **Copy** (`client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx`): change the approval instruction from "the Jetpack or WordPress mobile app" to "the Jetpack mobile app".

Introduces **1 new translatable string** — the "[Status] String Freeze" label should be added.

Builds on #112392, which added the OAuth2 login-screen app branding and the `MOBILE_APP_LOGO_URLS` infrastructure this reuses.

## Why are these changes being made?

The push two-step screen is where you **authorize** a login that was started somewhere else — a browser, or another device. The mobile app isn't the client that initiated the login; it's the thing you approve *with*. Two consequences:

- The centered logo used to reflect whichever OAuth client began the login (the WordPress app icon for a WordPress-app flow; nothing at all for a plain browser login). That's the wrong signal on this screen — the relevant app is the Jetpack app you approve in. The heading already hardcodes "Continue with the Jetpack app"; the logo now matches it.
- The body copy still read "the Jetpack or WordPress mobile app", contradicting the Jetpack-only heading. Push approval is Jetpack-only, so the copy is now "the Jetpack mobile app".

The logo override is scoped to the push route only — the other two-step screens and the normal login screen keep the existing per-client branding.

## Testing Instructions

- [ ] Log out, then start a login for a WordPress.com account that has push (mobile app) two-step enabled, so you land on `/log-in/push`.
- [ ] The centered logo above the "Continue with the Jetpack app" heading is the green Jetpack app icon — present even for a plain browser login (no OAuth client).
- [ ] The body copy reads "Check your device. Approve your login with the Jetpack mobile app."
- [ ] Regression: the other two-step screens (`/log-in/authenticator`, `/sms`, `/email`, `/backup`, `/webauthn`) and the normal login screen are visually unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

The logged-out `/log-in/push` screen — the centered logo becomes the Jetpack app icon and the approval copy drops the "or WordPress" wording.

| Before (`trunk`) | After (this PR) |
|:---:|:---:|
| <img width="450" alt="/log-in/push on trunk: blue WordPress app icon above the heading" src="https://github.com/user-attachments/assets/611a0b36-56ee-45d4-9402-fbc83c41b504" /> | <img width="450" alt="/log-in/push on this PR: green Jetpack app icon above the heading" src="https://github.com/user-attachments/assets/fa732305-1622-426e-b1b9-68ca884e4e5a" /> |
| WordPress app icon; copy reads "…the Jetpack **or WordPress** mobile app." | Jetpack app icon; copy reads "…the Jetpack mobile app." |
