### PR TITLE
A4A: Add Performance card and detailed view to the agency site page

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -1,8 +1,9 @@
-import { agencySiteQuery } from '@automattic/api-queries';
+import { agencySiteQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { backup, category, formatListBullets, shield } from '@wordpress/icons';
+import { backup, category, chartBar, formatListBullets, shield } from '@wordpress/icons';
 import { agencySiteRoute } from '../../../app/router/agency';
 import {
 	SidebarBackButton,
@@ -10,11 +11,15 @@ import {
 	SidebarMenu,
 	SidebarMenuItem,
 } from '../../../components/sidebar';
+import { siteTypeSupportsFeature } from '../../../utils/site-type-feature-support';
 import AgencySiteSwitcherItem from './site-switcher-item';
 
 export default function AgencySiteSidebar() {
 	const { siteSlug } = agencySiteRoute.useParams();
 	const { data: site } = useQuery( agencySiteQuery( siteSlug ) );
+	const { data: fullSite } = useQuery( siteBySlugQuery( siteSlug ) );
+	const supportsPerformance = fullSite ? siteTypeSupportsFeature( fullSite, 'performance' ) : false;
+	const isApmEnabled = isEnabled( 'performance/apm' );
 
 	return (
 		<VStack spacing={ 2 }>
@@ -32,6 +37,25 @@ export default function AgencySiteSidebar() {
 						>
 							{ __( 'Overview' ) }
 						</SidebarMenuItem>
+						{ supportsPerformance &&
+							( isApmEnabled ? (
+								<SidebarExpandableMenuItem
+									label={ __( 'Performance' ) }
+									icon={ chartBar }
+									to={ `/sites/${ siteSlug }/performance` }
+								>
+									<SidebarMenuItem to={ `/sites/${ siteSlug }/performance/frontend` }>
+										{ __( 'Frontend' ) }
+									</SidebarMenuItem>
+									<SidebarMenuItem to={ `/sites/${ siteSlug }/performance/backend` }>
+										{ __( 'Backend' ) }
+									</SidebarMenuItem>
+								</SidebarExpandableMenuItem>
+							) : (
+								<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
+									{ __( 'Performance' ) }
+								</SidebarMenuItem>
+							) ) }
 						{ site.has_backup && (
 							<SidebarMenuItem icon={ backup } to={ `/sites/${ siteSlug }/backups` }>
 								{ __( 'Backups' ) }

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -1,8 +1,11 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { agencySiteRoute } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import PerformanceCard from '../../../sites/overview-performance-card';
 import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
 import ActivityCard from './activity-card';
 import BackupCard from './backup-card';
@@ -11,6 +14,7 @@ import ScanCard from './scan-card';
 export default function AgencySiteOverview() {
 	const { siteSlug } = agencySiteRoute.useParams();
 	const site = agencySiteRoute.useLoaderData();
+	const { data: fullSite } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 
 	return (
@@ -20,6 +24,10 @@ export default function AgencySiteOverview() {
 			<Grid columns={ isSmallViewport ? 1 : 2 } gap={ isSmallViewport ? 4 : 6 }>
 				<BackupCard site={ site } />
 				<ScanCard site={ site } siteSlug={ siteSlug } />
+				{ /* TODO (A4A): for private/coming-soon/unlaunched sites this card links to
+				     `/sites/$slug/settings/site-visibility`, which has no route in the agency
+				     site view yet. Guard the link (or add settings) once A4A settings lands. */ }
+				<PerformanceCard site={ fullSite } />
 			</Grid>
 			<ActivityCard />
 		</PageLayout>

--- a/client/dashboard/agency/sites/site/performance.tsx
+++ b/client/dashboard/agency/sites/site/performance.tsx
@@ -1,0 +1,7 @@
+import { agencySiteRoute } from '../../../app/router/agency';
+import { SitePerformanceContent } from '../../../sites/performance';
+
+export default function AgencySitePerformance() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	return <SitePerformanceContent siteSlug={ siteSlug } />;
+}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -17,12 +17,14 @@ import {
 	rawUserPreferencesQuery,
 	siteBackupsQuery,
 	siteBySlugQuery,
+	sitePerformancePagesQuery,
 	siteScanQuery,
 	siteSettingsQuery,
 	referralsQuery,
 	referralCommissionPayoutQuery,
 	tipaltiPayeeQuery,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
@@ -428,6 +430,10 @@ export const agencySiteRoute = createRoute( {
 const agencySiteOverviewRoute = createRoute( {
 	getParentRoute: () => agencySiteRoute,
 	path: '/',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		queryClient.prefetchQuery( sitePerformancePagesQuery( site.ID ) );
+	},
 } ).lazy( () =>
 	import( '../../agency/sites/site/overview' ).then( ( d ) =>
 		createLazyRoute( 'agency-site-overview' )( {
@@ -611,6 +617,172 @@ export const agencySiteScanHistoryRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteSlug/performance` – layout gated by the site's Performance hosting feature
+const agencySitePerformanceRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Performance' ) } ] } ),
+	getParentRoute: () => agencySiteRoute,
+	path: 'performance',
+	loader: async ( { params: { siteSlug } } ) => {
+		await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+	},
+} ).lazy( () =>
+	import( '../../agency/sites/site/performance' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySitePerformanceIndexRoute = createRoute( {
+	getParentRoute: () => agencySitePerformanceRoute,
+	path: '/',
+	beforeLoad: ( { params: { siteSlug } } ) => {
+		throw dashboardRedirect( { to: `/sites/${ siteSlug }/performance/frontend` } );
+	},
+} );
+
+export const agencySitePerformanceFrontendRoute = createRoute( {
+	head: () => ( {
+		meta: [ { title: isEnabled( 'performance/apm' ) ? __( 'Frontend' ) : undefined } ],
+	} ),
+	getParentRoute: () => agencySitePerformanceRoute,
+	path: 'frontend',
+} ).lazy( () =>
+	import( '../../sites/performance/frontend' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-frontend' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+export const agencySitePerformanceBackendRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Backend' ) } ] } ),
+	getParentRoute: () => agencySitePerformanceRoute,
+	path: 'backend',
+} );
+
+async function prefetchAgencyApmAggregate( siteSlug: string ) {
+	const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+	const [ { siteApmAggregateRollingQuery }, { getStoredOrDefaultTimeframe, TIMEFRAME_SECONDS } ] =
+		await Promise.all( [
+			import( '@automattic/api-queries' ),
+			import( '../../sites/performance/backend/timeframe' ),
+		] );
+	const windowSec = TIMEFRAME_SECONDS[ getStoredOrDefaultTimeframe() ];
+	await queryClient.ensureQueryData( siteApmAggregateRollingQuery( site.ID, windowSec ) );
+}
+
+export const agencySitePerformanceBackendIndexRoute = createRoute( {
+	getParentRoute: () => agencySitePerformanceBackendRoute,
+	path: '/',
+	loader: ( { params: { siteSlug } } ) => prefetchAgencyApmAggregate( siteSlug ),
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-backend' )( {
+			component: () => (
+				<d.default siteSlug={ agencySiteRoute.useParams().siteSlug } tab="overview" />
+			),
+		} )
+	)
+);
+
+export const agencySitePerformanceBackendTransactionsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Transactions' ) } ] } ),
+	getParentRoute: () => agencySitePerformanceBackendRoute,
+	path: 'transactions',
+	loader: ( { params: { siteSlug } } ) => prefetchAgencyApmAggregate( siteSlug ),
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-backend-transactions' )( {
+			component: () => (
+				<d.default siteSlug={ agencySiteRoute.useParams().siteSlug } tab="transactions" />
+			),
+		} )
+	)
+);
+
+export const agencySitePerformanceBackendWordPressRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'WordPress' ) } ] } ),
+	getParentRoute: () => agencySitePerformanceBackendRoute,
+	path: 'wordpress',
+	loader: ( { params: { siteSlug } } ) => prefetchAgencyApmAggregate( siteSlug ),
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-backend-wordpress' )( {
+			component: () => (
+				<d.default siteSlug={ agencySiteRoute.useParams().siteSlug } tab="wordpress" />
+			),
+		} )
+	)
+);
+
+export const agencySitePerformanceBackendDatabaseRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Database' ) } ] } ),
+	getParentRoute: () => agencySitePerformanceBackendRoute,
+	path: 'database',
+	loader: ( { params: { siteSlug } } ) => prefetchAgencyApmAggregate( siteSlug ),
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-backend-database' )( {
+			component: () => (
+				<d.default siteSlug={ agencySiteRoute.useParams().siteSlug } tab="database" />
+			),
+		} )
+	)
+);
+
+export const agencySitePerformanceBackendExternalRequestsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'External requests' ) } ] } ),
+	getParentRoute: () => agencySitePerformanceBackendRoute,
+	path: 'external-requests',
+	loader: ( { params: { siteSlug } } ) => prefetchAgencyApmAggregate( siteSlug ),
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-backend-external-requests' )( {
+			component: () => (
+				<d.default siteSlug={ agencySiteRoute.useParams().siteSlug } tab="external-requests" />
+			),
+		} )
+	)
+);
+
+export const agencySitePerformanceBackendRequestDetailRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Request' ) } ] } ),
+	getParentRoute: () => agencySitePerformanceBackendRoute,
+	path: 'requests',
+	validateSearch: ( search ): { method: string; route: string; bucket?: string } => ( {
+		method: typeof search.method === 'string' ? search.method : '',
+		route: typeof search.route === 'string' ? search.route : '',
+		bucket: typeof search.bucket === 'string' ? search.bucket : undefined,
+	} ),
+	loaderDeps: ( { search: { method, route } } ) => ( { method, route } ),
+	loader: async ( { params: { siteSlug }, deps: { method, route } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const [ { siteApmDetailQuery }, { TIMEFRAME_SECONDS, getStoredOrDefaultTimeframe } ] =
+			await Promise.all( [
+				import( '@automattic/api-queries' ),
+				import( '../../sites/performance/backend/timeframe' ),
+			] );
+		const windowSec = TIMEFRAME_SECONDS[ getStoredOrDefaultTimeframe() ];
+		await queryClient.ensureQueryData(
+			siteApmDetailQuery( site.ID, { method, route, windowSec } )
+		);
+	},
+} ).lazy( () =>
+	import( '../../sites/performance/backend/request-detail' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-performance-backend-request-detail' )( {
+			component: () => {
+				const { siteSlug } = agencySiteRoute.useParams();
+				const { method, route, bucket } =
+					agencySitePerformanceBackendRequestDetailRoute.useSearch();
+				return (
+					<d.default siteSlug={ siteSlug } method={ method } route={ route } bucket={ bucket } />
+				);
+			},
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -644,6 +816,18 @@ export const createAgencyRoutes = () => [
 				agencySiteScanIndexRoute,
 				agencySiteScanActiveRoute,
 				agencySiteScanHistoryRoute,
+			] ),
+			agencySitePerformanceRoute.addChildren( [
+				agencySitePerformanceIndexRoute,
+				agencySitePerformanceFrontendRoute,
+				agencySitePerformanceBackendRoute.addChildren( [
+					agencySitePerformanceBackendIndexRoute,
+					agencySitePerformanceBackendTransactionsRoute,
+					agencySitePerformanceBackendWordPressRoute,
+					agencySitePerformanceBackendDatabaseRoute,
+					agencySitePerformanceBackendExternalRequestsRoute,
+					agencySitePerformanceBackendRequestDetailRoute,
+				] ),
 			] ),
 			agencySiteLogsRoute.addChildren( [ agencySiteLogsIndexRoute, agencySiteActivityRoute ] ),
 		] ),

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -27,6 +27,7 @@ import {
 import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 import type { AgencyCapability } from '@automattic/api-core';
@@ -412,8 +413,33 @@ export const agencySiteRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_managed_sites' },
 	getParentRoute: () => agencyRoute,
 	path: 'sites/$siteSlug',
+	beforeLoad: async ( { cause, params: { siteSlug }, matches } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		let site;
+		try {
+			site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		} catch {
+			// Do nothing and propagate the error through the loader function.
+			return;
+		}
+
+		const siteTypeSupports = getSiteTypeFeatureSupports( site );
+		for ( const match of matches ) {
+			const required = match.staticData?.requiresSiteTypeSupport;
+			if ( required && ! siteTypeSupports[ required ] ) {
+				throw redirectAsNotAllowed( { to: `/sites/${ siteSlug }` } );
+			}
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( agencySiteQuery( siteSlug ) );
+		// The sidebar needs the full site to decide section visibility before first paint.
+		const [ site ] = await Promise.all( [
+			queryClient.ensureQueryData( agencySiteQuery( siteSlug ) ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
 		if ( ! site ) {
 			throw notFound();
 		}
@@ -617,14 +643,12 @@ export const agencySiteScanHistoryRoute = createRoute( {
 	)
 );
 
-// `/sites/$siteSlug/performance` – layout gated by the site's Performance hosting feature
+// `/sites/$siteSlug/performance` – layout hosting the Frontend and Backend views
 const agencySitePerformanceRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'performance' },
 	head: () => ( { meta: [ { title: __( 'Performance' ) } ] } ),
 	getParentRoute: () => agencySiteRoute,
 	path: 'performance',
-	loader: async ( { params: { siteSlug } } ) => {
-		await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-	},
 } ).lazy( () =>
 	import( '../../agency/sites/site/performance' ).then( ( d ) =>
 		createLazyRoute( 'agency-site-performance' )( {

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -15,6 +15,8 @@ import {
 	mcpSettingsQuery,
 	queryClient,
 	rawUserPreferencesQuery,
+	siteApmAggregateRollingQuery,
+	siteApmDetailQuery,
 	siteBackupsQuery,
 	siteBySlugQuery,
 	sitePerformancePagesQuery,
@@ -687,11 +689,9 @@ export const agencySitePerformanceBackendRoute = createRoute( {
 
 async function prefetchAgencyApmAggregate( siteSlug: string ) {
 	const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-	const [ { siteApmAggregateRollingQuery }, { getStoredOrDefaultTimeframe, TIMEFRAME_SECONDS } ] =
-		await Promise.all( [
-			import( '@automattic/api-queries' ),
-			import( '../../sites/performance/backend/timeframe' ),
-		] );
+	const { getStoredOrDefaultTimeframe, TIMEFRAME_SECONDS } = await import(
+		'../../sites/performance/backend/timeframe'
+	);
 	const windowSec = TIMEFRAME_SECONDS[ getStoredOrDefaultTimeframe() ];
 	await queryClient.ensureQueryData( siteApmAggregateRollingQuery( site.ID, windowSec ) );
 }
@@ -782,11 +782,9 @@ export const agencySitePerformanceBackendRequestDetailRoute = createRoute( {
 	loaderDeps: ( { search: { method, route } } ) => ( { method, route } ),
 	loader: async ( { params: { siteSlug }, deps: { method, route } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const [ { siteApmDetailQuery }, { TIMEFRAME_SECONDS, getStoredOrDefaultTimeframe } ] =
-			await Promise.all( [
-				import( '@automattic/api-queries' ),
-				import( '../../sites/performance/backend/timeframe' ),
-			] );
+		const { TIMEFRAME_SECONDS, getStoredOrDefaultTimeframe } = await import(
+			'../../sites/performance/backend/timeframe'
+		);
 		const windowSec = TIMEFRAME_SECONDS[ getStoredOrDefaultTimeframe() ];
 		await queryClient.ensureQueryData(
 			siteApmDetailQuery( site.ID, { method, route, windowSec } )

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -26,7 +26,8 @@ declare module '@tanstack/react-router' {
 	interface StaticDataRouteOption {
 		/**
 		 * If set, the route is only accessible when the site type supports this feature.
-		 * The check is performed in siteRoute.beforeLoad against getSiteTypeFeatureSupports(site).
+		 * The check is performed in siteRoute.beforeLoad and agencySiteRoute.beforeLoad
+		 * against getSiteTypeFeatureSupports(site).
 		 */
 		requiresSiteTypeSupport?: SiteTypeFeature;
 		availableToInaccessibleJetpackSites?: boolean;

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -13,8 +13,7 @@ import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callou
 import { SiteLaunchButton } from '../site-launch-button';
 import { getPerformanceCalloutProps } from './performance-callout';
 
-function SitePerformance() {
-	const { siteSlug } = siteRoute.useParams();
+export function SitePerformanceContent( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
 	return (
@@ -47,6 +46,11 @@ function SitePerformance() {
 			<PerformanceTrackerStop />
 		</HostingFeatureGatedWithCallout>
 	);
+}
+
+function SitePerformance() {
+	const { siteSlug } = siteRoute.useParams();
+	return <SitePerformanceContent siteSlug={ siteSlug } />;
 }
 
 export default SitePerformance;


### PR DESCRIPTION
Resolves A4A-2936

## Proposed Changes

Adds Performance to a site's page in the Automattic for Agencies dashboard:

* A **Performance card** on the site Overview showing the latest performance result, shown alongside the Backup and Scan cards.
* A **Performance** section in the sidebar with **Frontend** and **Backend**.
* A full **Performance page**:
  * **Frontend** — page-speed results for mobile and desktop, with recommendations.
  * **Backend** — server-side performance with tabs for an overview, transactions, WordPress, database, and external requests, plus a details view for an individual request.
* Sites that don't support Performance see the standard upgrade prompt.

This reuses the same Performance experience the main dashboard already has, so agency-managed sites get the exact same views.

## Why are these changes being made?

Agencies could open a site's overview but had no way to review its performance from the new site page. This brings Performance to agency-managed sites, matching the recent addition of Scan.

## Testing Instructions

1. Open the Dashboard Live (A4A) link > Replace the `/sites` in the URL with `/overview` to see the A4A dashboard.
2. Open a site that supports Performance.
3. On the Overview, confirm the **Performance card** shows next to the Backup and Scan cards with the latest result.
4. In the sidebar, open **Performance** and confirm **Frontend** and **Backend**.
5. On **Frontend**, confirm mobile and desktop results and recommendations load.
6. On **Backend**, confirm the tabs (Overview, Transactions, WordPress, Database, External requests) and that opening a request shows its details. Backend is behind an in-development flag, so it may not appear in every environment.
7. Open a site that does not support Performance and confirm it shows the upgrade prompt with no broken navigation.
8. Confirm nothing changed on the main dashboard.

<img width="1920" height="896" alt="Screenshot 2026-07-10 at 3 50 13 PM" src="https://github.com/user-attachments/assets/bd9748b8-b99b-47e3-80be-1489c41d63fb" />

<img width="617" height="155" alt="Screenshot 2026-07-10 at 3 50 28 PM" src="https://github.com/user-attachments/assets/b61d4c13-2380-449a-a8f9-f49d5745f8e6" />

<img width="673" height="276" alt="Screenshot 2026-07-10 at 3 50 55 PM" src="https://github.com/user-attachments/assets/921ffef7-24d6-47e7-8232-4dcccf06c53b" />

<img width="645" height="276" alt="Screenshot 2026-07-10 at 3 51 00 PM" src="https://github.com/user-attachments/assets/1e392316-6533-4d72-b089-d94685209bcc" />

<img width="1298" height="963" alt="Screenshot 2026-07-10 at 3 51 19 PM" src="https://github.com/user-attachments/assets/f792babd-b31b-4218-b975-80c8e005358f" />

<img width="1298" height="963" alt="Screenshot 2026-07-10 at 3 51 29 PM" src="https://github.com/user-attachments/assets/d5c82727-7fb0-4801-846b-b714e6cf3208" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?