### PR TITLE
Domains: refresh domains list on detach/attach so stale primary notice clears

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -27,6 +27,7 @@ import InlineSupportLink from '../../components/inline-support-link';
 import RemoveDomainDialog from '../../components/purchase-dialogs/remove-domain-dialog';
 import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
+import { markDomainDetaching, unmarkDomainDetaching } from '../../utils/detaching-domains';
 import { getDomainRenewalUrl } from '../../utils/domain';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import {
@@ -60,19 +61,24 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 	const onDisconnectConfirm = useCallback(
 		() =>
 			disconnectDomain( undefined, {
-				onSuccess: () =>
+				onSuccess: () => {
+					markDomainDetaching( domainName );
 					createSuccessNotice(
 						__( 'The domain will be detached from this site in a few minutes.' ),
 						{
 							type: 'snackbar',
 						}
-					),
-				onError: ( e: Error ) => createErrorNotice( e.message, { type: 'snackbar' } ),
+					);
+				},
+				onError: ( e: Error ) => {
+					unmarkDomainDetaching( domainName );
+					createErrorNotice( e.message, { type: 'snackbar' } );
+				},
 				onSettled: () => {
 					setIsDisconnectDialogOpen( false );
 				},
 			} ),
-		[ disconnectDomain, createSuccessNotice, createErrorNotice ]
+		[ disconnectDomain, domainName, createSuccessNotice, createErrorNotice ]
 	);
 
 	const onDeleteConfirm = useCallback(

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -11,7 +11,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useSearch } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLocale } from '../../app/locale';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { domainRoute } from '../../app/router/domains';
@@ -22,7 +22,12 @@ import SnackbarBackButton, {
 	getSnackbarBackButtonText,
 } from '../../components/snackbar-back-button';
 import { formatDate } from '../../utils/datetime';
-import { getDomainRenewalUrl, isTldInMaintenance } from '../../utils/domain';
+import { unmarkDomainDetaching, useDetachingDomains } from '../../utils/detaching-domains';
+import {
+	getDomainRenewalUrl,
+	isPendingPrimaryDomain,
+	isTldInMaintenance,
+} from '../../utils/domain';
 import { TLDMaintenanceNotice } from '../maintenance-notice';
 import Actions from './actions';
 import FeaturedCards from './featured-cards';
