### PR TITLE
Odyssey Stats: Open upsell card product links in a new tab

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/upsell-card/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/upsell-card/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Product } from './available-upsells';
 
@@ -37,19 +37,18 @@ export function UpsellCard( { siteTitle, upsells }: UpsellCardProps ) {
 						</div>
 						<h3 className="jetpack-upsell-card__product-title">{ title }</h3>
 						<p className="jetpack-upsell-card__product-description">{ description }</p>
-						<a
+						<ExternalLink
 							href={ href }
 							className="jetpack-upsell-card__product-link"
-							target="_blank"
-							rel="noopener noreferrer"
+							icon
+							iconSize={ 16 }
 						>
 							<span className="jetpack-upsell-card__product-link-text">
 								{ translate( 'More about %(productName)s', {
 									args: { productName: title },
 								} ) }
 							</span>
-							<Gridicon icon="external" size={ 16 } />
-						</a>
+						</ExternalLink>
 						<Button
 							href={ checkoutUrl! }
 							className="jetpack-upsell-card__product-button"

--- a/client/my-sites/stats/jetpack-upsell-section/upsell-card/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/upsell-card/index.tsx
@@ -37,7 +37,12 @@ export function UpsellCard( { siteTitle, upsells }: UpsellCardProps ) {
 						</div>
 						<h3 className="jetpack-upsell-card__product-title">{ title }</h3>
 						<p className="jetpack-upsell-card__product-description">{ description }</p>
-						<a href={ href } className="jetpack-upsell-card__product-link">
+						<a
+							href={ href }
+							className="jetpack-upsell-card__product-link"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
 							<span className="jetpack-upsell-card__product-link-text">
 								{ translate( 'More about %(productName)s', {
 									args: { productName: title },

--- a/client/my-sites/stats/jetpack-upsell-section/upsell-card/style.scss
+++ b/client/my-sites/stats/jetpack-upsell-section/upsell-card/style.scss
@@ -65,7 +65,6 @@
 	font-size: $font-body-small;
 	grid-area: link;
 	justify-self: end;
-	margin-bottom: 0.5em;
 	text-decoration: underline;
 
 	&.external-link .gridicon {

--- a/client/my-sites/stats/jetpack-upsell-section/upsell-card/style.scss
+++ b/client/my-sites/stats/jetpack-upsell-section/upsell-card/style.scss
@@ -68,10 +68,11 @@
 	margin-bottom: 0.5em;
 	text-decoration: underline;
 
-	.gridicon {
-		align-self: flex-end;
+	&.external-link .gridicon {
+		align-self: center;
 		fill: var(--studio-gray-80);
-		margin-left: 3px;
+		// Cancel .external-link's baseline nudge; flex centering handles alignment.
+		top: 0;
 	}
 
 	&:visited {


### PR DESCRIPTION
Fixes STATS-307

## Proposed Changes

* Replace the hand-rolled `<a>` for the “More about %(productName)s” links on the Odyssey Stats Jetpack upsell cards with the shared `ExternalLink` component, which opens in a new tab (`target="_blank"`, `rel="external noopener noreferrer"`), adds a screen-reader-only “(opens in a new tab)” label, and localizes the jetpack.com URL.
* Fix the link’s icon alignment: the card SCSS pinned the icon to the bottom of the flex row (`align-self: flex-end`), sinking it below the text’s visual center. Center it instead, cancel `ExternalLink`’s inline `top: 2px` baseline nudge (which doesn’t apply inside a flex container), and drop the `margin-bottom: 0.5em` optical fudge carried over from the original implementation — with real centering it pushed the link above the row’s visual center.

## Why are these changes being made?

* The links render an external-link Gridicon — signaling “opens in a new tab” — but navigated in the same tab, taking the user from wp-admin Stats to jetpack.com with no way back except browser history. The anchor now matches its affordance.

## Testing Instructions

* On a Jetpack site, open Odyssey Stats (wp-admin → Jetpack → Stats, Traffic tab) on a site with visible upsell cards (a site without paid upgrades shows all six).
* Click “More about Security” (or any card’s link): the jetpack.com page should open in a new tab and the Stats page should stay put.
* Check the link visually: the external icon should be vertically centered with the link text (previously it sat slightly low).

|Before|After|
|-|-|
|<img width="1231" height="481" alt="截圖 2026-07-10 下午2 00 10" src="https://github.com/user-attachments/assets/f9011704-a3e3-40e5-a959-c1c68f14444d" />|<img width="1225" height="472" alt="截圖 2026-07-10 下午2 02 08" src="https://github.com/user-attachments/assets/f7cc1cad-84db-4373-bdcf-116e315518e7" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


