### PR TITLE
Odyssey Stats: Use existing feature constants for upsell entitlements

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/upsell-card/available-upsells.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/upsell-card/available-upsells.tsx
@@ -1,12 +1,19 @@
 import {
+	FEATURE_CLOUD_CRITICAL_CSS,
+	FEATURE_SOCIAL_ENHANCED_PUBLISHING,
 	PLAN_JETPACK_SECURITY_T1_YEARLY,
 	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 	PRODUCT_JETPACK_BOOST,
 	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SOCIAL_BASIC,
 	PRODUCT_JETPACK_VIDEOPRESS,
+	WPCOM_FEATURES_ANTISPAM,
+	WPCOM_FEATURES_BACKUPS,
+	WPCOM_FEATURES_CLASSIC_SEARCH,
+	WPCOM_FEATURES_SCAN,
+	WPCOM_FEATURES_VIDEOPRESS,
 } from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import SecurityIcon from './icons/jetpack-icon-lock.svg';
 import BackupIcon from './icons/jetpack-product-icon-backup.svg';
 import BoostIcon from './icons/jetpack-product-icon-boost.svg';
@@ -15,7 +22,7 @@ import SocialIcon from './icons/jetpack-product-icon-social.svg';
 import VideoPressIcon from './icons/jetpack-product-icon-videopress.svg';
 
 export type Product = {
-	description: string;
+	description: TranslateResult;
 	href: string;
 	iconUrl: string;
 	isFree: boolean;
@@ -25,7 +32,7 @@ export type Product = {
 	// owned. The upsell is hidden when the site has all of them.
 	ownedFeatures: string[];
 	checkoutSlug: string;
-	checkoutUrl: string | null;
+	checkoutUrl?: string;
 };
 
 export function getAvailableUpsells() {
@@ -39,7 +46,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'security',
 			title: 'Security',
-			ownedFeatures: [ 'backups', 'scan', 'antispam' ],
+			ownedFeatures: [ WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN, WPCOM_FEATURES_ANTISPAM ],
 			checkoutSlug: PLAN_JETPACK_SECURITY_T1_YEARLY,
 		},
 		{
@@ -51,7 +58,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'backup',
 			title: 'Backup',
-			ownedFeatures: [ 'backups' ],
+			ownedFeatures: [ WPCOM_FEATURES_BACKUPS ],
 			checkoutSlug: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 		},
 		{
@@ -63,7 +70,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'search',
 			title: 'Search',
-			ownedFeatures: [ 'search' ],
+			ownedFeatures: [ WPCOM_FEATURES_CLASSIC_SEARCH ],
 			checkoutSlug: PRODUCT_JETPACK_SEARCH,
 		},
 		{
@@ -75,7 +82,7 @@ export function getAvailableUpsells() {
 			isFree: false,
 			slug: 'video',
 			title: 'VideoPress',
-			ownedFeatures: [ 'videopress' ],
+			ownedFeatures: [ WPCOM_FEATURES_VIDEOPRESS ],
 			checkoutSlug: PRODUCT_JETPACK_VIDEOPRESS,
 		},
 		{
@@ -87,7 +94,7 @@ export function getAvailableUpsells() {
 			isFree: true,
 			slug: 'boost',
 			title: 'Boost',
-			ownedFeatures: [ 'cloud-critical-css' ],
+			ownedFeatures: [ FEATURE_CLOUD_CRITICAL_CSS ],
 			checkoutSlug: PRODUCT_JETPACK_BOOST,
 		},
 		{
@@ -99,17 +106,17 @@ export function getAvailableUpsells() {
 			isFree: true,
 			slug: 'social',
 			title: 'Social',
-			ownedFeatures: [ 'social-enhanced-publishing' ],
+			ownedFeatures: [ FEATURE_SOCIAL_ENHANCED_PUBLISHING ],
 			checkoutSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
 		},
-	] as Product[];
+	] satisfies Product[];
 }
 
 // TODO: Reconfigure this to separate const data and translate calls.
 // Currently we end up calling getAvailableUpsells() twice per render.
 export function getUpsellFeatureSlugs(): string[] {
 	const upsells = getAvailableUpsells();
-	return upsells.flatMap( ( upsell ) => upsell.ownedFeatures );
+	return [ ...new Set( upsells.flatMap( ( upsell ) => upsell.ownedFeatures ) ) ];
 }
 
 export function filterUpsellsBySiteFeatures(


### PR DESCRIPTION
Related to STATS-286

## Proposed Changes

Follow-up to #112461, addressing the review feedback there:

* Replace the raw entitlement slug strings in `ownedFeatures` with the existing constants from `@automattic/calypso-products` (`WPCOM_FEATURES_BACKUPS`, `WPCOM_FEATURES_SCAN`, `WPCOM_FEATURES_ANTISPAM`, `WPCOM_FEATURES_CLASSIC_SEARCH`, `WPCOM_FEATURES_VIDEOPRESS`, `FEATURE_CLOUD_CRITICAL_CSS`, `FEATURE_SOCIAL_ENHANCED_PUBLISHING`), so slug spelling has a single source of truth and matches the `siteHasFeature()` + constants pattern used elsewhere (e.g. `client/my-sites/scan/wpcom-scan-upsell.tsx`).
* Make `Product.checkoutUrl` optional and validate the upsell list with `satisfies Product[]` instead of an `as Product[]` assertion (which required widening `description` to `TranslateResult` — its real type).
* Dedupe the slugs returned by `getUpsellFeatureSlugs()` (`backups` was listed for both Security and Backup, causing redundant `siteHasFeature` checks).

## Why are these changes being made?

* Review feedback on #112461 suggested using existing feature sets rather than hand-rolled strings that are hard to keep in sync, plus two Copilot nits (type assertion masking mismatches; duplicate selector checks). No behavior change — the constants have the same values as the strings they replace.

### Design notes: why feature-slug entitlements rather than an existing mechanism

The codebase has two prior models for "don't sell what the user already owns", and this section deliberately uses neither wholesale:

* **Single-feature checks** — `siteHasFeature()` + one `WPCOM_FEATURES_*` constant (e.g. `client/my-sites/scan/wpcom-scan-upsell.tsx`, `client/jetpack-cloud/sections/landing/selectors.ts`). This is the established ownership-check idiom; `ownedFeatures` is that idiom generalized to a small set per card (Security needs all of Backup/Scan/Anti-spam to count as owned).
* **Product-slug model** — the Jetpack pricing store (`client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx`) resolves ownership at the product level via `getPurchaseByProductSlug` (site purchases), `planHasFeature` (static plan definitions), and `isSupersedingJetpackItem` + `JETPACK_PLAN_UPGRADE_MAP` / `JETPACK_PRODUCT_UPGRADE_MAP` (explicit supersession maps). It wasn't reused here because it depends on purchases data plus `@automattic/calypso-products` static plan→feature definitions — a client-side duplicate of data the backend owns (the package is frozen for that reason) — whereas the feature slugs this section reads come from the backend-computed `features.active` that `stats-admin` already inlines into the page, so the server stays the single source of truth for plan bundling and no extra requests are needed.

There is no maintained client-side product → entitlement *grouping* anywhere (bundling lives server-side in `WPCOM_Features`), so the per-card `ownedFeatures` sets are defined here, with slug spelling now coming from the shared constants.

Why Security needs a *set* while every other card is a single slug: Security is a bundle, and there is no `security` feature slug — its ownership can only be expressed as "all of its contents are present" (`backups` + `scan` + `antispam`). The other five cards degenerate to the same single-feature idiom the codebase already uses (`UpsellSwitch`'s `productSlugTest` and the pricing store cover the product-slug variants of the same question).

The behavior was also cross-checked against checkout's own two validators: the client-side `PrePurchaseNotices` feature-overlap warning and the server-side cart validation that removes or substitutes products already covered by the owned plan (e.g. VideoPress on a Complete site is removed; Backup T1 on Complete is swapped for the storage add-on). In every scenario tested (Security Daily, Backup T1 + Search Free, Complete, no purchases) the card visibility agrees with what checkout would say — including the deliberate case where checkout *allows* buying Backup T1 on Security Daily (real-time is technically an upgrade over daily backup) while the generic "get Backup" card stays hidden for a site that already has backups.

The check is also fail-open by design: if site features are missing or a slug is ever renamed server-side, the worst case is showing an upsell to an owner (the pre-#112461 behavior) — never hiding a legitimate upsell or crashing.

## Testing Instructions

* `yarn test-client client/my-sites/stats/jetpack-upsell-section` — 4/4 tests pass.
* Behavior is unchanged from #112461; the visibility scenarios documented and screenshotted there still apply.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? (Covered by the tests added in #112461.)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



