### PR TITLE
STATS-306: Fix vertical spacing around the summary nav date picker

### DIFF
--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -71,6 +71,21 @@ $summary-nav-swap-width: 661px;
 		padding: $summary-small-padding;
 	}
 
+	// When the date picker is stacked above the heading, the picker's
+	// bottom padding provides the gap; drop the heading's own top margins
+	// so the spacing stays even. The h3 margin only exists in Odyssey,
+	// where wp-admin core styles aren't reset.
+	@media (max-width: 1160px) {
+		.stats-summary-nav__date-control + & {
+			margin-top: 0;
+
+			.stats-section-title,
+			h3 {
+				margin-top: 0;
+			}
+		}
+	}
+
 	h3 {
 		@include stats-section-header;
 	}
@@ -84,10 +99,15 @@ $summary-nav-swap-width: 661px;
 	display: flex;
 	align-items: center;
 
+	// No top padding: .stats-summary__positioned already separates the
+	// content from the page header with a 32px margin from $break-small up.
 	@media (max-width: 1160px) {
-		padding: 16px 0;
+		padding: 0 0 16px;
 	}
 
+	// Below $break-small that page-level margin is gone, so the picker
+	// carries its own spacing. $summary-small-padding is horizontal-only
+	// and would zero the vertical padding here.
 	@media (max-width: $break-small) {
 		padding: 16px;
 	}

--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -89,7 +89,7 @@ $summary-nav-swap-width: 661px;
 	}
 
 	@media (max-width: $break-small) {
-		padding: $summary-small-padding;
+		padding: 16px;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

On Stats summary pages the date range picker stacks above the page heading at viewports up to 1160px. This fixes the vertical rhythm around it:

* **Mobile (≤600px):** the `max-width: $break-small` rule overrode the nav's padding with `$summary-small-padding` (`0 16px`, horizontal-only), dropping the vertical 16px applied below 1160px and leaving the picker flush against the tab bar. Changed it to `padding: 16px`.
* **600–1160px:** removed the picker's top padding. `.stats-summary__positioned` already separates the content from the page header with a 32px margin at these widths, so the picker's own 16px stacked on top of it to a 48px gap.
* **Stacked heading:** dropped the heading's top margins when it renders below the picker, so the picker's bottom padding provides an even 16px gap instead of 36–48px. In Odyssey the extra margin comes from wp-admin's default `h3` styles, which Calypso's reset doesn't cover there.

## Why are these changes being made?

* The picker sat flush against the tab bar on mobile, while at all stacked widths there was a disproportionate dead zone between the picker and the heading (and a doubled-up gap above the picker at ≥600px). The picker and heading now read as one header block with a consistent 16px rhythm.

## Testing Instructions

* Open any Stats summary page (e.g. Stats → Posts & Pages summary, or a Referrers summary).
* Check three widths: mobile (≤600px), ~760px, and ~1000px (desktop with sidebar — still stacked).
* Confirm: 16px between the tab bar border and the picker on mobile, a single 32px gap above the picker at wider stacked widths, and 16px between the picker and the "Stats for …" heading everywhere it stacks.
* Test in both Calypso and a Jetpack site's wp-admin (Odyssey) — the heading margin behaves differently in each.

Before/after screenshots (mobile width):

| Before | After |
| --- | --- |
| <img width="1080" height="410" alt="Google Chrome -2026-07-10 at 14 34 39@2x" src="https://github.com/user-attachments/assets/b3b7cda1-8d56-42de-b62c-7326d4080873" /> | <img width="1088" height="536" alt="Google Chrome -2026-07-10 at 14 33 10@2x" src="https://github.com/user-attachments/assets/49d25c8e-74c9-43b1-aa44-a4827fef5dba" /> |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
