### PR TITLE
Revert "Dashboard: serve shell for unknown routes instead of default Express 404 (#112403)"

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -46,15 +46,6 @@ const indexRoute = createRoute( {
 	},
 } );
 
-// Catch-all so every unmatched path still resolves to a route. Without it, an
-// unmatched path renders the not-found component but has no matched route, and
-// navigation APIs like useBlocker throw "No route found for location".
-const catchAllRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: '$',
-	component: NotFound,
-} );
-
 const createRouteTree = ( config: AppConfig ) => {
 	const children = [];
 
@@ -91,8 +82,6 @@ const createRouteTree = ( config: AppConfig ) => {
 	if ( config.supports.startStoreRoute ) {
 		children.push( startStoreRoute );
 	}
-
-	children.push( catchAllRoute );
 
 	return rootRoute.addChildren( children );
 };

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -878,11 +878,6 @@ const setUpSectionContext = ( section, entrypoint ) => ( req, res, next ) => {
 	next();
 };
 
-const setNotFoundStatus = ( req, res, next ) => {
-	res.status( 404 );
-	next();
-};
-
 const render404 =
 	( entrypoint = 'entry-main' ) =>
 	( req, res ) => {
@@ -892,33 +887,6 @@ const render404 =
 
 		res.status( 404 ).send( renderJsx( '404', ctx ) );
 	};
-
-const DASHBOARD_VARIANTS = [
-	{
-		definition: DOTCOM_DASHBOARD_SECTION_DEFINITION,
-		paths: DOTCOM_DASHBOARD_SECTION_PATHS,
-		entrypoint: 'entry-dashboard-dotcom',
-		devEnv: 'development',
-		isAllowedHostname: isAllowedDotcomDashboardHostname,
-		extraMiddleware: [ loadDashboardLocaleData ],
-	},
-	{
-		definition: CIAB_DASHBOARD_SECTION_DEFINITION,
-		paths: CIAB_DASHBOARD_SECTION_PATHS,
-		entrypoint: 'entry-dashboard-ciab',
-		devEnv: 'development',
-		isAllowedHostname: isAllowedCiabDashboardHostname,
-		extraMiddleware: [ loadDashboardLocaleData ],
-	},
-	{
-		definition: A4A_DASHBOARD_SECTION_DEFINITION,
-		paths: A4A_DASHBOARD_SECTION_PATHS,
-		entrypoint: 'entry-dashboard-a4a',
-		devEnv: 'a8c-for-agencies-development',
-		isAllowedHostname: isAllowedA4ADashboardHostname,
-		extraMiddleware: [],
-	},
-];
 
 /*
 We don't use `next` but need to add it for express.js to
@@ -1240,7 +1208,7 @@ export default function pages() {
 	 * SSR middleware if the request wasn't going to be resolved with SSR anyways.
 	 */
 	function handleSectionPath( section, sectionPath, entrypoint, reqFilter, extraMiddleware ) {
-		const pathRegex = sectionPath instanceof RegExp ? sectionPath : pathToRegExp( sectionPath );
+		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get(
 			pathRegex,
@@ -1259,12 +1227,12 @@ export default function pages() {
 				next();
 			},
 			setUpRoute, // For SSR requests, this will happen in the serverRouter.
-			...( extraMiddleware ? [].concat( extraMiddleware ) : [] ),
+			...( extraMiddleware ? [ extraMiddleware ] : [] ),
 			serverRender
 		);
 	}
 
-	// Special Calypso routes which also appear on `my.wordpress.com`
+	// Multi-site Dashboard routing.
 	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
 		const signupSectionDefinition = sections.find( ( s ) => s.name === 'signup' );
 		handleSectionPath( signupSectionDefinition, '/start', undefined, ( req ) =>
@@ -1277,6 +1245,24 @@ export default function pages() {
 		handleSectionPath( STEPPER_SECTION_DEFINITION, '/setup', 'entry-stepper', ( req ) =>
 			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
 		);
+		DOTCOM_DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
+			handleSectionPath(
+				DOTCOM_DASHBOARD_SECTION_DEFINITION,
+				route,
+				'entry-dashboard-dotcom',
+				( req ) => isAllowedDotcomDashboardHostname( req.hostname ),
+				loadDashboardLocaleData
+			);
+		} );
+		CIAB_DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
+			handleSectionPath(
+				CIAB_DASHBOARD_SECTION_DEFINITION,
+				route,
+				'entry-dashboard-ciab',
+				( req ) => isAllowedCiabDashboardHostname( req.hostname ),
+				loadDashboardLocaleData
+			);
+		} );
 	}
 
 	// Multi-site Dashboard (A4A) routing.
@@ -1289,23 +1275,12 @@ export default function pages() {
 				isAllowedA4ADashboardHostname( req.hostname )
 			);
 		} );
+		A4A_DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
+			handleSectionPath( A4A_DASHBOARD_SECTION_DEFINITION, route, 'entry-dashboard-a4a', ( req ) =>
+				isAllowedA4ADashboardHostname( req.hostname )
+			);
+		} );
 	}
