### PR TITLE
Remove the site-options step from the site-setup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -8,7 +8,6 @@ import { addQueryArgs } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -49,7 +48,6 @@ const siteSetupFlow: Flow = {
 	useSteps() {
 		const steps = [
 			STEPS.GOALS,
-			STEPS.OPTIONS,
 			STEPS.DESIGN_SETUP,
 			STEPS.IMPORT,
 			STEPS.IMPORT_LIST,
@@ -112,11 +110,6 @@ const siteSetupFlow: Flow = {
 			( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
 			[ site ]
 		);
-		const storeType = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStoreType(),
-			[]
-		);
-
 		const { setPendingAction, resetOnboardStoreWithSkipFlags } = useDispatch( ONBOARD_STORE );
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
@@ -253,18 +246,6 @@ const siteSetupFlow: Flow = {
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
-				case 'options': {
-					if ( intent === 'sell' ) {
-						/**
-						 * Part of the theme/plugin bundling is simplyfing the seller flow.
-						 *
-						 * Instead of having the user manually choose between "Start simple" and "More power", we let them select a theme and use the theme choice to determine which path to take.
-						 */
-						return navigate( 'design-setup' );
-					}
-					return navigate( 'design-setup' );
-				}
-
 				case 'design-setup': {
 					return navigate( 'processing' );
 				}
@@ -274,13 +255,6 @@ const siteSetupFlow: Flow = {
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
-					}
-
-					// End of woo flow
-					if ( intent === 'sell' && storeType === 'power' ) {
-						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
-
-						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 
 					// Check current theme: Does it have a plugin bundled?
@@ -479,9 +453,6 @@ const siteSetupFlow: Flow = {
 				case 'importReadyPreview':
 					return navigate( `import?siteSlug=${ siteSlug }` );
 
-				case 'options':
-					return navigate( 'goals' );
-
 				case 'import':
 					return navigate( 'goals' );
 
@@ -496,12 +467,6 @@ const siteSetupFlow: Flow = {
 
 		const goNext = () => {
 			switch ( currentStep ) {
-				case 'options':
-					if ( intent === 'sell' ) {
-						return navigate( 'design-setup' );
-					}
-					return navigate( 'design-setup' );
-
 				case 'import':
 					return navigate( 'importList' );
 


### PR DESCRIPTION
## Proposed Changes

* Remove the site-options step from the site-setup flow — unregister it from `useSteps` and drop its submit/goBack/goNext routing.
* Remove the now-dead WooCommerce "power" store-type branch in `processing` (nothing sets `storeType` anymore) and the now-unused `recordTracksEvent` import.

## Why are these changes being made?

The site-options step has no forward entry in site-setup now that the goals branch feeding it (goals → options) is gone. This continues the incremental teardown of the dead goals onboarding branch, one step per PR (after `design-choices`, `courses`, `bloggerStartingPoint`, and `difmStartingPoint`).

**Kept:** the `STEPS.OPTIONS` registration and the `site-options` step component — they are still used by the `update-options` flow. This PR only removes site-setup's use of the step.

## Testing Instructions

* Type-check and lint pass. The site-options step no longer appears in the site-setup flow's steps; the `update-options` flow is unaffected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
