### PR TITLE
Agents Manager: fix duplicated picker on reload and disable pickers once the user replies

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -88,10 +88,7 @@ jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
 } ) );
-jest.mock(
-	'../../hooks/use-conversation',
-	() => ( config: unknown ) => mockUseConversation( config )
-);
+jest.mock( '../../hooks/use-conversation', () => () => mockUseConversation() );
 jest.mock( '../../hooks/use-save-new-chat-route', () => () => {} );
 jest.mock( '../../hooks/use-checkpoint-action', () => () => {} );
 jest.mock( '../../hooks/use-feedback-action', () => () => ( {
@@ -778,7 +775,8 @@ describe( 'OrchestratorChat', () => {
 	it( 'does not retain the live show-component message when the history is replaced', () => {
 		// The same picker serializes differently live (no tool_call_id) and in
 		// loaded history (with tool_call_id), so their identities never match.
-		// Replacing the history via loadMessages must not resurrect the live copy.
+		// Server hydration replaces the whole history with freshly-id'd messages;
+		// that swap must not resurrect the live copy as a retained duplicate.
 		const pickerMessage = ( id: string, content: Record< string, unknown > ) => ( {
 			id,
 			role: 'agent',
@@ -848,21 +846,15 @@ describe( 'OrchestratorChat', () => {
 			/>
 		);
 
-		let hydrate: ( ( messages: unknown[], sessionId: string ) => void ) | undefined;
-		mockUseConversation.mockImplementation(
-			( config?: { onSuccess?: ( messages: unknown[], sessionId: string ) => void } ) => {
-				hydrate = config?.onSuccess;
-				return { isLoading: false };
-			}
-		);
-
 		// Seeded from storage: the live-form picker is showing.
 		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage, livePicker ] ) );
 		const { rerender } = render( chat() );
 
-		// Server hydration replaces the whole history with the loaded form.
-		act( () => hydrate?.( [], 'session-id' ) );
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage, loadedPicker ] ) );
+		// Server hydration replaces the whole history; every loaded message gets
+		// a fresh id, including the echoed user message.
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( [ { ...userMessage, id: 'user-loaded' }, loadedPicker ] )
+		);
 		rerender( chat() );
 
 		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable import/order -- jest.mock calls must precede imports */
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { Suggestion } from '@automattic/agenttic-ui';
+import type { ComponentProps } from 'react';
 
 const mockUseAgentChat = jest.fn();
 const mockUseRegenerateAction = jest.fn();
@@ -128,48 +129,97 @@ jest.mock( '../agent-chat', () => ( {
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import OrchestratorChat from '../orchestrator-chat';
 
+const chat = ( props: Partial< ComponentProps< typeof OrchestratorChat > > = {} ) => (
+	<OrchestratorChat
+		emptyViewSuggestions={ [] }
+		isDocked={ false }
+		isOpen
+		onClose={ jest.fn() }
+		onExpand={ jest.fn() }
+		chatHeaderOptions={ [] }
+		markdownComponents={ {} }
+		markdownExtensions={ {} }
+		isCompactMode={ false }
+		onHasMessagesChange={ jest.fn() }
+		{ ...props }
+	/>
+);
+
+const agentChatReturn = ( overrides: Record< string, unknown > = {} ) => ( {
+	addMessage: jest.fn(),
+	messages: [],
+	suggestions: [],
+	isProcessing: false,
+	error: null,
+	loadMessages: jest.fn(),
+	onSubmit: jest.fn(),
+	abortCurrentRequest: jest.fn(),
+	clearSuggestions: jest.fn(),
+	registerSuggestions: jest.fn(),
+	registerMessageActions: jest.fn(),
+	unregisterMessageActions: jest.fn(),
+	// Mirror production: agenttic hands back a real regenerate handler.
+	getRegenerateHandler: jest.fn( () => jest.fn() ),
+	progressMessage: null,
+	...overrides,
+} );
+
+// Show-component fixtures shared by the retention tests.
+const SHOW_COMPONENT_CONTENT = JSON.stringify( {
+	tool_id: 'big_sky__show_component',
+	tool_call_id: 'title-picker-call',
+	data: { type: 'titlePicker', summary: 'Optimize title' },
+} );
+
+const userMessage = {
+	id: 'user-1',
+	role: 'user',
+	content: [ { type: 'text', text: 'Optimize the title' } ],
+	timestamp: 0,
+	archived: false,
+	showIcon: true,
+};
+
+const showComponentMessage = ( id: string, content: string = SHOW_COMPONENT_CONTENT ) => ( {
+	id,
+	role: 'agent',
+	content: [ { type: 'text', text: content } ],
+	timestamp: 1,
+	archived: false,
+	showIcon: true,
+} );
+
+const countShowComponentMessages = () => {
+	const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+		content?: Array< { text?: string } >;
+	} >;
+	return messages.filter( ( message ) => {
+		const text = message?.content?.[ 0 ]?.text;
+		if ( typeof text !== 'string' ) {
+			return false;
+		}
+		try {
+			return JSON.parse( text )?.tool_id === 'big_sky__show_component';
+		} catch ( _error ) {
+			return false;
+		}
+	} ).length;
+};
+
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		// Default getter: contributes no actions.
 		mockUseRegenerateAction.mockReturnValue( () => [] );
 		mockUseConversation.mockReturnValue( { isLoading: false } );
-		mockUseAgentChat.mockReturnValue( {
-			addMessage: jest.fn(),
-			messages: [],
-			suggestions: [],
-			isProcessing: false,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			unregisterMessageActions: jest.fn(),
-			getRegenerateHandler: jest.fn(),
-			progressMessage: null,
-		} );
+		mockUseAgentChat.mockReturnValue( agentChatReturn() );
 	} );
 
 	it( 'dispatches the inline suggestion event when an Agenttic suggestion is clicked', () => {
 		const listener = jest.fn();
 		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat() );
 
 		fireEvent.click( screen.getByText( 'Click suggestion' ) );
 
@@ -186,20 +236,7 @@ describe( 'OrchestratorChat', () => {
 		const listener = jest.fn();
 		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat() );
 
 		fireEvent.click( screen.getByText( 'Click string suggestion' ) );
 
@@ -216,20 +253,7 @@ describe( 'OrchestratorChat', () => {
 		const listener = jest.fn();
 		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat() );
 
 		fireEvent.click( screen.getByText( 'Click auto-submit suggestion' ) );
 
@@ -252,21 +276,7 @@ describe( 'OrchestratorChat', () => {
 	it( 'passes the floating suggestion limit to external providers', () => {
 		const useSuggestions = jest.fn( () => ( { suggestions: [] } ) );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				useSuggestions={ useSuggestions }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { useSuggestions: useSuggestions } ) );
 
 		expect( useSuggestions ).toHaveBeenCalledWith( 3, { suggestionsVisible: true } );
 	} );
@@ -274,21 +284,7 @@ describe( 'OrchestratorChat', () => {
 	it( 'does not limit external provider suggestions while docked', () => {
 		const useSuggestions = jest.fn( () => ( { suggestions: [] } ) );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				useSuggestions={ useSuggestions }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { isDocked: true, useSuggestions: useSuggestions } ) );
 
 		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
 	} );
@@ -307,36 +303,9 @@ describe( 'OrchestratorChat', () => {
 
 		// Store is empty (as it is right after clearSuggestions()), no messages,
 		// and the input is empty — the empty-view fallback branch.
-		mockUseAgentChat.mockReturnValue( {
-			addMessage: jest.fn(),
-			messages: [],
-			suggestions: [],
-			isProcessing: false,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			progressMessage: null,
-		} );
+		mockUseAgentChat.mockReturnValue( agentChatReturn() );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ staticDefaults }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				useSuggestions={ useSuggestions }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { emptyViewSuggestions: staticDefaults, useSuggestions: useSuggestions } ) );
 
 		expect( screen.getByText( 'What needs my attention today?' ) ).toBeTruthy();
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
@@ -348,21 +317,7 @@ describe( 'OrchestratorChat', () => {
 		];
 		const useSuggestions = jest.fn( () => ( { suggestions: [] } ) );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ staticDefaults }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				useSuggestions={ useSuggestions }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { emptyViewSuggestions: staticDefaults, useSuggestions: useSuggestions } ) );
 
 		expect( screen.getByText( 'Getting started with WordPress' ) ).toBeTruthy();
 	} );
@@ -372,20 +327,7 @@ describe( 'OrchestratorChat', () => {
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
 		];
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ staticDefaults }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { emptyViewSuggestions: staticDefaults } ) );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
 			suggestions: '|getting-started|',
