### PR TITLE
MSD Purchases: Redirect to site page after product removal

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
@@ -1,13 +1,12 @@
 import { removePurchaseMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useCallback } from 'react';
-import { purchaseSettingsRoute } from '../../../app/router/me';
 import DomainRemovalConfirmationStep from './domain-removal-confirmation-step';
 import DomainRemovalWarningStep from './domain-removal-warning-step';
+import { usePostRemovalNavigation } from './use-post-removal-navigation';
 import type { Purchase } from '@automattic/api-core';
 
 import './style.scss';
@@ -21,8 +20,8 @@ type RemovalStep = 'warning' | 'confirmation';
 
 export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemovalFlowProps ) {
 	const [ currentStep, setCurrentStep ] = useState< RemovalStep >( 'warning' );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const navigate = useNavigate();
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const { navigateAfterRemoval, invalidateSiteAfterRemoval } = usePostRemovalNavigation( purchase );
 	const { mutate: removePurchase, isPending: isRemovingPurchase } = useMutation(
 		removePurchaseMutation()
 	);
@@ -35,20 +34,16 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 		removePurchase( purchase.ID, {
 			onSuccess: () => {
 				const domainName = purchase.meta || purchase.product_name;
-				createSuccessNotice(
+				invalidateSiteAfterRemoval();
+				navigateAfterRemoval(
 					sprintf(
 						/* translators: %(domain)s is a domain name */
 						__( 'The domain %(domain)s was removed from your account.' ),
 						{
 							domain: domainName,
 						}
-					),
-					{ type: 'snackbar' }
+					)
 				);
-				navigate( {
-					to: purchaseSettingsRoute.fullPath,
-					params: { purchaseId: purchase.ID },
-				} );
 			},
 			onError: () => {
 				const domainName = purchase.meta || purchase.product_name;
@@ -64,7 +59,13 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 				);
 			},
 		} );
