### PR TITLE
CI: add TeamCity merge-queue nudge (validate reachability)

### DIFF
--- a/.github/workflows/teamcity-merge-queue-nudge.yml
+++ b/.github/workflows/teamcity-merge-queue-nudge.yml
@@ -1,0 +1,32 @@
+name: TeamCity merge-queue nudge
+
+# Ask TeamCity to check the wp-calypso VCS root for changes immediately, so the
+# required builds for a merge-group branch get enqueued within seconds instead of
+# waiting up to a full VCS polling cycle (~60s). Uses guest auth — no token needed.
+#
+# The `pull_request` trigger is here only to validate reachability from CI; the
+# nudge is only meaningful for `merge_group`. Drop `pull_request` before relying on this.
+on:
+  merge_group:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  nudge:
+    # teamcity.a8c.com must be reachable from this runner; use a self-hosted runner if it is internal-only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Ask TeamCity to check for changes now (guest auth, no token)
+        run: |
+          set -uo pipefail
+          code=$(curl -sS --max-time 30 -o /tmp/resp -w "%{http_code}" -X POST \
+            "https://teamcity.a8c.com/guestAuth/app/rest/vcs-root-instances/commitHookNotification?locator=vcsRoot:(id:calypso_WpCalypso)")
+          echo "HTTP $code"
+          cat /tmp/resp 2>/dev/null || true
+          echo
+          case "$code" in
+            2*) echo "Nudge OK" ;;
+            *)  echo "Nudge failed (unreachable or rejected)"; exit 1 ;;
+          esac


### PR DESCRIPTION
## Proposed Changes

* Add a small GitHub Actions workflow that, on `merge_group`, calls TeamCity's commit-hook REST endpoint (`commitHookNotification`) for the `wp-calypso` VCS root. This asks TeamCity to check for changes **immediately** rather than waiting for its ~60s VCS polling cycle, so the required builds on a merge-group branch get enqueued within a few seconds.
* Uses **guest auth** (`/guestAuth/…`) — no token or secret required. Verified against the server: a cookieless guest POST returns `202 Scheduled checking for changes for 1 VCS roots`.
* A `pull_request` trigger is included **temporarily**, purely to validate that a GitHub-hosted runner can reach `teamcity.a8c.com`. The step fails loudly on any non-2xx so this PR's check makes reachability obvious.

## Why are these changes being made?

Merge-queue entries occasionally sit until GitHub's 60-minute merge-queue timeout and get ejected. Part of the latency is that every merge-group branch waits up to a full VCS polling cycle before TeamCity even notices it and starts the required checks. Nudging TeamCity to check on `merge_group` removes that detection lag from the critical path.

## Testing Instructions

* Open this PR and watch the **TeamCity merge-queue nudge** check.
  * Green + log showing `HTTP 202 … Scheduled checking for changes for 1 VCS roots` → the runner can reach TeamCity and guest auth works.
  * Red / timeout → GitHub-hosted runners can't reach `teamcity.a8c.com`; we'd need a self-hosted runner with network access.
* This does not change any product code.

## Follow-ups before this is merged for real

* Remove the `pull_request` trigger (keep `merge_group` only) — the nudge is meaningless on regular PRs.
* Decide whether to keep the step fatal (`exit 1`) or make it non-blocking; for production `merge_group` use it should be non-fatal so a TeamCity hiccup never blocks a merge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