@@ -398,20 +340,7 @@ describe( 'OrchestratorChat', () => {
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
 		];
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ staticDefaults }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { emptyViewSuggestions: staticDefaults } ) );
 
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
@@ -425,20 +354,7 @@ describe( 'OrchestratorChat', () => {
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
 		];
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ staticDefaults }
-				isDocked={ false }
-				isOpen={ false }
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { emptyViewSuggestions: staticDefaults, isOpen: false } ) );
 
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
@@ -461,21 +377,7 @@ describe( 'OrchestratorChat', () => {
 			uploadImagesToWordPress,
 		} );
 
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				useImageUpload={ useImageUpload as never }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { useImageUpload: useImageUpload as never } ) );
 
 		fireEvent.click( screen.getByText( 'Submit with images' ) );
 
@@ -488,20 +390,7 @@ describe( 'OrchestratorChat', () => {
 	} );
 
 	it( 'keeps regenerate disabled unless a provider opts in', () => {
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat() );
 
 		expect( mockUseRegenerateAction ).toHaveBeenCalledWith(
 			expect.objectContaining( { enabled: false } )
@@ -509,21 +398,7 @@ describe( 'OrchestratorChat', () => {
 	} );
 
 	it( 'enables regenerate when a provider opts in', () => {
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				capabilities={ { supportsRegenerateAction: true } }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
+		render( chat( { capabilities: { supportsRegenerateAction: true } } ) );
 
 		expect( mockUseRegenerateAction ).toHaveBeenCalledWith(
 			expect.objectContaining( { enabled: true } )
@@ -547,54 +422,30 @@ describe( 'OrchestratorChat', () => {
 					  ]
 					: []
 		);
-		mockUseAgentChat.mockReturnValue( {
-			addMessage: jest.fn(),
-			messages: [
-				{
-					id: 'agent-1',
-					role: 'agent',
-					content: [ { type: 'text', text: 'First response' } ],
-					timestamp: 1,
-					archived: false,
-					showIcon: true,
-				},
-				{
-					id: 'agent-2',
-					role: 'agent',
-					content: [ { type: 'text', text: 'Second response' } ],
-					timestamp: 2,
-					archived: false,
-					showIcon: true,
-				},
-			],
-			suggestions: [],
-			isProcessing: false,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			getRegenerateHandler: jest.fn(),
-			progressMessage: null,
-		} );
-
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				capabilities={ { supportsRegenerateAction: true } }
-				onHasMessagesChange={ jest.fn() }
-			/>
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					{
+						id: 'agent-1',
+						role: 'agent',
+						content: [ { type: 'text', text: 'First response' } ],
+						timestamp: 1,
+						archived: false,
+						showIcon: true,
+					},
+					{
+						id: 'agent-2',
+						role: 'agent',
+						content: [ { type: 'text', text: 'Second response' } ],
+						timestamp: 2,
+						archived: false,
+						showIcon: true,
+					},
+				],
+			} )
 		);
+
+		render( chat( { capabilities: { supportsRegenerateAction: true } } ) );
 
 		const messages = mockAgentChat.mock.calls[ 0 ][ 0 ].messages as Array< {
 			actions: Array< { id: string; disabled?: boolean } >;
@@ -617,54 +468,31 @@ describe( 'OrchestratorChat', () => {
 	it( 'tells the regenerate getter which message is latest and whether it is streaming', () => {
 		const getRegenerateActions = jest.fn( () => [] );
 		mockUseRegenerateAction.mockReturnValue( getRegenerateActions );
-		mockUseAgentChat.mockReturnValue( {
-			addMessage: jest.fn(),
-			messages: [
-				{
-					id: 'agent-1',
-					role: 'agent',
-					content: [ { type: 'text', text: 'First response' } ],
-					timestamp: 1,
-					archived: false,
-					showIcon: true,
-				},
-				{
-					id: 'agent-2',
-					role: 'agent',
-					content: [ { type: 'text', text: 'Streaming response' } ],
-					timestamp: 2,
-					archived: false,
-					showIcon: true,
-				},
-			],
-			suggestions: [],
-			isProcessing: true,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			getRegenerateHandler: jest.fn(),
-			progressMessage: null,
-		} );
-
-		render(
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				capabilities={ { supportsRegenerateAction: true } }
-				onHasMessagesChange={ jest.fn() }
-			/>
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					{
+						id: 'agent-1',
+						role: 'agent',
+						content: [ { type: 'text', text: 'First response' } ],
+						timestamp: 1,
+						archived: false,
+						showIcon: true,
+					},
+					{
+						id: 'agent-2',
+						role: 'agent',
+						content: [ { type: 'text', text: 'Streaming response' } ],
+						timestamp: 2,
+						archived: false,
+						showIcon: true,
+					},
+				],
+				isProcessing: true,
+			} )
 		);
+
+		render( chat( { capabilities: { supportsRegenerateAction: true } } ) );
 
 		expect( getRegenerateActions ).toHaveBeenCalledWith(
 			expect.objectContaining( { id: 'agent-1' } ),
@@ -677,264 +505,68 @@ describe( 'OrchestratorChat', () => {
 	} );
 
 	it( 'does not stack retained show-component messages across repeated regenerations', () => {
-		// A "show component" payload (e.g. a title picker). Its identity —
-		// tool_call_id|type|summary — is stable across regenerations even though
-		// each regenerated agent turn gets a fresh message id.
-		const showComponentContent = JSON.stringify( {
-			tool_id: 'big_sky__show_component',
-			tool_call_id: 'title-picker-call',
-			data: { type: 'titlePicker', summary: 'Optimize title' },
-		} );
-		const userMessage = {
-			id: 'user-1',
-			role: 'user',
-			content: [ { type: 'text', text: 'Optimize the title' } ],
-			timestamp: 0,
-			archived: false,
-			showIcon: true,
-		};
-		const showComponentMessage = ( id: string ) => ( {
-			id,
-			role: 'agent',
-			content: [ { type: 'text', text: showComponentContent } ],
-			timestamp: 1,
-			archived: false,
-			showIcon: true,
-		} );
-		const agentChatReturn = ( messages: unknown[], isProcessing: boolean ) => ( {
-			addMessage: jest.fn(),
-			messages,
-			suggestions: [],
-			isProcessing,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			getRegenerateHandler: jest.fn(),
-			progressMessage: null,
-		} );
-		const countShowComponentMessages = (
-			messages: Array< { content?: Array< { text?: string } > } >
-		) =>
-			messages.filter( ( message ) => {
-				const text = message?.content?.[ 0 ]?.text;
-				if ( typeof text !== 'string' ) {
-					return false;
-				}
-				try {
-					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
-				} catch ( _error ) {
-					return false;
-				}
-			} ).length;
-		const chat = () => (
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				capabilities={ { supportsRegenerateAction: true } }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
-
+		// The picker's identity — tool_call_id|type|summary — is stable across
+		// regenerations even though each regenerated turn gets a fresh message id.
 		// Steady state: the title picker is showing.
 		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( [ userMessage, showComponentMessage( 'agent-1' ) ], false )
+			agentChatReturn( { messages: [ userMessage, showComponentMessage( 'agent-1' ) ] } )
 		);
 		const { rerender } = render( chat() );
 
 		// Regenerate: the picker briefly disappears while the new turn streams.
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage ], isProcessing: true } )
+		);
 		rerender( chat() );
 
 		// New picker arrives — same identity, fresh agent message id.
 		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( [ userMessage, showComponentMessage( 'agent-2' ) ], false )
+			agentChatReturn( { messages: [ userMessage, showComponentMessage( 'agent-2' ) ] } )
 		);
 		rerender( chat() );
 
 		// Regenerate again: the picker disappears once more while streaming.
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage ], isProcessing: true } )
+		);
 		rerender( chat() );
 
