### PR TITLE
Pricing grid redesign: add discount tooltips

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@automattic/calypso-products';
 import { PlanPrice } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/number-formatters';
 import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import { type TranslateResult, useTranslate } from 'i18n-calypso';
@@ -98,21 +99,65 @@ const HeaderPriceBadgeTooltip = ( {
 
 const getPricingBadgeTooltipText = ( {
 	billingPeriod,
+	cheaperPrice,
+	currencyCode,
+	referencePrice,
 	translate,
 }: {
 	billingPeriod?: -1 | ( typeof PERIOD_LIST )[ number ];
-	translate: ( text: string ) => TranslateResult;
-} ): TranslateResult => {
+	cheaperPrice?: number | null;
+	currencyCode?: string | null;
+	referencePrice?: number | null;
+	translate: (
+		text: string,
+		options?: {
+			args: Record< string, string >;
+			comment?: string;
+		}
+	) => TranslateResult;
+} ): TranslateResult | undefined => {
+	if (
+		! currencyCode ||
+		typeof cheaperPrice !== 'number' ||
+		typeof referencePrice !== 'number' ||
+		! Number.isFinite( cheaperPrice ) ||
+		! Number.isFinite( referencePrice )
+	) {
+		return undefined;
+	}
+	const args = {
+		cheaperPrice: formatCurrency( cheaperPrice, currencyCode, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} ),
+		referencePrice: formatCurrency( referencePrice, currencyCode, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} ),
+	};
+
 	switch ( billingPeriod ) {
 		case PLAN_MONTHLY_PERIOD:
-			return translate( '1-month savings' );
+			return translate( '%(cheaperPrice)s/first month vs. %(referencePrice)s monthly after that', {
+				args,
+				comment: 'Example: $5/first month vs. $10 monthly after that',
+			} );
 		case PLAN_BIENNIAL_PERIOD:
-			return translate( '2-year savings' );
+			return translate( '%(cheaperPrice)s/2 years vs. %(referencePrice)s paying monthly', {
+				args,
+				comment: 'Example: $200/2 years vs. $300 paying monthly',
+			} );
 		case PLAN_TRIENNIAL_PERIOD:
-			return translate( '3-year savings' );
+			return translate( '%(cheaperPrice)s/3 years vs. %(referencePrice)s paying monthly', {
+				args,
+				comment: 'Example: $300/3 years vs. $450 paying monthly',
+			} );
 		case PLAN_ANNUAL_PERIOD:
 		default:
-			return translate( '1-year savings' );
+			return translate( '%(cheaperPrice)s/year vs. %(referencePrice)s paying monthly', {
+				args,
+				comment: 'Example: $100/year vs. $150 paying monthly',
+			} );
 	}
 };
 
@@ -141,7 +186,6 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer, billingPeriod },
 		isMonthlyPlan,
 	} = gridPlansIndex[ planSlug ];
