### PR TITLE
MSD advance notice: update opted-in copy

### DIFF
--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -39,14 +39,14 @@ function getBannerCopy(
 		const hasUpdatedOptedInTranslations =
 			hasEnTranslation( 'New dashboard is here to stay' ) &&
 			hasEnTranslation(
-				'The new dashboard you’ve been using becomes the default for everyone, and this classic view will be retired.'
+				'The new dashboard you’ve been testing is now the default. We’re retiring the earlier design.'
 			);
 
 		if ( hasUpdatedOptedInTranslations ) {
 			return {
 				heading: translate( 'New dashboard is here to stay' ),
 				description: translate(
-					'The new dashboard you’ve been using becomes the default for everyone, and this classic view will be retired.'
+					'The new dashboard you’ve been testing is now the default. We’re retiring the earlier design.'
 				),
 				button: translate( 'Go to new dashboard' ),
 			};


### PR DESCRIPTION
Part of DOTMSD-1174

Follow-up to #112350.

## Proposed Changes

* Update the advance notice paragraph shown to opted-in users to: "The new dashboard you’ve been testing is now the default. We’re retiring the earlier design."
* Heading ("New dashboard is here to stay") and button ("Go to new dashboard") are unchanged.
* The `hasEnTranslation` gate now checks the new paragraph, so the updated copy only renders once it has been translated. The no-translation fallback copy is unchanged.

<img width="600" height="632" alt="CleanShot 2026-07-09 at 12 35 23@2x" src="https://github.com/user-attachments/assets/4aa81525-7e7c-4c28-beb7-c581acf2e4cc" />


## Why are these changes being made?

* The previous paragraph described the change as still upcoming ("becomes the default"). The new dashboard is now the default, so the copy should say so in the past tense and be shorter.

## Testing Instructions

* Opt in to the Hosting Dashboard, then load a page where the opt-in banner is shown (e.g. a site in the classic view).
* Confirm the banner reads "New dashboard is here to stay" / "The new dashboard you’ve been testing is now the default. We’re retiring the earlier design." / "Go to new dashboard".
* Switch to a locale where the new string is not yet translated and confirm the fallback copy ("The new dashboard is here to stay" / "Soon, the Hosting Dashboard…") renders instead, with no mix of old and new strings.
* If your test user ID is `id % 100 >= 50` you may need to hardcode the `ROLLOUT_PERCENTAGE` constant.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