-		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
-			content?: Array< { text?: string } >;
-		} >;
-		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+		expect( countShowComponentMessages() ).toBe( 1 );
 	} );
-
 	it( 'does not retain the live show-component message when the history is replaced', () => {
 		// The same picker serializes differently live (no tool_call_id) and in
 		// loaded history (with tool_call_id), so their identities never match.
 		// Server hydration replaces the whole history with freshly-id'd messages;
 		// that swap must not resurrect the live copy as a retained duplicate.
-		const pickerMessage = ( id: string, content: Record< string, unknown > ) => ( {
-			id,
-			role: 'agent',
-			content: [ { type: 'text', text: JSON.stringify( content ) } ],
-			timestamp: 1,
-			archived: false,
-			showIcon: true,
-		} );
-		const livePicker = pickerMessage( 'agent-live', {
-			tool_id: 'big_sky__show_component',
-			data: { type: 'titlePicker', summary: 'Optimize title' },
-		} );
-		const loadedPicker = pickerMessage( 'agent-loaded', {
-			tool_id: 'big_sky__show_component',
-			tool_call_id: 'title-picker-call',
-			data: { type: 'titlePicker', summary: 'Optimize title' },
-		} );
-		const userMessage = {
-			id: 'user-1',
-			role: 'user',
-			content: [ { type: 'text', text: 'Optimize the title' } ],
-			timestamp: 0,
-			archived: false,
-			showIcon: true,
-		};
-		const agentChatReturn = ( messages: unknown[] ) => ( {
-			addMessage: jest.fn(),
-			messages,
-			suggestions: [],
-			isProcessing: false,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			getRegenerateHandler: jest.fn(),
-			progressMessage: null,
-		} );
-		const countShowComponentMessages = (
-			messages: Array< { content?: Array< { text?: string } > } >
-		) =>
-			messages.filter( ( message ) => {
-				const text = message?.content?.[ 0 ]?.text;
-				if ( typeof text !== 'string' ) {
-					return false;
-				}
-				try {
-					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
-				} catch ( _error ) {
-					return false;
-				}
-			} ).length;
-		const chat = () => (
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				onHasMessagesChange={ jest.fn() }
-			/>
+		const livePicker = showComponentMessage(
+			'agent-live',
+			JSON.stringify( {
+				tool_id: 'big_sky__show_component',
+				data: { type: 'titlePicker', summary: 'Optimize title' },
+			} )
 		);
 
 		// Seeded from storage: the live-form picker is showing.
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage, livePicker ] ) );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, livePicker ] } )
+		);
 		const { rerender } = render( chat() );
 
 		// Server hydration replaces the whole history; every loaded message gets
 		// a fresh id, including the echoed user message.
 		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( [ { ...userMessage, id: 'user-loaded' }, loadedPicker ] )
+			agentChatReturn( {
+				messages: [ { ...userMessage, id: 'user-loaded' }, showComponentMessage( 'agent-loaded' ) ],
+			} )
 		);
 		rerender( chat() );
 
-		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
-			content?: Array< { text?: string } >;
-		} >;
-		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+		expect( countShowComponentMessages() ).toBe( 1 );
 	} );
-
 	it( 'hides the previous component while a regeneration is processing', async () => {
-		const showComponentContent = JSON.stringify( {
-			tool_id: 'big_sky__show_component',
-			tool_call_id: 'title-picker-call',
-			data: { type: 'titlePicker', summary: 'Optimize title' },
-		} );
-		const userMessage = {
-			id: 'user-1',
-			role: 'user',
-			content: [ { type: 'text', text: 'Optimize the title' } ],
-			timestamp: 0,
-			archived: false,
-			showIcon: true,
-		};
-		const showComponentMessage = ( id: string ) => ( {
-			id,
-			role: 'agent',
-			content: [ { type: 'text', text: showComponentContent } ],
-			timestamp: 1,
-			archived: false,
-			showIcon: true,
-		} );
-		const agentChatReturn = ( messages: unknown[], isProcessing: boolean ) => ( {
-			addMessage: jest.fn(),
-			messages,
-			suggestions: [],
-			isProcessing,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			// Mirror production: agenttic hands back a real regenerate handler for
-			// the completed latest turn.
-			getRegenerateHandler: jest.fn( () => jest.fn() ),
-			progressMessage: null,
-		} );
-		const countShowComponentMessages = (
-			messages: Array< { content?: Array< { text?: string } > } >
-		) =>
-			messages.filter( ( message ) => {
-				const text = message?.content?.[ 0 ]?.text;
-				if ( typeof text !== 'string' ) {
-					return false;
-				}
-				try {
-					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
-				} catch ( _error ) {
-					return false;
-				}
-			} ).length;
-		const chat = () => (
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				capabilities={ { supportsRegenerateAction: true } }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
-
 		// Steady state: the picker is showing for the completed turn.
 		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( [ userMessage, showComponentMessage( 'agent-1' ) ], false )
+			agentChatReturn( { messages: [ userMessage, showComponentMessage( 'agent-1' ) ] } )
 		);
 		const { rerender } = render( chat() );
 
@@ -950,85 +582,17 @@ describe( 'OrchestratorChat', () => {
 
 		// agenttic rewinds the turn and streams the new response; the old picker is
 		// gone from the live messages while it processes.
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage ], isProcessing: true } )
+		);
 		rerender( chat() );
 
-		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
-			content?: Array< { text?: string } >;
-		} >;
-		expect( countShowComponentMessages( lastMessages ) ).toBe( 0 );
+		expect( countShowComponentMessages() ).toBe( 0 );
 	} );
