### PR TITLE
Agents Manager: add AI disclosure below the chat input

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -8,16 +8,19 @@ import type { Suggestion } from '@automattic/agenttic-ui';
 const mockUseAgentChat = jest.fn();
 const mockUseRegenerateAction = jest.fn();
 const mockUseConversation = jest.fn();
+const mockIsReaderChatAgent = jest.fn();
 const mockAgentChat = jest.fn(
 	( {
 		onSuggestionClick,
 		onSubmit,
 		emptyViewSuggestions = [],
+		disclosure,
 	}: {
 		messages?: unknown[];
 		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
 		onSubmit: ( message: string ) => void;
 		emptyViewSuggestions?: Suggestion[];
+		disclosure?: React.ReactNode;
 	} ) => (
 		<>
 			<button
@@ -52,6 +55,7 @@ const mockAgentChat = jest.fn(
 					<li key={ suggestion.id }>{ suggestion.label }</li>
 				) ) }
 			</ul>
+			<div data-testid="disclosure">{ disclosure }</div>
 		</>
 	)
 );
@@ -69,7 +73,10 @@ jest.mock(
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: () => undefined,
 } ) );
-jest.mock( '@wordpress/element', () => jest.requireActual( 'react' ) );
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( 'react' ),
+	createInterpolateElement: jest.requireActual( '@wordpress/element' ).createInterpolateElement,
+} ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
 jest.mock( 'react-router-dom', () => ( {
 	useNavigate: () => jest.fn(),
@@ -115,7 +122,7 @@ jest.mock( '../../utils/external-context', () => ( {
 	removeExternalContextEntry: jest.fn(),
 } ) );
 jest.mock( '../../utils/is-reader-chat-agent', () => ( {
-	isReaderChatAgent: () => false,
+	isReaderChatAgent: ( ...args: unknown[] ) => mockIsReaderChatAgent( ...args ),
 } ) );
 jest.mock( '../../utils/persist-last-activity', () => ( {
 	persistLastActivity: jest.fn(),
@@ -131,6 +138,7 @@ import OrchestratorChat from '../orchestrator-chat';
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockIsReaderChatAgent.mockReturnValue( false );
 		// Default getter: contributes no actions.
 		mockUseRegenerateAction.mockReturnValue( () => [] );
 		mockUseConversation.mockReturnValue( { isLoading: false } );
@@ -966,5 +974,27 @@ describe( 'OrchestratorChat', () => {
 			content?: Array< { text?: string } >;
 		} >;
 		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+	} );
+
+	it( 'passes the AI disclosure with a guidelines link to the chat', () => {
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		const disclosureEl = screen.getByTestId( 'disclosure' );
+		expect( disclosureEl ).toHaveTextContent( 'chatting with an AI agent.' );
+		const link = screen.getByRole( 'link', { name: 'See Guidelines' } );
+		expect( link ).toHaveAttribute( 'href', 'https://automattic.com/ai-guidelines/' );
 	} );
 } );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -31,6 +31,7 @@ import type { ExternalContextCard, ExternalContextCardAction } from '../../utils
 import type { Message, NoticeConfig } from '@automattic/agenttic-ui/dist/types';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 import type { ComponentProps, RefObject } from 'react';
+import './style.scss';
 
 interface Props {
 	/** Chat messages to display. */
@@ -80,6 +81,8 @@ interface Props {
 	onInputChange?: ( value: string ) => void;
 	/** Notice to display in the chat. */
 	notice?: NoticeConfig;
+	/** Muted caption rendered below the input (e.g. AI disclosure). */
+	disclosure?: React.ReactNode;
 	/** Indicates if the floating chat is in compact mode. */
 	isCompactMode?: boolean;
 	/** Image upload state from the parent component. When provided, enables the image uploader UI. */
@@ -155,6 +158,7 @@ export default function AgentChat( {
 	clearSuggestions,
 	onSuggestionClick,
 	notice,
+	disclosure,
 	markdownComponents = {},
 	markdownExtensions = {},
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Kept for API compatibility with `ZendeskChat`
@@ -342,6 +346,7 @@ export default function AgentChat( {
 						/>
 					</AgentUI.Footer>
 				) }
+				{ disclosure && <p className="agents-manager-chat__disclosure">{ disclosure }</p> }
 			</AgentUI.ConversationView>
 		</AgentUI.Container>
 	);

--- a/packages/agents-manager/src/components/agent-chat/style.scss
+++ b/packages/agents-manager/src/components/agent-chat/style.scss
@@ -1,0 +1,13 @@
+.agents-manager-chat__disclosure {
+	color: var( --color-muted-foreground, #757575 );
+	font-size: 12px;
+	line-height: 1.4;
+	margin: 0;
+	padding: 10px 8px 0;
+	text-align: center;
+
+	a {
+		color: inherit;
+		text-decoration: underline;
+	}
+}

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -5,7 +5,14 @@ import {
 	type MarkdownExtensions,
 } from '@automattic/agenttic-ui';
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback, useMemo, useEffect, useRef } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useState,
+	useCallback,
+	useMemo,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
@@ -328,6 +335,16 @@ export default function OrchestratorChat( {
 	const chatError = isReaderChat
 		? getReaderChatErrorMessage( error )
 		: getOrchestratorErrorMessage( error );
+
+	const disclosure = createInterpolateElement(
+		__( "You're chatting with an AI agent. <a>See Guidelines</a>.", __i18n_text_domain__ ),
+		{
+			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			a: (
+				<a href="https://automattic.com/ai-guidelines/" target="_blank" rel="noopener noreferrer" />
+			),
+		}
+	);
 
 	const { isLoading: isLoadingConversation } = useConversation( {
 		maxPages: isReaderChat ? 1 : 10,
@@ -844,6 +861,7 @@ export default function OrchestratorChat( {
 			markdownExtensions={ markdownExtensions }
 			inputValue={ inputValue }
 			onInputChange={ setInputValue }
+			disclosure={ disclosure }
 			isCompactMode={ isCompactMode }
 			imageUpload={ imageUpload }
 			showFeedbackInput={ showFeedbackInput }


### PR DESCRIPTION
## Proposed Changes

* Render a muted, centered AI-disclosure caption below the chat input on all AI chat surfaces rendered by `OrchestratorChat` (Reader Chat, AI sidebar, masterbar chat, editor): "You’re chatting with an AI agent. See Guidelines." — with "See Guidelines" linking to the Automattic AI guidelines page.
* Implemented as a new `disclosure` prop on `AgentChat`, rendered outside the input card; the pre-existing `notice` API is unchanged. The Zendesk (human) chat is a separate component and shows no disclosure.

## Why are these changes being made?

* EU AI Act §50(1) requires that users are clearly informed they are interacting with an AI at or before first interaction. Reader chat runs on public blog frontends for logged-out visitors and currently has no AI-identity disclosure anywhere in its UI, so a visitor could reasonably assume a human is answering. The notice is visible from the moment the panel opens, before the first message is sent.

## Testing Instructions

Calypso:
1. `yarn start`, then open the AI chat from the masterbar Help menu.
2. Confirm the caption "You’re chatting with an AI agent. See Guidelines." appears below the input, and the link opens the AI guidelines page.

Sandbox (reader chat):
1. `cd apps/agents-manager && yarn dev --sync` with widgets.wp.com sandboxed.
2. Visit a blog with reader chat enabled and open the chat.
3. Confirm the same caption renders below the input, is visible before sending any message, and persists during the conversation. Also verify in the editor AI sidebar.

Unit tests: `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager` (38 suites / 397 tests passing).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

