### PR TITLE
Stats: use the admin accent color for charts, heatmaps, and interactive elements

### DIFF
--- a/apps/odyssey-stats/src/widget/mini-chart.scss
+++ b/apps/odyssey-stats/src/widget/mini-chart.scss
@@ -57,7 +57,7 @@ $barDarkColor: var(--color-primary-60);
 			vertical-align: middle;
 			margin-top: -3px;
 
-			&.is-dark-blue {
+			&.is-secondary {
 				background-color: $barDarkColor;
 			}
 		}

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -26,7 +26,7 @@ class ChartLegend extends Component {
 	};
 
 	render() {
-		const legendColors = [ 'chart__legend-color is-dark-blue' ];
+		const legendColors = [ 'chart__legend-color is-secondary' ];
 		const activeTab = this.props.activeTab;
 
 		const legendItems = this.props.availableCharts.map( function ( legendItem, index ) {
@@ -51,7 +51,7 @@ class ChartLegend extends Component {
 				<ul className="chart__legend-options">
 					<li className="chart__legend-option" key="default-tab">
 						<span className="chart__legend-label">
-							<span className="chart__legend-color is-wordpress-blue" />
+							<span className="chart__legend-color" />
 							{ activeTab.label }
 						</span>
 					</li>

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -178,7 +178,7 @@ $y-axis-padding: 0 20px;
 
 	&.is-selected {
 		cursor: default;
-		background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
+		background-color: color-mix(in srgb, var(--color-accent) 10%, transparent);
 	}
 }
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -292,7 +292,7 @@ $y-axis-padding: 0 20px;
 		vertical-align: top;
 		margin: 0 8px 0 0;
 
-		&.is-dark-blue {
+		&.is-secondary {
 			background: var(--color-accent-dark);
 		}
 	}

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -203,7 +203,7 @@ $y-axis-padding: 0 20px;
 
 .chart__bar-section {
 	display: inline-block;
-	background-color: var(--color-primary);
+	background-color: var(--color-accent);
 	position: absolute;
 	right: 16%; // 1
 	bottom: 0; // 1
@@ -218,7 +218,7 @@ $y-axis-padding: 0 20px;
 }
 
 .chart__bar-section-inner {
-	background-color: var(--color-primary-dark);
+	background-color: var(--color-accent-dark);
 	position: absolute;
 	right: 23.33%;
 	bottom: 0;
@@ -286,14 +286,14 @@ $y-axis-padding: 0 20px;
 	.chart__legend-color {
 		width: 20px;
 		height: 20px;
-		background: var(--color-primary);
+		background: var(--color-accent);
 		display: inline-block;
 		border-radius: 4px;
 		vertical-align: top;
 		margin: 0 8px 0 0;
 
 		&.is-dark-blue {
-			background: var(--color-primary-dark);
+			background: var(--color-accent-dark);
 		}
 	}
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -275,7 +275,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 
 .date-range__picker {
-	--date-range-picker-highlight-color: color-mix(in srgb, var(--color-primary-light) 40%, transparent);
+	--date-range-picker-highlight-color: color-mix(in srgb, var(--color-accent-light) 40%, transparent);
 
 	.DayPicker-Day,
 	.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
@@ -305,12 +305,12 @@ $date-range-mobile-layout-switch: $break-small;
 	.DayPicker-Day--end.DayPicker-Day--range-end {
 		& .date-picker__day {
 			color: var(--color-text-inverted);
-			background-color: var(--color-primary);
+			background-color: var(--color-accent);
 		}
 		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
 			border-radius: 200px; /* stylelint-disable-line scales/radii */
 			&.DayPicker-Day--range {
-				background-color: var(--color-primary);
+				background-color: var(--color-accent);
 				.date-picker__day {
 					&:hover,
 					&:focus {
@@ -398,7 +398,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 
 	&:hover {
-		background-color: var(--color-primary-0);
+		background-color: var(--color-accent-0);
 	}
 
 	& + & {

--- a/client/my-sites/stats/_modernized-mixins.scss
+++ b/client/my-sites/stats/_modernized-mixins.scss
@@ -11,11 +11,11 @@ $common-border-radius: 4px;
 		&.is-primary {
 			.segmented-control__item.is-selected {
 				.segmented-control__link {
-					border-color: var(--color-primary);
-					background-color: var(--color-primary);
+					border-color: var(--color-accent);
+					background-color: var(--color-accent);
 
 					&:hover {
-						background-color: var(--color-primary);
+						background-color: var(--color-accent);
 					}
 				}
 			}
@@ -102,8 +102,8 @@ $common-border-radius: 4px;
 
 			&.is-selected {
 				.segmented-control__link {
-					background-color: var(--color-primary);
-					border-color: var(--color-primary);
+					background-color: var(--color-accent);
+					border-color: var(--color-accent);
 					color: var(--studio-white);
 					position: relative;
 					z-index: 1;

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.scss
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.scss
@@ -49,19 +49,19 @@
 
 	.pie-chart__chart-section-0,
 	.pie-chart__legend-sample-0 {
-		fill: var(--color-primary-70);
+		fill: var(--color-accent-70);
 	}
 	.pie-chart__chart-section-1,
 	.pie-chart__legend-sample-1 {
-		fill: var(--color-primary-50);
+		fill: var(--color-accent-50);
 	}
 	.pie-chart__chart-section-2,
 	.pie-chart__legend-sample-2 {
-		fill: var(--color-primary-30);
+		fill: var(--color-accent-30);
 	}
 	.pie-chart__chart-section-3,
 	.pie-chart__legend-sample-3 {
-		fill: var(--color-primary-10);
+		fill: var(--color-accent-10);
 	}
 }
 

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -178,7 +178,7 @@ $custom-stats-tab-mobile-break: $break-medium;
 			&.is-selected.is-low {
 				a {
 					color: var(--studio-black);
-					border-color: var(--color-primary);
+					border-color: var(--color-accent);
 					background-color: var(--color-surface);
 
 					// Keep the original mobile stats-tabs border styles

--- a/client/my-sites/stats/modernized-stats-table-styles.scss
+++ b/client/my-sites/stats/modernized-stats-table-styles.scss
@@ -78,8 +78,8 @@ $common-border-radius: 4px;
 
 			&.is-selected {
 				.segmented-control__link {
-					background-color: var(--color-primary);
-					border-color: var(--color-primary);
+					background-color: var(--color-accent);
+					border-color: var(--color-accent);
 					color: var(--studio-white);
 					position: relative;
 					z-index: 1;
@@ -138,25 +138,25 @@ $common-border-radius: 4px;
 			}
 
 			&.level-1 {
-				background-color: var(--color-primary-5);
+				background-color: var(--color-accent-5);
 			}
 
 			&.level-2 {
-				background-color: var(--color-primary-10);
+				background-color: var(--color-accent-10);
 			}
 
 			&.level-3 {
-				background-color: var(--color-primary-light);
+				background-color: var(--color-accent-light);
 				color: var(--studio-white);
 			}
 
 			&.level-4 {
-				background-color: var(--color-primary);
+				background-color: var(--color-accent);
 				color: var(--studio-white);
 			}
 
 			&.level-5 {
-				background-color: var(--color-primary-dark);
+				background-color: var(--color-accent-dark);
 				color: var(--studio-white);
 			}
 		}

--- a/client/my-sites/stats/pages/realtime/style.scss
+++ b/client/my-sites/stats/pages/realtime/style.scss
@@ -18,11 +18,11 @@
 
 	/* Style the line chart svg using the user admin color scheme */
 	path.visx-line {
-		stroke: var(--color-primary);
+		stroke: var(--color-accent);
 	}
 
 	#area-gradient-1 > stop:first-child {
-		stop-color: var(--color-primary);
+		stop-color: var(--color-accent);
 	}
 	/* Style the line chart svg using the user admin color scheme */
 }

--- a/client/my-sites/stats/post-detail-table-section/style.scss
+++ b/client/my-sites/stats/post-detail-table-section/style.scss
@@ -83,7 +83,7 @@ $common-border-radius: 4px;
 		}
 
 		td {
-			background-color: var(--color-primary-5);
+			background-color: var(--color-accent-5);
 
 			&.stats-detail__row-label,
 			&.has-no-data,
@@ -92,7 +92,7 @@ $common-border-radius: 4px;
 			}
 
 			&.highest-count {
-				background-color: var(--color-primary-10);
+				background-color: var(--color-accent-10);
 			}
 
 			&.stats-detail__row-label {

--- a/client/my-sites/stats/sections/posting-activity-section/style.scss
+++ b/client/my-sites/stats/sections/posting-activity-section/style.scss
@@ -129,19 +129,19 @@ $lowestLevelColor: var(--color-neutral-5);
 	}
 
 	&.is-level-1 {
-		background-color: var(--color-primary-10);
+		background-color: var(--color-accent-10);
 	}
 
 	&.is-level-2 {
-		background-color: var(--color-primary-light);
+		background-color: var(--color-accent-light);
 	}
 
 	&.is-level-3 {
-		background-color: var(--color-primary);
+		background-color: var(--color-accent);
 	}
 
 	&.is-level-4 {
-		background-color: var(--color-primary-dark);
+		background-color: var(--color-accent-dark);
 	}
 
 	&.is-hovered {

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -415,8 +415,8 @@ const withCssColors = ( WrappedComponent ) => {
 	const WithCssColorsComponent = ( props ) => {
 		const chartContainerRef = useRef( null );
 
-		const primaryColor = useCssVariable( '--color-primary-light', chartContainerRef.current );
-		const secondaryColor = useCssVariable( '--color-primary-dark', chartContainerRef.current );
+		const primaryColor = useCssVariable( '--color-accent-light', chartContainerRef.current );
+		const secondaryColor = useCssVariable( '--color-accent-dark', chartContainerRef.current );
 
 		return (
 			<WrappedComponent

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -94,7 +94,7 @@ ul.module-tabs {
 			clear: both;
 			display: block;
 			line-height: 24px;
-			color: var(--color-primary);
+			color: var(--color-accent);
 			transition: font-size 0.3s 0 ease-out;
 
 			@include breakpoint-deprecated( "<480px" ) {
@@ -150,7 +150,7 @@ ul.module-tabs {
 		&.is-selected a .value,
 		&.is-selected.is-low a .value,
 		&.is-selected a:hover .value {
-			color: var(--color-primary);
+			color: var(--color-accent);
 		}
 
 		// Low state ('disabled')

--- a/client/my-sites/stats/stats-date-label/date-label-drill/index.scss
+++ b/client/my-sites/stats/stats-date-label/date-label-drill/index.scss
@@ -14,7 +14,7 @@
 		cursor: pointer;
 
 		&:hover {
-			fill: var(--color-primary);
+			fill: var(--color-accent);
 		}
 	}
 }

--- a/client/my-sites/stats/stats-email-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-email-chart-tabs/style.scss
@@ -93,7 +93,7 @@ ul.module-tabs {
 			clear: both;
 			display: block;
 			line-height: 24px;
-			color: var(--color-primary);
+			color: var(--color-accent);
 			transition: font-size 0.3s 0 ease-out;
 
 			@include breakpoint-deprecated( "<480px" ) {
@@ -149,7 +149,7 @@ ul.module-tabs {
 		&.is-selected a .value,
 		&.is-selected.is-low a .value,
 		&.is-selected a:hover .value {
-			color: var(--color-primary);
+			color: var(--color-accent);
 		}
 
 		// Low state ('disabled')

--- a/client/my-sites/stats/stats-heap-map/style.scss
+++ b/client/my-sites/stats/stats-heap-map/style.scss
@@ -32,22 +32,22 @@
 	}
 
 	&.level-1 {
-		background-color: var(--color-primary-5);
+		background-color: var(--color-accent-5);
 	}
 
 	&.level-2 {
-		background-color: var(--color-primary-10);
+		background-color: var(--color-accent-10);
 	}
 
 	&.level-3 {
-		background-color: var(--color-primary-light);
+		background-color: var(--color-accent-light);
 	}
 
 	&.level-4 {
-		background-color: var(--color-primary);
+		background-color: var(--color-accent);
 	}
 
 	&.level-5 {
-		background-color: var(--color-primary-dark);
+		background-color: var(--color-accent-dark);
 	}
 }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -114,7 +114,7 @@
 	// Post was published within the selected period
 	// 1: Move so far out left that only half the icon is showing to reduce footprint
 	.module-content-list-item.published & {
-		box-shadow: inset 4px 0 0 var( --color-primary );
+		box-shadow: inset 4px 0 0 var( --color-accent );
 	}
 }
 
@@ -759,7 +759,7 @@ ul.module-content-list-legend {
 
 	// Change colors to highlight label when row is highlighted
 	.stats-list__module-content-list-item-label {
-		color: var( --color-primary );
+		color: var( --color-accent );
 	}
 
 	// Highlight main action (usually what's indicated in the label)

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -325,7 +325,7 @@ ul.module-header-actions {
 
 	// Representation of what the published status looks like within a list of posts and pages
 	.legend.published {
-		border-left: 4px solid var(--color-primary);
+		border-left: 4px solid var(--color-accent);
 		padding-left: 12px;
 	}
 

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -193,7 +193,7 @@ export default function SubscribersChartSection( {
 		}
 	}, [ status, isError ] );
 
-	const subscriberLineStroke = useCssVariable( '--color-primary-light', containerRef.current );
+	const subscriberLineStroke = useCssVariable( '--color-accent-light', containerRef.current );
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
 	// Products with an undefined value rather than an empty array means the API call has not been completed yet.

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -66,7 +66,7 @@ $stats-tab-outer-padding: 10px;
 			}
 
 			.value {
-				color: var(--color-primary);
+				color: var(--color-accent);
 				display: block;
 				line-height: 24px;
 				text-align: center;
@@ -132,7 +132,7 @@ $stats-tab-outer-padding: 10px;
 
 		.value {
 			clear: both;
-			color: var(--color-primary);
+			color: var(--color-accent);
 			display: block;
 			float: none;
 			line-height: 24px;
@@ -192,7 +192,7 @@ $stats-tab-outer-padding: 10px;
 		&.is-selected a .value,
 		&.is-selected.is-low a .value,
 		&.is-selected a:hover .value {
-			color: var(--color-primary);
+			color: var(--color-accent);
 		}
 
 		// Low state ('disabled')

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -37,7 +37,7 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 }
 
 .stats {
-	--color-link: var(--theme-highlight-color);
+	--color-link: var(--color-accent);
 	--color-link-dark: var(--color-accent-dark);
 }
 

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -48,7 +48,7 @@
 	}
 
 	.videopress-stats-module__grid-link {
-		color: var(--color-primary);
+		color: var(--color-accent);
 		overflow: hidden;
 		padding: 0 12px 0 24px;
 
@@ -90,7 +90,7 @@
 				top: 0;
 				height: 100%;
 				width: var(--bar-fill-percentage, 0%);
-				background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+				background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
 				border-radius: 2px;
 				transition: background-color 0.2s ease-out;
 				z-index: 0;
@@ -107,10 +107,10 @@
 
 	.videopress-stats-module__row-wrapper {
 		&:hover {
-			background-color: var(--theme-highlight-color);
+			background-color: var(--color-accent);
 
 			.videopress-stats-module__bar::before {
-				background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+				background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
 			}
 
 			.videopress-stats-module__grid-metric span,

--- a/packages/components/src/horizontal-bar-list/style.scss
+++ b/packages/components/src/horizontal-bar-list/style.scss
@@ -27,7 +27,7 @@
 
 		&:hover,
 		&:focus {
-			background-color: var(--theme-highlight-color);
+			background-color: var(--color-accent);
 			color: var(--studio-white);
 
 			@media (min-width: 481px) {
@@ -83,7 +83,7 @@
 			height: 100%;
 			content: "";
 			border-radius: 2px;
-			background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+			background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
 			position: absolute;
 			left: 0;
 			z-index: 0;
@@ -129,7 +129,7 @@
 }
 
 .horizontal-bar-list-item--indicated {
-	box-shadow: inset $item-indicator-width 0 0 var(--color-primary);
+	box-shadow: inset $item-indicator-width 0 0 var(--color-accent);
 }
 
 .horizontal-bar-list-item--static {


### PR DESCRIPTION
Fixes STATS-323

## Why are these changes being made?

Across Stats, many UI elements were themed with `--color-primary` (Calypso's static brand-blue) or `--theme-highlight-color` (only reliably set in some schemes) instead of `--color-accent` — the one variable every scheme in `packages/calypso-color-schemes` wires to `--wp-admin-theme-color`, which is what `@wordpress/components` primary buttons actually use. In most schemes `--color-primary` and `--color-accent` coincide, so this went unnoticed; but in schemes where they diverge (Classic Blue, Classic Dark, Classic Bright, Nightfall, Sunset, Contrast, Sakura, Aquatic) these elements stayed blue — or, in the list-bar hover case, leaked an uncontrolled Jetpack green — while the surrounding buttons correctly followed the site's admin color.

The result is a Stats surface where charts and interactive elements now match the site's admin accent everywhere, instead of only where the two variables happened to coincide.

## Proposed Changes

Charts and interactive elements throughout Stats now read `--color-accent*` instead of `--color-primary*` / `--theme-highlight-color`:

- **Charts:** the Views/Visitors bar chart (bars, nested bar, legend, bar-selection highlight), the realtime line chart, the subscriber-growth line chart, and the Devices donut.
- **Heatmaps:** the Insights posting-activity calendar and the all-time "Total views" table, including their "Fewer → More" legends.
- **List bars & indicators:** the horizontal bar lists (Most viewed, Referrers, Search terms, Authors, etc.), their hover state, and the "published in period" bar indicator.
- **Tabs & toggles:** the chart/section tab highlights, the segmented-control "active" state (Posts & pages / Countries / Size, etc.), and the data-table row selection and level shading.
- **Date range picker:** the in-range highlight, selected-day/range circles, and preset-shortcut hover.

Purchase / paywall CTAs, the classic-dark contrast override, and a few minor bits of chrome (plain links, focus rings) are intentionally left on `--color-primary`.

## Screenshots

Captured on a Jetpack site using the **Classic Bright** admin scheme, where `--color-primary` (blue `#0675c4`) and `--color-accent` (pink `#c9356e`) diverge. Before, these elements stayed blue regardless of the theme; after, they follow the admin accent.

| Section | Before (`--color-primary`) | After (`--color-accent`) |
| --- | --- | --- |
| **Traffic** | <img width="430" alt="Traffic before" src="https://github.com/user-attachments/assets/59362d78-3b4a-4889-b42e-056705dbc807" /> | <img width="430" alt="Traffic after" src="https://github.com/user-attachments/assets/ec849cbc-4bc4-43b9-9473-1695f1d57da7" /> |
| **Realtime** | <img width="430" alt="Realtime before" src="https://github.com/user-attachments/assets/d3cc192d-9d67-4d98-b638-7c9762f35977" /> | <img width="430" alt="Realtime after" src="https://github.com/user-attachments/assets/daeb6be3-7896-4ac1-8523-bb22ef335243" /> |
| **Insights** | <img width="430" alt="Insights before" src="https://github.com/user-attachments/assets/ad5b9150-731f-411d-8b54-a91c87fe2208" /> | <img width="430" alt="Insights after" src="https://github.com/user-attachments/assets/93ac0bd4-014a-404a-bc16-c5a57b6156ba" /> |
| **Subscribers** | <img width="430" alt="Subscribers before" src="https://github.com/user-attachments/assets/34caf433-e60c-4cb0-bbbc-6d8e90ce882b" /> | <img width="430" alt="Subscribers after" src="https://github.com/user-attachments/assets/7c72fd65-3713-48b2-b7c3-b21e5b44793b" /> |

## Testing Instructions

1. Set an admin color scheme where `--color-primary` and `--color-accent` diverge — e.g. **Classic Bright** (pink accent) or **Classic Blue** — via wp-admin → Users → Profile → Admin Color Scheme.
2. On **Stats → Traffic**, confirm the following now match the admin accent (the same color as the "Create campaign" button and the chart-type toggle), not blue:
   - the Views/Visitors bar chart and its legend swatches, plus the selected-bar highlight;
   - the Most viewed / Referrers / UTM / Clicks / Authors / Search terms / Videos / File downloads list bars, **and their hover state** (previously an uncontrolled green);
   - the Posts & pages / Archive, Countries / Regions / Cities, and Size / Browser / OS toggles;
   - the Locations map shading and the Devices donut chart.
3. Open the **date range picker** (top-right) and confirm the in-range highlight, the selected-day/range circles, and the preset-shortcut hover use the accent.
4. **Realtime:** the current-views line chart uses the accent.
5. **Insights:** the Posting activity heatmap and the all-time "Total views" heatmap — including both "Fewer → More" legends — use the accent gradient; the Tags & categories / Comments / Number of Shares bars and the "Months and years" / "By authors" toggles match too.
6. **Subscribers:** the subscriber-growth chart line/fill and the Days / Weeks / Months / Years toggle use the accent.
7. **Regression — default theme:** switch to the default **Fresh** admin color scheme (where `--color-primary` and `--color-accent` coincide) and re-check the elements from steps 2–6. They should look exactly as they did before this change (standard WordPress blue, unchanged), confirming the swap is a no-op where the two variables already matched.
8. Confirm the Stats purchase/upgrade CTAs (paywall, tier-upgrade slider) are unchanged — they intentionally stay on brand blue.

**Odyssey Stats (wp-admin):** the color swaps are a visual no-op in Odyssey — it pins both `--color-primary` and `--color-accent` to Jetpack green, so there is no accent behavior to test there. The only Odyssey-facing change is the `is-dark-blue` → `is-secondary` legend class rename. On a Jetpack-connected site, open **wp-admin → Dashboard** and check the **Jetpack Stats mini-chart** widget: its comparison-series legend swatch should still match the darker inner bar (both Jetpack green), i.e. no orphaned/mismatched swatch.

Shared components touched here (`client/components/chart`, `packages/components/src/horizontal-bar-list`, `client/components/date-range`) were checked against their other consumers (Jetpack Cloud, WooCommerce store stats, customer-home, Promote Post/Blaze, Activity Log, Backup) — none override these variables in a way that would regress.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?