-
 	it( 'restores component retention after a regeneration finishes', async () => {
-		const showComponentContent = JSON.stringify( {
-			tool_id: 'big_sky__show_component',
-			tool_call_id: 'title-picker-call',
-			data: { type: 'titlePicker', summary: 'Optimize title' },
-		} );
-		const userMessage = {
-			id: 'user-1',
-			role: 'user',
-			content: [ { type: 'text', text: 'Optimize the title' } ],
-			timestamp: 0,
-			archived: false,
-			showIcon: true,
-		};
-		const showComponentMessage = ( id: string ) => ( {
-			id,
-			role: 'agent',
-			content: [ { type: 'text', text: showComponentContent } ],
-			timestamp: 1,
-			archived: false,
-			showIcon: true,
-		} );
-		const agentChatReturn = ( messages: unknown[], isProcessing: boolean ) => ( {
-			addMessage: jest.fn(),
-			messages,
-			suggestions: [],
-			isProcessing,
-			error: null,
-			loadMessages: jest.fn(),
-			onSubmit: jest.fn(),
-			abortCurrentRequest: jest.fn(),
-			clearSuggestions: jest.fn(),
-			registerSuggestions: jest.fn(),
-			registerMessageActions: jest.fn(),
-			getRegenerateHandler: jest.fn( () => jest.fn() ),
-			progressMessage: null,
-		} );
-		const countShowComponentMessages = (
-			messages: Array< { content?: Array< { text?: string } > } >
-		) =>
-			messages.filter( ( message ) => {
-				const text = message?.content?.[ 0 ]?.text;
-				if ( typeof text !== 'string' ) {
-					return false;
-				}
-				try {
-					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
-				} catch ( _error ) {
-					return false;
-				}
-			} ).length;
-		const chat = () => (
-			<OrchestratorChat
-				emptyViewSuggestions={ [] }
-				isDocked={ false }
-				isOpen
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				chatHeaderOptions={ [] }
-				markdownComponents={ {} }
-				markdownExtensions={ {} }
-				isCompactMode={ false }
-				capabilities={ { supportsRegenerateAction: true } }
-				onHasMessagesChange={ jest.fn() }
-			/>
-		);
-
 		// Steady state, then a full regeneration cycle.
 		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( [ userMessage, showComponentMessage( 'agent-1' ) ], false )
+			agentChatReturn( { messages: [ userMessage, showComponentMessage( 'agent-1' ) ] } )
 		);
 		const { rerender } = render( chat() );
 
@@ -1041,21 +605,22 @@ describe( 'OrchestratorChat', () => {
 		} );
 
 		// Regeneration streams, then settles with the fresh component.
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage ], isProcessing: true } )
+		);
 		rerender( chat() );
 		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( [ userMessage, showComponentMessage( 'agent-2' ) ], false )
+			agentChatReturn( { messages: [ userMessage, showComponentMessage( 'agent-2' ) ] } )
 		);
 		rerender( chat() );
 
 		// A later turn (not a regeneration) transiently drops the component —
-		// retention should cover it again now the flag has cleared.
-		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		// retention should cover it again now the regeneration has settled.
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage ], isProcessing: true } )
+		);
 		rerender( chat() );
 
-		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
-			content?: Array< { text?: string } >;
-		} >;
-		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+		expect( countShowComponentMessages() ).toBe( 1 );
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -88,7 +88,10 @@ jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
 } ) );
