### PR TITLE
Remove the site-setup "Back to goals" affordances

### DIFF
--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -142,7 +142,7 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 					<Title>{ __( "Your existing content can't be imported" ) }</Title>
 					<SubTitle>
 						{ __(
-							"Unfortunately, your content is on a platform that we don't yet support. Try Building a new WordPress site instead."
+							"Unfortunately, your content is on a platform that we don't yet support. Try a different site."
 						) }
 					</SubTitle>
 
@@ -279,7 +279,7 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 							sprintf(
 								/* translators: the website could be any domain (eg: "yourname.com") */
 								__(
-									'It looks like <strong>%(website)s</strong> is already on WordPress.com. Try a different address or start building a new site instead.'
+									'It looks like <strong>%(website)s</strong> is already on WordPress.com. Try a different address.'
 								),
 								{
 									website: convertToFriendlyWebsiteName( urlData.url ),

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -1,16 +1,12 @@
-import { Onboard } from '@automattic/data-stores';
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect, useState } from 'react';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { UrlData, GoToStep, RecordTracksEvent } from '../types';
 import { convertPlatformName, convertToFriendlyWebsiteName } from '../util';
 import ImportPlatformDetails, { coveredPlatforms } from './platform-details';
 import ImportPreview from './preview';
-import type { OnboardSelect } from '@automattic/data-stores';
 import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
 
@@ -117,11 +113,6 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 	recordTracksEvent,
 } ) => {
 	const { __ } = useI18n();
-	const goals = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
-		[]
-	);
-	const { setGoals } = useDispatch( ONBOARD_STORE );
 
 	const recordReadyScreenEvent = () => {
 		recordTracksEvent( trackEventName, {
@@ -142,14 +133,6 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 		goToStep( 'capture' );
 	};
 
-	const onBackToGoalsBtnClick = () => {
-		// clean up the import goal
-		const goalSet = new Set( goals );
-		goalSet.delete( Onboard.SiteGoal.Import );
-		setGoals( Array.from( goalSet ) );
-		goToStep( 'goals' );
-	};
-
 	useEffect( recordReadyScreenEvent, [] );
 
 	return (
@@ -164,7 +147,6 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ onBackToGoalsBtnClick }>{ __( 'Back to goals' ) }</NextButton>
 						<div>
 							<BackButton onClick={ onBackBtnClick }>{ __( 'Back to start' ) }</BackButton>
 						</div>
@@ -264,11 +246,6 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 	recordTracksEvent,
 } ) => {
 	const { __ } = useI18n();
-	const goals = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
-		[]
-	);
-	const { setGoals } = useDispatch( ONBOARD_STORE );
 
 	const recordReadyScreenEvent = () => {
 		recordTracksEvent( trackEventName, {
@@ -285,26 +262,9 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 		} );
 	};
 
-	const recordStartBuildingEvent = () => {
-		recordTracksEvent( trackEventName, {
-			...trackEventParams,
-			action: 'start-building',
-		} );
-	};
-
 	const onBackBtnClick = () => {
 		recordBackToStartEvent();
 		goToStep( 'capture' );
-	};
-
-	const onBackToGoalsBtnClick = () => {
-		// event tracking
-		recordStartBuildingEvent();
-		// clean up the import goal
-		const goalSet = new Set( goals );
-		goalSet.delete( Onboard.SiteGoal.Import );
-		setGoals( Array.from( goalSet ) );
-		goToStep( 'goals' );
 	};
 
 	useEffect( recordReadyScreenEvent, [] );
@@ -330,7 +290,6 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ onBackToGoalsBtnClick }>{ __( 'Back to goals' ) }</NextButton>
 						<div>
 							<BackButton onClick={ onBackBtnClick }>{ __( 'Back to start' ) }</BackButton>
 						</div>

--- a/client/blocks/importer/components/error-message/index.tsx
+++ b/client/blocks/importer/components/error-message/index.tsx
@@ -8,14 +8,12 @@ import './style.scss';
 
 interface Props {
 	primaryBtnText?: string;
-	secondaryBtnText?: string;
 	onPrimaryBtnClick?: () => void;
-	onSecondaryBtnClick?: () => void;
 }
 
 const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
