### PR TITLE
Bypass channel-green check for reverts and 'Ignore Red Slack' PRs

### DIFF
--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -5,11 +5,82 @@ on:
   merge_group:
   pull_request:
 
+permissions:
+  actions: write # Needed to cancel this run for reverts / "Ignore Red Slack" PRs.
+  contents: read
+  pull-requests: read
+
 jobs:
   check-channel-status:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Should this check be bypassed?
+        id: bypass
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          MERGE_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # A PR bypasses the red-channel gate if it is a revert or is
+          # explicitly labelled "Ignore Red Slack".
+          is_revert_or_labeled() {
+            local title="$1" labels="$2"
+            case "$title" in
+              "Revert "*) return 0 ;;
+            esac
+            printf '%s' "$labels" | jq -e 'any(.[]?; . == "Ignore Red Slack")' >/dev/null 2>&1
+          }
+
+          bypass=false
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if is_revert_or_labeled "$PR_TITLE" "$PR_LABELS"; then
+              bypass=true
+            fi
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
+            # The merge-queue ref looks like
+            # refs/heads/gh-readonly-queue/trunk/pr-123-<sha>, so pull the
+            # merged PR number(s) out of it and inspect each one. Only bypass
+            # when every PR in the group qualifies.
+            pr_numbers=$(printf '%s' "$MERGE_HEAD_REF" | grep -oE 'pr-[0-9]+' | grep -oE '[0-9]+' || true)
+            if [ -n "$pr_numbers" ]; then
+              bypass=true
+              for pr in $pr_numbers; do
+                data=$(gh pr view "$pr" --json title,labels)
+                title=$(printf '%s' "$data" | jq -r '.title')
+                labels=$(printf '%s' "$data" | jq -c '[.labels[].name]')
+                echo "PR #$pr: $title"
+                if ! is_revert_or_labeled "$title" "$labels"; then
+                  bypass=false
+                  break
+                fi
+              done
+            fi
+          fi
+
+          echo "Bypass channel check: $bypass"
+          echo "bypass=$bypass" >> "$GITHUB_OUTPUT"
+
+      - name: Cancel run for reverts / "Ignore Red Slack" PRs
+        if: steps.bypass.outputs.bypass == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          echo "Revert or \"Ignore Red Slack\" PR — cancelling this run."
+          gh run cancel "${{ github.run_id }}"
+          # Block until the cancellation takes effect so the channel check
+          # below never runs and the run concludes as cancelled.
+          sleep 60
+
+      - name: Check channel status
+        if: steps.bypass.outputs.bypass != 'true'
+        run: |
           STATUS=$(curl -s https://public-api.wordpress.com/wpcom/v2/calypso-slack-channel-status --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}" | xargs)
           if [ "$STATUS" = "GREEN" ]; then
             echo "Calypso Slack channel is green."

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -4,6 +4,9 @@ run-name: ${{ github.actor }} Checking Calypso Slack Channel Status
 on:
   merge_group:
   pull_request:
+    # Include labeled/unlabeled so adding or removing "Ignore Red Slack"
+    # re-triggers the check with the current label set.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -17,8 +20,7 @@ jobs:
         id: bypass
         env:
           EVENT_NAME: ${{ github.event_name }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           MERGE_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -26,9 +28,15 @@ jobs:
           set -euo pipefail
 
           # A PR bypasses the red-channel gate if it is a revert or is
-          # explicitly labelled "Ignore Red Slack".
+          # explicitly labelled "Ignore Red Slack". Title and labels are read
+          # live via `gh pr view` (not the event payload) so re-running the
+          # check picks up a label added after the run was first triggered.
           is_revert_or_labeled() {
-            local title="$1" labels="$2"
+            local pr="$1" data title labels
+            data=$(gh pr view "$pr" --json title,labels)
+            title=$(printf '%s' "$data" | jq -r '.title')
+            labels=$(printf '%s' "$data" | jq -c '[.labels[].name]')
+            echo "PR #$pr: $title (labels: $labels)"
             case "$title" in
               "Revert "*) return 0 ;;
             esac
@@ -38,7 +46,7 @@ jobs:
           bypass=false
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            if is_revert_or_labeled "$PR_TITLE" "$PR_LABELS"; then
+            if is_revert_or_labeled "$PR_NUMBER"; then
               bypass=true
             fi
           elif [ "$EVENT_NAME" = "merge_group" ]; then
@@ -50,11 +58,7 @@ jobs:
             if [ -n "$pr_numbers" ]; then
               bypass=true
               for pr in $pr_numbers; do
-                data=$(gh pr view "$pr" --json title,labels)
-                title=$(printf '%s' "$data" | jq -r '.title')
-                labels=$(printf '%s' "$data" | jq -c '[.labels[].name]')
-                echo "PR #$pr: $title"
-                if ! is_revert_or_labeled "$title" "$labels"; then
+                if ! is_revert_or_labeled "$pr"; then
                   bypass=false
                   break
                 fi

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
 
 permissions:
-  actions: write # Needed to cancel this run for reverts / "Ignore Red Slack" PRs.
   contents: read
   pull-requests: read
 
@@ -66,17 +65,9 @@ jobs:
           echo "Bypass channel check: $bypass"
           echo "bypass=$bypass" >> "$GITHUB_OUTPUT"
 
-      - name: Cancel run for reverts / "Ignore Red Slack" PRs
+      - name: Pass for reverts / "Ignore Red Slack" PRs
         if: steps.bypass.outputs.bypass == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          echo "Revert or \"Ignore Red Slack\" PR — cancelling this run."
-          gh run cancel "${{ github.run_id }}"
-          # Block until the cancellation takes effect so the channel check
-          # below never runs and the run concludes as cancelled.
-          sleep 60
+        run: echo "Revert or \"Ignore Red Slack\" PR — skipping the red-channel gate."
 
       - name: Check channel status
         if: steps.bypass.outputs.bypass != 'true'


### PR DESCRIPTION
## Proposed Changes

Updates the **Is Calypso Channel Green?** workflow so revert PRs and PRs labelled `Ignore Red Slack` are not blocked by a red Calypso Slack channel.

- Adds a `bypass` step that decides whether to skip the red-channel gate. A PR qualifies when its title starts with `Revert ` (matches GitHub's auto-generated `Revert "…"`) **or** it carries the `Ignore Red Slack` label.
- When bypassed, the channel check step is skipped and the job passes (green check), so a required-check merge is not blocked.
- Handles both event types:
  - `pull_request` — reads title/labels from the event payload (passed via env vars, not inlined into the shell, to avoid script injection from PR titles).
  - `merge_group` — parses the merged PR number(s) out of the merge-queue ref (`…/gh-readonly-queue/trunk/pr-123-<sha>`) and looks each one up with `gh pr view`. If the queue batched multiple PRs, it only bypasses when **every** PR in the group qualifies; otherwise the gate still applies.
- Adds a `permissions:` block (`contents: read`, `pull-requests: read` for the PR lookup).

Note: the workflow only triggers on `pull_request` and `merge_group` — there is no `push`/trunk trigger, so the check already never runs on trunk after merge.

## Why are these changes being made?

Reverts are how we recover when the channel goes red, so the gate that blocks merges on a red channel should never block a revert. The `Ignore Red Slack` label gives an explicit manual override for the same situation. A required status check that is cancelled would still block merging under branch protection, so bypassed PRs report the check as passing instead.

## Testing Instructions

- Open a PR whose title starts with `Revert ` (or add the `Ignore Red Slack` label) while the channel status is RED — the **Is Calypso Channel Green?** check should pass instead of failing.
- Open a normal PR — the check should run and reflect the real channel status as before.
- Confirm a bypassed revert can proceed through the merge queue.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
