### PR TITLE
Stats: sort WordAds earnings history rows by date, not display string

### DIFF
--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -231,7 +231,7 @@ class WordAdsEarnings extends Component {
 			'is-showing-info': this.getInfoToggle( type ),
 		} );
 
-		const sortedPeriods = Object.keys( earnings ).sort( ( a, b ) => new Date( b ) - new Date( a ) );
+		const sortedPeriods = Object.keys( earnings ).sort( ( a, b ) => b.localeCompare( a ) );
 
 		for ( const period of sortedPeriods ) {
 			rows.push(

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -231,23 +231,23 @@ class WordAdsEarnings extends Component {
 			'is-showing-info': this.getInfoToggle( type ),
 		} );
 
-		for ( const period in earnings ) {
-			if ( earnings.hasOwnProperty( period ) ) {
-				rows.push(
-					<tr key={ type + '-' + period }>
-						<td className="ads__earnings-history-value">{ this.swapYearMonth( period ) }</td>
-						<td className="ads__earnings-history-value">
-							${ formatNumber( earnings[ period ].amount, { decimals: 2 } ) }
-						</td>
-						<td className="ads__earnings-history-value">
-							{ formatNumber( earnings[ period ].pageviews ) }
-						</td>
-						<td className="ads__earnings-history-value">
-							{ this.getStatus( earnings[ period ].status ) }
-						</td>
-					</tr>
-				);
-			}
+		const sortedPeriods = Object.keys( earnings ).sort( ( a, b ) => new Date( b ) - new Date( a ) );
+
+		for ( const period of sortedPeriods ) {
+			rows.push(
+				<tr key={ type + '-' + period }>
+					<td className="ads__earnings-history-value">{ this.swapYearMonth( period ) }</td>
+					<td className="ads__earnings-history-value">
+						${ formatNumber( earnings[ period ].amount, { decimals: 2 } ) }
+					</td>
+					<td className="ads__earnings-history-value">
+						{ formatNumber( earnings[ period ].pageviews ) }
+					</td>
+					<td className="ads__earnings-history-value">
+						{ this.getStatus( earnings[ period ].status ) }
+					</td>
+				</tr>
+			);
 		}
 
 		return (

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import QueryWordadsEarnings from 'calypso/components/data/query-wordads-earnings';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getWordAdsEarnings } from 'calypso/state/wordads/earnings/selectors';
+import { sortEarningsPeriods, swapYearMonth } from './utils';
 import './earnings.scss';
 
 class WordAdsEarnings extends Component {
@@ -67,11 +68,6 @@ class WordAdsEarnings extends Component {
 		}
 
 		return Object.keys( obj ).length;
-	}
-
-	swapYearMonth( date ) {
-		const splits = date.split( '-' );
-		return splits[ 1 ] + '-' + splits[ 0 ];
 	}
 
 	getStatus( status ) {
@@ -231,12 +227,12 @@ class WordAdsEarnings extends Component {
 			'is-showing-info': this.getInfoToggle( type ),
 		} );
 
-		const sortedPeriods = Object.keys( earnings ).sort( ( a, b ) => b.localeCompare( a ) );
+		const sortedPeriods = sortEarningsPeriods( Object.keys( earnings ) );
 
 		for ( const period of sortedPeriods ) {
 			rows.push(
 				<tr key={ type + '-' + period }>
-					<td className="ads__earnings-history-value">{ this.swapYearMonth( period ) }</td>
+					<td className="ads__earnings-history-value">{ swapYearMonth( period ) }</td>
 					<td className="ads__earnings-history-value">
 						${ formatNumber( earnings[ period ].amount, { decimals: 2 } ) }
 					</td>

--- a/client/my-sites/stats/wordads/test/utils.js
+++ b/client/my-sites/stats/wordads/test/utils.js
@@ -1,0 +1,43 @@
+import { sortEarningsPeriods, swapYearMonth } from '../utils';
+
+describe( 'sortEarningsPeriods', () => {
+	test( 'orders periods by date, most recent first', () => {
+		expect( sortEarningsPeriods( [ '2025-10', '2025-06', '2024-09' ] ) ).toEqual( [
+			'2025-10',
+			'2025-06',
+			'2024-09',
+		] );
+	} );
+
+	test( 'sorts regardless of the input order', () => {
+		expect( sortEarningsPeriods( [ '2024-09', '2025-06', '2025-10' ] ) ).toEqual( [
+			'2025-10',
+			'2025-06',
+			'2024-09',
+		] );
+	} );
+
+	test( 'orders across a year boundary', () => {
+		expect( sortEarningsPeriods( [ '2025-12', '2026-01', '2025-11' ] ) ).toEqual( [
+			'2026-01',
+			'2025-12',
+			'2025-11',
+		] );
+	} );
+
+	test( 'does not mutate the input array', () => {
+		const periods = [ '2025-06', '2025-10' ];
+		sortEarningsPeriods( periods );
+		expect( periods ).toEqual( [ '2025-06', '2025-10' ] );
+	} );
+
+	test( 'returns an empty array for no periods', () => {
+		expect( sortEarningsPeriods( [] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'swapYearMonth', () => {
+	test( 'converts a YYYY-MM period into MM-YYYY for display', () => {
+		expect( swapYearMonth( '2025-10' ) ).toBe( '10-2025' );
+	} );
+} );

--- a/client/my-sites/stats/wordads/utils.js
+++ b/client/my-sites/stats/wordads/utils.js
@@ -1,0 +1,8 @@
+export function sortEarningsPeriods( periods ) {
+	return [ ...periods ].sort( ( a, b ) => b.localeCompare( a ) );
+}
+
+export function swapYearMonth( period ) {
+	const [ year, month ] = period.split( '-' );
+	return `${ month }-${ year }`;
+}


### PR DESCRIPTION
Fixes STATS-277

## Proposed Changes

* Sort the WordAds earnings history table (`client/my-sites/stats/wordads/earnings.jsx`, rendered on the Earn page at `client/my-sites/earn`) by the underlying `YYYY-MM` period date instead of relying on object key iteration order.

## Why are these changes being made?

* The earnings history table iterated the `earnings` object with `for...in`, which just preserves whatever order the API response happened to produce. Rows ended up out of chronological order (e.g. 10-2025, 06-2025, 09-2024 mixed together instead of properly ordered), and the previous approach risked sorting by the display-formatted `MM-YYYY` string rather than the actual date value. Explicitly sorting the raw `YYYY-MM` period keys by date fixes this regardless of API ordering.

## Testing Instructions

* Go to a site's Earn page (`/earn/<site>`) with WordAds enabled and multiple earnings history entries.
* Confirm rows in the "Period" column of the earnings history table are ordered chronologically (most recent first), regardless of the order the API returns them in.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?