### PR TITLE
MSD Notifications: Add a clarifying link to Sites notifications settings to the Achievements toggle

### DIFF
--- a/client/dashboard/me/notifications-extras/achievements-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/achievements-card/index.tsx
@@ -1,7 +1,9 @@
 import { userPreferenceOptimisticMutation, userPreferenceQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import { ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../../app/analytics';
@@ -45,6 +47,15 @@ export const AchievementsCard = () => {
 		} );
 	};
 
+	const helpText = createInterpolateElement(
+		__(
+			'Receive notifications when you unlock new achievements. This setting overrides <link>site-level settings</link>.'
+		),
+		{
+			link: <Link to="/me/notifications/sites" />,
+		}
+	);
+
 	return (
 		<Card>
 			<CardBody>
@@ -53,9 +64,7 @@ export const AchievementsCard = () => {
 					checked={ notifications !== 'disabled' }
 					disabled={ isPending }
 					label={ __( 'Achievements' ) }
-					help={ __(
-						'Receive notifications when you unlock new achievements. This setting overrides site-level settings.'
-					) }
+					help={ helpText }
 					onChange={ handleChange }
 				/>
 			</CardBody>

--- a/client/dashboard/me/notifications-extras/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/test/index.test.tsx
@@ -249,10 +249,9 @@ describe( 'NotificationsExtras', () => {
 		expect( screen.getByText( 'Reminders about your posts from past years.' ) ).toBeVisible();
 		expect( screen.getByLabelText( 'Achievements' ) ).toBeVisible();
 		expect(
-			screen.getByText(
-				'Receive notifications when you unlock new achievements. This setting overrides site-level settings.'
-			)
+			screen.getByText( /Receive notifications when you unlock new achievements\./ )
 		).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'site-level settings' } ) ).toBeVisible();
 	} );
 
 	it( 'saves the On this day setting when toggled', async () => {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/112442

## Proposed Changes

* Add a link to `/me/notifications/sites` from the global Achievements notifications card.

| Before | After |
|--------|--------|
| <img width="687" height="101" alt="Screenshot 2026-07-09 at 11 58 56" src="https://github.com/user-attachments/assets/1e3c52e1-a8c6-4690-80b7-ce9584516c8a" /> | <img width="687" height="101" alt="Screenshot 2026-07-09 at 11 58 48" src="https://github.com/user-attachments/assets/8cb15008-80f7-4055-985e-c2e9b1d97fc5" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The global Achievements notifications toggle was originally introduced in `/reader/users/me/achievements`, where it included (and still does) a link to `/me/notifications`, to clarify where to find site-level Achievements settings.

When the toggle was moved to `/me/notifications, the link was correctly dropped.

However, the MSD version of Notifications splits Sites and Extras settings. The Achievements setting is now in Extras, separated from Sites, so it needs the link again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `https://my.wordpress.com/me/notifications/extras`.
* Ensure the Achievements card contain a link to `/me/notifications/sites`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