-jest.mock( '../../hooks/use-conversation', () => () => mockUseConversation() );
+jest.mock(
+	'../../hooks/use-conversation',
+	() => ( config: unknown ) => mockUseConversation( config )
+);
 jest.mock( '../../hooks/use-save-new-chat-route', () => () => {} );
 jest.mock( '../../hooks/use-checkpoint-action', () => () => {} );
 jest.mock( '../../hooks/use-feedback-action', () => () => ( {
@@ -764,6 +767,102 @@ describe( 'OrchestratorChat', () => {
 
 		// Regenerate again: the picker disappears once more while streaming.
 		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		rerender( chat() );
+
+		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			content?: Array< { text?: string } >;
+		} >;
+		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+	} );
+
+	it( 'does not retain the live show-component message when the history is replaced', () => {
+		// The same picker serializes differently live (no tool_call_id) and in
+		// loaded history (with tool_call_id), so their identities never match.
+		// Replacing the history via loadMessages must not resurrect the live copy.
+		const pickerMessage = ( id: string, content: Record< string, unknown > ) => ( {
+			id,
+			role: 'agent',
+			content: [ { type: 'text', text: JSON.stringify( content ) } ],
+			timestamp: 1,
+			archived: false,
+			showIcon: true,
+		} );
+		const livePicker = pickerMessage( 'agent-live', {
+			tool_id: 'big_sky__show_component',
+			data: { type: 'titlePicker', summary: 'Optimize title' },
+		} );
+		const loadedPicker = pickerMessage( 'agent-loaded', {
+			tool_id: 'big_sky__show_component',
+			tool_call_id: 'title-picker-call',
+			data: { type: 'titlePicker', summary: 'Optimize title' },
+		} );
+		const userMessage = {
+			id: 'user-1',
+			role: 'user',
+			content: [ { type: 'text', text: 'Optimize the title' } ],
+			timestamp: 0,
+			archived: false,
+			showIcon: true,
+		};
+		const agentChatReturn = ( messages: unknown[] ) => ( {
+			addMessage: jest.fn(),
+			messages,
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			getRegenerateHandler: jest.fn(),
+			progressMessage: null,
+		} );
+		const countShowComponentMessages = (
+			messages: Array< { content?: Array< { text?: string } > } >
+		) =>
+			messages.filter( ( message ) => {
+				const text = message?.content?.[ 0 ]?.text;
+				if ( typeof text !== 'string' ) {
+					return false;
+				}
+				try {
+					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
+				} catch ( _error ) {
+					return false;
+				}
+			} ).length;
+		const chat = () => (
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		let hydrate: ( ( messages: unknown[], sessionId: string ) => void ) | undefined;
+		mockUseConversation.mockImplementation(
+			( config?: { onSuccess?: ( messages: unknown[], sessionId: string ) => void } ) => {
+				hydrate = config?.onSuccess;
+				return { isLoading: false };
+			}
+		);
+
+		// Seeded from storage: the live-form picker is showing.
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage, livePicker ] ) );
+		const { rerender } = render( chat() );
+
+		// Server hydration replaces the whole history with the loaded form.
+		act( () => hydrate?.( [], 'session-id' ) );
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage, loadedPicker ] ) );
 		rerender( chat() );
 
 		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -210,7 +210,7 @@ export default function OrchestratorChat( {
 		suggestions,
 		isProcessing,
 		error,
-		loadMessages: loadAgentMessages,
+		loadMessages,
 		onSubmit,
 		abortCurrentRequest,
 		clearSuggestions,
@@ -224,8 +224,15 @@ export default function OrchestratorChat( {
 	const showComponentOrderRef = useRef< Map< string, number > >( new Map() );
 	const nextShowComponentOrderRef = useRef( 0 );
 	const wasProcessingRef = useRef( isProcessing );
-	const skipRetentionRef = useRef( false );
 	messagesRef.current = messages;
+
+	// Drop all retained placeholders, keeping the map reference stable when
+	// already empty so no re-render is triggered.
+	const clearRetainedShowComponentMessages = useCallback( () => {
+		setRetainedShowComponentMessages( ( previousRetainedMessages ) =>
+			previousRetainedMessages.size > 0 ? new Map() : previousRetainedMessages
+		);
+	}, [] );
 
 	// A regeneration is finished once its streaming turn settles — either the new
 	// response arrives or an error restores the previous one. Re-enable component
@@ -253,13 +260,11 @@ export default function OrchestratorChat( {
 				// Drop any retained placeholders up front; the turn is being
 				// rewound, so a leftover picker would otherwise reappear once
 				// regeneration settles if the new response omits the component.
-				setRetainedShowComponentMessages( ( previousRetainedMessages ) =>
-					previousRetainedMessages.size > 0 ? new Map() : previousRetainedMessages
-				);
+				clearRetainedShowComponentMessages();
 				await handler();
 			};
 		},
-		[ getRegenerateHandler ]
+		[ clearRetainedShowComponentMessages, getRegenerateHandler ]
 	);
 
 	const getShowComponentOrder = useCallback( ( message: UIMessage ): number | undefined => {
@@ -279,17 +284,28 @@ export default function OrchestratorChat( {
 	}, [] );
 
 	useEffect( () => {
+		const previousMessages = previousMessagesRef.current;
+
+		// A full history replacement (server hydration, clearing the chat) swaps
+		// every message id at once. Nothing in it was transiently dropped, and
+		// the same picker can carry a different identity in loaded history than
+		// it did live — retaining across the swap would show it as a duplicate.
+		const previousMessageIds = new Set( previousMessages.map( ( message ) => message.id ) );
+		const isHistoryReplaced =
+			previousMessages.length > 0 &&
+			! messages.some( ( message ) => previousMessageIds.has( message.id ) );
+
 		// While regenerating, the dropped component is being replaced, not lost —
-		// don't retain it. A full history replacement (`loadMessages`) likewise
-		// drops nothing transiently. Keep the ref current so the next run
-		// compares against the latest messages.
-		if ( isRegenerating || skipRetentionRef.current ) {
-			skipRetentionRef.current = false;
+		// don't retain it either. Keep the ref current so the next run compares
+		// against the latest messages.
+		if ( isRegenerating || isHistoryReplaced ) {
+			if ( isHistoryReplaced ) {
+				clearRetainedShowComponentMessages();
+			}
 			previousMessagesRef.current = messages;
 			return;
 		}
 
-		const previousMessages = previousMessagesRef.current;
 		messages.filter( isShowComponentMessage ).forEach( getShowComponentOrder );
 
 		const currentShowComponentIdentities = new Set(
@@ -321,23 +337,7 @@ export default function OrchestratorChat( {
 		}
 
 		previousMessagesRef.current = messages;
-	}, [ getShowComponentOrder, messages, isRegenerating ] );
-
-	// A full history replacement (server hydration, clearing the chat) is not
-	// a transient drop, and the same picker can carry a different identity in
-	// loaded history than it did live — retaining the live copy would show it
-	// as a duplicate. Skip the next retention pass and drop any retained
-	// placeholders instead.
-	const loadMessages = useCallback(
-		( nextMessages: Parameters< typeof loadAgentMessages >[ 0 ] ) => {
-			skipRetentionRef.current = true;
-			setRetainedShowComponentMessages( ( previousRetainedMessages ) =>
-				previousRetainedMessages.size > 0 ? new Map() : previousRetainedMessages
-			);
-			return loadAgentMessages( nextMessages );
-		},
-		[ loadAgentMessages ]
-	);
+	}, [ clearRetainedShowComponentMessages, getShowComponentOrder, messages, isRegenerating ] );
 
 	// Reader-chat sessions are short (usually < 50 messages) — don't waste
 	// time paginating 10 pages deep. One page covers typical use.

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -723,7 +723,6 @@ export default function OrchestratorChat( {
 			messages: currentMessages,
 			getChatComponent,
 			currentPostId,
-			onSubmit: onSubmitWithImages,
 		} );
 
 		const latestAgentMessageId = getLatestAgentMessageId( currentMessages );
@@ -772,7 +771,6 @@ export default function OrchestratorChat( {
 		isBuildingSite,
 		isProcessing,
 		messages,
-		onSubmitWithImages,
 		retainedShowComponentMessages,
 		siteBuildUtils,
 		thinkingMessage,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -210,7 +210,7 @@ export default function OrchestratorChat( {
 		suggestions,
 		isProcessing,
 		error,
-		loadMessages,
+		loadMessages: loadAgentMessages,
 		onSubmit,
 		abortCurrentRequest,
 		clearSuggestions,
@@ -224,6 +224,7 @@ export default function OrchestratorChat( {
 	const showComponentOrderRef = useRef< Map< string, number > >( new Map() );
 	const nextShowComponentOrderRef = useRef( 0 );
 	const wasProcessingRef = useRef( isProcessing );
+	const skipRetentionRef = useRef( false );
 	messagesRef.current = messages;
 
 	// A regeneration is finished once its streaming turn settles — either the new
@@ -279,9 +280,11 @@ export default function OrchestratorChat( {
 
 	useEffect( () => {
 		// While regenerating, the dropped component is being replaced, not lost —
-		// don't retain it. Keep the ref current so the next non-regenerating run
-		// compares against the post-regeneration messages.
-		if ( isRegenerating ) {
+		// don't retain it. A full history replacement (`loadMessages`) likewise
+		// drops nothing transiently. Keep the ref current so the next run
+		// compares against the latest messages.
+		if ( isRegenerating || skipRetentionRef.current ) {
+			skipRetentionRef.current = false;
 			previousMessagesRef.current = messages;
 			return;
 		}
@@ -319,6 +322,22 @@ export default function OrchestratorChat( {
 
 		previousMessagesRef.current = messages;
 	}, [ getShowComponentOrder, messages, isRegenerating ] );
+
+	// A full history replacement (server hydration, clearing the chat) is not
+	// a transient drop, and the same picker can carry a different identity in
+	// loaded history than it did live — retaining the live copy would show it
+	// as a duplicate. Skip the next retention pass and drop any retained
+	// placeholders instead.
+	const loadMessages = useCallback(
+		( nextMessages: Parameters< typeof loadAgentMessages >[ 0 ] ) => {
+			skipRetentionRef.current = true;
+			setRetainedShowComponentMessages( ( previousRetainedMessages ) =>
+				previousRetainedMessages.size > 0 ? new Map() : previousRetainedMessages
+			);
+			return loadAgentMessages( nextMessages );
+		},
+		[ loadAgentMessages ]
+	);
 
 	// Reader-chat sessions are short (usually < 50 messages) — don't waste
 	// time paginating 10 pages deep. One page covers typical use.

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -27,13 +27,8 @@ import {
 import type { UIMessage } from '@automattic/agenttic-client';
 
 const MockComponent = jest.fn();
-const mockOnSubmit = jest.fn();
 const SHOW_COMPONENT_TOOL_ID = JETPACK_AI_SHOW_COMPONENT_TOOL_ID;
 const LEGACY_SHOW_COMPONENT_TOOL_ID = BIG_SKY_SHOW_COMPONENT_TOOL_ID;
-
-const convertWithDefaults = (
-	options: Omit< Parameters< typeof convertToolMessagesToComponents >[ 0 ], 'onSubmit' >
-) => convertToolMessagesToComponents( { ...options, onSubmit: mockOnSubmit } );
 
 const createMessage = ( overrides: Partial< UIMessage > = {} ): UIMessage =>
 	( {
@@ -61,7 +56,7 @@ describe( 'convertToolMessagesToComponents', () => {
 	it( 'passes through user messages unchanged', () => {
 		const message = createMessage( { role: 'user' } );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -73,7 +68,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			content: [ { type: 'text', text: 'Hello, how can I help?' } ],
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -86,7 +81,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			context: { flags: { context_only: true } },
 		} as Partial< UIMessage > );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -98,7 +93,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			content: [ { type: 'context', text: 'This is only context for the model.' } ],
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -113,7 +108,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			],
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -129,7 +124,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -158,7 +153,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -179,7 +174,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -193,7 +188,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( null );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -208,7 +203,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		] as UIMessage[ 'actions' ];
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [
 				createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, data, { id: 'msg-1', actions } ),
 				createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, data, { id: 'msg-2', actions } ),
@@ -226,7 +221,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		( isEditorPage as jest.Mock ).mockReturnValue( false );
 		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, { type: 'my-component' } );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -243,7 +238,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			assistantId: 'big-sky-site-admin',
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -259,7 +254,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		const supportText = 'Here is some help for your domain question.';
 		const message = createToolMessage( 'big_sky__wordpress_com_support', supportText );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -277,7 +272,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			calypsoCheckpointId: 'checkpoint-1',
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -299,7 +294,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			},
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -316,7 +311,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			summary: 'Tried to update the header, but it did not stick.',
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -330,7 +325,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			isCurrent: true,
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -350,7 +345,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			returnToAgent: true,
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -367,7 +362,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			summary: 'Updated the header and footer.',
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -394,7 +389,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		);
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ intermediateMessage, finalMessage ],
 			getChatComponent,
 		} );
@@ -415,7 +410,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			},
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -437,7 +432,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			],
 		} );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
 
@@ -452,7 +447,7 @@ describe( 'convertToolMessagesToComponents', () => {
 	} );
 
 	it( 'filters out unhandled tool messages', () => {
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ createToolMessage( 'other_tool' ) ],
 		} );
 
@@ -472,7 +467,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ toolMessage, prose ],
 			getChatComponent,
 		} );
@@ -492,7 +487,7 @@ describe( 'convertToolMessagesToComponents', () => {
 			{ id: 'tool-1' }
 		);
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ prose, toolMessage ],
 		} );
 
@@ -518,7 +513,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ toolMessage, userMessage, prose ],
 			getChatComponent,
 		} );
