### PR TITLE
Plugins "Get started": fix blank page when backing out of checkout

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -26,15 +26,9 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	const isGravatarDomain = isDomainForGravatarFlow( flowName );
 	const queryArgs = getQueryArgs() ?? {};
 
-	// For the with-plugin flow, backing out of checkout should return to the plans grid step, not
-	// the post-purchase thank-you/install destination — that page can't render before the purchase
-	// and would leave the user stuck. Rebuild the plans step URL from the flow dependencies; the
-	// current URL query no longer carries the plugin params at this point.
-	//
-	// Known limitation: re-entering the flow restarts from the domains step and creates a new site
-	// (signup progress is lost on the hard navigation, and there is no fulfilled-step check to skip
-	// site creation). Accepted for now as it beats landing on a blank page; a proper resume /
-	// no-recreate fix is a follow-up.
+	// with-plugin: point "back" at the plans grid (params from the dependency store — the URL query
+	// is empty by now), not the post-purchase destination which can't render pre-purchase. Known
+	// tradeoff: this re-enters signup and recreates the site; kept over a blank page for now.
 	let backDestination = destination;
 	if ( flowName === 'with-plugin' ) {
 		const { pluginParameter, pluginBillingPeriod } = dependencies;
@@ -43,7 +37,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 				...( pluginParameter && { plugin: pluginParameter } ),
 				...( pluginBillingPeriod && {
 					billing_period: pluginBillingPeriod,
-					// Match the plans grid's default interval to the plugin's billing period.
+					// Default the grid to the plugin's billing interval.
 					intervalType: pluginBillingPeriod === 'MONTHLY' ? 'monthly' : 'yearly',
 				} ),
 			},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -28,15 +28,19 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 
 	// For the with-plugin flow, backing out of checkout should return to the plans grid step, not
 	// the post-purchase thank-you/install destination — that page can't render before the purchase
-	// and would leave the user stuck. Rebuild the plans step URL from the current query.
+	// and would leave the user stuck. Rebuild the plans step URL from the flow dependencies; the
+	// current URL query no longer carries the plugin params at this point.
 	let backDestination = destination;
 	if ( flowName === 'with-plugin' ) {
-		const { plugin, billing_period: billingPeriod, intervalType } = queryArgs;
+		const { pluginParameter, pluginBillingPeriod } = dependencies;
 		backDestination = addQueryArgs(
 			{
-				...( plugin && { plugin } ),
-				...( billingPeriod && { billing_period: billingPeriod } ),
-				...( intervalType && { intervalType } ),
+				...( pluginParameter && { plugin: pluginParameter } ),
+				...( pluginBillingPeriod && {
+					billing_period: pluginBillingPeriod,
+					// Match the plans grid's default interval to the plugin's billing period.
+					intervalType: pluginBillingPeriod === 'MONTHLY' ? 'monthly' : 'yearly',
+				} ),
 			},
 			`/start/with-plugin/plans-with-plugin${ localeSlug ? `/${ localeSlug }` : '' }`
 		);

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -30,6 +30,11 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	// the post-purchase thank-you/install destination — that page can't render before the purchase
 	// and would leave the user stuck. Rebuild the plans step URL from the flow dependencies; the
 	// current URL query no longer carries the plugin params at this point.
+	//
+	// Known limitation: re-entering the flow restarts from the domains step and creates a new site
+	// (signup progress is lost on the hard navigation, and there is no fulfilled-step check to skip
+	// site creation). Accepted for now as it beats landing on a blank page; a proper resume /
+	// no-recreate fix is a follow-up.
 	let backDestination = destination;
 	if ( flowName === 'with-plugin' ) {
 		const { pluginParameter, pluginBillingPeriod } = dependencies;

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -109,5 +109,27 @@ describe( 'Signup Flows Configuration', () => {
 			expect( result ).toContain( 'checkoutBackUrl=' );
 			expect( result ).not.toContain( 'celebrateLaunch%3Dtrue' );
 		} );
+
+		test( 'should return to the plans grid with the plugin params for the with-plugin flow', () => {
+			// getQueryArgs is mocked to return {} above, so this also guards that the params come
+			// from the dependency store rather than the (empty) current URL query.
+			const flowsModule = require( 'calypso/signup/config/flows' );
+			const { filterDestination } = flowsModule.default;
+
+			const dependencies = {
+				siteSlug: 'test-site',
+				cartItem: 'business_plan',
+				pluginParameter: 'sensei-pro',
+				pluginBillingPeriod: 'ANNUALLY',
+			};
+			const destination = '/marketplace/thank-you/test-site?plugins=sensei-pro';
+
+			const result = filterDestination( destination, dependencies, 'with-plugin', 'en' );
+
+			expect( result ).toContain( 'plans-with-plugin' );
+			expect( result ).toContain( 'plugin%3Dsensei-pro' );
+			expect( result ).toContain( 'billing_period%3DANNUALLY' );
+			expect( result ).toContain( 'intervalType%3Dyearly' );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

- Fix the per-plugin "Get started" (`with-plugin`) checkout **back** URL so backing out of checkout returns to the plans grid step instead of a blank page. The back URL was rebuilt from the current URL query (`getQueryArgs`), which is empty by the time the flow constructs the checkout URL, so the returned page had no plugin. The values now come from the signup dependency store (`pluginParameter` / `pluginBillingPeriod`), with `intervalType` derived from the billing period.

## Known limitation (accepted for now)

Backing out re-enters the signup flow, which **restarts from the domains step and creates a new site** — signup progress is lost on the hard navigation and there is no fulfilled-step check to skip site creation. This is accepted as a stopgap because it beats landing on a blank page. A proper fix (resume the flow without recreating the site, or route "back" somewhere that doesn't re-enter signup) is a follow-up.

## Why are these changes being made?

Follow-up to the plans-grid change: that PR pointed the checkout back URL at the plans grid step but sourced the params from a place that is empty at flow-completion time, so the returned page was blank. The dependency store is populated at flow start and is the reliable source.

## Testing Instructions

1. Log out, open a paid marketplace plugin (e.g. Sensei Pro), click "Get started".
2. Create an account, pick a domain, land on the plans grid, pick a plan → checkout.
3. Click the checkout **back** control.
4. Confirm you return to the plans grid with the plugin selected (not a blank page). Note the known duplicate-site behavior above.

Unit test in `client/signup/test/flows.js` asserts the back URL contains `plans-with-plugin` and the `plugin` / `billing_period` / `intervalType` params even when the current-URL query is empty.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
