### PR TITLE
Plugins: clear manager state immediately after deleting a plugin (DOTMSD-1305)

### DIFF
--- a/client/dashboard/plugins/manage/utils/index.ts
+++ b/client/dashboard/plugins/manage/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './build-bulk-sites-plugin-action';
 export * from './map-api-plugins-to-dataview';
+export * from './remove-plugins-from-sites';

--- a/client/dashboard/plugins/manage/utils/remove-plugins-from-sites.ts
+++ b/client/dashboard/plugins/manage/utils/remove-plugins-from-sites.ts
@@ -4,8 +4,7 @@ import type { PluginsResponse } from '@automattic/api-core';
 /**
  * Drop the given plugins from the sites they were removed from in a cached
  * `/me/sites/plugins` response. Used to update the shared plugins cache the
- * moment a delete succeeds, so the manager reflects the removal immediately
- * instead of waiting for the eventually-consistent backend refetch.
+ * moment a delete succeeds, so the manager reflects the removal immediately.
  */
 export function removePluginsFromSites(
 	response: PluginsResponse | undefined,

--- a/client/dashboard/plugins/manage/utils/remove-plugins-from-sites.ts
+++ b/client/dashboard/plugins/manage/utils/remove-plugins-from-sites.ts
@@ -1,0 +1,36 @@
+import type { PluginListRow } from '../types';
+import type { PluginsResponse } from '@automattic/api-core';
+
+/**
+ * Drop the given plugins from the sites they were removed from in a cached
+ * `/me/sites/plugins` response. Used to update the shared plugins cache the
+ * moment a delete succeeds, so the manager reflects the removal immediately
+ * instead of waiting for the eventually-consistent backend refetch.
+ */
+export function removePluginsFromSites(
+	response: PluginsResponse | undefined,
+	items: PluginListRow[]
+): PluginsResponse | undefined {
+	if ( ! response?.sites ) {
+		return response;
+	}
+
+	const removedIdsBySite = new Map< number, Set< string > >();
+	items.forEach( ( { id, siteIds } ) => {
+		siteIds.forEach( ( siteId ) => {
+			const ids = removedIdsBySite.get( siteId ) ?? new Set< string >();
+			ids.add( id );
+			removedIdsBySite.set( siteId, ids );
+		} );
+	} );
+
+	const sites: PluginsResponse[ 'sites' ] = {};
+	for ( const [ siteId, plugins ] of Object.entries( response.sites ) ) {
+		const removedIds = removedIdsBySite.get( Number( siteId ) );
+		sites[ siteId ] = removedIds
+			? plugins.filter( ( plugin ) => ! removedIds.has( plugin.id ) )
+			: plugins;
+	}
+
+	return { ...response, sites };
+}

--- a/client/dashboard/plugins/manage/utils/test/remove-plugins-from-sites.test.ts
+++ b/client/dashboard/plugins/manage/utils/test/remove-plugins-from-sites.test.ts
@@ -1,0 +1,57 @@
+import { removePluginsFromSites } from '../remove-plugins-from-sites';
+import type { PluginListRow } from '../../types';
+import type { PluginItem, PluginsResponse } from '@automattic/api-core';
+
+const makePlugin = ( id: string ): PluginItem => ( { id, slug: id, name: id } ) as PluginItem;
+
+const makeRow = ( id: string, siteIds: number[] ): PluginListRow =>
+	( { id, siteIds } ) as PluginListRow;
+
+describe( 'removePluginsFromSites', () => {
+	test( 'removes the deleted plugin from every affected site', () => {
+		const response: PluginsResponse = {
+			sites: {
+				1: [ makePlugin( 'jetpack' ), makePlugin( 'akismet' ) ],
+				2: [ makePlugin( 'jetpack' ) ],
+			},
+		};
+
+		const result = removePluginsFromSites( response, [ makeRow( 'jetpack', [ 1, 2 ] ) ] );
+
+		expect( result?.sites[ 1 ].map( ( p ) => p.id ) ).toEqual( [ 'akismet' ] );
+		expect( result?.sites[ 2 ] ).toEqual( [] );
+	} );
+
+	test( 'leaves untargeted sites untouched', () => {
+		const response: PluginsResponse = {
+			sites: {
+				1: [ makePlugin( 'jetpack' ) ],
+				2: [ makePlugin( 'jetpack' ) ],
+			},
+		};
+
+		const result = removePluginsFromSites( response, [ makeRow( 'jetpack', [ 1 ] ) ] );
+
+		expect( result?.sites[ 1 ] ).toEqual( [] );
+		expect( result?.sites[ 2 ].map( ( p ) => p.id ) ).toEqual( [ 'jetpack' ] );
+	} );
+
+	test( 'handles removing several plugins at once', () => {
+		const response: PluginsResponse = {
+			sites: {
+				1: [ makePlugin( 'jetpack' ), makePlugin( 'akismet' ), makePlugin( 'woocommerce' ) ],
+			},
+		};
+
+		const result = removePluginsFromSites( response, [
+			makeRow( 'jetpack', [ 1 ] ),
+			makeRow( 'akismet', [ 1 ] ),
+		] );
+
+		expect( result?.sites[ 1 ].map( ( p ) => p.id ) ).toEqual( [ 'woocommerce' ] );
+	} );
+
+	test( 'returns the response unchanged when there are no sites', () => {
+		expect( removePluginsFromSites( undefined, [ makeRow( 'jetpack', [ 1 ] ) ] ) ).toBeUndefined();
+	} );
+} );

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -433,6 +433,18 @@ export const SitesWithThisPlugin = ( {
 										} );
 										return newState;
 									} );
