### PR TITLE
Pricing grid redesign: implement variant4

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -29,6 +29,7 @@ import {
 	isWooHostedPlan,
 	isWooHostedFreePlan,
 	isWpcomEnterpriseGridPlan,
+	isEcommercePlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -690,6 +691,8 @@ const PlansFeaturesMain = ( {
 	const {
 		isLoading: isPlansGridRedesignExperimentLoading,
 		showDifferentiatorHeader: showPlansGridRedesignDifferentiatorHeader,
+		showEnterpriseBottomCard,
+		showWooCommerceBottomCard,
 		usePlansGridRedesignFeatures,
 		usePlansGridRedesign,
 		usePlansGridRedesignNewDescription,
@@ -938,20 +941,74 @@ const PlansFeaturesMain = ( {
 		[ isIndiaA4A, translate ]
 	);
 
-	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
-	const gridPlansForFeaturesGrid = useMemo(
-		() =>
-			applyA4AIndiaCopy(
-				gridPlansForFeaturesGridRaw?.filter( ( { planSlug } ) => {
-					if ( deemphasizeFreePlan ) {
-						return planSlug !== PLAN_FREE;
-					}
-
-					return true;
-				} ) ?? null // optional chaining can result in `undefined`; we don't want to introduce it here.
-			),
-		[ gridPlansForFeaturesGridRaw, deemphasizeFreePlan, applyA4AIndiaCopy ]
+	const gridPlansForFeaturesGridWithA4AIndiaCopy = useMemo(
+		() => applyA4AIndiaCopy( gridPlansForFeaturesGridRaw ?? null ),
+		[ gridPlansForFeaturesGridRaw, applyA4AIndiaCopy ]
 	);
+
+	const bottomGridPlanForFeaturesGrid = useMemo( () => {
+		if ( ! gridPlansForFeaturesGridWithA4AIndiaCopy ) {
+			return undefined;
+		}
+
+		let bottomGridPlan: GridPlan | undefined;
+
+		if ( showEnterpriseBottomCard ) {
+			bottomGridPlan = gridPlansForFeaturesGridWithA4AIndiaCopy.find( ( { planSlug } ) =>
+				isWpcomEnterpriseGridPlan( planSlug )
+			);
+		} else if ( showWooCommerceBottomCard ) {
+			bottomGridPlan = gridPlansForFeaturesGridWithA4AIndiaCopy.find( ( { planSlug } ) =>
+				isEcommercePlan( planSlug )
+			);
+		}
+
+		if (
+			bottomGridPlan &&
+			showWooCommerceBottomCard &&
+			isEcommercePlan( bottomGridPlan.planSlug )
+		) {
+			return {
+				...bottomGridPlan,
+				planTitle: translate( 'WooCommerce' ),
+			};
+		}
+
+		return bottomGridPlan;
+	}, [
+		gridPlansForFeaturesGridWithA4AIndiaCopy,
+		showEnterpriseBottomCard,
+		showWooCommerceBottomCard,
+		translate,
+	] );
+
+	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
+	const gridPlansForFeaturesGrid = useMemo( () => {
+		const bottomGridPlanSlug = bottomGridPlanForFeaturesGrid?.planSlug;
+
+		return (
+			gridPlansForFeaturesGridWithA4AIndiaCopy?.filter( ( { planSlug } ) => {
+				if ( planSlug === bottomGridPlanSlug ) {
+					return false;
+				}
+
+				if ( showWooCommerceBottomCard && isWpcomEnterpriseGridPlan( planSlug ) ) {
+					return false;
+				}
+
+				if ( deemphasizeFreePlan ) {
+					return planSlug !== PLAN_FREE;
+				}
+
+				return true;
+			} ) ?? null
+		);
+	}, [
+		bottomGridPlanForFeaturesGrid,
+		gridPlansForFeaturesGridWithA4AIndiaCopy,
+		deemphasizeFreePlan,
+		showWooCommerceBottomCard,
+	] );
 
 	const gridPlansForComparisonGridFinal = useMemo(
 		() => applyA4AIndiaCopy( gridPlansForComparisonGrid ),
@@ -1421,6 +1478,7 @@ const PlansFeaturesMain = ( {
 								{ gridPlansForFeaturesGrid && (
 									<FeaturesGrid
 										allFeaturesList={ getFeaturesList() }
+										bottomGridPlan={ bottomGridPlanForFeaturesGrid }
 										className={ clsx( 'plans-features-main__features-grid', {
 											'is-plan-differentiators-experiment': isExperimentVariant,
 											'is-plans-grid-redesign-experiment': usePlansGridRedesign,

--- a/packages/plans-grid-next/src/components/features-grid/bottom-plan-card.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/bottom-plan-card.tsx
@@ -1,0 +1,96 @@
+import {
+	getPlanClass,
+	isEcommercePlan,
+	isWpcomEnterpriseGridPlan,
+} from '@automattic/calypso-products';
+import { WooLogo } from '@automattic/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { usePlansGridContext } from '../../grid-context';
+import ActionButton from '../shared/action-button';
+import ClientLogoList from './client-logo-list';
+import type { GridPlan, PlanActionOverrides } from '../../types';
+
+const ENTERPRISE_BOTTOM_CARD_LOGO_SLUGS = [
+	'slack',
+	'usa-today',
+	'salesforce',
+	'meta',
+	'intuit',
+	'capgemini',
+	'news-corp',
+	'samsung',
+	'nasa',
+];
+
+type BottomPlanCardProps = {
+	currentSitePlanSlug?: string | null;
+	gridPlan: GridPlan;
+	isInSignup: boolean;
+	planActionOverrides?: PlanActionOverrides;
+};
+
+const BottomPlanCard = ( {
+	currentSitePlanSlug,
+	gridPlan,
+	isInSignup,
+	planActionOverrides,
+}: BottomPlanCardProps ) => {
+	const translate = useTranslate();
+	const { isEnterpriseA4AIndia } = usePlansGridContext();
+	const isEnterprise = isWpcomEnterpriseGridPlan( gridPlan.planSlug );
+	const isWooCommerce = isEcommercePlan( gridPlan.planSlug );
+
+	return (
+		<div
+			className={ clsx(
+				'plans-grid-next-features-grid__bottom-plan-card',
+				getPlanClass( gridPlan.planSlug ),
+				{
+					'is-enterprise-bottom-card': isEnterprise,
+					'is-woocommerce-bottom-card': isWooCommerce,
+				}
+			) }
+		>
+			<div className="plans-grid-next-features-grid__bottom-plan-card-copy">
+				<h4 className="plans-grid-next-features-grid__bottom-plan-card-title">
+					{ gridPlan.planTitle }
+				</h4>
+				<p className="plans-grid-next-features-grid__bottom-plan-card-tagline">
+					{ gridPlan.tagline }
+				</p>
+				<div className="plans-grid-next-features-grid__bottom-plan-card-action">
+					<ActionButton
+						availableForPurchase={ gridPlan.availableForPurchase }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						isInSignup={ isInSignup }
+						isMonthlyPlan={ gridPlan.isMonthlyPlan }
+						isStuck={ false }
+						planActionOverrides={ planActionOverrides }
+						planSlug={ gridPlan.planSlug }
+						showMonthlyPrice
+						showPostButtonText={ false }
+						visibleGridPlans={ [ gridPlan ] }
+					/>
+				</div>
+			</div>
+			<div
+				className={ clsx( 'plans-grid-next-features-grid__bottom-plan-card-media', {
+					'is-empty': isEnterprise && isEnterpriseA4AIndia,
+				} ) }
+				aria-label={
+					isEnterprise ? translate( 'Enterprise customer logos' ).toString() : undefined
+				}
+			>
+				{ isEnterprise && ! isEnterpriseA4AIndia && (
+					<ClientLogoList slugs={ ENTERPRISE_BOTTOM_CARD_LOGO_SLUGS } />
+				) }
+				{ isWooCommerce && (
+					<WooLogo className="plans-grid-next-features-grid__bottom-plan-card-woo-logo" />
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default BottomPlanCard;

--- a/packages/plans-grid-next/src/components/features-grid/bottom-plan-card.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/bottom-plan-card.tsx
@@ -6,7 +6,6 @@ import {
 import { WooLogo } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { usePlansGridContext } from '../../grid-context';
 import ActionButton from '../shared/action-button';
 import ClientLogoList from './client-logo-list';
 import type { GridPlan, PlanActionOverrides } from '../../types';
@@ -37,7 +36,6 @@ const BottomPlanCard = ( {
 	planActionOverrides,
 }: BottomPlanCardProps ) => {
 	const translate = useTranslate();
-	const { isEnterpriseA4AIndia } = usePlansGridContext();
 	const isEnterprise = isWpcomEnterpriseGridPlan( gridPlan.planSlug );
 	const isWooCommerce = isEcommercePlan( gridPlan.planSlug );
 
@@ -75,16 +73,12 @@ const BottomPlanCard = ( {
 				</div>
 			</div>
 			<div
-				className={ clsx( 'plans-grid-next-features-grid__bottom-plan-card-media', {
-					'is-empty': isEnterprise && isEnterpriseA4AIndia,
-				} ) }
+				className="plans-grid-next-features-grid__bottom-plan-card-media"
 				aria-label={
 					isEnterprise ? translate( 'Enterprise customer logos' ).toString() : undefined
 				}
 			>
-				{ isEnterprise && ! isEnterpriseA4AIndia && (
-					<ClientLogoList slugs={ ENTERPRISE_BOTTOM_CARD_LOGO_SLUGS } />
-				) }
+				{ isEnterprise && <ClientLogoList slugs={ ENTERPRISE_BOTTOM_CARD_LOGO_SLUGS } /> }
 				{ isWooCommerce && (
 					<WooLogo className="plans-grid-next-features-grid__bottom-plan-card-woo-logo" />
 				) }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -15,6 +15,7 @@ import useGridSize from '../../hooks/use-grid-size';
 import { PlanFeaturesItem } from '../item';
 import { PlanStorage } from '../shared/storage';
 import BillingTimeframes from './billing-timeframes';
+import BottomPlanCard from './bottom-plan-card';
 import EnterpriseFeatures from './enterprise-features';
 import PlanFeaturesList from './plan-features-list';
 import PlanHeaders from './plan-headers';
@@ -307,6 +308,7 @@ const TabletView = ( {
 // Now that everything under is functional component, we can deprecate this wrapper and only keep ComparisonGrid instead.
 // More details can be found in https://github.com/Automattic/wp-calypso/issues/87047
 const FeaturesGrid = ( {
+	bottomGridPlan,
 	currentSitePlanSlug,
 	generatedWPComSubdomain,
 	gridPlanForSpotlight,
@@ -348,7 +350,11 @@ const FeaturesGrid = ( {
 		<div className="plans-grid-next-features-grid">
 			{ 'small' !== gridSize && <SpotlightPlan { ...spotlightPlanProps } /> }
 			<div className="plan-features">
-				<div className="plan-features-2023-grid__content">
+				<div
+					className={ clsx( 'plan-features-2023-grid__content', {
+						'has-bottom-plan-card': bottomGridPlan,
+					} ) }
+				>
 					<div>
 						{ 'large' === gridSize && (
 							<div className="plan-features-2023-grid__desktop-view">
@@ -369,6 +375,14 @@ const FeaturesGrid = ( {
 							</div>
 						) }
 					</div>
+					{ bottomGridPlan && (
+						<BottomPlanCard
+							currentSitePlanSlug={ currentSitePlanSlug }
+							gridPlan={ bottomGridPlan }
+							isInSignup={ isInSignup }
+							planActionOverrides={ planActionOverrides }
+						/>
+					) }
 				</div>
 			</div>
 		</div>
@@ -379,6 +393,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 	const {
 		siteId,
 		intent,
+		bottomGridPlan,
 		gridPlans,
 		useCheckPlanAvailabilityForPurchase,
 		useAction,
@@ -439,12 +454,23 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		'is-large': 'large' === gridSize,
 	} );
 
+	const gridPlansForContext = useMemo( () => {
+		if (
+			! bottomGridPlan ||
+			gridPlans.some( ( gridPlan ) => gridPlan.planSlug === bottomGridPlan.planSlug )
+		) {
+			return gridPlans;
+		}
+
+		return [ ...gridPlans, bottomGridPlan ];
+	}, [ bottomGridPlan, gridPlans ] );
+
 	return (
 		<div ref={ gridContainerRef } className={ classNames }>
 			<PlansGridContextProvider
 				intent={ intent }
 				siteId={ siteId }
-				gridPlans={ gridPlans }
+				gridPlans={ gridPlansForContext }
 				coupon={ coupon }
 				useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 				useAction={ useAction }

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -1193,30 +1193,74 @@
 			border-radius: 8px;
 			border-top: 1px solid #e0e0e0;
 			flex-direction: column;
-			gap: 24px;
+			gap: 0;
 			margin-top: 20px;
 			max-width: 100%;
 			min-height: 0;
-			padding: 24px 16px;
+			padding: 32px 24px 24px;
 		}
 
 		.plans-grid-next-features-grid__bottom-plan-card-copy {
+			display: contents;
 			flex-basis: auto;
 			max-width: none;
 			min-width: 0;
 			width: 100%;
 		}
 
+		.plans-grid-next-features-grid__bottom-plan-card-title {
+			font-size: 26px;
+			font-weight: 400;
+			letter-spacing: 0.21px;
+			line-height: 30px;
+			margin-bottom: 8px;
+			order: 1;
+		}
+
+		.plans-grid-next-features-grid__bottom-plan-card-tagline {
+			font-size: 13px;
+			font-weight: 400;
+			letter-spacing: -0.15px;
+			line-height: 20px;
+			margin: 0;
+			order: 2;
+		}
+
 		.plans-grid-next-features-grid__bottom-plan-card-media {
 			justify-content: flex-start;
+			margin: 20px 0;
+			order: 3;
 			width: 100%;
 		}
 
 		.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
-			--bottom-plan-card-logo-height: 32px;
-			column-gap: 24px;
-			justify-content: flex-start;
-			row-gap: 12px;
+			--bottom-plan-card-logo-height: 22px;
+			column-gap: 12px;
+			justify-content: space-between;
+			row-gap: 8px;
+			width: 100%;
+
+			svg {
+				fill: #757575;
+			}
+		}
+
+		.plans-grid-next-features-grid__bottom-plan-card-action {
+			order: 4;
+			width: 100%;
+
+			.plans-grid-next-action-button,
+			.plans-grid-next-action-button__content {
+				display: flex;
+				width: 100%;
+			}
+
+			.button.plan-features-2023-grid__actions-button {
+				font-size: 16px;
+				height: 48px;
+				padding: 12px 16px;
+				width: 100%;
+			}
 		}
 	}
 }

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -799,6 +799,7 @@
 		row-gap: 16px;
 
 		svg {
+			color: #949494;
 			fill: #949494;
 			height: var( --bottom-plan-card-logo-height );
 		}
@@ -1241,6 +1242,7 @@
 			width: 100%;
 
 			svg {
+				color: #757575;
 				fill: #757575;
 			}
 		}

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -761,7 +761,7 @@
 		color: var( --studio-gray-80 );
 		font-size: 13px;
 		line-height: 20px;
-		margin: 0 0 14px;
+		margin: 0 0 12px;
 	}
 
 	.plans-grid-next-features-grid__bottom-plan-card-action {
@@ -791,11 +791,21 @@
 	}
 
 	.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
+		--bottom-plan-card-logo-height: 40px;
 		align-items: center;
-		column-gap: 42px;
+		column-gap: 64px;
 		justify-content: flex-end;
-		max-width: 720px;
+		max-width: 1015px;
 		row-gap: 16px;
+
+		svg {
+			fill: #949494;
+			height: var( --bottom-plan-card-logo-height );
+		}
+
+		.plans-grid-next-client-logo-list__item {
+			--adjustment-unit: calc( var( --bottom-plan-card-logo-height ) / 60 );
+		}
 	}
 
 	.plans-grid-next-features-grid__bottom-plan-card-woo-logo {
@@ -1203,6 +1213,7 @@
 		}
 
 		.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
+			--bottom-plan-card-logo-height: 32px;
 			column-gap: 24px;
 			justify-content: flex-start;
 			row-gap: 12px;

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -784,10 +784,6 @@
 		flex: 1;
 		justify-content: flex-end;
 		min-width: 0;
-
-		&.is-empty {
-			display: none;
-		}
 	}
 
 	.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
@@ -799,8 +795,8 @@
 		row-gap: 16px;
 
 		svg {
-			color: #949494;
-			fill: #949494;
+			color: var( --wp-components-color-gray-600, #949494 );
+			fill: var( --wp-components-color-gray-600, #949494 );
 			height: var( --bottom-plan-card-logo-height );
 		}
 
@@ -1242,8 +1238,8 @@
 			width: 100%;
 
 			svg {
-				color: #757575;
-				fill: #757575;
+				color: var( --wp-components-color-gray-700, #757575 );
+				fill: var( --wp-components-color-gray-700, #757575 );
 			}
 		}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -718,6 +718,91 @@
 		}
 	}
 
+	.plan-features-2023-grid__content.has-bottom-plan-card {
+		.plan-features-2023-grid__table {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card {
+		align-items: center;
+		background-color: var( --studio-white );
+		border: 1px solid #e0e0e0;
+		border-radius: 0 0 8px 8px;
+		border-top: 0;
+		box-sizing: border-box;
+		display: flex;
+		gap: 32px;
+		justify-content: space-between;
+		margin: 0 auto;
+		min-height: 136px;
+		padding: 24px 32px;
+		width: 100%;
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-copy {
+		flex: 0 0 34%;
+		max-width: 420px;
+		min-width: 220px;
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-title {
+		color: var( --studio-gray-100 );
+		font-family: 'SF Pro Display', $sans;
+		font-size: 26px;
+		font-weight: 400;
+		letter-spacing: 0;
+		line-height: 30px;
+		margin: 0 0 4px;
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-tagline {
+		color: var( --studio-gray-80 );
+		font-size: 13px;
+		line-height: 20px;
+		margin: 0 0 14px;
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-action {
+		.plans-grid-next-action-button,
+		.plans-grid-next-action-button__content {
+			display: inline-flex;
+		}
+
+		.button.plan-features-2023-grid__actions-button {
+			height: 32px;
+			min-width: 92px;
+			padding: 6px 16px;
+			width: auto;
+		}
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-media {
+		align-items: center;
+		display: flex;
+		flex: 1;
+		justify-content: flex-end;
+		min-width: 0;
+
+		&.is-empty {
+			display: none;
+		}
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
+		align-items: center;
+		column-gap: 42px;
+		justify-content: flex-end;
+		max-width: 720px;
+		row-gap: 16px;
+	}
+
+	.plans-grid-next-features-grid__bottom-plan-card-woo-logo {
+		height: 48px;
+		width: auto;
+	}
+
 	.plan-features-2023-grid__table-top,
 	.plan-features-2023-grid__table-bottom {
 		.plan-features-2023-grid__table {
@@ -1084,6 +1169,43 @@
 
 		.plan-features-2023-grid__header-tagline {
 			min-height: 0;
+		}
+
+		.plan-features-2023-grid__content.has-bottom-plan-card {
+			.plan-features-2023-grid__table {
+				border-bottom-left-radius: 8px;
+				border-bottom-right-radius: 8px;
+			}
+		}
+
+		.plans-grid-next-features-grid__bottom-plan-card {
+			align-items: flex-start;
+			border-radius: 8px;
+			border-top: 1px solid #e0e0e0;
+			flex-direction: column;
+			gap: 24px;
+			margin-top: 20px;
+			max-width: 100%;
+			min-height: 0;
+			padding: 24px 16px;
+		}
+
+		.plans-grid-next-features-grid__bottom-plan-card-copy {
+			flex-basis: auto;
+			max-width: none;
+			min-width: 0;
+			width: 100%;
+		}
+
+		.plans-grid-next-features-grid__bottom-plan-card-media {
+			justify-content: flex-start;
+			width: 100%;
+		}
+
+		.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
+			column-gap: 24px;
+			justify-content: flex-start;
+			row-gap: 12px;
 		}
 	}
 }

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -142,6 +142,7 @@ export interface CommonGridProps {
 }
 
 export interface FeaturesGridProps extends CommonGridProps {
+	bottomGridPlan?: GridPlan;
 	gridPlans: GridPlan[];
 	currentPlanManageHref?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17772

## Proposed Changes

* Show the new design for the Enterprise card in onboarding for five_plan_new_description variant.

<img width="1377" height="781" alt="Screenshot 2026-07-09 at 22 56 35" src="https://github.com/user-attachments/assets/93e5f4fa-c201-4091-919a-f739a9163ed7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the five_plan_new_description variant and navigate to /setup/onboarding.
* Confirm that new Enterprise card appears on the bottom and matches the Figma design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
