### PR TITLE
Stats: always link the breadcrumb root back to Stats

### DIFF
--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -12,7 +12,7 @@ import Main, { MainProps } from 'calypso/components/main';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import StatsUpsellModal from 'calypso/my-sites/stats/stats-upsell-modal';
 import { useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { STATS_HEADER_TITLE } from '../../constants';
@@ -36,9 +36,12 @@ interface StatsMainProps extends MainProps {
 
 function StatsBreadcrumbs( { items }: { items: BreadcrumbItem[] } ) {
 	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
-	// First item is always "Stats" with Jetpack logo, using the first item's URL.
-	const rootUrl = items[ 0 ]?.to;
+	// First item is always "Stats" with Jetpack logo, using the first item's URL and
+	// falling back to the top-level Stats page so the root is always a working link.
+	const rootUrl = items[ 0 ]?.to ?? ( siteSlug ? `/stats/day/${ siteSlug }` : undefined );
 	const restItems = items.slice( 1 );
 
 	return (

--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode } from 'react';
+import { MouseEvent, ReactNode } from 'react';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
@@ -44,16 +44,30 @@ function StatsBreadcrumbs( { items }: { items: BreadcrumbItem[] } ) {
 	const rootUrl = items[ 0 ]?.to ?? ( siteSlug ? `/stats/day/${ siteSlug }` : undefined );
 	const restItems = items.slice( 1 );
 
+	// Route unmodified primary-button clicks through the SPA router while leaving
+	// modified clicks (Cmd/Ctrl/middle-click, etc.) to open in a new tab natively.
+	const handleClick = ( e: MouseEvent, to: string ) => {
+		if (
+			e.defaultPrevented ||
+			e.button !== 0 ||
+			e.metaKey ||
+			e.altKey ||
+			e.ctrlKey ||
+			e.shiftKey
+		) {
+			return;
+		}
+		e.preventDefault();
+		page( to );
+	};
+
 	return (
 		<nav className="stats-breadcrumbs" aria-label={ translate( 'Breadcrumbs' ) }>
 			{ rootUrl ? (
 				<a
 					className="stats-breadcrumbs__link"
 					href={ rootUrl }
-					onClick={ ( e ) => {
-						e.preventDefault();
-						page( rootUrl );
-					} }
+					onClick={ ( e ) => handleClick( e, rootUrl ) }
 				>
 					{ STATS_HEADER_TITLE }
 				</a>
@@ -68,21 +82,7 @@ function StatsBreadcrumbs( { items }: { items: BreadcrumbItem[] } ) {
 							key={ `item-${ index }` }
 							className="stats-breadcrumbs__link"
 							href={ item.to }
-							onClick={ ( e ) => {
-								// Only handle unmodified primary-button clicks via the SPA router.
-								if (
-									e.defaultPrevented ||
-									e.button !== 0 ||
-									e.metaKey ||
-									e.altKey ||
-									e.ctrlKey ||
-									e.shiftKey
-								) {
-									return;
-								}
-								e.preventDefault();
-								page( item.to! );
-							} }
+							onClick={ ( e ) => handleClick( e, item.to! ) }
 						>
 							{ item.label }
 						</a>

--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -39,8 +39,9 @@ function StatsBreadcrumbs( { items }: { items: BreadcrumbItem[] } ) {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
-	// First item is always "Stats" with Jetpack logo, using the first item's URL and
-	// falling back to the top-level Stats page so the root is always a working link.
+	// First item is always "Stats" with the Jetpack logo, linking to the first item's URL.
+	// Fall back to the top-level Stats page so the root renders as a working link from the
+	// first frame, before the breadcrumb-trail effect has populated the items.
 	const rootUrl = items[ 0 ]?.to ?? ( siteSlug ? `/stats/day/${ siteSlug }` : undefined );
 	const restItems = items.slice( 1 );
 

--- a/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
+++ b/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
@@ -144,6 +144,30 @@ describe( 'use-stats-navigation-history back-link param forwarding', () => {
 			expect( result.current[ 0 ].url ).toContain( 'shortcut=last_12_months' );
 			expect( result.current[ 0 ].url ).toContain( 'tab=views' );
 		} );
+
+		it( 'falls back to a top-level Traffic crumb when there is no history', () => {
+			const { result } = renderHook( () => useStatsBreadcrumbTrail() );
+
+			expect( result.current ).toHaveLength( 1 );
+			expect( result.current[ 0 ].label ).toBe( 'Traffic' );
+			expect( result.current[ 0 ].url ).toContain( '/stats/day/example.com' );
+		} );
+
+		it( 'falls back to a top-level Traffic crumb when no history entry has a back link', () => {
+			sessionStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify( [
+					{ screen: 'postDetails', queryParams: {}, period: null },
+					{ screen: 'postDetails', queryParams: {}, period: null },
+				] )
+			);
+
+			const { result } = renderHook( () => useStatsBreadcrumbTrail() );
+
+			expect( result.current ).toHaveLength( 1 );
+			expect( result.current[ 0 ].label ).toBe( 'Traffic' );
+			expect( result.current[ 0 ].url ).toContain( '/stats/day/example.com' );
+		} );
 	} );
 
 	describe( 'recordCurrentScreen', () => {

--- a/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
+++ b/client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts
@@ -168,6 +168,16 @@ describe( 'use-stats-navigation-history back-link param forwarding', () => {
 			expect( result.current[ 0 ].label ).toBe( 'Traffic' );
 			expect( result.current[ 0 ].url ).toContain( '/stats/day/example.com' );
 		} );
+
+		it( 'falls back to a top-level Traffic crumb when sessionStorage holds corrupted JSON', () => {
+			sessionStorage.setItem( STORAGE_KEY, '{oops' );
+
+			const { result } = renderHook( () => useStatsBreadcrumbTrail() );
+
+			expect( result.current ).toHaveLength( 1 );
+			expect( result.current[ 0 ].label ).toBe( 'Traffic' );
+			expect( result.current[ 0 ].url ).toContain( '/stats/day/example.com' );
+		} );
 	} );
 
 	describe( 'recordCurrentScreen', () => {

--- a/client/my-sites/stats/hooks/use-stats-navigation-history.ts
+++ b/client/my-sites/stats/hooks/use-stats-navigation-history.ts
@@ -299,33 +299,33 @@ export const useStatsBreadcrumbTrail = (
 	const [ trail, setTrail ] = useState< Array< { label: string; url: string | null } > >( [] );
 
 	useEffect( () => {
-		try {
-			// A top-level Traffic crumb synthesized from the current screen, so the root
-			// "Stats" breadcrumb always links back to Stats even when there is no usable
-			// history (direct load, a full page load that clears sessionStorage, or a
-			// trail made up entirely of screens without a back link). When a current
-			// screen entry is available its date range is carried so it survives the
-			// round-trip back to Traffic; otherwise it links to the default range.
-			const trafficFallback = ( current?: {
-				queryParams: QueryArgs;
-				period: string | null;
-			} ): Array< { label: string; url: string | null } > => {
-				const label = localizedTabNames[ defaultLastScreen ];
-				const link = possibleBackLinks[ defaultLastScreen ];
-				if ( ! link || ! label || ! siteSlug ) {
-					return [];
-				}
-				return [
-					{
-						label,
-						url: addQueryArgs(
-							link.replace( '{period}', current?.period || 'day' ) + siteSlug,
-							getTrafficQueryParams( current?.queryParams || {} )
-						),
-					},
-				];
-			};
+		// A top-level Traffic crumb synthesized from the current screen, so the root
+		// "Stats" breadcrumb always links back to Stats even when there is no usable
+		// history (direct load, a full page load that clears sessionStorage, a trail
+		// made up entirely of screens without a back link, or corrupted storage). When
+		// a current screen entry is available its date range is carried so it survives
+		// the round-trip back to Traffic; otherwise it links to the default range.
+		const trafficFallback = ( current?: {
+			queryParams: QueryArgs;
+			period: string | null;
+		} ): Array< { label: string; url: string | null } > => {
+			const label = localizedTabNames[ defaultLastScreen ];
+			const link = possibleBackLinks[ defaultLastScreen ];
+			if ( ! link || ! label || ! siteSlug ) {
+				return [];
+			}
+			return [
+				{
+					label,
+					url: addQueryArgs(
+						link.replace( '{period}', current?.period || 'day' ) + siteSlug,
+						getTrafficQueryParams( current?.queryParams || {} )
+					),
+				},
+			];
+		};
 
+		try {
 			const navState = JSON.parse( sessionStorage.getItem( STORAGE_KEY ) || '[]' );
 			if ( ! Array.isArray( navState ) || navState.length < 1 ) {
 				setTrail( trafficFallback() );
@@ -380,7 +380,7 @@ export const useStatsBreadcrumbTrail = (
 
 			setTrail( breadcrumbs.length ? breadcrumbs : trafficFallback( currentItem ) );
 		} catch ( e ) {
-			setTrail( [] );
+			setTrail( trafficFallback() );
 		}
 	}, [ localizedTabNames, siteSlug, adminBaseUrl, currentQuery ] );
 

--- a/client/my-sites/stats/hooks/use-stats-navigation-history.ts
+++ b/client/my-sites/stats/hooks/use-stats-navigation-history.ts
@@ -303,8 +303,9 @@ export const useStatsBreadcrumbTrail = (
 			// A top-level Traffic crumb synthesized from the current screen, so the root
 			// "Stats" breadcrumb always links back to Stats even when there is no usable
 			// history (direct load, a full page load that clears sessionStorage, or a
-			// trail made up entirely of screens without a back link). Carries the current
-			// screen's date range so it survives the round-trip back to Traffic.
+			// trail made up entirely of screens without a back link). When a current
+			// screen entry is available its date range is carried so it survives the
+			// round-trip back to Traffic; otherwise it links to the default range.
 			const trafficFallback = ( current?: {
 				queryParams: QueryArgs;
 				period: string | null;

--- a/client/my-sites/stats/hooks/use-stats-navigation-history.ts
+++ b/client/my-sites/stats/hooks/use-stats-navigation-history.ts
@@ -300,33 +300,39 @@ export const useStatsBreadcrumbTrail = (
 
 	useEffect( () => {
 		try {
-			const navState = JSON.parse( sessionStorage.getItem( STORAGE_KEY ) || '[]' );
-			if ( ! Array.isArray( navState ) || navState.length < 1 ) {
-				setTrail( [] );
-				return;
-			}
-
-			// No prior history (e.g. direct load or a full page load that clears sessionStorage):
-			// synthesize a Traffic back-breadcrumb from the current screen so the selected date
-			// range survives the round-trip back to Traffic.
-			if ( navState.length === 1 ) {
-				const current = navState[ 0 ];
+			// A top-level Traffic crumb synthesized from the current screen, so the root
+			// "Stats" breadcrumb always links back to Stats even when there is no usable
+			// history (direct load, a full page load that clears sessionStorage, or a
+			// trail made up entirely of screens without a back link). Carries the current
+			// screen's date range so it survives the round-trip back to Traffic.
+			const trafficFallback = ( current?: {
+				queryParams: QueryArgs;
+				period: string | null;
+			} ): Array< { label: string; url: string | null } > => {
 				const label = localizedTabNames[ defaultLastScreen ];
-				let link = possibleBackLinks[ defaultLastScreen ];
+				const link = possibleBackLinks[ defaultLastScreen ];
 				if ( ! link || ! label || ! siteSlug ) {
-					setTrail( [] );
-					return;
+					return [];
 				}
-				link = link.replace( '{period}', current.period || 'day' );
-				setTrail( [
+				return [
 					{
 						label,
 						url: addQueryArgs(
-							link + siteSlug,
-							getTrafficQueryParams( current.queryParams || {} )
+							link.replace( '{period}', current?.period || 'day' ) + siteSlug,
+							getTrafficQueryParams( current?.queryParams || {} )
 						),
 					},
-				] );
+				];
+			};
+
+			const navState = JSON.parse( sessionStorage.getItem( STORAGE_KEY ) || '[]' );
+			if ( ! Array.isArray( navState ) || navState.length < 1 ) {
+				setTrail( trafficFallback() );
+				return;
+			}
+
+			if ( navState.length === 1 ) {
+				setTrail( trafficFallback( navState[ 0 ] ) );
 				return;
 			}
 
@@ -371,7 +377,7 @@ export const useStatsBreadcrumbTrail = (
 				} )
 				.filter( Boolean ) as Array< { label: string; url: string | null } >;
 
-			setTrail( breadcrumbs );
+			setTrail( breadcrumbs.length ? breadcrumbs : trafficFallback( currentItem ) );
 		} catch ( e ) {
 			setTrail( [] );
 		}


### PR DESCRIPTION
Part of STATS-308

## Proposed Changes

* Guarantee the Stats breadcrumb trail is never empty: `useStatsBreadcrumbTrail` now synthesizes a top-level Traffic crumb in *every* "no usable history" branch (empty history, and a trail made up entirely of screens without a back link), not just the single-entry direct-load case. The existing single-entry synthesis was extracted into one `trafficFallback()` helper and reused.
* Hardened the `StatsBreadcrumbs` component so the root "Stats" crumb is never a dead label: when the first trail item still lacks a URL, it falls back to the top-level Stats page (`/stats/day/:slug`).

## Why are these changes being made?

The root "Stats" breadcrumb on detail and summary pages (`stats-post-detail`, `stats-email-detail`, `stats-email-summary`, `summary`) is derived from the first navigation-history entry — i.e. the previous page in the session. `StatsBreadcrumbs` collapses that first item into the "Stats" root and links it to the item's URL.

When the session history is empty — direct load, bookmark, a full page reload that clears `sessionStorage`, or a trail composed only of screens without a back link — that first item is the *current* page, which has no URL. The "Stats" root then rendered as a non-clickable `<span>` and the page title was swallowed, leaving detail pages with no breadcrumb and no way back to Stats.

The normal collapse behavior (root "Stats" points to the origin page and preserves the selected date range) is unchanged; the top-level link is only a fallback for the empty case.

## Testing Instructions

* Open a Stats detail page directly (e.g. paste `/stats/post/<post_id>/<site>` into a fresh tab, or reload the page) so there is no in-session navigation history.
* Confirm the breadcrumb shows **Stats / <post title>** and the "Stats" crumb is a working link back to the top-level Stats page.
* Navigate normally (Traffic/Insights → a post or module summary) and confirm the previous behavior still holds: "Stats" links back to the originating page with the selected date range preserved.
* `yarn test-client client/my-sites/stats/hooks/test/use-stats-navigation-history.test.ts` — 8/8 pass (includes 2 new cases for the empty-history and no-back-link fallbacks).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
