### PR TITLE
Reader Spaces: add membership lookup, drop dead per-source feed mutations

### DIFF
--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -2,12 +2,13 @@ import {
 	createReadSpaceMutation,
 	deleteReadSpaceMutation,
 	readSpaceBySlugQuery,
+	readSpaceMembershipQuery,
 	readSpaceQuery,
 	readSpacesQuery,
 	updateReadSpaceMutation,
 } from '@automattic/api-queries';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { ReadSpace, ReadSpaceDetails } from '@automattic/api-core';
+import type { ReadSpace, ReadSpaceDetails, ReadSpaceMembershipLookup } from '@automattic/api-core';
 
 /**
  * The user's spaces for the sidebar and space views, from the live list
@@ -53,6 +54,19 @@ export function useSpacesDetails( spaceIds: string[] ): {
 			isError: results.some( ( result ) => result.isError ),
 			isLoading: results.some( ( result ) => result.isLoading ),
 		} ),
+	} );
+}
+
+/**
+ * Which of the caller's spaces already contain a feed (or tag), via
+ * `GET /reader/spaces/membership` — a server-side lookup, so a surface can answer
+ * "already in a space?" without loading every space's full source list. Disabled
+ * until a feed/tag is known.
+ */
+export function useSpaceMembership( lookup: ReadSpaceMembershipLookup | null ) {
+	return useQuery( {
+		...readSpaceMembershipQuery( lookup ?? { feed: '' } ),
+		enabled: Boolean( lookup ),
 	} );
 }
 

--- a/client/reader/spaces/AGENTS.md
+++ b/client/reader/spaces/AGENTS.md
@@ -15,13 +15,14 @@ only, and wired to the real `wpcom/v2` backend.
   `adapters.ts` (renames `follows` → `sources`). No JSX, no routes here — api-core
   stays serializable.
 - **Queries & mutations** — `@automattic/api-queries` → `read-spaces.ts`:
-  `readSpacesQuery`/`readSpaceQuery` and the create/update/delete/feed mutations.
+  `readSpacesQuery`/`readSpaceQuery` and the create/update/delete mutations.
   Each mutation returns the full detail and writes it back to the caches.
 - **Consumer hooks** — `client/reader/data/spaces/`: `useSpaces`, `useSpace`,
+  `useSpaceMembership` (the `GET /reader/spaces/membership` lookup),
   `useCreateSpace`, `useUpdateSpace`, `useDeleteSpace`. The Customize modal edits
   sources as local draft state and persists them via the `feeds` replace on
-  `useUpdateSpace`, so there are no per-source consumer hooks (the underlying
-  `addReadSpaceSource`/`deleteReadSpaceSource` endpoints stay in `api-core`).
+  `useUpdateSpace` — there are no per-source add/remove endpoints, so a space's
+  feed set only ever changes through the bulk `update`.
 - **UI (this folder)** — `view.tsx`, `controller.tsx`, `index.tsx` (routes),
   `icons.ts`, `colors.ts`/`colors.scss`, `routes.ts`, `form-helpers.ts`,
   `color-picker.tsx`, `icon-picker.tsx`, `create-modal/`, `customize-modal/`.

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -60,17 +60,17 @@ Every mutation returns the **full updated detail**, so the client writes that
 straight to the caches for an immediate UI update, then invalidates the affected
 queries for a canonical refresh.
 
