### PR TITLE
Plugins: open the purchase modal from "Upgrade and activate"

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import AsyncLoad from 'calypso/components/async-load';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -23,10 +24,10 @@ import {
 	isMarketplaceProduct as isMarketplaceProductSelector,
 	getProductsList,
 } from 'calypso/state/products-list/selectors';
+import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -36,11 +37,28 @@ import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { getPeriodVariationValue } from '../plugin-price';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 
-export default function CTAButton( { plugin, hasEligibilityMessages, disabled } ) {
+const loadIsEligibleForOneClickCheckoutWrapper = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-checkout-purchase-modal-is-eligible-for-one-click-checkout-wrapper" */ 'calypso/my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper'
+	);
+
+const loadUpgradePurchaseModal = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-plugins-plugin-details-cta-upgrade-purchase-modal" */ './upgrade-purchase-modal'
+	);
+
+function CTAButton( {
+	plugin,
+	hasEligibilityMessages,
+	disabled,
+	shouldUpgrade,
+	isEligibleForOneClickCheckout,
+} ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ showEligibility, setShowEligibility ] = useState( false );
 	const [ showAddCustomDomain, setShowAddCustomDomain ] = useState( false );
+	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 
 	const billingPeriod = useSelector( getBillingInterval );
 
@@ -65,9 +83,11 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 		isSiteOnECommerceTrial( state, selectedSite?.ID )
 	);
 
-	const shouldUpgrade =
-		useSelector( ( state ) => ! siteHasFeature( state, selectedSite?.ID, pluginFeature ) ) &&
-		! isJetpackSelfHosted;
+	// The cheapest plan that unlocks this plugin, as reported by the site's features.
+	const plansWithPluginFeature = useSelector( ( state ) =>
+		getPlansForFeature( state, selectedSite?.ID, pluginFeature )
+	);
+	const upgradePlanSlug = plansWithPluginFeature ? plansWithPluginFeature[ 0 ] : undefined;
 
 	// Keep me updated
 	const userId = useSelector( getCurrentUserId );
@@ -129,8 +149,41 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 		setShowAddCustomDomain( false );
 	}, [ setShowEligibility, setShowAddCustomDomain ] );
 
