### PR TITLE
Dashboard: only record sites the user belongs to as recent/omnibar site

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -53,7 +53,7 @@ export function InterimOmnibar( {
 	onToggleNotifications,
 }: Props ) {
 	const user = userProp ?? emptyUser;
-	const siteId = user.primary_blog ?? null;
+	const siteId = site?.ID ?? null;
 	const siteSlug = site?.slug ?? null;
 	const siteAdminUrl = site?.options?.admin_url ?? null;
 	const isUnlaunchedSite = !! site && site.launch_status === 'unlaunched' && ! site.is_a4a_dev_site;

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -52,62 +52,74 @@ export function useInitializeOmnibarSite() {
 		queryClient.getQueryData< number | null >( omnibarSiteIdQuery().queryKey ) ||
 		recentSiteIds?.[ 0 ];
 
-	const { data: originSite, isLoading: isLoadingOriginSite } = useQuery( {
-		...siteByIdQuery( originSiteId ?? 0 ),
-		enabled: !! originSiteId,
-	} );
-
-	const { data: fallbackSite, isLoading: isLoadingFallbackSite } = useQuery( {
-		...siteByIdQuery( fallbackSiteId ?? 0 ),
-		enabled: !! fallbackSiteId,
-	} );
-
 	useEffect( () => {
-		// Wait until the required data are fully loaded, to avoid flicker.
-		if (
-			! isRouteLoaded ||
-			isLoadingRecentSiteIds ||
-			isLoadingOriginSite ||
-			isLoadingFallbackSite
-		) {
+		// Wait until the route and recent sites are loaded, to avoid flicker.
+		if ( ! isRouteLoaded || isLoadingRecentSiteIds ) {
 			return;
 		}
 
-		// `omnibarSiteIdQuery` is used as cross-tree shared state — its placeholder
-		// queryFn resolves to `null`. If it's still in flight when we write here,
-		// the resolution will overwrite our value and the omnibar loses the site.
-		queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
+		let cancelled = false;
 
-		const omnibarSite = [ routeSite, originSite, fallbackSite ].find(
-			( site ) => site && isMemberOfSite( site )
-		);
-		const omnibarSiteId = omnibarSite?.ID ?? user?.primary_blog;
-		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => omnibarSiteId );
-
-		// Remove the `origin_site_id` query param from the URL.
-		if ( originSiteId ) {
-			window.history.replaceState(
-				null,
-				'',
-				removeQueryArgs( window.location.pathname + window.location.search, 'origin_site_id' )
+		( async () => {
+			// Resolve the omnibar site in priority order, keeping only sites the user
+			// is a member of. The route site is already hydrated; the rest are fetched
+			// on demand and we stop at the first member, so a crafted or inaccessible
+			// candidate is skipped rather than recorded.
+			const candidateIds = [ routeSite?.ID, originSiteId, fallbackSiteId ].filter(
+				( id ): id is number => !! id
 			);
-		}
 
-		if ( omnibarSiteId && omnibarSiteId !== recentSiteIds?.[ 0 ] ) {
-			updateRecentSites(
-				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 )
-			);
-		}
+			let member: Site | undefined;
+			for ( const id of candidateIds ) {
+				const site =
+					routeSite?.ID === id
+						? routeSite
+						: await queryClient.ensureQueryData( siteByIdQuery( id ) ).catch( () => undefined );
+
+				if ( site && isMemberOfSite( site ) ) {
+					member = site;
+					break;
+				}
+			}
+
+			if ( cancelled ) {
+				return;
+			}
+
+			const omnibarSiteId = member?.ID ?? user?.primary_blog;
+
+			// `omnibarSiteIdQuery` is used as cross-tree shared state — its placeholder
+			// queryFn resolves to `null`. If it's still in flight when we write here,
+			// the resolution will overwrite our value and the omnibar loses the site.
+			queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
+			queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => omnibarSiteId );
+
+			// Remove the `origin_site_id` query param from the URL.
+			if ( originSiteId ) {
+				window.history.replaceState(
+					null,
+					'',
+					removeQueryArgs( window.location.pathname + window.location.search, 'origin_site_id' )
+				);
+			}
+
+			if ( omnibarSiteId && omnibarSiteId !== recentSiteIds?.[ 0 ] ) {
+				updateRecentSites(
+					[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 )
+				);
+			}
+		} )();
+
+		return () => {
+			cancelled = true;
+		};
 	}, [
 		isRouteLoaded,
+		isLoadingRecentSiteIds,
 		routeSite,
 		originSiteId,
-		originSite,
-		isLoadingOriginSite,
-		fallbackSite,
-		isLoadingFallbackSite,
+		fallbackSiteId,
 		recentSiteIds,
-		isLoadingRecentSiteIds,
 		user,
 		updateRecentSites,
 	] );

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -1,6 +1,7 @@
 import {
 	omnibarSiteIdQuery,
 	queryClient,
+	siteByIdQuery,
 	userPreferenceQuery,
 	userPreferenceOptimisticMutation,
 } from '@automattic/api-queries';
@@ -11,6 +12,11 @@ import { useEffect } from 'react';
 import { AUTH_QUERY_KEY } from '../auth';
 import type { Site, User } from '@automattic/api-core';
 
+function isMemberOfSite( site: Site ) {
+	// If the user is a member of the site, the capabilities property will exist
+	return !! site.capabilities;
+}
+
 /**
  * Initializes the current site for the omnibar, which is extracted from the URL,
  * or the most recent sites, or the user's primary blog, in that priority.
@@ -18,7 +24,10 @@ import type { Site, User } from '@automattic/api-core';
 export function useInitializeOmnibarSite() {
 	const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 
-	const { data: recentSiteIds } = useQuery( userPreferenceQuery( 'recentSites' ), queryClient );
+	const { data: recentSiteIds, isLoading: isLoadingRecentSiteIds } = useQuery(
+		userPreferenceQuery( 'recentSites' ),
+		queryClient
+	);
 	const { mutate: updateRecentSites } = useMutation(
 		userPreferenceOptimisticMutation( 'recentSites' ),
 		queryClient
@@ -39,13 +48,28 @@ export function useInitializeOmnibarSite() {
 		( location.search as Record< string, string | undefined > ).origin_site_id
 	);
 	const originSiteId = originSiteIdParam > 0 ? originSiteIdParam : undefined;
+	const fallbackSiteId =
+		queryClient.getQueryData< number | null >( omnibarSiteIdQuery().queryKey ) ||
+		recentSiteIds?.[ 0 ];
 
-	const selectedSiteId = routeSite?.ID || originSiteId;
-	const fallbackSiteId = recentSiteIds?.[ 0 ] || user?.primary_blog;
+	const { data: originSite, isLoading: isLoadingOriginSite } = useQuery( {
+		...siteByIdQuery( originSiteId ?? 0 ),
+		enabled: !! originSiteId,
+	} );
+
+	const { data: fallbackSite, isLoading: isLoadingFallbackSite } = useQuery( {
+		...siteByIdQuery( fallbackSiteId ?? 0 ),
+		enabled: !! fallbackSiteId,
+	} );
 
 	useEffect( () => {
-		// Wait until the route and recent sites are fully loaded, to avoid flicker.
-		if ( ! isRouteLoaded || ! recentSiteIds ) {
+		// Wait until the required data are fully loaded, to avoid flicker.
+		if (
+			! isRouteLoaded ||
+			isLoadingRecentSiteIds ||
+			isLoadingOriginSite ||
+			isLoadingFallbackSite
+		) {
 			return;
 		}
 
@@ -53,10 +77,12 @@ export function useInitializeOmnibarSite() {
 		// queryFn resolves to `null`. If it's still in flight when we write here,
 		// the resolution will overwrite our value and the omnibar loses the site.
 		queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
-		queryClient.setQueryData(
-			omnibarSiteIdQuery().queryKey,
-			( currentSiteId ) => selectedSiteId || currentSiteId || fallbackSiteId
+
+		const omnibarSite = [ routeSite, originSite, fallbackSite ].find(
+			( site ) => site && isMemberOfSite( site )
 		);
+		const omnibarSiteId = omnibarSite?.ID ?? user?.primary_blog;
+		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => omnibarSiteId );
 
 		// Remove the `origin_site_id` query param from the URL.
 		if ( originSiteId ) {
@@ -67,16 +93,22 @@ export function useInitializeOmnibarSite() {
 			);
 		}
 
-		// Push the selected site id as the most recent site.
-		if ( selectedSiteId && selectedSiteId !== recentSiteIds[ 0 ] ) {
-			updateRecentSites( [ ...new Set( [ selectedSiteId, ...recentSiteIds ] ) ].slice( 0, 5 ) );
+		if ( omnibarSiteId && omnibarSiteId !== recentSiteIds?.[ 0 ] ) {
+			updateRecentSites(
+				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 )
+			);
 		}
 	}, [
 		isRouteLoaded,
+		routeSite,
 		originSiteId,
-		selectedSiteId,
-		fallbackSiteId,
+		originSite,
+		isLoadingOriginSite,
+		fallbackSite,
+		isLoadingFallbackSite,
 		recentSiteIds,
+		isLoadingRecentSiteIds,
+		user,
 		updateRecentSites,
 	] );
 }


### PR DESCRIPTION
## Proposed Changes

* Validate that the current user is a member of a site before setting it as the omnibar site or persisting it as a recent site.
* Resolve the omnibar site from the route, then `origin_site_id`, then the recent-sites fallback — keeping only sites the user belongs to — and fall back to the user's primary blog otherwise.
* Derive the interim omnibar's `siteId` from the resolved site instead of always the user's primary blog.

## Why are these changes being made?

* When arriving from a site's wp-admin, the URL can carry an `origin_site_id`. Previously that id was set as the omnibar site and recorded in recent sites without checking access, so a crafted or inaccessible `origin_site_id` could be persisted for a site the user doesn't belong to. Membership is now required before a site is set or recorded.

## Testing Instructions

* Load the dashboard normally and confirm the omnibar shows the current site.
* Append `?origin_site_id=<a site you belong to>` to a dashboard URL — confirm it becomes the omnibar site and is added to recent sites.
* Append `?origin_site_id=<a site you do NOT belong to>` — confirm it is **not** set as the omnibar site and **not** added to recent sites; the omnibar falls back to a valid recent site or the primary blog.
* Confirm no TypeScript/console errors.

## Considerations

* Membership is inferred from the presence of `capabilities` on the fetched site (the WPCOM API returns it only for sites the user has a role on). This matches existing precedent in the codebase. Validating a candidate requires fetching the site to read `capabilities`; the route site is already hydrated, so the common case adds no request.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