-| #   | Method & path                                | Body                                                                   | Returns               | Wired as                     |
-| --- | -------------------------------------------- | ---------------------------------------------------------------------- | --------------------- | ---------------------------- |
-| 1   | `GET /reader/spaces`                         | —                                                                      | `200` summary[]       | `fetchReadSpaces()`          |
-| 2   | `GET /reader/spaces/{id}`                    | —                                                                      | `200` detail          | `fetchReadSpace(id)`         |
-| 3   | `GET /reader/spaces/slug/{slug}`             | —                                                                      | `200` detail          | `fetchReadSpaceBySlug(slug)` |
-| 3b  | `GET /reader/spaces/membership`              | query: exactly one of `feed` (id/url) or `tag` (slug)                  | `200 { exists, spaces }` | `fetchReadSpaceMembership()` |
-| 4   | `POST /reader/spaces`                        | `{ title*, feeds?, tags?, layout? }`                                   | `201` detail          | `createReadSpace()`          |
-| 5   | `PUT /reader/spaces/{id}`                    | `{ title?, feeds?, tags?, layout? }` (≥1; `layout` is a partial merge) | `200` detail          | `updateReadSpace()`          |
-| 6   | `DELETE /reader/spaces/{id}`                 | —                                                                      | `200 { deleted, id }` | `deleteReadSpace()`          |
-| 7   | `GET /reader/spaces/{id}/posts`              | query: `count?` (≤15), `tag_limit?`, `page_handle?`                    | `200` stream          | `space:{id}` stream          |
-| 8   | `GET /reader/spaces/{id}/discover`           | query: `count?` (≤7), `page_handle?`                                   | `200` stream          | `space_discover:{id}` stream |
+| #   | Method & path                      | Body                                                                   | Returns                  | Wired as                     |
+| --- | ---------------------------------- | ---------------------------------------------------------------------- | ------------------------ | ---------------------------- |
+| 1   | `GET /reader/spaces`               | —                                                                      | `200` summary[]          | `fetchReadSpaces()`          |
+| 2   | `GET /reader/spaces/{id}`          | —                                                                      | `200` detail             | `fetchReadSpace(id)`         |
+| 3   | `GET /reader/spaces/slug/{slug}`   | —                                                                      | `200` detail             | `fetchReadSpaceBySlug(slug)` |
+| 3b  | `GET /reader/spaces/membership`    | query: exactly one of `feed` (id/url) or `tag` (slug)                  | `200 { exists, spaces }` | `fetchReadSpaceMembership()` |
+| 4   | `POST /reader/spaces`              | `{ title*, feeds?, tags?, layout? }`                                   | `201` detail             | `createReadSpace()`          |
+| 5   | `PUT /reader/spaces/{id}`          | `{ title?, feeds?, tags?, layout? }` (≥1; `layout` is a partial merge) | `200` detail             | `updateReadSpace()`          |
+| 6   | `DELETE /reader/spaces/{id}`       | —                                                                      | `200 { deleted, id }`    | `deleteReadSpace()`          |
+| 7   | `GET /reader/spaces/{id}/posts`    | query: `count?` (≤15), `tag_limit?`, `page_handle?`                    | `200` stream             | `space:{id}` stream          |
+| 8   | `GET /reader/spaces/{id}/discover` | query: `count?` (≤7), `page_handle?`                                   | `200` stream             | `space_discover:{id}` stream |
 
 Notes:
 
