### PR TITLE
Domain search: lay the exact-match card and bundle card side by side

### DIFF
--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -1,5 +1,8 @@
 .bundle-card {
 	box-sizing: border-box;
+	// Shares the featured row equally with the exact-match card (matching
+	// .domain-suggestion-featured's `flex: 1`); inert when not a flex child.
+	flex: 1;
 	padding: 24px;
 	border-radius: 8px;
 	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 ), 0 1px 2px rgba( 0, 0, 0, 0.05 );

--- a/packages/domain-search/src/components/featured-search-results/index.tsx
+++ b/packages/domain-search/src/components/featured-search-results/index.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { FeaturedSuggestionWithReason } from '../../helpers/partition-suggestions';
 import { FeaturedDomainSuggestionsList } from '../../ui';
 import { FeaturedSearchResultsItem } from './item';
@@ -5,10 +6,15 @@ import { FeaturedSearchResultsPlaceholder } from './placeholder';
 
 const FeaturedSearchResults = ( {
 	suggestions,
+	children,
 }: {
 	suggestions: FeaturedSuggestionWithReason[];
+	children?: ReactNode;
 } ) => {
-	const isSingleFeaturedSuggestion = suggestions.length === 1;
+	// A trailing card (the bundle card on the FQDN path) shares the featured row, so
+	// a lone exact-match card is no longer "single": it renders in the narrower
+	// column form beside the bundle card rather than the full-width horizontal one.
+	const isSingleFeaturedSuggestion = suggestions.length === 1 && ! children;
 
 	return (
 		<FeaturedDomainSuggestionsList>
@@ -20,6 +26,7 @@ const FeaturedSearchResults = ( {
 					isSingleFeaturedSuggestion={ isSingleFeaturedSuggestion }
 				/>
 			) ) }
+			{ children }
 		</FeaturedDomainSuggestionsList>
 	);
 };

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -216,22 +216,23 @@ export const ResultsPage = () => {
 				{ isLoadingSuggestions ? (
 					<FeaturedSearchResults.Placeholder />
 				) : (
-					<FeaturedSearchResults suggestions={ featuredSuggestions } />
-				) }
-				{ ! isLoadingSuggestions && visibleBundleSuggestion && (
-					<BundleCard
-						suggestion={ visibleBundleSuggestion }
-						onAddToCart={ ( bundle ) => {
-							addBundleToCart( { bundle, query } );
-						} }
-						isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
-							cart.hasItem( domain )
+					<FeaturedSearchResults suggestions={ featuredSuggestions }>
+						{ visibleBundleSuggestion && (
+							<BundleCard
+								suggestion={ visibleBundleSuggestion }
+								onAddToCart={ ( bundle ) => {
+									addBundleToCart( { bundle, query } );
+								} }
+								isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
+									cart.hasItem( domain )
+								) }
+								onContinue={ events.onContinue }
+								isBusy={ isAddingBundle }
+								disabled={ isMutating }
+								errorMessage={ bundleErrorMessage }
+							/>
 						) }
-						onContinue={ events.onContinue }
-						isBusy={ isAddingBundle }
-						disabled={ isMutating }
-						errorMessage={ bundleErrorMessage }
-					/>
+					</FeaturedSearchResults>
 				) }
 				{ isLoadingSuggestions ? (
 					<SearchResults.Placeholder />


### PR DESCRIPTION
Related to #DOMAINS-2189

## Problem

On an FQDN search, the exact-match featured card and the "Protect your brand" bundle card both render full-width, stacked vertically — they should sit side by side.

The featured list holds a single exact-match card, which renders in its full-width "single" horizontal form, and the `BundleCard` was rendered as a *separate* block below the featured list. With nothing pairing them, both spanned the 64rem content width and stacked.

## Fix

Render the bundle card as a sibling *inside* the featured row instead of below it:

- `FeaturedSearchResults` accepts the bundle card as `children` and appends it to `FeaturedDomainSuggestionsList`. When that trailing card is present, a lone exact-match card is no longer "single", so it drops to its narrower **column** form (price/CTA below the name) — the same shape multi-featured cards already use.
- `.bundle-card` gets `flex: 1`, matching `.domain-suggestion-featured`, so the two share the row as equal columns.
- On mobile they stack, via the featured list's existing 600px container-query breakpoint — no new responsive logic.

`results.tsx` now nests `BundleCard` inside `FeaturedSearchResults` rather than emitting it as a separate `VStack` child.

<img width="2366" height="1352" alt="CleanShot 2026-07-09 at 14 29 43@2x" src="https://github.com/user-attachments/assets/65c3723e-0043-492d-8963-2c7369913063" />


## Testing

- Verified locally on wide and mobile viewports: exact-match card (column form) and bundle card sit side by side as equal columns on desktop, stacking on mobile.
- `yarn jest -c=test/packages/jest.config.js packages/domain-search/src/page/test/results.tsx packages/domain-search/src/components/featured-search-results packages/domain-search/src/components/bundle-card` → **97 passed**.
- ESLint / Prettier / stylelint clean.

Co-Authored-By: Claude <noreply@anthropic.com>
