### PR TITLE
MSD contact info: Fix Country selector search and hidden validation errors

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -23,12 +23,8 @@ import { RegionAddressFieldsets } from './region-address-fieldsets';
 import type { CountryListItem } from './custom-form-fieldsets/types';
 import type { DomainContactDetails, StatesListItem } from '@automattic/api-core';
 
-// The supported-countries endpoint repeats the most popular countries at the top
-// of the list and inserts an empty-code separator between them and the full list.
-// That is meant for a plain <select>, but the country field renders as a searchable
-// combobox whose option keys are the country codes, so the repeats and the empty
-// entry produce duplicate React keys that break list rendering. Keep a single,
-// non-empty entry per country code.
+// The supported-countries list repeats popular countries and includes an empty-code
+// separator; the combobox keys options by code, so dedupe to avoid duplicate React keys.
 const getCountryElements = ( countryList: CountryListItem[] | undefined ) => {
 	const seen = new Set< string >();
 	const elements: { label: string; value: string }[] = [];

--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -23,6 +23,25 @@ import { RegionAddressFieldsets } from './region-address-fieldsets';
 import type { CountryListItem } from './custom-form-fieldsets/types';
 import type { DomainContactDetails, StatesListItem } from '@automattic/api-core';
 
+// The supported-countries endpoint repeats the most popular countries at the top
+// of the list and inserts an empty-code separator between them and the full list.
+// That is meant for a plain <select>, but the country field renders as a searchable
+// combobox whose option keys are the country codes, so the repeats and the empty
+// entry produce duplicate React keys that break list rendering. Keep a single,
+// non-empty entry per country code.
+const getCountryElements = ( countryList: CountryListItem[] | undefined ) => {
+	const seen = new Set< string >();
+	const elements: { label: string; value: string }[] = [];
+	for ( const country of countryList ?? [] ) {
+		if ( ! country.code || seen.has( country.code ) ) {
+			continue;
+		}
+		seen.add( country.code );
+		elements.push( { label: country.name, value: country.code } );
+	}
+	return elements;
+};
+
 export const getContactFormFields = (
 	countryList: CountryListItem[] | undefined,
 	statesList: StatesListItem[] | undefined,
@@ -131,11 +150,7 @@ export const getContactFormFields = (
 			id: 'countryCode',
 			label: __( 'Country' ),
 			type: 'text',
-			elements:
-				countryList?.map( ( country ) => ( {
-					label: country.name,
-					value: country.code,
-				} ) ) ?? [],
+			elements: getCountryElements( countryList ),
 			isValid: {
 				required: true,
 				custom: createFieldAsyncValidator( 'countryCode', asyncValidator ),

--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -137,11 +137,9 @@ export default function ContactForm( {
 
 	const { validity, isValid: isFormValid } = useFormValidity( normalizedFormData, fields, form );
 
-	// The validation endpoint validates the whole form, so a change to one field
-	// (e.g. the country) can invalidate another (e.g. the postal code) whose own
-	// async validator DataForm won't re-run. Surface every field error from the
-	// latest response so those errors appear without the user having to touch each
-	// field, and keep Save disabled while any of them remain.
+	// A whole-form validation can invalidate a field (e.g. postal code) whose own
+	// validator DataForm won't re-run after another field (e.g. country) changes.
+	// Surface every field's error from the latest response, and gate Save on them.
 	const serverFieldErrors = useMemo(
 		() =>
 			mapValidationMessagesToFieldErrors(
@@ -159,10 +157,8 @@ export default function ContactForm( {
 		}
 		const merged: NonNullable< typeof validity > = { ...validity };
 		for ( const [ fieldId, message ] of fieldErrors ) {
-			// Replace rather than merge: an empty required field also has a
-			// message-less `required` validity that DataForm prioritises over
-			// `custom`, which would hide the server message. The server error is
-			// the authoritative one to display for these fields.
+			// Replace, not merge: a message-less `required` validity (empty required
+			// field) would otherwise take precedence over and hide this message.
 			merged[ fieldId ] = { custom: { type: 'invalid', message } };
 		}
 		return merged;
@@ -170,32 +166,9 @@ export default function ContactForm( {
 
 	const canSave = isFormValid && Object.keys( serverFieldErrors ).length === 0;
 
-	const fieldLabels = useMemo( () => {
-		const labels: Partial< Record< keyof DomainContactDetails, string > > = {};
-		for ( const field of fields ) {
-			if ( field.label ) {
-				labels[ field.id as keyof DomainContactDetails ] = field.label;
-			}
-		}
-		return labels;
-	}, [ fields ] );
-
-	const validationErrors = useMemo(
-		() =>
-			Object.entries( serverFieldErrors ).map( ( [ fieldId, message ] ) => ( {
-				fieldId,
-				label: fieldLabels[ fieldId as keyof DomainContactDetails ],
-				message,
-			} ) ),
-		[ serverFieldErrors, fieldLabels ]
-	);
-
-	// DataForm keeps a field's validation message hidden until the field is
-	// touched, so a field invalidated by another field's change (e.g. the postal
-	// code becoming required after switching country) stays silent. When the set
-	// of server-flagged fields changes, reveal their errors by triggering native
-	// validation, which DataForm surfaces inline. Keyed on the set of fields (not
-	// the messages) so it does not re-fire — and move focus — while the user types.
+	// DataForm hides a field's error until it's touched. Reveal server-flagged fields
+	// by re-running native validation when the flagged set changes (keyed on the set,
+	// not the messages, so it doesn't re-fire or move focus while the user types).
 	const fieldsContainerRef = useRef< HTMLDivElement >( null );
 	const revealedErrorKeyRef = useRef( '' );
 	const serverErrorKey = Object.keys( serverFieldErrors ).sort().join( ',' );
@@ -215,14 +188,15 @@ export default function ContactForm( {
 			if ( ! container ) {
 				return;
 			}
-			const controls = container.querySelectorAll< HTMLInputElement >( 'input, select, textarea' );
-			let firstInvalid: HTMLElement | null = null;
-			controls.forEach( ( control ) => {
-				if ( ! control.checkValidity() ) {
-					firstInvalid = firstInvalid ?? control;
-				}
-			} );
-			firstInvalid?.focus();
+			const controls = Array.from(
+				container.querySelectorAll< HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement >(
+					'input, select, textarea'
+				)
+			);
+			// filter (not find) so checkValidity() runs on every control and reveals
+			// each invalid field, then focus the first invalid one.
+			const invalidControls = controls.filter( ( control ) => ! control.checkValidity() );
+			invalidControls[ 0 ]?.focus();
 		} );
 		return () => cancelAnimationFrame( raf );
 	}, [ isDirty, serverErrorKey ] );
@@ -294,20 +268,6 @@ export default function ContactForm( {
 								</Text>
 							</VStack>
 						</Notice>
-						{ isDirty && validationErrors.length > 0 && (
-							<Notice
-								variant="error"
-								title={ __( 'Please fix the following to save your changes' ) }
-							>
-								<VStack spacing={ 1 }>
-									{ validationErrors.map( ( { fieldId, label, message } ) => (
-										<Text as="p" key={ fieldId }>
-											{ label ? `${ label }: ${ message }` : message }
-										</Text>
-									) ) }
-								</VStack>
-							</Notice>
-						) }
 						<form onSubmit={ handleSubmit }>
 							<ButtonStack justify="flex-start">
 								<Button

--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -11,7 +11,7 @@ import { debounce } from '@wordpress/compose';
 import { DataForm, Field, useFormValidity, FormField } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ButtonStack } from '../button-stack';
 import { Card, CardBody } from '../card';
 import InlineSupportLink from '../inline-support-link';
@@ -159,15 +159,73 @@ export default function ContactForm( {
 		}
 		const merged: NonNullable< typeof validity > = { ...validity };
 		for ( const [ fieldId, message ] of fieldErrors ) {
-			merged[ fieldId ] = {
-				...merged[ fieldId ],
-				custom: { type: 'invalid', message },
-			};
+			// Replace rather than merge: an empty required field also has a
+			// message-less `required` validity that DataForm prioritises over
+			// `custom`, which would hide the server message. The server error is
+			// the authoritative one to display for these fields.
+			merged[ fieldId ] = { custom: { type: 'invalid', message } };
 		}
 		return merged;
 	}, [ validity, serverFieldErrors, isDirty ] );
 
 	const canSave = isFormValid && Object.keys( serverFieldErrors ).length === 0;
+
+	const fieldLabels = useMemo( () => {
+		const labels: Partial< Record< keyof DomainContactDetails, string > > = {};
+		for ( const field of fields ) {
+			if ( field.label ) {
+				labels[ field.id as keyof DomainContactDetails ] = field.label;
+			}
+		}
+		return labels;
+	}, [ fields ] );
+
+	const validationErrors = useMemo(
+		() =>
+			Object.entries( serverFieldErrors ).map( ( [ fieldId, message ] ) => ( {
+				fieldId,
+				label: fieldLabels[ fieldId as keyof DomainContactDetails ],
+				message,
+			} ) ),
+		[ serverFieldErrors, fieldLabels ]
+	);
+
+	// DataForm keeps a field's validation message hidden until the field is
+	// touched, so a field invalidated by another field's change (e.g. the postal
+	// code becoming required after switching country) stays silent. When the set
+	// of server-flagged fields changes, reveal their errors by triggering native
+	// validation, which DataForm surfaces inline. Keyed on the set of fields (not
+	// the messages) so it does not re-fire — and move focus — while the user types.
+	const fieldsContainerRef = useRef< HTMLDivElement >( null );
+	const revealedErrorKeyRef = useRef( '' );
+	const serverErrorKey = Object.keys( serverFieldErrors ).sort().join( ',' );
+	useEffect( () => {
+		if ( ! isDirty || ! serverErrorKey ) {
+			revealedErrorKeyRef.current = '';
+			return;
+		}
+		if ( revealedErrorKeyRef.current === serverErrorKey ) {
+			return;
+		}
+		revealedErrorKeyRef.current = serverErrorKey;
+
+		// Defer so DataForm has applied the custom validity to the inputs first.
+		const raf = requestAnimationFrame( () => {
+			const container = fieldsContainerRef.current;
+			if ( ! container ) {
+				return;
+			}
+			const controls = container.querySelectorAll< HTMLInputElement >( 'input, select, textarea' );
+			let firstInvalid: HTMLElement | null = null;
+			controls.forEach( ( control ) => {
+				if ( ! control.checkValidity() ) {
+					firstInvalid = firstInvalid ?? control;
+				}
+			} );
+			firstInvalid?.focus();
+		} );
+		return () => cancelAnimationFrame( raf );
+	}, [ isDirty, serverErrorKey ] );
 
 	return (
 		<VStack spacing={ 10 }>
@@ -205,15 +263,17 @@ export default function ContactForm( {
 				<CardBody>
 					<VStack spacing={ 4 }>
 						{ beforeForm }
-						<DataForm< DomainContactDetails >
-							data={ normalizedFormData }
-							fields={ fields }
-							form={ form }
-							validity={ validityWithServerErrors }
-							onChange={ ( edits: Partial< DomainContactDetails > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
+						<div ref={ fieldsContainerRef }>
+							<DataForm< DomainContactDetails >
+								data={ normalizedFormData }
+								fields={ fields }
+								form={ form }
+								validity={ validityWithServerErrors }
+								onChange={ ( edits: Partial< DomainContactDetails > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+						</div>
 						<Notice>
 							<VStack>
 								<Text as="p">
@@ -234,6 +294,20 @@ export default function ContactForm( {
 								</Text>
 							</VStack>
 						</Notice>
+						{ isDirty && validationErrors.length > 0 && (
+							<Notice
+								variant="error"
+								title={ __( 'Please fix the following to save your changes' ) }
+							>
+								<VStack spacing={ 1 }>
+									{ validationErrors.map( ( { fieldId, label, message } ) => (
+										<Text as="p" key={ fieldId }>
+											{ label ? `${ label }: ${ message }` : message }
+										</Text>
+									) ) }
+								</VStack>
+							</Notice>
+						) }
 						<form onSubmit={ handleSubmit }>
 							<ButtonStack justify="flex-start">
 								<Button

--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -17,6 +17,7 @@ import { Card, CardBody } from '../card';
 import InlineSupportLink from '../inline-support-link';
 import Notice from '../notice';
 import { getContactFormFields } from './contact-form-fields';
+import { mapValidationMessagesToFieldErrors } from './contact-validation-utils';
 import { RegionAddressFieldsLayout } from './region-address-fieldsets';
 import type { UseMutateAsyncFunction } from '@tanstack/react-query';
 interface ContactFormProps {
@@ -40,6 +41,8 @@ export default function ContactForm( {
 	const [ formData, setFormData ] = useState< DomainContactDetails >(
 		initialData ?? { optOutTransferLock: false }
 	);
+	const [ lastValidationResult, setLastValidationResult ] =
+		useState< DomainContactValidationResponse | null >( null );
 	const selectedCountryCode = formData.countryCode ?? initialData?.countryCode ?? '';
 	const { data: statesList } = useQuery( statesListQuery( selectedCountryCode ) );
 
@@ -78,6 +81,7 @@ export default function ContactForm( {
 
 			validate( item )
 				.then( ( result ) => {
+					setLastValidationResult( result );
 					callbacks.forEach( ( callback ) => callback.resolve( result ) );
 				} )
 				.catch( ( error ) => {
@@ -131,7 +135,39 @@ export default function ContactForm( {
 		],
 	};
 
-	const { validity, isValid: canSave } = useFormValidity( normalizedFormData, fields, form );
+	const { validity, isValid: isFormValid } = useFormValidity( normalizedFormData, fields, form );
+
+	// The validation endpoint validates the whole form, so a change to one field
+	// (e.g. the country) can invalidate another (e.g. the postal code) whose own
+	// async validator DataForm won't re-run. Surface every field error from the
+	// latest response so those errors appear without the user having to touch each
+	// field, and keep Save disabled while any of them remain.
+	const serverFieldErrors = useMemo(
+		() =>
+			mapValidationMessagesToFieldErrors(
+				lastValidationResult && ! lastValidationResult.success
+					? lastValidationResult.messages
+					: undefined
+			),
+		[ lastValidationResult ]
+	);
+
+	const validityWithServerErrors = useMemo( () => {
+		const fieldErrors = Object.entries( serverFieldErrors );
+		if ( ! isDirty || fieldErrors.length === 0 ) {
+			return validity;
+		}
+		const merged: NonNullable< typeof validity > = { ...validity };
+		for ( const [ fieldId, message ] of fieldErrors ) {
+			merged[ fieldId ] = {
+				...merged[ fieldId ],
+				custom: { type: 'invalid', message },
+			};
+		}
+		return merged;
+	}, [ validity, serverFieldErrors, isDirty ] );
+
+	const canSave = isFormValid && Object.keys( serverFieldErrors ).length === 0;
 
 	return (
 		<VStack spacing={ 10 }>
@@ -173,7 +209,7 @@ export default function ContactForm( {
 							data={ normalizedFormData }
 							fields={ fields }
 							form={ form }
-							validity={ validity }
+							validity={ validityWithServerErrors }
 							onChange={ ( edits: Partial< DomainContactDetails > ) => {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }

--- a/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
+++ b/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
@@ -90,6 +90,41 @@ export const createFieldAsyncValidator = (
 	};
 };
 
+/**
+ * Maps a full validation response's per-field messages to form field IDs.
+ *
+ * The validation endpoint checks the whole contact form and returns errors keyed
+ * by every affected field, but DataForm's per-field async validators only re-run
+ * for the field the user changed. Changing the country, for example, can invalidate
+ * the postal code without re-running the postal code's own validator. This lets the
+ * form surface the first error for each affected field from a single response.
+ * @param messages - The `messages` object from a failed validation response
+ * @returns A map of field IDs (camelCase) to their first error message
+ */
+export const mapValidationMessagesToFieldErrors = (
+	messages: ContactValidationResponseMessages | undefined
+): Partial< Record< keyof DomainContactDetails, string > > => {
+	const fieldErrors: Partial< Record< keyof DomainContactDetails, string > > = {};
+	if ( ! messages ) {
+		return fieldErrors;
+	}
+
+	for ( const [ fieldId, apiKey ] of Object.entries( FIELD_TO_API_KEY_MAP ) as [
+		keyof DomainContactDetails,
+		keyof ContactValidationResponseMessages | null,
+	][] ) {
+		if ( ! apiKey ) {
+			continue;
+		}
+		const messagesForField = messages[ apiKey ];
+		if ( Array.isArray( messagesForField ) && messagesForField.length > 0 ) {
+			fieldErrors[ fieldId ] = messagesForField[ 0 ];
+		}
+	}
+
+	return fieldErrors;
+};
+
 export function sanitizePhoneCountryCode( phoneCountryCode: string ): string {
 	return phoneCountryCode ? '+' + phoneCountryCode.replace( /[^0-9]/g, '' ) : '';
 }

--- a/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
+++ b/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
@@ -91,20 +91,16 @@ export const createFieldAsyncValidator = (
 };
 
 /**
- * Maps a full validation response's per-field messages to form field IDs.
- *
- * The validation endpoint checks the whole contact form and returns errors keyed
- * by every affected field, but DataForm's per-field async validators only re-run
- * for the field the user changed. Changing the country, for example, can invalidate
- * the postal code without re-running the postal code's own validator. This lets the
- * form surface the first error for each affected field from a single response.
+ * Maps a validation response's per-field messages (snake_case API keys) to form
+ * field IDs (camelCase), keeping the first message per field. Lets the form surface
+ * errors for every affected field from a single whole-form validation response.
  * @param messages - The `messages` object from a failed validation response
- * @returns A map of field IDs (camelCase) to their first error message
+ * @returns A map of field IDs to their first error message
  */
 export const mapValidationMessagesToFieldErrors = (
 	messages: ContactValidationResponseMessages | undefined
-): Partial< Record< keyof DomainContactDetails, string > > => {
-	const fieldErrors: Partial< Record< keyof DomainContactDetails, string > > = {};
+): Record< string, string > => {
+	const fieldErrors: Record< string, string > = {};
 	if ( ! messages ) {
 		return fieldErrors;
 	}

--- a/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getContactFormFields } from '../contact-form-fields';
+import type { CountryListItem } from '../custom-form-fieldsets/types';
+
+const asyncValidator = async () => null;
+
+// Mirrors the shape returned by the supported-countries endpoint: the popular
+// countries are repeated at the top of the list and an empty-code separator sits
+// between them and the full alphabetical list.
+const countryList = [
+	{ code: 'US', name: 'United States' },
+	{ code: 'FR', name: 'France' },
+	{ code: '', name: '' },
+	{ code: 'AF', name: 'Afghanistan' },
+	{ code: 'FR', name: 'France' },
+	{ code: 'US', name: 'United States' },
+] as CountryListItem[];
+
+describe( 'getContactFormFields country field', () => {
+	const getCountryField = () => {
+		const fields = getContactFormFields( countryList, [], 'US', asyncValidator );
+		const field = fields.find( ( f ) => f.id === 'countryCode' );
+		if ( ! field ) {
+			throw new Error( 'countryCode field not found' );
+		}
+		return field;
+	};
+
+	it( 'excludes the empty-code separator entry', () => {
+		const values = ( getCountryField().elements ?? [] ).map( ( e ) => e.value );
+		expect( values ).not.toContain( '' );
+	} );
+
+	it( 'lists each country code only once', () => {
+		const values = ( getCountryField().elements ?? [] ).map( ( e ) => e.value );
+		expect( values ).toEqual( [ ...new Set( values ) ] );
+		expect( values ).toEqual( [ 'US', 'FR', 'AF' ] );
+	} );
+} );

--- a/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-form-fields.test.tsx
@@ -4,7 +4,7 @@
 import { getContactFormFields } from '../contact-form-fields';
 import type { CountryListItem } from '../custom-form-fieldsets/types';
 
-const asyncValidator = async () => null;
+const asyncValidator = async () => ( { success: true as const } );
 
 // Mirrors the shape returned by the supported-countries endpoint: the popular
 // countries are repeated at the top of the list and an empty-code separator sits

--- a/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
@@ -1,0 +1,30 @@
+import { mapValidationMessagesToFieldErrors } from '../contact-validation-utils';
+import type { ContactValidationResponseMessages } from '@automattic/api-core';
+
+describe( 'mapValidationMessagesToFieldErrors', () => {
+	it( 'returns an empty map when there are no messages', () => {
+		expect( mapValidationMessagesToFieldErrors( undefined ) ).toEqual( {} );
+		expect( mapValidationMessagesToFieldErrors( {} ) ).toEqual( {} );
+	} );
+
+	it( 'maps API (snake_case) message keys to field IDs and keeps the first message', () => {
+		const messages: ContactValidationResponseMessages = {
+			postal_code: [ 'Please use the A1B 2C3 format.', 'Second message' ],
+			country_code: [ 'Invalid country.' ],
+		};
+
+		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {
+			postalCode: 'Please use the A1B 2C3 format.',
+			countryCode: 'Invalid country.',
+		} );
+	} );
+
+	it( 'ignores fields with empty message arrays and non-field keys', () => {
+		const messages = {
+			state: [],
+			extra: { ca: { cira_agreement_accepted: [ 'nope' ] } },
+		} as unknown as ContactValidationResponseMessages;
+
+		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {} );
+	} );
+} );


### PR DESCRIPTION
Fixes DOMENG-787

## Proposed Changes

Two independent fixes to the domain contact-info form (`client/dashboard/components/domain-contact-details-form/`), which is shared by the single-domain and bulk contact screens via `ContactForm`.

- **Country combobox** — dedupe the country options by code and drop the empty-code separator entry when building the field in `getContactFormFields`.

**Before**

https://github.com/user-attachments/assets/bf683136-ccd8-4415-aff1-9ac35e1cab84


**After**

https://github.com/user-attachments/assets/57827187-2a6e-4a8e-81c4-154d05dc1d91


- **Cross-field validation feedback** — drive per-field errors from the form's single whole-form validation response: map every returned field error, surface it inline on the affected field, and keep **Save** disabled while any server-side error remains.

**Before**

https://github.com/user-attachments/assets/4948766b-5281-4c34-ba60-c45b35b76af1



**After**

https://github.com/user-attachments/assets/25d1ae26-00aa-4087-9af2-01f8dc37b596


**Note**
We're intentionally leaving the loading indicator misalignment out of this iteration.

## Why are these changes being made?

Both bugs surface on the domain contact-info screen (`/domains/<domain>/contact-info`).


<!-- Before/after screenshots would help here since the change is visual. Please attach:
     - Country search filtering (before: unfiltered/duplicate; after: narrowed)
     - Postal-code error shown inline after a Brazil → Canada switch -->

## Testing Instructions

Assumes: access to the dashboard and a domain you can open the contact-info screen for.

1. Open a domain's contact-info screen in the dashboard: `/domains/<domain>/contact-info`.
2. **Search filters correctly:** open the **Country** field and type `Portu`. The list narrows to just **Portugal**, with no "same key" warnings in the console.
3. **Selection applies:** pick a different country from the list and confirm it's applied to the field.
4. **Cross-field validation is visible:** switch to a country whose requirements invalidate the current address — e.g. **Canada**, which requires a postal code in the `A1B 2C3` format.
   - The **Postal Code** field shows its error inline.
   - **Save** stays disabled.
5. Enter a valid postal code for that country and confirm the error clears and **Save** becomes enabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? (no new strings)
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?