@@ -81,7 +81,7 @@ Notes:
 - **Membership** (endpoint 3b) is a read-only lookup answering "which of my
   spaces already contain this feed/tag?" — pass exactly one of `feed` or `tag`.
   An unresolvable feed/tag is not an error: it returns `{ exists: false,
-  spaces: [] }`. Exposed as `useSpaceMembership()` — a building block for surfaces
+spaces: [] }`. Exposed as `useSpaceMembership()` — a building block for surfaces
   that need "already in a space?" without loading every space's sources. It never
   mutates.
 - **Tags** are a full replace via `update` (endpoint 5) — there are no per-tag

--- a/client/reader/spaces/README.md
+++ b/client/reader/spaces/README.md
@@ -65,21 +65,26 @@ queries for a canonical refresh.
 | 1   | `GET /reader/spaces`                         | —                                                                      | `200` summary[]       | `fetchReadSpaces()`          |
 | 2   | `GET /reader/spaces/{id}`                    | —                                                                      | `200` detail          | `fetchReadSpace(id)`         |
 | 3   | `GET /reader/spaces/slug/{slug}`             | —                                                                      | `200` detail          | `fetchReadSpaceBySlug(slug)` |
+| 3b  | `GET /reader/spaces/membership`              | query: exactly one of `feed` (id/url) or `tag` (slug)                  | `200 { exists, spaces }` | `fetchReadSpaceMembership()` |
 | 4   | `POST /reader/spaces`                        | `{ title*, feeds?, tags?, layout? }`                                   | `201` detail          | `createReadSpace()`          |
 | 5   | `PUT /reader/spaces/{id}`                    | `{ title?, feeds?, tags?, layout? }` (≥1; `layout` is a partial merge) | `200` detail          | `updateReadSpace()`          |
 | 6   | `DELETE /reader/spaces/{id}`                 | —                                                                      | `200 { deleted, id }` | `deleteReadSpace()`          |
-| 7   | `POST /reader/spaces/{id}/feeds`             | `{ feed* }` (feed id or url)                                           | `200` detail          | `addReadSpaceSource()`       |
-| 8   | `DELETE /reader/spaces/{id}/feeds/{feed_id}` | —                                                                      | `200` detail          | `deleteReadSpaceSource()`    |
-| 9   | `GET /reader/spaces/{id}/posts`              | query: `count?` (≤15), `tag_limit?`, `page_handle?`                    | `200` stream          | `space:{id}` stream          |
-| 10  | `GET /reader/spaces/{id}/discover`           | query: `count?` (≤7), `page_handle?`                                   | `200` stream          | `space_discover:{id}` stream |
+| 7   | `GET /reader/spaces/{id}/posts`              | query: `count?` (≤15), `tag_limit?`, `page_handle?`                    | `200` stream          | `space:{id}` stream          |
+| 8   | `GET /reader/spaces/{id}/discover`           | query: `count?` (≤7), `page_handle?`                                   | `200` stream          | `space_discover:{id}` stream |
 
 Notes:
 
 - **Feeds** must already exist (a feed id or url the backend can resolve); the
   client only offers feeds the user already follows. Create/update send the
-  complete desired feed set as `feeds`; the per-feed endpoints remain available
-  for consumers that need immediate add/remove behavior.
-- **Tags** are a full replace via `update` (endpoint 4) — there are no per-tag
+  complete desired feed set as `feeds` — there are no per-feed add/remove
+  endpoints; membership changes go through the bulk `update` (endpoint 5).
+- **Membership** (endpoint 3b) is a read-only lookup answering "which of my
+  spaces already contain this feed/tag?" — pass exactly one of `feed` or `tag`.
+  An unresolvable feed/tag is not an error: it returns `{ exists: false,
+  spaces: [] }`. Exposed as `useSpaceMembership()` — a building block for surfaces
+  that need "already in a space?" without loading every space's sources. It never
+  mutates.
+- **Tags** are a full replace via `update` (endpoint 5) — there are no per-tag
   endpoints. Pass the complete desired set; `[]` clears them.
 - **Create** sends `title`, selected `feeds`, `tags`, and the persisted layout
   fields (`color`/`icon`/`view`) from the shared upsert modal.
@@ -87,7 +92,7 @@ Notes:
   it behind a confirm dialog (`customize-modal/confirm-delete.tsx`) in edit mode.
   `useCreateSpace()`, `useUpdateSpace()` (Save), and `useDeleteSpace()` (Delete
   space) are all consumed by `customize-modal/`.
-- **Feed** (endpoint 8) returns the standard Reader stream shape
+- **Feed** (endpoint 7) returns the standard Reader stream shape
   (`{ cards, next_page_handle }`), built server-side from the space's followed
   feeds and tags. It is wired as a normal Reader stream keyed `space:{id}` (see
   `read-streams` `fetchReadSpacePosts` and the `space` case in
@@ -97,7 +102,7 @@ Notes:
   merged in, capped per page at `tag_limit` (server default 3, `0` = feeds
   only); the rest of each page is followed-feed posts. The client does not
   send `tag_limit` today, so the server default applies.
-- **Discover** (endpoint 9) is the same stream shape and consumer as the Feed —
+- **Discover** (endpoint 8) is the same stream shape and consumer as the Feed —
   the Discover tab renders the same `client/reader/spaces/feed/` shell with
   `variant="discover"`, keyed `space_discover:{id}` (see `fetchReadSpaceDiscover`
   and the `space_discover` case in `build-query-params`). The backend recommends
@@ -112,13 +117,11 @@ Notes:
 | ---- | ------------------------------ | -------------------------------------- |
 | 403  | `rest_forbidden`               | not logged in / not an Automattician   |
 | 404  | `reader_spaces_not_found`      | space doesn't exist or isn't yours     |
-| 404  | `reader_spaces_item_not_found` | removing a feed not in the space       |
 | 400  | `reader_spaces_invalid_title`  | empty title (create or update)         |
 | 400  | `reader_spaces_invalid_feed`   | a feed isn't an existing feedbag feed  |
 | 400  | `reader_spaces_invalid_tag`    | a tag slug isn't a valid Reader tag    |
 | 400  | `reader_spaces_no_changes`     | `update` with no recognized fields     |
 | 409  | `reader_spaces_duplicate_slug` | a space with that title already exists |
-| 409  | `reader_spaces_duplicate_feed` | feed already in the space              |
 | 500  | `reader_spaces_delete_failed`  | delete didn't persist (rare)           |
 
 The create modal maps `rest_forbidden` / `reader_spaces_invalid_title` /

--- a/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/adapters.test.ts
@@ -1,4 +1,9 @@
-import { adaptReadSpace, adaptReadSpaceDetails, type ReadSpaceApiItem } from '../adapters';
+import {
+	adaptReadSpace,
+	adaptReadSpaceDetails,
+	adaptReadSpaceMembership,
+	type ReadSpaceApiItem,
+} from '../adapters';
 
 const wireSpace = ( overrides: Partial< ReadSpaceApiItem > = {} ): ReadSpaceApiItem => ( {
 	id: 3,
@@ -132,6 +137,26 @@ describe( 'read spaces adapters', () => {
 				tags: [],
 				languages: [],
 			} );
+		} );
+	} );
+
+	describe( 'adaptReadSpaceMembership', () => {
+		it( 'maps wire entries onto the client shape (title → name, id stringified)', () => {
+			expect(
+				adaptReadSpaceMembership( {
+					exists: true,
+					spaces: [ { id: 23, title: 'ATProto', slug: 'atproto' } ],
+				} )
+			).toEqual( {
+				exists: true,
+				spaces: [ { id: '23', name: 'ATProto', slug: 'atproto' } ],
+			} );
+		} );
+
+		it( 'coerces a missing spaces array and falsy exists to safe defaults', () => {
+			expect(
+				adaptReadSpaceMembership( {} as Parameters< typeof adaptReadSpaceMembership >[ 0 ] )
+			).toEqual( { exists: false, spaces: [] } );
 		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/fetchers.test.ts
@@ -3,6 +3,7 @@ import {
 	canonicalizeReadSpaceSlug,
 	fetchReadSpace,
 	fetchReadSpaceBySlug,
+	fetchReadSpaceMembership,
 	fetchReadSpaces,
 } from '../fetchers';
 import type { ReadSpaceApiItem } from '../adapters';
@@ -182,6 +183,50 @@ describe( 'read spaces fetchers', () => {
 
 			await expect( fetchReadSpaceBySlug( 'gone' ) ).rejects.toMatchObject( {
 				code: 'reader_spaces_not_found',
+			} );
+		} );
+	} );
+
+	describe( 'fetchReadSpaceMembership', () => {
+		it( 'looks up by feed and adapts the response to the client shape', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/spaces/membership' )
+				.query( { feed: '456' } )
+				.reply( 200, {
+					exists: true,
+					spaces: [ { id: 23, title: 'ATProto', slug: 'atproto' } ],
+				} );
+
+			const membership = await fetchReadSpaceMembership( { feed: 456 } );
+
+			expect( scope.isDone() ).toBe( true );
+			expect( membership ).toEqual( {
+				exists: true,
+				spaces: [ { id: '23', name: 'ATProto', slug: 'atproto' } ],
+			} );
+		} );
+
+		it( 'looks up by tag', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/spaces/membership' )
+				.query( { tag: 'photography' } )
+				.reply( 200, { exists: false, spaces: [] } );
+
+			const membership = await fetchReadSpaceMembership( { tag: 'photography' } );
+
+			expect( scope.isDone() ).toBe( true );
+			expect( membership ).toEqual( { exists: false, spaces: [] } );
+		} );
+
+		it( 'normalizes a missing spaces array to an empty list', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/spaces/membership' )
+				.query( { feed: '456' } )
+				.reply( 200, { exists: false } );
+
+			await expect( fetchReadSpaceMembership( { feed: 456 } ) ).resolves.toEqual( {
+				exists: false,
+				spaces: [],
 			} );
 		} );
 	} );

--- a/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
+++ b/packages/api-core/src/read-spaces/__tests__/mutators.test.ts
@@ -1,30 +1,9 @@
 import nock from 'nock';
-import {
-	addReadSpaceSource,
-	createReadSpace,
-	deleteReadSpace,
-	deleteReadSpaceSource,
-	updateReadSpace,
-} from '../mutators';
-import type { SiteSubscriptionItem } from '../../read-follows';
+import { createReadSpace, deleteReadSpace, updateReadSpace } from '../mutators';
 
 const BASE = 'https://public-api.wordpress.com';
 
-const makeSubscription = (
-	overrides: Partial< SiteSubscriptionItem > = {}
-): SiteSubscriptionItem => ( {
-	ID: 1,
-	URL: 'https://stratechery.com',
-	feed_URL: 'https://stratechery.com/feed',
-	blog_ID: 123,
-	feed_ID: 456,
-	name: 'Stratechery',
-	site_icon: 'https://stratechery.com/icon.png',
-	is_following: true,
-	...overrides,
-} );
-
-// A detail wire response (returned by create/update/add-feed/remove-feed).
+// A detail wire response (returned by create/update).
 const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
 	id: 42,
 	title: 'Work',
@@ -188,91 +167,6 @@ describe( 'read spaces mutators', () => {
 			await expect( deleteReadSpace( '999' ) ).rejects.toMatchObject( {
 				code: 'reader_spaces_not_found',
 			} );
-		} );
-	} );
-
-	describe( 'addReadSpaceSource', () => {
-		it( 'posts the feed id to feeds and adapts the returned detail', async () => {
-			let body: unknown;
-			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds', ( sent ) => {
-					body = sent;
-					return true;
-				} )
-				.reply(
-					200,
-					detailResponse( {
-						id: 3,
-						follows: [
-							{
-								feed_id: 456,
-								feed_url: 'https://stratechery.com/feed',
-								blog_id: 123,
-								name: 'Stratechery',
-								icon: null,
-							},
-						],
-					} )
-				);
-
-			const space = await addReadSpaceSource( {
-				spaceId: '3',
-				subscription: makeSubscription(),
-			} );
-
-			expect( body ).toEqual( { feed: 456 } );
-			expect( space.sources ).toEqual( [
-				{
-					feedId: 456,
-					feedUrl: 'https://stratechery.com/feed',
-					blogId: 123,
-					name: 'Stratechery',
-					siteIcon: null,
-				},
-			] );
-		} );
-
-		it( 'falls back to the feed URL when the subscription has no feed id', async () => {
-			let body: unknown;
-			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds', ( sent ) => {
-					body = sent;
-					return true;
-				} )
-				.reply( 200, detailResponse( { id: 3 } ) );
-
-			await addReadSpaceSource( {
-				spaceId: '3',
-				subscription: makeSubscription( { feed_ID: null } ),
-			} );
-
-			expect( body ).toEqual( { feed: 'https://stratechery.com/feed' } );
-		} );
-	} );
-
-	describe( 'deleteReadSpaceSource', () => {
-		it( 'DELETEs feeds/<feed_id> and adapts the returned detail', async () => {
-			const scope = nock( BASE )
-				.delete( '/wpcom/v2/reader/spaces/3/feeds/456' )
-				.reply( 200, detailResponse( { id: 3, follows: [] } ) );
-
-			const space = await deleteReadSpaceSource( {
-				spaceId: '3',
-				subscription: makeSubscription(),
-			} );
-
-			expect( scope.isDone() ).toBe( true );
-			expect( space.sources ).toEqual( [] );
-		} );
-
-		it( 'rejects without a request when the subscription has no numeric feed id', async () => {
-			// No nock interceptor: the guard must throw before any request is made.
-			await expect(
-				deleteReadSpaceSource( {
-					spaceId: '3',
-					subscription: makeSubscription( { feed_ID: null } ),
-				} )
-			).rejects.toThrow( 'numeric feed id' );
 		} );
 	} );
 } );

--- a/packages/api-core/src/read-spaces/adapters.ts
+++ b/packages/api-core/src/read-spaces/adapters.ts
@@ -1,4 +1,10 @@
-import type { ReadSpace, ReadSpaceDetails, SpaceLayout, SpaceSource } from './types';
+import type {
+	ReadSpace,
+	ReadSpaceDetails,
+	ReadSpaceMembership,
+	SpaceLayout,
+	SpaceSource,
+} from './types';
 
 /**
  * A followed feed as returned in a detail response's `follows` array. The client
@@ -77,5 +83,35 @@ export function adaptReadSpaceDetails( item: ReadSpaceApiItem ): ReadSpaceDetail
 		sources: ( item.follows ?? [] ).map( adaptSpaceSource ),
 		tags: item.tags ?? [],
 		languages: item.languages ?? [],
+	};
+}
+
+/**
+ * Wire shape of the membership lookup (`GET /reader/spaces/membership`): slim
+ * space entries (`id`, `title`, `slug`) plus the `exists` flag.
+ */
+export interface ReadSpaceMembershipApiEntry {
+	id: number;
+	title: string;
+	slug: string;
+}
+
+export interface ReadSpaceMembershipApiResponse {
+	exists: boolean;
+	spaces: ReadSpaceMembershipApiEntry[];
+}
+
+/** Map the membership lookup wire response onto the client `ReadSpaceMembership`. */
+export function adaptReadSpaceMembership(
+	response: ReadSpaceMembershipApiResponse
+): ReadSpaceMembership {
+	const spaces = Array.isArray( response?.spaces ) ? response.spaces : [];
+	return {
+		exists: Boolean( response?.exists ),
+		spaces: spaces.map( ( entry ) => ( {
+			id: String( entry.id ),
+			name: entry.title,
+			slug: entry.slug,
+		} ) ),
 	};
 }

--- a/packages/api-core/src/read-spaces/fetchers.ts
+++ b/packages/api-core/src/read-spaces/fetchers.ts
@@ -1,6 +1,17 @@
 import { wpcom } from '../wpcom-fetcher';
-import { adaptReadSpace, adaptReadSpaceDetails, type ReadSpaceApiItem } from './adapters';
-import type { ReadSpace, ReadSpaceDetails } from './types';
+import {
+	adaptReadSpace,
+	adaptReadSpaceDetails,
+	adaptReadSpaceMembership,
+	type ReadSpaceApiItem,
+	type ReadSpaceMembershipApiResponse,
+} from './adapters';
+import type {
+	ReadSpace,
+	ReadSpaceDetails,
+	ReadSpaceMembership,
+	ReadSpaceMembershipLookup,
+} from './types';
 
 /**
  * Canonicalize a space slug to a single representation for cache keys and
@@ -65,4 +76,22 @@ export async function fetchReadSpaceBySlug( slug: string ): Promise< ReadSpaceDe
 	} );
 
 	return adaptReadSpaceDetails( item );
+}
+
+/**
+ * Look up which of the caller's spaces already contain a feed or tag via the
+ * wpcom/v2 `GET /reader/spaces/membership` endpoint. Pass exactly one of `feed`
+ * (feed id or url) or `tag` (a Reader tag slug). An unresolvable feed/tag is not
+ * an error — the server returns `{ exists: false, spaces: [] }` (200).
+ */
+export async function fetchReadSpaceMembership(
+	lookup: ReadSpaceMembershipLookup
+): Promise< ReadSpaceMembership > {
+	const query = 'feed' in lookup ? { feed: lookup.feed } : { tag: lookup.tag };
+	const response: ReadSpaceMembershipApiResponse = await wpcom.req.get(
+		{ path: '/reader/spaces/membership', apiNamespace: 'wpcom/v2' },
+		query
+	);
+
+	return adaptReadSpaceMembership( response );
 }

--- a/packages/api-core/src/read-spaces/mutators.ts
+++ b/packages/api-core/src/read-spaces/mutators.ts
@@ -4,7 +4,6 @@ import type {
 	CreateReadSpaceParams,
 	ReadSpaceDeletionResult,
 	ReadSpaceDetails,
-	ReadSpaceSourceMutationParams,
 	UpdateReadSpaceParams,
 } from './types';
 
@@ -93,50 +92,4 @@ export async function deleteReadSpace( spaceId: string ): Promise< ReadSpaceDele
 		apiNamespace: 'wpcom/v2',
 		method: 'DELETE',
 	} );
-}
-
-/**
- * Add a followed feed to a space via `POST /reader/spaces/{id}/feeds`, returning
- * the updated detail. The feed is identified by the subscription's feed id
- * (falling back to its feed URL); the server resolves it.
- */
-export async function addReadSpaceSource( {
-	spaceId,
-	subscription,
-}: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
-	const item: ReadSpaceApiItem = await wpcom.req.post(
-		{
-			path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds`,
-			apiNamespace: 'wpcom/v2',
-		},
-		{ feed: subscription.feed_ID ?? subscription.feed_URL }
-	);
-
-	return adaptReadSpaceDetails( item );
-}
-
-/**
- * Remove a followed feed from a space via
- * `DELETE /reader/spaces/{id}/feeds/{feed_id}`, returning the updated detail.
- * Removal is keyed by the numeric feed id (from `follows[].feed_id`).
- */
-export async function deleteReadSpaceSource( {
-	spaceId,
-	subscription,
-}: ReadSpaceSourceMutationParams ): Promise< ReadSpaceDetails > {
-	// Removal is keyed strictly by the numeric feedbag feed id (from
-	// `follows[].feed_id`). `feed_ID` is loosely typed, so guard against a
-	// missing/non-numeric value rather than issuing a `/feeds/null` request.
-	const feedId = Number( subscription.feed_ID );
-	if ( ! Number.isInteger( feedId ) || feedId <= 0 ) {
-		throw new Error( 'Cannot remove a space feed without a numeric feed id.' );
-	}
-
-	const item: ReadSpaceApiItem = await wpcom.req.post( {
-		path: `/reader/spaces/${ encodeURIComponent( spaceId ) }/feeds/${ feedId }`,
-		apiNamespace: 'wpcom/v2',
-		method: 'DELETE',
-	} );
-
-	return adaptReadSpaceDetails( item );
 }

