### PR TITLE
Themes "with-theme": fix free .org theme install hanging after signup

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -193,7 +193,10 @@ function getWithThemeDestination( {
 	}
 
 	if ( DOT_ORG_THEME === themeType ) {
-		return `/marketplace/theme/${ themeParameter }/install/${ siteSlug }`;
+		// Mark the redirect as trusted (directInstall) so the install page initiates the
+		// transfer/install itself — the in-memory purchase-flow handoff it relies on doesn't
+		// survive this redirect out of signup.
+		return `/marketplace/theme/${ themeParameter }/install/${ siteSlug }?directInstall=1`;
 	}
 
 	const style = styleVariation ? `&styleVariation=${ styleVariation }` : '';


### PR DESCRIPTION
## Proposed Changes

- Fix a free `.org` theme installed via the `with-theme` signup flow hanging on a blank "Putting the pieces together" screen after signup. `getWithThemeDestination` sends `.org` themes to the same marketplace install page as free plugins (`/marketplace/theme/:theme/install/:site`), which only initiates the atomic transfer + install when the in-memory purchase-flow handoff is present. That handoff doesn't survive the full-page redirect out of signup, so the page polled the site indefinitely. The redirect is now marked trusted (`?directInstall=1`) so the install page initiates the transfer/install itself.

## Why are these changes being made?

This is the theme counterpart of the free-plugin install hang already fixed for the `with-plugin` flow — the two flows route to the same install page, and the install page already reads `directInstall` for theme installs (its init effect handles `wpOrgTheme`), so this is a one-line parity fix.

## Testing Instructions

1. Log out, start the `with-theme` flow with a free `.org` theme and a paid plan in the cart.
2. Complete account + domain + plan → checkout.
3. Confirm the post-checkout install **completes** (transfer + theme install) instead of hanging on "Putting the pieces together".

No unit test added: `getWithThemeDestination` is not exported and has no existing coverage (its siblings mock the function rather than exercise it); the `directInstall` mechanism it relies on is already shipped and exercised via the free-plugin path.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