-
-	// Register each dashboard variant's explicit section paths.
-	DASHBOARD_VARIANTS.forEach( ( variant ) => {
-		if ( ! ( isDashboardEnv() || calypsoEnv === variant.devEnv ) ) {
-			return;
-		}
-		variant.paths.forEach( ( route ) =>
-			handleSectionPath(
-				variant.definition,
-				route,
-				variant.entrypoint,
-				( req ) => variant.isAllowedHostname( req.hostname ),
-				variant.extraMiddleware
-			)
-		);
-	} );
 
 	sections
 		.filter( ( section ) => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
@@ -1331,19 +1306,8 @@ export default function pages() {
 	registerCspReportRoute( app );
 
 	// Multi-site Dashboard routing.
+	// Return earlier since we don't need to set up any other routes.
 	if ( isDashboardEnv() ) {
-		// Serve the dashboard shell for any otherwise-unmatched path so the client
-		// router renders its own not-found page, instead of falling through to default.
-		DASHBOARD_VARIANTS.forEach( ( variant ) =>
-			handleSectionPath(
-				variant.definition,
-				/.*/,
-				variant.entrypoint,
-				( req ) => variant.isAllowedHostname( req.hostname ),
-				[ setNotFoundStatus, ...variant.extraMiddleware ]
-			)
-		);
-
 		return app;
 	}
 

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -207,9 +207,6 @@ const buildApp = ( environment ) => {
 					'entry-browsehappy': assetsList.map( ( asset ) =>
 						asset.replace( 'entry-main', 'entry-browsehappy' )
 					),
-					'entry-dashboard-dotcom': assetsList.map( ( asset ) =>
-						asset.replace( 'entry-main', 'entry-dashboard-dotcom' )
-					),
 					...Object.fromEntries(
 						sections.map( ( section ) => [
 							section.name,
@@ -1566,46 +1563,5 @@ describe( 'main app', () => {
 
 			expect( request.logger.error ).toHaveBeenCalledWith( { error: 'fake error' } );
 		} );
-	} );
-} );
-
-describe( 'dashboard app', () => {
-	let app;
-
-	beforeAll( () => {
-		app = buildApp( 'dashboard-production' );
-	} );
-
-	beforeEach( () => {
-		app.withConfigEnabled( { 'use-translation-chunks': true } );
-		app.withServerRender( '' );
-		app.withMockFilesystem();
-		app.withEvergreenBrowser();
-		app.withReduxStore( { dispatch: jest.fn(), getState: jest.fn( () => ( {} ) ) } );
-	} );
-
-	afterEach( () => {
-		jest.clearAllMocks();
-		app.reset();
-	} );
-
-	it( 'serves the dashboard shell with a 404 for unmatched paths', async () => {
-		const { request, response } = await app.run( {
-			request: { url: '/does-not-exist', hostname: 'my.wordpress.com' },
-		} );
-
-		expect( request.context.sectionName ).toBe( 'dashboard-dotcom' );
-		expect( response.statusCode ).toBe( 404 );
-		expect( app.getMocks().serverRender ).toHaveBeenCalled();
-	} );
-
-	it( 'serves known dashboard routes without a 404', async () => {
-		const { request, response } = await app.run( {
-			request: { url: '/sites', hostname: 'my.wordpress.com' },
-		} );
-
-		expect( request.context.sectionName ).toBe( 'dashboard-dotcom' );
-		expect( response.statusCode ).not.toBe( 404 );
-		expect( app.getMocks().serverRender ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Reverts #112403.

## Proposed Changes

* Revert the dashboard client catch-all route (`path: '$'`) and the server-side change that served the dashboard shell (with a 404 status) for unmatched paths.

## Why are these changes being made?

#112403 broke the masterbar notifications panel on the dashboard.

The interim omnibar installs a global click interceptor on `#wpcom-omnibar`: any click on an `<a href>` emits a `linkClick` event, and `Root` turns it into a client-side navigation **only if the href matches a TanStack route** (`getMatchedRoutes(...).foundRoute`). Otherwise it bails and lets the anchor's own handler run.

The notifications bell is a classic masterbar `<a href="/notifications">` whose `onClick` `preventDefault`s and toggles the panel. `/notifications` is not a real route — just a conventional href for a JS-handled button.

* Before: `/notifications` matched no route, so the interceptor did nothing and the bell toggled the panel. URL unchanged.
* After #112403: the client catch-all made every path match, so the interceptor navigated to `/notifications`, which the catch-all rendered as the 404 page. The panel never opened.

Reverting restores the panel. A re-land needs the catch-all and the omnibar link interceptor to coexist — e.g. skip anchors already handled by their own `onClick`, or don't treat a catch-all match as a real destination.

## Testing Instructions

* On the dashboard, click the masterbar notifications bell → the notifications panel opens and the URL stays put (no navigation to `/notifications`, no 404).
* Confirm known dashboard routes still work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?