--- a/packages/api-core/src/read-spaces/types.ts
+++ b/packages/api-core/src/read-spaces/types.ts
@@ -1,5 +1,3 @@
-import type { SiteSubscriptionItem } from '../read-follows';
-
 /**
  * Reader Spaces — a Space groups followed feeds (`sources`) and followed tags
  * under a name (see RSM-4110).
@@ -92,8 +90,8 @@ export interface ReadSpace {
 
 /**
  * A space plus its followed feeds (`sources`) and tags. Returned by every
- * endpoint except the list — the detail GET, create, update, and the feed
- * mutations all resolve a `ReadSpaceDetails`.
+ * endpoint except the list — the detail GET, create, and update all resolve a
+ * `ReadSpaceDetails`.
  */
 export interface ReadSpaceDetails extends ReadSpace {
 	sources: SpaceSource[];
@@ -159,7 +157,30 @@ export interface SpaceSource {
 	siteIcon: string | null;
 }
 
-export interface ReadSpaceSourceMutationParams {
-	spaceId: string;
-	subscription: SiteSubscriptionItem;
+/**
+ * A space as returned by the membership lookup (`GET /reader/spaces/membership`):
+ * the slim identity fields only (no layout, sources, or tags), enough to badge
+ * the space and deep-link to it by `slug` or `id`.
+ */
+export interface ReadSpaceMembershipEntry {
+	id: string;
+	name: string;
+	slug: string;
 }
+
+/**
+ * Result of the membership lookup: whether the feed/tag is in any of the caller's
+ * spaces, and which ones. An unresolvable feed/tag is not an error — it simply
+ * isn't in any space (`exists: false`, empty `spaces`).
+ */
+export interface ReadSpaceMembership {
+	exists: boolean;
+	spaces: ReadSpaceMembershipEntry[];
+}
+
+/**
+ * Membership lookup input — exactly one of `feed` (feed id or url) or `tag` (a
+ * Reader tag slug). Modeled as a discriminated union so the "exactly one"
+ * contract is enforced at the type level.
+ */
+export type ReadSpaceMembershipLookup = { feed: number | string } | { tag: string };

--- a/packages/api-queries/src/__tests__/read-spaces.test.tsx
+++ b/packages/api-queries/src/__tests__/read-spaces.test.tsx
@@ -7,17 +7,16 @@ import {
 import { act, renderHook } from '@testing-library/react';
 import nock from 'nock';
 import {
-	addReadSpaceSourceMutation,
 	createReadSpaceMutation,
 	deleteReadSpaceMutation,
-	deleteReadSpaceSourceMutation,
 	readSpaceBySlugQuery,
+	readSpaceMembershipQuery,
 	readSpaceQuery,
 	readSpacesQuery,
 	updateReadSpaceMutation,
 } from '../read-spaces';
 import { getStreamInfiniteQueryKeyPrefix } from '../read-streams';
-import type { ReadSpace, ReadSpaceDetails, SiteSubscriptionItem } from '@automattic/api-core';
+import type { ReadSpace, ReadSpaceDetails } from '@automattic/api-core';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
@@ -50,21 +49,7 @@ async function runMutation< TData, TError, TVars, TContext >(
 	} );
 }
 
-const makeSubscription = (
-	overrides: Partial< SiteSubscriptionItem > = {}
-): SiteSubscriptionItem => ( {
-	ID: 1,
-	URL: 'https://stratechery.com',
-	feed_URL: 'https://stratechery.com/feed',
-	blog_ID: 123,
-	feed_ID: 456,
-	name: 'Stratechery',
-	site_icon: 'https://stratechery.com/icon.png',
-	is_following: true,
-	...overrides,
-} );
-
-// A detail wire response (create/update/add-feed/remove-feed all return one).
+// A detail wire response (create/update both return one).
 const detailResponse = ( overrides: Record< string, unknown > = {} ) => ( {
 	id: 3,
 	slug: 'work',
@@ -134,6 +119,26 @@ describe( 'read spaces mutations', () => {
 
 			expect( encoded ).toEqual( [ 'read', 'spaces', 'detail-by-slug', 'привет' ] );
 			expect( encoded ).toEqual( decoded );
+		} );
+
+		it( 'keys the membership query by feed or tag and refetches on mount', () => {
+			expect( readSpaceMembershipQuery( { feed: 456 } ).queryKey ).toEqual( [
+				'read',
+				'spaces',
+				'membership',
+				'feed',
+				'456',
+			] );
+			expect( readSpaceMembershipQuery( { tag: 'photography' } ).queryKey ).toEqual( [
+				'read',
+				'spaces',
+				'membership',
+				'tag',
+				'photography',
+			] );
+			// Editing a space can stale membership, so it must refetch on each mount
+			// (i.e. each time the picker reopens).
+			expect( readSpaceMembershipQuery( { feed: 456 } ).refetchOnMount ).toBe( 'always' );
 		} );
 	} );
 
@@ -353,113 +358,6 @@ describe( 'read spaces mutations', () => {
 			expect( invalidateQueries ).toHaveBeenCalledWith( {
 				queryKey: readSpacesQuery().queryKey,
 			} );
-		} );
-	} );
-
-	describe( 'feed (source) mutations', () => {
-		it( 'writes the returned detail to the cache after adding a feed', async () => {
-			const client = newClient();
-			const resetQueries = jest.spyOn( client, 'resetQueries' );
-			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
-			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds' )
-				.reply(
-					200,
-					detailResponse( {
-						follows: [
-							{
-								feed_id: 456,
-								feed_url: 'https://stratechery.com/feed',
-								blog_id: 123,
-								name: 'Stratechery',
-								icon: null,
-							},
-						],
-					} )
-				);
-
-			await runMutation( client, addReadSpaceSourceMutation( client ), {
-				spaceId: '3',
-				subscription: makeSubscription(),
-			} );
-
-			expect(
-				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )?.sources
-			).toEqual( [
-				{
-					feedId: 456,
-					feedUrl: 'https://stratechery.com/feed',
-					blogId: 123,
-					name: 'Stratechery',
-					siteIcon: null,
-				},
-			] );
-			expect( resetQueries ).toHaveBeenCalledWith( {
-				queryKey: getStreamInfiniteQueryKeyPrefix( 'space:3' ),
-			} );
-			expect( resetQueries ).toHaveBeenCalledWith( {
-				queryKey: getStreamInfiniteQueryKeyPrefix( 'space_discover:3' ),
-			} );
-			expect( invalidateQueries ).toHaveBeenCalledWith( {
-				queryKey: readSpaceQuery( '3' ).queryKey,
-			} );
-		} );
-
-		it( 'writes the returned detail to the cache after removing a feed', async () => {
-			const client = newClient();
-			const resetQueries = jest.spyOn( client, 'resetQueries' );
-			const invalidateQueries = jest.spyOn( client, 'invalidateQueries' );
-			nock( BASE )
-				.delete( '/wpcom/v2/reader/spaces/3/feeds/456' )
-				.reply( 200, detailResponse( { follows: [] } ) );
-
-			await runMutation( client, deleteReadSpaceSourceMutation( client ), {
-				spaceId: '3',
-				subscription: makeSubscription(),
-			} );
-
-			expect(
-				client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey )?.sources
-			).toEqual( [] );
-			// Removing a feed reloads both streams, same as adding one.
-			expect( resetQueries ).toHaveBeenCalledWith( {
-				queryKey: getStreamInfiniteQueryKeyPrefix( 'space:3' ),
-			} );
-			expect( resetQueries ).toHaveBeenCalledWith( {
-				queryKey: getStreamInfiniteQueryKeyPrefix( 'space_discover:3' ),
-			} );
-			expect( invalidateQueries ).toHaveBeenCalledWith( {
-				queryKey: readSpaceQuery( '3' ).queryKey,
-			} );
-		} );
-
-		it( 'leaves the detail cache untouched when the add request fails', async () => {
-			const client = newClient();
-			const seeded: ReadSpaceDetails = {
-				id: '3',
-				name: 'Work',
-				layout: { color: 'blue', icon: 'inbox' },
-				sources: [],
-				tags: [],
-				languages: [],
-			};
-			client.setQueryData( readSpaceQuery( '3' ).queryKey, seeded );
-			nock( BASE )
-				.post( '/wpcom/v2/reader/spaces/3/feeds' )
-				.reply( 409, {
-					code: 'reader_spaces_duplicate_feed',
-					message: '…',
-					data: { status: 409 },
-				} );
-
-			await runMutation( client, addReadSpaceSourceMutation( client ), {
-				spaceId: '3',
-				subscription: makeSubscription(),
-			} );
-
-			expect( client.getQueryData< ReadSpaceDetails >( readSpaceQuery( '3' ).queryKey ) ).toEqual(
-				seeded
-			);
 		} );
 	} );
 } );

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -1,18 +1,17 @@
 import {
-	addReadSpaceSource,
 	canonicalizeReadSpaceSlug,
 	createReadSpace,
 	deleteReadSpace,
-	deleteReadSpaceSource,
 	fetchReadSpace,
 	fetchReadSpaceBySlug,
+	fetchReadSpaceMembership,
 	fetchReadSpaces,
 	isWpError,
 	updateReadSpace,
 	type ReadSpace,
 	type ReadSpaceDeletionResult,
 	type ReadSpaceDetails,
-	type ReadSpaceSourceMutationParams,
+	type ReadSpaceMembershipLookup,
 	type UpdateReadSpaceParams,
 } from '@automattic/api-core';
 import {
@@ -107,6 +106,24 @@ export const readSpaceBySlugQuery = ( slug: string ) =>
 		refetchOnMount: 'always',
 		retry: ( failureCount, error ) => ! isClientError( error ) && failureCount < 3,
 		meta: { persist: true },
+	} );
+
+const readSpaceMembershipKey = ( lookup: ReadSpaceMembershipLookup ) =>
+	'feed' in lookup
+		? ( [ 'read', 'spaces', 'membership', 'feed', String( lookup.feed ) ] as const )
+		: ( [ 'read', 'spaces', 'membership', 'tag', lookup.tag ] as const );
+
+// Which of the caller's spaces already contain a feed/tag (`GET
+// /reader/spaces/membership`). It's derived from the spaces' current feed/tag
+// sets, so editing a space can stale it; `refetchOnMount: 'always'` keeps each
+// modal open showing the current answer without a bespoke invalidation. Not
+// persisted — it's a cheap, request-time lookup, not durable space data.
+export const readSpaceMembershipQuery = ( lookup: ReadSpaceMembershipLookup ) =>
+	queryOptions( {
+		queryKey: readSpaceMembershipKey( lookup ),
+		queryFn: () => fetchReadSpaceMembership( lookup ),
+		staleTime: Infinity,
+		refetchOnMount: 'always',
 	} );
 
 // The summary (list) shape is the detail minus its `sources`, `tags`, and
