### PR TITLE
Dashboard: silence benign "Transition was skipped" rejection

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -11,6 +11,7 @@ import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
 import { omnibarEvents } from './omnibar/events';
+import { suppressSkippedViewTransitions } from './router/suppress-skipped-view-transitions';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
 import type { AppConfig } from './context';
 
@@ -32,6 +33,7 @@ function boot( config: AppConfig ) {
 	loadDevHelpers();
 	loadPreferencesHelper();
 	limitTotalSnackbars();
+	suppressSkippedViewTransitions();
 	initSentry();
 
 	const rootElement = document.getElementById( 'wpcom' );

--- a/client/dashboard/app/router/suppress-skipped-view-transitions.ts
+++ b/client/dashboard/app/router/suppress-skipped-view-transitions.ts
@@ -1,0 +1,41 @@
+let isWrapped = false;
+
+/**
+ * TanStack Router drives navigations through `document.startViewTransition()`
+ * but discards the returned `ViewTransition`. When a navigation supersedes an
+ * in-flight one, the browser skips the pending transition and its `ready`
+ * promise rejects with `AbortError: Transition was skipped`, surfacing as an
+ * uncaught promise rejection. Skipping is the correct browser behavior; only
+ * the unhandled rejection is noise.
+ *
+ * Wrap `startViewTransition` once so the transition's promises always have a
+ * handler. Only the skip `AbortError` is swallowed; any other rejection is
+ * re-thrown so real failures stay visible.
+ */
+export function suppressSkippedViewTransitions() {
+	if (
+		isWrapped ||
+		typeof document === 'undefined' ||
+		typeof document.startViewTransition !== 'function'
+	) {
+		return;
+	}
+	isWrapped = true;
+
+	const startViewTransition = document.startViewTransition.bind( document );
+
+	const swallowSkippedTransition = ( error: unknown ) => {
+		if ( error instanceof DOMException && error.name === 'AbortError' ) {
+			return;
+		}
+		throw error;
+	};
+
+	document.startViewTransition = ( ...args: Parameters< typeof startViewTransition > ) => {
+		const transition = startViewTransition( ...args );
+		transition.ready.catch( swallowSkippedTransition );
+		transition.updateCallbackDone.catch( swallowSkippedTransition );
+		transition.finished.catch( swallowSkippedTransition );
+		return transition;
+	};
+}

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -1,10 +1,13 @@
 import pagejs from '@automattic/calypso-router';
 import { createMemoryHistory } from '@tanstack/react-router';
+import { suppressSkippedViewTransitions } from 'calypso/dashboard/app/router/suppress-skipped-view-transitions';
 import UnknownError from '../components/500';
 import type { AnyRoute, AnyRouter } from '@tanstack/react-router';
 import type { AppConfig } from 'calypso/dashboard/app/context';
 
 export function getRouterOptions( config: AppConfig ) {
+	suppressSkippedViewTransitions();
+
 	return {
 		basepath: config.basePath,
 		context: {


### PR DESCRIPTION
## Proposed Changes

* Add `suppressSkippedViewTransitions()`, a small helper that wraps `document.startViewTransition` once so the transition's `ready` / `updateCallbackDone` / `finished` promises always have a handler. Only the skip `AbortError` is swallowed; any other rejection is re-thrown so real failures stay visible.
* Call it from the two boot paths that enable TanStack Router view transitions (`defaultViewTransition: true`):
  * `client/dashboard/app/boot.tsx` — the standalone Multi-site Dashboard.
  * `client/sites/v2/utils/router.ts` (`getRouterOptions`) — the classic-Calypso "Dashboard Backport" routers (site overview / settings / sites list).

## Why are these changes being made?

Navigating the dashboard logs `Uncaught (in promise) AbortError: Transition was skipped` to the console.

TanStack Router drives every navigation through `document.startViewTransition()` but **discards the returned `ViewTransition`**. When a navigation supersedes an in-flight one (rapid filter/search/pagination changes, intent preloading, redirects, or React 19's more-deferred concurrent commits), the browser skips the pending transition and its `ready` promise rejects with `AbortError: Transition was skipped`. Because the return value is dropped, nothing attaches a handler, so it surfaces as an uncaught rejection.

The skip itself is correct browser behavior — only the unhandled rejection is noise. This is not fixed in any released TanStack Router version (the current implementation still drops the return value), so it has to be handled at our layer.

Empirically, on a skipped transition it is specifically the `ready` promise that rejects (`finished` / `updateCallbackDone` resolve when the skip happens after the update callback runs), so the helper guards all three and swallows only the `AbortError`.

## Testing Instructions

1. Log into a WordPress.com sandbox and open a site's overview/settings (`/sites/:slug`), which runs the TanStack backport router.
2. Open DevTools → Console.
3. Navigate rapidly between the site menu tabs (Overview / Monitoring / Logs / Settings) and hover site rows to trigger intent preloading.
4. **Before this change:** `Uncaught (in promise) AbortError: Transition was skipped` appears in the console.
5. **After this change:** the message no longer appears; navigation and animations are otherwise unchanged.

Confirmed live on a Simple site: reproduced the console error on the backport surfaces, and verified that attaching handlers to the transition's promises fully suppresses it while leaving non-`AbortError` rejections visible.

> Note: local `yarn typecheck-client` / `yarn lint` were not run — this branch is an emdash worktree without `node_modules`. The change is a small, type-safe addition; CI's `type_check_client` covers it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)