-	}, [ purchase, removePurchase, createSuccessNotice, createErrorNotice, navigate ] );
+	}, [
+		purchase,
+		removePurchase,
+		createErrorNotice,
+		navigateAfterRemoval,
+		invalidateSiteAfterRemoval,
+	] );
 
 	return (
 		<div>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1266,12 +1266,9 @@ function CancelPurchaseInner() {
 	};
 
 	const submitRemovePurchase = ( purchase: Purchase ) => {
-		// Callers gate this on the effective flow type (see onSurveyComplete's
-		// switch). Don't re-guard on the base `flowType` heuristic here: for a
-		// refundable purchase with auto-renew off it resolves to
-		// CANCEL_WITH_REFUND while the effective flow is REMOVE, and the mismatch
-		// would silently early-return — leaving the user stranded on a spinning
-		// "Complete removal" button with no navigation.
+		// Callers gate this on the effective flow type (see onSurveyComplete). Don't
+		// re-guard on the base `flowType` heuristic — it diverges from the effective
+		// flow (e.g. refundable + auto-renew off) and would silently early-return.
 		setTimeout( () => {
 			// 1. Optimistic cache strip
 			const stripPurchaseFromList = () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -16,6 +16,7 @@ import {
 	purchaseCancelFeaturesQuery,
 	purchaseQuery,
 	siteByIdQuery,
+	siteQueryFilter,
 	siteDomainsQuery,
 	sitePurchasesQuery,
 	userPreferenceMutation,
@@ -549,6 +550,19 @@ function CancelPurchaseInner() {
 		},
 		[ purchase, navigate, createSuccessNotice ]
 	);
+
+	// The removal mutations only invalidate the purchases list, so the site the
+	// product belonged to keeps serving a stale plan (and features/products).
+	// Refresh the Site record and its site-scoped caches so the destination —
+	// most importantly the site page — reflects the removal. Mirrors the
+	// invalidation siteDeleteMutation does.
+	const invalidateSiteAfterRemoval = useCallback( () => {
+		if ( ! purchase.blog_id || purchase.is_attached_to_holding_site ) {
+			return;
+		}
+		queryClient.invalidateQueries( siteQueryFilter( purchase.blog_id ) );
+		queryClient.invalidateQueries( { queryKey: [ 'site', purchase.blog_id ] } );
+	}, [ queryClient, purchase.blog_id, purchase.is_attached_to_holding_site ] );
 
 	const track = useCallback( () => {
 		if ( productSlug ) {
@@ -1238,6 +1252,7 @@ function CancelPurchaseInner() {
 							cancelAllMarketplaceSubscriptions();
 						}
 						invokeSurvicateEvent( 'purchaseRefunded' );
+						invalidateSiteAfterRemoval();
 						navigateAfterRemoval(
 							__( 'Your refund has been processed and your purchase removed.' )
 						);
@@ -1371,20 +1386,27 @@ function CancelPurchaseInner() {
 			//    re-strip happens synchronously inside the QueryCache notify callback,
 			//    so the list's useEffect never observes transient success-path
 			//    reappearances.
-			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
-				cleanupGuard();
-				queryClient.setQueryData(
-					userPurchasesQuery().queryKey,
-					( old: Purchase[] | undefined ) => {
-						const list = old ?? [];
-						return list.some( ( p ) => p.ID === purchase.ID ) ? list : [ ...list, purchase ];
-					}
-				);
-				createErrorNotice( __( 'Failed to remove your purchase. Please try again.' ), {
-					type: 'snackbar',
+			removePurchaseMutator
+				.mutateAsync( purchase.ID )
+				.then( () => {
+					// The server has removed the purchase; refresh the site caches so
+					// the destination site page drops the now-defunct plan.
+					invalidateSiteAfterRemoval();
+				} )
+				.catch( () => {
+					cleanupGuard();
+					queryClient.setQueryData(
+						userPurchasesQuery().queryKey,
+						( old: Purchase[] | undefined ) => {
+							const list = old ?? [];
+							return list.some( ( p ) => p.ID === purchase.ID ) ? list : [ ...list, purchase ];
+						}
+					);
+					createErrorNotice( __( 'Failed to remove your purchase. Please try again.' ), {
+						type: 'snackbar',
+					} );
+					queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
 				} );
-				queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
-			} );
 		}, 1500 );
 	};
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1279,10 +1279,12 @@ function CancelPurchaseInner() {
 	};
 
 	const submitRemovePurchase = ( purchase: Purchase ) => {
-		if ( CANCEL_FLOW_TYPE.REMOVE !== flowType ) {
-			return;
-		}
-
+		// Callers gate this on the effective flow type (see onSurveyComplete's
+		// switch). Don't re-guard on the base `flowType` heuristic here: for a
+		// refundable purchase with auto-renew off it resolves to
+		// CANCEL_WITH_REFUND while the effective flow is REMOVE, and the mismatch
+		// would silently early-return — leaving the user stranded on a spinning
+		// "Complete removal" button with no navigation.
 		setTimeout( () => {
 			// 1. Optimistic cache strip
 			const stripPurchaseFromList = () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -44,6 +44,7 @@ import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { cancelPurchaseRoute, purchaseSettingsRoute, purchasesRoute } from '../../../app/router/me';
+import { siteRoute } from '../../../app/router/sites';
 import { Card, CardBody } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -532,6 +533,22 @@ function CancelPurchaseInner() {
 
 		navigate( { to: purchasesRoute.to } );
 	}, [ purchase, navigate ] );
+
+	// Once a purchase is removed, its settings page is no longer useful. Send the
+	// user to the site the purchase was attached to, or the purchases list for
+	// siteless/holding-site products. A snackbar confirms the action since the
+	// destination screens don't carry the removal notice.
+	const navigateAfterRemoval = useCallback(
+		( successMessage: string ) => {
+			createSuccessNotice( successMessage, { type: 'snackbar' } );
+			if ( purchase.site_slug && ! purchase.is_attached_to_holding_site ) {
+				navigate( { to: siteRoute.fullPath, params: { siteSlug: purchase.site_slug } } );
+				return;
+			}
+			navigate( { to: purchasesRoute.to } );
+		},
+		[ purchase, navigate, createSuccessNotice ]
+	);
 
 	const track = useCallback( () => {
 		if ( productSlug ) {
@@ -1221,11 +1238,9 @@ function CancelPurchaseInner() {
 							cancelAllMarketplaceSubscriptions();
 						}
 						invokeSurvicateEvent( 'purchaseRefunded' );
-						navigate( {
-							to: purchaseSettingsRoute.fullPath,
-							params: { purchaseId: purchase.ID },
-							search: { refunded: true },
-						} );
+						navigateAfterRemoval(
+							__( 'Your refund has been processed and your purchase removed.' )
+						);
 					},
 					onError: ( error: Error ) => {
 						createErrorNotice( ( error as Error ).message, { type: 'snackbar' } );
@@ -1321,25 +1336,39 @@ function CancelPurchaseInner() {
 				queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
 			}, CACHE_GUARD_DURATION_MS );
 
-			// 3. Navigate with notice params
+			// 3. Navigate away — the purchase is gone, so its settings page is no
+			//    longer useful. Atomic-revert removals still route to the purchases
+			//    list so the backup-download notice (with its export CTA) can show;
+			//    everything else follows the site-page / purchases-list rule.
 			invokeSurvicateEvent( 'purchaseRemoved' );
 			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
-			navigate( {
-				to: purchasesRoute.to,
-				search: {
-					removed: productNoun,
-					removedId: purchase.ID,
-					...( purchase.will_atomic_revert_after_removal
-						? { removedDomain: purchase.domain }
-						: {} ),
-				},
-			} );
+			if ( purchase.will_atomic_revert_after_removal ) {
+				navigate( {
+					to: purchasesRoute.to,
+					search: {
+						removed: productNoun,
+						removedId: purchase.ID,
+						removedDomain: purchase.domain,
+					},
+				} );
+			} else {
+				navigateAfterRemoval(
+					sprintf(
+						/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+						__( 'Your %(productNoun)s has been removed.' ),
+						{ productNoun }
+					)
+				);
+			}
 
 			// 4. Fire mutation in background. On failure, restore the purchase to
-			//    the cache — the list watches userPurchasesQuery for reappearance
-			//    and self-dismisses its notice. The cache guard's re-strip happens
-			//    synchronously inside the QueryCache notify callback, so the list's
-			//    useEffect never observes transient successes-path reappearances.
+			//    the cache and surface an error snackbar (visible on whichever
+			//    destination the user landed on). When the atomic-revert path routed
+			//    to the purchases list, that list also watches userPurchasesQuery for
+			//    reappearance and self-dismisses its notice. The cache guard's
+			//    re-strip happens synchronously inside the QueryCache notify callback,
+			//    so the list's useEffect never observes transient success-path
+			//    reappearances.
 			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
 				cleanupGuard();
 				queryClient.setQueryData(

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1416,16 +1416,19 @@ function CancelPurchaseInner() {
 		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
 
 		if ( shouldFireMutationOnConfirm() ) {
-			// Cancel intent: the mutation already fired at confirm-click via
-			// fireMutationFromConfirm. Navigate with the appropriate search param
-			// so the inline notice renders on the destination screen.
+			// The mutation already fired at confirm-click via fireMutationFromConfirm.
+			// A refund removes the purchase, so route away like the other removal
+			// paths; disabling auto-renew keeps it, so return to its settings page
+			// where the cancelled notice renders.
+			if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
+				invalidateSiteAfterRemoval();
+				navigateAfterRemoval( __( 'Your refund has been processed and your purchase removed.' ) );
+				return;
+			}
 			navigate( {
 				to: purchaseSettingsRoute.fullPath,
 				params: { purchaseId: purchase.ID },
-				search:
-					effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
-						? { refunded: true }
-						: getCancelledSearch(),
+				search: getCancelledSearch(),
 			} );
 			return;
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -16,7 +16,6 @@ import {
 	purchaseCancelFeaturesQuery,
 	purchaseQuery,
 	siteByIdQuery,
-	siteQueryFilter,
 	siteDomainsQuery,
 	sitePurchasesQuery,
 	userPreferenceMutation,
@@ -45,7 +44,6 @@ import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { cancelPurchaseRoute, purchaseSettingsRoute, purchasesRoute } from '../../../app/router/me';
-import { siteRoute } from '../../../app/router/sites';
 import { Card, CardBody } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -101,6 +99,7 @@ import RefundEligibilityNotice from './refund-eligibility-notice';
 import TimeRemainingNotice from './time-remaining-notice';
 import { useCancelMutationOnConfirm } from './use-cancel-mutation-on-confirm';
 import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
+import { usePostRemovalNavigation } from './use-post-removal-navigation';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
@@ -535,34 +534,7 @@ function CancelPurchaseInner() {
 		navigate( { to: purchasesRoute.to } );
 	}, [ purchase, navigate ] );
 
-	// Once a purchase is removed, its settings page is no longer useful. Send the
-	// user to the site the purchase was attached to, or the purchases list for
-	// siteless/holding-site products. A snackbar confirms the action since the
-	// destination screens don't carry the removal notice.
-	const navigateAfterRemoval = useCallback(
-		( successMessage: string ) => {
-			createSuccessNotice( successMessage, { type: 'snackbar' } );
-			if ( purchase.site_slug && ! purchase.is_attached_to_holding_site ) {
-				navigate( { to: siteRoute.fullPath, params: { siteSlug: purchase.site_slug } } );
-				return;
-			}
-			navigate( { to: purchasesRoute.to } );
-		},
-		[ purchase, navigate, createSuccessNotice ]
-	);
-
-	// The removal mutations only invalidate the purchases list, so the site the
-	// product belonged to keeps serving a stale plan (and features/products).
-	// Refresh the Site record and its site-scoped caches so the destination —
-	// most importantly the site page — reflects the removal. Mirrors the
-	// invalidation siteDeleteMutation does.
-	const invalidateSiteAfterRemoval = useCallback( () => {
-		if ( ! purchase.blog_id || purchase.is_attached_to_holding_site ) {
-			return;
-		}
-		queryClient.invalidateQueries( siteQueryFilter( purchase.blog_id ) );
-		queryClient.invalidateQueries( { queryKey: [ 'site', purchase.blog_id ] } );
-	}, [ queryClient, purchase.blog_id, purchase.is_attached_to_holding_site ] );
+	const { navigateAfterRemoval, invalidateSiteAfterRemoval } = usePostRemovalNavigation( purchase );
 
 	const track = useCallback( () => {
 		if ( productSlug ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-post-removal-navigation.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-post-removal-navigation.ts
@@ -8,11 +8,6 @@ import { purchasesRoute } from '../../../app/router/me';
 import { siteRoute } from '../../../app/router/sites';
 import type { Purchase } from '@automattic/api-core';
 
-/**
- * Shared navigation + cache handling for the point where a purchase is removed.
- * Used by both the survey-based cancel flow and the standalone domain-removal
- * flow so they behave consistently regardless of the split-cancel-remove flag.
- */
 export function usePostRemovalNavigation( purchase: Purchase ) {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-post-removal-navigation.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-post-removal-navigation.ts
@@ -1,0 +1,47 @@
+import { siteQueryFilter } from '@automattic/api-queries';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { useCallback } from 'react';
+import { purchasesRoute } from '../../../app/router/me';
+import { siteRoute } from '../../../app/router/sites';
+import type { Purchase } from '@automattic/api-core';
+
+/**
+ * Shared navigation + cache handling for the point where a purchase is removed.
+ * Used by both the survey-based cancel flow and the standalone domain-removal
+ * flow so they behave consistently regardless of the split-cancel-remove flag.
+ */
+export function usePostRemovalNavigation( purchase: Purchase ) {
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	const navigateAfterRemoval = useCallback(
+		( successMessage: string ) => {
+			createSuccessNotice( successMessage, { type: 'snackbar' } );
+			if ( purchase.site_slug && ! purchase.is_attached_to_holding_site ) {
+				navigate( { to: siteRoute.fullPath, params: { siteSlug: purchase.site_slug } } );
+				return;
+			}
+			navigate( { to: purchasesRoute.to } );
+		},
+		[ purchase, navigate, createSuccessNotice ]
+	);
+
+	// The removal mutations only invalidate the purchases list, so the site the
+	// product belonged to keeps serving a stale plan (and features/products).
+	// Refresh the Site record and its site-scoped caches so the destination —
+	// most importantly the site page — reflects the removal. Mirrors the
+	// invalidation siteDeleteMutation does.
+	const invalidateSiteAfterRemoval = useCallback( () => {
+		if ( ! purchase.blog_id || purchase.is_attached_to_holding_site ) {
+			return;
+		}
+		queryClient.invalidateQueries( siteQueryFilter( purchase.blog_id ) );
+		queryClient.invalidateQueries( { queryKey: [ 'site', purchase.blog_id ] } );
+	}, [ queryClient, purchase.blog_id, purchase.is_attached_to_holding_site ] );
+
+	return { navigateAfterRemoval, invalidateSiteAfterRemoval };
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2192/

## Proposed changes

After a purchase is removed in the Dashboard, this redirects the user to the site the purchase was attached to (or the purchases list for siteless products) and refreshes the site's cached plan data, instead of stranding them on the now-stale purchase settings page. It also fixes a remove flow that could hang forever.

* Add a `usePostRemovalNavigation( purchase )` hook exposing `navigateAfterRemoval()` (snackbar + redirect to `/sites/{slug}` when attached to a real site, else the purchases list) and `invalidateSiteAfterRemoval()` (invalidates the `Site` record and `[ 'site', blogId ]` caches, mirroring `siteDeleteMutation`).
* Route every post-removal exit through the hook: cancel-with-refund (`submitCancelAndRefundPurchase`), plain remove (`submitRemovePurchase`), the fire-on-confirm refund exit in `onSurveyComplete`, and the standalone `DomainRemovalFlow`.
* Preserve the purchases-list route for atomic-revert removals so the backup-download notice still shows, and keep purchase settings for paths that only disable auto-renew (product retained).
* Remove the stale `flowType` early-return guard in `submitRemovePurchase` that caused a refundable + auto-renew-off remove to silently no-op and spin the "Complete removal" button forever.


> [!NOTE]
> These screenshots show the content of these post-removal pages but I've disabled the actual removal for testing so the pages in production would look a little different (you'd see "This purchase is expired and no longer in use" on the purchase settings page after the removal).

Before             |  After
:-------------------------:|:-------------------------:
<img width="1512" height="982" alt="Screenshot 2026-07-08 at 4 53 45 PM" src="https://github.com/user-attachments/assets/24195eba-a85a-4610-8b02-21aaa8588a55" /> | <img width="1512" height="982" alt="Screenshot 2026-07-08 at 4 50 22 PM" src="https://github.com/user-attachments/assets/12ca1091-ed6a-4b43-b2ed-7909746e2d71" />
<img width="1512" height="982" alt="Screenshot 2026-07-08 at 4 33 44 PM" src="https://github.com/user-attachments/assets/f51ffacd-5978-43d2-b155-60f3d145d44d" /> | <img width="1512" height="982" alt="Screenshot 2026-07-08 at 4 28 14 PM" src="https://github.com/user-attachments/assets/d9f6280a-2bb8-4e9e-98d6-120cb046bdf2" />


## Why are these changes being made?

When a subscription was deleted, the code navigated the user back to that purchase's settings page. Since the product no longer exists, the page shows stale/empty state with no useful actions — the user is stranded on a dead-end screen. Compounding this, the removal mutations only invalidated the purchases list, so the site the product belonged to kept serving its old plan/features/products until a hard refresh.

The fix sends the user somewhere actionable (the site overview, or the purchases list for siteless/holding-site products like Akismet or Jetpack licenses) and invalidates the relevant site caches so the destination reflects reality. Because neither destination carries the inline removal notice purchase settings used to render, a snackbar confirms the action. Centralizing this in one hook lets every removal exit — the survey-based flows, the fire-on-confirm refund path, and the standalone domain-removal flow — behave consistently, regardless of the `purchases/split-cancel-remove` flag. Paths that merely disable auto-renew still return to purchase settings, since the product is retained and its cancelled notice belongs there.

While testing, a second bug surfaced: `submitRemovePurchase` re-guarded on the base `flowType` heuristic (`getPurchaseCancellationFlowType`), which resolves to `CANCEL_WITH_REFUND` for a refundable purchase even when its auto-renew is off — while the effective flow the caller selected was `REMOVE`. The mismatch made the function early-return with no mutation and no navigation, leaving the button stuck in its loading state. The caller (`onSurveyComplete`'s switch) already gates on the effective flow, so the redundant guard was removed.

## Testing instructions

### Refundable plan
* You'll need a subscription that's still within its initial refund period.
* Open `/me/billing/purchases` (you can use calypso.live – see "dashboard live" link below, or run locally with `my.localhost:3000`).
* Remove a refundable plan attached to a site; confirm you land on that site's page (`/sites/{slug}`) with a success snackbar, and the site no longer shows the removed plan.

### Non-refundable plan

* You'll need a subscription that's no longer within its refund period.
* Remove a non-refundable plan whose auto-renew is off; confirm the "Complete removal" button completes (no infinite spinner) and redirects correctly. (If auto-renew isn't already off, it will be turned off rather than removing the plan).

### Siteless product (optional)
* Remove a siteless product (e.g. Akismet or a Jetpack license); confirm you land on `/me/billing/purchases` with a success snackbar.
