### PR TITLE
Dashboard: add On this day and Achievements toggles to Notifications Extras

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -1010,7 +1010,11 @@ export const notificationsExtrasRoute = createRoute( {
 	} ),
 	getParentRoute: () => notificationsRoute,
 	path: '/extras',
-	loader: () => queryClient.ensureQueryData( userNotificationsSettingsQuery() ),
+	loader: () =>
+		Promise.all( [
+			queryClient.ensureQueryData( userNotificationsSettingsQuery() ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+		] ),
 } ).lazy( () =>
 	import( '../../me/notifications-extras' ).then( ( d ) =>
 		createLazyRoute( 'notifications-extras' )( {

--- a/client/dashboard/me/notifications-extras/achievements-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/achievements-card/index.tsx
@@ -1,0 +1,60 @@
+import { userPreferenceOptimisticMutation, userPreferenceQuery } from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { ToggleControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../../app/analytics';
+import { Card, CardBody } from '../../../components/card';
+
+export const AchievementsCard = () => {
+	const { recordTracksEvent } = useAnalytics();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const { data: notifications } = useSuspenseQuery(
+		userPreferenceQuery( 'achievements-global-notifications' )
+	);
+	const { mutate: setNotifications, isPending } = useMutation(
+		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
+	);
+
+	const handleChange = ( nextValue: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_notifications_achievements_settings_updated', {
+			setting_value: nextValue,
+		} );
+
+		setNotifications( nextValue ? 'enabled' : 'disabled', {
+			onSuccess: () => {
+				createSuccessNotice(
+					sprintf(
+						/* translators: %s is the name of the settings */ __( '"%s" settings saved.' ),
+						__( 'Achievements' )
+					),
+					{ type: 'snackbar' }
+				);
+			},
+			onError: () => {
+				createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					checked={ notifications !== 'disabled' }
+					disabled={ isPending }
+					label={ __( 'Achievements' ) }
+					help={ __(
+						'Receive notifications when you unlock new achievements. This setting overrides site-level settings.'
+					) }
+					onChange={ handleChange }
+				/>
+			</CardBody>
+		</Card>
+	);
+};

--- a/client/dashboard/me/notifications-extras/achievements-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/achievements-card/index.tsx
@@ -34,9 +34,13 @@ export const AchievementsCard = () => {
 				);
 			},
 			onError: () => {
-				createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
-					type: 'snackbar',
-				} );
+				createErrorNotice(
+					sprintf(
+						/* translators: %s is the name of the setting */ __( 'Failed to save %s settings.' ),
+						__( 'Achievements' )
+					),
+					{ type: 'snackbar' }
+				);
 			},
 		} );
 	};

