### PR TITLE
TEMP diagnostic: log isManageSiteFlow for with-plugin (do not merge)

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -249,6 +249,24 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
+		// TEMP diagnostic — remove before merge. Logs why isManageSiteFlow resolves as it does when
+		// re-entering the with-plugin flow after backing out of checkout (duplicate-site debugging).
+		if ( flowName === 'with-plugin' ) {
+			// eslint-disable-next-line no-console
+			console.log( '[with-plugin manage-site debug]', {
+				isManageSiteFlow,
+				excludeFromManageSiteFlows: !! excludeFromManageSiteFlows,
+				isAddNewSiteFlow,
+				wasSignupCheckoutPageUnloaded: wasSignupCheckoutPageUnloaded(),
+				signupDestinationCookieExists: !! signupDestinationCookieExists,
+				isReEnteringFlow,
+				signupCompleteFlowName: getSignupCompleteFlowName(),
+				flowName,
+				stepName,
+				url: window.location.href,
+			} );
+		}
+
 		// Hydrate the store with domains dependencies from session storage,
 		// only in the onboarding flow.
 		const domainsDependencies = getDomainsDependencies();


### PR DESCRIPTION
**Do not merge.** Temporary diagnostic to find why the duplicate-site guard (`isManageSiteFlow`) doesn't fire when backing out of checkout in `/start/with-plugin`.

Logs `isManageSiteFlow` and its four inputs to the browser console, gated to the `with-plugin` flow.

## How to test
1. Open the Calypso Live build below.
2. Log out, open a paid marketplace plugin, "Get started" → account → domain → plans grid → pick a plan → checkout.
3. Open the browser console.
4. Click the checkout **back** control.
5. Read the `[with-plugin manage-site debug]` line(s) on the `/start/with-plugin/plans-with-plugin` and `/start/with-plugin/domains` loads — whichever input is `false`/wrong is the culprit.