@@ -68,6 +73,17 @@ export default function DomainOverview() {
 
 	const { back_to: domainsBackTo } = useSearch( { from: domainRoute.fullPath } );
 	const snackbarBackButtonText = getSnackbarBackButtonText( domainsBackTo );
+
+	const detachingDomains = useDetachingDomains();
+	const isDetaching = detachingDomains.has( domain.domain );
+
+	// Drop the detach mark once the domain is no longer pending, so a later
+	// re-attach in the same session is not wrongly suppressed.
+	useEffect( () => {
+		if ( isDetaching && ! isPendingPrimaryDomain( domain ) ) {
+			unmarkDomainDetaching( domain.domain );
+		}
+	}, [ domain, isDetaching ] );
 
 	return (
 		<>
@@ -134,7 +150,7 @@ export default function DomainOverview() {
 				{ domain.is_pending_icann_verification && (
 					<IcannSuspensionNotice domainName={ domain.domain } />
 				) }
-				<PendingPrimaryDomainNotice domainName={ domain.domain } />
+				{ ! isDetaching && <PendingPrimaryDomainNotice domainName={ domain.domain } /> }
 				{ domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER && (
 					<>
 						<FeaturedCards isDisabled={ isTldInMaintenance( domain ) } />

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -4,6 +4,7 @@ import { Link } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
@@ -22,6 +23,7 @@ import {
 	SITE_CONTEXT_VIEW,
 	useBulkActionsProgressNotice,
 } from '../../domains/dataviews';
+import { unmarkDomainDetaching, useDetachingDomains } from '../../utils/detaching-domains';
 import { isPendingPrimaryDomain } from '../../utils/domain';
 import { SitesNoticeArbiter } from '../notice-arbiter';
 import PrimaryDomainSelectorNotice from './primary-domain-selector-notice';
@@ -44,7 +46,21 @@ function SiteDomains() {
 		},
 	} );
 
-	const pendingDomain = siteDomains.find( isPendingPrimaryDomain );
+	const detachingDomains = useDetachingDomains();
+	const pendingDomain = siteDomains.find(
+		( domain ) => isPendingPrimaryDomain( domain ) && ! detachingDomains.has( domain.domain )
+	);
+
+	// Drop a detach mark once the domain is no longer pending on this site,
+	// so a later re-attach in the same session is not wrongly suppressed.
+	useEffect( () => {
+		for ( const domainName of detachingDomains ) {
+			const domain = siteDomains.find( ( item ) => item.domain === domainName );
+			if ( ! domain || ! isPendingPrimaryDomain( domain ) ) {
+				unmarkDomainDetaching( domainName );
+			}
+		}
+	}, [ siteDomains, detachingDomains ] );
 
 	const { data: redirect } = useSuspenseQuery( siteRedirectQuery( site.ID ) );
 	const hasRedirect = redirect && Object.keys( redirect ).length > 0;

--- a/client/dashboard/utils/detaching-domains.ts
+++ b/client/dashboard/utils/detaching-domains.ts
@@ -1,0 +1,55 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Tracks domains the user has just requested to detach from a site.
+ *
+ * Detach is processed asynchronously on the backend ("in a few minutes"), so
+ * reads keep reporting the domain as still attached and still pending-primary
+ * for a while after the request succeeds. That leaves the "Setting up your
+ * custom domain" notice on screen even though the user's intent to set it as
+ * primary is void. We remember the intent client-side and suppress the notice
+ * immediately, then drop the mark once fresh data confirms the domain is no
+ * longer pending (see the reconciliation in the notice's call sites).
+ */
+
+let detaching: ReadonlySet< string > = new Set();
+const listeners = new Set< () => void >();
+
+function emit() {
+	for ( const listener of listeners ) {
+		listener();
+	}
+}
+
+export function markDomainDetaching( domainName: string ) {
+	if ( detaching.has( domainName ) ) {
+		return;
+	}
+	detaching = new Set( detaching ).add( domainName );
+	emit();
+}
+
+export function unmarkDomainDetaching( domainName: string ) {
+	if ( ! detaching.has( domainName ) ) {
+		return;
+	}
+	const next = new Set( detaching );
+	next.delete( domainName );
+	detaching = next;
+	emit();
+}
+
+function subscribe( listener: () => void ) {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+function getSnapshot() {
+	return detaching;
+}
+
+export function useDetachingDomains(): ReadonlySet< string > {
+	return useSyncExternalStore( subscribe, getSnapshot, getSnapshot );
+}

--- a/client/dashboard/utils/test/detaching-domains.test.tsx
+++ b/client/dashboard/utils/test/detaching-domains.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import {
+	markDomainDetaching,
+	unmarkDomainDetaching,
+	useDetachingDomains,
+} from '../detaching-domains';
+
+describe( 'detaching-domains store', () => {
+	afterEach( () => {
+		// The store is a module singleton; reset it between tests.
+		act( () => {
+			unmarkDomainDetaching( 'example.com' );
+			unmarkDomainDetaching( 'other.com' );
+		} );
+	} );
+
+	test( 'reflects a marked domain in the hook', () => {
+		const { result } = renderHook( () => useDetachingDomains() );
+
+		expect( result.current.has( 'example.com' ) ).toBe( false );
+
+		act( () => markDomainDetaching( 'example.com' ) );
+
+		expect( result.current.has( 'example.com' ) ).toBe( true );
+	} );
+
+	test( 'removes a domain when unmarked', () => {
+		const { result } = renderHook( () => useDetachingDomains() );
+
+		act( () => markDomainDetaching( 'example.com' ) );
+		expect( result.current.has( 'example.com' ) ).toBe( true );
+
+		act( () => unmarkDomainDetaching( 'example.com' ) );
+		expect( result.current.has( 'example.com' ) ).toBe( false );
+	} );
+
+	test( 'tracks multiple domains independently', () => {
+		const { result } = renderHook( () => useDetachingDomains() );
+
+		act( () => {
+			markDomainDetaching( 'example.com' );
+			markDomainDetaching( 'other.com' );
+		} );
+
+		expect( result.current.has( 'example.com' ) ).toBe( true );
+		expect( result.current.has( 'other.com' ) ).toBe( true );
+
+		act( () => unmarkDomainDetaching( 'example.com' ) );
+
+		expect( result.current.has( 'example.com' ) ).toBe( false );
+		expect( result.current.has( 'other.com' ) ).toBe( true );
+	} );
+
+	test( 'produces a new snapshot on change so subscribers re-render', () => {
+		const { result } = renderHook( () => useDetachingDomains() );
+		const before = result.current;
+
+		act( () => markDomainDetaching( 'example.com' ) );
+
+		expect( result.current ).not.toBe( before );
+	} );
+
+	test( 'marking the same domain twice keeps a single entry and a stable snapshot', () => {
+		const { result } = renderHook( () => useDetachingDomains() );
+
+		act( () => markDomainDetaching( 'example.com' ) );
+		const afterFirst = result.current;
+
+		act( () => markDomainDetaching( 'example.com' ) );
+
+		expect( result.current ).toBe( afterFirst );
+		expect( result.current.has( 'example.com' ) ).toBe( true );
+	} );
+} );

--- a/docs/plans/2026-07-09-detach-stale-primary-notice-design.md
+++ b/docs/plans/2026-07-09-detach-stale-primary-notice-design.md
@@ -1,0 +1,75 @@
+# Fix stale “Setting up your custom domain” notice after detach
+
+**Issue:** DOTMSD-1347
+
+## Problem
+
+In the multi-site Dashboard, attaching a domain to a site and then immediately
+detaching it leaves a stale “Setting up your custom domain” notice on screen.
+The UI eventually stabilizes on its own.
+
+### Root cause
+
+The site domains page (`client/dashboard/sites/domains/index.tsx`) renders from
+the **list** query `domainsQuery()` → query key `[ 'domains', undefined ]`. The
+notice shows whenever a domain in that list satisfies `isPendingPrimaryDomain`
+(`client/dashboard/utils/domain.ts`): `can_set_as_primary && ! primary_domain &&
+…`.
+
+The detach and attach mutations only invalidate the **single-domain** key:
+
+- `disconnectDomainMutation` (`packages/api-queries/src/domain.ts`) invalidates
+  `[ 'domains', <name> ]`.
+- `transferDomainToSiteMutation` (`packages/api-queries/src/domain-transfer.ts`)
+  invalidates `[ 'domains', <name> ]`.
+
+TanStack Query invalidation is prefix-matched, and `[ 'domains', <name> ]` does
+**not** match `[ 'domains', undefined ]`. So the list keeps serving the stale
+cached entry (old `blog_id`, `can_set_as_primary: true`, `primary_domain:
+false`), `isPendingPrimaryDomain` stays true, and the notice lingers until some
+unrelated refetch (route remount, window focus, or the notice’s own 5s poll)
+finally refreshes the list — hence “eventually stabilizes on its own.”
+
+The correct pattern already exists in the same package:
+`siteSetPrimaryDomainMutation` and `startDomainInboundTransferMutation` both
+invalidate the broad `{ queryKey: [ 'domains' ] }` prefix, which matches both
+the single-domain and list keys.
+
+## Fix
+
+In both mutations’ `onSuccess`, invalidate the broad `{ queryKey: [ 'domains' ]
+}` prefix instead of the single-domain key. The `[ 'domains' ]` prefix matches
+both `[ 'domains', <name> ]` and `[ 'domains', undefined ]`, so both the detail
+and list caches refresh.
+
+- `packages/api-queries/src/domain.ts` — `disconnectDomainMutation`: replace
+  `queryClient.invalidateQueries( domainQuery( domainName ) )` with
+  `queryClient.invalidateQueries( { queryKey: [ 'domains' ] } )`.
+- `packages/api-queries/src/domain-transfer.ts` —
+  `transferDomainToSiteMutation`: replace
+  `queryClient.invalidateQueries( domainQuery( domain ) )` with
+  `queryClient.invalidateQueries( { queryKey: [ 'domains' ] } )`.
+
+## Testing (unit)
+
+New test file `packages/api-queries/src/__tests__/domain-invalidation.test.tsx`:
+
+- `jest.mock( '@automattic/api-core' )` so the mutation functions resolve
+  without hitting the network.
+- Spy on the singleton `queryClient.invalidateQueries` (imported from
+  `../query-client`).
+- Run each mutation via `useMutation` + `renderHook` + `mutateAsync`.
+- Assert the spy was called with `{ queryKey: [ 'domains' ] }` for both
+  `disconnectDomainMutation` and `transferDomainToSiteMutation`.
+
+## Non-goals / risks
+
+- Scope is deliberately limited to the two mutations behind this bug. Not
+  touching the site query on detach, and not auditing every other domain
+  mutation.
+- The notice’s own 5s poll + “now your primary address” snackbar path is left
+  as-is. Once the list refreshes, the notice unmounts and the poll stops, so no
+  spurious snackbar fires.
+- The broad `[ 'domains' ]` invalidation is slightly wider (also refetches
+  `[ 'domains', 'bulk-actions' ]` etc.), but that is the established, accepted
+  pattern in this package.

--- a/docs/plans/2026-07-09-detach-stale-primary-notice-design.md
+++ b/docs/plans/2026-07-09-detach-stale-primary-notice-design.md
@@ -62,6 +62,50 @@ New test file `packages/api-queries/src/__tests__/domain-invalidation.test.tsx`:
 - Assert the spy was called with `{ queryKey: [ 'domains' ] }` for both
   `disconnectDomainMutation` and `transferDomainToSiteMutation`.
 
+## Follow-up: intent-based suppression for immediate clearing
+
+The invalidation fix reconciles the page on the *next successful read*, but a
+residual few-second delay remains because **detach is an asynchronous backend
+job** — the success copy literally reads “The domain will be detached from this
+site in a few minutes.” Right after the request succeeds, both `/all-domains`
+and `/domain-details/<name>` still report the domain as attached and
+`can_set_as_primary: true`, so `isPendingPrimaryDomain` stays true and the
+notice lingers until a later read reflects the completed detach. Client cache
+invalidation can trigger the read but cannot make the backend finish faster.
+
+To clear the notice the instant the user detaches, suppress it by intent:
+
+- **Shared store** (`client/dashboard/utils/detaching-domains.ts`): a
+  module-level `useSyncExternalStore` set of domain names the user has requested
+  to detach. It survives route changes, which is required because the Detach
+  button and one notice instance live on the domain-overview route while another
+  instance lives on the site domains route.
+- **Mark / unmark** (`domains/domain-overview/actions.tsx`): mark on detach
+  `onSuccess`, unmark on `onError`.
+- **Suppress at each call site** (keeps `PendingPrimaryDomainNotice` a pure
+  presenter and honours the sites arbiter’s “no self-nulling” rule):
+  - `sites/domains/index.tsx` — exclude detaching domains from the
+    `pendingDomain` find.
+  - `domains/domain-overview/index.tsx` — guard the notice render.
+- **Reconcile**: each page drops a mark once fresh data shows the domain is no
+  longer pending on that site. That happens exactly when the backend finishes
+  the detach (the domain leaves the site’s list / `can_set_as_primary` flips),
+  so an attach → detach → re-attach cycle in the same session is not wrongly
+  suppressed.
+
+Naive optimistic cache patching was rejected: an immediate refetch returns the
+still-attached backend state and would clobber the patch, making the notice
+flicker back. Out-of-cache intent state avoids that because refetches never
+overwrite it.
+
+### Testing (follow-up)
+
+`client/dashboard/utils/test/detaching-domains.test.tsx` covers the store:
+mark/unmark reflected in the hook, independent tracking of multiple domains,
+new snapshot identity on change (so subscribers re-render), and idempotent
+marking. Page-level suppression wiring is thin and type-checked; the end-to-end
+behaviour is verified manually against the real detach repro.
+
 ## Non-goals / risks
 
 - Scope is deliberately limited to the two mutations behind this bug. Not

--- a/packages/api-queries/src/__tests__/domain-invalidation.test.tsx
+++ b/packages/api-queries/src/__tests__/domain-invalidation.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@automattic/api-core', () => ( {
+	disconnectDomain: jest.fn( () => Promise.resolve( {} ) ),
+	transferDomainToSite: jest.fn( () => Promise.resolve( {} ) ),
+} ) );
+
+import { QueryClientProvider, useMutation } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { disconnectDomainMutation } from '../domain';
+import { transferDomainToSiteMutation } from '../domain-transfer';
+import { queryClient } from '../query-client';
+
+function makeWrapper() {
+	return function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
+}
+
+function invalidatedWithDomainsPrefix( spy: jest.SpyInstance ) {
+	return spy.mock.calls.some( ( [ filters ] ) => {
+		const queryKey = ( filters as { queryKey?: readonly unknown[] } )?.queryKey;
+		return Array.isArray( queryKey ) && JSON.stringify( queryKey ) === JSON.stringify( [ 'domains' ] );
+	} );
+}
+
+describe( 'domain detach/attach invalidation', () => {
+	afterEach( () => jest.restoreAllMocks() );
+
+	it( 'disconnectDomainMutation invalidates the broad [ "domains" ] prefix', async () => {
+		const invalidateSpy = jest.spyOn( queryClient, 'invalidateQueries' );
+		const { result } = renderHook( () => useMutation( disconnectDomainMutation( 'example.com' ) ), {
+			wrapper: makeWrapper(),
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( undefined );
+		} );
+
+		expect( invalidatedWithDomainsPrefix( invalidateSpy ) ).toBe( true );
+	} );
+
+	it( 'transferDomainToSiteMutation invalidates the broad [ "domains" ] prefix', async () => {
+		const invalidateSpy = jest.spyOn( queryClient, 'invalidateQueries' );
+		const { result } = renderHook(
+			() => useMutation( transferDomainToSiteMutation( 'example.com', 123 ) ),
+			{ wrapper: makeWrapper() }
+		);
+
+		await act( async () => {
+			await result.current.mutateAsync( 456 );
+		} );
+
+		expect( invalidatedWithDomainsPrefix( invalidateSpy ) ).toBe( true );
+	} );
+} );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -86,7 +86,7 @@ export const transferDomainToSiteMutation = ( domain: string, siteId: number ) =
 	mutationOptions( {
 		mutationFn: ( targetSiteId: number ) => transferDomainToSite( domain, siteId, targetSiteId ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( domainQuery( domain ) );
+			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
 		},
 	} );
 

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -20,7 +20,7 @@ export const disconnectDomainMutation = ( domainName: string ) =>
 	mutationOptions( {
 		mutationFn: () => disconnectDomain( domainName ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( domainQuery( domainName ) );
+			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
 		},
 	} );
 


### PR DESCRIPTION
Part of DOTMSD-1347

## Proposed Changes

* In the multi-site Dashboard, attaching a domain to a site and then immediately detaching it left a stale "Setting up your custom domain" notice on screen until an unrelated refetch (route remount, window focus, or the notice's own 5s poll) eventually refreshed the list.
* Root cause: the site domains page renders from the domains **list** query (`[ 'domains', undefined ]`), but `disconnectDomainMutation` (detach) and `transferDomainToSiteMutation` (attach) only invalidated the **single-domain** key (`[ 'domains', <name> ]`). TanStack Query invalidation is prefix-matched, and `[ 'domains', <name> ]` does not match `[ 'domains', undefined ]`, so the list kept serving the stale entry and the notice lingered.
* Both mutations now invalidate the broad `{ queryKey: [ 'domains' ] }` prefix, which matches both the detail and list keys. This mirrors the established pattern already used by `siteSetPrimaryDomainMutation` and `startDomainInboundTransferMutation` in the same package.
* Added a unit test (`packages/api-queries/src/__tests__/domain-invalidation.test.tsx`) asserting both mutations invalidate the `[ 'domains' ]` prefix.

### Second phase: intent-based suppression

* Broadening cache invalidation ensures fresh data is fetched, but detach is an **asynchronous backend job**: for a few seconds after the request succeeds, reads still report the domain as pending-primary, so the notice reappears until the backend finishes detaching.
* This phase adds intent-based suppression so the notice clears **immediately** on detach instead of waiting for the backend's asynchronous detach to complete. Detach intent is tracked in a small client store (`client/dashboard/utils/detaching-domains.ts`, a `useSyncExternalStore` module store). The domain is marked on the detach mutation's `onSuccess` (and unmarked on `onError`), and the notice call sites suppress the notice while a domain is marked.
* The mark is reconciled once fresh data confirms the domain is no longer pending, so a later re-attach in the same session is not wrongly suppressed. This is applied at both notice call sites: the domain overview page (`client/dashboard/domains/domain-overview/index.tsx`) and the site Domains page (`client/dashboard/sites/domains/index.tsx`), where the detaching domain is also excluded from the pending-domain computation.
* Added a unit test for the store (`client/dashboard/utils/test/detaching-domains.test.tsx`).

## Why are these changes being made?

* To fix the stale primary-domain notice after detach/attach so the UI reflects the change immediately rather than "eventually stabilizing on its own."

## Testing Instructions

* In the Dashboard, attach a domain to a site, then immediately detach it.
* Confirm the "Setting up your custom domain" notice disappears immediately (rather than lingering until the backend's asynchronous detach completes), on **both** the domain overview page and the site Domains page.
* Run the unit tests:
    * `yarn jest --config=packages/api-queries/jest.config.js src/__tests__/domain-invalidation.test.tsx`
    * `yarn test-client client/dashboard/utils/test/detaching-domains.test.tsx`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