--- a/client/dashboard/me/notifications-extras/index.tsx
+++ b/client/dashboard/me/notifications-extras/index.tsx
@@ -12,6 +12,7 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
+import { AchievementsCard } from './achievements-card';
 import {
 	WPCOM_OPTION_KEYS,
 	WPCOM_TITLES,
@@ -22,6 +23,7 @@ import {
 	getSettingsTitle,
 } from './extras-config';
 import { ExtrasToggleCard } from './extras-toggle-card';
+import { OnThisDayCard } from './on-this-day-card';
 import type { WpcomNotificationSettings } from '@automattic/api-core';
 
 export default function NotificationsExtras() {
@@ -104,6 +106,10 @@ export default function NotificationsExtras() {
 			}
 		>
 			<VStack spacing={ 8 }>
+				<OnThisDayCard />
+
+				<AchievementsCard />
+
 				<ExtrasToggleCard
 					extraSettings={ extraSettings }
 					isSaving={ isSaving }

--- a/client/dashboard/me/notifications-extras/on-this-day-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/on-this-day-card/index.tsx
@@ -1,0 +1,66 @@
+import {
+	userNotificationsSettingsMutation,
+	userNotificationsSettingsQuery,
+} from '@automattic/api-queries';
+import { useIsMutating, useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { ToggleControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../../app/analytics';
+import { Card, CardBody } from '../../../components/card';
+
+export const OnThisDayCard = () => {
+	const { recordTracksEvent } = useAnalytics();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const { data } = useSuspenseQuery( userNotificationsSettingsQuery() );
+	const { mutate: updateSettings } = useMutation( userNotificationsSettingsMutation() );
+
+	const isMutating =
+		useIsMutating( {
+			mutationKey: userNotificationsSettingsMutation().mutationKey,
+		} ) > 0;
+
+	const handleChange = ( nextValue: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_notifications_timeline_settings_updated', {
+			setting_name: 'on_this_day',
+			setting_value: nextValue,
+		} );
+
+		updateSettings(
+			{ data: { other: { timeline: { on_this_day: nextValue } } } },
+			{
+				onSuccess: () => {
+					createSuccessNotice(
+						sprintf(
+							/* translators: %s is the name of the settings */ __( '"%s" settings saved.' ),
+							__( 'On this day' )
+						),
+						{ type: 'snackbar' }
+					);
+				},
+				onError: () => {
+					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					checked={ !! data.other.timeline.on_this_day }
+					disabled={ isMutating }
+					label={ __( 'On this day' ) }
+					help={ __( 'Reminders about your posts from past years' ) }
+					onChange={ handleChange }
+				/>
+			</CardBody>
+		</Card>
+	);
+};

--- a/client/dashboard/me/notifications-extras/on-this-day-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/on-this-day-card/index.tsx
@@ -41,9 +41,13 @@ export const OnThisDayCard = () => {
 					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
-						type: 'snackbar',
-					} );
+					createErrorNotice(
+						sprintf(
+							/* translators: %s is the name of the setting */ __( 'Failed to save %s settings.' ),
+							__( 'On this day' )
+						),
+						{ type: 'snackbar' }
+					);
 				},
 			}
 		);

--- a/client/dashboard/me/notifications-extras/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/test/index.test.tsx
@@ -64,6 +64,12 @@ const mockSaveNotificationSettingsApi = (
 		.reply( 200, { wpcom: expectedSettings } );
 };
 
+const mockGetPreferencesApi = ( preferences: Record< string, unknown > = {} ) => {
+	return nock( 'https://public-api.wordpress.com:443' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: preferences } );
+};
+
 const notificationSnackBar = () => {
 	// Snackbar requires a custom matcher because its aria-live is not supported by the testing library
 	return document.getElementById( 'a11y-speak-polite' );
@@ -77,6 +83,7 @@ describe( 'NotificationsExtras', () => {
 
 	it( 'renders the page header and sections correctly', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 
 		dashboardRender(
 			<>
@@ -105,6 +112,7 @@ describe( 'NotificationsExtras', () => {
 
 	it( 'displays all WordPress.com notification options', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 
 		dashboardRender(
 			<>
@@ -139,6 +147,7 @@ describe( 'NotificationsExtras', () => {
 
 	it( 'displays all Jetpack notification options', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 
 		dashboardRender(
 			<>
@@ -179,6 +188,7 @@ describe( 'NotificationsExtras', () => {
 		};
 
 		mockGetNotificationSettingsApi( customSettings );
+		mockGetPreferencesApi();
 
 		dashboardRender(
 			<>
@@ -221,8 +231,106 @@ describe( 'NotificationsExtras', () => {
 		expect( screen.getAllByLabelText( 'Reports' )[ 1 ] ).not.toBeChecked();
 	} );
 
+	it( 'renders the On this day and Achievements toggles', async () => {
+		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
+
+		dashboardRender(
+			<>
+				<Snackbars />
+				<NotificationsExtras />
+			</>
+		);
+
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'On this day' ) ).toBeVisible();
+		} );
+
+		expect( screen.getByText( 'Reminders about your posts from past years' ) ).toBeVisible();
+		expect( screen.getByLabelText( 'Achievements' ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				'Receive notifications when you unlock new achievements. This setting overrides site-level settings.'
+			)
+		).toBeVisible();
+	} );
+
+	it( 'saves the On this day setting when toggled', async () => {
+		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.1/me/notifications/settings', {
+				other: { timeline: { on_this_day: true } },
+			} )
+			.reply( 200, { other: { timeline: { on_this_day: true } } } );
+
+		dashboardRender(
+			<>
+				<Snackbars />
+				<NotificationsExtras />
+			</>
+		);
+
+		const onThisDayToggle = await screen.findByLabelText( 'On this day' );
+		expect( onThisDayToggle ).not.toBeChecked();
+
+		await userEvent.click( onThisDayToggle );
+
+		await waitFor( () => {
+			const snackbar = notificationSnackBar();
+			expect( snackbar ).toBeVisible();
+			expect( snackbar ).toHaveTextContent( '"On this day" settings saved.' );
+		} );
+	} );
+
+	it( 'shows the Achievements toggle as unchecked when notifications are disabled', async () => {
+		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi( { 'achievements-global-notifications': 'disabled' } );
+
+		dashboardRender(
+			<>
+				<Snackbars />
+				<NotificationsExtras />
+			</>
+		);
+
+		const achievementsToggle = await screen.findByLabelText( 'Achievements' );
+		expect( achievementsToggle ).not.toBeChecked();
+	} );
+
+	it( 'saves the Achievements setting when toggled', async () => {
+		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.1/me/preferences', {
+				calypso_preferences: { 'achievements-global-notifications': 'disabled' },
+			} )
+			.reply( 200, {
+				calypso_preferences: { 'achievements-global-notifications': 'disabled' },
+			} );
+
+		dashboardRender(
+			<>
+				<Snackbars />
+				<NotificationsExtras />
+			</>
+		);
+
+		const achievementsToggle = await screen.findByLabelText( 'Achievements' );
+		expect( achievementsToggle ).toBeChecked();
+
+		await userEvent.click( achievementsToggle );
+
+		await waitFor( () => {
+			const snackbar = notificationSnackBar();
+			expect( snackbar ).toBeVisible();
+			expect( snackbar ).toHaveTextContent( '"Achievements" settings saved.' );
+		} );
+	} );
+
 	it( 'shows snackbar notification on single setting change', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 		mockSaveNotificationSettingsApi( { marketing: true } );
 
 		dashboardRender(
@@ -250,6 +358,7 @@ describe( 'NotificationsExtras', () => {
 
 	it( 'shows snackbar notification when all settings are saved', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 		mockSaveNotificationSettingsApi( {
 			marketing: true,
 			research: true,
@@ -285,6 +394,7 @@ describe( 'NotificationsExtras', () => {
 
 	it( 'disables controls while saving', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 		// Don't mock the save API to simulate a pending request
 		nock( 'https://public-api.wordpress.com:443' )
 			.post( '/rest/v1.1/me/notifications/settings' )
@@ -316,6 +426,7 @@ describe( 'NotificationsExtras', () => {
 
 	it( 'shows error message when save fails', async () => {
 		mockGetNotificationSettingsApi();
+		mockGetPreferencesApi();
 		nock( 'https://public-api.wordpress.com:443' )
 			.post( '/rest/v1.1/me/notifications/settings' )
 			.reply( 500, { error: 'Internal server error' } );


### PR DESCRIPTION
Fixes phcsdm-PD-p2#comment-5237 

## Proposed Changes

* Add an "On this day" toggle card to the Dashboard's Notifications → Extras screen, wired to the `other.timeline.on_this_day` field of the `/me/notifications/settings` endpoint (the same field the classic notification settings page saves).
* Add an "Achievements" toggle card wired to the `achievements-global-notifications` user preference via `userPreferenceQuery` / `userPreferenceOptimisticMutation` (same storage as the classic page, so the two UIs stay in sync).
* Both cards render in their own groups at the top of the Extras screen, before the "Email from WordPress.com" group. Labels and help text are copied verbatim from the classic UI, so no new translatable strings are introduced.
* Saving shows the standard snackbar notices and records Tracks events (`calypso_dashboard_notifications_timeline_settings_updated` with `setting_name: 'on_this_day'`, and `calypso_dashboard_notifications_achievements_settings_updated`).
* Extend the Extras screen unit tests: four new tests covering rendering, saving each toggle, and the disabled-preference state, plus a `/me/preferences` mock for existing tests since the Achievements card now suspends on that endpoint.

## Why are these changes being made?

* The "On this day" and "Achievements" notification toggles currently only exist in the classic notification settings page. The new Dashboard's notification settings had no equivalent, so users managing notifications there couldn't control these two settings. This folds them into the Extras screen.

## Testing Instructions

* Run `yarn test-client client/dashboard/me/notifications-extras`.
* Start the dashboard with `yarn start-dashboard` and go to Notifications → Extras.
* Verify the "On this day" and "Achievements" cards appear above the "Email from WordPress.com" group.
* Toggle each one: a `"<name>" settings saved.` snackbar should appear, and the state should match the corresponding toggles in the classic notification settings page after a reload of either page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
