### PR TITLE
Transferred purchases: fetch via v1.2 upgrades endpoint

### DIFF
--- a/packages/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases.tsx
@@ -16,8 +16,9 @@ export function getUseTransferredPurchasesOptions(
 		queryKey,
 		queryFn: async (): Promise< Purchase[] > => {
 			const purchases: RawPurchase[] = await wpcomRequest( {
-				path: '/me/purchases/transferred',
-				apiVersion: '1.1',
+				path: '/upgrades',
+				apiVersion: '1.2',
+				query: 'type=transferred',
 			} );
 
 			return purchases.map( ( rawPurchase ) => createPurchaseObject( rawPurchase ) );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2246/transferred-purchases-fetch-via-v12-upgrades-endpoint

## Proposed changes

This migrates the transferred-ownership purchases fetch used by the classic `/me/purchases` DataViews list off the schema-less 1.1 `/me/purchases/transferred` endpoint and onto the well-defined 1.2 `/upgrades?type=transferred` endpoint, which returns serialized `Billing_Upgrade` records.

* Repoint `useGetJetpackTransferredLicensePurchases` (in `@automattic/data-stores`) from `path: '/me/purchases/transferred'` / `apiVersion: '1.1'` to `path: '/upgrades'` / `apiVersion: '1.2'` with `query: 'type=transferred'`.

## Why are these changes being made?

The 1.1 `/me/purchases/transferred` endpoint has no defined output schema and is backed by the slow, fragile `get_user_purchases` server function that SHILL-1200 is retiring. The 1.2 `/upgrades` endpoint returns record-based `Billing_Upgrade` instances with a defined schema and better performance.

The change is deliberately made inside the data-stores hook rather than by swapping the caller to the `@automattic/api-queries` `userTransferredPurchasesQuery`. Both endpoints return the same `Billing_Upgrade` (snake_case `RawPurchase`) serialization, and the hook already parses `RawPurchase` and converts it to the camelCase `Purchases.Purchase` shape that all downstream consumers expect. Switching the caller to the api-queries version instead would hand consumers the api-core snake_case `Purchase` (`ID`) and silently break `isTransferredOwnership`, which reads `.id`. Repointing the endpoint inside the hook keeps the raw→camelCase conversion intact, so the only thing that changes is which endpoint supplies the identical payload.

## Testing instructions

TC:
```
yarn test-packages packages/data-stores/src/purchases
```

Manual testing:
* Use a sandbox/environment where the account owns at least one transferred-ownership purchase (e.g. a Jetpack license whose site ownership was transferred).
* Visit `/me/purchases`.
* Confirm transferred purchases still appear in the list and that the "Manage purchase" action is hidden for them (this is driven by `isTransferredOwnership`).
* In the network tab, confirm the request goes to `/rest/v1.2/upgrades?type=transferred` and no longer to `/rest/v1.1/me/purchases/transferred`.
