### PR TITLE
Show Blaze Traffic card for coming-soon sites

### DIFF
--- a/client/sites/marketing/traffic/test/traffic.jsx
+++ b/client/sites/marketing/traffic/test/traffic.jsx
@@ -1,0 +1,86 @@
+import { getBlazeAdvertisingUrl, shouldShowBlazeAdvertisingOption } from '../traffic';
+
+const siteId = 123;
+
+const getState = ( {
+	canBlaze,
+	isComingSoon = false,
+	isSiteKnown = true,
+	siteSettingsComingSoon = false,
+} ) => {
+	const site = {
+		ID: siteId,
+		URL: 'https://example.wordpress.com',
+		is_coming_soon: isComingSoon,
+		options: {
+			can_blaze: canBlaze,
+			is_wpcom_simple: true,
+		},
+	};
+
+	return {
+		sites: {
+			items: isSiteKnown ? { [ siteId ]: site } : {},
+		},
+		siteSettings: {
+			items: {
+				[ siteId ]: {
+					wpcom_coming_soon: siteSettingsComingSoon ? 1 : 0,
+				},
+			},
+		},
+	};
+};
+
+describe( 'shouldShowBlazeAdvertisingOption', () => {
+	test( 'returns true when the site can use Blaze', () => {
+		const state = getState( { canBlaze: true } );
+
+		expect( shouldShowBlazeAdvertisingOption( state, siteId ) ).toBe( true );
+	} );
+
+	test( 'returns true when the site is coming soon', () => {
+		const state = getState( { canBlaze: false, isComingSoon: true } );
+
+		expect( shouldShowBlazeAdvertisingOption( state, siteId ) ).toBe( true );
+	} );
+
+	test( 'returns true when site settings identify the site as coming soon', () => {
+		const state = getState( {
+			canBlaze: false,
+			isSiteKnown: false,
+			siteSettingsComingSoon: true,
+		} );
+
+		expect( shouldShowBlazeAdvertisingOption( state, siteId ) ).toBe( true );
+	} );
+
+	test( 'returns false when the site cannot use Blaze and is not coming soon', () => {
+		const state = getState( { canBlaze: false } );
+
+		expect( shouldShowBlazeAdvertisingOption( state, siteId ) ).toBe( false );
+	} );
+} );
+
+describe( 'getBlazeAdvertisingUrl', () => {
+	test( 'returns the Calypso Advertising route when the site slug is available', () => {
+		expect(
+			getBlazeAdvertisingUrl( {
+				siteSlug: 'example.wordpress.com',
+				wpAdminAdvertisingUrl: 'https://example.wordpress.com/wp-admin/tools.php?page=advertising',
+			} )
+		).toBe( '/advertising/example.wordpress.com' );
+	} );
+
+	test( 'returns the wp-admin Advertising URL as a fallback', () => {
+		const wpAdminAdvertisingUrl =
+			'https://example.wordpress.com/wp-admin/tools.php?page=advertising';
+
+		expect(
+			getBlazeAdvertisingUrl( {
+				siteSlug: null,
+				wpAdminAdvertisingUrl,
+			} )
+		).toBe( wpAdminAdvertisingUrl );
+	} );
+} );

--- a/client/sites/marketing/traffic/traffic.jsx
+++ b/client/sites/marketing/traffic/traffic.jsx
@@ -25,7 +25,8 @@ import Sitemaps from 'calypso/my-sites/site-settings/sitemaps';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isBlazeEnabled from 'calypso/state/selectors/is-blaze-enabled';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -34,6 +35,18 @@ const loadForm = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-my-sites-site-settings-seo-settings-form" */ 'calypso/my-sites/site-settings/seo-settings/form'
 	);
