### PR TITLE
Reader Spaces: stepped create wizard + Feeds/Topics reorganization

### DIFF
--- a/client/reader/sidebar/spaces/test/index.test.tsx
+++ b/client/reader/sidebar/spaces/test/index.test.tsx
@@ -84,6 +84,14 @@ function render( ui: React.ReactElement, initialState?: object ) {
 	} );
 }
 
+async function reachCreateStep( user: ReturnType< typeof userEvent.setup > ) {
+	await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
+	await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+	await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+	await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+	await screen.findByRole( 'button', { name: 'Create' } );
+}
+
 describe( 'ReaderSidebarSpaces', () => {
 	beforeEach( () => {
 		jest.mocked( page ).mockClear();
@@ -247,7 +255,7 @@ describe( 'ReaderSidebarSpaces', () => {
 		render( <ReaderSidebarSpaces path={ OPEN_PATH } /> );
 
 		await user.click( screen.getByRole( 'button', { name: 'Create a space' } ) );
-		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
+		await reachCreateStep( user );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 
 		// The redirect happens in the create mutation's onSuccess, after the POST

--- a/client/reader/spaces/AGENTS.md
+++ b/client/reader/spaces/AGENTS.md
@@ -29,15 +29,16 @@ only, and wired to the real `wpcom/v2` backend.
 
 ## Editing a space (RSM-4117)
 
-`customize-modal/` is the **single upsert editor** for a space: a `TabPanel` with
-**Identity** (name, tags, accent color, icon), **Layout** (the feed-layout
-presets), **Sources** (the subscription add/remove list — migrated here from the
-old standalone `sources-modal/`, which no longer exists), and **Delete** (edit
-mode only, destructive _Delete space_ action that confirms via
-`confirm-delete.tsx`). The **Customize** header button opens edit mode on
-Identity. `create-modal/index.tsx` is a thin wrapper around the same upsert modal
-in create mode; after create, the sidebar navigates to the new space route
-without an action hash.
+`customize-modal/` is the **single upsert editor** for a space. Edit mode uses a
+`TabPanel` with **Identity** (name, accent color, icon), **Layout** (the
+feed-layout presets), **Feeds** (the subscription add/remove list — internally
+still keyed as `sources` because the API/client model maps wire `follows` to
+`sources`), **Topics** (tags and languages), and **Delete** (edit mode only,
+destructive _Delete space_ action that confirms via `confirm-delete.tsx`). The
+**Customize** header button opens edit mode on Identity. `create-modal/index.tsx`
+is a thin wrapper around the same upsert modal in create mode, rendered as a
+step-by-step wizard over Identity → Layout → Feeds → Topics; after create, the
+sidebar navigates to the new space route without an action hash.
 
 - **Save/Create batches the editable fields.** "Save changes" and "Create" send
   the same draft model: `name`, `tags`, `feeds`, and
@@ -105,8 +106,8 @@ without an action hash.
 
 - Create and edit share the upsert implementation in `customize-modal/index.tsx`;
   `create-modal/index.tsx` only adapts the existing public `CreateSpaceModal`
-  export to create mode. Keep Identity/Layout/Sources behavior in the shared
-  upsert modal so create and edit do not drift.
+  export to create mode. Keep the Identity/Layout/Feeds/Topics draft behavior in
+  the shared upsert modal so create and edit do not drift.
 - Validation: name required, <= `MAX_SPACE_NAME_LENGTH`, and case-insensitive
   duplicate against the existing names (edit passes the list with the current
   space removed). The error message is rendered manually

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -299,6 +299,25 @@ describe( 'CreateSpaceModal', () => {
 		);
 	} );
 
+	it( 'sends topics entered in the wizard when creating', async () => {
+		const { user, onClose } = setup();
+		const onBody = jest.fn();
+		mockCreateEndpoint( 'Reading', onBody );
+
+		await reachTopicsStep( user );
+		await user.type( screen.getByRole( 'combobox', { name: 'Tags' } ), 'design[Enter]' );
+		await user.type( screen.getByRole( 'combobox', { name: 'Languages' } ), 'English[Enter]' );
+		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
+		expect( onBody ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				tags: [ 'design' ],
+				languages: [ 'en' ],
+			} )
+		);
+	} );
+
 	it( 'sends no languages when the account has no locale', async () => {
 		const { user, onClose } = setup();
 		const onBody = jest.fn();

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -107,6 +107,22 @@ function setup( {
 	return { queryClient, onClose, onCreated, user };
 }
 
+type User = ReturnType< typeof userEvent.setup >;
+
+// Walk from the opening Identity step to the Feeds step. The name is required to
+// leave the first step, so it is entered here.
+async function reachFeedsStep( user: User, name = 'Reading' ) {
+	await user.type( screen.getByLabelText( 'Name' ), name );
+	await user.click( screen.getByRole( 'button', { name: 'Next' } ) ); // Identity → Layout
+	await user.click( screen.getByRole( 'button', { name: 'Next' } ) ); // Layout → Feeds
+}
+
+// Walk all the way to the final Topics step, where Create lives.
+async function reachTopicsStep( user: User, name = 'Reading' ) {
+	await reachFeedsStep( user, name );
+	await user.click( screen.getByRole( 'button', { name: 'Next' } ) ); // Feeds → Topics
+}
+
 describe( 'CreateSpaceModal', () => {
 	beforeEach( () => {
 		mockSubscriptions = [];
@@ -121,46 +137,65 @@ describe( 'CreateSpaceModal', () => {
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'keeps Create disabled until a valid name is entered', async () => {
+	it( 'keeps Next disabled until a valid name is entered', async () => {
 		const { user } = setup();
 
-		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Next' } ) ).toBeDisabled();
 
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
 
-		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeEnabled();
+		expect( screen.getByRole( 'button', { name: 'Next' } ) ).toBeEnabled();
 	} );
 
-	it( 'uses the shared tabbed upsert modal while creating', async () => {
+	it( 'steps through the identity, layout, feeds and topics sections', async () => {
 		mockSubscriptions = [ mockSubscription ];
 		const { user } = setup();
 
 		const dialog = screen.getByRole( 'dialog', { name: 'Create a new space' } );
 
-		expect( within( dialog ).getByRole( 'tab', { name: 'Identity' } ) ).toBeVisible();
-		expect( within( dialog ).getByRole( 'tab', { name: 'Layout' } ) ).toBeVisible();
-		expect( within( dialog ).getByRole( 'tab', { name: 'Sources' } ) ).toBeVisible();
-		expect( within( dialog ).queryByRole( 'tab', { name: 'Delete' } ) ).not.toBeInTheDocument();
+		// The wizard replaces the tab strip with one step at a time.
+		expect( within( dialog ).queryByRole( 'tab' ) ).not.toBeInTheDocument();
+		expect( within( dialog ).getByLabelText( 'Name' ) ).toBeVisible();
+		expect( within( dialog ).getByLabelText( 'Step 1 of 4' ) ).toBeInTheDocument();
 
-		await user.click( within( dialog ).getByRole( 'tab', { name: 'Layout' } ) );
+		await user.type( within( dialog ).getByLabelText( 'Name' ), 'Reading' );
+		await user.click( within( dialog ).getByRole( 'button', { name: 'Next' } ) );
+
+		// Layout step.
 		expect( within( dialog ).getByRole( 'radio', { name: /Classic/ } ) ).toBeChecked();
+		await user.click( within( dialog ).getByRole( 'button', { name: 'Next' } ) );
 
-		await user.click( within( dialog ).getByRole( 'tab', { name: 'Sources' } ) );
+		// Feeds step: only the subscription picker.
 		expect(
-			within( dialog ).getByText( 'Choose which of your subscriptions appear in this space.' )
+			within( dialog ).getByText(
+				'Pick the subscriptions whose posts make up this space’s main feed.'
+			)
 		).toBeVisible();
+		expect( within( dialog ).getByRole( 'button', { name: 'All subscriptions' } ) ).toBeVisible();
 		expect( within( dialog ).getByRole( 'listitem', { name: 'Example Blog' } ) ).toBeVisible();
+		expect( within( dialog ).queryByRole( 'combobox', { name: 'Tags' } ) ).not.toBeInTheDocument();
+		await user.click( within( dialog ).getByRole( 'button', { name: 'Next' } ) );
+
+		// Topics step is last, so it carries the Create button.
+		expect( within( dialog ).getByRole( 'combobox', { name: 'Tags' } ) ).toBeVisible();
+		expect( within( dialog ).getByRole( 'combobox', { name: 'Languages' } ) ).toBeVisible();
+		expect( within( dialog ).getByRole( 'button', { name: 'Create' } ) ).toBeVisible();
+
+		// Back returns to the previous step.
+		await user.click( within( dialog ).getByRole( 'button', { name: 'Back' } ) );
+		expect( within( dialog ).getByRole( 'button', { name: 'All subscriptions' } ) ).toBeVisible();
 	} );
 
-	it( 'shows a required error once the name is cleared', async () => {
+	it( 'cannot advance past the identity step without a name', async () => {
 		const { user } = setup();
 
-		const input = screen.getByLabelText( 'Name' );
-		await user.type( input, 'Reading' );
-		await user.clear( input );
+		expect( screen.getByRole( 'button', { name: 'Next' } ) ).toBeDisabled();
+
+		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
+		await user.clear( screen.getByLabelText( 'Name' ) );
 
 		expect( await screen.findByText( 'Name is required' ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Next' } ) ).toBeDisabled();
 	} );
 
 	it( 'rejects a name longer than the maximum length', async () => {
@@ -169,7 +204,7 @@ describe( 'CreateSpaceModal', () => {
 		await user.type( screen.getByLabelText( 'Name' ), 'a'.repeat( 51 ) );
 
 		expect( await screen.findByText( /50 characters or fewer/ ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Next' } ) ).toBeDisabled();
 	} );
 
 	it( 'rejects a duplicate name regardless of case', async () => {
@@ -178,7 +213,7 @@ describe( 'CreateSpaceModal', () => {
 		await user.type( screen.getByLabelText( 'Name' ), 'work' );
 
 		expect( await screen.findByText( 'A space with this name already exists' ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Next' } ) ).toBeDisabled();
 	} );
 
 	it( 'creates a space with identity and layout settings, updates the caches, and closes', async () => {
@@ -187,6 +222,7 @@ describe( 'CreateSpaceModal', () => {
 		const onBody = jest.fn();
 		mockCreateEndpoint( 'Reading', onBody );
 
+		// Identity step.
 		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
 		await user.click(
 			within( screen.getByRole( 'radiogroup', { name: 'Accent color' } ) ).getByRole( 'radio', {
@@ -194,10 +230,17 @@ describe( 'CreateSpaceModal', () => {
 			} )
 		);
 		await user.click( screen.getByRole( 'radio', { name: 'Star' } ) );
-		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+
+		// Layout step.
 		await user.click( screen.getByRole( 'radio', { name: /Classic/ } ) );
-		await user.click( screen.getByRole( 'tab', { name: 'Sources' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+
+		// Feeds step.
 		await user.click( screen.getByRole( 'button', { name: 'Add Example Blog' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+
+		// Topics step (last) carries the Create button.
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 
 		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
@@ -243,10 +286,11 @@ describe( 'CreateSpaceModal', () => {
 		const onBody = jest.fn();
 		mockCreateEndpoint( 'Leitura', onBody );
 
+		// The languages field lives on the final Topics step.
+		await reachTopicsStep( user, 'Leitura' );
 		const dialog = screen.getByRole( 'dialog', { name: 'Create a new space' } );
 		expect( within( dialog ).getByText( 'Português' ) ).toBeVisible();
 
-		await user.type( screen.getByLabelText( 'Name' ), 'Leitura' );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 
 		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
@@ -260,7 +304,7 @@ describe( 'CreateSpaceModal', () => {
 		const onBody = jest.fn();
 		mockCreateEndpoint( 'Reading', onBody );
 
-		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
+		await reachTopicsStep( user );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 
 		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
@@ -271,7 +315,7 @@ describe( 'CreateSpaceModal', () => {
 		const { user, onCreated } = setup();
 		mockCreateEndpoint( 'Reading' );
 
-		await user.type( screen.getByLabelText( 'Name' ), 'Reading' );
+		await reachTopicsStep( user );
 		await user.click( screen.getByRole( 'button', { name: 'Create' } ) );
 
 		await waitFor( () =>

--- a/client/reader/spaces/create-modal/test/index.test.tsx
+++ b/client/reader/spaces/create-modal/test/index.test.tsx
@@ -121,6 +121,7 @@ async function reachFeedsStep( user: User, name = 'Reading' ) {
 async function reachTopicsStep( user: User, name = 'Reading' ) {
 	await reachFeedsStep( user, name );
 	await user.click( screen.getByRole( 'button', { name: 'Next' } ) ); // Feeds → Topics
+	await screen.findByRole( 'button', { name: 'Create' } );
 }
 
 describe( 'CreateSpaceModal', () => {
@@ -179,7 +180,7 @@ describe( 'CreateSpaceModal', () => {
 		// Topics step is last, so it carries the Create button.
 		expect( within( dialog ).getByRole( 'combobox', { name: 'Tags' } ) ).toBeVisible();
 		expect( within( dialog ).getByRole( 'combobox', { name: 'Languages' } ) ).toBeVisible();
-		expect( within( dialog ).getByRole( 'button', { name: 'Create' } ) ).toBeVisible();
+		expect( await within( dialog ).findByRole( 'button', { name: 'Create' } ) ).toBeVisible();
 
 		// Back returns to the previous step.
 		await user.click( within( dialog ).getByRole( 'button', { name: 'Back' } ) );

--- a/client/reader/spaces/customize-modal/identity-tab.tsx
+++ b/client/reader/spaces/customize-modal/identity-tab.tsx
@@ -1,24 +1,14 @@
-import { FormTokenField, TextControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { TextControl, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { SpaceColorPicker } from 'calypso/reader/spaces/color-picker';
 import { SpaceIconPicker } from 'calypso/reader/spaces/icon-picker';
-import {
-	SPACE_LANGUAGE_SUGGESTIONS,
-	getLanguageCodeByName,
-	getLanguageName,
-	resolveLanguageTokens,
-} from 'calypso/reader/spaces/languages';
 import type { SpaceColor, SpaceIcon, SpaceTextColor } from '@automattic/api-core';
 
 interface Props {
 	name: string;
 	onNameChange: ( name: string ) => void;
 	nameError: string | null;
-	tags: string[];
-	onTagsChange: ( tags: string[] ) => void;
-	languages: string[];
-	onLanguagesChange: ( languages: string[] ) => void;
 	color: SpaceTextColor;
 	onColorChange: ( color: SpaceTextColor ) => void;
 	iconColor: SpaceColor;
@@ -31,10 +21,6 @@ export function IdentityTab( {
 	name,
 	onNameChange,
 	nameError,
-	tags,
-	onTagsChange,
-	languages,
-	onLanguagesChange,
 	color,
 	onColorChange,
 	iconColor,
@@ -64,36 +50,6 @@ export function IdentityTab( {
 						{ nameError }
 					</p>
 				) : null }
-				<FormTokenField
-					__next40pxDefaultSize
-					label={ translate( 'Tags' ) }
-					value={ tags }
-					placeholder={ translate( 'Add tags' ) }
-					onChange={ ( tokens ) =>
-						onTagsChange(
-							tokens.map( ( token ) => ( typeof token === 'string' ? token : token.value ) )
-						)
-					}
-					help={ translate( 'Type and press Enter to add; click x to remove.' ) }
-				/>
-				<FormTokenField
-					__next40pxDefaultSize
-					__experimentalExpandOnFocus
-					// Restrict tokens to known languages so only valid base codes are
-					// stored; free-typed text that doesn't resolve to a language is rejected.
-					__experimentalValidateInput={ ( input: string ) =>
-						getLanguageCodeByName( input ) !== undefined
-					}
-					label={ translate( 'Languages' ) }
-					// The field works in display names; the parent state is base codes.
-					value={ languages.map( getLanguageName ) }
-					suggestions={ SPACE_LANGUAGE_SUGGESTIONS }
-					placeholder={ translate( 'Add languages' ) }
-					onChange={ ( tokens ) => onLanguagesChange( resolveLanguageTokens( tokens, languages ) ) }
-					help={ translate(
-						'Filters Discover results to these languages. Starts from your account language; add more as needed.'
-					) }
-				/>
 			</VStack>
 
 			<VStack spacing={ 2 }>

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -21,6 +21,7 @@ import {
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
+import { StepIndicator } from 'calypso/reader/components/step-indicator';
 import {
 	useCreateSpace,
 	useDeleteSpace,
@@ -48,10 +49,11 @@ import { DeleteTab } from './delete-tab';
 import { IdentityTab } from './identity-tab';
 import { DEFAULT_SPACE_WIDTH, getLayoutPresetTitle, LayoutTab } from './layout-tab';
 import { SourcesTab } from './sources-tab';
+import { TopicsTab } from './topics-tab';
 
 import './style.scss';
 
-export type CustomizeTab = 'identity' | 'layout' | 'sources' | 'delete';
+export type CustomizeTab = 'identity' | 'layout' | 'sources' | 'topics' | 'delete';
 
 // Ties the hidden Modal header's accessible name to our custom visible heading.
 const SPACE_MODAL_HEADING_ID = 'customize-space-modal__heading';
@@ -194,6 +196,9 @@ function SpaceUpsertModalContent( {
 	const [ width, setWidth ] = useState< SpaceLayoutWidth >( DEFAULT_SPACE_WIDTH );
 	const [ selectedSources, setSelectedSources ] = useState< SourceDraftItem[] >( [] );
 	const [ isConfirmingDelete, setIsConfirmingDelete ] = useState( false );
+	// Create is a guided wizard that walks through the sections one step at a time;
+	// edit keeps the tabbed layout so any section is reachable directly.
+	const [ step, setStep ] = useState( 0 );
 
 	useEffect( () => {
 		if ( ! isCreate && space && ! isSeeded ) {
@@ -344,7 +349,8 @@ function SpaceUpsertModalContent( {
 	const baseTabs: ModalTab[] = [
 		{ name: 'identity', title: translate( 'Identity' ) as string },
 		{ name: 'layout', title: translate( 'Layout' ) as string },
-		{ name: 'sources', title: translate( 'Sources' ) as string },
+		{ name: 'sources', title: translate( 'Feeds' ) as string },
+		{ name: 'topics', title: translate( 'Topics' ) as string },
 	];
 	const tabs: ModalTab[] = isCreate
 		? baseTabs
@@ -372,6 +378,16 @@ function SpaceUpsertModalContent( {
 				/>
 			);
 		}
+		if ( tabName === 'topics' ) {
+			return (
+				<TopicsTab
+					tags={ tags }
+					onTagsChange={ setTags }
+					languages={ languages }
+					onLanguagesChange={ setLanguages }
+				/>
+			);
+		}
 		if ( tabName === 'delete' && ! isCreate ) {
 			return (
 				<DeleteTab
@@ -385,10 +401,6 @@ function SpaceUpsertModalContent( {
 				name={ name }
 				onNameChange={ setName }
 				nameError={ nameError }
-				tags={ tags }
-				onTagsChange={ setTags }
-				languages={ languages }
-				onLanguagesChange={ setLanguages }
 				color={ color }
 				onColorChange={ setColor }
 				iconColor={ iconColor }
@@ -402,11 +414,26 @@ function SpaceUpsertModalContent( {
 	const sourceCount = selectedSources.length;
 	const footerSummary = [
 		getLayoutPresetTitle( view, translate ),
-		translate( '%(count)d source', '%(count)d sources', {
+		translate( '%(count)d feed', '%(count)d feeds', {
 			count: sourceCount,
 			args: { count: sourceCount },
 		} ),
 	].join( ' · ' );
+
+	// The create wizard walks the base sections in order; the current step maps to
+	// the matching entry in `baseTabs` for its heading.
+	const wizardSteps = baseTabs;
+	const isLastStep = step === wizardSteps.length - 1;
+	const currentStep = wizardSteps[ step ];
+
+	const goBack = () => setStep( ( current ) => Math.max( current - 1, 0 ) );
+	const goNext = () => {
+		if ( isLastStep ) {
+			handleSave();
+			return;
+		}
+		setStep( ( current ) => Math.min( current + 1, wizardSteps.length - 1 ) );
+	};
 
 	const modalTitle = isCreate ? translate( 'Create a new space' ) : translate( 'Customize space' );
 
@@ -434,17 +461,28 @@ function SpaceUpsertModalContent( {
 				<p className="customize-space-modal__subtitle">
 					{ isCreate
 						? translate( 'Set up a space for the feeds and tags you want to read together.' )
-						: translate( "Update this space's identity, layout and sources." ) }
+						: translate( "Update this space's identity, layout and feeds." ) }
 				</p>
 			</VStack>
 
-			<TabPanel className="customize-space-modal__tabs" initialTabName={ initialTab } tabs={ tabs }>
-				{ ( tab ) => (
-					<div className="customize-space-modal__panel">
-						{ renderTab( tab.name as CustomizeTab ) }
-					</div>
-				) }
-			</TabPanel>
+			{ isCreate ? (
+				<div className="customize-space-modal__step">
+					<h2 className="customize-space-modal__step-heading">{ currentStep.title }</h2>
+					<div className="customize-space-modal__panel">{ renderTab( currentStep.name ) }</div>
+				</div>
+			) : (
+				<TabPanel
+					className="customize-space-modal__tabs"
+					initialTabName={ initialTab }
+					tabs={ tabs }
+				>
+					{ ( tab ) => (
+						<div className="customize-space-modal__panel">
+							{ renderTab( tab.name as CustomizeTab ) }
+						</div>
+					) }
+				</TabPanel>
+			) }
 
 			{ createSpace.isError || updateSpace.isError ? (
 				<p className="customize-space-modal__error" role="alert">
@@ -452,46 +490,79 @@ function SpaceUpsertModalContent( {
 				</p>
 			) : null }
 
-			<HStack className="customize-space-modal__footer" justify="space-between" alignment="center">
+			{ isCreate ? (
 				<HStack
-					className="customize-space-modal__footer-space"
-					spacing={ 2 }
-					justify="flex-start"
-					expanded={ false }
+					className="customize-space-modal__footer"
+					justify="space-between"
+					alignment="center"
 				>
-					<span
-						className={ `customize-space-modal__footer-icon customize-space-modal__footer-icon--${ iconColor }` }
-						aria-hidden="true"
+					<StepIndicator totalSteps={ wizardSteps.length } currentStep={ step + 1 } />
+					<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							disabled={ isPending }
+							onClick={ step === 0 ? onClose : goBack }
+						>
+							{ step === 0 ? translate( 'Cancel' ) : translate( 'Back' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							isBusy={ isPending }
+							disabled={ !! nameError || isPending }
+							onClick={ goNext }
+						>
+							{ isLastStep ? translate( 'Create' ) : translate( 'Next' ) }
+						</Button>
+					</HStack>
+				</HStack>
+			) : (
+				<HStack
+					className="customize-space-modal__footer"
+					justify="space-between"
+					alignment="center"
+				>
+					<HStack
+						className="customize-space-modal__footer-space"
+						spacing={ 2 }
+						justify="flex-start"
+						expanded={ false }
 					>
-						<Icon icon={ SPACE_ICONS[ icon ] } size={ 18 } />
-					</span>
-					<VStack spacing={ 0 } className="customize-space-modal__footer-text">
-						<span className="customize-space-modal__footer-name">
-							{ name.trim() || translate( 'New space' ) }
+						<span
+							className={ `customize-space-modal__footer-icon customize-space-modal__footer-icon--${ iconColor }` }
+							aria-hidden="true"
+						>
+							<Icon icon={ SPACE_ICONS[ icon ] } size={ 18 } />
 						</span>
-						<span className="customize-space-modal__footer-summary">{ footerSummary }</span>
-					</VStack>
+						<VStack spacing={ 0 } className="customize-space-modal__footer-text">
+							<span className="customize-space-modal__footer-name">
+								{ name.trim() || translate( 'New space' ) }
+							</span>
+							<span className="customize-space-modal__footer-summary">{ footerSummary }</span>
+						</VStack>
+					</HStack>
+					<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							disabled={ isPending }
+							onClick={ onClose }
+						>
+							{ translate( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							isBusy={ isPending }
+							disabled={ ! isSeeded || !! nameError || isPending }
+							onClick={ handleSave }
+						>
+							{ translate( 'Save changes' ) }
+						</Button>
+					</HStack>
 				</HStack>
-				<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						disabled={ isPending }
-						onClick={ onClose }
-					>
-						{ translate( 'Cancel' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						isBusy={ isPending }
-						disabled={ ! isSeeded || !! nameError || isPending }
-						onClick={ handleSave }
-					>
-						{ isCreate ? translate( 'Create' ) : translate( 'Save changes' ) }
-					</Button>
-				</HStack>
-			</HStack>
+			) }
 
 			{ isConfirmingDelete ? (
 				<ConfirmDeleteDialog

--- a/client/reader/spaces/customize-modal/sources-tab.tsx
+++ b/client/reader/spaces/customize-modal/sources-tab.tsx
@@ -87,10 +87,9 @@ export function SourcesTab( { selectedSourceKeys, onAddDraftSource, onRemoveDraf
 
 	return (
 		<VStack spacing={ 4 } justify="flex-start" className="space-sources">
-			<p className="space-sources__description">
-				{ translate( 'Choose which of your subscriptions appear in this space.' ) }
+			<p className="customize-space-modal__field-help">
+				{ translate( 'Pick the subscriptions whose posts make up this space’s main feed.' ) }
 			</p>
-
 			<SearchControl
 				__nextHasNoMarginBottom
 				label={ translate( 'Search your subscriptions' ) }

--- a/client/reader/spaces/customize-modal/style.scss
+++ b/client/reader/spaces/customize-modal/style.scss
@@ -40,6 +40,25 @@
 	margin-block-end: 0;
 }
 
+// Create-mode wizard: one section at a time in place of the tab strip.
+.customize-space-modal__step {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-block-size: 0;
+}
+
+.customize-space-modal__step-heading {
+	margin: 0;
+	padding-block: 12px 0;
+	border-block-start: 1px solid var( --color-neutral-5 );
+	color: var( --color-text-subtle );
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+}
+
 .customize-space-modal__tabs {
 	display: flex;
 	flex: 1;
@@ -244,12 +263,6 @@
 	flex: 1;
 	min-block-size: 0;
 	overflow: hidden;
-}
-
-.space-sources__description {
-	margin: 0;
-	color: var( --color-text-subtle );
-	font-size: 0.875rem;
 }
 
 .space-sources__filters {

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -346,6 +346,26 @@ describe( 'CustomizeModal', () => {
 		);
 	} );
 
+	it( 'saves edited topics with the rest of the edit draft', async () => {
+		const user = userEvent.setup();
+		const { onClose } = render();
+		const onBody = jest.fn();
+		mockUpdateEndpoint( onBody );
+
+		await user.click( screen.getByRole( 'tab', { name: 'Topics' } ) );
+		await user.type( screen.getByRole( 'combobox', { name: 'Tags' } ), 'design[Enter]' );
+		await user.type( screen.getByRole( 'combobox', { name: 'Languages' } ), 'Português[Enter]' );
+		await user.click( screen.getByRole( 'button', { name: 'Save changes' } ) );
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
+		expect( onBody ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				tags: [ 'tech', 'design' ],
+				languages: [ 'en', 'pt' ],
+			} )
+		);
+	} );
+
 	it( 'keeps unsaved identity edits when a source is changed (seeds the draft once)', async () => {
 		mockSubscriptions = [ existingSubscription, newSubscription ];
 		const user = userEvent.setup();

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -160,8 +160,6 @@ describe( 'CustomizeModal', () => {
 		render();
 
 		expect( screen.getByLabelText( 'Name' ) ).toHaveValue( 'Work' );
-		// The saved language base code is shown by its display name.
-		expect( screen.getByText( 'English' ) ).toBeVisible();
 		expect(
 			within( screen.getByRole( 'radiogroup', { name: 'Accent color' } ) ).getByRole( 'radio', {
 				name: 'Blue',
@@ -188,7 +186,7 @@ describe( 'CustomizeModal', () => {
 		).toBeTruthy();
 	} );
 
-	it( 'switches between the Identity, Layout and Sources tabs', async () => {
+	it( 'switches between the Identity, Layout, Feeds, Topics and Delete tabs', async () => {
 		const user = userEvent.setup();
 		render();
 
@@ -199,10 +197,15 @@ describe( 'CustomizeModal', () => {
 		expect( screen.getByRole( 'radio', { name: /Compact list/ } ) ).toBeChecked();
 		expect( screen.getByRole( 'radio', { name: /Classic/ } ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'tab', { name: 'Sources' } ) );
-		expect(
-			screen.getByText( 'Choose which of your subscriptions appear in this space.' )
-		).toBeVisible();
+		// Feeds have their own tab.
+		await user.click( screen.getByRole( 'tab', { name: 'Feeds' } ) );
+		expect( screen.getByRole( 'button', { name: 'All subscriptions' } ) ).toBeVisible();
+
+		// Tags and languages share the Topics tab.
+		await user.click( screen.getByRole( 'tab', { name: 'Topics' } ) );
+		expect( screen.getByRole( 'combobox', { name: 'Tags' } ) ).toBeVisible();
+		// The saved language base code is shown by its display name.
+		expect( screen.getByText( 'English' ) ).toBeVisible();
 
 		await user.click( screen.getByRole( 'tab', { name: 'Delete' } ) );
 		expect( screen.getByRole( 'button', { name: 'Delete space' } ) ).toBeVisible();
@@ -329,7 +332,7 @@ describe( 'CustomizeModal', () => {
 		const onBody = jest.fn();
 		mockUpdateEndpoint( onBody );
 
-		await user.click( screen.getByRole( 'tab', { name: 'Sources' } ) );
+		await user.click( screen.getByRole( 'tab', { name: 'Feeds' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Remove Existing Blog' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Add New Blog' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Save changes' } ) );
@@ -370,7 +373,7 @@ describe( 'CustomizeModal', () => {
 
 		// ...then toggle a source on another tab. This must not re-seed the draft and
 		// wipe the pending name edit.
-		await user.click( screen.getByRole( 'tab', { name: 'Sources' } ) );
+		await user.click( screen.getByRole( 'tab', { name: 'Feeds' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Add New Blog' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Save changes' } ) );
 

--- a/client/reader/spaces/customize-modal/test/topics-tab.test.tsx
+++ b/client/reader/spaces/customize-modal/test/topics-tab.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { TopicsTab } from '../topics-tab';
+
+function setup( overrides: Partial< React.ComponentProps< typeof TopicsTab > > = {} ) {
+	const props: React.ComponentProps< typeof TopicsTab > = {
+		tags: [],
+		onTagsChange: jest.fn(),
+		languages: [],
+		onLanguagesChange: jest.fn(),
+		...overrides,
+	};
+	const user = userEvent.setup();
+	renderWithProvider( <TopicsTab { ...props } /> );
+	return { props, user };
+}
+
+describe( 'TopicsTab', () => {
+	it( 'renders the description, tags and languages controls together', () => {
+		setup( { languages: [ 'en' ] } );
+
+		expect(
+			screen.getByText(
+				'Besides posts from the feeds you follow, this space can show posts that match these tags, in the languages you choose.'
+			)
+		).toBeVisible();
+		expect( screen.getByRole( 'combobox', { name: 'Tags' } ) ).toBeVisible();
+		expect( screen.getByRole( 'combobox', { name: 'Languages' } ) ).toBeVisible();
+		// The selected language is shown by its display name.
+		expect( screen.getByText( 'English' ) ).toBeVisible();
+	} );
+
+	it( 'reports an added tag', async () => {
+		const { props, user } = setup();
+
+		await user.type( screen.getByRole( 'combobox', { name: 'Tags' } ), 'design[Enter]' );
+
+		expect( props.onTagsChange ).toHaveBeenCalledWith( [ 'design' ] );
+	} );
+
+	it( 'reports an added language as a base code', async () => {
+		const { props, user } = setup();
+
+		await user.type( screen.getByRole( 'combobox', { name: 'Languages' } ), 'English[Enter]' );
+
+		expect( props.onLanguagesChange ).toHaveBeenCalledWith( [ 'en' ] );
+	} );
+} );

--- a/client/reader/spaces/customize-modal/test/topics-tab.test.tsx
+++ b/client/reader/spaces/customize-modal/test/topics-tab.test.tsx
@@ -5,9 +5,10 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { TopicsTab } from '../topics-tab';
+import type { ComponentProps } from 'react';
 
-function setup( overrides: Partial< React.ComponentProps< typeof TopicsTab > > = {} ) {
-	const props: React.ComponentProps< typeof TopicsTab > = {
+function setup( overrides: Partial< ComponentProps< typeof TopicsTab > > = {} ) {
+	const props: ComponentProps< typeof TopicsTab > = {
 		tags: [],
 		onTagsChange: jest.fn(),
 		languages: [],

--- a/client/reader/spaces/customize-modal/topics-tab.tsx
+++ b/client/reader/spaces/customize-modal/topics-tab.tsx
@@ -1,0 +1,59 @@
+import { FormTokenField, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import {
+	SPACE_LANGUAGE_SUGGESTIONS,
+	getLanguageCodeByName,
+	getLanguageName,
+	resolveLanguageTokens,
+} from 'calypso/reader/spaces/languages';
+
+interface Props {
+	tags: string[];
+	onTagsChange: ( tags: string[] ) => void;
+	languages: string[];
+	onLanguagesChange: ( languages: string[] ) => void;
+}
+
+export function TopicsTab( { tags, onTagsChange, languages, onLanguagesChange }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<VStack spacing={ 4 }>
+			<p className="customize-space-modal__field-help">
+				{ translate(
+					'Besides posts from the feeds you follow, this space can show posts that match these tags, in the languages you choose.'
+				) }
+			</p>
+			<FormTokenField
+				__next40pxDefaultSize
+				label={ translate( 'Tags' ) }
+				value={ tags }
+				placeholder={ translate( 'Add tags' ) }
+				onChange={ ( tokens ) =>
+					onTagsChange(
+						tokens.map( ( token ) => ( typeof token === 'string' ? token : token.value ) )
+					)
+				}
+				help={ translate( 'Type and press Enter to add; click x to remove.' ) }
+			/>
+			<FormTokenField
+				__next40pxDefaultSize
+				__experimentalExpandOnFocus
+				// Restrict tokens to known languages so only valid base codes are
+				// stored; free-typed text that doesn't resolve to a language is rejected.
+				__experimentalValidateInput={ ( input: string ) =>
+					getLanguageCodeByName( input ) !== undefined
+				}
+				label={ translate( 'Languages' ) }
+				// The field works in display names; the parent state is base codes.
+				value={ languages.map( getLanguageName ) }
+				suggestions={ SPACE_LANGUAGE_SUGGESTIONS }
+				placeholder={ translate( 'Add languages' ) }
+				onChange={ ( tokens ) => onLanguagesChange( resolveLanguageTokens( tokens, languages ) ) }
+				help={ translate(
+					'Filters Discover results to these languages. Starts from your account language; add more as needed.'
+				) }
+			/>
+		</VStack>
+	);
+}

--- a/client/reader/spaces/feed/components/states.tsx
+++ b/client/reader/spaces/feed/components/states.tsx
@@ -54,13 +54,13 @@ export function SpaceFeedEmpty( {
 
 	return (
 		<div className="space-feed__status">
-			<p className="space-feed__status-title">{ translate( 'Add sources to get started' ) }</p>
+			<p className="space-feed__status-title">{ translate( 'Add feeds to get started' ) }</p>
 			<p className="space-feed__status-line">
 				{ translate( 'Follow blogs, tags, or sites to fill this space with posts you’ll love.' ) }
 			</p>
 			{ onAddSources && (
 				<Button variant="primary" onClick={ onAddSources }>
-					{ translate( 'Add sources' ) }
+					{ translate( 'Add feeds' ) }
 				</Button>
 			) }
 		</div>

--- a/client/reader/spaces/feed/test/index.test.tsx
+++ b/client/reader/spaces/feed/test/index.test.tsx
@@ -173,7 +173,7 @@ describe( 'SpaceFeed', () => {
 		);
 	} );
 
-	it( 'shows an actionable empty state with an Add sources CTA when the feed has no posts', async () => {
+	it( 'shows an actionable empty state with an Add feeds CTA when the feed has no posts', async () => {
 		const user = userEvent.setup();
 		const onAddSources = jest.fn();
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
@@ -183,14 +183,14 @@ describe( 'SpaceFeed', () => {
 			initialState: { currentUser: { id: 1 } },
 		} );
 
-		expect( screen.getByText( 'Add sources to get started' ) ).toBeVisible();
+		expect( screen.getByText( 'Add feeds to get started' ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'button', { name: 'Add sources' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Add feeds' } ) );
 
 		expect( onAddSources ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'shows the Add sources CTA in the legacy layout empty state', async () => {
+	it( 'shows the Add feeds CTA in the legacy layout empty state', async () => {
 		const user = userEvent.setup();
 		const onAddSources = jest.fn();
 		const legacy = makeSpace( 'work-id', 'Work', 'legacy' );
@@ -201,12 +201,12 @@ describe( 'SpaceFeed', () => {
 			initialState: { currentUser: { id: 1 } },
 		} );
 
-		await user.click( screen.getByRole( 'button', { name: 'Add sources' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Add feeds' } ) );
 
 		expect( onAddSources ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'shows the Discover empty state without an Add sources CTA', () => {
+	it( 'shows the Discover empty state without an Add feeds CTA', () => {
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
 		renderWithProvider(
@@ -215,7 +215,7 @@ describe( 'SpaceFeed', () => {
 		);
 
 		expect( screen.getByText( 'Nothing here yet' ) ).toBeVisible();
-		expect( screen.queryByRole( 'button', { name: 'Add sources' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Add feeds' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'requests the space posts stream keyed by the space id', () => {
@@ -355,7 +355,7 @@ describe( 'SpaceFeed', () => {
 	it( 'shows the empty state for the legacy layout when the legacy stream has no posts', () => {
 		render( makeSpace( 'work-id', 'Work', 'legacy' ) );
 
-		expect( screen.getByText( 'Add sources to get started' ) ).toBeVisible();
+		expect( screen.getByText( 'Add feeds to get started' ) ).toBeVisible();
 	} );
 
 	it( 'shows an error with a retry for the legacy layout when the legacy stream fails', async () => {

--- a/client/reader/spaces/test/view.test.tsx
+++ b/client/reader/spaces/test/view.test.tsx
@@ -223,7 +223,7 @@ describe( 'SpacesView', () => {
 		expect( within( dialog ).getByLabelText( 'Name' ) ).toHaveValue( 'Work' );
 	} );
 
-	it( 'opens the Customize modal on the Sources tab from the feed Add sources CTA', async () => {
+	it( 'opens the Customize modal on the Feeds tab from the feed Add feeds CTA', async () => {
 		render( <SpacesView slug={ WORK.slug } /> );
 
 		// The feed tab's SpaceFeed is wired with the empty-state CTA handler.
@@ -238,7 +238,7 @@ describe( 'SpacesView', () => {
 		);
 
 		const dialog = await screen.findByRole( 'dialog', { name: 'Customize space' } );
-		expect( within( dialog ).getByRole( 'tab', { name: 'Sources' } ) ).toHaveAttribute(
+		expect( within( dialog ).getByRole( 'tab', { name: 'Feeds' } ) ).toHaveAttribute(
 			'aria-selected',
 			'true'
 		);


### PR DESCRIPTION
Part of RSM-4651

## Proposed Changes

* Turn space **creation** into a guided multi-step wizard — Identity → Layout → Feeds → Topics — with clear Back / Next / Create navigation and a step indicator, so the options behind the former tabs aren't skipped. Editing a space keeps the tabbed layout for direct access to any section.
* Reorganize the shared modal into four sections: Identity (name, icon, colors), Layout, **Feeds** (subscription picker), and **Topics** (tags + languages), each with a short description of how it's used.
* Rename the user-facing "Sources" wording to "Feeds" across the modal (tab label, footer summary, edit subtitle) and the feed empty state ("Add feeds to get started"). Internal data/analytics identifiers are unchanged.
* Add and update unit tests for the wizard flow, the section reorganization, and the renamed copy.

## Why are these changes being made?

In the create-space modal the extra options behind the Layout and Feeds tabs were easy to overlook — users saw the tabs but skipped them, or expected **Create** to advance to the next tab. Walking through each section in sequence makes every option visible before the space is created, while editing keeps the faster tabbed access.

## Testing Instructions

### Scenario 1 - Create a space with the wizard:
- Go to `/reader` and start the "Add a space" flow from the sidebar
- Check you move through Identity → Layout → Feeds → Topics with Back / Next and a step indicator, and that the **Create** button appears only on the final Topics step

### Scenario 2 - Name is required to advance:
- Start the create wizard on the Identity step
- Check that **Next** stays disabled until a valid space name is entered, and shows a "Name is required" error when cleared

### Scenario 3 - Editing keeps the tabs:
- Open an existing space and choose **Customize**
- Check the modal shows tabs Identity / Layout / Feeds / Topics / Delete, with tags and languages together under **Topics**

### Scenario 4 - Empty state wording:
- Open a Reader Space that has no feeds at `/reader/spaces/<id>`
- Check the empty state reads "Add feeds to get started" with an **Add feeds** button that opens the Customize modal on the Feeds tab

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?