### PR TITLE
Reader: Add mark all as seen on sidebar

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -43,7 +43,7 @@ const ExpandableSidebarHeading = ( {
 			{ undefined !== customIcon && customIcon }
 			<span className="sidebar__expandable-title">
 				{ decodeEntities( title ) }
-				<span className="sidebar__menu-item-more-menu">
+				<span className="sidebar__actions-and-count">
 					{ moreMenuActions }
 					{ count > 0 && <Count count={ count } /> }
 				</span>

--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -21,6 +21,7 @@ const ExpandableSidebarHeading = ( {
 	expandableIconClick,
 	prependContent,
 	appendContent,
+	moreMenuActions,
 	...props
 } ) => {
 	const translate = useTranslate();
@@ -42,7 +43,10 @@ const ExpandableSidebarHeading = ( {
 			{ undefined !== customIcon && customIcon }
 			<span className="sidebar__expandable-title">
 				{ decodeEntities( title ) }
-				{ undefined !== count && <Count count={ count } /> }
+				<span className="sidebar__menu-item-more-menu">
+					{ moreMenuActions }
+					{ count > 0 && <Count count={ count } /> }
+				</span>
 				{ inlineText && <span className="sidebar__inline-text">{ inlineText }</span> }
 			</span>
 			{ appendContent }
@@ -83,6 +87,7 @@ ExpandableSidebarHeading.propTypes = {
 	expandableIconClick: PropTypes.func,
 	prependContent: PropTypes.node,
 	appendContent: PropTypes.node,
+	moreMenuActions: PropTypes.node,
 };
 
 export default ExpandableSidebarHeading;

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -50,6 +50,7 @@ export const ExpandableSidebarMenu = ( menuProps ) => {
 		disableFlyout,
 		prependContent,
 		appendContent,
+		moreMenuActions,
 		...props
 	} = menuProps;
 	let { expanded } = props;
@@ -128,6 +129,7 @@ export const ExpandableSidebarMenu = ( menuProps ) => {
 					menuId={ menuId }
 					prependContent={ prependContent }
 					appendContent={ appendContent }
+					moreMenuActions={ moreMenuActions }
 					{ ...props }
 				/>
 				<li
@@ -158,6 +160,7 @@ ExpandableSidebarMenu.propTypes = {
 	expandableIconClick: PropTypes.func,
 	prependContent: PropTypes.node,
 	appendContent: PropTypes.node,
+	moreMenuActions: PropTypes.node,
 	children: PropTypes.node,
 };
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -257,7 +257,7 @@
 		flex: 1 1 0;
 	}
 
-	.sidebar__menu-item-more-menu {
+	.sidebar__actions-and-count {
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -257,6 +257,18 @@
 		flex: 1 1 0;
 	}
 
+	.sidebar__menu-item-more-menu {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-inline-start: 8px;
+		justify-content: flex-end;
+
+		.a8c-count {
+			margin-left: 0;
+		}
+	}
+
 	.sidebar__expandable-arrow {
 		transition: transform 0.1s linear;
 		fill: var(--color-sidebar-gridicon-fill);

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -61,24 +61,30 @@ export const useOrganizationSiteSubscriptions = ( organizationId: number ) => {
 	return getOrganizationSiteSubscriptionsFromData( data, organizationId );
 };
 
+interface FeedsInfo {
+	unseenCount: number;
+	feedIds: number[];
+	feedUrls: string[];
+}
+
+const getFeedsInfo = ( sites: SiteSubscriptionItem[] ): FeedsInfo => ( {
+	unseenCount: sites.reduce( ( sum, item ) => sum + ( item.unseen_count ?? 0 ), 0 ),
+	feedIds: sites
+		.map( ( item ) => ( item.feed_ID ? Number( item.feed_ID ) : null ) )
+		.filter( ( id ) => typeof id === 'number' ),
+	feedUrls: sites.map( ( item ) => item.feed_URL ).filter( Boolean ),
+} );
+
 export const useOrganizationFeedsInfo = ( organizationId: number ) => {
 	const sites = useOrganizationSiteSubscriptions( organizationId );
 
-	return {
-		unseenCount: sites.reduce( ( sum, item ) => sum + ( item.unseen_count ?? 0 ), 0 ),
-		feedIds: sites.map( ( item ) => item.feed_ID ).filter( Boolean ),
-		feedUrls: sites.map( ( item ) => item.feed_URL ).filter( Boolean ),
-	};
+	return getFeedsInfo( sites );
 };
 
 export const useSubscribedFeedsInfo = () => {
 	const sites = useSubscribedSites();
 
-	return {
-		unseenCount: sites.reduce( ( sum, item ) => sum + ( item.unseen_count ?? 0 ), 0 ),
-		feedIds: sites.map( ( item ) => item.feed_ID ).filter( Boolean ),
-		feedUrls: sites.map( ( item ) => item.feed_URL || null ).filter( Boolean ),
-	};
+	return getFeedsInfo( sites );
 };
 
 export const useHasSiteSubscriptionOrganization = ( feedId?: FollowId, blogId?: FollowId ) => {

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -6,6 +6,7 @@ import {
 	getSubscribedSitesFromData,
 	getOrganizationSiteSubscriptionsFromData,
 } from '@automattic/api-queries';
+import { SiteSubscriptionItem } from '@automattic/data-stores/src/reader/types';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { useSiteSubscriptions } from './use-site-subscriptions';
 
@@ -48,7 +49,7 @@ export const useAliasedSiteSubscriptionFeedUrl = ( feedUrl: string ) => {
 	return getAliasedSiteSubscriptionFeedUrl( data, feedUrl ) ?? feedUrl;
 };
 
-export const useSubscribedSites = () => {
+export const useSubscribedSites = (): SiteSubscriptionItem[] => {
 	const { data } = useSiteSubscriptions();
 
 	return getSubscribedSitesFromData( data, NO_ORG_ID );
@@ -67,6 +68,16 @@ export const useOrganizationFeedsInfo = ( organizationId: number ) => {
 		unseenCount: sites.reduce( ( sum, item ) => sum + ( item.unseen_count ?? 0 ), 0 ),
 		feedIds: sites.map( ( item ) => item.feed_ID ).filter( Boolean ),
 		feedUrls: sites.map( ( item ) => item.feed_URL ).filter( Boolean ),
+	};
+};
+
+export const useSubscribedFeedsInfo = () => {
+	const sites = useSubscribedSites();
+
+	return {
+		unseenCount: sites.reduce( ( sum, item ) => sum + ( item.unseen_count ?? 0 ), 0 ),
+		feedIds: sites.map( ( item ) => item.feed_ID ).filter( Boolean ),
+		feedUrls: sites.map( ( item ) => item.feed_URL || null ).filter( Boolean ),
 	};
 };
 

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -6,9 +6,9 @@ import {
 	getSubscribedSitesFromData,
 	getOrganizationSiteSubscriptionsFromData,
 } from '@automattic/api-queries';
-import { SiteSubscriptionItem } from '@automattic/data-stores/src/reader/types';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { useSiteSubscriptions } from './use-site-subscriptions';
+import type { SiteSubscriptionItem } from '@automattic/api-core';
 
 type FollowId = number | string;
 

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -1,5 +1,7 @@
 import './style.scss';
 
+import { isAutomatticianQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { DropdownMenu } from '@wordpress/components';
 import { check, moreHorizontal } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -20,8 +22,14 @@ export function MoreMenuActions( {
 	unseenCount,
 }: MoreMenuActionsProps ) {
 	const translate = useTranslate();
+	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 	const { mutate: markAllAsSeen } = useMarkAllAsSeenMutation();
+
+	// Remove when "Mark all as seen" is available to all users.
+	if ( ! isAutomattician ) {
+		return null;
+	}
 
 	const handleMarkAllAsSeen = () => {
 		recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked', { source: identifier } );
@@ -49,16 +57,16 @@ export function MoreMenuActions( {
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<span
-			className="reader-sidebar__more-menu"
+			className="sidebar__more-menu"
 			onClick={ swallowClick }
 			onKeyDown={ swallowActivationKey }
 		>
 			<DropdownMenu
 				icon={ moreHorizontal }
 				label={ translate( 'More actions' ) as string }
-				className="reader-sidebar__more-menu-dropdown"
+				className="sidebar__more-menu-dropdown"
 				popoverProps={ {
-					className: 'reader-sidebar__more-menu-dropdown-content',
+					className: 'sidebar__more-menu-dropdown-content',
 					focusOnMount: true,
 					placement: 'bottom-end',
 				} }

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -12,7 +12,7 @@ type MoreMenuActionsProps = {
 	identifier: string;
 	feedIds: number[];
 	feedUrls: string[];
-	unseenCount?: number;
+	unseenCount: number;
 };
 
 export function MoreMenuActions( {

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -1,0 +1,76 @@
+import './style.scss';
+
+import { DropdownMenu } from '@wordpress/components';
+import { check, moreHorizontal } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+
+type MoreMenuActionsProps = {
+	identifier: string;
+	feedIds: number[];
+	feedUrls: string[];
+	unseenCount?: number;
+};
+
+export function MoreMenuActions( {
+	identifier,
+	feedIds,
+	feedUrls,
+	unseenCount,
+}: MoreMenuActionsProps ) {
+	const translate = useTranslate();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+	const { mutate: markAllAsSeen } = useMarkAllAsSeenMutation();
+
+	const handleMarkAllAsSeen = () => {
+		recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked', { source: identifier } );
+		markAllAsSeen( { identifier, feedIds, feedUrls } );
+	};
+
+	// The trigger sits inside an <a href> (menu-item rows) or an <a> with a
+	// click handler (section header). stopPropagation prevents the row's own
+	// click handler from firing; preventDefault stops the browser from
+	// following the row's href.
+	const swallowClick = ( event: React.MouseEvent ) => {
+		event.stopPropagation();
+		event.preventDefault();
+	};
+
+	// Only stop propagation for the keys that would activate the surrounding
+	// row (Enter fires SidebarHeading's onClick; Space activates buttons).
+	// Leave Tab, arrow keys, etc. alone so keyboard navigation still works.
+	const swallowActivationKey = ( event: React.KeyboardEvent ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.stopPropagation();
+		}
+	};
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<span
+			className="reader-sidebar__more-menu"
+			onClick={ swallowClick }
+			onKeyDown={ swallowActivationKey }
+		>
+			<DropdownMenu
+				icon={ moreHorizontal }
+				label={ translate( 'More actions' ) as string }
+				className="reader-sidebar__more-menu-dropdown"
+				popoverProps={ {
+					className: 'reader-sidebar__more-menu-dropdown-content',
+					focusOnMount: true,
+					placement: 'bottom-end',
+				} }
+				controls={ [
+					{
+						title: translate( 'Mark all as seen' ) as string,
+						icon: check,
+						onClick: handleMarkAllAsSeen,
+						isDisabled: unseenCount === 0,
+					},
+				] }
+			/>
+		</span>
+	);
+}

--- a/client/reader/sidebar/more-menu-actions/style.scss
+++ b/client/reader/sidebar/more-menu-actions/style.scss
@@ -1,0 +1,38 @@
+.is-reader-page {
+
+	.reader-sidebar__more-menu .components-dropdown-menu__toggle {
+		min-width: auto;
+		width: 20px;
+		height: 20px;
+		padding: 0;
+		color: inherit;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.1s;
+	}
+
+	.reader-sidebar__more-menu-dropdown button.is-opened,
+	.sidebar__heading:hover .reader-sidebar__more-menu .components-dropdown-menu__toggle,
+	.sidebar__heading:has(:focus-visible) .reader-sidebar__more-menu .components-dropdown-menu__toggle,
+	.sidebar__menu-link:hover .reader-sidebar__more-menu .components-dropdown-menu__toggle,
+	.sidebar__menu-link:has(:focus-visible) .reader-sidebar__more-menu .components-dropdown-menu__toggle {
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	// Touch pointers can't hover — surface the ellipsis and drop the count.
+	@media (hover: none) {
+		.reader-sidebar__more-menu {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+
+	.reader-sidebar__more-menu-dropdown-content {
+		.components-popover__content {
+			position: relative;
+			top: -10px;
+			padding: 5px;
+		}
+	}
+}

--- a/client/reader/sidebar/more-menu-actions/style.scss
+++ b/client/reader/sidebar/more-menu-actions/style.scss
@@ -1,6 +1,6 @@
 .is-section-reader {
 
-	.reader-sidebar__more-menu .components-dropdown-menu__toggle {
+	.sidebar__more-menu .components-dropdown-menu__toggle {
 		min-width: auto;
 		width: 20px;
 		height: 20px;
@@ -11,7 +11,7 @@
 		transition: opacity 0.1s;
 	}
 
-	.reader-sidebar__more-menu-dropdown-content {
+	.sidebar__more-menu-dropdown-content {
 		.components-popover__content {
 			position: relative;
 			top: -10px;
@@ -20,18 +20,18 @@
 		}
 	}
 
-	.reader-sidebar__more-menu-dropdown button.is-opened,
-	.sidebar__heading:hover .reader-sidebar__more-menu .components-dropdown-menu__toggle,
-	.sidebar__heading:has(:focus-visible) .reader-sidebar__more-menu .components-dropdown-menu__toggle,
-	.sidebar__menu-link:hover .reader-sidebar__more-menu .components-dropdown-menu__toggle,
-	.sidebar__menu-link:has(:focus-visible) .reader-sidebar__more-menu .components-dropdown-menu__toggle {
+	.sidebar__more-menu-dropdown button.is-opened,
+	.sidebar__heading:hover .sidebar__more-menu .components-dropdown-menu__toggle,
+	.sidebar__heading:has(:focus-visible) .sidebar__more-menu .components-dropdown-menu__toggle,
+	.sidebar__menu-link:hover .sidebar__more-menu .components-dropdown-menu__toggle,
+	.sidebar__menu-link:has(:focus-visible) .sidebar__more-menu .components-dropdown-menu__toggle {
 		opacity: 1;
 		pointer-events: auto;
 	}
 
 	// Touch pointers can't hover — surface the ellipsis and drop the count.
 	@media (hover: none) {
-		.reader-sidebar__more-menu {
+		.sidebar__more-menu {
 			opacity: 1;
 			pointer-events: auto;
 		}

--- a/client/reader/sidebar/more-menu-actions/style.scss
+++ b/client/reader/sidebar/more-menu-actions/style.scss
@@ -1,4 +1,4 @@
-.is-reader-page {
+.is-section-reader {
 
 	.reader-sidebar__more-menu .components-dropdown-menu__toggle {
 		min-width: auto;
@@ -9,6 +9,15 @@
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 0.1s;
+	}
+
+	.reader-sidebar__more-menu-dropdown-content {
+		.components-popover__content {
+			position: relative;
+			top: -10px;
+			padding: 5px;
+			box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+		}
 	}
 
 	.reader-sidebar__more-menu-dropdown button.is-opened,
@@ -25,14 +34,6 @@
 		.reader-sidebar__more-menu {
 			opacity: 1;
 			pointer-events: auto;
-		}
-	}
-
-	.reader-sidebar__more-menu-dropdown-content {
-		.components-popover__content {
-			position: relative;
-			top: -10px;
-			padding: 5px;
 		}
 	}
 }

--- a/client/reader/sidebar/more-menu-actions/test/index.test.tsx
+++ b/client/reader/sidebar/more-menu-actions/test/index.test.tsx
@@ -96,19 +96,4 @@ describe( 'MoreMenuActions', () => {
 		expect( mockRecordReaderTracksEvent ).not.toHaveBeenCalled();
 		expect( mockMarkAllAsSeen ).not.toHaveBeenCalled();
 	} );
-
-	test( 'prevents clicks from activating the surrounding row', async () => {
-		const user = userEvent.setup();
-		const handleParentClick = jest.fn();
-
-		renderMoreMenuActions(
-			<a href="/reader" onClick={ handleParentClick }>
-				<MoreMenuActions { ...defaultProps } />
-			</a>
-		);
-
-		await user.click( screen.getByRole( 'button', { name: 'More actions' } ) );
-
-		expect( handleParentClick ).not.toHaveBeenCalled();
-	} );
 } );

--- a/client/reader/sidebar/more-menu-actions/test/index.test.tsx
+++ b/client/reader/sidebar/more-menu-actions/test/index.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isAutomatticianQuery } from '@automattic/api-queries';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComponentProps } from 'react';
+import { MoreMenuActions } from '../index';
+
+const mockMarkAllAsSeen = jest.fn();
+jest.mock( 'calypso/reader/data/seen-posts', () => ( {
+	useMarkAllAsSeenMutation: () => ( { mutate: mockMarkAllAsSeen } ),
+} ) );
+
+const mockRecordReaderTracksEvent = jest.fn();
+jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( {
+	useRecordReaderTracksEvent: () => mockRecordReaderTracksEvent,
+} ) );
+
+const defaultProps: ComponentProps< typeof MoreMenuActions > = {
+	identifier: 'following',
+	feedIds: [ 1, 2 ],
+	feedUrls: [ 'https://example.com/feed', 'https://another.example.com/feed' ],
+	unseenCount: 3,
+};
+
+function renderMoreMenuActions( props = {} ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	} );
+
+	queryClient.setQueryData( isAutomatticianQuery().queryKey, {
+		number: 1,
+		teams: [ { slug: 'a8c', title: 'Automattic' } ],
+	} );
+
+	return render(
+		<QueryClientProvider client={ queryClient }>
+			<MoreMenuActions { ...defaultProps } { ...props } />
+		</QueryClientProvider>
+	);
+}
+
+async function openMoreActionsMenu( user: ReturnType< typeof userEvent.setup > ) {
+	await user.click( screen.getByRole( 'button', { name: 'More actions' } ) );
+}
+
+describe( 'MoreMenuActions', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the mark all as seen action', async () => {
+		const user = userEvent.setup();
+		renderMoreMenuActions();
+
+		expect( screen.getByRole( 'button', { name: 'More actions' } ) ).toBeVisible();
+
+		await openMoreActionsMenu( user );
+
+		expect( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) ).toBeEnabled();
+	} );
+
+	test( 'marks all posts as seen and records the tracks event', async () => {
+		const user = userEvent.setup();
+		renderMoreMenuActions();
+
+		await openMoreActionsMenu( user );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) );
+
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_mark_all_as_seen_clicked',
+			{ source: defaultProps.identifier }
+		);
+		expect( mockMarkAllAsSeen ).toHaveBeenCalledWith( {
+			identifier: defaultProps.identifier,
+			feedIds: defaultProps.feedIds,
+			feedUrls: defaultProps.feedUrls,
+		} );
+	} );
+
+	test( 'disables the action when there are no unseen posts', async () => {
+		const user = userEvent.setup();
+		renderMoreMenuActions( { unseenCount: 0 } );
+
+		await openMoreActionsMenu( user );
+
+		const markAllAsSeenButton = screen.getByRole( 'menuitem', { name: 'Mark all as seen' } );
+		expect( markAllAsSeenButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await user.click( markAllAsSeenButton );
+
+		expect( mockRecordReaderTracksEvent ).not.toHaveBeenCalled();
+		expect( mockMarkAllAsSeen ).not.toHaveBeenCalled();
+	} );
+
+	test( 'prevents clicks from activating the surrounding row', async () => {
+		const user = userEvent.setup();
+		const handleParentClick = jest.fn();
+
+		renderMoreMenuActions(
+			<a href="/reader" onClick={ handleParentClick }>
+				<MoreMenuActions { ...defaultProps } />
+			</a>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'More actions' } ) );
+
+		expect( handleParentClick ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import AutoDirection from 'calypso/components/auto-direction';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { MoreMenuActions } from 'calypso/reader/sidebar/more-menu-actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarHelper from '../helper';
@@ -32,6 +33,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 		);
 
 		const selected = computedClassName.includes( 'selected' );
+		const feedId = site.feed_ID ? Number( site.feed_ID ) : null;
 
 		return (
 			<MenuItem selected={ selected } key={ this.props.title }>
@@ -50,7 +52,17 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 							{ site.last_updated > 0 && moment( new Date( site.last_updated ) ).fromNow() }
 						</span>
 					</span>
-					{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
+					<span className="sidebar__menu-item-more-menu">
+						{ feedId && site.feed_URL && (
+							<MoreMenuActions
+								identifier={ `feed:${ feedId }` }
+								feedIds={ [ feedId ] }
+								feedUrls={ [ site.feed_URL ] }
+								unseenCount={ site.unseen_count }
+							/>
+						) }
+						{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
+					</span>
 				</MenuItemLink>
 			</MenuItem>
 		);

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -52,7 +52,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 							{ site.last_updated > 0 && moment( new Date( site.last_updated ) ).fromNow() }
 						</span>
 					</span>
-					<span className="sidebar__menu-item-more-menu">
+					<span className="sidebar__actions-and-count">
 						{ feedId && site.feed_URL && (
 							<MoreMenuActions
 								identifier={ `feed:${ feedId }` }

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -56,7 +56,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 			return 'p2';
 		}
 
-		return null;
+		return `organization-${ organizationId }`;
 	}
 
 	render() {

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -4,16 +4,27 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import { useOrganizationSiteSubscriptions } from 'calypso/reader/data/site-subscriptions';
+import {
+	useOrganizationFeedsInfo,
+	useOrganizationSiteSubscriptions,
+} from 'calypso/reader/data/site-subscriptions';
+import { AUTOMATTIC_ORG_ID, P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
 import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
+import { MoreMenuActions } from '../more-menu-actions';
 import ReaderSidebarOrganizationsListItem from './list-item';
+
 export class ReaderSidebarOrganizationsList extends Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,
 		organization: PropTypes.object,
 		sites: PropTypes.array,
 		teams: PropTypes.array,
+		feedsInfo: PropTypes.shape( {
+			unseenCount: PropTypes.number,
+			feedIds: PropTypes.array,
+			feedUrls: PropTypes.array,
+		} ),
 	};
 
 	toggleMenu = () => {
@@ -36,21 +47,32 @@ export class ReaderSidebarOrganizationsList extends Component {
 		);
 	}
 
+	identifierForOrganizationId( organizationId ) {
+		if ( organizationId === AUTOMATTIC_ORG_ID ) {
+			return 'a8c';
+		}
+
+		if ( organizationId === P2_ORG_ID ) {
+			return 'p2';
+		}
+
+		return null;
+	}
+
 	render() {
-		const { organization, path, sites } = this.props;
+		const { organization, path, sites, feedsInfo } = this.props;
 
 		if ( ! organization.sites_count ) {
 			return null;
 		}
 
 		const isChildSelected = sites.some( ( site ) => path === `/reader/feeds/${ site.feed_ID }` );
-		const unseenCount = sites.reduce( ( acc, item ) => acc + ( item.unseen_count ?? 0 ), 0 );
 
 		return (
 			<ExpandableSidebarMenu
 				expanded={ this.props.isOrganizationOpen }
 				title={ organization.title }
-				count={ unseenCount > 0 ? unseenCount : undefined }
+				count={ feedsInfo.unseenCount }
 				onClick={ this.selectMenu }
 				expandableIconClick={ this.toggleMenu }
 				disableFlyout
@@ -59,6 +81,13 @@ export class ReaderSidebarOrganizationsList extends Component {
 						'/reader/' + organization.slug === path ||
 						( ! this.props.isOrganizationOpen && isChildSelected ),
 				} ) }
+				moreMenuActions={
+					<MoreMenuActions
+						identifier={ this.identifierForOrganizationId( organization.id ) }
+						feedIds={ feedsInfo.feedIds }
+						feedUrls={ feedsInfo.feedUrls }
+					/>
+				}
 			>
 				{ this.renderSites() }
 			</ExpandableSidebarMenu>
@@ -68,7 +97,9 @@ export class ReaderSidebarOrganizationsList extends Component {
 
 function OrganizationsListWithFollows( props ) {
 	const sites = useOrganizationSiteSubscriptions( props.organization.id );
-	return <ReaderSidebarOrganizationsList { ...props } sites={ sites } />;
+	const feedsInfo = useOrganizationFeedsInfo( props.organization.id );
+
+	return <ReaderSidebarOrganizationsList { ...props } sites={ sites } feedsInfo={ feedsInfo } />;
 }
 
 export default connect(

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -86,6 +86,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 						identifier={ this.identifierForOrganizationId( organization.id ) }
 						feedIds={ feedsInfo.feedIds }
 						feedUrls={ feedsInfo.feedUrls }
+						unseenCount={ feedsInfo.unseenCount }
 					/>
 				}
 			>

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -9,9 +9,10 @@ import { SiteIcon } from 'calypso/blocks/site-icon';
 import AutoDirection from 'calypso/components/auto-direction';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import { useSubscribedSites } from 'calypso/reader/data/site-subscriptions';
+import { useSubscribedFeedsInfo, useSubscribedSites } from 'calypso/reader/data/site-subscriptions';
 import { getSiteDomain } from 'calypso/reader/get-helpers';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { MoreMenuActions } from 'calypso/reader/sidebar/more-menu-actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { getSelectedRecentFeedId } from 'calypso/state/reader-ui/sidebar/selectors';
@@ -66,6 +67,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 	const translate = useTranslate();
 	const [ showAllSites, setShowAllSites ] = useState( false );
 	const sites = useSubscribedSites();
+	const feedsInfo = useSubscribedFeedsInfo();
 	const totalUnseenCount = sites.reduce( ( sum, site ) => sum + ( site.unseen_count ?? 0 ), 0 );
 	const selectedSiteFeedId = useSelector< AppState, number | null >( getSelectedRecentFeedId );
 	const moment = useLocalizedMoment();
@@ -122,6 +124,14 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 			materialIcon={ null }
 			materialIconStyle={ null }
 			expandableIconClick={ onClick }
+			moreMenuActions={
+				<MoreMenuActions
+					identifier="following"
+					feedIds={ feedsInfo.feedIds }
+					feedUrls={ feedsInfo.feedUrls }
+					unseenCount={ totalUnseenCount }
+				/>
+			}
 		>
 			{ sitesToShow.map( ( site ) => {
 				const displayName = getReaderSidebarSiteName( site );
@@ -131,19 +141,15 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 					args: { count: unseenCount },
 					comment: '%(count)d is the number of unseen posts.',
 				} );
+				const feedId = site.feed_ID ? Number( site.feed_ID ) : null;
 
 				return (
-					<MenuItem
-						key={ site.ID }
-						selected={ isRecentStream && site.feed_ID === selectedSiteFeedId }
-					>
+					<MenuItem key={ site.ID } selected={ isRecentStream && feedId === selectedSiteFeedId }>
 						<AutoDirection>
 							<MenuItemLink
-								href={ `/reader/recent/${ site.feed_ID }` }
+								href={ `/reader/recent/${ feedId }` }
 								className={ clsx( 'reader-sidebar-recent__item sidebar__menu-link' ) }
-								onClick={ () =>
-									trackMenuClick( site.feed_ID == null ? null : Number( site.feed_ID ) )
-								}
+								onClick={ () => trackMenuClick( feedId ) }
 							>
 								<SiteIcon iconUrl={ site.site_icon } size={ 22 } />
 								<span title={ displayName } className="sidebar__menu-item-sitename">
@@ -154,9 +160,19 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 										</span>
 									) }
 								</span>
-								{ unseenCount > 0 && (
-									<Count count={ unseenCount } compact aria-label={ unseenCountLabel } />
-								) }
+								<span className="sidebar__menu-item-more-menu">
+									{ feedId && site.feed_URL && (
+										<MoreMenuActions
+											identifier={ `feed:${ feedId }` }
+											feedIds={ [ feedId ] }
+											feedUrls={ [ site.feed_URL ] }
+											unseenCount={ unseenCount }
+										/>
+									) }
+									{ unseenCount > 0 && (
+										<Count count={ unseenCount } compact aria-label={ unseenCountLabel } />
+									) }
+								</span>
 							</MenuItemLink>
 						</AutoDirection>
 					</MenuItem>

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -115,8 +115,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 			expanded={ isOpen }
 			title={ translate( 'Recent' ) }
 			disableFlyout
-			className={ clsx( 'reader-sidebar-recent', className, {
-				'has-counts': totalUnseenCount > 0,
+			className={ clsx( 'reader-sidebar-recent', 'has-counts', className, {
 				'sidebar__menu--selected': isRecentStream && ( ! isOpen || selectedSiteFeedId === null ),
 			} ) }
 			count={ totalUnseenCount > 0 ? totalUnseenCount : undefined }
@@ -160,7 +159,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 										</span>
 									) }
 								</span>
-								<span className="sidebar__menu-item-more-menu">
+								<span className="sidebar__actions-and-count">
 									{ feedId && site.feed_URL && (
 										<MoreMenuActions
 											identifier={ `feed:${ feedId }` }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -68,7 +68,6 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 	const [ showAllSites, setShowAllSites ] = useState( false );
 	const sites = useSubscribedSites();
 	const feedsInfo = useSubscribedFeedsInfo();
-	const totalUnseenCount = sites.reduce( ( sum, site ) => sum + ( site.unseen_count ?? 0 ), 0 );
 	const selectedSiteFeedId = useSelector< AppState, number | null >( getSelectedRecentFeedId );
 	const moment = useLocalizedMoment();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
@@ -118,7 +117,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 			className={ clsx( 'reader-sidebar-recent', 'has-counts', className, {
 				'sidebar__menu--selected': isRecentStream && ( ! isOpen || selectedSiteFeedId === null ),
 			} ) }
-			count={ totalUnseenCount > 0 ? totalUnseenCount : undefined }
+			count={ feedsInfo.unseenCount > 0 ? feedsInfo.unseenCount : undefined }
 			icon={ null }
 			materialIcon={ null }
 			materialIconStyle={ null }
@@ -128,7 +127,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 					identifier="following"
 					feedIds={ feedsInfo.feedIds }
 					feedUrls={ feedsInfo.feedUrls }
-					unseenCount={ totalUnseenCount }
+					unseenCount={ feedsInfo.unseenCount }
 				/>
 			}
 		>

--- a/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
@@ -20,6 +20,7 @@ jest.mock( 'calypso/reader/stats', () => ( {
 let mockSubscribedSites: Partial< SiteSubscriptionItem >[] = [];
 jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
 	useSubscribedSites: () => mockSubscribedSites,
+	useSubscribedFeedsInfo: () => ( { unseenCount: 0, feedIds: [], feedUrls: [] } ),
 } ) );
 
 function createSubscriptionItem(
@@ -80,22 +81,6 @@ describe( 'ReaderSidebarRecent unseen counts', () => {
 		expect( alphaRow?.querySelector( '.a8c-count' ) ).toHaveTextContent( '4' );
 		expect( alphaRow?.querySelector( '.a8c-count' ) ).toHaveAccessibleName( '4 unseen posts' );
 		expect( betaRow?.querySelector( '.a8c-count' ) ).toBeNull();
-	} );
-
-	test( 'flags the section with the has-counts modifier when there are unseen posts', () => {
-		const { container } = renderRecentDropdown( [
-			createSubscriptionItem( { ID: 1, unseen_count: 2 } ),
-		] );
-
-		expect( container.querySelector( '.reader-sidebar-recent' ) ).toHaveClass( 'has-counts' );
-	} );
-
-	test( 'does not flag the section with has-counts when there are no unseen posts', () => {
-		const { container } = renderRecentDropdown( [
-			createSubscriptionItem( { ID: 1, unseen_count: 0 } ),
-		] );
-
-		expect( container.querySelector( '.reader-sidebar-recent' ) ).not.toHaveClass( 'has-counts' );
 	} );
 } );
 

--- a/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
@@ -18,9 +18,10 @@ jest.mock( 'calypso/reader/stats', () => ( {
 } ) );
 
 let mockSubscribedSites: Partial< SiteSubscriptionItem >[] = [];
+let mockSubscribedFeedsInfo = { unseenCount: 0, feedIds: [], feedUrls: [] };
 jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
 	useSubscribedSites: () => mockSubscribedSites,
-	useSubscribedFeedsInfo: () => ( { unseenCount: 0, feedIds: [], feedUrls: [] } ),
+	useSubscribedFeedsInfo: () => mockSubscribedFeedsInfo,
 } ) );
 
 function createSubscriptionItem(
@@ -49,9 +50,12 @@ function getUnseenCount( container: HTMLElement ): HTMLElement | null {
 describe( 'ReaderSidebarRecent unseen counts', () => {
 	afterEach( () => {
 		mockSubscribedSites = [];
+		mockSubscribedFeedsInfo = { unseenCount: 0, feedIds: [], feedUrls: [] };
 	} );
 
 	test( 'shows the total unseen count for the section, summed across all followed sites', () => {
+		mockSubscribedFeedsInfo = { unseenCount: 8, feedIds: [], feedUrls: [] };
+
 		const { container } = renderRecentDropdown( [
 			createSubscriptionItem( { ID: 1, name: 'Alpha', unseen_count: 3 } ),
 			createSubscriptionItem( { ID: 2, name: 'Beta', unseen_count: 5 } ),

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -392,7 +392,7 @@ body.is-section-reader {
 		}
 
 		.add-tags-form {
-			padding-left: 39px;
+			padding-inline-start: 39px;
 		}
 
 		.selected {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-586

## Proposed Changes

Add "Mark all as Seen" functionality on Reader sidebar.

Note: Currently only visible to A12s.

<img width="289" height="979" alt="image" src="https://github.com/user-attachments/assets/803f4d13-1365-4f63-8ba3-4a525b97cab1" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To easily mark posts as seen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader
- Test marking posts as seen from sidebar. (both individual and all action)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