-	const { primaryBtnText, secondaryBtnText, onPrimaryBtnClick, onSecondaryBtnClick } = props;
+	const { primaryBtnText, onPrimaryBtnClick } = props;
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_start_import_failure' );
@@ -41,11 +39,6 @@ const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						{ onSecondaryBtnClick && (
-							<NextButton type="button" variant="secondary" onClick={ onSecondaryBtnClick }>
-								{ secondaryBtnText ?? translate( 'Back to goals' ) }
-							</NextButton>
-						) }
 						{ onPrimaryBtnClick && (
 							<div>
 								<NextButton type="button" onClick={ onPrimaryBtnClick }>

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -10,7 +10,6 @@ export type QueryObject = {
 export type StepNavigator = {
 	flow: string | null;
 	supportLinkModal?: boolean;
-	goToGoalsPage?: () => void;
 	goToImportCapturePage?: () => void;
 	goToImportContentOnlyPage?: () => void;
 	goToAdmin?: () => void;

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -122,11 +122,6 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 		dispatch( resetImport( siteItem?.ID, job?.importerId ) );
 	}, [ siteItem, job ] );
 
-	const onBackToGoalsClick = useCallback( () => {
-		dispatch( resetImport( siteItem?.ID, job?.importerId ) );
-		stepNavigator?.goToGoalsPage?.();
-	}, [] );
-
 	/**
 	 ↓ Effects
 	 */
@@ -148,14 +143,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 		>
 			{ renderState === 'progress' && <ProgressScreen job={ job } showHeading={ renderHeading } /> }
 
-			{ renderState === 'error' && (
-				<ErrorMessage
-					onPrimaryBtnClick={ onTryAgainClick }
-					onSecondaryBtnClick={
-						stepNavigator?.flow === 'site-setup' ? onBackToGoalsClick : undefined
-					}
-				/>
-			) }
+			{ renderState === 'error' && <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } /> }
 
 			{ renderState === 'upgrade-plan' && (
 				<UpgradePlan

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -479,19 +479,7 @@ const siteSetupFlow: Flow = {
 			}
 		};
 
-		// The goals step used to be the back target for the design picker and
-		// import capture steps. With it gone they have no in-flow step to return
-		// to, so leave goBack undefined and let Stepper fall back to browser
-		// history instead of pointing at the removed step.
-		const isEntryStep = currentStep === 'design-setup' || currentStep === 'import';
-
-		return {
-			goNext,
-			goBack: isEntryStep ? undefined : goBack,
-			goToStep,
-			submit,
-			exitFlow,
-		};
+		return { goNext, goBack, goToStep, submit, exitFlow };
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -391,9 +391,6 @@ const siteSetupFlow: Flow = {
 			}
 
 			switch ( currentStep ) {
-				case 'design-setup':
-					return navigate( 'goals' );
-
 				case 'importList': {
 					if ( backToStep ) {
 						return navigate( `${ backToStep }?siteSlug=${ siteSlug }` );
@@ -453,15 +450,12 @@ const siteSetupFlow: Flow = {
 				case 'importReadyPreview':
 					return navigate( `import?siteSlug=${ siteSlug }` );
 
-				case 'import':
-					return navigate( 'goals' );
-
 				case 'verifyEmail':
 				case 'trialAcknowledge':
 					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 
 				default:
-					return navigate( 'goals' );
+					return exitFlow( `/home/${ siteId ?? siteSlug }` );
 			}
 		};
 
@@ -471,7 +465,7 @@ const siteSetupFlow: Flow = {
 					return navigate( 'importList' );
 
 				default:
-					return navigate( 'goals' );
+					return exitFlow( `/home/${ siteId ?? siteSlug }` );
 			}
 		};
 
@@ -485,7 +479,19 @@ const siteSetupFlow: Flow = {
 			}
 		};
 
-		return { goNext, goBack, goToStep, submit, exitFlow };
+		// The goals step used to be the back target for the design picker and
+		// import capture steps. With it gone they have no in-flow step to return
+		// to, so leave goBack undefined and let Stepper fall back to browser
+		// history instead of pointing at the removed step.
+		const isEntryStep = currentStep === 'design-setup' || currentStep === 'import';
+
+		return {
+			goNext,
+			goBack: isEntryStep ? undefined : goBack,
+			goToStep,
+			submit,
+			exitFlow,
+		};
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -426,13 +426,19 @@ const UnifiedDesignPickerStep: StepType< {
 		if ( isComingFromSuccessfulImport ) {
 			return undefined;
 		}
+		// Site Setup enters directly on the design picker, so there is nothing to
+		// go back to. Return no handler so Stepper's automatic history-back button
+		// (which would just leave the flow) is suppressed.
+		if ( isSiteSetupFlow( flow ) ) {
+			return undefined;
+		}
 		if ( intent === 'update-design' ) {
 			return () =>
 				submit?.( {
 					eventProps: commonFilterProperties,
 				} );
 		}
-		return goBack ? () => handleBackClick() : undefined;
+		return () => handleBackClick();
 	};
 
 	const backButton = getGoBackHandler();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -426,12 +426,13 @@ const UnifiedDesignPickerStep: StepType< {
 		if ( isComingFromSuccessfulImport ) {
 			return undefined;
 		}
-		return intent === 'update-design'
-			? () =>
-					submit?.( {
-						eventProps: commonFilterProperties,
-					} )
-			: () => handleBackClick();
+		if ( intent === 'update-design' ) {
+			return () =>
+				submit?.( {
+					eventProps: commonFilterProperties,
+				} );
+		}
+		return goBack ? () => handleBackClick() : undefined;
 	};
 
 	const backButton = getGoBackHandler();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -55,9 +55,6 @@ export function getFinalImporterUrl(
  */
 export function generateStepPath( stepName: string, stepSectionName?: string ) {
 	switch ( stepName ) {
-		case 'goals':
-			return 'goals';
-
 		case 'capture':
 			return BASE_ROUTE;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -19,10 +19,11 @@ export const ImportWrapper: StepType< {
 	accepts: {
 		text?: string;
 		subText?: string;
+		hideBack?: boolean;
 	};
 } > = function ( props ) {
 	const { __ } = useI18n();
-	const { navigation, children, stepName, text, subText } = props;
+	const { navigation, children, stepName, text, subText, hideBack } = props;
 	const useContainerV2 = stepName === 'importList';
 	const documentTitle = __( 'Import your site content' );
 	const showHeading = text && subText;
@@ -55,6 +56,7 @@ export const ImportWrapper: StepType< {
 				className="import__onboarding-page"
 				hideFormattedHeader
 				goBack={ navigation.goBack }
+				hideBack={ hideBack }
 				skipLabelText={ __( "I don't have a site address" ) }
 				isFullLayout
 				stepContent={ children as ReactElement }
@@ -75,7 +77,7 @@ const ImportStep: StepType< {
 	const fromUrl = useQuery().get( 'from' ) || '';
 
 	return (
-		<ImportWrapper { ...props }>
+		<ImportWrapper { ...props } hideBack>
 			<CaptureStep
 				initialUrl={ fromUrl }
 				goToStep={ ( step, section, params ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -30,10 +30,6 @@ export function useStepNavigator(
 		navigation.goToStep?.( stepPath as string );
 	}
 
-	function goToGoalsPage() {
-		navigation.goToStep?.( 'goals' );
-	}
-
 	function goToImportCapturePage() {
 		const migrationUrl = `/setup/site-migration?siteSlug=${ siteSlug }&ref=importer`;
 		const urlWithFromParam = fromSite ? `${ migrationUrl }&from=${ fromSite }` : migrationUrl;
@@ -129,7 +125,6 @@ export function useStepNavigator(
 	return {
 		flow,
 		supportLinkModal: false,
-		goToGoalsPage,
 		goToImportCapturePage,
 		goToImportContentOnlyPage,
 		goToAdmin,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -205,12 +205,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 			}
 
 			if ( ! hasPermission() ) {
-				return (
-					<NotAuthorized
-						onStartBuilding={ stepNavigator?.goToGoalsPage }
-						onBackToStart={ stepNavigator?.goToImportCapturePage }
-					/>
-				);
+				return <NotAuthorized onBackToStart={ stepNavigator?.goToImportCapturePage } />;
 			}
 
 			return (


### PR DESCRIPTION
## Proposed Changes

* Remove the UI affordances that navigate to the site-setup `goals` step, ahead of removing the step itself:
  * the importer not-authorized "Start building" CTA (and its `goToGoalsPage` navigator),
  * the WordPress content-import error "Back to goals" button,
  * the import-ready "can't be imported" and "already on WordPress.com" screens' "Back to goals" buttons.
* Remove the now-unused `ErrorMessage` secondary-button surface and the dead `generateStepPath('goals')` case.

## Why are these changes being made?

This is a precursor to removing the dead site-setup `goals` step. Splitting the inbound navigation removal out first keeps that follow-up a clean delete with nothing pointing at the step. The `goals` step itself is unchanged in this PR.

## Testing Instructions

* Type-check and lint pass. The importer not-authorized and error screens, and the import-ready screens, no longer offer a "Back to goals" / "Start building" action; their remaining actions ("Back to start", "Try again") are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
