### PR TITLE
MSD Emails: Restrict Titan plan upgrade billing interval

### DIFF
--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -62,10 +62,7 @@ export default function ChooseEmailSolution() {
 	const { intent } = chooseEmailSolutionRoute.useSearch();
 	const isUpgradeIntent = intent === 'upgrade' && hasTitanMailWithUs( domain );
 
-	// A monthly subscriber may keep monthly or move up to yearly when upgrading, so the
-	// billing-interval toggle stays available for them. A yearly subscriber can only
-	// upgrade to another yearly plan (no yearly -> monthly downgrade), so the toggle is
-	// hidden and the interval is locked to yearly.
+	// Yearly -> monthly billing downgrade is not supported during an upgrade.
 	const isUpgradingFromMonthly = isUpgradeIntent && isMonthlyEmailProduct( titanEmailSubscription );
 	const showIntervalSelector = ! isUpgradeIntent || isUpgradingFromMonthly;
 	const [ billingInterval, setBillingInterval ] = useState< IntervalLength >(

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -62,12 +62,14 @@ export default function ChooseEmailSolution() {
 	const { intent } = chooseEmailSolutionRoute.useSearch();
 	const isUpgradeIntent = intent === 'upgrade' && hasTitanMailWithUs( domain );
 
-	// An upgrade keeps the existing subscription's billing cycle, so lock the
-	// interval to it (the billing-interval toggle is hidden during an upgrade).
+	// A monthly subscriber may keep monthly or move up to yearly when upgrading, so the
+	// billing-interval toggle stays available for them. A yearly subscriber can only
+	// upgrade to another yearly plan (no yearly -> monthly downgrade), so the toggle is
+	// hidden and the interval is locked to yearly.
+	const isUpgradingFromMonthly = isUpgradeIntent && isMonthlyEmailProduct( titanEmailSubscription );
+	const showIntervalSelector = ! isUpgradeIntent || isUpgradingFromMonthly;
 	const [ billingInterval, setBillingInterval ] = useState< IntervalLength >(
-		isUpgradeIntent && isMonthlyEmailProduct( titanEmailSubscription )
-			? IntervalLength.Monthly
-			: IntervalLength.Annually
+		isUpgradingFromMonthly ? IntervalLength.Monthly : IntervalLength.Annually
 	);
 
 	const { bestAnnualSavings } = useAnnualSavings( domain );
@@ -271,7 +273,7 @@ export default function ChooseEmailSolution() {
 			}
 		>
 			{ /* Billing interval selector */ }
-			{ ! isUpgradeIntent &&
+			{ showIntervalSelector &&
 				( isTitanPlanSelectionEnabled ? (
 					<div className="choose-email-solution-narrow">{ intervalSelector }</div>
 				) : (


### PR DESCRIPTION
Part of DOTEMP-112

## Proposed Changes

* Restrict the billing-interval choice during a Professional Email (Titan) plan upgrade so a yearly subscriber can no longer switch to monthly.
* The billing-interval toggle is now shown during an upgrade **only when the current subscription is monthly**. A monthly subscriber can upgrade to monthly or yearly; a yearly subscriber is locked to yearly.
* Introduces `isUpgradingFromMonthly` / `showIntervalSelector` in `choose-email-solution` and seeds the initial `billingInterval` from them.

## Why are these changes being made?

* Downgrading the billing cycle (yearly -> monthly) as part of a tier upgrade is not a supported transition. Previously the interval was fully locked to the existing cycle during an upgrade; this opens the valid monthly -> yearly path while explicitly preventing the invalid yearly -> monthly one. Since `handleTierUpgrade` reads the same `billingInterval`, checkout is constrained too.

## Testing Instructions

* On the Dashboard, open `/emails/choose-email-solution/:domain?intent=upgrade` for a domain that has an active Professional Email subscription.
* With a **monthly** subscription: the billing-interval toggle is visible; you can pick Monthly or Annually, and the tier upgrade proceeds with the chosen interval.
* With a **yearly** subscription: the toggle is hidden and the interval is locked to yearly; there is no way to reach a monthly upgrade.
* New purchase flow (no `intent=upgrade`) is unchanged: the toggle is still shown.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