+
+export const shouldShowBlazeAdvertisingOption = ( state, siteId ) => {
+	return isBlazeEnabled( state, siteId ) || isSiteComingSoon( state, siteId );
+};
+
+export const getBlazeAdvertisingUrl = ( { siteSlug, wpAdminAdvertisingUrl } ) => {
+	if ( siteSlug ) {
+		return `/advertising/${ siteSlug }`;
+	}
+
+	return wpAdminAdvertisingUrl;
+};
 
 const SiteSettingsTraffic = ( {
 	fields,
@@ -46,6 +59,7 @@ const SiteSettingsTraffic = ( {
 	isSavingSettings,
 	setFieldValue,
 	siteId,
+	siteSlug,
 	shouldShowAdvertisingOption,
 	translate,
 } ) => {
@@ -57,6 +71,10 @@ const SiteSettingsTraffic = ( {
 	}, [] );
 
 	const advertisingUrl = useAdvertisingUrl();
+	const blazeAdvertisingUrl = getBlazeAdvertisingUrl( {
+		siteSlug,
+		wpAdminAdvertisingUrl: advertisingUrl,
+	} );
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -95,7 +113,7 @@ const SiteSettingsTraffic = ( {
 							) }
 							ctaText={ translate( 'Get started' ) }
 							image={ blazeIllustration }
-							href={ advertisingUrl }
+							href={ blazeAdvertisingUrl }
 						/>
 					) }
 					{ isAdmin && (
@@ -142,14 +160,16 @@ const connectComponent = connect( ( state ) => {
 	const isAdmin = canCurrentUser( state, siteId, 'manage_options' );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isJetpackAdmin = isJetpack && isAdmin;
-	const shouldShowAdvertisingOption = isBlazeEnabled( state, siteId );
+	const siteSlug = getSiteSlug( state, siteId );
+	const showAdvertisingOption = shouldShowBlazeAdvertisingOption( state, siteId );
 
 	return {
 		siteId,
 		isAdmin,
 		isJetpack,
 		isJetpackAdmin,
-		shouldShowAdvertisingOption,
+		siteSlug,
+		shouldShowAdvertisingOption: showAdvertisingOption,
 	};
 } );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/ADS-1379/jetpack-traffic-inconsistent-blaze-module

## Proposed Changes

* Show the Blaze promo card on the Traffic page when a site is coming soon, even when `can_blaze` is false.
* Route the Traffic page Blaze CTA through Calypso's `/advertising/{site}` route when a site slug is available, so coming-soon sites land on the existing "Site is not published" Blaze gate instead of a generic wp-admin missing-page error.
* Add focused tests for the Traffic page Blaze visibility and CTA URL helpers.

## Why are these changes being made?

* Coming-soon sites currently hide the Blaze card because WPCOM sets `can_blaze: false` for unlaunched sites, and the Traffic page used that campaign eligibility flag as the card visibility flag.
* ADS-1379 asks us to keep Blaze discoverable for unlaunched sites and nudge users to launch before they can run campaigns.
* Campaign setup remains gated by the existing Advertising route. The Traffic page only changes discoverability and the CTA destination.

## Media

| Before | After |
| --- | --- |
| Production Traffic page for a coming-soon site. The Blaze card is hidden. | Local branch Traffic page for the same coming-soon site. The Blaze card is visible. |
|  <img width="1713" height="825" alt="Before" src="https://github.com/user-attachments/assets/506a371e-dd78-43b8-8190-c677d16ccf09" /> | <img width="1728" height="849" alt="After" src="https://github.com/user-attachments/assets/0ea47221-cc31-44b1-8a87-95d5e4032b5d" /> |

| CTA behavior |
| --- |
| Clicking **Get started** opens the Calypso Advertising route and shows the existing **Site is not published** gate with launch guidance. |
| <img width="1728" height="849" alt="Launch gate" src="https://github.com/user-attachments/assets/cbc5bab9-fe31-4758-befa-d55178ddeb20" /> |

## Testing Instructions

* Automated checks run locally:
  * `corepack yarn test-client client/sites/marketing/traffic --runInBand`
  * `corepack yarn eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json client/sites/marketing/traffic/traffic.jsx client/sites/marketing/traffic/test/traffic.jsx`
  * `git diff --check`
  * `corepack yarn typecheck-client`
* Production before check:
  * Open `/marketing/traffic/:site`.
  * Confirm the coming-soon simple site Traffic page loads without the Blaze card.
* Local after check:
  * Start Calypso locally with Node `v24.15.0`.
  * Open the local Calypso route `/marketing/traffic/:site`.
  * Confirm the Blaze card appears with the heading "Reach new readers and customers" and the "Get started" CTA.
  * Click "Get started".
  * Confirm it opens `/advertising/:site`, shows "Site is not published", includes the launch guidance, and does not show the generic wp-admin missing-page error.
* Launched-site regression:
  * Open the local Calypso route `/marketing/traffic/:site`.
  * Confirm the Blaze card still appears.
  * Click "Get started".
  * Confirm it opens `/advertising/:site` and shows the Blaze Advertising dashboard with campaign content.
* Browser console check:
  * No console errors observed on the production before page, the local coming-soon Traffic page, or the local coming-soon Advertising launch gate.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
