### PR TITLE
Plugins "Get started": fix blank page + duplicate site when backing out of checkout

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -130,6 +130,9 @@ export function generateFlows( {
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'plugin', 'billing_period', 'intervalType' ],
 			optionalDependenciesInQuery: [ 'intervalType' ],
+			// Persist domains data so re-entering via browser back from checkout skips the domains
+			// step and reuses the created site instead of making a duplicate.
+			persistsDomainsOnReEntry: true,
 			hideProgressIndicator: true,
 		},
 		{
@@ -141,6 +144,7 @@ export function generateFlows( {
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
+			persistsDomainsOnReEntry: true,
 			hideProgressIndicator: true,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -27,17 +27,19 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	const queryArgs = getQueryArgs() ?? {};
 
 	// with-plugin: point "back" at the plans grid (params from the dependency store — the URL query
-	// is empty by now), not the post-purchase destination which can't render pre-purchase. Known
-	// tradeoff: this re-enters signup and recreates the site; kept over a blank page for now.
+	// is empty by now), not the post-purchase destination which can't render pre-purchase. The flow
+	// skips the domains step on this re-entry (see controller.js) so it reuses the created site.
 	let backDestination = destination;
 	if ( flowName === 'with-plugin' ) {
 		const { pluginParameter, pluginBillingPeriod } = dependencies;
 		backDestination = addQueryArgs(
 			{
 				...( pluginParameter && { plugin: pluginParameter } ),
+				// billing_period is a required query dependency of this flow, so always include it
+				// (empty for free plugins) — otherwise the flow controller rejects the URL.
+				billing_period: pluginBillingPeriod ?? '',
+				// Default the grid to the plugin's billing interval.
 				...( pluginBillingPeriod && {
-					billing_period: pluginBillingPeriod,
-					// Default the grid to the plugin's billing interval.
 					intervalType: pluginBillingPeriod === 'MONTHLY' ? 'monthly' : 'yearly',
 				} ),
 			},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -209,10 +209,8 @@ export default {
 		const flowName = getFlowName( context.params, userLoggedIn );
 		const stepName = getStepName( context.params );
 		const stepSectionName = getStepSectionName( context.params );
-		const { providesDependenciesInQuery, excludeFromManageSiteFlows } = flows.getFlow(
-			flowName,
-			userLoggedIn
-		);
+		const { providesDependenciesInQuery, excludeFromManageSiteFlows, persistsDomainsOnReEntry } =
+			flows.getFlow( flowName, userLoggedIn );
 
 		// Update initialContext to help woocommerce-install support site switching.
 		if ( 'woocommerce-install' === flowName ) {
@@ -255,7 +253,7 @@ export default {
 		if (
 			domainsDependencies &&
 			isManageSiteFlow &&
-			[ 'onboarding', 'with-plugin' ].includes( flowName ) &&
+			persistsDomainsOnReEntry &&
 			stepName !== 'domains'
 		) {
 			const { step, dependencies } = JSON.parse( domainsDependencies );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -249,13 +249,13 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
-		// Hydrate the store with domains dependencies from session storage,
-		// only in the onboarding flow.
+		// Hydrate the store with domains dependencies from session storage so re-entering via
+		// browser back from checkout skips the domains step instead of recreating the site.
 		const domainsDependencies = getDomainsDependencies();
 		if (
 			domainsDependencies &&
 			isManageSiteFlow &&
-			flowName === 'onboarding' &&
+			[ 'onboarding', 'with-plugin' ].includes( flowName ) &&
 			stepName !== 'domains'
 		) {
 			const { step, dependencies } = JSON.parse( domainsDependencies );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -453,7 +453,7 @@ class Signup extends Component {
 
 		// Persist current domains data so re-entering via browser back from checkout can skip the
 		// domains step instead of recreating the site.
-		if ( [ 'onboarding', 'with-plugin' ].includes( this.props.flowName ) ) {
+		if ( flows.getFlow( this.props.flowName, this.props.isLoggedIn ).persistsDomainsOnReEntry ) {
 			const { domainItem, siteUrl, domainCart } = dependencies;
 			const { stepSectionName } = this.props;
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -451,8 +451,9 @@ class Signup extends Component {
 			setSignupCompleteFlowName( this.props.flowName );
 		}
 
-		// Persist current domains data in the onboarding flow.
-		if ( this.props.flowName === 'onboarding' ) {
+		// Persist current domains data so re-entering via browser back from checkout can skip the
+		// domains step instead of recreating the site.
+		if ( [ 'onboarding', 'with-plugin' ].includes( this.props.flowName ) ) {
 			const { domainItem, siteUrl, domainCart } = dependencies;
 			const { stepSectionName } = this.props;
 

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -131,5 +131,26 @@ describe( 'Signup Flows Configuration', () => {
 			expect( result ).toContain( 'billing_period%3DANNUALLY' );
 			expect( result ).toContain( 'intervalType%3Dyearly' );
 		} );
+
+		test( 'should still include an empty billing_period for a free plugin', () => {
+			// A free plugin has no billing period, but billing_period is a required query dependency,
+			// so the back URL must still carry it (empty) or the flow controller rejects the URL.
+			const flowsModule = require( 'calypso/signup/config/flows' );
+			const { filterDestination } = flowsModule.default;
+
+			const dependencies = {
+				siteSlug: 'test-site',
+				cartItem: 'personal_plan',
+				pluginParameter: 'mailpoet',
+			};
+			const destination = '/marketplace/plugin/mailpoet/install/test-site';
+
+			const result = filterDestination( destination, dependencies, 'with-plugin', 'en' );
+
+			expect( result ).toContain( 'plans-with-plugin' );
+			expect( result ).toContain( 'plugin%3Dmailpoet' );
+			expect( result ).toContain( 'billing_period%3D' );
+			expect( result ).not.toContain( 'intervalType' );
+		} );
 	} );
 } );

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -20,6 +20,7 @@ export interface Flow {
 	disallowResume?: boolean;
 	showRecaptcha?: boolean;
 	enableBranchSteps?: boolean;
+	persistsDomainsOnReEntry?: boolean;
 	hideProgressIndicator?: boolean;
 	helpCenterButtonText?: string;
 	enableHotjar?: boolean;


### PR DESCRIPTION
## Proposed Changes

Fix backing out of checkout in the per-plugin "Get started" (`with-plugin`) flow, which had two separate failures:

- **Blank page.** The checkout back URL dropped the required `billing_period` query dependency for **free** plugins (which have no billing period), so the flow controller rejected the URL and the plans step rendered blank. It now always includes `billing_period` (empty for free plugins).
- **Duplicate site.** Re-entering the flow restarted at the domains step and created a second site. The framework already has a "skip the domains step on browser-back from checkout" path for the onboarding flow (persist domains data on completion, re-submit it on re-entry so the site is reused). This extends that path to the `with-plugin` flow.

Net result: backing out of checkout lands on the plans grid with the plugin selected — no blank page, no duplicate site.

## Testing Instructions

1. Log out, open a **free** marketplace plugin (e.g. MailPoet) and a **paid** one (e.g. Sensei Pro), "Get started".
2. Create an account, pick a domain, land on the plans grid, pick a plan → checkout.
3. Click the checkout **back** control.
4. Confirm you return to the **plans grid** (not blank, not the domains step) and that **no duplicate site** was created.

Unit tests in `client/signup/test/flows.js` cover the back URL carrying `billing_period` for both paid and free plugins. The domains-skip behavior was verified manually for both plugin types.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