@@ -536,7 +531,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -553,7 +548,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -572,7 +567,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 			currentPostId: 20,
@@ -591,7 +586,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 			currentPostId: 20,
@@ -611,7 +606,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 			currentPostId: 10,
@@ -628,7 +623,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 			currentPostId: 20,
@@ -646,7 +641,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 			getChatComponent,
 		} );
@@ -664,7 +659,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		const userReply = createMessage( { id: 'user-1', role: 'user' } );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ toolMessage, userReply ],
 			getChatComponent,
 		} );
@@ -684,7 +679,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ toolMessage, agentFollowUp ],
 			getChatComponent,
 		} );
@@ -705,7 +700,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-		const result = convertWithDefaults( {
+		const result = convertToolMessagesToComponents( {
 			messages: [ toolMessage, contextMessage ],
 			getChatComponent,
 		} );

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -654,4 +654,62 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
 	} );
+
+	it( 'disables the picker once the user replies after it', () => {
+		const toolMessage = createToolMessage(
+			LEGACY_SHOW_COMPONENT_TOOL_ID,
+			{ type: 'my-component', isCurrent: true },
+			{ id: 'tool-1' }
+		);
+		const userReply = createMessage( { id: 'user-1', role: 'user' } );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolMessage, userReply ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ] ).toMatchObject( { disabled: true } );
+	} );
+
+	it( 'keeps the picker enabled when only agent messages follow it', () => {
+		const toolMessage = createToolMessage(
+			LEGACY_SHOW_COMPONENT_TOOL_ID,
+			{ type: 'my-component', isCurrent: true },
+			{ id: 'tool-1' }
+		);
+		const agentFollowUp = createMessage( {
+			id: 'agent-1',
+			content: [ { type: 'text', text: 'Anything else?' } ],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolMessage, agentFollowUp ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
+	} );
+
+	it( 'does not treat a context-only user message as a reply', () => {
+		const toolMessage = createToolMessage(
+			LEGACY_SHOW_COMPONENT_TOOL_ID,
+			{ type: 'my-component', isCurrent: true },
+			{ id: 'tool-1' }
+		);
+		const contextMessage = createMessage( {
+			id: 'context-1',
+			role: 'user',
+			content: [ { type: 'context', text: 'hidden continuation' } ],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolMessage, contextMessage ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
+	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -75,39 +75,30 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [ message ] );
 	} );
 
-	it( 'filters out context-only messages', () => {
-		const message = createMessage( {
-			content: [ { type: 'text', text: 'This is only context for the model.' } ],
-			context: { flags: { context_only: true } },
-		} as Partial< UIMessage > );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toEqual( [] );
-	} );
-
-	it( 'filters out messages transformed to context content', () => {
-		const message = createMessage( {
-			content: [ { type: 'context', text: 'This is only context for the model.' } ],
-		} );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toEqual( [] );
-	} );
-
-	it( 'filters out messages with context-only data flags', () => {
-		const message = createMessage( {
-			content: [
-				{ type: 'text', text: 'This is only context for the model.' },
-				{ type: 'data', data: { flags: { context_only: true } } },
-			],
-		} );
-
+	it.each( [
+		{
+			name: 'context flags',
+			message: createMessage( {
+				content: [ { type: 'text', text: 'This is only context for the model.' } ],
+				context: { flags: { context_only: true } },
+			} as Partial< UIMessage > ),
+		},
+		{
+			name: 'context content',
+			message: createMessage( {
+				content: [ { type: 'context', text: 'This is only context for the model.' } ],
+			} ),
+		},
+		{
+			name: 'context-only data flags',
+			message: createMessage( {
+				content: [
+					{ type: 'text', text: 'This is only context for the model.' },
+					{ type: 'data', data: { flags: { context_only: true } } },
+				],
+			} ),
+		},
+	] )( 'filters out messages with $name', ( { message } ) => {
 		const result = convertToolMessagesToComponents( {
 			messages: [ message ],
 		} );
@@ -166,6 +157,24 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
+	it( 'omits the summary text when the summary is blank', () => {
+		const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
+			type: 'my-component',
+			summary: '   ',
+			isCurrent: true,
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertToolMessagesToComponents( {
+			messages: [ message ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ].content ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( { type: 'component' } );
+		expect( result[ 0 ].content[ 0 ].componentProps.summary ).toBeUndefined();
+	} );
+
 	it( 'does not suppress the thinking indicator for component messages with follow-up tasks', () => {
 		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
 			type: 'my-component',
@@ -196,7 +205,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [] );
 	} );
 
-	it( 'does not append a move-to-next-step button for active messages with follow-up tasks', () => {
+	it( 'renders consecutive follow-up pickers as components', () => {
 		const data = { type: 'my-component', followUpTasks: true, isCurrent: true };
 		const actions = [
 			{ id: 'action-1', label: 'Do something', onClick: jest.fn() },
@@ -250,58 +259,74 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
-	it( 'renders support tool data as plain text', () => {
-		const supportText = 'Here is some help for your domain question.';
-		const message = createToolMessage( 'big_sky__wordpress_com_support', supportText );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			type: 'text',
-			text: supportText,
-		} );
-	} );
-
-	it( 'renders apply-block-edits tool summary as plain text', () => {
-		const summaryText = 'Updated the heading and added a new paragraph.';
-		const message = createToolMessage( 'big_sky__apply_block_edits', {
-			summary: summaryText,
-			calypsoCheckpointId: 'checkpoint-1',
-		} );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			type: 'text',
-			text: summaryText,
-		} );
-	} );
-
-	it( 'renders apply-block-edits structured result message as plain text', () => {
-		const message = createToolMessage( 'big_sky__apply_block_edits', {
-			result: {
-				success: true,
-				message: 'Updated the header and footer.',
-				details: {
-					changes: { added: [], removed: [], modified: [] },
+	it.each( [
+		{
+			name: 'support tool text',
+			toolId: 'big_sky__wordpress_com_support',
+			data: 'Here is some help for your domain question.',
+			expected: 'Here is some help for your domain question.',
+		},
+		{
+			name: 'apply-block-edits summary',
+			toolId: 'big_sky__apply_block_edits',
+			data: {
+				summary: 'Updated the heading and added a new paragraph.',
+				calypsoCheckpointId: 'checkpoint-1',
+			},
+			expected: 'Updated the heading and added a new paragraph.',
+		},
+		{
+			name: 'apply-block-edits structured result',
+			toolId: 'big_sky__apply_block_edits',
+			data: {
+				result: {
+					success: true,
+					message: 'Updated the header and footer.',
+					details: {
+						changes: { added: [], removed: [], modified: [] },
+					},
 				},
 			},
-		} );
-
+			expected: 'Updated the header and footer.',
+		},
+		{
+			name: 'stream-page-design summary',
+			toolId: 'big_sky__stream_page_design',
+			data: {
+				summary: 'A bold hero with three airy feature sections in the theme accent colors.',
+				isCurrent: true,
+			},
+			expected: 'A bold hero with three airy feature sections in the theme accent colors.',
+		},
+		{
+			name: 'stream-page-design structured result',
+			toolId: 'big_sky__stream_page_design',
+			data: {
+				result: {
+					success: true,
+					message: 'The generated page content has been staged in the editor for review.',
+				},
+				returnToAgent: true,
+			},
+			expected: 'The generated page content has been staged in the editor for review.',
+		},
+		{
+			name: 'update-theme structured result',
+			toolId: 'big_sky__apply_update_theme',
+			data: {
+				result: { success: true, message: 'Updated the color palette.' },
+			},
+			expected: 'Updated the color palette.',
+		},
+	] )( 'renders $name as plain text', ( { toolId, data, expected } ) => {
 		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
+			messages: [ createToolMessage( toolId, data ) ],
 		} );
 
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
 			type: 'text',
-			text: 'Updated the header and footer.',
+			text: expected,
 		} );
 	} );
 
@@ -316,44 +341,6 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 
 		expect( result ).toEqual( [] );
-	} );
-
-	it( 'renders stream-page-design tool summary as plain text', () => {
-		const summaryText = 'A bold hero with three airy feature sections in the theme accent colors.';
-		const message = createToolMessage( 'big_sky__stream_page_design', {
-			summary: summaryText,
-			isCurrent: true,
-		} );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			type: 'text',
-			text: summaryText,
-		} );
-	} );
-
-	it( 'renders stream-page-design structured result message as plain text', () => {
-		const message = createToolMessage( 'big_sky__stream_page_design', {
-			result: {
-				success: true,
-				message: 'The generated page content has been staged in the editor for review.',
-			},
-			returnToAgent: true,
-		} );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			type: 'text',
-			text: 'The generated page content has been staged in the editor for review.',
-		} );
 	} );
 
 	it( 'suppresses transient thinking for converted apply-block-edits messages', () => {
@@ -399,25 +386,6 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
 			type: 'text',
 			text: 'Pick a blue palette.',
-		} );
-	} );
-
-	it( 'renders update-theme structured result message as plain text', () => {
-		const message = createToolMessage( 'big_sky__apply_update_theme', {
-			result: {
-				success: true,
-				message: 'Updated the color palette.',
-			},
-		} );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			type: 'text',
-			text: 'Updated the color palette.',
 		} );
 	} );
 