+	const openPurchaseModal = useCallback( () => {
+		handleDismissEligibilityWarnings();
+		setShowPurchaseModal( true );
+	}, [ handleDismissEligibilityWarnings ] );
+
+	// Buying the plan in place only works for a plugin that comes free with the plan, and only
+	// once we know the plan and that the user can be charged without a full checkout. Anything
+	// else falls back to the Plans page.
+	const upgradeInPurchaseModal =
+		shouldUpgrade &&
+		! isMarketplaceProduct &&
+		! isPreinstalledPremiumPlugin &&
+		! isECommerceTrial &&
+		!! upgradePlanSlug &&
+		isEligibleForOneClickCheckout?.result === true
+			? openPurchaseModal
+			: undefined;
+
+	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite?.slug }`;
+
 	return (
 		<>
+			{ showPurchaseModal && (
+				<AsyncLoad
+					require={ loadUpgradePurchaseModal }
+					placeholder={ null }
+					planSlug={ upgradePlanSlug }
+					siteSlug={ selectedSite.slug }
+					onClose={ () => setShowPurchaseModal( false ) }
+					onPurchaseSuccess={ () => {
+						setShowPurchaseModal( false );
+						page( installPluginURL );
+					} }
+				/>
+			) }
 			<PluginCustomDomainDialog
 				onProceed={ () => {
 					if ( hasEligibilityMessages ) {
@@ -147,6 +200,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 						isMarketplaceProduct,
 						billingPeriod,
 						productsList,
+						upgradeInPurchaseModal,
 					} );
 				} }
 				isDialogVisible={ showAddCustomDomain }
@@ -176,6 +230,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 								isMarketplaceProduct,
 								billingPeriod,
 								productsList,
+								upgradeInPurchaseModal,
 							} )
 						}
 					/>
@@ -211,6 +266,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 						isPreinstalledPremiumPlugin,
 						preinstalledPremiumPluginProduct,
 						productsList,
+						upgradeInPurchaseModal,
 					} );
 				} }
 				disabled={
@@ -244,6 +300,25 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	);
 }
 
+export default function CTAButtonWithOneClickCheckout( props ) {
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, props.plugin.slug )
+	);
+
+	if ( props.shouldUpgrade && ! isMarketplaceProduct ) {
+		return (
+			<AsyncLoad
+				require={ loadIsEligibleForOneClickCheckoutWrapper }
+				placeholder={ <CTAButton { ...props } /> }
+				component={ CTAButton }
+				componentProps={ props }
+			/>
+		);
+	}
+
+	return <CTAButton { ...props } />;
+}
+
 function onClickInstallPlugin( {
 	dispatch,
 	selectedSite,
@@ -254,6 +329,7 @@ function onClickInstallPlugin( {
 	isPreinstalledPremiumPlugin,
 	preinstalledPremiumPluginProduct,
 	productsList,
+	upgradeInPurchaseModal,
 } ) {
 	const tags = Object.keys( plugin.tags );
 
@@ -311,6 +387,9 @@ function onClickInstallPlugin( {
 	// After buying a plan we need to redirect to the plugin install page.
 	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 	if ( upgradeAndInstall ) {
+		if ( upgradeInPurchaseModal ) {
+			return upgradeInPurchaseModal();
+		}
 		// Redirect to plans page to let user choose a plan, then redirect to plugin install
 		return page(
 			`/plans/${ selectedSite.slug }?plan=personal-bundle&redirect_to=${ encodeURIComponent(

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -461,6 +461,7 @@ function PrimaryButton( {
 		<CTAButton
 			plugin={ plugin }
 			hasEligibilityMessages={ hasEligibilityMessages }
+			shouldUpgrade={ shouldUpgrade }
 			disabled={
 				incompatiblePlugin ||
 				userCantManageTheSite ||

--- a/client/my-sites/plugins/plugin-details-CTA/upgrade-purchase-modal.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/upgrade-purchase-modal.tsx
@@ -1,0 +1,44 @@
+import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { createRequestCartProduct } from '@automattic/shopping-cart';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
+import type { SiteSlug } from 'calypso/types';
+
+export default function UpgradePurchaseModal( {
+	planSlug,
+	siteSlug,
+	onClose,
+	onPurchaseSuccess,
+}: {
+	planSlug: string;
+	siteSlug: SiteSlug;
+	onClose: () => void;
+	onPurchaseSuccess: () => void;
+} ) {
+	const translate = useTranslate();
+	const productToAdd = useMemo(
+		() => createRequestCartProduct( { product_slug: planSlug } ),
+		[ planSlug ]
+	);
+
+	return (
+		<CalypsoShoppingCartProvider>
+			<StripeHookProvider
+				fetchStripeConfiguration={ getStripeConfiguration }
+				locale={ translate.localeSlug }
+			>
+				<PurchaseModal
+					productToAdd={ productToAdd }
+					onClose={ onClose }
+					onPurchaseSuccess={ onPurchaseSuccess }
+					disabledThankYouPage
+					showFeatureList
+					siteSlug={ siteSlug }
+				/>
+			</StripeHookProvider>
+		</CalypsoShoppingCartProvider>
+	);
+}


### PR DESCRIPTION
Fixes DOTMKT-38

## Proposed Changes

* On the plugin details page, the "Upgrade and activate" CTA for a plugin that comes free with a paid plan now opens the one-click purchase modal in place, instead of navigating to the site's Plans page.
* After a successful purchase, the user goes straight to the plugin install page.
* Users who can't be charged without a full checkout — no usable stored card, or incomplete contact details — keep the existing Plans page redirect, as do marketplace products, preinstalled premium plugins, and eCommerce trials.
* The plan offered for the upgrade is now taken from the site's available features rather than a hardcoded Personal plan.

## Why are these changes being made?

Now that plugins are available on all paid plans, sending someone from a plugin page to the Plans page and back through checkout is a long detour for what is a single, already-decided purchase. The user has picked the plugin; the only thing left is to pay. The purchase modal collapses that into one step without leaving the plugin.

Hardcoding the Personal plan also meant the client was asserting which plan unlocks plugins. Reading it from the site's features keeps that decision on the backend, matching how the plugins upgrade nudge already picks its plan.

## Testing Instructions

Requires a Simple site on the Free plan, with a saved credit card on the account and complete contact/tax details (otherwise you get the old redirect — which is itself worth testing).

1. Go to Plugins and open a plugin that is free on paid plans, e.g. Jetpack CRM. The CTA should read "Upgrade and activate".
2. Click it. You may first see the "One more step" eligibility dialog; proceed from there.
3. The purchase modal should open over the plugin page, showing the plan the site needs and its feature list. It should *not* navigate to `/plans/<site>`.
4. Complete the purchase. You should land on the plugin install page and the plugin should install and activate.

Also confirm the fallbacks still redirect to the Plans page as before:

* An account with no saved card.
* A marketplace (paid) plugin — the CTA reads "Purchase and activate" and behaviour is unchanged.
* A site on an eCommerce trial.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