-	const pricingBadgeTooltipText = getPricingBadgeTooltipText( { billingPeriod, translate } );
 	const isPricedPlan = null !== originalPrice.monthly;
 
 	/**
@@ -173,27 +217,41 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		? fromPricingMetaForGridPlan( termVariantPricing )
 		: null;
 	const currentPlanInfo = fromPricingMetaForGridPlan( gridPlansIndex[ planSlug ].pricing );
-	let savings =
+	const termVariantReferencePrice =
 		termVariantInfo && currentPlanInfo
-			? calculateDiscountPercentage(
-					getPlanPriceForDuration( termVariantInfo, currentPlanInfo.termMonths ),
-					getPlanPriceForDuration( currentPlanInfo, currentPlanInfo.termMonths )
-			  ) ?? 0
+			? getPlanPriceForDuration( termVariantInfo, currentPlanInfo.termMonths )
+			: null;
+	const currentPlanPrice =
+		currentPlanInfo && termVariantInfo
+			? getPlanPriceForDuration( currentPlanInfo, currentPlanInfo.termMonths )
+			: null;
+	const termSavingsTooltipText = getPricingBadgeTooltipText( {
+		billingPeriod,
+		cheaperPrice: currentPlanPrice,
+		currencyCode,
+		referencePrice: termVariantReferencePrice,
+		translate,
+	} );
+	let savings =
+		termVariantReferencePrice && currentPlanPrice
+			? calculateDiscountPercentage( termVariantReferencePrice, currentPlanPrice ) ?? 0
 			: 0;
 
 	const renderPricingBadge = (
 		children: ReactNode,
 		{
 			isHidden = false,
+			tooltipText,
 			tooltipId,
 		}: {
 			isHidden?: boolean;
+			tooltipText?: TranslateResult;
 			tooltipId?: string;
 		} = {}
 	) => {
 		const className = clsx( pricingBadgeClassName, { 'is-hidden': isHidden } );
 
-		if ( isHidden || ! showPricingBadgeTooltip ) {
+		if ( isHidden || ! showPricingBadgeTooltip || ! tooltipText ) {
 			return <div className={ className }>{ children }</div>;
 		}
 
@@ -201,7 +259,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			<HeaderPriceBadgeTooltip
 				className={ className }
 				planSlug={ planSlug }
-				text={ pricingBadgeTooltipText }
+				text={ tooltipText }
 				tooltipId={ tooltipId }
 			>
 				{ children }
@@ -257,6 +315,16 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			typeof discountedPrice.monthly === 'number'
 				? discountedPrice.monthly
 				: introOffer.rawPrice.monthly;
+		const introOfferTooltipText =
+			billingPeriod === PLAN_MONTHLY_PERIOD
+				? getPricingBadgeTooltipText( {
+						billingPeriod,
+						cheaperPrice: monthlyPrice,
+						currencyCode,
+						referencePrice: compareToMonthlyPrice,
+						translate,
+				  } )
+				: termSavingsTooltipText;
 		// Recalculate the savings for Monthly plans with introductory offers
 		// since we are comparing the introductory price with the same plan
 		// renewal price, instead of comparing yearly to monthly costs for
@@ -278,7 +346,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 									comment: 'Example: Save 35%',
 							  } )
 							: translate( 'Special Offer' ),
-						{ tooltipId: 'intro-offer' }
+						{ tooltipId: 'intro-offer', tooltipText: introOfferTooltipText }
 					) }
 				{ current &&
 					visibleGridPlans.length > 1 &&
@@ -331,7 +399,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 							args: { savings },
 							comment: 'Example: Save 35%',
 						} ),
-						{ tooltipId: 'renewal-savings' }
+						{ tooltipId: 'renewal-savings', tooltipText: termSavingsTooltipText }
 					) }
 				{ ( ( ! current && savings <= 0 ) || ( current && visibleGridPlans.length > 1 ) ) &&
 					renderPricingBadge( "' '", {
@@ -369,10 +437,19 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	}
 
 	if ( isGridPlanOneTimeDiscounted ) {
+		const oneTimeDiscountTooltipText = getPricingBadgeTooltipText( {
+			billingPeriod,
+			cheaperPrice: discountedPrice.monthly,
+			currencyCode,
+			referencePrice: originalPrice.monthly,
+			translate,
+		} );
+
 		return (
 			<div className="plans-grid-next-header-price">
 				{ renderPricingBadge( translate( 'One time discount' ), {
 					tooltipId: 'one-time-discount',
+					tooltipText: oneTimeDiscountTooltipText,
 				} ) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
@@ -410,7 +487,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						args: { savings },
 						comment: 'Example: Save 35%',
 					} ),
-					{ tooltipId: 'term-savings' }
+					{ tooltipId: 'term-savings', tooltipText: termSavingsTooltipText }
 				) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
@@ -449,7 +526,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 								args: { savings },
 								comment: 'Example: Save 35%',
 							} ),
-							{ tooltipId: 'fallback-savings' }
+							{ tooltipId: 'fallback-savings', tooltipText: termSavingsTooltipText }
 					  )
 					: renderPricingBadge( "' '", { isHidden: true, tooltipId: 'fallback-placeholder' } ) }
 				{ isLargeCurrency ? (

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -102,12 +102,14 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		helpers,
 		showBillingDescriptionForIncreasedRenewalPrice,
 		isExperimentVariant,
+		showFeatureCheckmarks,
 		isEnterpriseA4AIndia,
 	} = usePlansGridContext();
 
 	const pricingBadgeClassName = clsx( 'plans-grid-next-header-price__badge', {
 		'is-plan-differentiators-experiment-badge': isExperimentVariant,
 	} );
+	const showPricingBadgeTooltip = isExperimentVariant && showFeatureCheckmarks;
 	const { isAnyPlanPriceDiscounted, setIsAnyPlanPriceDiscounted } = useHeaderPriceContext();
 	const {
 		current,
@@ -165,7 +167,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	) => {
 		const className = clsx( pricingBadgeClassName, { 'is-hidden': isHidden } );
 
-		if ( isHidden || ! isExperimentVariant ) {
+		if ( isHidden || ! showPricingBadgeTooltip ) {
 			return <div className={ className }>{ children }</div>;
 		}
 

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -2,6 +2,10 @@ import {
 	getPlanSlugForTermVariant,
 	isFreePlan,
 	isWpcomEnterpriseGridPlan,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
 	PERIOD_LIST,
 	TERM_MONTHLY,
 	type PlanSlug,
@@ -10,7 +14,7 @@ import { PlanPrice } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
 import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { type TranslateResult, useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
 import { useManageTooltipToggle } from '../../../hooks/use-manage-tooltip-toggle';
@@ -68,27 +72,48 @@ const HeaderPriceBadgeTooltip = ( {
 	children,
 	className,
 	planSlug,
+	text,
 	tooltipId,
 }: {
 	children: ReactNode;
 	className: string;
 	planSlug: PlanSlug;
+	text: TranslateResult;
 	tooltipId?: string;
 } ) => {
-	const translate = useTranslate();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const badge = <span className={ className }>{ children }</span>;
 
 	return (
 		<Plans2023Tooltip
 			id={ `plans-grid-next-header-price-badge-${ planSlug }-${ tooltipId ?? 'default' }` }
-			text={ translate( 'What a savings!' ) }
+			text={ text }
 			activeTooltipId={ activeTooltipId }
 			setActiveTooltipId={ setActiveTooltipId }
 		>
 			{ badge }
 		</Plans2023Tooltip>
 	);
+};
+
+const getPricingBadgeTooltipText = ( {
+	billingPeriod,
+	translate,
+}: {
+	billingPeriod?: -1 | ( typeof PERIOD_LIST )[ number ];
+	translate: ( text: string ) => TranslateResult;
+} ): TranslateResult => {
+	switch ( billingPeriod ) {
+		case PLAN_MONTHLY_PERIOD:
+			return translate( '1-month savings' );
+		case PLAN_BIENNIAL_PERIOD:
+			return translate( '2-year savings' );
+		case PLAN_TRIENNIAL_PERIOD:
+			return translate( '3-year savings' );
+		case PLAN_ANNUAL_PERIOD:
+		default:
+			return translate( '1-year savings' );
+	}
 };
 
 const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
@@ -116,6 +141,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer, billingPeriod },
 		isMonthlyPlan,
 	} = gridPlansIndex[ planSlug ];
+	const pricingBadgeTooltipText = getPricingBadgeTooltipText( { billingPeriod, translate } );
 	const isPricedPlan = null !== originalPrice.monthly;
 
 	/**
@@ -175,6 +201,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			<HeaderPriceBadgeTooltip
 				className={ className }
 				planSlug={ planSlug }
+				text={ pricingBadgeTooltipText }
 				tooltipId={ tooltipId }
 			>
 				{ children }

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -108,13 +108,7 @@ const getPricingBadgeTooltipText = ( {
 	cheaperPrice?: number | null;
 	currencyCode?: string | null;
 	referencePrice?: number | null;
-	translate: (
-		text: string,
-		options?: {
-			args: Record< string, string >;
-			comment?: string;
-		}
-	) => TranslateResult;
+	translate: ReturnType< typeof useTranslate >;
 } ): TranslateResult | undefined => {
 	if (
 		! currencyCode ||
@@ -222,7 +216,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			? getPlanPriceForDuration( termVariantInfo, currentPlanInfo.termMonths )
 			: null;
 	const currentPlanPrice =
-		currentPlanInfo && termVariantInfo
+		termVariantInfo && currentPlanInfo
 			? getPlanPriceForDuration( currentPlanInfo, currentPlanInfo.termMonths )
 			: null;
 	const termSavingsTooltipText = getPricingBadgeTooltipText( {

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -431,20 +431,9 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	}
 
 	if ( isGridPlanOneTimeDiscounted ) {
-		const oneTimeDiscountTooltipText = getPricingBadgeTooltipText( {
-			billingPeriod,
-			cheaperPrice: discountedPrice.monthly,
-			currencyCode,
-			referencePrice: originalPrice.monthly,
-			translate,
-		} );
-
 		return (
 			<div className="plans-grid-next-header-price">
-				{ renderPricingBadge( translate( 'One time discount' ), {
-					tooltipId: 'one-time-discount',
-					tooltipText: oneTimeDiscountTooltipText,
-				} ) }
+				{ renderPricingBadge( translate( 'One time discount' ) ) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -13,6 +13,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
+import { useManageTooltipToggle } from '../../../hooks/use-manage-tooltip-toggle';
 import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';
 import {
 	calculateDiscountPercentage,
@@ -20,8 +21,10 @@ import {
 	getPlanPriceForDuration,
 } from '../../../lib/plan-pricing-utils';
 import ClientLogoList from '../../features-grid/client-logo-list';
+import { Plans2023Tooltip } from '../../plans-2023-tooltip';
 import { useHeaderPriceContext } from './header-price-context';
 import type { GridPlan } from '../../../types';
+import type { ReactNode } from 'react';
 import './style.scss';
 
 export const ALL_ENTERPRISE_LOGO_SLUGS = [
@@ -59,6 +62,33 @@ const useTermVariantPlanSlugForSavings = ( {
 	}
 
 	return null;
+};
+
+const HeaderPriceBadgeTooltip = ( {
+	children,
+	className,
+	planSlug,
+	tooltipId,
+}: {
+	children: ReactNode;
+	className: string;
+	planSlug: PlanSlug;
+	tooltipId?: string;
+} ) => {
+	const translate = useTranslate();
+	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
+	const badge = <span className={ className }>{ children }</span>;
+
+	return (
+		<Plans2023Tooltip
+			id={ `plans-grid-next-header-price-badge-${ planSlug }-${ tooltipId ?? 'default' }` }
+			text={ translate( 'What a savings!' ) }
+			activeTooltipId={ activeTooltipId }
+			setActiveTooltipId={ setActiveTooltipId }
+		>
+			{ badge }
+		</Plans2023Tooltip>
+	);
 };
 
 const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
@@ -123,6 +153,33 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			  ) ?? 0
 			: 0;
 
+	const renderPricingBadge = (
+		children: ReactNode,
+		{
+			isHidden = false,
+			tooltipId,
+		}: {
+			isHidden?: boolean;
+			tooltipId?: string;
+		} = {}
+	) => {
+		const className = clsx( pricingBadgeClassName, { 'is-hidden': isHidden } );
+
+		if ( isHidden || ! isExperimentVariant ) {
+			return <div className={ className }>{ children }</div>;
+		}
+
+		return (
+			<HeaderPriceBadgeTooltip
+				className={ className }
+				planSlug={ planSlug }
+				tooltipId={ tooltipId }
+			>
+				{ children }
+			</HeaderPriceBadgeTooltip>
+		);
+	};
+
 	useEffect( () => {
 		if (
 			isGridPlanOneTimeDiscounted ||
@@ -184,19 +241,22 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		}
 		return (
 			<div className="plans-grid-next-header-price">
-				{ ! current && (
-					<div className={ pricingBadgeClassName }>
-						{ showBillingDescriptionForIncreasedRenewalPrice
+				{ ! current &&
+					renderPricingBadge(
+						showBillingDescriptionForIncreasedRenewalPrice
 							? translate( 'Save %(savings)d%%', {
 									args: { savings },
 									comment: 'Example: Save 35%',
 							  } )
-							: translate( 'Special Offer' ) }
-					</div>
-				) }
-				{ current && visibleGridPlans.length > 1 && (
-					<div className={ clsx( pricingBadgeClassName, 'is-hidden' ) }>' '</div>
-				) }
+							: translate( 'Special Offer' ),
+						{ tooltipId: 'intro-offer' }
+					) }
+				{ current &&
+					visibleGridPlans.length > 1 &&
+					renderPricingBadge( "' '", {
+						isHidden: true,
+						tooltipId: 'intro-offer-placeholder',
+					} ) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,
@@ -235,17 +295,20 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 				: originalPrice.monthly ?? 0;
 		return (
 			<div className="plans-grid-next-header-price">
-				{ ! current && savings > 0 && (
-					<div className={ pricingBadgeClassName }>
-						{ translate( 'Save %(savings)d%%', {
+				{ ! current &&
+					savings > 0 &&
+					renderPricingBadge(
+						translate( 'Save %(savings)d%%', {
 							args: { savings },
 							comment: 'Example: Save 35%',
-						} ) }
-					</div>
-				) }
-				{ ( ( ! current && savings <= 0 ) || ( current && visibleGridPlans.length > 1 ) ) && (
-					<div className={ clsx( pricingBadgeClassName, 'is-hidden' ) }>' '</div>
-				) }
+						} ),
+						{ tooltipId: 'renewal-savings' }
+					) }
+				{ ( ( ! current && savings <= 0 ) || ( current && visibleGridPlans.length > 1 ) ) &&
+					renderPricingBadge( "' '", {
+						isHidden: true,
+						tooltipId: 'renewal-savings-placeholder',
+					} ) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,
@@ -279,7 +342,9 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isGridPlanOneTimeDiscounted ) {
 		return (
 			<div className="plans-grid-next-header-price">
-				<div className={ pricingBadgeClassName }>{ translate( 'One time discount' ) }</div>
+				{ renderPricingBadge( translate( 'One time discount' ), {
+					tooltipId: 'one-time-discount',
+				} ) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,
@@ -311,12 +376,13 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( enableTermSavingsPriceDisplay && termVariantPricing && savings ) {
 		return (
 			<div className="plans-grid-next-header-price">
-				<div className={ pricingBadgeClassName }>
-					{ translate( 'Save %(savings)d%%', {
+				{ renderPricingBadge(
+					translate( 'Save %(savings)d%%', {
 						args: { savings },
 						comment: 'Example: Save 35%',
-					} ) }
-				</div>
+					} ),
+					{ tooltipId: 'term-savings' }
+				) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,
@@ -348,16 +414,15 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isAnyPlanPriceDiscounted ) {
 		return (
 			<div className="plans-grid-next-header-price">
-				{ showBillingDescriptionForIncreasedRenewalPrice && savings ? (
-					<div className={ pricingBadgeClassName }>
-						{ translate( 'Save %(savings)d%%', {
-							args: { savings },
-							comment: 'Example: Save 35%',
-						} ) }
-					</div>
-				) : (
-					<div className={ clsx( pricingBadgeClassName, 'is-hidden' ) }>' '</div>
-				) }
+				{ showBillingDescriptionForIncreasedRenewalPrice && savings
+					? renderPricingBadge(
+							translate( 'Save %(savings)d%%', {
+								args: { savings },
+								comment: 'Example: Save 35%',
+							} ),
+							{ tooltipId: 'fallback-savings' }
+					  )
+					: renderPricingBadge( "' '", { isHidden: true, tooltipId: 'fallback-placeholder' } ) }
 				{ isLargeCurrency ? (
 					<div className="plans-grid-next-header-price__pricing-group is-large-currency">
 						<PlanPrice

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -266,6 +266,7 @@ describe( 'HeaderPrice', () => {
 				},
 			},
 			isExperimentVariant: true,
+			showFeatureCheckmarks: true,
 			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
 		} ) );
 
@@ -283,6 +284,48 @@ describe( 'HeaderPrice', () => {
 		await waitFor( () => {
 			expect( screen.getByText( /What a\s+savings!/ ) ).toBeInTheDocument();
 		} );
+	} );
+
+	test( 'should not show a pricing badge tooltip outside the plans grid redesign experiment', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 20, full: 240 },
+				discountedPrice: { monthly: null, full: null },
+				billingPeriod: 31,
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+			isExperimentVariant: true,
+			showFeatureCheckmarks: false,
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const badge = container.querySelector(
+			'.plans-grid-next-header-price__badge.is-plan-differentiators-experiment-badge:not(.is-hidden)'
+		);
+
+		expect( badge ).toHaveTextContent( 'Save 50%' );
+		expect( container.querySelector( '.plans-2023-tooltip__hover-area-container' ) ).toBeNull();
 	} );
 
 	test( 'should show the monthly plan price crossed out and the annual monthly-equivalent as the current price', () => {

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -58,6 +58,18 @@ const Wrapper = ( { children } ) => {
 	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
 };
 
+const expectTooltipText = async ( text: string ) => {
+	await waitFor( () => {
+		expect(
+			screen.getByText(
+				( _content, element ) =>
+					element?.classList.contains( 'popover__inner' ) &&
+					element.textContent?.replace( /\s+/g, ' ' ) === text
+			)
+		).toBeInTheDocument();
+	} );
+};
+
 describe( 'HeaderPrice', () => {
 	const defaultProps = {
 		isLargeCurrency: false,
@@ -243,15 +255,15 @@ describe( 'HeaderPrice', () => {
 	} );
 
 	test.each( [
-		[ '1-year savings', PLAN_PERSONAL, PLAN_ANNUAL_PERIOD ],
-		[ '2-year savings', PLAN_PERSONAL_2_YEARS, PLAN_BIENNIAL_PERIOD ],
-		[ '3-year savings', PLAN_PERSONAL_3_YEARS, PLAN_TRIENNIAL_PERIOD ],
+		[ '$120/year vs. $240 paying monthly', PLAN_PERSONAL, PLAN_ANNUAL_PERIOD ],
+		[ '$240/2 years vs. $480 paying monthly', PLAN_PERSONAL_2_YEARS, PLAN_BIENNIAL_PERIOD ],
+		[ '$360/3 years vs. $720 paying monthly', PLAN_PERSONAL_3_YEARS, PLAN_TRIENNIAL_PERIOD ],
 	] )(
 		'should show "%s" on pricing badge tooltips in the plans grid redesign experiment',
 		async ( expectedTooltipText, planSlug, billingPeriod ) => {
 			const pricing = {
 				currencyCode: 'USD',
-				originalPrice: { full: 120, monthly: 10 },
+				originalPrice: { full: 12000, monthly: 1000 },
 				discountedPrice: { full: null, monthly: null },
 				billingPeriod,
 			};
@@ -262,7 +274,7 @@ describe( 'HeaderPrice', () => {
 			} );
 			( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
 				[ PLAN_PERSONAL_MONTHLY ]: {
-					originalPrice: { monthly: 20, full: 240 },
+					originalPrice: { monthly: 2000, full: 24000 },
 					discountedPrice: { monthly: null, full: null },
 					billingPeriod: PLAN_MONTHLY_PERIOD,
 				},
@@ -278,7 +290,7 @@ describe( 'HeaderPrice', () => {
 				},
 				isExperimentVariant: true,
 				showFeatureCheckmarks: true,
-				showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+				enableTermSavingsPriceDisplay: true,
 			} ) );
 
 			const { container } = render(
@@ -297,19 +309,76 @@ describe( 'HeaderPrice', () => {
 
 			fireEvent.mouseEnter( hoverArea as Element );
 
-			await waitFor( () => {
-				expect(
-					screen.getByText( new RegExp( expectedTooltipText.replace( ' ', '\\s+' ) ) )
-				).toBeInTheDocument();
-			} );
+			await expectTooltipText( expectedTooltipText );
 		}
 	);
 
-	test( 'should show "1-month savings" on monthly pricing badge tooltips', async () => {
+	test( 'should show full-term renewal pricing on renewal pricing badge tooltips', async () => {
 		const pricing = {
 			currencyCode: 'USD',
-			originalPrice: { full: 120, monthly: 10 },
-			discountedPrice: { full: 60, monthly: 5 },
+			originalPrice: { full: 21600, monthly: 1800 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+			introOffer: {
+				formattedPrice: '$48.00',
+				rawPrice: { monthly: 400, full: 4800 },
+				intervalUnit: 'year',
+				intervalCount: 1,
+				isOfferComplete: false,
+			},
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 1800, full: 21600 },
+				discountedPrice: { monthly: null, full: null },
+				billingPeriod: PLAN_MONTHLY_PERIOD,
+				introOffer: {
+					formattedPrice: '$9.00',
+					rawPrice: { monthly: 900, full: 900 },
+					intervalUnit: 'month',
+					intervalCount: 1,
+					isOfferComplete: false,
+				},
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: false,
+					pricing,
+				},
+			},
+			isExperimentVariant: true,
+			showFeatureCheckmarks: true,
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const badge = container.querySelector(
+			'.plans-grid-next-header-price__badge.is-plan-differentiators-experiment-badge:not(.is-hidden)'
+		);
+		const hoverArea = container.querySelector( '.plans-2023-tooltip__hover-area-container' );
+
+		expect( badge ).toHaveTextContent( 'Save 76%' );
+		expect( hoverArea ).toContainElement( badge );
+
+		fireEvent.mouseEnter( hoverArea as Element );
+
+		await expectTooltipText( '$48/year vs. $207 paying monthly' );
+	} );
+
+	test( 'should show first-month pricing on monthly pricing badge tooltips', async () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 1000, monthly: 1000 },
+			discountedPrice: { full: 500, monthly: 500 },
 			billingPeriod: PLAN_MONTHLY_PERIOD,
 		};
 
@@ -342,9 +411,7 @@ describe( 'HeaderPrice', () => {
 
 		fireEvent.mouseEnter( hoverArea as Element );
 
-		await waitFor( () => {
-			expect( screen.getByText( /1-month\s+savings/ ) ).toBeInTheDocument();
-		} );
+		await expectTooltipText( '$5/first month vs. $10 monthly after that' );
 	} );
 
 	test( 'should not show a pricing badge tooltip outside the plans grid redesign experiment', () => {

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -24,6 +24,9 @@ jest.mock( '@automattic/data-stores', () => ( {
 		usePricingMetaForGridPlans: jest.fn(),
 	},
 } ) );
+jest.mock( '../../lib/touch-detect', () => ( {
+	hasTouch: () => false,
+} ) );
 
 jest.mock( '../shared/header-price/header-price-context', () => ( {
 	useHeaderPriceContext: () => mockUseHeaderPriceContext(),
@@ -38,7 +41,7 @@ import {
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { useMemo } from 'react';
 import { usePlansGridContext } from '../../grid-context';
 import { GridPlan } from '../../types';
@@ -232,6 +235,54 @@ describe( 'HeaderPrice', () => {
 		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
 
 		expect( badge ).toHaveTextContent( 'Save 50%' );
+	} );
+
+	test( 'should show a tooltip on pricing badges in the plans grid redesign experiment', async () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 20, full: 240 },
+				discountedPrice: { monthly: null, full: null },
+				billingPeriod: 31,
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+			isExperimentVariant: true,
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const badge = container.querySelector(
+			'.plans-grid-next-header-price__badge.is-plan-differentiators-experiment-badge:not(.is-hidden)'
+		);
+		const hoverArea = container.querySelector( '.plans-2023-tooltip__hover-area-container' );
+
+		expect( badge ).toHaveTextContent( 'Save 50%' );
+		expect( hoverArea ).toContainElement( badge );
+
+		fireEvent.mouseEnter( hoverArea as Element );
+
+		await waitFor( () => {
+			expect( screen.getByText( /What a\s+savings!/ ) ).toBeInTheDocument();
+		} );
 	} );
 
 	test( 'should show the monthly plan price crossed out and the annual monthly-equivalent as the current price', () => {

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -35,9 +35,14 @@ jest.mock( '../shared/header-price/header-price-context', () => ( {
 import {
 	type PlanSlug,
 	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
 	PLAN_ENTERPRISE_GRID_WPCOM,
+	PLAN_MONTHLY_PERIOD,
 	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
 	PLAN_PERSONAL_MONTHLY,
+	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -237,29 +242,80 @@ describe( 'HeaderPrice', () => {
 		expect( badge ).toHaveTextContent( 'Save 50%' );
 	} );
 
-	test( 'should show a tooltip on pricing badges in the plans grid redesign experiment', async () => {
+	test.each( [
+		[ '1-year savings', PLAN_PERSONAL, PLAN_ANNUAL_PERIOD ],
+		[ '2-year savings', PLAN_PERSONAL_2_YEARS, PLAN_BIENNIAL_PERIOD ],
+		[ '3-year savings', PLAN_PERSONAL_3_YEARS, PLAN_TRIENNIAL_PERIOD ],
+	] )(
+		'should show "%s" on pricing badge tooltips in the plans grid redesign experiment',
+		async ( expectedTooltipText, planSlug, billingPeriod ) => {
+			const pricing = {
+				currencyCode: 'USD',
+				originalPrice: { full: 120, monthly: 10 },
+				discountedPrice: { full: null, monthly: null },
+				billingPeriod,
+			};
+
+			mockUseHeaderPriceContext.mockReturnValue( {
+				isAnyPlanPriceDiscounted: true,
+				setIsAnyPlanPriceDiscounted: jest.fn(),
+			} );
+			( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+				[ PLAN_PERSONAL_MONTHLY ]: {
+					originalPrice: { monthly: 20, full: 240 },
+					discountedPrice: { monthly: null, full: null },
+					billingPeriod: PLAN_MONTHLY_PERIOD,
+				},
+			} );
+
+			usePlansGridContext.mockImplementation( () => ( {
+				gridPlansIndex: {
+					[ planSlug ]: {
+						current: false,
+						isMonthlyPlan: false,
+						pricing,
+					},
+				},
+				isExperimentVariant: true,
+				showFeatureCheckmarks: true,
+				showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+			} ) );
+
+			const { container } = render(
+				<HeaderPrice { ...defaultProps } planSlug={ planSlug as PlanSlug } />,
+				{
+					wrapper: Wrapper,
+				}
+			);
+			const badge = container.querySelector(
+				'.plans-grid-next-header-price__badge.is-plan-differentiators-experiment-badge:not(.is-hidden)'
+			);
+			const hoverArea = container.querySelector( '.plans-2023-tooltip__hover-area-container' );
+
+			expect( badge ).toHaveTextContent( 'Save 50%' );
+			expect( hoverArea ).toContainElement( badge );
+
+			fireEvent.mouseEnter( hoverArea as Element );
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( new RegExp( expectedTooltipText.replace( ' ', '\\s+' ) ) )
+				).toBeInTheDocument();
+			} );
+		}
+	);
+
+	test( 'should show "1-month savings" on monthly pricing badge tooltips', async () => {
 		const pricing = {
 			currencyCode: 'USD',
 			originalPrice: { full: 120, monthly: 10 },
-			discountedPrice: { full: null, monthly: null },
-			billingPeriod: PLAN_ANNUAL_PERIOD,
+			discountedPrice: { full: 60, monthly: 5 },
+			billingPeriod: PLAN_MONTHLY_PERIOD,
 		};
-
-		mockUseHeaderPriceContext.mockReturnValue( {
-			isAnyPlanPriceDiscounted: true,
-			setIsAnyPlanPriceDiscounted: jest.fn(),
-		} );
-		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
-			[ PLAN_PERSONAL_MONTHLY ]: {
-				originalPrice: { monthly: 20, full: 240 },
-				discountedPrice: { monthly: null, full: null },
-				billingPeriod: 31,
-			},
-		} );
 
 		usePlansGridContext.mockImplementation( () => ( {
 			gridPlansIndex: {
-				[ PLAN_PERSONAL ]: {
+				[ PLAN_PERSONAL_MONTHLY ]: {
 					current: false,
 					isMonthlyPlan: true,
 					pricing,
@@ -270,19 +326,24 @@ describe( 'HeaderPrice', () => {
 			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
 		} ) );
 
-		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const { container } = render(
+			<HeaderPrice { ...defaultProps } planSlug={ PLAN_PERSONAL_MONTHLY } />,
+			{
+				wrapper: Wrapper,
+			}
+		);
 		const badge = container.querySelector(
 			'.plans-grid-next-header-price__badge.is-plan-differentiators-experiment-badge:not(.is-hidden)'
 		);
 		const hoverArea = container.querySelector( '.plans-2023-tooltip__hover-area-container' );
 
-		expect( badge ).toHaveTextContent( 'Save 50%' );
+		expect( badge ).toHaveTextContent( 'One time discount' );
 		expect( hoverArea ).toContainElement( badge );
 
 		fireEvent.mouseEnter( hoverArea as Element );
 
 		await waitFor( () => {
-			expect( screen.getByText( /What a\s+savings!/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /1-month\s+savings/ ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -374,19 +374,19 @@ describe( 'HeaderPrice', () => {
 		await expectTooltipText( '$48/year vs. $207 paying monthly' );
 	} );
 
-	test( 'should show first-month pricing on monthly pricing badge tooltips', async () => {
+	test( 'should not show pricing badge tooltips for one-time discounts', () => {
 		const pricing = {
 			currencyCode: 'USD',
-			originalPrice: { full: 1000, monthly: 1000 },
-			discountedPrice: { full: 500, monthly: 500 },
-			billingPeriod: PLAN_MONTHLY_PERIOD,
+			originalPrice: { full: 12000, monthly: 1000 },
+			discountedPrice: { full: 6000, monthly: 500 },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
 		};
 
 		usePlansGridContext.mockImplementation( () => ( {
 			gridPlansIndex: {
-				[ PLAN_PERSONAL_MONTHLY ]: {
+				[ PLAN_PERSONAL ]: {
 					current: false,
-					isMonthlyPlan: true,
+					isMonthlyPlan: false,
 					pricing,
 				},
 			},
@@ -395,23 +395,14 @@ describe( 'HeaderPrice', () => {
 			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
 		} ) );
 
-		const { container } = render(
-			<HeaderPrice { ...defaultProps } planSlug={ PLAN_PERSONAL_MONTHLY } />,
-			{
-				wrapper: Wrapper,
-			}
-		);
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
 		const badge = container.querySelector(
 			'.plans-grid-next-header-price__badge.is-plan-differentiators-experiment-badge:not(.is-hidden)'
 		);
 		const hoverArea = container.querySelector( '.plans-2023-tooltip__hover-area-container' );
 
 		expect( badge ).toHaveTextContent( 'One time discount' );
-		expect( hoverArea ).toContainElement( badge );
-
-		fireEvent.mouseEnter( hoverArea as Element );
-
-		await expectTooltipText( '$5/first month vs. $10 monthly after that' );
+		expect( hoverArea ).toBeNull();
 	} );
 
 	test( 'should not show a pricing badge tooltip outside the plans grid redesign experiment', () => {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17809

## Proposed Changes

* Add discount tooltips on savings badges
<img width="301" height="293" alt="Screenshot 2026-07-09 at 18 47 01" src="https://github.com/user-attachments/assets/0f75b895-44e0-4ec9-a85c-3950af91506b" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to `six_plan_new_features` / `six_plan_new_design` / `six_plan_new_description` variant.
* Navigate to /setup/onboarding/plans and hover on the 'Save x%' badges.
* Test the /plans page with different billing intervals.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
