### PR TITLE
STATS-300: Use shared summary header with date filters on videos page

### DIFF
--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -304,13 +304,12 @@ class StatsSummary extends Component {
 				moduleQuery.complete_stats = 1;
 				summaryView = (
 					<Fragment key="videopress-stats-module">
-						{ /* For CSV button to work, video page needs to pass custom data to the button.
-								It can't use the shared header as long as the CSV download button stays there. */ }
+						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<VideoPressStatsModule
 							path={ path }
 							moduleStrings={ statsStrings.videoplays }
 							period={ this.props.period }
-							query={ query }
+							query={ moduleQuery }
 							statType={ statType }
 							summary
 							listItemClassName={ listItemClassName }

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -17,7 +17,6 @@ import {
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCardVideo from '../features/modules/shared/stats-empty-module-video';
-import DatePicker from '../stats-date-label';
 import ErrorPanel from '../stats-error';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import '../stats-module/style.scss';
@@ -106,13 +105,11 @@ class VideoPressStatsModule extends Component {
 		const {
 			className,
 			summary,
-			path,
 			data,
 			moduleStrings,
 			requesting,
 			statType,
 			query,
-			period,
 			siteSlug,
 			translate,
 			siteId,
@@ -184,19 +181,6 @@ class VideoPressStatsModule extends Component {
 			<div>
 				{ siteId && statType && query && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
-				) }
-				{ summary && (
-					<div className="stats-module__date-picker-header">
-						<h3>
-							<DatePicker
-								period={ period.period }
-								date={ period.startOf }
-								path={ path }
-								query={ query }
-								summary
-							/>
-						</h3>
-					</div>
 				) }
 				<Card compact className={ cardClasses }>
 					<SectionHeader

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -1,29 +1,5 @@
 @import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
-@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
-
-.stats-module__date-picker-header {
-	margin: 20px 0;
-
-	h3 {
-		color: var(--studio-gray-100);
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 2rem;
-		font-weight: 400;
-		line-height: 40px;
-		margin: 0;
-	}
-
-	@media (max-width: $break-medium) {
-		margin: 24px 0 16px;
-		padding: 0 16px;
-	}
-
-	@media (max-width: $break-mobile) {
-		margin: 16px 0;
-	}
-}
 
 .videopress-stats-module__grid {
 	display: grid;


### PR DESCRIPTION
Fixes STATS-300

## Proposed Changes

* Render the shared summary header (`AllTimeNav` with the date range picker and CSV download button) on the Videos summary page, replacing the VideoPress module's own date-picker header.
* Pass the `complete_stats` module query through to `VideoPressStatsModule` so the list and the CSV export use the same query.

### Before

<img width="2674" height="310" alt="Google Chrome -2026-07-10 at 12 42 39@2x" src="https://github.com/user-attachments/assets/ece17407-2235-4144-a985-446747ed0406" />

### After

<img width="2602" height="398" alt="Google Chrome -2026-07-10 at 12 18 36@2x" src="https://github.com/user-attachments/assets/711f100d-ea95-4946-89ef-19f24c51437f" />


## Why are these changes being made?

* The Videos summary page was the odd one out: every other summary module uses the shared header with date filters, while VideoPress rendered its own date label and had no date range picker. A previous comment claimed the shared header couldn't be used because of the CSV button, but the header accepts the module query, so the CSV download keeps working.

## Testing Instructions

* Go to Stats → Videos summary page (`/stats/day/videoplays/:site` → "View all").
* Verify the shared header with the date range picker appears, matching other summary pages (Referrers, Clicks, etc.).
* Change the date range and confirm the video plays list updates accordingly.
* Click "Download data as CSV" and confirm the export works and reflects the selected period.
* Before/after screenshots

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?