### PR TITLE
Login: keep Jetpack app branding across 2FA screens

### DIFF
--- a/client/state/selectors/get-is-jetpack-app.ts
+++ b/client/state/selectors/get-is-jetpack-app.ts
@@ -22,7 +22,14 @@ export default function getIsJetpackApp( state: AppState ): boolean {
 		return false;
 	}
 
-	const query = getCurrentQueryArguments( state ) ?? getInitialQueryArguments( state );
+	// The redirect_uri that distinguishes the Jetpack app from the WordPress app lives
+	// only on the initial login URL. Navigating to a 2FA sub-route (e.g. `/log-in/webauthn`)
+	// lands on a query that no longer carries it, and that query is a non-nullish object,
+	// so a whole-query `??` fallback would never reach the initial query. Fall back on the
+	// redirect_uri itself instead, so the app identity survives across the 2FA screens.
+	const redirectUri =
+		getOAuth2RedirectUri( getCurrentQueryArguments( state ) ) ??
+		getOAuth2RedirectUri( getInitialQueryArguments( state ) );
 
-	return isJetpackAppRedirectUri( getOAuth2RedirectUri( query ) );
+	return isJetpackAppRedirectUri( redirectUri );
 }

--- a/client/state/selectors/test/get-is-jetpack-app.js
+++ b/client/state/selectors/test/get-is-jetpack-app.js
@@ -1,6 +1,6 @@
 import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 
-const buildState = ( { clientId, redirectTo } ) => ( {
+const buildState = ( { clientId, redirectTo, initialRedirectTo } ) => ( {
 	oauth2Clients: {
 		ui: { currentClientId: clientId ?? null },
 		clients: clientId ? { [ clientId ]: { id: clientId } } : {},
@@ -11,6 +11,9 @@ const buildState = ( { clientId, redirectTo } ) => ( {
 				...( clientId ? { client_id: String( clientId ) } : {} ),
 				...( redirectTo ? { redirect_to: redirectTo } : {} ),
 			},
+			...( initialRedirectTo
+				? { initial: { client_id: String( clientId ), redirect_to: initialRedirectTo } }
+				: {} ),
 		},
 	},
 } );
@@ -62,6 +65,19 @@ describe( 'getIsJetpackApp', () => {
 
 	test( 'is false for a shared mobile client with no redirect', () => {
 		expect( getIsJetpackApp( buildState( { clientId: 11 } ) ) ).toBe( false );
+	} );
+
+	test( 'falls back to the initial redirect_uri when the 2FA route drops it from the current query', () => {
+		// 2FA sub-routes (e.g. /log-in/webauthn) navigate away from the launching URL,
+		// so the current query keeps the sticky client_id but loses the jetpack:// redirect.
+		const state = buildState( {
+			clientId: 11,
+			initialRedirectTo: authorizeUrl( {
+				clientId: 11,
+				redirectUri: 'jetpack%3A%2F%2Foauth2-callback',
+			} ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( true );
 	} );
 
 	test( 'is false when there is no current OAuth2 client', () => {


### PR DESCRIPTION
Follow-up to #112439.

## Proposed Changes

* Fix `getIsJetpackApp` so a login that began in the Jetpack mobile app keeps its Jetpack identity after it navigates to a 2FA screen (`/log-in/webauthn`, `sms`, `email`, `authenticator`, `backup`). The selector drives two pieces of branding, and both fell back to WordPress for a Jetpack-app login:
  * The centered logo showed the WordPress app icon instead of the Jetpack app icon — on all five screens.
  * The heading read "Log in to WordPress for iOS with WordPress.com" instead of "...Jetpack for iOS..." — but only on `webauthn` and `sms`. The `email`, `authenticator`, and `backup` screens replace the heading with a generic 2FA string ("Continue with an authentication code" / "Continue with a backup code"), so on those three only the icon was wrong.

## Why are these changes being made?

The WordPress and Jetpack apps share OAuth2 client IDs, so the app is distinguished only by its `jetpack://` `redirect_uri`. That `redirect_uri` reaches the login page on the initial URL, but 2FA navigation (`handleTwoFactorRequested`) rebuilds the route without `redirect_to`, while the sticky `currentClientId` keeps the client resolving as the shared mobile app. `getIsJetpackApp` re-derives the scheme from the route query on every render, and its `??` fallback to the initial query only fired when the current query was **entirely** absent — but `setRoute` defaults the query to a non-null `{}`, so the fallback never ran and the launching `jetpack://` scheme was never consulted. The selector returned false, and both consumers — the centered icon and the branded heading — followed it to the WordPress-app branch.

The fix falls back on the `redirect_uri` **value** rather than the whole query object, so the initial query is consulted whenever the current one carries no redirect. An explicit current-route redirect still wins, so a WordPress-app session can't be mislabeled as Jetpack.

#112439 sidestepped this on the push screen by hardcoding its logo to the Jetpack app icon — push is always approved from the Jetpack app, so its branding is fixed by route. That doesn't generalize to the other 2FA screens, where a security-key or SMS screen must reflect whichever client began the login, so the identity has to be preserved in the selector instead.

## Testing Instructions

The Jetpack-app identity is carried entirely by the login URL — a shared mobile-app `client_id` (`11` = iOS, `2697` = Android) plus a `redirect_to` whose nested `redirect_uri` uses the `jetpack://` scheme — so this reproduces in a desktop browser without the mobile app. You do need a test account with a real 2FA method enrolled; the server decides which 2FA screen appears.

* Load this URL against your Calypso dev or Horizon host (e.g. `calypso.localhost:3000`):

  ```
  <host>/log-in?client_id=11&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26response_type%3Dcode%26redirect_uri%3Djetpack%3A%2F%2Foauth2-callback
  ```

  The initial login screen should show the Jetpack app icon and "Log in to Jetpack for iOS with WordPress.com".
* Enter the credentials for an account with security-key (WebAuthn) 2FA and advance past the password step to `/log-in/webauthn`.
  * **Before:** the security key screen reverts to the WordPress app icon and "Log in to WordPress for iOS with WordPress.com".
  * **After:** it stays Jetpack — Jetpack app icon and "Log in to Jetpack for iOS with WordPress.com", matching the initial screen.
* On `authenticator`, `email`, and `backup` the heading is a generic 2FA string, so the centered icon is the only thing that should stay the Jetpack app icon there — a TOTP/authenticator account is the easiest to set up if you only need to check the icon.
* Control: swap the trailing `redirect_uri=jetpack%3A%2F%2F...` for `wordpress%3A%2F%2F...` and confirm every screen stays WordPress-branded.
* `yarn test-client client/state/selectors/test/get-is-jetpack-app.js` — adds a regression test for the 2FA-route fallback (verified it fails without the fix).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