@@ -524,187 +492,88 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result.map( ( m ) => m.id ) ).toEqual( [ 'tool-1', 'user-1', 'prose-1' ] );
 	} );
 
-	it( 'disables component when `isCurrent` is false', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			isCurrent: false,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ] ).toMatchObject( { disabled: true } );
-	} );
-
-	it( 'does not append `NextStepButton` when `isCurrent` is false', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			followUpTasks: true,
-			isCurrent: false,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			component: MockComponent,
-		} );
-	} );
-
-	it( 'disables component when `postId` differs from `currentPostId`', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			isCurrent: true,
-			postId: 10,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
+	const stalenessCases: Array< {
+		name: string;
+		data: Record< string, unknown >;
+		currentPostId?: number;
+		laterMessages?: UIMessage[];
+		disabled: boolean;
+	} > = [
+		{
+			name: 'is disabled when `isCurrent` is false',
+			data: { type: 'my-component', isCurrent: false },
+			disabled: true,
+		},
+		{
+			name: 'is disabled when `postId` differs from `currentPostId`',
+			data: { type: 'my-component', isCurrent: true, postId: 10 },
 			currentPostId: 20,
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ] ).toMatchObject( { disabled: true } );
-	} );
-
-	it( 'does not append `NextStepButton` when `postId` differs from `currentPostId`', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			followUpTasks: true,
-			isCurrent: true,
-			postId: 10,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
-			currentPostId: 20,
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-			component: MockComponent,
-		} );
-	} );
-
-	it( 'does not disable component when `postId` matches `currentPostId`', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			isCurrent: true,
-			postId: 10,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
+			disabled: true,
+		},
+		{
+			name: 'stays enabled when `postId` matches `currentPostId`',
+			data: { type: 'my-component', isCurrent: true, postId: 10 },
 			currentPostId: 10,
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
-	} );
-
-	it( 'does not disable component when `postId` is missing from the tool message', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			isCurrent: true,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
+			disabled: false,
+		},
+		{
+			name: 'stays enabled when `postId` is missing from the tool message',
+			data: { type: 'my-component', isCurrent: true },
 			currentPostId: 20,
-		} );
+			disabled: false,
+		},
+		{
+			name: 'stays enabled when `currentPostId` is undefined',
+			data: { type: 'my-component', isCurrent: true, postId: 10 },
+			disabled: false,
+		},
+		{
+			name: 'is disabled once the user replies after it',
+			data: { type: 'my-component', isCurrent: true },
+			laterMessages: [ createMessage( { id: 'user-1', role: 'user' } ) ],
+			disabled: true,
+		},
+		{
+			name: 'stays enabled when only agent messages follow it',
+			data: { type: 'my-component', isCurrent: true },
+			laterMessages: [
+				createMessage( {
+					id: 'agent-1',
+					content: [ { type: 'text', text: 'Anything else?' } ],
+				} ),
+			],
+			disabled: false,
+		},
+		{
+			name: 'stays enabled when only a context-only user message follows it',
+			data: { type: 'my-component', isCurrent: true },
+			laterMessages: [
+				createMessage( {
+					id: 'context-1',
+					role: 'user',
+					content: [ { type: 'context', text: 'hidden continuation' } ],
+				} ),
+			],
+			disabled: false,
+		},
+	];
 
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
-	} );
+	it.each( stalenessCases )(
+		'the picker $name',
+		( { data, currentPostId, laterMessages = [], disabled } ) => {
+			const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
-	it( 'does not disable component when `currentPostId` is undefined', () => {
-		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			isCurrent: true,
-			postId: 10,
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+			const result = convertToolMessagesToComponents( {
+				messages: [
+					createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, data, { id: 'tool-1' } ),
+					...laterMessages,
+				],
+				getChatComponent,
+				currentPostId,
+			} );
 
-		const result = convertToolMessagesToComponents( {
-			messages: [ message ],
-			getChatComponent,
-		} );
-
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
-	} );
-
-	it( 'disables the picker once the user replies after it', () => {
-		const toolMessage = createToolMessage(
-			LEGACY_SHOW_COMPONENT_TOOL_ID,
-			{ type: 'my-component', isCurrent: true },
-			{ id: 'tool-1' }
-		);
-		const userReply = createMessage( { id: 'user-1', role: 'user' } );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ toolMessage, userReply ],
-			getChatComponent,
-		} );
-
-		expect( result[ 0 ] ).toMatchObject( { disabled: true } );
-	} );
-
-	it( 'keeps the picker enabled when only agent messages follow it', () => {
-		const toolMessage = createToolMessage(
-			LEGACY_SHOW_COMPONENT_TOOL_ID,
-			{ type: 'my-component', isCurrent: true },
-			{ id: 'tool-1' }
-		);
-		const agentFollowUp = createMessage( {
-			id: 'agent-1',
-			content: [ { type: 'text', text: 'Anything else?' } ],
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ toolMessage, agentFollowUp ],
-			getChatComponent,
-		} );
-
-		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
-	} );
-
-	it( 'does not treat a context-only user message as a reply', () => {
-		const toolMessage = createToolMessage(
-			LEGACY_SHOW_COMPONENT_TOOL_ID,
-			{ type: 'my-component', isCurrent: true },
-			{ id: 'tool-1' }
-		);
-		const contextMessage = createMessage( {
-			id: 'context-1',
-			role: 'user',
-			content: [ { type: 'context', text: 'hidden continuation' } ],
-		} );
-		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
-
-		const result = convertToolMessagesToComponents( {
-			messages: [ toolMessage, contextMessage ],
-			getChatComponent,
-		} );
-
-		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
-	} );
+			expect( result[ 0 ] ).toMatchObject( { disabled } );
+			expect( result[ 0 ].content[ 0 ] ).toMatchObject( { component: MockComponent } );
+		}
+	);
 } );

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -4,7 +4,7 @@ import { isEditorPage } from './is-editor-page';
 import { isShowComponentTool } from './show-component-tools';
 import { getDisplayMessageFromToolData, isDisplayableToolMessageTool } from './tool-message-utils';
 import type { GetChatComponent } from './load-external-providers';
