### PR TITLE
Reader: sync subscribe/unsubscribe button with the feed query cache

### DIFF
--- a/client/blocks/reader-feed-item/index.tsx
+++ b/client/blocks/reader-feed-item/index.tsx
@@ -114,6 +114,7 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 			onUnsubscribe( {
 				subscriptionId: currentSubscriptionId,
 				blog_id: blogId ?? undefined,
+				feed_id: feedId,
 				url: subscribeUrl,
 				onSuccess: () => {
 					setLocalSubscriptionId( null );

--- a/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	getSiteSubscriptionsQueryKey,
+	readFeedQueryKey,
 	type SiteSubscriptionsInfiniteData,
 } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -100,6 +101,32 @@ describe( 'site subscription mutations', () => {
 		} );
 	} );
 
+	it( 'invalidates the feed query so the subscribe button reflects the new subscription', async () => {
+		const queryClient = makeQueryClient();
+		const invalidateQueries = jest.spyOn( queryClient, 'invalidateQueries' );
+		( callApi as jest.Mock ).mockResolvedValue( { subscribed: true } );
+
+		const { result } = renderHook( () => useSiteSubscribeMutation(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		act( () => {
+			result.current.mutate( {
+				feed_id: 456,
+				url: 'https://example.com/feed',
+				doNotInvalidateSiteSubscriptions: true,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		const invalidatedKeys = invalidateQueries.mock.calls.map(
+			( [ filters ] ) => filters?.queryKey
+		);
+		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
+		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 456 ] );
+	} );
+
 	it( 'rolls back site subscription restore when subscribe fails', async () => {
 		const queryClient = makeQueryClient();
 		const previousData = makeSiteSubscriptionsData(
@@ -182,6 +209,31 @@ describe( 'site subscription mutations', () => {
 			is_following: true,
 			isDeleted: false,
 		} );
+	} );
+
+	it( 'invalidates the feed query so the subscribe button reflects the removed subscription', async () => {
+		const queryClient = makeQueryClient();
+		const invalidateQueries = jest.spyOn( queryClient, 'invalidateQueries' );
+		( callApi as jest.Mock ).mockResolvedValue( { subscribed: false } );
+
+		const { result } = renderHook( () => useSiteUnsubscribeMutation(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		act( () => {
+			result.current.mutate( {
+				subscriptionId: 123,
+				feed_id: 456,
+				doNotInvalidateSiteSubscriptions: true,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		const invalidatedKeys = invalidateQueries.mock.calls.map(
+			( [ filters ] ) => filters?.queryKey
+		);
+		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
 	} );
 
 	it( 'rolls back site subscription delete when unsubscribe fails', async () => {

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,5 +1,6 @@
 import {
 	getSiteSubscriptionsQueryKey,
+	readFeedQueryKey,
 	type SiteSubscriptionsInfiniteData,
 } from '@automattic/api-queries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -175,9 +176,8 @@ const useSiteSubscribeMutation = () => {
 			}
 
 			if ( isValidId( params.feed_id ) ) {
-				const feedCacheKey = [ 'read', 'feeds', Number( params.feed_id ) ];
 				queryClient.invalidateQueries( {
-					queryKey: feedCacheKey,
+					queryKey: readFeedQueryKey( params.feed_id ),
 				} );
 			}
 

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -1,5 +1,6 @@
 import {
 	getSiteSubscriptionsQueryKey,
+	readFeedQueryKey,
 	type SiteSubscriptionsInfiniteData,
 } from '@automattic/api-queries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -12,6 +13,7 @@ type UnsubscribeParams = {
 	subscriptionId: number;
 	url?: string;
 	blog_id?: number | string;
+	feed_id?: number | string;
 	doNotInvalidateSiteSubscriptions?: boolean;
 	emailId?: string;
 	onSuccess?: () => void;
@@ -230,6 +232,12 @@ const useSiteUnsubscribeMutation = () => {
 				} );
 				queryClient.invalidateQueries( {
 					queryKey: [ 'read', 'sites', Number( params.blog_id ) ],
+				} );
+			}
+
+			if ( isValidId( params.feed_id ) ) {
+				queryClient.invalidateQueries( {
+					queryKey: readFeedQueryKey( params.feed_id ),
 				} );
 			}
 


### PR DESCRIPTION
Part of READ-219

## Proposed Changes

* Fix the subscribe mutation invalidating the wrong React Query key: it used `[ 'read', 'feeds', id ]` (plural) while the feed query is keyed `[ 'read', 'feed', id ]` (singular). It now invalidates via the canonical `readFeedQueryKey()` helper.
* Add the same feed-query invalidation to the unsubscribe mutation, which previously never invalidated the single-feed query at all.
* Pass `feed_id` from `ReaderFeedItem` into the unsubscribe mutation so it can target the feed cache.
* Add regression tests asserting both mutations invalidate `readFeedQueryKey( feed_id )`.

`ReaderFeedItem` is shared, so this fix applies anywhere it renders — not just `/reader/new`. The affected surfaces are:

* `/reader/new` — the add-subscription form's related-sites search list.
* The Reader Subscriptions Manager at `/reader/subscriptions`, which also renders the unsubscribed-feeds search list.
* The feed preview shown in both of the above.

Both mutation changes are gated on `feed_id` being passed, and only `ReaderFeedItem` passes it, so other callers of the subscribe/unsubscribe mutations (resubscribe in subscription details, the add-sites form, the subscription row) are unaffected.

After subscribing: 

Before | After
--- | ---
<img width="800" height="366" alt="Screenshot 2026-07-08 at 4 42 54 PM" src="https://github.com/user-attachments/assets/87ebea01-e966-4441-8a17-80572aec3eb1" /> | <img width="799" height="375" alt="Screenshot 2026-07-08 at 4 43 26 PM" src="https://github.com/user-attachments/assets/75df8307-17a8-4b52-b5ea-18c5fda103db" />


## Why are these changes being made?

On `/reader/new`, subscribing to a site left the button showing “Subscribe” until a manual reload. The `ReaderFeedItem` button derives its state from the feed query’s `subscription_id`, but the subscribe mutation’s invalidation key never matched the query key (introduced during the React Query follows migration), so the cache stayed stale. The unsubscribe side had the mirror problem: it never invalidated the single-feed query, so after subscribing then unsubscribing the button would snap back to “Unsubscribe” on the next render/reload. Using the shared key helper on both mutations keeps the button in sync without a reload and prevents the key from drifting again.

## Testing Instructions

`ReaderFeedItem` is shared, so verify the button behaviour on each surface below. In every case the button should flip immediately (no reload) and hold its state after reloading the page.

* **`/reader/new`:** enter a feed you are not subscribed to, then toggle Subscribe → Unsubscribe → Subscribe.
* **Reader Subscriptions Manager (`/reader/subscriptions`):** search for a feed you are not subscribed to in the unsubscribed-feeds results and toggle Subscribe/Unsubscribe.
* **Feed preview:** open a feed preview from either surface above and toggle Subscribe/Unsubscribe from the preview.
* In each case: **Subscribe** should flip to **Unsubscribe** immediately with no reload; **Unsubscribe** should flip back to **Subscribe** and stay **Subscribe** after reloading.
* Run `yarn test-packages packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aytCPCWJUsKkmSt2ZMLbF
