### PR TITLE
Odyssey Stats: Hide Jetpack upsells for products the site already owns

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -6,6 +6,7 @@ import { getSiteTitle } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import UpsellCard from './upsell-card';
 import {
+	filterUpsellsBySiteFeatures,
 	getAvailableUpsells,
 	getUpsellFeatureSlugs,
 	Product,
@@ -43,11 +44,9 @@ function getVisibleUpsells( siteId: number | null, siteFeatures: string[] ): Pro
 		return [];
 	}
 
-	// Filter available upsells against site features.
-	// If an upsell has even one feature that is not active on the site, present it to the user.
-	const filteredUpsells = getAvailableUpsells().filter( ( upsell ) =>
-		upsell.features.some( ( feature ) => ! siteFeatures.includes( feature ) )
-	);
+	// Hide upsells for products the site already owns, either directly or through
+	// a bundling plan (e.g. don't upsell Backup to a site on Jetpack Security).
+	const filteredUpsells = filterUpsellsBySiteFeatures( getAvailableUpsells(), siteFeatures );
 
 	// Add the checkout URL to the results.
 	const finalUpsells = filteredUpsells.map( ( upsell ) => {

--- a/client/my-sites/stats/jetpack-upsell-section/test/available-upsells.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/test/available-upsells.tsx
@@ -1,0 +1,52 @@
+import { filterUpsellsBySiteFeatures, getAvailableUpsells } from '../upsell-card/available-upsells';
+
+// Feature slugs a site on Jetpack Security (Daily) reports: Backup, Scan and
+// Anti-spam are bundled, but not Search, VideoPress, Boost or Social.
+const SECURITY_DAILY_FEATURES = [
+	'antispam',
+	'backups',
+	'backups-daily',
+	'full-activity-log',
+	'scan',
+];
+
+describe( 'filterUpsellsBySiteFeatures', () => {
+	const upsells = getAvailableUpsells();
+	const visibleSlugs = ( siteFeatures: string[] ) =>
+		filterUpsellsBySiteFeatures( upsells, siteFeatures ).map( ( upsell ) => upsell.slug );
+
+	it( 'shows all upsells when the site has no features', () => {
+		expect( visibleSlugs( [] ) ).toEqual( [
+			'security',
+			'backup',
+			'search',
+			'video',
+			'boost',
+			'social',
+		] );
+	} );
+
+	it( 'hides the Backup and Security upsells when a plan already bundles them', () => {
+		expect( visibleSlugs( SECURITY_DAILY_FEATURES ) ).toEqual( [
+			'search',
+			'video',
+			'boost',
+			'social',
+		] );
+	} );
+
+	it( 'hides the Backup upsell but keeps Security when only Backup is owned', () => {
+		expect( visibleSlugs( [ 'backups' ] ) ).toEqual( [
+			'security',
+			'search',
+			'video',
+			'boost',
+			'social',
+		] );
+	} );
+
+	it( 'hides every upsell when the site has all owned features', () => {
+		const allOwnedFeatures = upsells.flatMap( ( upsell ) => upsell.ownedFeatures );
+		expect( visibleSlugs( allOwnedFeatures ) ).toEqual( [] );
+	} );
+} );

--- a/client/my-sites/stats/jetpack-upsell-section/upsell-card/available-upsells.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/upsell-card/available-upsells.tsx
@@ -21,7 +21,9 @@ export type Product = {
 	isFree: boolean;
 	slug: string;
 	title: string;
-	features: string[];
+	// Feature slugs that indicate the product (or a plan bundling it) is already
+	// owned. The upsell is hidden when the site has all of them.
+	ownedFeatures: string[];
 	checkoutSlug: string;
 	checkoutUrl: string | null;
 };
@@ -37,26 +39,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'security',
 			title: 'Security',
-			features: [
-				'akismet',
-				'antispam',
-				'backups',
-				'backups-daily',
-				'core/audio',
-				'full-activity-log',
-				'google-analytics',
-				'google-my-business',
-				'priority_support',
-				'real-time-backups',
-				'scan',
-				'simple-payments',
-				'subscriber-unlimited-imports',
-				'support',
-				'vaultpress-backups',
-				'video-hosting',
-				'wordads',
-				'wordads-jetpack',
-			],
+			ownedFeatures: [ 'backups', 'scan', 'antispam' ],
 			checkoutSlug: PLAN_JETPACK_SECURITY_T1_YEARLY,
 		},
 		{
@@ -68,7 +51,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'backup',
 			title: 'Backup',
-			features: [ 'backups', 'full-activity-log', 'real-time-backups', 'priority_support' ],
+			ownedFeatures: [ 'backups' ],
 			checkoutSlug: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 		},
 		{
@@ -80,7 +63,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'search',
 			title: 'Search',
-			features: [ 'search', 'instant-search' ],
+			ownedFeatures: [ 'search' ],
 			checkoutSlug: PRODUCT_JETPACK_SEARCH,
 		},
 		{
@@ -92,7 +75,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'video',
 			title: 'VideoPress',
-			features: [ 'videopress', 'videopress-1tb-storage' ],
+			ownedFeatures: [ 'videopress' ],
 			checkoutSlug: PRODUCT_JETPACK_VIDEOPRESS,
 		},
 		{
@@ -104,14 +87,7 @@ export function getAvailableUpsells() {
 			isFree: true,
 			slug: 'boost',
 			title: 'Boost',
-			features: [
-				'cloud-critical-css',
-				'cornerstone-10-pages',
-				'image-cdn-liar',
-				'image-cdn-quality',
-				'image-size-analysis',
-				'performance-history',
-			],
+			ownedFeatures: [ 'cloud-critical-css' ],
 			checkoutSlug: PRODUCT_JETPACK_BOOST,
 		},
 		{
@@ -123,11 +99,7 @@ export function getAvailableUpsells() {
 			isFree: true,
 			slug: 'social',
 			title: 'Social',
-			features: [
-				'social-enhanced-publishing',
-				'social-image-generator',
-				'subscriber-unlimited-imports',
-			],
+			ownedFeatures: [ 'social-enhanced-publishing' ],
 			checkoutSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
 		},
 	] as Product[];
@@ -137,5 +109,14 @@ export function getAvailableUpsells() {
 // Currently we end up calling getAvailableUpsells() twice per render.
 export function getUpsellFeatureSlugs(): string[] {
 	const upsells = getAvailableUpsells();
-	return upsells.flatMap( ( upsell ) => upsell.features );
+	return upsells.flatMap( ( upsell ) => upsell.ownedFeatures );
+}
+
+export function filterUpsellsBySiteFeatures(
+	upsells: Product[],
+	siteFeatures: string[]
+): Product[] {
+	return upsells.filter(
+		( upsell ) => ! upsell.ownedFeatures.every( ( feature ) => siteFeatures.includes( feature ) )
+	);
 }


### PR DESCRIPTION
Fixes STATS-286

## Proposed Changes

* Invert the visibility check for the Stats page Jetpack upsell section: each upsell now declares the `ownedFeatures` entitlement slugs that mean the product is already owned (directly or via a bundling plan), and the card is hidden when the site has all of them.
* Previously an upsell was shown when the site was missing *any one* of the product's feature slugs, so a site on Jetpack Security (which bundles VaultPress Backup) was still prompted to upgrade to Backup — only Jetpack Complete owned every slug and escaped the prompts. The redundancy was only surfaced at checkout ("The product you are about to purchase, VaultPress Backup, is already included in this plan.").
* Extract the filter into a pure `filterUpsellsBySiteFeatures()` helper and add unit tests covering the Security-plan scenario from the issue.

### Before / after, per card

The old `features` arrays were product selling-point dumps used as ownership checks — "show the card if the site lacks **any** slug in the list". The new `ownedFeatures` are the minimal entitlement set meaning "the product's substance is already owned" — "hide the card if the site has **all** of them".

| Card | Old check (show if missing any) | New check (hide if has all) | On a Jetpack Security Daily site |
|---|---|---|---|
| Backup | `backups`, `full-activity-log`, `real-time-backups`, `priority_support` | `backups` | Old: missing `real-time-backups` (Daily = daily backups) → wrongly shown. New: has `backups` → hidden. |
| Security | 18 slugs incl. unrelated ones (`wordads`, `google-analytics`, `core/audio`, `simple-payments`, …) plus both `backups-daily` **and** `real-time-backups` | `backups`, `scan`, `antispam` | Old: missing `real-time-backups`, `google-my-business` → **Security owners were upsold Security**. New: has all three → hidden. |
| Search | `search`, `instant-search` | `search` | unchanged behavior |
| VideoPress | `videopress`, `videopress-1tb-storage` | `videopress` | unchanged behavior |
| Boost | 6 paid-Boost slugs | `cloud-critical-css` | unchanged behavior |
| Social | 3 slugs | `social-enhanced-publishing` | unchanged behavior |

Because the old Security list contained both mutually-exclusive backup granularities (`backups-daily` and `real-time-backups`), it was unsatisfiable for any plan except Complete — matching the report that the card showed "for any site that isn't on the Jetpack Complete plan".

## Why are these changes being made?

* On a site that already owns Jetpack Security, the Stats page upsell card ("Enhance … with Jetpack Security, Performance, and Growth tools") prompted a Backup upgrade even though the plan already includes VaultPress Backup. The card should key off actual entitlements rather than "not on Complete". See STATS-286 for the full report.

## Testing Instructions

* `yarn test-client client/my-sites/stats/jetpack-upsell-section` — 4/4 tests pass.
* On a Jetpack site **without** any paid upgrades, open Odyssey Stats (wp-admin → Jetpack → Stats, Traffic tab) and scroll to the upsell section: all six cards (Security, Backup, Search, VideoPress, Boost, Social) should still appear.
* On a Jetpack site with **Jetpack Security** (or another plan bundling Backup/Scan/Anti-spam): the Security and Backup cards should no longer appear, while unowned products (e.g. Search, VideoPress) still show.
  * To reproduce the exact STATS-286 scenario you need the legacy **Jetpack Security Daily** plan, which is no longer purchasable — attach it to a test site with internal tooling, or simulate any plan by filtering the feature source: `add_filter( 'option_jetpack_active_plan', fn( $plan ) => array_merge_recursive( $plan, [ 'features' => [ 'active' => [ 'backups', 'scan', 'antispam' ] ] ] ) );` in an mu-plugin. The section reads entitlements from these slugs, so the filter exercises the same code path as a real purchase.
* On a site with **Jetpack Complete**: no upsell cards should appear.

### Test results (verified on a self-hosted Jetpack site, local Docker)

Verified against real plan data (the section reads entitlements from the `jetpack_active_plan` feature slugs that `stats-admin` inlines into the page):

* ✅ With **VaultPress Backup (10GB) + Jetpack Search Free**: the Backup and Search cards are hidden (`backups` / `search` are in the site's active features); Security, VideoPress, Boost and Social still show.
* ✅ With **Jetpack Security Daily** attached (the exact plan from STATS-286 — its active features include `backups`, `backups-daily`, `scan`, `antispam` but **not** `real-time-backups`): only VideoPress, Boost and Social show. Under the previous logic this site was shown both the Backup and Security cards, because the missing `real-time-backups` slug satisfied the "any feature missing" check.
* ✅ Confirmed the feature slug names used in `ownedFeatures` (`backups`, `scan`, `antispam`, `search`) match what the plan actually reports.
* Note: Jetpack Search **Free** reports both `search` and `instant-search`, so the Search card is also hidden for free-tier Search sites — there is no feature slug distinguishing free from paid Search; keying off entitlement is the intended behavior here.

#### My purchases

<img width="1061" height="460" alt="截圖 2026-07-09 晚上10 37 07" src="https://github.com/user-attachments/assets/f7abea48-6c6d-43a6-9aff-64c470f17def" />

#### Upsell cards
|Before|After|
|-|-|
|<img width="1172" height="600" alt="截圖 2026-07-09 晚上10 30 14" src="https://github.com/user-attachments/assets/a5f2a5a2-a39b-4209-a9b6-62556ecbb8d3" />|<img width="1162" height="404" alt="截圖 2026-07-09 晚上10 29 32" src="https://github.com/user-attachments/assets/4f89a93d-1fd4-4fd2-b03a-99b8add2140b" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? (Self-hosted Jetpack — the only environment where this Odyssey-gated section renders.)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


