### PR TITLE
Dashboard: add trailing period to On this day reminder help text

### DIFF
--- a/client/dashboard/me/notifications-extras/on-this-day-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/on-this-day-card/index.tsx
@@ -61,7 +61,7 @@ export const OnThisDayCard = () => {
 					checked={ !! data.other.timeline.on_this_day }
 					disabled={ isMutating }
 					label={ __( 'On this day' ) }
-					help={ __( 'Reminders about your posts from past years' ) }
+					help={ __( 'Reminders about your posts from past years.' ) }
 					onChange={ handleChange }
 				/>
 			</CardBody>

--- a/client/dashboard/me/notifications-extras/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/test/index.test.tsx
@@ -246,7 +246,7 @@ describe( 'NotificationsExtras', () => {
 			expect( screen.getByLabelText( 'On this day' ) ).toBeVisible();
 		} );
 
-		expect( screen.getByText( 'Reminders about your posts from past years' ) ).toBeVisible();
+		expect( screen.getByText( 'Reminders about your posts from past years.' ) ).toBeVisible();
 		expect( screen.getByLabelText( 'Achievements' ) ).toBeVisible();
 		expect(
 			screen.getByText(


### PR DESCRIPTION
## Proposed Changes

* Add a trailing period to the "On this day" toggle help text in the Notifications → Extras screen: "Reminders about your posts from past years."
* Update the corresponding unit test assertion to match.

## Why are these changes being made?

* The help text was missing a terminating period, unlike the surrounding help copy on the screen. This is a small copy consistency fix.

## Testing Instructions

* Run `yarn test-client client/dashboard/me/notifications-extras`.
* In the dashboard, go to Notifications → Extras and confirm the "On this day" toggle help text ends with a period.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?