+
+									// `/me/sites/plugins` lags behind writes, so apply the removal to the
+									// cache and mark it stale rather than refetching, letting the next
+									// read reconcile once the server has caught up.
+									queryClient.setQueryData(
+										pluginsQuery().queryKey,
+										( old: PluginsResponse | undefined ) => removePluginsFromSites( old, items )
+									);
+									queryClient.invalidateQueries( {
+										queryKey: pluginsQuery().queryKey,
+										refetchType: 'none',
+									} );
 								}
 
 								return { successCount, errorCount };
@@ -460,20 +472,6 @@ export const SitesWithThisPlugin = ( {
 									items={ [ mapToPluginListRow( plugin, items ) as PluginListRow ] }
 									closeModal={ closeModal }
 									onExecute={ action }
-									onActionPerformed={ ( deletedItems ) => {
-										// `/me/sites/plugins` lags behind writes, so apply the removal to the
-										// cache and mark it stale rather than refetching, letting the next
-										// read reconcile once the server has caught up.
-										queryClient.setQueryData(
-											pluginsQuery().queryKey,
-											( old: PluginsResponse | undefined ) =>
-												removePluginsFromSites( old, deletedItems as PluginListRow[] )
-										);
-										queryClient.invalidateQueries( {
-											queryKey: pluginsQuery().queryKey,
-											refetchType: 'none',
-										} );
-									} }
 								/>
 							);
 						},

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -461,9 +461,9 @@ export const SitesWithThisPlugin = ( {
 									closeModal={ closeModal }
 									onExecute={ action }
 									onActionPerformed={ ( deletedItems ) => {
-										// `/me/sites/plugins` is eventually consistent, so refetching now can
-										// re-add the just-deleted plugin. Update the cache optimistically and
-										// only mark it stale so the next natural access reconciles it.
+										// `/me/sites/plugins` lags behind writes, so apply the removal to the
+										// cache and mark it stale rather than refetching, letting the next
+										// read reconcile once the server has caught up.
 										queryClient.setQueryData(
 											pluginsQuery().queryKey,
 											( old: PluginsResponse | undefined ) =>

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -1,6 +1,6 @@
 import {
 	invalidatePlugins,
-	resetPlugins,
+	pluginsQuery,
 	sitePluginActivateMutation,
 	sitePluginAutoupdateDisableMutation,
 	sitePluginAutoupdateEnableMutation,
@@ -8,7 +8,7 @@ import {
 	sitePluginRemoveMutation,
 	sitePluginUpdateMutation,
 } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
 import {
 	DataViews,
@@ -24,7 +24,7 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import ActionRenderModal, { getModalHeader } from '../manage/components/action-render-modal';
 import { PluginsHeaderActions } from '../manage/components/plugins-header-actions';
-import { buildBulkSitesPluginAction } from '../manage/utils';
+import { buildBulkSitesPluginAction, removePluginsFromSites } from '../manage/utils';
 import { getViewFilteredByUpdates } from '../utils/update-filters';
 import { ActionRenderModalWrapper } from './components/action-render-modal-wrapper';
 import { ActiveToggle } from './components/active-toggle';
@@ -34,7 +34,7 @@ import { SiteWithPluginData } from './use-plugin';
 import { getAllowedPluginActions } from './utils/get-allowed-plugin-actions';
 import { mapToPluginListRow } from './utils/map-to-plugin-list-row';
 import type { PluginListRow } from '../manage/types';
-import type { PluginItem } from '@automattic/api-core';
+import type { PluginItem, PluginsResponse } from '@automattic/api-core';
 
 const defaultView: View = {
 	type: 'table',
@@ -402,6 +402,7 @@ export const SitesWithThisPlugin = ( {
 						label: __( 'Delete' ),
 						modalHeader: getModalHeader( 'delete' ),
 						RenderModal: ( { items, closeModal } ) => {
+							const queryClient = useQueryClient();
 							const { mutateAsync: deactivate } = useMutation(
 								sitePluginDeactivateMutation( false )
 							);
@@ -459,11 +460,19 @@ export const SitesWithThisPlugin = ( {
 									items={ [ mapToPluginListRow( plugin, items ) as PluginListRow ] }
 									closeModal={ closeModal }
 									onExecute={ action }
-									onActionPerformed={ () => {
-										resetPlugins();
-
-										// Delay invalidation to allow backend to settle
-										setTimeout( invalidatePlugins, 500 );
+									onActionPerformed={ ( deletedItems ) => {
+										// `/me/sites/plugins` is eventually consistent, so refetching now can
+										// re-add the just-deleted plugin. Update the cache optimistically and
+										// only mark it stale so the next natural access reconciles it.
+										queryClient.setQueryData(
+											pluginsQuery().queryKey,
+											( old: PluginsResponse | undefined ) =>
+												removePluginsFromSites( old, deletedItems as PluginListRow[] )
+										);
+										queryClient.invalidateQueries( {
+											queryKey: pluginsQuery().queryKey,
+											refetchType: 'none',
+										} );
 									} }
 								/>
 							);

--- a/client/dashboard/plugins/plugin/test/sites-with-this-plugin.test.tsx
+++ b/client/dashboard/plugins/plugin/test/sites-with-this-plugin.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { pluginsQuery } from '@automattic/api-queries';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -122,14 +121,12 @@ describe( '<SitesWithThisPlugin> delete flow', () => {
 		const user = userEvent.setup();
 		mockEndpoints( { removeStatus: 500 } );
 
-		const { queryClient } = render( <PluginSites selectedPluginSlug={ PLUGIN_SLUG } /> );
+		render( <PluginSites selectedPluginSlug={ PLUGIN_SLUG } /> );
 
 		await openDeleteModalForSiteOne( user );
 
 		expect( await screen.findByRole( 'link', { name: /Test Site One/ } ) ).toBeVisible();
-
-		const cached = queryClient.getQueryData< PluginsResponse >( pluginsQuery().queryKey );
-		expect( cached?.sites[ 1 ] ).toHaveLength( 1 );
+		expect( screen.getByRole( 'link', { name: /Test Site Two/ } ) ).toBeVisible();
 	} );
 
 	test( 'removes only the deleted site when its delete succeeds', async () => {

--- a/client/dashboard/plugins/plugin/test/sites-with-this-plugin.test.tsx
+++ b/client/dashboard/plugins/plugin/test/sites-with-this-plugin.test.tsx
@@ -118,8 +118,6 @@ async function openDeleteModalForSiteOne( user: ReturnType< typeof userEvent.set
 }
 
 describe( '<SitesWithThisPlugin> delete flow', () => {
-	afterEach( () => nock.cleanAll() );
-
 	test( 'keeps the site visible when its delete fails', async () => {
 		const user = userEvent.setup();
 		mockEndpoints( { removeStatus: 500 } );

--- a/client/dashboard/plugins/plugin/test/sites-with-this-plugin.test.tsx
+++ b/client/dashboard/plugins/plugin/test/sites-with-this-plugin.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { pluginsQuery } from '@automattic/api-queries';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { PluginSites } from '../../manage/components/plugin-sites';
+import type { PluginsResponse, Site } from '@automattic/api-core';
+
+const PLUGIN_SLUG = 'test-plugin';
+const PLUGIN_ID = 'test-plugin/test-plugin.php';
+const API = 'https://public-api.wordpress.com';
+
+function makeSite( id: number, name: string ): Site {
+	return {
+		ID: id,
+		name,
+		slug: `${ name.toLowerCase().replace( /\s+/g, '-' ) }.wordpress.com`,
+		URL: `https://${ name.toLowerCase().replace( /\s+/g, '-' ) }.wordpress.com`,
+		jetpack: true,
+		is_wpcom_atomic: false,
+		is_coming_soon: false,
+		is_private: false,
+		site_migration: {},
+		capabilities: { update_plugins: true },
+		plan: { product_slug: 'business-bundle', features: { active: [] } },
+	} as unknown as Site;
+}
+
+function makePluginEntry() {
+	return {
+		slug: PLUGIN_SLUG,
+		id: PLUGIN_ID,
+		name: 'Test Plugin',
+		author: 'Test Author',
+		active: false,
+		autoupdate: false,
+		update: null,
+		version: '1.0.0',
+		network: false,
+		is_managed: false,
+	};
+}
+
+/**
+ * Mock every endpoint the plugin screen reads, plus the three write endpoints a
+ * delete triggers on site 1 (deactivate + disable-autoupdate share the plugin
+ * path; remove hits `/delete`). `removeStatus` controls whether the remove
+ * succeeds or fails so a test can exercise the partial/failed-delete path.
+ */
+function mockEndpoints( { removeStatus }: { removeStatus: number } ) {
+	const pluginsResponse: PluginsResponse = {
+		sites: {
+			1: [ makePluginEntry() ],
+			2: [ makePluginEntry() ],
+		},
+	} as unknown as PluginsResponse;
+
+	nock( API )
+		.persist()
+		.get( '/rest/v1.1/me/sites/plugins' )
+		.query( true )
+		.reply( 200, pluginsResponse );
+	nock( API )
+		.persist()
+		.get( '/rest/v1.2/me/sites' )
+		.query( true )
+		.reply( 200, { sites: [ makeSite( 1, 'Test Site One' ), makeSite( 2, 'Test Site Two' ) ] } );
+	nock( API )
+		.persist()
+		.get( '/wpcom/v2/marketplace/products' )
+		.query( true )
+		.reply( 200, { results: {} } );
+	nock( API )
+		.persist()
+		.get( /\/rest\/v1\.2\/sites\/\d+\/plugins\/test-plugin$/ )
+		.query( true )
+		.reply( 200, {} );
+	nock( 'https://api.wordpress.org' )
+		.persist()
+		.get( '/plugins/info/1.2/' )
+		.query( true )
+		.reply( 200, {} );
+
+	// Deactivate + disable-autoupdate both POST to the plugin path; always succeed.
+	nock( API )
+		.persist()
+		.post( /\/sites\/1\/plugins\/[^/]+$/ )
+		.query( true )
+		.reply( 200, {} );
+	// Remove.
+	nock( API )
+		.post( /\/sites\/1\/plugins\/[^/]+\/delete$/ )
+		.query( true )
+		.reply( removeStatus, {} );
+}
+
+async function openDeleteModalForSiteOne( user: ReturnType< typeof userEvent.setup > ) {
+	const table = await screen.findByRole( 'table' );
+	await waitFor( () =>
+		expect( within( table ).getByRole( 'link', { name: /Test Site One/ } ) ).toBeVisible()
+	);
+
+	const row = within( table )
+		.getAllByRole( 'row' )
+		.find( ( r ) => within( r ).queryByRole( 'link', { name: /Test Site One/ } ) );
+	await user.click( within( row! ).getByRole( 'button', { name: 'Actions' } ) );
+
+	await user.click( await screen.findByRole( 'menuitem', { name: 'Delete' } ) );
+
+	const dialog = await screen.findByRole( 'dialog' );
+	await user.click( within( dialog ).getByRole( 'button', { name: 'Delete' } ) );
+
+	await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument() );
+}
+
+describe( '<SitesWithThisPlugin> delete flow', () => {
+	afterEach( () => nock.cleanAll() );
+
+	test( 'keeps the site visible when its delete fails', async () => {
+		const user = userEvent.setup();
+		mockEndpoints( { removeStatus: 500 } );
+
+		const { queryClient } = render( <PluginSites selectedPluginSlug={ PLUGIN_SLUG } /> );
+
+		await openDeleteModalForSiteOne( user );
+
+		expect( await screen.findByRole( 'link', { name: /Test Site One/ } ) ).toBeVisible();
+
+		const cached = queryClient.getQueryData< PluginsResponse >( pluginsQuery().queryKey );
+		expect( cached?.sites[ 1 ] ).toHaveLength( 1 );
+	} );
+
+	test( 'removes only the deleted site when its delete succeeds', async () => {
+		const user = userEvent.setup();
+		mockEndpoints( { removeStatus: 200 } );
+
+		render( <PluginSites selectedPluginSlug={ PLUGIN_SLUG } /> );
+
+		await openDeleteModalForSiteOne( user );
+
+		await waitFor( () =>
+			expect( screen.queryByRole( 'link', { name: /Test Site One/ } ) ).not.toBeInTheDocument()
+		);
+		expect( screen.getByRole( 'link', { name: /Test Site Two/ } ) ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Related to: DOTMSD-1305

## Proposed Changes

* On a successful plugin delete, optimistically remove the plugin from the shared `pluginsQuery` cache so both the plugin list and the detail panel update immediately.
* Mark the query stale so the next refresh reconciles with the server.

## Why are these changes being made?

Deleting a plugin from all sites left the plugin manager in a stale state where the deleted plugin lingered in the list and detail panel until an unrelated refetch (hovering a switcher item, which prefetches the query, or reloading) cleared it. 

Both panels derive from one shared query (`/me/sites/plugins`). We were using an intentional delay to wait to refresh but if the process took longer than 500ms, which is possible, the list would be stuck in a stale state and would appear to the user that the plugin wasn't deleted and the state wouldn't clear itself up without user interaction.

## Considerations

It's still possible that the query is refetched before the server reflects the delete properly. This change doesn't close out that possibility. There are more robust solutions that could be tested, for now, this solves the bug I am seeing with the old state and still feels like a step forward.

## Testing Instructions

1. `yarn start-dashboard`, open `/plugins/manage`.
2. Select a plugin installed on one or more sites, then delete it from all sites.
3. Confirm the plugin disappears from the left list and the detail panel updates right away.
4. Delete a plugin from only some of its sites and confirm it remains in the list with the correct remaining sites.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)