### PR TITLE
STATS-282: Replace summary period pills with the date range picker

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -24,7 +24,6 @@ const DateControl = ( {
 	const siteToday = momentInSite();
 
 	const getButtonLabel = () => {
-		// Shortcuts without a fixed date range (e.g. "All time") show their own label.
 		const selectedShortcut = shortcutList?.find( ( { id } ) => id === dateRange.shortcutId );
 		if ( selectedShortcut && ! selectedShortcut.startDate ) {
 			return selectedShortcut.label;

--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -24,6 +24,12 @@ const DateControl = ( {
 	const siteToday = momentInSite();
 
 	const getButtonLabel = () => {
+		// Shortcuts without a fixed date range (e.g. "All time") show their own label.
+		const selectedShortcut = shortcutList?.find( ( { id } ) => id === dateRange.shortcutId );
+		if ( selectedShortcut && ! selectedShortcut.startDate ) {
+			return selectedShortcut.label;
+		}
+
 		const localizedStartDate = moment( dateRange.chartStart );
 		const localizedEndDate = moment( dateRange.chartEnd );
 
@@ -48,8 +54,8 @@ const DateControl = ( {
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<DateRange
-				selectedStartDate={ moment( dateRange.chartStart ) }
-				selectedEndDate={ moment( dateRange.chartEnd ) }
+				selectedStartDate={ dateRange.chartStart ? moment( dateRange.chartStart ) : undefined }
+				selectedEndDate={ dateRange.chartEnd ? moment( dateRange.chartEnd ) : undefined }
 				selectedShortcutId={ dateRange.shortcutId }
 				lastSelectableDate={ siteToday }
 				firstSelectableDate={ moment( '2010-01-01' ) }
@@ -84,7 +90,7 @@ const DateControl = ( {
 				displayShortcuts
 				useArrowNavigation
 				customTitle="Date Range"
-				focusedMonth={ moment( dateRange.chartEnd ).toDate() }
+				focusedMonth={ dateRange.chartEnd ? moment( dateRange.chartEnd ).toDate() : undefined }
 				shortcutList={ shortcutList }
 				onShortcutClick={ onShortcutClick }
 				trackExternalDateChanges

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -5,13 +5,18 @@ interface DateControlProps {
 	onApplyButtonClick: ( startDate: Moment, endDate: Moment, selectedShortcutId?: string ) => void;
 	onDateControlClick?: () => void;
 	dateRange: {
-		chartStart: string;
-		chartEnd: string;
+		// Absent for shortcuts without a fixed range (e.g. "All time").
+		chartStart?: string;
+		chartEnd?: string;
 		daysInRange: number;
 		shortcutId?: string;
 	};
 	shortcutList: DateRangePickerShortcut[];
-	onShortcutClick: ( shortcut: DateRangePickerShortcut, closePopoverAndCommit: () => void ) => void;
+	onShortcutClick: (
+		shortcut: DateRangePickerShortcut,
+		closePopoverAndCommit: () => void,
+		closePopover: () => void
+	) => void;
 	tooltip?: string;
 	overlay?: JSX.Element;
 }

--- a/client/components/date-range/index.jsx
+++ b/client/components/date-range/index.jsx
@@ -470,9 +470,12 @@ export class DateRange extends Component {
 		} );
 	};
 
-	// Expose closePopoverAndCommit to the parent component for shortcut clicks.
+	// Expose both close helpers to the parent component for shortcut clicks.
+	// Commit applies the shortcut's range; the plain close neither commits nor
+	// reverts (used by shortcuts that navigate elsewhere, e.g. "All time" —
+	// revert would fire onDateCommit with the stale range and navigate back).
 	handleShortcutClick = ( shortcut ) => {
-		this.props.onShortcutClick( shortcut, this.closePopoverAndCommit );
+		this.props.onShortcutClick( shortcut, this.closePopoverAndCommit, this.closePopover );
 	};
 
 	/**

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -121,7 +121,6 @@ const StatsDateControl = ( {
 		].forEach( ( key ) => delete queryParamsObject[ key ] );
 	};
 
-	// Build a path, optionally including the module segment for summary pages.
 	const basePath = ( period: string ) =>
 		module ? `/stats/${ period }/${ module }/${ slug }` : `/stats/${ period }/${ slug }`;
 
@@ -244,8 +243,6 @@ const StatsDateControl = ( {
 		} else {
 			recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ] );
 			if ( shortcut.id === 'all_time' ) {
-				// "All time" has no fixed date range; close the popover without committing a
-				// calendar range, then navigate straight to the legacy contract.
 				closePopover();
 				setTimeout( () => page( generateAllTimeLink() ), 250 );
 			} else if ( shortcut.id !== 'custom_date_range' ) {

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -6,6 +6,7 @@ import qs from 'qs';
 import { findShortcutForRange } from 'calypso/components/date-range/use-shortcuts';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useMomentInSite } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { useSelector } from 'calypso/state';
 import getSiteId from 'calypso/state/sites/selectors/get-site-id';
 import DateControl from '../date-control';
@@ -13,18 +14,23 @@ import { DateRangePickerShortcut } from '../date-range/shortcuts';
 import type { JSX } from 'react';
 
 type DateRange = {
-	chartStart: string;
-	chartEnd: string;
+	// Absent for shortcuts without a fixed range (e.g. "All time").
+	chartStart?: string;
+	chartEnd?: string;
 	daysInRange: number;
 	shortcutId?: string;
 };
 interface StatsDateControlProps {
 	slug: string;
-	queryParams: string;
+	// Either a raw query string or an already-parsed query object; both are accepted by `qs.parse`.
+	queryParams: string | Record< string, string >;
 	period: 'day' | 'week' | 'month' | 'year';
 	dateRange: DateRange;
 	shortcutList: DateRangePickerShortcut[];
 	overlay?: JSX.Element;
+	// Optional module segment used by summary pages so links resolve to
+	// `/stats/{period}/{module}/{slug}` instead of the Traffic `/stats/{period}/{slug}`.
+	module?: string;
 	onGatedHandler: (
 		events: { name: string; params?: object }[],
 		event_from: string,
@@ -41,6 +47,7 @@ type EventNameKey =
 	| 'last_12_months'
 	| 'year_to_date'
 	| 'last_3_years'
+	| 'all_time'
 	| 'custom_date_range'
 	| 'apply_button'
 	| 'trigger_button';
@@ -61,6 +68,7 @@ const eventNames: EventNames = {
 		last_12_months: 'jetpack_odyssey_stats_date_picker_shortcut_last_12_months_clicked',
 		year_to_date: 'jetpack_odyssey_stats_date_picker_shortcut_year_to_date_clicked',
 		last_3_years: 'jetpack_odyssey_stats_date_picker_shortcut_last_3_years_clicked',
+		all_time: 'jetpack_odyssey_stats_date_picker_shortcut_all_time_clicked',
 		custom_date_range: 'jetpack_odyssey_stats_date_picker_shortcut_custom_date_range_clicked',
 		apply_button: 'jetpack_odyssey_stats_date_picker_apply_button_clicked',
 		trigger_button: 'jetpack_odyssey_stats_date_picker_opened',
@@ -73,6 +81,7 @@ const eventNames: EventNames = {
 		last_12_months: 'calypso_stats_date_picker_shortcut_last_12_months_clicked',
 		year_to_date: 'calypso_stats_date_picker_shortcut_year_to_date_clicked',
 		last_3_years: 'calypso_stats_date_picker_shortcut_last_3_years_clicked',
+		all_time: 'calypso_stats_date_picker_shortcut_all_time_clicked',
 		custom_date_range: 'calypso_stats_date_picker_shortcut_custom_date_range_clicked',
 		apply_button: 'calypso_stats_date_picker_apply_button_clicked',
 		trigger_button: 'calypso_stats_date_picker_opened',
@@ -85,6 +94,7 @@ const StatsDateControl = ( {
 	dateRange,
 	shortcutList,
 	overlay,
+	module,
 	onGatedHandler,
 }: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
@@ -94,25 +104,26 @@ const StatsDateControl = ( {
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteId = useSelector( ( state ) => getSiteId( state, slug ) );
+	const momentInSite = useMomentInSite( siteId );
 
-	/**
-	 * Remove start date from query params if it's out of range.
-	 * @param queryParamsObject
-	 * @param startDate
-	 * @param endDate
-	 */
-	const removeOutOfRangeStartDate = (
-		queryParamsObject: Record< string, any >,
-		startDate: string,
-		endDate: string
-	): void => {
-		const selectedStartDate = queryParamsObject.startDate as string | undefined;
-
-		if ( selectedStartDate && ( selectedStartDate < startDate || selectedStartDate > endDate ) ) {
-			// When there is no selected date, it takes today by default.
-			delete queryParamsObject.startDate;
-		}
+	// Drop params that belong to the legacy summary date contract so it can't
+	// coexist with the modern `chartStart`/`chartEnd` one in the same URL.
+	const removeLegacyRangeParams = ( queryParamsObject: Record< string, unknown > ): void => {
+		[
+			'startDate',
+			'endDate',
+			'num',
+			'summarize',
+			'customRangeStart',
+			'customRangeEnd',
+			'shortcut',
+			'navigation',
+		].forEach( ( key ) => delete queryParamsObject[ key ] );
 	};
+
+	// Build a path, optionally including the module segment for summary pages.
+	const basePath = ( period: string ) =>
+		module ? `/stats/${ period }/${ module }/${ slug }` : `/stats/${ period }/${ slug }`;
 
 	// Shared link generation helper.
 	const generateNewLink = (
@@ -122,9 +133,7 @@ const StatsDateControl = ( {
 		shortcutId?: string
 	) => {
 		const queryParamsObject = qs.parse( queryParams );
-		removeOutOfRangeStartDate( queryParamsObject, startDate, endDate );
-		delete queryParamsObject.shortcut;
-		delete queryParamsObject.navigation;
+		removeLegacyRangeParams( queryParamsObject );
 
 		const dateRangeParams = Object.assign( {}, queryParamsObject, {
 			chartStart: startDate,
@@ -138,8 +147,27 @@ const StatsDateControl = ( {
 		const newRangeQuery = qs.stringify( dateRangeParams, {
 			addQueryPrefix: true,
 		} );
-		const url = `/stats/${ period }/${ slug }`;
-		return `${ url }${ newRangeQuery }`;
+		return `${ basePath( period ) }${ newRangeQuery }`;
+	};
+
+	// "All time" keeps the legacy `num=-1&summarize=1` contract so the existing
+	// query/label logic keeps working instead of a synthetic huge chart range.
+	const generateAllTimeLink = () => {
+		const queryParamsObject = qs.parse( queryParams );
+		removeLegacyRangeParams( queryParamsObject );
+		delete queryParamsObject.chartStart;
+		delete queryParamsObject.chartEnd;
+
+		const allTimeParams = Object.assign( {}, queryParamsObject, {
+			startDate: momentInSite().format( 'YYYY-MM-DD' ),
+			summarize: 1,
+			num: -1,
+		} );
+
+		const newRangeQuery = qs.stringify( allTimeParams, {
+			addQueryPrefix: true,
+		} );
+		return `${ basePath( 'day' ) }${ newRangeQuery }`;
 	};
 
 	// Determine period based on number of days in date range.
@@ -200,7 +228,8 @@ const StatsDateControl = ( {
 	// handler for shortcut clicks
 	const onShortcutClickHandler = (
 		shortcut: DateRangePickerShortcut,
-		closePopoverAndCommit: () => void
+		closePopoverAndCommit: () => void,
+		closePopover: () => void
 	) => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 
@@ -214,7 +243,12 @@ const StatsDateControl = ( {
 			}
 		} else {
 			recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ] );
-			if ( shortcut.id !== 'custom_date_range' ) {
+			if ( shortcut.id === 'all_time' ) {
+				// "All time" has no fixed date range; close the popover without committing a
+				// calendar range, then navigate straight to the legacy contract.
+				closePopover();
+				setTimeout( () => page( generateAllTimeLink() ), 250 );
+			} else if ( shortcut.id !== 'custom_date_range' ) {
 				// Prevent the unclickable shortcut from being applied.
 				closePopoverAndCommit();
 			}

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -246,6 +246,39 @@ export function redirectToDaySummary( context ) {
 	page.redirect( url );
 }
 
+// Resolve the summary page's date/date-range from the query string.
+// The modern `chartStart`/`chartEnd` pair (matching the Traffic page contract) takes precedence
+// when both are valid `YYYY-MM-DD` dates with `chartStart <= chartEnd`. Otherwise we fall back to
+// the legacy `startDate`/`endDate` params so existing links keep working.
+export function getSummaryDateRangeFromQuery( queryOptions, momentSiteZone, period ) {
+	const parseChartDate = ( value ) =>
+		value && moment( value, 'YYYY-MM-DD', true ).isValid()
+			? momentSiteZone( value ).locale( 'en' )
+			: null;
+
+	const chartStart = parseChartDate( queryOptions.chartStart );
+	const chartEnd = parseChartDate( queryOptions.chartEnd );
+
+	if ( chartStart && chartEnd && ! chartEnd.isBefore( chartStart ) ) {
+		return { date: chartStart, dateRange: { startDate: chartStart, endDate: chartEnd } };
+	}
+
+	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
+	const date = isValidStartDate
+		? momentSiteZone( queryOptions.startDate ).locale( 'en' )
+		: momentSiteZone().endOf( period ).locale( 'en' );
+
+	// Support for custom date ranges.
+	// Evaluate the endDate param if provided and create a date range object if valid.
+	// Valid means endDate is a valid date and is not before the startDate.
+	const isValidEndDate = queryOptions.endDate && moment( queryOptions.endDate ).isValid();
+	const endDate = isValidEndDate ? momentSiteZone( queryOptions.endDate ).locale( 'en' ) : null;
+	const isValidRange = isValidEndDate && ! endDate.isBefore( date );
+	const dateRange = isValidRange ? { startDate: date, endDate: endDate } : null;
+
+	return { date, dateRange };
+}
+
 export function summary( context, next ) {
 	let siteId = context.params.site;
 	const siteFragment = getSiteFragment( context.path );
@@ -295,19 +328,12 @@ export function summary( context, next ) {
 	}
 
 	const momentSiteZone = getMomentSiteZone( context.store.getState(), siteId );
-	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
-	const date = isValidStartDate
-		? momentSiteZone( queryOptions.startDate ).locale( 'en' )
-		: momentSiteZone().endOf( activeFilter.period ).locale( 'en' );
+	const { date, dateRange } = getSummaryDateRangeFromQuery(
+		queryOptions,
+		momentSiteZone,
+		activeFilter.period
+	);
 	const period = rangeOfPeriod( activeFilter.period, date );
-
-	// Support for custom date ranges.
-	// Evaluate the endDate param if provided and create a date range object if valid.
-	// Valid means endDate is a valid date and is not before the startDate.
-	const isValidEndDate = queryOptions.endDate && moment( queryOptions.endDate ).isValid();
-	const endDate = isValidEndDate ? momentSiteZone( queryOptions.endDate ).locale( 'en' ) : null;
-	const isValidRange = isValidEndDate && ! endDate.isBefore( date );
-	const dateRange = isValidRange ? { startDate: date, endDate: endDate } : null;
 
 	const extraProps =
 		context.params.module === 'videodetails' ? { postId: parseInt( queryOptions.post, 10 ) } : {};

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -145,11 +145,15 @@ const StatsModuleUTM = ( {
 
 			// Some modules do not have view all abilities
 			if ( ! summary && period && path && siteSlug ) {
-				if ( ! clonedParams.has( 'startDate' ) ) {
-					clonedParams.set( 'startDate', period.startOf.format( 'YYYY-MM-DD' ) );
-				}
-				if ( ! clonedParams.has( 'endDate' ) ) {
-					clonedParams.set( 'endDate', period.endOf.format( 'YYYY-MM-DD' ) );
+				// Only fall back to the legacy single-date contract when a modern
+				// `chartStart`/`chartEnd` range isn't already being forwarded.
+				if ( ! clonedParams.has( 'chartStart' ) ) {
+					if ( ! clonedParams.has( 'startDate' ) ) {
+						clonedParams.set( 'startDate', period.startOf.format( 'YYYY-MM-DD' ) );
+					}
+					if ( ! clonedParams.has( 'endDate' ) ) {
+						clonedParams.set( 'endDate', period.endOf.format( 'YYYY-MM-DD' ) );
+					}
 				}
 
 				return `${ basePath }?${ clonedParams.toString() }`;

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -145,9 +145,9 @@ const StatsModuleUTM = ( {
 
 			// Some modules do not have view all abilities
 			if ( ! summary && period && path && siteSlug ) {
-				// Only fall back to the legacy single-date contract when a modern
-				// `chartStart`/`chartEnd` range isn't already being forwarded.
-				if ( ! clonedParams.has( 'chartStart' ) ) {
+				if ( ! clonedParams.has( 'chartStart' ) || ! clonedParams.has( 'chartEnd' ) ) {
+					clonedParams.delete( 'chartStart' );
+					clonedParams.delete( 'chartEnd' );
 					if ( ! clonedParams.has( 'startDate' ) ) {
 						clonedParams.set( 'startDate', period.startOf.format( 'YYYY-MM-DD' ) );
 					}

--- a/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
+++ b/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug, getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import {
+	useStatsNavigationHistory,
+	useStatsBreadcrumbTrail,
+	recordCurrentScreen,
+} from '../use-stats-navigation-history';
+
+jest.mock( 'calypso/state', () => ( { useSelector: jest.fn() } ) );
+jest.mock( 'calypso/state/sites/selectors' );
+jest.mock( 'calypso/state/ui/selectors' );
+jest.mock( 'i18n-calypso', () => {
+	const translate = ( text: string ) => text;
+	const localize = ( component: unknown ) => component;
+	const getLocaleSlug = () => 'en';
+
+	return {
+		__esModule: true,
+		default: { translate, localize, getLocaleSlug },
+		translate,
+		localize,
+		getLocaleSlug,
+	};
+} );
+
+const STORAGE_KEY = 'jp-stats-navigation';
+
+describe( 'use-stats-navigation-history back-link param forwarding', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		sessionStorage.clear();
+		( getSelectedSiteId as jest.Mock ).mockReturnValue( 123 );
+		( getSiteSlug as jest.Mock ).mockReturnValue( 'example.com' );
+		( getSiteAdminUrl as jest.Mock ).mockReturnValue( 'https://example.com/wp-admin/' );
+		( useSelector as jest.Mock ).mockImplementation( ( selector ) => selector( {} ) );
+	} );
+
+	const summaryEntry = {
+		screen: 'referrers',
+		queryParams: {
+			chartStart: '2025-07-01',
+			chartEnd: '2025-07-31',
+			shortcut: 'last_12_months',
+			tab: 'views',
+		},
+		period: 'month',
+	};
+
+	describe( 'useStatsNavigationHistory', () => {
+		it( 'derives the Traffic back link from the current screen when there is no prior history', () => {
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ summaryEntry ] ) );
+
+			const { result } = renderHook( () => useStatsNavigationHistory() );
+
+			expect( result.current.text ).toBe( 'Traffic' );
+			expect( result.current.url ).toContain( '/stats/month/example.com' );
+			expect( result.current.url ).toContain( 'chartStart=2025-07-01' );
+			expect( result.current.url ).toContain( 'chartEnd=2025-07-31' );
+			expect( result.current.url ).toContain( 'shortcut=last_12_months' );
+			expect( result.current.url ).toContain( 'tab=views' );
+		} );
+
+		it( 'uses the recorded previous screen when history exists', () => {
+			const trafficEntry = {
+				screen: 'traffic',
+				queryParams: { chartStart: '2024-01-01', chartEnd: '2024-12-31', shortcut: 'last_3_years' },
+				period: 'year',
+			};
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ trafficEntry, summaryEntry ] ) );
+
+			const { result } = renderHook( () => useStatsNavigationHistory() );
+
+			expect( result.current.url ).toContain( '/stats/year/example.com' );
+			expect( result.current.url ).toContain( 'chartStart=2024-01-01' );
+			expect( result.current.url ).toContain( 'shortcut=last_3_years' );
+		} );
+	} );
+
+	describe( 'useStatsBreadcrumbTrail', () => {
+		it( 'synthesizes a Traffic breadcrumb carrying the range on direct load', () => {
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ summaryEntry ] ) );
+
+			const { result } = renderHook( () => useStatsBreadcrumbTrail() );
+
+			expect( result.current ).toHaveLength( 1 );
+			expect( result.current[ 0 ].label ).toBe( 'Traffic' );
+			expect( result.current[ 0 ].url ).toContain( '/stats/month/example.com' );
+			expect( result.current[ 0 ].url ).toContain( 'chartStart=2025-07-01' );
+			expect( result.current[ 0 ].url ).toContain( 'shortcut=last_12_months' );
+			expect( result.current[ 0 ].url ).toContain( 'tab=views' );
+		} );
+	} );
+
+	describe( 'recordCurrentScreen', () => {
+		it( 'persists only supported query params, including tab', () => {
+			recordCurrentScreen(
+				'traffic',
+				{
+					queryParams: { chartStart: '2025-07-01', tab: 'views', irrelevant: 'x' },
+					period: 'day',
+				},
+				true
+			);
+
+			const stored = JSON.parse( sessionStorage.getItem( STORAGE_KEY ) || '[]' );
+			expect( stored[ 0 ].queryParams ).toEqual( { chartStart: '2025-07-01', tab: 'views' } );
+		} );
+	} );
+} );

--- a/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
+++ b/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
@@ -65,13 +65,63 @@ describe( 'use-stats-navigation-history back-link param forwarding', () => {
 			expect( result.current.url ).toContain( 'tab=views' );
 		} );
 
-		it( 'uses the recorded previous screen when history exists', () => {
+		it( 'overrides the recorded previous range with the current screen range', () => {
+			const trafficEntry = {
+				screen: 'traffic',
+				queryParams: {
+					chartStart: '2024-01-01',
+					chartEnd: '2024-12-31',
+					shortcut: 'last_3_years',
+					tab: 'visitors',
+				},
+				period: 'year',
+			};
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ trafficEntry, summaryEntry ] ) );
+
+			const { result } = renderHook( () => useStatsNavigationHistory() );
+
+			// The current (summary) range wins; other recorded params are kept.
+			expect( result.current.url ).toContain( 'chartStart=2025-07-01' );
+			expect( result.current.url ).toContain( 'chartEnd=2025-07-31' );
+			expect( result.current.url ).toContain( 'shortcut=last_12_months' );
+			expect( result.current.url ).toContain( 'tab=visitors' );
+			// Period is recomputed for the overridden range (31 days -> week).
+			expect( result.current.url ).toContain( '/stats/week/example.com' );
+		} );
+
+		it( 'drops the recorded stale shortcut when the current range is custom', () => {
 			const trafficEntry = {
 				screen: 'traffic',
 				queryParams: { chartStart: '2024-01-01', chartEnd: '2024-12-31', shortcut: 'last_3_years' },
 				period: 'year',
 			};
-			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ trafficEntry, summaryEntry ] ) );
+			const customRangeEntry = {
+				screen: 'referrers',
+				queryParams: { chartStart: '2025-05-01', chartEnd: '2025-05-20' },
+				period: 'day',
+			};
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ trafficEntry, customRangeEntry ] ) );
+
+			const { result } = renderHook( () => useStatsNavigationHistory() );
+
+			expect( result.current.url ).toContain( '/stats/day/example.com' );
+			expect( result.current.url ).toContain( 'chartStart=2025-05-01' );
+			expect( result.current.url ).toContain( 'chartEnd=2025-05-20' );
+			expect( result.current.url ).not.toContain( 'shortcut' );
+		} );
+
+		it( 'keeps the recorded range when the current screen has none (e.g. all-time)', () => {
+			const trafficEntry = {
+				screen: 'traffic',
+				queryParams: { chartStart: '2024-01-01', chartEnd: '2024-12-31', shortcut: 'last_3_years' },
+				period: 'year',
+			};
+			const allTimeEntry = {
+				screen: 'referrers',
+				queryParams: { startDate: '2025-07-08', summarize: '1', num: '-1' },
+				period: 'day',
+			};
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( [ trafficEntry, allTimeEntry ] ) );
 
 			const { result } = renderHook( () => useStatsNavigationHistory() );
 

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -302,3 +302,15 @@ export const useShouldGateStats = ( statType: string ) => {
 
 	return isGatedStats;
 };
+
+/*
+ * Decorate a date-range shortcut with its per-shortcut gating state.
+ * Intended for mapping over a shortcut list inside mapStateToProps.
+ */
+export const addIsGatedFor =
+	( state: object, siteId: number | null ) =>
+	< T extends { id: string } >( shortcut: T ) => ( {
+		...shortcut,
+		isGated: shouldGateStats( state, siteId, `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }` ),
+		statType: `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }`,
+	} );

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -302,15 +302,3 @@ export const useShouldGateStats = ( statType: string ) => {
 
 	return isGatedStats;
 };
-
-/*
- * Decorate a date-range shortcut with its per-shortcut gating state.
- * Intended for mapping over a shortcut list inside mapStateToProps.
- */
-export const addIsGatedFor =
-	( state: object, siteId: number | null ) =>
-	< T extends { id: string } >( shortcut: T ) => ( {
-		...shortcut,
-		isGated: shouldGateStats( state, siteId, `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }` ),
-		statType: `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }`,
-	} );

--- a/client/my-sites/stats/hooks/use-stats-navigation-history.ts
+++ b/client/my-sites/stats/hooks/use-stats-navigation-history.ts
@@ -40,6 +40,7 @@ const SUPPORTED_QUERY_PARAMS: string[] = [
 	'chartStart',
 	'chartEnd',
 	'shortcut',
+	'tab',
 	'jp_s',
 	'jp_post_type',
 	'jp_status',
@@ -57,6 +58,17 @@ const defaultLastScreen = 'traffic';
 const getFilteredQueryParams = ( queryParams: QueryArgs ): QueryArgs => {
 	return Object.fromEntries(
 		Object.entries( queryParams ).filter( ( [ key ] ) => SUPPORTED_QUERY_PARAMS.includes( key ) )
+	);
+};
+
+// Params the Traffic page actually understands. Used when synthesizing a Traffic
+// back link from the current screen, so summary-only params (startDate, num,
+// summarize, …) don't leak onto the Traffic URL.
+const TRAFFIC_QUERY_PARAMS: string[] = [ 'chartStart', 'chartEnd', 'shortcut', 'tab' ];
+
+const getTrafficQueryParams = ( queryParams: QueryArgs ): QueryArgs => {
+	return Object.fromEntries(
+		Object.entries( queryParams ).filter( ( [ key ] ) => TRAFFIC_QUERY_PARAMS.includes( key ) )
 	);
 };
 
@@ -135,16 +147,26 @@ export const useStatsNavigationHistory = (): { text: string; url: string | null 
 				// Select the second last item from the history stack as the back link.
 				// The last item in the stack if the current screen.
 				const lastItem =
-					Array.isArray( navState ) && navState.length >= 2 ? navState[ navState.length - 2 ] : {};
+					Array.isArray( navState ) && navState.length >= 2
+						? navState[ navState.length - 2 ]
+						: null;
 
 				// Make sure it's array and select last item
 				if ( lastItem && lastItem.screen ) {
 					setLastScreen( lastItem );
 				} else {
+					// No prior history (e.g. direct load or a full page load that clears
+					// sessionStorage): fall back to Traffic, but carry the current screen's
+					// query params/period so the selected date range survives the round-trip.
+					const currentItem =
+						Array.isArray( navState ) && navState.length >= 1
+							? navState[ navState.length - 1 ]
+							: null;
+
 					setLastScreen( {
 						screen: defaultLastScreen,
-						queryParams: {},
-						period: 'day',
+						queryParams: getTrafficQueryParams( currentItem?.queryParams || {} ),
+						period: currentItem?.period || 'day',
 					} );
 				}
 			}
@@ -226,8 +248,32 @@ export const useStatsBreadcrumbTrail = (): Array< { label: string; url: string |
 	useEffect( () => {
 		try {
 			const navState = JSON.parse( sessionStorage.getItem( STORAGE_KEY ) || '[]' );
-			if ( ! Array.isArray( navState ) || navState.length < 2 ) {
+			if ( ! Array.isArray( navState ) || navState.length < 1 ) {
 				setTrail( [] );
+				return;
+			}
+
+			// No prior history (e.g. direct load or a full page load that clears sessionStorage):
+			// synthesize a Traffic back-breadcrumb from the current screen so the selected date
+			// range survives the round-trip back to Traffic.
+			if ( navState.length === 1 ) {
+				const current = navState[ 0 ];
+				const label = localizedTabNames[ defaultLastScreen ];
+				let link = possibleBackLinks[ defaultLastScreen ];
+				if ( ! link || ! label || ! siteSlug ) {
+					setTrail( [] );
+					return;
+				}
+				link = link.replace( '{period}', current.period || 'day' );
+				setTrail( [
+					{
+						label,
+						url: addQueryArgs(
+							link + siteSlug,
+							getTrafficQueryParams( current.queryParams || {} )
+						),
+					},
+				] );
 				return;
 			}
 

--- a/client/my-sites/stats/hooks/use-stats-navigation-history.ts
+++ b/client/my-sites/stats/hooks/use-stats-navigation-history.ts
@@ -72,6 +72,50 @@ const getTrafficQueryParams = ( queryParams: QueryArgs ): QueryArgs => {
 	);
 };
 
+const DATE_RANGE_PARAMS: string[] = [ 'chartStart', 'chartEnd', 'shortcut' ];
+
+// Mirrors StatsDateControl's bestPeriodForDays, so a back link lands on a period
+// able to display the range (e.g. hour-period pages clamp longer ranges).
+const bestPeriodForRange = ( chartStart: string, chartEnd: string ): string => {
+	const days = Math.round( ( Date.parse( chartEnd ) - Date.parse( chartStart ) ) / 86400000 ) + 1;
+	if ( days <= 30 ) {
+		return 'day';
+	}
+	if ( days <= 175 ) {
+		return 'week';
+	}
+	if ( days <= 750 ) {
+		return 'month';
+	}
+	return 'year';
+};
+
+// The date range is a global filter across Stats screens: when navigating back, the
+// range selected on the current screen wins over the one recorded when the previous
+// screen was left. Only applies to period-aware screens (Traffic, module summaries).
+const applyCurrentDateRange = < T extends { screen: string; queryParams: QueryArgs } >(
+	entry: T,
+	currentParams: QueryArgs
+): T => {
+	const { chartStart, chartEnd, shortcut } = currentParams;
+	if ( ! possibleBackLinks[ entry.screen ]?.includes( '{period}' ) || ! chartStart || ! chartEnd ) {
+		return entry;
+	}
+
+	const queryParams = Object.fromEntries(
+		Object.entries( entry.queryParams || {} ).filter(
+			( [ key ] ) => ! DATE_RANGE_PARAMS.includes( key )
+		)
+	);
+	queryParams.chartStart = chartStart;
+	queryParams.chartEnd = chartEnd;
+	if ( shortcut ) {
+		queryParams.shortcut = shortcut;
+	}
+
+	return { ...entry, queryParams, period: bestPeriodForRange( chartStart, chartEnd ) };
+};
+
 const prepareAdminQueryParams = ( queryParams: QueryArgs ) => {
 	const JP_PREFIX = 'jp_';
 	return Object.fromEntries(
@@ -87,7 +131,11 @@ const prepareAdminQueryParams = ( queryParams: QueryArgs ) => {
  * Supports reading/writing from sessionStorage and initializing from query params
  * @returns { { text: string; url: string | null } }
  */
-export const useStatsNavigationHistory = (): { text: string; url: string | null } => {
+export const useStatsNavigationHistory = (
+	// Pass the current screen's query (e.g. `context.query`) so the back link
+	// re-derives after in-place range changes; the history is read once otherwise.
+	currentQuery?: unknown
+): { text: string; url: string | null } => {
 	const localizedTabNames: { [ key: string ]: string | null } = useMemo(
 		() => ( {
 			traffic: translate( 'Traffic' ),
@@ -153,7 +201,8 @@ export const useStatsNavigationHistory = (): { text: string; url: string | null 
 
 				// Make sure it's array and select last item
 				if ( lastItem && lastItem.screen ) {
-					setLastScreen( lastItem );
+					const currentItem = navState[ navState.length - 1 ];
+					setLastScreen( applyCurrentDateRange( lastItem, currentItem?.queryParams || {} ) );
 				} else {
 					// No prior history (e.g. direct load or a full page load that clears
 					// sessionStorage): fall back to Traffic, but carry the current screen's
@@ -171,7 +220,7 @@ export const useStatsNavigationHistory = (): { text: string; url: string | null 
 				}
 			}
 		} catch ( e ) {}
-	}, [ localizedTabNames ] );
+	}, [ localizedTabNames, currentQuery ] );
 
 	const backLink = useMemo( () => {
 		if ( ! siteSlug ) {
@@ -212,7 +261,11 @@ export const useStatsNavigationHistory = (): { text: string; url: string | null 
  * Excludes the current screen (last item in history).
  * Each item has a label and URL for building breadcrumb navigation.
  */
-export const useStatsBreadcrumbTrail = (): Array< { label: string; url: string | null } > => {
+export const useStatsBreadcrumbTrail = (
+	// Pass the current screen's query (e.g. `context.query`) so the trail re-derives
+	// after in-place range changes; the history is read once otherwise.
+	currentQuery?: unknown
+): Array< { label: string; url: string | null } > => {
 	const localizedTabNames: { [ key: string ]: string | null } = useMemo(
 		() => ( {
 			traffic: translate( 'Traffic' ),
@@ -279,9 +332,11 @@ export const useStatsBreadcrumbTrail = (): Array< { label: string; url: string |
 
 			// Exclude the last item (current screen).
 			const items = navState.slice( 0, -1 );
+			const currentItem = navState[ navState.length - 1 ];
 
 			const breadcrumbs = items
-				.map( ( entry: { screen: string; queryParams: QueryArgs; period: string | null } ) => {
+				.map( ( rawEntry: { screen: string; queryParams: QueryArgs; period: string | null } ) => {
+					const entry = applyCurrentDateRange( rawEntry, currentItem?.queryParams || {} );
 					const label = localizedTabNames[ entry.screen ];
 					if ( ! label ) {
 						return null;
@@ -320,7 +375,7 @@ export const useStatsBreadcrumbTrail = (): Array< { label: string; url: string |
 		} catch ( e ) {
 			setTrail( [] );
 		}
-	}, [ localizedTabNames, siteSlug, adminBaseUrl ] );
+	}, [ localizedTabNames, siteSlug, adminBaseUrl, currentQuery ] );
 
 	return trail;
 };

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -81,7 +81,11 @@ import StatsPeriodHeader from './stats-period-header';
 import StatsPeriodNavigation from './stats-period-navigation';
 import StatsPlanUsage from './stats-plan-usage';
 import StatsUpsell from './stats-upsell/traffic-upsell';
-import { appendQueryStringForRedirection, getPathWithUpdatedQueryString } from './utils';
+import {
+	appendQueryStringForRedirection,
+	buildSummaryUrl,
+	getPathWithUpdatedQueryString,
+} from './utils';
 
 const loadJetpackUpsellSection = () =>
 	import(
@@ -353,20 +357,13 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	// Note: This is only used in the empty version of the module.
 	// There's a similar function inside stats-module/index.jsx that is used when we have content.
 	const getStatHref = ( modulePath, query ) => {
-		const paramsValid = props.period && modulePath && slug;
-		if ( ! paramsValid ) {
-			return undefined;
-		}
-
-		let url = `/stats/${ props.period.period }/${ modulePath }/${ slug }`;
-
-		if ( query?.start_date ) {
-			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;
-		} else {
-			url += `?startDate=${ props.period.endOf.format( DATE_FORMAT ) }`;
-		}
-
-		return url;
+		return buildSummaryUrl( {
+			period: props.period,
+			module: modulePath,
+			siteSlug: slug,
+			query,
+			shortcut: context.query?.shortcut,
+		} );
 	};
 
 	// Set up a custom range for the chart.

--- a/client/my-sites/stats/stats-date-label/index.jsx
+++ b/client/my-sites/stats/stats-date-label/index.jsx
@@ -16,6 +16,16 @@ import DateLabelDrill from './date-label-drill';
 
 import './style.scss';
 
+// "Month to date"/"Year to date" read worse than the explicit date they resolve to
+// (e.g. "July 2026"), so those fall through to the date-based label.
+const DATE_LABELED_SHORTCUT_IDS = [ 'month_to_date', 'year_to_date' ];
+
+function getShortcutDisplayLabel( selectedShortcut ) {
+	return selectedShortcut?.label && ! DATE_LABELED_SHORTCUT_IDS.includes( selectedShortcut.id )
+		? selectedShortcut.label
+		: null;
+}
+
 function StatsDateLabel( {
 	date,
 	period,
@@ -99,9 +109,13 @@ function StatsDateLabel( {
 		return `${ localizedStartDate.format( 'll' ) } - ${ localizedEndDate.format( 'll' ) }`;
 	}
 
-	function dateForSummarize() {
+	function dateForSummarize( selectedShortcut = null ) {
 		if ( query.start_date ) {
-			return dateForCustomRange( query.start_date, query.date );
+			const shortcutLabel = getShortcutDisplayLabel( selectedShortcut );
+			if ( shortcutLabel ) {
+				return shortcutLabel;
+			}
+			return dateForCustomRange( query.start_date, query.date, selectedShortcut );
 		}
 
 		const localizedDate = momentSiteZone();
@@ -123,11 +137,9 @@ function StatsDateLabel( {
 	}
 
 	function dateForDisplay( selectedShortcut = null ) {
-		if (
-			selectedShortcut?.label &&
-			! [ 'month_to_date', 'year_to_date' ].includes( selectedShortcut?.id )
-		) {
-			return selectedShortcut.label;
+		const shortcutLabel = getShortcutDisplayLabel( selectedShortcut );
+		if ( shortcutLabel ) {
+			return shortcutLabel;
 		}
 
 		const weekPeriodFormat = isShort ? 'll' : 'LL';
@@ -193,7 +205,7 @@ function StatsDateLabel( {
 	const isSummarizeQuery = query?.summarize;
 	const { selectedShortcut } = getShortcuts( reduxState, dateRange, translate );
 	const shortDisplayDate = isShort ? dateForDisplay( selectedShortcut ) : null;
-	const summarizeDisplayDate = isSummarizeQuery ? dateForSummarize() : null;
+	const summarizeDisplayDate = isSummarizeQuery ? dateForSummarize( selectedShortcut ) : null;
 	const displayDate = isShort ? shortDisplayDate : summarizeDisplayDate;
 
 	const previousDisplayDate = useMemo( () => {
@@ -235,7 +247,9 @@ function StatsDateLabel( {
 					period: (
 						<span className="period">
 							<span className="date">
-								{ isSummarizeQuery ? dateForSummarize() : dateForDisplay( selectedShortcut ) }
+								{ isSummarizeQuery
+									? dateForSummarize( selectedShortcut )
+									: dateForDisplay( selectedShortcut ) }
 							</span>
 						</span>
 					),
@@ -248,7 +262,9 @@ function StatsDateLabel( {
 					period: (
 						<span className="period">
 							<span className="date">
-								{ isSummarizeQuery ? dateForSummarize() : dateForDisplay( selectedShortcut ) }
+								{ isSummarizeQuery
+									? dateForSummarize( selectedShortcut )
+									: dateForDisplay( selectedShortcut ) }
 							</span>
 						</span>
 					),

--- a/client/my-sites/stats/stats-date-label/index.jsx
+++ b/client/my-sites/stats/stats-date-label/index.jsx
@@ -16,16 +16,6 @@ import DateLabelDrill from './date-label-drill';
 
 import './style.scss';
 
-// "Month to date"/"Year to date" read worse than the explicit date they resolve to
-// (e.g. "July 2026"), so those fall through to the date-based label.
-const DATE_LABELED_SHORTCUT_IDS = [ 'month_to_date', 'year_to_date' ];
-
-function getShortcutDisplayLabel( selectedShortcut ) {
-	return selectedShortcut?.label && ! DATE_LABELED_SHORTCUT_IDS.includes( selectedShortcut.id )
-		? selectedShortcut.label
-		: null;
-}
-
 function StatsDateLabel( {
 	date,
 	period,
@@ -111,9 +101,11 @@ function StatsDateLabel( {
 
 	function dateForSummarize( selectedShortcut = null ) {
 		if ( query.start_date ) {
-			const shortcutLabel = getShortcutDisplayLabel( selectedShortcut );
-			if ( shortcutLabel ) {
-				return shortcutLabel;
+			if (
+				selectedShortcut?.label &&
+				! [ 'month_to_date', 'year_to_date' ].includes( selectedShortcut?.id )
+			) {
+				return selectedShortcut.label;
 			}
 			return dateForCustomRange( query.start_date, query.date, selectedShortcut );
 		}
@@ -137,9 +129,11 @@ function StatsDateLabel( {
 	}
 
 	function dateForDisplay( selectedShortcut = null ) {
-		const shortcutLabel = getShortcutDisplayLabel( selectedShortcut );
-		if ( shortcutLabel ) {
-			return shortcutLabel;
+		if (
+			selectedShortcut?.label &&
+			! [ 'month_to_date', 'year_to_date' ].includes( selectedShortcut?.id )
+		) {
+			return selectedShortcut.label;
 		}
 
 		const weekPeriodFormat = isShort ? 'll' : 'LL';

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -15,9 +15,10 @@ import {
 	STATS_FEATURE_SUMMARY_LINKS_ALL,
 } from '../constants';
 import { useMomentInSite } from '../hooks/use-moment-site-zone';
-import { addIsGatedFor, shouldGateStats } from '../hooks/use-should-gate-stats';
+import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import StatsCardUpsell from '../stats-card-upsell';
 import DatePicker from '../stats-date-label';
+import { addIsGatedFor } from '../stats-period-navigation';
 import './summary-nav.scss';
 
 export const StatsModuleSummaryLinks = ( props ) => {

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -76,7 +76,7 @@ export const StatsModuleSummaryLinks = ( props ) => {
 			...shortcutList,
 			{
 				id: 'all_time',
-				label: translate( 'All time' ),
+				label: translate( 'All Time' ),
 				startDate: '',
 				endDate: '',
 				period: 'day',

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -1,26 +1,23 @@
-import { ComponentSwapper, SegmentedControl, SelectDropdown } from '@automattic/components';
-import { Icon, lock } from '@wordpress/icons';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { compose } from 'redux';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getShortcuts } from 'calypso/components/date-range/use-shortcuts';
+import StatsDateControl from 'calypso/components/stats-date-control';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
-	STATS_FEATURE_SUMMARY_LINKS_30_DAYS,
-	STATS_FEATURE_SUMMARY_LINKS_7_DAYS,
+	DATE_FORMAT,
+	STATS_FEATURE_DATE_CONTROL,
 	STATS_FEATURE_SUMMARY_LINKS_ALL,
-	STATS_FEATURE_SUMMARY_LINKS_DAY,
-	STATS_FEATURE_SUMMARY_LINKS_QUARTER,
-	STATS_FEATURE_SUMMARY_LINKS_YEAR,
 } from '../constants';
 import { useMomentInSite } from '../hooks/use-moment-site-zone';
-import { shouldGateStats } from '../hooks/use-should-gate-stats';
+import { addIsGatedFor, shouldGateStats } from '../hooks/use-should-gate-stats';
+import StatsCardUpsell from '../stats-card-upsell';
 import DatePicker from '../stats-date-label';
-import { trackStatsAnalyticsEvent } from '../utils';
 import './summary-nav.scss';
 
 export const StatsModuleSummaryLinks = ( props ) => {
@@ -32,194 +29,73 @@ export const StatsModuleSummaryLinks = ( props ) => {
 		period,
 		hideNavigation,
 		navigationSwap,
-		shouldGateOptions,
+		shortcutList,
+		gateDateControl,
+		gateAllTimeSummaryLink,
+		isSiteJetpackNotAtomic,
 		siteId,
 		context,
 	} = props;
 
 	const dispatch = useDispatch();
 	const momentInSite = useMomentInSite( siteId );
-	const getSummaryPeriodLabel = () => {
-		// Check for custom range in query or preserved custom range params.
-		const queryParams = new URLSearchParams( context.query );
-		const hasPreservedCustomRange =
-			queryParams.has( 'customRangeStart' ) && queryParams.has( 'customRangeEnd' );
 
-		if ( query.start_date || hasPreservedCustomRange ) {
-			return translate( 'Custom Range Summary' );
-		}
-		switch ( period.period ) {
-			case 'day':
-				return translate( 'Day Summary' );
-			case 'week':
-				return translate( 'Week Summary' );
-			case 'month':
-				return translate( 'Month Summary' );
-			case 'year':
-				return translate( 'Year Summary' );
-		}
-	};
+	const isAllTime = String( query?.num ) === '-1';
+	let chartStart;
+	let chartEnd;
+	if ( isAllTime ) {
+		// "All time" has no bounded range: leave the selection empty so the picker
+		// shows no dates (rather than defaulting to today).
+		chartStart = undefined;
+		chartEnd = undefined;
+	} else if ( query?.start_date ) {
+		chartStart = query.start_date;
+		chartEnd = query.date;
+	} else if ( Number( query?.num ) > 0 && query?.summarize ) {
+		// Legacy pill-era links (`?num=30&summarize=1`): seed the picker with the
+		// actual "N days ending {date}" range the page is summarizing.
+		chartEnd = momentInSite( query.date ).format( DATE_FORMAT );
+		chartStart = momentInSite( query.date )
+			.subtract( Number( query.num ) - 1, 'days' )
+			.format( DATE_FORMAT );
+	} else {
+		// Legacy single-date entry (e.g. default "View details", `?startDate={periodEnd}`) has no
+		// custom range: seed the picker from the summarized period instead of an empty range.
+		chartStart = period.startOf.format( DATE_FORMAT );
+		chartEnd = period.endOf.format( DATE_FORMAT );
+	}
+	const shortcutId = context.query?.shortcut || ( isAllTime ? 'all_time' : undefined );
+	const daysInRange =
+		chartStart && chartEnd
+			? momentInSite( chartEnd ).diff( momentInSite( chartStart ), 'days' ) + 1
+			: 0;
+	const dateRange = { chartStart, chartEnd, daysInRange, shortcutId };
 
-	const recordStats = ( item ) => {
-		props.recordGoogleEvent( 'Stats', `Clicked Summary Link: ${ path } ${ item.stat }` );
-		trackStatsAnalyticsEvent( 'stats_summary_nav_period_clicked', {
-			path,
-			stat_type: item.statType,
-		} );
-	};
-
-	const handleClick = ( item ) => ( event ) => {
-		if ( item.isGated ) {
-			event.preventDefault();
-			dispatch( toggleUpsellModal( siteId, item.statType ) );
-		}
-		recordStats( item );
-	};
-
-	const summaryPeriodPath = useMemo( () => {
-		let periodPath = `/stats/${
-			period.period
-		}/${ path }/${ siteSlug }?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
-
-		// Override if custom range was used in query.
-		if ( query.start_date ) {
-			periodPath = `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ query.start_date }&endDate=${ query.date }`;
-		}
-
-		// Check for preserved custom range params (when returning from a different period view).
-		const queryParams = new URLSearchParams( context.query );
-		if ( queryParams.has( 'customRangeStart' ) && queryParams.has( 'customRangeEnd' ) ) {
-			periodPath = `/stats/day/${ path }/${ siteSlug }?startDate=${ queryParams.get(
-				'customRangeStart'
-			) }&endDate=${ queryParams.get( 'customRangeEnd' ) }`;
-		}
-
-		return periodPath;
-	}, [ period.period, period.endOf, path, siteSlug, query, context.query ] );
-
-	const getSummaryPathForDaysRange = ( numberDays ) => {
-		const queryParams = new URLSearchParams( context.query );
-
-		// Preserve the custom date range (if any) to allow returning to it later.
-		// Only save if we're currently on a custom range (has startDate and endDate without num).
-		const hasCustomRange =
-			queryParams.has( 'startDate' ) && queryParams.has( 'endDate' ) && ! queryParams.has( 'num' );
-		const hasPreservedCustomRange =
-			queryParams.has( 'customRangeStart' ) && queryParams.has( 'customRangeEnd' );
-
-		if ( hasCustomRange && ! hasPreservedCustomRange ) {
-			queryParams.set( 'customRangeStart', queryParams.get( 'startDate' ) );
-			queryParams.set( 'customRangeEnd', queryParams.get( 'endDate' ) );
-		}
-
-		queryParams.set( 'startDate', momentInSite().format( 'YYYY-MM-DD' ) );
-		queryParams.set( 'summarize', 1 );
-		queryParams.set( 'num', numberDays );
-		queryParams.delete( 'endDate' );
-
-		return `/stats/day/${ path }/${ siteSlug }?${ queryParams.toString() }`;
-	};
-
-	const options = [
-		{
-			value: '0',
-			label: getSummaryPeriodLabel(),
-			path: summaryPeriodPath,
-			stat: 'Period Summary',
-			isGated: shouldGateOptions[ STATS_FEATURE_SUMMARY_LINKS_DAY ],
-			statType: STATS_FEATURE_SUMMARY_LINKS_DAY,
-		},
-		{
-			value: '7',
-			label: translate( '7 days' ),
-			path: getSummaryPathForDaysRange( 7 ),
-			stat: '7 Days',
-			isGated: shouldGateOptions[ STATS_FEATURE_SUMMARY_LINKS_7_DAYS ],
-			statType: STATS_FEATURE_SUMMARY_LINKS_7_DAYS,
-		},
-		{
-			value: '30',
-			label: translate( '30 days' ),
-			path: getSummaryPathForDaysRange( 30 ),
-			stat: '30 Days',
-			isGated: shouldGateOptions[ STATS_FEATURE_SUMMARY_LINKS_30_DAYS ],
-			statType: STATS_FEATURE_SUMMARY_LINKS_30_DAYS,
-		},
-		{
-			value: '90',
-			label: translate( 'Quarter' ),
-			path: getSummaryPathForDaysRange( 90 ),
-			stat: 'Quarter',
-			isGated: shouldGateOptions[ STATS_FEATURE_SUMMARY_LINKS_QUARTER ],
-			statType: STATS_FEATURE_SUMMARY_LINKS_QUARTER,
-		},
-		{
-			value: '365',
-			label: translate( 'Year' ),
-			path: getSummaryPathForDaysRange( 365 ),
-			stat: 'Year',
-			isGated: shouldGateOptions[ STATS_FEATURE_SUMMARY_LINKS_YEAR ],
-			statType: STATS_FEATURE_SUMMARY_LINKS_YEAR,
-		},
-		{
-			value: '-1',
-			label: translate( 'All Time' ),
-			path: getSummaryPathForDaysRange( -1 ),
-			stat: 'All Time',
-			isGated: shouldGateOptions[ STATS_FEATURE_SUMMARY_LINKS_ALL ],
-			statType: STATS_FEATURE_SUMMARY_LINKS_ALL,
-		},
-	];
-
-	const numberDays = query?.num ?? '0';
-	let selected = options.find( ( option ) => option.value === numberDays );
-	selected = selected || options[ 0 ];
-
-	const tabs = (
-		<SegmentedControl
-			primary
-			className={ clsx( 'stats-summary-nav__intervals' ) }
-			compact={ false }
-		>
-			{ options.map( ( i ) => (
-				<SegmentedControl.Item
-					key={ i.value }
-					path={ i.isGated ? '' : i.path }
-					selected={ i.value === selected.value }
-					onClick={ handleClick( i ) }
-				>
-					{ i.label }
-					{ i.isGated && <Icon icon={ lock } width={ 16 } height={ 16 } /> }
-				</SegmentedControl.Item>
-			) ) }
-		</SegmentedControl>
+	const fullShortcutList = useMemo(
+		() => [
+			...shortcutList,
+			{
+				id: 'all_time',
+				label: translate( 'All time' ),
+				startDate: '',
+				endDate: '',
+				period: 'day',
+				isGated: gateAllTimeSummaryLink,
+				statType: STATS_FEATURE_SUMMARY_LINKS_ALL,
+			},
+		],
+		[ shortcutList, gateAllTimeSummaryLink, translate ]
 	);
-	const select = (
-		<SelectDropdown
-			className="section-nav-tabs__dropdown stats-summary-nav__select"
-			selectedText={ selected.label }
-		>
-			{ options.map( ( i, index ) => (
-				<SelectDropdown.Item
-					{ ...i }
-					key={ 'navTabsDropdown-' + index }
-					path={ i.path }
-					selected={ i.value === selected.value }
-					onClick={ handleClick( i ) }
-				>
-					{ i.label }
-					{ i.isGated && (
-						<Icon
-							className="stats-summary-nav__gated-icon"
-							icon={ lock }
-							width={ 16 }
-							height={ 16 }
-						/>
-					) }
-				</SelectDropdown.Item>
-			) ) }
-		</SelectDropdown>
-	);
+
+	const onGatedHandler = ( events, source, statType ) => {
+		// Stop the popup from showing for Jetpack sites.
+		if ( isSiteJetpackNotAtomic ) {
+			return;
+		}
+
+		events.forEach( ( event ) => recordTracksEvent( event.name, event.params ) );
+		dispatch( toggleUpsellModal( siteId, statType ) );
+	};
 
 	const navClassName = clsx( 'stats-summary-nav', {
 		[ 'stats-summary-nav--with-button' ]: hideNavigation && navigationSwap,
@@ -227,20 +103,34 @@ export const StatsModuleSummaryLinks = ( props ) => {
 
 	return (
 		<div className={ navClassName }>
-			{ ! hideNavigation && (
-				<ComponentSwapper
-					className={ clsx( 'stats-summary-nav__intervals-container' ) }
-					breakpoint="<660px"
-					breakpointActiveComponent={ select }
-					breakpointInactiveComponent={ tabs }
+			{ /* The container is row-reversed at wide widths, so the first child renders on the right. */ }
+			<div className="stats-summary-nav__date-control">
+				<StatsDateControl
+					slug={ siteSlug }
+					period={ period.period }
+					module={ path }
+					queryParams={ context.query }
+					dateRange={ dateRange }
+					shortcutList={ fullShortcutList }
+					onGatedHandler={ onGatedHandler }
+					overlay={
+						gateDateControl && (
+							<StatsCardUpsell
+								className="stats-module__upsell"
+								statType={ STATS_FEATURE_DATE_CONTROL }
+								siteId={ siteId }
+							/>
+						)
+					}
 				/>
-			) }
+			</div>
 			<div className="stats-summary-nav__header">
 				<DatePicker
 					period={ period.period }
 					date={ period.startOf }
 					path={ path }
 					query={ query }
+					dateRange={ dateRange }
 					summary={ false }
 				/>
 			</div>
@@ -249,46 +139,20 @@ export const StatsModuleSummaryLinks = ( props ) => {
 	);
 };
 
-const connectComponent = connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const siteSlug = getSiteSlug( state, siteId );
-		const shouldGateOptions = {
-			[ STATS_FEATURE_SUMMARY_LINKS_DAY ]: shouldGateStats(
-				state,
-				siteId,
-				STATS_FEATURE_SUMMARY_LINKS_DAY
-			),
-			[ STATS_FEATURE_SUMMARY_LINKS_7_DAYS ]: shouldGateStats(
-				state,
-				siteId,
-				STATS_FEATURE_SUMMARY_LINKS_7_DAYS
-			),
-			[ STATS_FEATURE_SUMMARY_LINKS_30_DAYS ]: shouldGateStats(
-				state,
-				siteId,
-				STATS_FEATURE_SUMMARY_LINKS_30_DAYS
-			),
-			[ STATS_FEATURE_SUMMARY_LINKS_QUARTER ]: shouldGateStats(
-				state,
-				siteId,
-				STATS_FEATURE_SUMMARY_LINKS_QUARTER
-			),
-			[ STATS_FEATURE_SUMMARY_LINKS_YEAR ]: shouldGateStats(
-				state,
-				siteId,
-				STATS_FEATURE_SUMMARY_LINKS_YEAR
-			),
-			[ STATS_FEATURE_SUMMARY_LINKS_ALL ]: shouldGateStats(
-				state,
-				siteId,
-				STATS_FEATURE_SUMMARY_LINKS_ALL
-			),
-		};
+const connectComponent = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+	const { supportedShortcutList } = getShortcuts( state, {} );
+	const shortcutList = supportedShortcutList.map( addIsGatedFor( state, siteId ) );
 
-		return { siteId, siteSlug, shouldGateOptions };
-	},
-	{ recordGoogleEvent }
-);
+	return {
+		siteId,
+		siteSlug,
+		shortcutList,
+		gateDateControl: shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL ),
+		gateAllTimeSummaryLink: shouldGateStats( state, siteId, STATS_FEATURE_SUMMARY_LINKS_ALL ),
+		isSiteJetpackNotAtomic: isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ),
+	};
+} );
 
 export default compose( connectComponent, localize )( StatsModuleSummaryLinks );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -374,7 +374,6 @@ export default connect( ( state, ownProps ) => {
 	const gateStats = shouldGateStats( state, siteId, statType );
 	const gateDownloads = shouldGateStats( state, siteId, STATS_FEATURE_DOWNLOAD_CSV );
 
-	// Forward the active shortcut (matched by the current range) to summary links.
 	const { selectedShortcut } = getShortcuts( state, {
 		chartStart: query?.start_date,
 		chartEnd: query?.date,

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { getShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	isRequestingSiteStatsForQuery,
@@ -20,6 +21,7 @@ import StatsCardUpsell from '../stats-card-upsell';
 import DatePicker from '../stats-date-label';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
+import { buildSummaryUrl } from '../utils';
 import StatsModulePlaceholder from './placeholder';
 
 import './style.scss';
@@ -38,6 +40,7 @@ class StatsModule extends Component {
 		statType: PropTypes.string,
 		showSummaryLink: PropTypes.bool,
 		summaryLinkModifier: PropTypes.func,
+		summaryShortcutId: PropTypes.string,
 		translate: PropTypes.func,
 		metricLabel: PropTypes.string,
 		mainItemLabel: PropTypes.string,
@@ -184,22 +187,22 @@ class StatsModule extends Component {
 	}
 
 	getSummaryLink() {
-		const { summary, period, path, siteSlug, query, summaryLinkModifier } = this.props;
+		const { summary, period, path, siteSlug, query, summaryLinkModifier, summaryShortcutId } =
+			this.props;
 		if ( summary ) {
 			return;
 		}
 
-		const paramsValid = period?.period && path && siteSlug;
-		if ( ! paramsValid ) {
+		const url = buildSummaryUrl( {
+			period,
+			module: path,
+			siteSlug,
+			query,
+			shortcut: summaryShortcutId,
+		} );
+
+		if ( ! url ) {
 			return undefined;
-		}
-
-		let url = `/stats/${ period.period }/${ path }/${ siteSlug }`;
-
-		if ( query?.start_date ) {
-			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;
-		} else {
-			url += `?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
 		}
 
 		return summaryLinkModifier( url );
@@ -371,6 +374,12 @@ export default connect( ( state, ownProps ) => {
 	const gateStats = shouldGateStats( state, siteId, statType );
 	const gateDownloads = shouldGateStats( state, siteId, STATS_FEATURE_DOWNLOAD_CSV );
 
+	// Forward the active shortcut (matched by the current range) to summary links.
+	const { selectedShortcut } = getShortcuts( state, {
+		chartStart: query?.start_date,
+		chartEnd: query?.date,
+	} );
+
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
@@ -378,5 +387,6 @@ export default connect( ( state, ownProps ) => {
 		siteSlug,
 		gateStats,
 		gateDownloads,
+		summaryShortcutId: selectedShortcut?.id,
 	};
 } )( localize( StatsModule ) );

--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -80,6 +80,19 @@ $summary-nav-swap-width: 661px;
 	}
 }
 
+.stats-summary-nav__date-control {
+	display: flex;
+	align-items: center;
+
+	@media (max-width: 1160px) {
+		padding: 16px 0;
+	}
+
+	@media (max-width: $break-small) {
+		padding: $summary-small-padding;
+	}
+}
+
 .stats-summary-nav__intervals-container {
 	display: flex;
 }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -21,7 +21,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getMomentSiteZone } from '../hooks/use-moment-site-zone';
-import { shouldGateStats } from '../hooks/use-should-gate-stats';
+import { addIsGatedFor, shouldGateStats } from '../hooks/use-should-gate-stats';
 import { withStatsPurchases } from '../hooks/use-stats-purchases';
 import NavigationArrows from '../navigation-arrows';
 import StatsCardUpsell from '../stats-card-upsell';
@@ -392,12 +392,6 @@ class StatsPeriodNavigation extends PureComponent {
 		);
 	}
 }
-
-const addIsGatedFor = ( state, siteId ) => ( shortcut ) => ( {
-	...shortcut,
-	isGated: shouldGateStats( state, siteId, `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }` ),
-	statType: `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }`,
-} );
 
 const connectComponent = connect(
 	( state, { period, translate } ) => {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -21,7 +21,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getMomentSiteZone } from '../hooks/use-moment-site-zone';
-import { addIsGatedFor, shouldGateStats } from '../hooks/use-should-gate-stats';
+import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { withStatsPurchases } from '../hooks/use-stats-purchases';
 import NavigationArrows from '../navigation-arrows';
 import StatsCardUpsell from '../stats-card-upsell';
@@ -392,6 +392,12 @@ class StatsPeriodNavigation extends PureComponent {
 		);
 	}
 }
+
+export const addIsGatedFor = ( state, siteId ) => ( shortcut ) => ( {
+	...shortcut,
+	isGated: shouldGateStats( state, siteId, `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }` ),
+	statType: `${ STATS_FEATURE_DATE_CONTROL }/${ shortcut.id }`,
+} );
 
 const connectComponent = connect(
 	( state, { period, translate } ) => {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -503,7 +503,7 @@ class StatsSummary extends Component {
 }
 
 const StatsSummaryWrapper = ( props ) => {
-	const breadcrumbTrail = useStatsBreadcrumbTrail();
+	const breadcrumbTrail = useStatsBreadcrumbTrail( props.context?.query );
 	const statsStrings = useStatsStrings( { supportsArchiveStats: props.supportsArchiveStats } );
 
 	return (

--- a/client/my-sites/stats/test/controller.js
+++ b/client/my-sites/stats/test/controller.js
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+import { getSummaryDateRangeFromQuery } from '../controller';
+
+// The controller uses a site-timezone-aware moment factory; plain `moment` is a
+// sufficient stand-in for exercising the parsing/precedence logic.
+const momentSiteZone = ( ...args ) => moment( ...args );
+
+const format = ( m ) => ( m ? m.format( 'YYYY-MM-DD' ) : m );
+
+describe( 'getSummaryDateRangeFromQuery', () => {
+	it( 'prefers a valid chartStart/chartEnd range', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery(
+			{ chartStart: '2024-07-10', chartEnd: '2025-07-09' },
+			momentSiteZone,
+			'day'
+		);
+
+		expect( format( date ) ).toBe( '2024-07-10' );
+		expect( format( dateRange.startDate ) ).toBe( '2024-07-10' );
+		expect( format( dateRange.endDate ) ).toBe( '2025-07-09' );
+	} );
+
+	it( 'gives chartStart/chartEnd precedence over legacy startDate/endDate', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery(
+			{
+				chartStart: '2024-01-01',
+				chartEnd: '2024-12-31',
+				startDate: '2020-01-01',
+				endDate: '2020-02-01',
+			},
+			momentSiteZone,
+			'day'
+		);
+
+		expect( format( date ) ).toBe( '2024-01-01' );
+		expect( format( dateRange.startDate ) ).toBe( '2024-01-01' );
+		expect( format( dateRange.endDate ) ).toBe( '2024-12-31' );
+	} );
+
+	it( 'ignores an invalid chartStart and falls back to the period end', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery(
+			{ chartStart: '2025-13-40', chartEnd: '2025-07-09' },
+			momentSiteZone,
+			'day'
+		);
+
+		expect( format( date ) ).toBe( momentSiteZone().endOf( 'day' ).format( 'YYYY-MM-DD' ) );
+		expect( dateRange ).toBeNull();
+	} );
+
+	it( 'ignores a chartEnd that is before chartStart', () => {
+		const { dateRange } = getSummaryDateRangeFromQuery(
+			{ chartStart: '2025-07-09', chartEnd: '2024-07-10' },
+			momentSiteZone,
+			'day'
+		);
+
+		expect( dateRange ).toBeNull();
+	} );
+
+	it( 'requires both chart bounds and falls back when only chartStart is present', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery(
+			{ chartStart: '2024-07-10', startDate: '2024-07-01' },
+			momentSiteZone,
+			'day'
+		);
+
+		expect( format( date ) ).toBe( '2024-07-01' );
+		expect( dateRange ).toBeNull();
+	} );
+
+	it( 'keeps back-compat with legacy startDate/endDate ranges', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery(
+			{ startDate: '2024-07-01', endDate: '2024-07-31' },
+			momentSiteZone,
+			'day'
+		);
+
+		expect( format( date ) ).toBe( '2024-07-01' );
+		expect( format( dateRange.startDate ) ).toBe( '2024-07-01' );
+		expect( format( dateRange.endDate ) ).toBe( '2024-07-31' );
+	} );
+
+	it( 'keeps back-compat with a lone startDate (no range)', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery(
+			{ startDate: '2024-07-01' },
+			momentSiteZone,
+			'day'
+		);
+
+		expect( format( date ) ).toBe( '2024-07-01' );
+		expect( dateRange ).toBeNull();
+	} );
+
+	it( 'defaults to the end of the period when nothing is provided', () => {
+		const { date, dateRange } = getSummaryDateRangeFromQuery( {}, momentSiteZone, 'month' );
+
+		expect( format( date ) ).toBe( momentSiteZone().endOf( 'month' ).format( 'YYYY-MM-DD' ) );
+		expect( dateRange ).toBeNull();
+	} );
+} );

--- a/client/my-sites/stats/test/utils.js
+++ b/client/my-sites/stats/test/utils.js
@@ -1,4 +1,4 @@
-import { getPathWithUpdatedQueryString } from '../utils';
+import { buildSummaryUrl, getPathWithUpdatedQueryString } from '../utils';
 
 describe( 'getPathWithUpdatedQueryString', () => {
 	it( 'should return the path with the updated query string', () => {
@@ -25,5 +25,59 @@ describe( 'getPathWithUpdatedQueryString', () => {
 		expect(
 			getPathWithUpdatedQueryString( { h: 'i' }, '/a/b/c?h=k?page=stats?page=stats?page=stats' )
 		).toEqual( '/a/b/c?h=i' );
+	} );
+} );
+
+describe( 'buildSummaryUrl', () => {
+	const period = { period: 'day', endOf: { format: () => '2025-07-09' } };
+
+	it( 'returns undefined when required params are missing', () => {
+		expect( buildSummaryUrl( {} ) ).toBeUndefined();
+		expect( buildSummaryUrl( { module: 'referrers', siteSlug: 'example.com' } ) ).toBeUndefined();
+		expect( buildSummaryUrl( { period, siteSlug: 'example.com' } ) ).toBeUndefined();
+		expect( buildSummaryUrl( { period, module: 'referrers' } ) ).toBeUndefined();
+	} );
+
+	it( 'forwards a custom range as chartStart/chartEnd', () => {
+		expect(
+			buildSummaryUrl( {
+				period,
+				module: 'referrers',
+				siteSlug: 'example.com',
+				query: { start_date: '2024-07-10', date: '2025-07-09' },
+			} )
+		).toEqual( '/stats/day/referrers/example.com?chartStart=2024-07-10&chartEnd=2025-07-09' );
+	} );
+
+	it( 'appends the shortcut when provided alongside a range', () => {
+		expect(
+			buildSummaryUrl( {
+				period,
+				module: 'referrers',
+				siteSlug: 'example.com',
+				query: { start_date: '2024-07-10', date: '2025-07-09' },
+				shortcut: 'last_12_months',
+			} )
+		).toEqual(
+			'/stats/day/referrers/example.com?chartStart=2024-07-10&chartEnd=2025-07-09&shortcut=last_12_months'
+		);
+	} );
+
+	it( 'falls back to the legacy single-date contract without a custom range', () => {
+		expect(
+			buildSummaryUrl( { period, module: 'referrers', siteSlug: 'example.com', query: {} } )
+		).toEqual( '/stats/day/referrers/example.com?startDate=2025-07-09' );
+	} );
+
+	it( 'ignores the shortcut when there is no custom range', () => {
+		expect(
+			buildSummaryUrl( {
+				period,
+				module: 'referrers',
+				siteSlug: 'example.com',
+				query: {},
+				shortcut: 'last_12_months',
+			} )
+		).toEqual( '/stats/day/referrers/example.com?startDate=2025-07-09' );
 	} );
 } );

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -40,6 +40,41 @@ export function getPathWithUpdatedQueryString( query = {}, path = page.current )
 }
 
 /**
+ * Build a module "View details" summary link that forwards the current date range.
+ * When the source query carries a custom range we emit the modern `chartStart`/`chartEnd`
+ * (plus the matched `shortcut`) contract; otherwise we keep the legacy single-date `startDate`.
+ * @param {Object} params params
+ * @param {Object} params.period period object with `period` string and `endOf` moment
+ * @param {string} params.module module path segment (e.g. `referrers`)
+ * @param {string} params.siteSlug site slug
+ * @param {Object} params.query stats query (may carry `start_date`/`date`)
+ * @param {string} [params.shortcut] active shortcut id to forward
+ * @returns {string|undefined} the summary URL or undefined when required params are missing
+ */
+export function buildSummaryUrl( { period, module, siteSlug, query, shortcut } = {} ) {
+	if ( ! period?.period || ! module || ! siteSlug ) {
+		return undefined;
+	}
+
+	const url = `/stats/${ period.period }/${ module }/${ siteSlug }`;
+
+	if ( ! query?.start_date ) {
+		return `${ url }?startDate=${ period.endOf.format( DATE_FORMAT ) }`;
+	}
+
+	// The range and shortcut originate from the URL, so serialize instead of interpolating.
+	const params = new URLSearchParams( {
+		chartStart: query.start_date,
+		chartEnd: query.date,
+	} );
+	if ( shortcut ) {
+		params.set( 'shortcut', shortcut );
+	}
+
+	return `${ url }?${ params.toString() }`;
+}
+
+/**
  * Add analytics event.
  * @param {*} eventName Analytics event name, automatically prefixed with 'jetpack_odyssey' or 'calypso'
  * @param {*} properties Analytics properties

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -58,7 +58,7 @@ export function buildSummaryUrl( { period, module, siteSlug, query, shortcut } =
 
 	const url = `/stats/${ period.period }/${ module }/${ siteSlug }`;
 
-	if ( ! query?.start_date ) {
+	if ( ! query?.start_date || ! query?.date ) {
 		return `${ url }?startDate=${ period.endOf.format( DATE_FORMAT ) }`;
 	}
 


### PR DESCRIPTION
Part of STATS-282

## Proposed Changes

* Replace the Day / 7 days / 30 days / Quarter / Year / All Time segmented control on stats summary pages with the same date range picker used on the Traffic page.
* Add an "All time" shortcut to the picker (gated like the other shortcuts) that keeps the legacy `num=-1&summarize=1` URL contract.
* Summary pages now accept the modern `chartStart`/`chartEnd` params, falling back to the legacy `startDate`/`endDate` ones so old links keep working.
* Module "View details" links forward the active range/shortcut, and back links/breadcrumbs carry the range back to the Traffic page.


https://github.com/user-attachments/assets/1be77fdb-6935-4f5a-a701-bf3b8ec1ab3a



## Why are these changes being made?

* Summary pages used their own period pills while the Traffic page already has a full date range picker, so date selection behaved differently between the two. Using the same picker everywhere unifies the UX and lets summary pages support arbitrary custom ranges.

## Testing Instructions

1. Go to Stats > Traffic (`/stats/day/:site`), select a date range, then open "View details" on a module (e.g. Posts & pages) — the summary page should open with the same range preselected in the picker instead of the old period pills.
2. On the summary page, switch ranges via the picker (shortcuts and a custom range) and confirm the module data updates and the URL uses `chartStart`/`chartEnd`.
3. Select the "All time" shortcut — the URL should switch to `num=-1&summarize=1`, the label should read "All Time", and on a free site the shortcut should show the upsell instead.
4. Use the back link/breadcrumb — it should return to Traffic with the selected range intact.
5. Open a legacy summary URL (e.g. `?startDate=YYYY-MM-DD&num=30&summarize=1`) and confirm it still renders the correct range.

Before/After screenshots: _(placeholder — to be added by the author)_

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?