@@ -274,26 +291,4 @@ export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 			}
 			void invalidateReadSpacesList( queryClient );
 		},
-	} );
-
-// Add/remove a followed feed. Both endpoints return the updated detail, so we
-// write it straight to the detail cache (the list summary is unaffected by
-// feeds). `subscription` carries the feed id/url the api-core mutator sends.
-const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails ) => {
-	setReadSpaceDetailCaches( queryClient, space );
-	// Adding/removing a feed changes the space's streams, so reload both.
-	void reloadReadSpaceStreams( queryClient, space.id );
-	void invalidateReadSpaceDetail( queryClient, space.id );
-};
-
-export const addReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
-	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {
-		mutationFn: addReadSpaceSource,
-		onSuccess: ( space ) => writeReadSpaceDetail( queryClient, space ),
-	} );
-
-export const deleteReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
-	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {
-		mutationFn: deleteReadSpaceSource,
-		onSuccess: ( space ) => writeReadSpaceDetail( queryClient, space ),
 	} );


### PR DESCRIPTION
## Proposed Changes

* Add a read-only membership lookup, `GET /reader/spaces/membership`, across `api-core` (fetcher/adapter/types), `api-queries` (`readSpaceMembershipQuery`), and a `useSpaceMembership` hook. Answers "which of my spaces already contain this feed/tag?"
* Remove the dead `addReadSpaceSource` / `deleteReadSpaceSource` mutators + factories + type — their `/feeds` routes no longer exist on the backend.

## Why are these changes being made?

* The dead mutators targeted removed routes; nothing called them. The membership endpoint gives surfaces a server-side "already in a space?" answer without loading every space's sources. Read-only — membership still changes via the bulk `PUT`.

## Testing Instructions

* Data-layer only, no UI change. `yarn test-packages read-spaces` (55 pass); `yarn typecheck-client` / `typecheck-packages` clean.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Tested in Simple / Atomic / Jetpack sites
- [ ] Dark mode / accessibility (no UI changes)
- [ ] String Freeze label (no new strings)
