### PR TITLE
STATS-306: Keep the date range picker popover inside the content area

### DIFF
--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -9,7 +9,7 @@ First, display a `jsx` code block to show an example of usage, including import 
 ```jsx
 import DateRange from 'calypso/components/date-range';
 
-export default class extends React.Component {
+export default class DateRangeExample extends React.Component {
 	render() {
 		return <DateRange />;
 	}

--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -58,7 +58,7 @@ General guidelines should be a list of tips and best practices. Example:
 - If you need to heavily customise the look and feel consider using one of the render prop overides to customise the appropriate aspect.
 - You can restrict the picker to certain date ranges using either/both of the `firstSelectableDate` and `lastSelectableDate` props to define a restriction.
 - The underlying `DatePicker` uses [React Day Picker](http://react-day-picker.js.org/)/
-- By default the layout will switch to a single calendar view at screens smaller than <480px
+- The popover opens with a two calendar view and automatically drops to a single calendar (and then stacks the shortcuts) when the measured content area around the trigger is too narrow to fit it
 
 ## Related components
 

--- a/client/components/date-range/index.jsx
+++ b/client/components/date-range/index.jsx
@@ -533,7 +533,10 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
-		const popoverMaxWidth = this.getPopoverAvailableWidth( this.state.availableWidth ) || undefined;
+		const popoverMaxWidth =
+			this.state.availableWidth != null
+				? this.getPopoverAvailableWidth( this.state.availableWidth )
+				: undefined;
 		const headerProps = {
 			customTitle: this.props.customTitle,
 			startDate: this.state.startDate,
@@ -576,7 +579,7 @@ export class DateRange extends Component {
 				<div
 					ref={ this.setPopoverContentRef }
 					className="date-range__popover-content"
-					style={ popoverMaxWidth ? { maxWidth: popoverMaxWidth } : undefined }
+					style={ popoverMaxWidth != null ? { maxWidth: popoverMaxWidth } : undefined }
 				>
 					<div
 						className={ clsx( 'date-range__popover-inner', {

--- a/client/components/date-range/index.jsx
+++ b/client/components/date-range/index.jsx
@@ -19,6 +19,7 @@ import './style.scss';
  * Module variables
  */
 const NO_DATE_SELECTED_VALUE = null;
+const POPOVER_GUTTER = 16;
 const noop = () => {};
 
 export class DateRange extends Component {
@@ -127,20 +128,24 @@ export class DateRange extends Component {
 			initialStartDate: startDate, // cache values in case we need to reset to them
 			initialEndDate: endDate, // cache values in case we need to reset to them
 			focusedMonth: this.props.focusedMonth,
-			numberOfMonths: this.getNumberOfMonths(),
+			availableWidth: null,
+			numberOfMonths: 2,
+			isPopoverStacked: false,
 		};
 
 		// Ref to the Trigger <button> used to position the Popover component
 		this.triggerButtonRef = createRef();
 		this.throttledHandleResize = debounce( () => {
-			this.setState( {
-				numberOfMonths: this.getNumberOfMonths(),
-			} );
+			this.setState( this.getOptimisticPopoverLayoutState() );
 		}, 250 );
 	}
 
 	componentDidMount() {
 		window.addEventListener( 'resize', this.throttledHandleResize );
+	}
+
+	componentDidUpdate() {
+		this.settleLayout();
 	}
 
 	componentWillUnmount() {
@@ -154,6 +159,7 @@ export class DateRange extends Component {
 	openPopover = () => {
 		const newState = {
 			popoverVisible: true,
+			...this.getOptimisticPopoverLayoutState(),
 		};
 		if ( this.props.trackExternalDateChanges ) {
 			newState.startDate = this.props.selectedStartDate;
@@ -267,7 +273,7 @@ export class DateRange extends Component {
 			return; // bail out
 		}
 
-		const numMonthsShowing = this.getNumberOfMonths(); // 2 or 1
+		const numMonthsShowing = this.state.numberOfMonths; // 2 or 1
 
 		// If we focused the endDate and we're showing more than 1 month
 		// then the picker should focus the month before
@@ -447,9 +453,53 @@ export class DateRange extends Component {
 		return this.getLocaleDateFormat(); // "MM/DD/YYY" or locale equivalent
 	}
 
-	getNumberOfMonths() {
-		return window.matchMedia( '(min-width: 520px)' ).matches ? 2 : 1;
+	getContentAreaElement() {
+		return (
+			this.triggerButtonRef?.current?.closest( '.main, #wpcontent, .layout__content' ) ||
+			document.body
+		);
 	}
+
+	getAvailableWidth() {
+		return this.getContentAreaElement().getBoundingClientRect().width || window.innerWidth;
+	}
+
+	getPopoverAvailableWidth( availableWidth ) {
+		return Math.max( 0, availableWidth - 2 * POPOVER_GUTTER );
+	}
+
+	getOptimisticPopoverLayoutState() {
+		return {
+			availableWidth: this.getAvailableWidth(),
+			numberOfMonths: 2,
+			isPopoverStacked: false,
+		};
+	}
+
+	setPopoverContentRef = ( element ) => {
+		this.popoverContentElement = element;
+
+		if ( element ) {
+			this.settleLayout();
+		}
+	};
+
+	settleLayout = () => {
+		const contentElement = this.popoverContentElement;
+		// Ignore a single pixel of overflow caused by subpixel layout rounding.
+		const isOverflowing =
+			contentElement && contentElement.scrollWidth > contentElement.clientWidth + 1;
+		if ( ! this.state.popoverVisible || ! contentElement || ! isOverflowing ) {
+			return;
+		}
+
+		// A settle cycle only degrades; open and resize restore the optimistic layout.
+		if ( this.state.numberOfMonths === 2 ) {
+			this.setState( { numberOfMonths: 1 } );
+		} else if ( ! this.state.isPopoverStacked ) {
+			this.setState( { isPopoverStacked: true } );
+		}
+	};
 
 	handleDateRangeChange = ( startDate, endDate ) => {
 		this.setState( {
@@ -483,6 +533,7 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
+		const popoverMaxWidth = this.getPopoverAvailableWidth( this.state.availableWidth ) || undefined;
 		const headerProps = {
 			customTitle: this.props.customTitle,
 			startDate: this.state.startDate,
@@ -506,13 +557,27 @@ export class DateRange extends Component {
 
 		return (
 			<Popover
-				className="date-range__popover"
+				className={ clsx( 'date-range__popover', {
+					'date-range__popover--stacked': this.state.isPopoverStacked,
+				} ) }
 				isVisible={ this.state.popoverVisible }
 				context={ this.triggerButtonRef.current }
+				leftBoundary={ () => {
+					const contentAreaRect = this.getContentAreaElement().getBoundingClientRect();
+					return contentAreaRect.left + window.scrollX + POPOVER_GUTTER;
+				} }
+				rightBoundary={ () => {
+					const contentAreaRect = this.getContentAreaElement().getBoundingClientRect();
+					return contentAreaRect.left + contentAreaRect.width + window.scrollX - POPOVER_GUTTER;
+				} }
 				position="bottom"
 				onClose={ this.closePopover }
 			>
-				<div className="date-range__popover-content">
+				<div
+					ref={ this.setPopoverContentRef }
+					className="date-range__popover-content"
+					style={ popoverMaxWidth ? { maxWidth: popoverMaxWidth } : undefined }
+				>
 					<div
 						className={ clsx( 'date-range__popover-inner', {
 							'date-range__popover-inner__hasoverlay': !! this.props.overlay,

--- a/client/components/date-range/index.jsx
+++ b/client/components/date-range/index.jsx
@@ -486,10 +486,12 @@ export class DateRange extends Component {
 
 	settleLayout = () => {
 		const contentElement = this.popoverContentElement;
+		if ( ! this.state.popoverVisible || ! contentElement ) {
+			return;
+		}
+
 		// Ignore a single pixel of overflow caused by subpixel layout rounding.
-		const isOverflowing =
-			contentElement && contentElement.scrollWidth > contentElement.clientWidth + 1;
-		if ( ! this.state.popoverVisible || ! contentElement || ! isOverflowing ) {
+		if ( contentElement.scrollWidth <= contentElement.clientWidth + 1 ) {
 			return;
 		}
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -6,6 +6,19 @@
 $date-range-shortcut-min-width: 140px;
 $date-range-mobile-layout-switch: $break-small;
 
+// Stacked (mobile-style) layout, applied both via the viewport media query and
+// via the JS-driven `--stacked` modifier when the content area next to the
+// admin sidebar is too narrow for the side-by-side layout.
+@mixin date-range-popover-stacked-content {
+	flex-direction: column-reverse; // Stack items vertically on small screens
+}
+
+@mixin date-range-popover-stacked-shortcuts {
+	border-left: 0 none;
+	border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
+	display: block; // Ensure it takes full width on mobile
+}
+
 .date-range {
 	position: relative;
 	display: flex;
@@ -345,7 +358,7 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	@media (max-width: $date-range-mobile-layout-switch) {
-		flex-direction: column-reverse; // Stack items vertically on small screens
+		@include date-range-popover-stacked-content;
 	}
 }
 
@@ -355,14 +368,22 @@ $date-range-mobile-layout-switch: $break-small;
 	box-sizing: border-box;
 
 	@media (max-width: $date-range-mobile-layout-switch) {
-		border-left: 0 none;
-		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
-		display: block; // Ensure it takes full width on mobile
+		@include date-range-popover-stacked-shortcuts;
 	}
 
 	@media (min-width: $date-range-mobile-layout-switch) {
 		// Adjust layout for larger screens
 		flex: 0 0 auto; // Allow it to take only necessary space
+	}
+}
+
+.date-range__popover--stacked {
+	.date-range__popover-content {
+		@include date-range-popover-stacked-content;
+	}
+
+	.date-range-picker-shortcuts {
+		@include date-range-popover-stacked-shortcuts;
 	}
 }
 

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { translate } from 'i18n-calypso';
 import MockDate from 'mockdate';
 import moment from 'moment';
+import { createRef } from 'react';
 import { DateRange } from '../index.jsx';
 
 jest.mock( '@wordpress/compose', () => ( {
@@ -18,19 +19,47 @@ function dateToLocaleString( date ) {
 	return moment.isDate( date ) || moment.isMoment( date ) ? moment( date ).format( 'L' ) : date;
 }
 
+function renderInContentArea( props = {}, initialRect = {} ) {
+	let contentAreaRect = {
+		left: 0,
+		width: window.innerWidth,
+		...initialRect,
+	};
+	const renderDateRange = () => (
+		<div className="main">
+			<DateRange moment={ moment } translate={ translate } { ...props } />
+		</div>
+	);
+	const result = render( renderDateRange() );
+	const contentArea = result.container.querySelector( '.main' );
+	jest.spyOn( contentArea, 'getBoundingClientRect' ).mockImplementation( () => contentAreaRect );
+
+	return {
+		...result,
+		setContentAreaRect: ( rect ) => {
+			contentAreaRect = { ...contentAreaRect, ...rect };
+		},
+		setPopoverContentDimensions: ( getDimensions ) => {
+			const popoverContent = screen
+				.getByRole( 'tooltip' )
+				.querySelector( '.date-range__popover-content' );
+			Object.defineProperties( popoverContent, {
+				scrollWidth: {
+					configurable: true,
+					get: () => getDimensions( popoverContent ).scrollWidth,
+				},
+				clientWidth: {
+					configurable: true,
+					get: () => getDimensions( popoverContent ).clientWidth,
+				},
+			} );
+			result.rerender( renderDateRange() );
+		},
+	};
+}
+
 describe( 'DateRange', () => {
 	beforeEach( () => {
-		// Mock matchMedia
-		window.matchMedia = jest.fn().mockImplementation( ( query ) => {
-			return {
-				matches: true,
-				media: query,
-				onchange: null,
-				addListener: jest.fn(),
-				removeListener: jest.fn(),
-			};
-		} );
-
 		// Set the clock for our test assertions so that new Date()
 		// will return a known deterministic date. This important
 		// for the component to render the expected calendars when
@@ -196,69 +225,118 @@ describe( 'DateRange', () => {
 		} );
 	} );
 
+	test( 'should pass guttered content-area boundaries to the Popover', () => {
+		const dateRangeRef = createRef();
+		const { setContentAreaRect } = renderInContentArea(
+			{ ref: dateRangeRef },
+			{ left: 160, width: 800 }
+		);
+		const { leftBoundary, rightBoundary } = dateRangeRef.current.renderPopover().props;
+
+		expect( leftBoundary ).toEqual( expect.any( Function ) );
+		expect( leftBoundary() ).toBe( 160 + window.scrollX + 16 );
+		expect( rightBoundary ).toEqual( expect.any( Function ) );
+		expect( rightBoundary() ).toBe( 160 + 800 + window.scrollX - 16 );
+
+		// An RTL admin sidebar sits on the right: the content area keeps its
+		// left edge but ends before the sidebar.
+		setContentAreaRect( { left: 0, width: 840 } );
+		expect( leftBoundary() ).toBe( 0 + window.scrollX + 16 );
+		expect( rightBoundary() ).toBe( 840 + window.scrollX - 16 );
+	} );
+
+	test( 'should cap the popover content width inside its gutters', async () => {
+		renderInContentArea( {}, { width: 800 } );
+
+		await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+
+		const popoverContent = screen
+			.getByRole( 'tooltip' )
+			.querySelector( '.date-range__popover-content' );
+		expect( popoverContent ).toHaveStyle( { maxWidth: '768px' } );
+	} );
+
 	describe( 'DatePicker element', () => {
-		const matchMediaDefaults = {
-			onchange: null,
-			addListener: jest.fn(),
-			removeListener: jest.fn(),
-		};
-
-		test( 'should set 2 month calendar view on screens >480px by default', async () => {
-			window.matchMedia = jest.fn().mockImplementation( ( query ) => {
-				return {
-					...matchMediaDefaults,
-					matches: true, // > 480px
-					media: query,
-				};
-			} );
-
-			const selectedStartDate = moment( '10-01-2018', 'MM-DD-YYYY' );
-			const selectedEndDate = moment( '11-01-2018', 'MM-DD-YYYY' );
-
-			render(
-				<DateRange
-					selectedStartDate={ selectedStartDate }
-					selectedEndDate={ selectedEndDate }
-					translate={ translate }
-					moment={ moment }
-				/>
-			);
-
-			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
-			const startMonthEl = screen.getByText( 'October 2018' );
-			const endMonthEl = screen.getByText( 'November 2018' );
-
-			expect( startMonthEl ).toBeVisible();
-			expect( endMonthEl ).toBeVisible();
+		const getSelectedDateProps = () => ( {
+			selectedStartDate: moment( '10-01-2018', 'MM-DD-YYYY' ),
+			selectedEndDate: moment( '11-01-2018', 'MM-DD-YYYY' ),
 		} );
 
-		test( 'should set 1 month calendar view on screens <480px by default', async () => {
-			window.matchMedia = jest.fn().mockImplementation( ( query ) => {
-				return {
-					...matchMediaDefaults,
-					matches: false, // < 480px
-					media: query,
-				};
+		test( 'should keep 2 months when the popover content does not overflow', async () => {
+			const { setPopoverContentDimensions } = renderInContentArea( getSelectedDateProps(), {
+				width: 800,
 			} );
 
-			const selectedStartDate = moment( '10-01-2018', 'MM-DD-YYYY' );
-			const selectedEndDate = moment( '11-01-2018', 'MM-DD-YYYY' );
+			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			setPopoverContentDimensions( () => ( { scrollWidth: 600, clientWidth: 600 } ) );
 
-			render(
-				<DateRange
-					selectedStartDate={ selectedStartDate }
-					selectedEndDate={ selectedEndDate }
-					translate={ translate }
-					moment={ moment }
-				/>
+			const popover = screen.getByRole( 'tooltip' );
+			expect( popover.querySelectorAll( '.DayPicker-Month' ) ).toHaveLength( 2 );
+			expect( popover ).not.toHaveClass( 'date-range__popover--stacked' );
+		} );
+
+		test( 'should settle at 1 month when only the 2 month layout overflows', async () => {
+			const { setPopoverContentDimensions } = renderInContentArea( getSelectedDateProps(), {
+				width: 600,
+			} );
+
+			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			setPopoverContentDimensions( ( content ) => ( {
+				scrollWidth: content.querySelectorAll( '.DayPicker-Month' ).length === 2 ? 700 : 600,
+				clientWidth: 600,
+			} ) );
+
+			await waitFor( () => {
+				const popover = screen.getByRole( 'tooltip' );
+				expect( popover.querySelectorAll( '.DayPicker-Month' ) ).toHaveLength( 1 );
+				expect( popover ).not.toHaveClass( 'date-range__popover--stacked' );
+			} );
+		} );
+
+		test( 'should stack when the 1 month layout still overflows', async () => {
+			const { setPopoverContentDimensions } = renderInContentArea( getSelectedDateProps(), {
+				width: 800,
+			} );
+
+			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			setPopoverContentDimensions( () => ( { scrollWidth: 700, clientWidth: 600 } ) );
+
+			await waitFor( () => {
+				const popover = screen.getByRole( 'tooltip' );
+				expect( popover.querySelectorAll( '.DayPicker-Month' ) ).toHaveLength( 1 );
+				expect( popover ).toHaveClass( 'date-range__popover--stacked' );
+			} );
+		} );
+
+		test( 'should restore 2 months when reopening without overflow', async () => {
+			let isNarrow = true;
+			const getDimensions = ( content ) => ( {
+				scrollWidth:
+					isNarrow && content.querySelectorAll( '.DayPicker-Month' ).length === 2 ? 700 : 600,
+				clientWidth: 600,
+			} );
+			const { setContentAreaRect, setPopoverContentDimensions } = renderInContentArea(
+				getSelectedDateProps(),
+				{ width: 600 }
 			);
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
-			const startMonthEl = screen.getByText( 'October 2018' );
-			const endMonthEl = screen.queryByText( 'November 2018' );
+			setPopoverContentDimensions( getDimensions );
+			await waitFor( () =>
+				expect( screen.getByRole( 'tooltip' ).querySelectorAll( '.DayPicker-Month' ) ).toHaveLength(
+					1
+				)
+			);
 
-			expect( startMonthEl ).toBeVisible();
-			expect( endMonthEl ).not.toBeInTheDocument();
+			await userEvent.click( screen.getByText( 'Apply' ) );
+			isNarrow = false;
+			setContentAreaRect( { width: 900 } );
+			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			setPopoverContentDimensions( getDimensions );
+
+			const popover = screen.getByRole( 'tooltip' );
+			expect( popover.querySelectorAll( '.DayPicker-Month' ) ).toHaveLength( 2 );
+			expect( popover ).not.toHaveClass( 'date-range__popover--stacked' );
 		} );
 
 		test( 'should disable dates before firstSelectableDate when set', async () => {

--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -89,7 +89,7 @@ $summary-nav-swap-width: 661px;
 	}
 
 	@media (max-width: $break-small) {
-		padding: 16px;
+		padding: $summary-small-padding;
 	}
 }
 

--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -89,7 +89,7 @@ $summary-nav-swap-width: 661px;
 	}
 
 	@media (max-width: $break-small) {
-		padding: $summary-small-padding;
+		padding: 16px;
 	}
 }
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -63,6 +63,20 @@ animate the opening/closing of the popover. This also keeps the parent's code
 clean and readable, with a minimal amount of boilerplate code required to show
 a popover.
 
+#### `leftBoundary { number | func } - default: 0`
+
+Sets the minimum document-relative left position for the Popover, e.g. to keep
+it clear of a fixed sidebar. A function is resolved whenever the Popover
+repositions.
+
+#### `rightBoundary { number | func } - default: viewport width`
+
+Sets the maximum right position for the Popover, in the same document-relative
+coordinate space as `leftBoundary` (the default viewport-width clamp assumes no
+horizontal page scroll, matching the Popover's existing behavior). A function
+is resolved whenever the Popover repositions. When the two boundaries conflict,
+`leftBoundary` wins.
+
 #### `position { string } - default: 'top'`
 
 The `position` property can be one of the following values:

--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -8,6 +8,7 @@ import {
 	unbindWindowListeners,
 	onViewportChange,
 	suggested as suggestPosition,
+	arrowLeftOffset,
 	constrainLeft,
 	offset,
 } from './util';
@@ -81,6 +82,7 @@ class PopoverInner extends Component {
 		left: -99999,
 		top: -99999,
 		positionClass: this.getPositionClass( this.props.position ),
+		arrowLeft: null,
 	};
 
 	/**
@@ -304,17 +306,22 @@ class PopoverInner extends Component {
 			suggestedPosition = suggestPosition( suggestedPosition, domContainer, domContext );
 		}
 
-		const reposition = Object.assign(
-			{},
-			constrainLeft(
-				offset( suggestedPosition, domContainer, domContext, relativePosition ),
-				domContainer,
-				this.props.ignoreViewportSize
-			),
-			{ positionClass: this.getPositionClass( suggestedPosition ) }
+		const constrainedOffset = constrainLeft(
+			offset( suggestedPosition, domContainer, domContext, relativePosition ),
+			domContainer,
+			this.props.ignoreViewportSize,
+			this.props.leftBoundary,
+			this.props.rightBoundary
 		);
 
-		return reposition;
+		return {
+			...constrainedOffset,
+			positionClass: this.getPositionClass( suggestedPosition ),
+			arrowLeft:
+				suggestedPosition === 'top' || suggestedPosition === 'bottom'
+					? arrowLeftOffset( constrainedOffset, domContainer, domContext )
+					: null,
+		};
 	}
 
 	setPosition = () => {
@@ -329,6 +336,7 @@ class PopoverInner extends Component {
 				},
 				this.props.customPosition
 			);
+			position.arrowLeft = null;
 		} else {
 			position = this.computePosition();
 		}
@@ -430,7 +438,12 @@ class PopoverInner extends Component {
 				onMouseEnter={ this.handleOnMouseEnter }
 				onMouseLeave={ this.handleOnMouseLeave }
 			>
-				{ ! this.props.hideArrow ? <div className="popover__arrow" /> : null }
+				{ ! this.props.hideArrow ? (
+					<div
+						className="popover__arrow"
+						style={ this.state.arrowLeft != null ? { left: this.state.arrowLeft } : undefined }
+					/>
+				) : null }
 				<div ref={ this.popoverInnerNodeRef } className="popover__inner">
 					{ this.props.children }
 				</div>
@@ -510,6 +523,8 @@ Popover.propTypes = {
 	id: PropTypes.string,
 	context: PropTypeElement,
 	ignoreContext: PropTypeElement,
+	leftBoundary: PropTypes.oneOfType( [ PropTypes.number, PropTypes.func ] ),
+	rightBoundary: PropTypes.oneOfType( [ PropTypes.number, PropTypes.func ] ),
 	isVisible: PropTypes.bool,
 	focusOnShow: PropTypes.bool,
 	position: PropTypes.oneOf( [

--- a/packages/components/src/popover/test/util.js
+++ b/packages/components/src/popover/test/util.js
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import Popover from '../index';
+import { arrowLeftOffset, constrainLeft, onViewportChange } from '../util';
+
+describe( 'arrowLeftOffset', () => {
+	const element = {
+		getBoundingClientRect: () => ( { width: 200 } ),
+	};
+
+	beforeEach( () => {
+		Object.defineProperty( window, 'pageXOffset', { configurable: true, value: 0 } );
+	} );
+
+	test( 'returns the container center for a centered target', () => {
+		const target = {
+			getBoundingClientRect: () => ( { left: 180, width: 40 } ),
+		};
+
+		expect( arrowLeftOffset( { left: 100 }, element, target ) ).toBe( 100 );
+	} );
+
+	test( 'returns the target center relative to a left-clamped popover', () => {
+		const target = {
+			getBoundingClientRect: () => ( { left: 180, width: 40 } ),
+		};
+
+		expect( arrowLeftOffset( { left: 160 }, element, target ) ).toBe( 40 );
+	} );
+
+	test( 'clamps the offset to the minimum inset', () => {
+		const target = {
+			getBoundingClientRect: () => ( { left: 100, width: 20 } ),
+		};
+
+		expect( arrowLeftOffset( { left: 200 }, element, target ) ).toBe( 20 );
+	} );
+
+	test( 'clamps the offset to the maximum inset', () => {
+		const target = {
+			getBoundingClientRect: () => ( { left: 300, width: 20 } ),
+		};
+
+		expect( arrowLeftOffset( { left: 100 }, element, target ) ).toBe( 180 );
+	} );
+} );
+
+describe( 'constrainLeft', () => {
+	const element = {
+		getBoundingClientRect: () => ( { width: 100 } ),
+	};
+
+	beforeEach( () => {
+		Object.defineProperty( window, 'innerWidth', { configurable: true, value: 1000 } );
+		onViewportChange();
+	} );
+
+	test( 'clamps the left offset at zero by default', () => {
+		expect( constrainLeft( { left: -20 }, element ) ).toEqual( { left: 0 } );
+	} );
+
+	test( 'respects a numeric left boundary', () => {
+		expect( constrainLeft( { left: 100 }, element, false, 160 ) ).toEqual( { left: 160 } );
+	} );
+
+	test( 'resolves a function left boundary', () => {
+		const leftBoundary = jest.fn( () => 160 );
+
+		expect( constrainLeft( { left: 100 }, element, false, leftBoundary ) ).toEqual( {
+			left: 160,
+		} );
+		expect( leftBoundary ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'uses the viewport width as the right boundary by default', () => {
+		expect( constrainLeft( { left: 950 }, element ) ).toEqual( { left: 900 } );
+	} );
+
+	test( 'respects a numeric right boundary', () => {
+		expect( constrainLeft( { left: 800 }, element, false, 0, 700 ) ).toEqual( { left: 600 } );
+	} );
+
+	test( 'resolves a function right boundary', () => {
+		const rightBoundary = jest.fn( () => 700 );
+
+		expect( constrainLeft( { left: 800 }, element, false, 0, rightBoundary ) ).toEqual( {
+			left: 600,
+		} );
+		expect( rightBoundary ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'lets the left boundary win when the boundaries conflict', () => {
+		expect( constrainLeft( { left: 500 }, element, false, 550, 600 ) ).toEqual( {
+			left: 550,
+		} );
+	} );
+} );
+
+test( 'positions the rendered arrow over the target after clamping', async () => {
+	const target = document.createElement( 'button' );
+	document.body.appendChild( target );
+	const rect = ( { left = 0, top = 0, width = 0, height = 0 } = {} ) => ( {
+		left,
+		top,
+		right: left + width,
+		bottom: top + height,
+		width,
+		height,
+		x: left,
+		y: top,
+		toJSON: () => {},
+	} );
+	const getBoundingClientRect = jest
+		.spyOn( Element.prototype, 'getBoundingClientRect' )
+		.mockImplementation( function () {
+			if ( this === target ) {
+				return rect( { left: 100, top: 100, width: 20, height: 20 } );
+			}
+			if ( this.classList?.contains( 'popover__inner' ) ) {
+				return rect( { width: 200, height: 100 } );
+			}
+			return rect();
+		} );
+	const renderPopover = ( props = {} ) => (
+		<Popover
+			isVisible
+			context={ target }
+			position="bottom"
+			autoPosition={ false }
+			focusOnShow={ false }
+			leftBoundary={ 50 }
+			{ ...props }
+		>
+			Popover content
+		</Popover>
+	);
+	const { rerender, unmount } = render( renderPopover() );
+
+	try {
+		await waitFor( () => {
+			const arrow = screen.getByRole( 'tooltip' ).querySelector( '.popover__arrow' );
+			expect( arrow ).toHaveStyle( { left: '60px' } );
+		} );
+
+		rerender( renderPopover( { position: 'bottom right' } ) );
+		await waitFor( () => {
+			const arrow = screen.getByRole( 'tooltip' ).querySelector( '.popover__arrow' );
+			expect( arrow ).not.toHaveStyle( { left: '60px' } );
+			expect( arrow.style.left ).toBe( '' );
+		} );
+
+		rerender( renderPopover( { customPosition: { left: 40, top: 120 } } ) );
+		await waitFor( () => {
+			const arrow = screen.getByRole( 'tooltip' ).querySelector( '.popover__arrow' );
+			expect( arrow.style.left ).toBe( '' );
+		} );
+	} finally {
+		unmount();
+		target.remove();
+		getBoundingClientRect.mockRestore();
+	}
+} );

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -324,18 +324,22 @@ const ARROW_EDGE_INSET = 20;
 
 export function arrowLeftOffset( off, el, target ) {
 	const docEl = document.documentElement;
-	const scrollLeft = window.pageXOffset || docEl.scrollLeft;
+	const body = document.body;
+	const scrollLeft = typeof window.pageXOffset === 'number' ? window.pageXOffset : docEl.scrollLeft;
+	const clientLeft = docEl.clientLeft || ( body && body.clientLeft ) || 0;
 	const containerWidth = el.getBoundingClientRect().width;
 	const targetRect = target.getBoundingClientRect();
-	const targetCenter = targetRect.left + scrollLeft + targetRect.width / 2 - off.left;
+	const targetCenter = targetRect.left + scrollLeft - clientLeft + targetRect.width / 2 - off.left;
+	// Center the arrow when the popover is too narrow for the full inset
+	const inset = Math.min( ARROW_EDGE_INSET, containerWidth / 2 );
 
-	return Math.min( Math.max( targetCenter, ARROW_EDGE_INSET ), containerWidth - ARROW_EDGE_INSET );
+	return Math.min( Math.max( targetCenter, inset ), containerWidth - inset );
 }
 
 /**
  * Constrain a left to keep the element in the window
  * @param {Object} off Proposed offset before constraining
- * @param {window.Element} el Element to be constained to viewport
+ * @param {window.Element} el Element to be constrained to viewport
  * @param {boolean} ignoreViewport Whether to skip the viewport's right boundary
  * @param {number|Function} leftBoundary Left boundary or function returning one
  * @param {number|Function} rightBoundary Right boundary or function returning one

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -320,17 +320,40 @@ function _offset( box, doc ) {
 	};
 }
 
+const ARROW_EDGE_INSET = 20;
+
+export function arrowLeftOffset( off, el, target ) {
+	const docEl = document.documentElement;
+	const scrollLeft = window.pageXOffset || docEl.scrollLeft;
+	const containerWidth = el.getBoundingClientRect().width;
+	const targetRect = target.getBoundingClientRect();
+	const targetCenter = targetRect.left + scrollLeft + targetRect.width / 2 - off.left;
+
+	return Math.min( Math.max( targetCenter, ARROW_EDGE_INSET ), containerWidth - ARROW_EDGE_INSET );
+}
+
 /**
  * Constrain a left to keep the element in the window
  * @param {Object} off Proposed offset before constraining
  * @param {window.Element} el Element to be constained to viewport
- * @returns {number}    the best width
+ * @param {boolean} ignoreViewport Whether to skip the viewport's right boundary
+ * @param {number|Function} leftBoundary Left boundary or function returning one
+ * @param {number|Function} rightBoundary Right boundary or function returning one
+ * @returns {Object}    the offset with its left constrained
  */
-export function constrainLeft( off, el, ignoreViewport = false ) {
-	const viewport = getViewport();
+export function constrainLeft(
+	off,
+	el,
+	ignoreViewport = false,
+	leftBoundary = 0,
+	rightBoundary = getViewport().width
+) {
 	const ew = el.getBoundingClientRect().width;
-	const offsetLeft = ignoreViewport ? off.left : Math.min( off.left, viewport.width - ew );
-	off.left = Math.max( 0, offsetLeft );
+	const resolvedLeftBoundary = typeof leftBoundary === 'function' ? leftBoundary() : leftBoundary;
+	const resolvedRightBoundary =
+		typeof rightBoundary === 'function' ? rightBoundary() : rightBoundary;
+	const offsetLeft = ignoreViewport ? off.left : Math.min( off.left, resolvedRightBoundary - ew );
+	off.left = Math.max( resolvedLeftBoundary, offsetLeft );
 
 	return off;
 }


### PR DESCRIPTION
Part of STATS-306

## Proposed Changes

* Add optional `leftBoundary`/`rightBoundary` props to `Popover` so callers can clamp it to a container instead of the viewport, with the arrow offset adjusted to keep pointing at the trigger when clamped.
* Use them in `DateRange` to confine the date range picker popover to the admin content area (`.main` / `#wpcontent` / `.layout__content`). The picker opens optimistically with two calendars and degrades to one calendar, then a stacked shortcuts layout, when the measured content actually overflows the available width.
* Fix the summary nav small-screen padding.

https://github.com/user-attachments/assets/afb52ff5-7a65-4698-add9-dc9e3fff1c22


## Why are these changes being made?

* The previous behavior picked the calendar layout from a `520px` viewport magic number, which only looked at the screen width — not the width actually available next to the admin sidebar. With wp-admin's/wpcom's wide default sidebar (or an expanded sidebar on smaller screens), the viewport could be well above 520px while the content area was much narrower, so the popover rendered two calendars and got clipped under the sidebar. The new version measures the real content area and settles the layout based on actual overflow, so it adapts correctly regardless of sidebar state.

## Testing Instructions

* Go to Jetpack Stats (or Calypso Stats) and open a traffic summary page with the date range picker.
* Open the picker with the browser window at various widths, with the admin sidebar expanded and collapsed:
  * The popover should never be clipped by or slide under the sidebar — it stays within the content area with a 16px gutter.
  * On narrow content areas it should drop to one calendar, and on even narrower ones stack the shortcuts above the calendar.
  * The popover arrow should keep pointing at the trigger button when the popover is clamped against a boundary.
* Verify in both wp-admin (Odyssey/Jetpack) and WP.com contexts.
* Before/after screenshots: _to be added_.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?