### PR TITLE
Odyssey Stats: fetch site purchases via v1.2 endpoint

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -34,7 +34,7 @@ async function queryOdysseyQuerySitePurchases(
 		wpcom.req
 			.get( {
 				path: getApiPath( apiPath, { siteId } ),
-				apiNamespace: getApiNamespace( apiNamespace ),
+				apiNamespace: getApiNamespace( apiNamespace, 'rest/v1.2' ),
 			} )
 			// Endpoint `site/purchases` returns a stringified JSON object as data.
 			// Our own endpoint `/sites/${ siteId }/purchases` returns a JSON object.
@@ -75,7 +75,7 @@ async function queryOdysseyQuerySitePurchasesFromMyJetpack(
 	return wpcom.req
 		.get( {
 			path: getApiPath( '/site/purchases', { siteId } ),
-			apiNamespace: getApiNamespace( 'my-jetpack/v1' ),
+			apiNamespace: getApiNamespace( 'my-jetpack/v1', 'rest/v1.2' ),
 		} )
 		.catch( ( error: APIError ) => error );
 }

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -3,10 +3,15 @@ import config from '@automattic/calypso-config';
 /**
  * Set the API namespace based on whether the app is running in a Jetpack site or not.
  * This is needed as WP.com Simple Classic is loading Odyssey Stats, which we will use the public-api.wordpress.com APIs.
+ * @param namespace The namespace to use when running in a Jetpack site.
+ * @param wpcomNamespace The namespace to use on WP.com Simple Classic (the public-api.wordpress.com REST version).
  * @returns {string} The API namespace to use.
  */
-export const getApiNamespace = ( namespace = 'jetpack/v4' ): string => {
-	return config.isEnabled( 'is_running_in_jetpack_site' ) ? namespace : 'rest/v1.1';
+export const getApiNamespace = (
+	namespace = 'jetpack/v4',
+	wpcomNamespace = 'rest/v1.1'
+): string => {
+	return config.isEnabled( 'is_running_in_jetpack_site' ) ? namespace : wpcomNamespace;
 };
 
 /**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2245/migrate-appsodyssey-stats-to-v12-of-site-purchases-endpoint

## Proposed changes

Migrates the Odyssey Stats site-purchases fetch off the schemaless `/rest/v1.1/sites/{siteId}/purchases` endpoint to `/rest/v1.2/…` on WP.com Simple Classic, retiring the last caller of the v1.1 site-purchases endpoint in this codebase.

* Add an optional `wpcomNamespace` argument to `getApiNamespace` so an individual caller can pick its REST version without changing the shared default.
* Pass `rest/v1.2` from both Odyssey purchases queries (`queryOdysseyQuerySitePurchases` and the My Jetpack fallback `queryOdysseyQuerySitePurchasesFromMyJetpack`).
* Leave `/site` and `/memberships/products` on `rest/v1.1` (they keep the default).

## Why are these changes being made?

The v1.1 purchases endpoint has no defined output schema, whereas v1.2 returns the schema-defined serialized `Billing_Upgrade` (api-core's `RawPurchase`). Odyssey Stats never reads raw API fields directly: it dispatches the response into the shared Redux `purchases` reducer, and `getSitePurchases` runs every row through the `createPurchaseObject` assembler (`packages/data-stores/src/purchases/lib/assembler.ts`) before `useStatsPurchases` reads the camelCase result. That assembler's declared input type is exactly `RawPurchase`, and every field it consumes — `blog_id`, `product_slug`, `expiry_status`, `expiry_date`, `subscribed_date` — is present in the v1.2 shape, so v1.2 is fully shape-compatible.

The shared `getApiNamespace` helper is used by `/site` and `/memberships/products` too, so rather than flipping its `rest/v1.1` default (which would silently move those endpoints as well), it now takes an optional per-caller override and only the purchases path opts into v1.2. This matches the broader effort in SHILL-1200 to stop using the slow/fragile `get_site_purchases`; the sibling data-stores caller was already bumped in #111288.

## Testing instructions

TC:
```
yarn test-apps apps/odyssey-stats/src/lib/test/get-api.test.js
```

Manual testing:

Not totally sure how to do this...

* Load Odyssey Stats inside wp-admin on a WP.com Simple Classic site (non-Jetpack).
* In the Network tab, confirm the purchases request now goes to `/rest/v1.2/sites/{siteId}/purchases` (no remaining `/rest/v1.1/sites/{siteId}/purchases` calls).
* Confirm stats plan gating still resolves correctly (free / PWYW / commercial ownership, paywall notices).
* On a self-hosted Jetpack site, confirm behavior is unchanged (requests still use the `jetpack/v4*` / `my-jetpack/v1` namespaces).