-import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
+import type { UIMessage } from '@automattic/agenttic-client';
 
 export type AgentsManagerUIMessage = UIMessage & {
 	disabled?: boolean;
@@ -16,7 +16,6 @@ interface Options {
 	messages: UIMessage[];
 	getChatComponent?: GetChatComponent;
 	currentPostId?: number;
-	onSubmit: UseAgentChatReturn[ 'onSubmit' ];
 }
 
 type MessageWithContextFlags = UIMessage & {

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -202,11 +202,20 @@ export default function convertToolMessagesToComponents( {
 			const summaryText =
 				typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
 
+			// A picker only stays interactive until the user replies past it — after
+			// that it documents a previous step. Hidden context messages (e.g.
+			// navigation continuations) are not real replies.
+			const hasUserReplied = array
+				.slice( index + 1 )
+				.some(
+					( laterMessage ) => laterMessage.role === 'user' && ! isContextOnlyMessage( laterMessage )
+				);
+
 			// In the site editor, React-Query caching keeps past conversations alive when the
 			// user navigates to a different page. Compare the picker's `postId` with the
 			// current editor page to disable pickers that no longer belong to this page.
 			const isPageChanged = !! postId && !! currentPostId && postId !== currentPostId;
-			const isStale = ! isCurrent || isPageChanged;
+			const isStale = hasUserReplied || ! isCurrent || isPageChanged;
 
 			const componentMessage: AgentsManagerUIMessage = {
 				...message,

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -54,7 +54,7 @@ function getShowComponentSummary( message: UIMessage ): string | undefined {
 		}
 
 		const summary = parsed?.data?.summary;
-		return typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
+		return typeof summary === 'string' ? summary.trim() || undefined : undefined;
 	} catch ( _error ) {
 		return undefined;
 	}
@@ -198,8 +198,7 @@ export default function convertToolMessagesToComponents( {
 				return [];
 			}
 
-			const summaryText =
-				typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
+			const summaryText = typeof summary === 'string' ? summary.trim() || undefined : undefined;
 
 			// A picker only stays interactive until the user replies past it — after
 			// that it documents a previous step. Hidden context messages (e.g.

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -6,11 +6,11 @@ import { getDisplayMessageFromToolData, isDisplayableToolMessageTool } from './t
 import type { GetChatComponent } from './load-external-providers';
 import type { UIMessage } from '@automattic/agenttic-client';
 
-export type AgentsManagerUIMessage = UIMessage & {
+export interface AgentsManagerUIMessage extends UIMessage {
 	disabled?: boolean;
 	/** Suppress Agenttic's transient thinking indicator while this message is the latest one. */
 	suppressThinking?: boolean;
-};
+}
 
 interface Options {
 	messages: UIMessage[];
@@ -18,13 +18,13 @@ interface Options {
 	currentPostId?: number;
 }
 
-type MessageWithContextFlags = UIMessage & {
+interface MessageWithContextFlags extends UIMessage {
 	context?: {
 		flags?: {
 			context_only?: boolean;
 		};
 	};
-};
+}
 
 function isContextOnlyMessage( message: UIMessage ): boolean {
 	return (


### PR DESCRIPTION
Related to AI-1065.

## Proposed Changes

* Detect a full history replacement directly in `OrchestratorChat`'s show-component retention pass — recognizable from the data because no message id survives the swap — skip retention for it, and drop any retained placeholders.
* Extract a shared `clearRetainedShowComponentMessages` helper used by both the regeneration path and the replacement path.
* Mark a picker stale once the user sends a later message, so only the picker at the conversation tail stays interactive. In-picker selections apply through editor abilities (not chat messages) and keep the picker active; hidden context-only user messages (e.g. navigation continuations) are ignored.
* Remove the converter's unused `onSubmit` option.
* Minor converter cleanups: extend `UIMessage` via interfaces instead of type intersections, and simplify the summary normalization ternaries.
* Add regression tests for the history-replacement and reply-staleness cases, and consolidate the picker test suites (shared fixtures, `it.each` matrices, dead `NextStepButton` cases removed).

## Why are these changes being made?

When a conversation containing a picker is reloaded, the same picker exists in two serializations: the live `agentMessage` form restored from sessionStorage (no `tool_call_id`, `isCurrent: true`) and the server-persisted `tool_result` row (has `tool_call_id`, no `isCurrent`). The retention mechanism identifies pickers by `toolCallId|componentType|summary`, so the two forms never match: when the server fetch replaces the seeded history, the live copy is treated as transiently dropped and retained — rendering a duplicate picker (one enabled, one dimmed) on the first reload after a live picker turn. The system self-heals on later reloads because the replacement is persisted back to sessionStorage, which is why the bug only shows once per live picker turn.

A full history replacement is not a transient drop, so retention must not fire across it. Hydration re-ids every message (`serverMessageToMessage` generates fresh ids), so a replacement is detected inside the retention pass by zero message-id overlap with the previous view. Detecting at the mechanism level — rather than flagging individual `loadMessages` call sites — is timing-independent and covers every replacement path with no call-site opt-in: server hydration, clearing the chat (`clearMessages` is `loadMessages( [] )`, and nothing previously cleared the retained map there), and agenttic's own new-chat clear which never goes through this component.

The reply-staleness rule keeps the conversation history honest: once the user has moved past a picker, it documents a previous step and should read as history rather than remain actionable.

Out of scope (known follow-ups): reloaded pickers still render disabled because persisted payloads never carry `isCurrent` (backend-owned fix), and aligning the two serializations by stamping `tool_call_id` into the client `agentMessage` (Big Sky plugin change).

## Testing Instructions

Run Calypso locally (`yarn start`) or sandbox `widgets.wp.com` (`cd apps/agents-manager && yarn dev --sync`), then open the Site Editor with the unified Agents Manager chat.

### The duplicated picker messages

- Go to the site editor, say `show red colors`, and then reload the page — the picker is no longer duplicated:

https://github.com/user-attachments/assets/4fddb0ad-abaf-4f23-9a11-44c34352b937

### The stale picker messages

- Go to the site editor, say `show red colors`, and then send a new message — the picker becomes stale:

https://github.com/user-attachments/assets/0eb97639-afae-4386-90ed-d24bbddc0594

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



