### PR TITLE
Dashboard: only use sites the user is a member of for the omnibar and recent sites

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -53,7 +53,7 @@ export function InterimOmnibar( {
 	onToggleNotifications,
 }: Props ) {
 	const user = userProp ?? emptyUser;
-	const siteId = user.primary_blog ?? null;
+	const siteId = site?.ID ?? null;
 	const siteSlug = site?.slug ?? null;
 	const siteAdminUrl = site?.options?.admin_url ?? null;
 	const isUnlaunchedSite = !! site && site.launch_status === 'unlaunched' && ! site.is_a4a_dev_site;

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -1,6 +1,7 @@
 import {
 	omnibarSiteIdQuery,
 	queryClient,
+	siteByIdQuery,
 	userPreferenceQuery,
 	userPreferenceOptimisticMutation,
 } from '@automattic/api-queries';
@@ -11,6 +12,11 @@ import { useEffect } from 'react';
 import { AUTH_QUERY_KEY } from '../auth';
 import type { Site, User } from '@automattic/api-core';
 
+function isMemberOfSite( site: Site ) {
+	// If the user is a member of the site, the capabilities property will exist
+	return !! site.capabilities;
+}
+
 /**
  * Initializes the current site for the omnibar, which is extracted from the URL,
  * or the most recent sites, or the user's primary blog, in that priority.
@@ -18,7 +24,10 @@ import type { Site, User } from '@automattic/api-core';
 export function useInitializeOmnibarSite() {
 	const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 
-	const { data: recentSiteIds } = useQuery( userPreferenceQuery( 'recentSites' ), queryClient );
+	const { data: recentSiteIds, isLoading: isLoadingRecentSiteIds } = useQuery(
+		userPreferenceQuery( 'recentSites' ),
+		queryClient
+	);
 	const { mutate: updateRecentSites } = useMutation(
 		userPreferenceOptimisticMutation( 'recentSites' ),
 		queryClient
@@ -39,13 +48,23 @@ export function useInitializeOmnibarSite() {
 		( location.search as Record< string, string | undefined > ).origin_site_id
 	);
 	const originSiteId = originSiteIdParam > 0 ? originSiteIdParam : undefined;
+	const recentSiteId =
+		queryClient.getQueryData< number | null >( omnibarSiteIdQuery().queryKey ) ||
+		recentSiteIds?.[ 0 ];
 
-	const selectedSiteId = routeSite?.ID || originSiteId;
-	const fallbackSiteId = recentSiteIds?.[ 0 ] || user?.primary_blog;
+	const { data: originSite, isLoading: isLoadingOriginSite } = useQuery( {
+		...siteByIdQuery( originSiteId ?? 0 ),
+		enabled: !! originSiteId,
+	} );
+
+	const { data: recentSite, isLoading: isLoadingRecentSite } = useQuery( {
+		...siteByIdQuery( recentSiteId ?? 0 ),
+		enabled: !! recentSiteId,
+	} );
 
 	useEffect( () => {
-		// Wait until the route and recent sites are fully loaded, to avoid flicker.
-		if ( ! isRouteLoaded || ! recentSiteIds ) {
+		// Wait until the required data are fully loaded, to avoid flicker.
+		if ( ! isRouteLoaded || isLoadingRecentSiteIds || isLoadingOriginSite || isLoadingRecentSite ) {
 			return;
 		}
 
@@ -53,10 +72,12 @@ export function useInitializeOmnibarSite() {
 		// queryFn resolves to `null`. If it's still in flight when we write here,
 		// the resolution will overwrite our value and the omnibar loses the site.
 		queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
-		queryClient.setQueryData(
-			omnibarSiteIdQuery().queryKey,
-			( currentSiteId ) => selectedSiteId || currentSiteId || fallbackSiteId
+
+		const omnibarSite = [ routeSite, originSite, recentSite ].find(
+			( site ) => site && isMemberOfSite( site )
 		);
+		const omnibarSiteId = omnibarSite?.ID ?? user?.primary_blog;
+		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => omnibarSiteId );
 
 		// Remove the `origin_site_id` query param from the URL.
 		if ( originSiteId ) {
@@ -67,16 +88,22 @@ export function useInitializeOmnibarSite() {
 			);
 		}
 
-		// Push the selected site id as the most recent site.
-		if ( selectedSiteId && selectedSiteId !== recentSiteIds[ 0 ] ) {
-			updateRecentSites( [ ...new Set( [ selectedSiteId, ...recentSiteIds ] ) ].slice( 0, 5 ) );
+		if ( omnibarSiteId && omnibarSiteId !== recentSiteIds?.[ 0 ] ) {
+			updateRecentSites(
+				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 )
+			);
 		}
 	}, [
 		isRouteLoaded,
+		routeSite,
 		originSiteId,
-		selectedSiteId,
-		fallbackSiteId,
+		originSite,
+		isLoadingOriginSite,
+		recentSite,
+		isLoadingRecentSite,
 		recentSiteIds,
+		isLoadingRecentSiteIds,
+		user,
 		updateRecentSites,
 	] );
 }


### PR DESCRIPTION
## Proposed Changes

* When initializing the omnibar's current site, resolve it from the route site, the `origin_site_id` URL param, then a fallback (last omnibar site → most recent → primary blog) — but only accept a candidate the user is actually a member of.
* Record that resolved site as the most recent site, so only sites the user belongs to are persisted to the `recentSites` preference.
* Gate initialization on each query's loading state (not on data presence), so an inaccessible or errored site id settles and can't block the omnibar from initializing forever.
* Interim omnibar (backport masterbar) now reflects the current site rather than always the primary blog.

## Why are these changes being made?

The dashboard set and recorded whatever site id it resolved — including one taken straight from the untrusted `origin_site_id` URL param — with no check that the site belongs to the user. Classic Calypso filtered recent sites against the user's own sites; the dashboard path dropped that guard, so a crafted or stale id could be persisted and then fail to load. Membership is now the gate (any role, not just admin), matching the classic behavior.

## Testing Instructions

* In the dashboard, navigate between several of your sites and confirm the omnibar and the most-recent-site list update as before.
* Load a dashboard URL with `?origin_site_id=<id of a site you do not belong to>` and confirm it is not set as the omnibar site or added to recents, the param is stripped from the URL, and the omnibar still initializes from a valid fallback.
* Load a dashboard URL with an inaccessible or garbage `origin_site_id` and confirm the omnibar still initializes (no hang).
* Confirm no TypeScript/React console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Considerations

Membership is detected via the presence of the site's `capabilities` property from `GET /sites/:id` (a local `isMemberOfSite` helper). This includes all member roles — broader than an admin-only `manage_options` check — and reliably excludes private sites the user cannot access, since that lookup errors. One edge remains unverified: whether the endpoint returns `capabilities` for a public site the user has no role on. If it does, such a site could still be recorded; impact is limited to the user's own preference.
