### PR TITLE
Reader Spaces: pre-fill saved tags when customizing a space

### DIFF
--- a/client/reader/AGENTS.md
+++ b/client/reader/AGENTS.md
@@ -65,6 +65,27 @@ New Reader data fetching follows a three-layer pattern — `api-core` fetchers/m
 
 See [`client/reader/data/README.md`](./data/README.md) for the full recipe — naming conventions, `queryKey`/`staleTime` rules, the consumer-`QueryClient` requirement, testing, and reference implementations (`read-sites`, `read-lists`, `read-follows`).
 
+#### Consumer query hooks take a second query-config argument
+
+A read hook that wraps `useQuery` should accept an optional **second argument** that overrides the query config, rather than encoding fetch control in the first argument (e.g. a `null` id/slug to disable). Type it as a narrow object of just the fields callers may tune — commonly `enabled` and `refetchOnMount` — so a caller can gate or reload the query without being able to swap out the `queryKey`/`queryFn` the hook owns. (Keep the shape a plain object; a `Pick< UseQueryOptions< … > >` widens the default `queryKey` generic and breaks the `useQuery` overload when spread onto a `queryOptions()` result.) Spread the options into the query, then re-assert any config the hook must keep (e.g. AND the caller's `enabled` with a known key):
+
+```ts
+type ReadFooQueryOptions = {
+	enabled?: boolean;
+	refetchOnMount?: boolean | 'always';
+};
+
+export function useReadFoo( id: string | null | undefined, options?: ReadFooQueryOptions ) {
+	return useQuery( {
+		...readFooQuery( id ?? '' ),
+		...options,
+		enabled: Boolean( id ) && ( options?.enabled ?? true ),
+	} );
+}
+```
+
+Callers then pass config explicitly — `useReadFoo( id, { enabled: ! isCreate, refetchOnMount: 'always' } )` — instead of `useReadFoo( isCreate ? null : id )`. See `useSpaceBySlug` in `client/reader/data/spaces/index.ts`.
+
 ### Mutation factories must accept the consumer's `QueryClient`
 
 Calypso boots its own `QueryClient` (see `client/state/query-client.ts`, with a per-user persistence key) and injects it via `<QueryClientProvider>` in `client/controller/index.web.js`. The Dashboard, in contrast, uses the singleton exported by `@automattic/api-queries` (`packages/api-queries/src/query-client.ts`).

--- a/client/reader/data/spaces/index.ts
+++ b/client/reader/data/spaces/index.ts
@@ -9,6 +9,11 @@ import {
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ReadSpace, ReadSpaceDetails } from '@automattic/api-core';
 
+type ReadSpaceQueryOptions = {
+	enabled?: boolean;
+	refetchOnMount?: boolean | 'always';
+};
+
 /**
  * The user's spaces for the sidebar and space views, from the live list
  * endpoint. Summary shape only (no sources or tags) — use `useSpaceBySlug` for those.
@@ -23,12 +28,14 @@ export function useSpaces(): ReadSpace[] {
  * This is how a slug-addressed space view resolves itself: the returned detail
  * carries the numeric `id` that then drives the streams and mutations. A 404
  * (unknown / renamed-away / not-yours slug) surfaces as the query's error, which
- * the view turns into the not-found state. Disabled until a slug is known.
+ * the view turns into the not-found state. `options` tunes the query config; the
+ * caller's `enabled` is ANDed with a known slug, so it never runs without one.
  */
-export function useSpaceBySlug( slug: string | null | undefined ) {
+export function useSpaceBySlug( slug: string | null | undefined, options?: ReadSpaceQueryOptions ) {
 	return useQuery( {
 		...readSpaceBySlugQuery( slug ?? '' ),
-		enabled: Boolean( slug ),
+		...options,
+		enabled: Boolean( slug ) && ( options?.enabled ?? true ),
 	} );
 }
 

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -204,7 +204,13 @@ function SpaceUpsertModalContent( {
 	// Seed once the open-time refetch has settled, not from the cache it returns
 	// immediately — a stale snapshot can omit tags and would lock in empty fields.
 	useEffect( () => {
-		if ( ! isCreate && space && spaceQuery.isFetchedAfterMount && ! isSeeded ) {
+		if (
+			! isCreate &&
+			space &&
+			spaceQuery.isSuccess &&
+			spaceQuery.isFetchedAfterMount &&
+			! isSeeded
+		) {
 			setName( space.name );
 			setTags( space.tags );
 			// `?? []` guards a persisted React Query cache written before `languages`
@@ -218,7 +224,7 @@ function SpaceUpsertModalContent( {
 			setSelectedSources( space.sources.map( getSpaceSourceDraftItem ) );
 			setIsSeeded( true );
 		}
-	}, [ isCreate, isSeeded, space, spaceQuery.isFetchedAfterMount ] );
+	}, [ isCreate, isSeeded, space, spaceQuery.isFetchedAfterMount, spaceQuery.isSuccess ] );
 
 	const existingNames = useMemo(
 		() =>

--- a/client/reader/spaces/customize-modal/index.tsx
+++ b/client/reader/spaces/customize-modal/index.tsx
@@ -161,10 +161,11 @@ function SpaceUpsertModalContent( {
 	// the current tab. Only meaningful in edit mode (we're on the space's URL).
 	const currentRoute = useSelector( getCurrentRoute );
 	const isCreate = mode === 'create';
-	// Resolve the space by its URL slug (edit mode), sharing the view's by-slug cache
-	// so opening the modal doesn't refetch. The numeric id — used by the update/delete
-	// mutations, which stay id-based — comes off the resolved detail.
-	const { data: space } = useSpaceBySlug( isCreate ? null : slug );
+	const spaceQuery = useSpaceBySlug( slug, {
+		enabled: ! isCreate,
+		refetchOnMount: 'always',
+	} );
+	const space = spaceQuery.data;
 	const editSpaceId = space?.id ?? null;
 	const spaces = useSpaces();
 	const createSpace = useCreateSpace();
@@ -200,8 +201,10 @@ function SpaceUpsertModalContent( {
 	// edit keeps the tabbed layout so any section is reachable directly.
 	const [ step, setStep ] = useState( 0 );
 
+	// Seed once the open-time refetch has settled, not from the cache it returns
+	// immediately — a stale snapshot can omit tags and would lock in empty fields.
 	useEffect( () => {
-		if ( ! isCreate && space && ! isSeeded ) {
+		if ( ! isCreate && space && spaceQuery.isFetchedAfterMount && ! isSeeded ) {
 			setName( space.name );
 			setTags( space.tags );
 			// `?? []` guards a persisted React Query cache written before `languages`
@@ -215,7 +218,7 @@ function SpaceUpsertModalContent( {
 			setSelectedSources( space.sources.map( getSpaceSourceDraftItem ) );
 			setIsSeeded( true );
 		}
-	}, [ isCreate, isSeeded, space ] );
+	}, [ isCreate, isSeeded, space, spaceQuery.isFetchedAfterMount ] );
 
 	const existingNames = useMemo(
 		() =>

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -272,6 +272,34 @@ describe( 'CustomizeModal', () => {
 		expect( await screen.findByText( 'tech' ) ).toBeVisible();
 	} );
 
+	it( 'does not seed stale cached detail when the open-time refetch fails', async () => {
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const { sources, tags, languages, ...summary } = SPACE;
+		queryClient.setQueryData( readSpacesQuery().queryKey, [ summary ] );
+		queryClient.setQueryData( readSpaceBySlugQuery( SPACE.slug ).queryKey, {
+			...SPACE,
+			tags: [],
+		} );
+		const failedRefetch = nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/reader/spaces/slug/${ SPACE.slug }` )
+			.reply( 404, { error: 'reader_spaces_not_found' } );
+
+		renderWithProvider( <CustomizeModal isOpen slug={ SPACE.slug } onClose={ jest.fn() } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		await waitFor( () => expect( failedRefetch.isDone() ).toBe( true ) );
+		await waitFor( () => {
+			const queryState = queryClient.getQueryState( readSpaceBySlugQuery( SPACE.slug ).queryKey );
+			expect( queryState?.fetchStatus ).toBe( 'idle' );
+			expect( queryState?.fetchFailureCount ).toBeGreaterThan( 0 );
+		} );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Loading…' );
+		expect( screen.queryByLabelText( 'Name' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Save changes' } ) ).toBeDisabled();
+	} );
+
 	it( 'saves edited identity and layout, then closes', async () => {
 		const user = userEvent.setup();
 		const { queryClient, onClose } = render();

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { canonicalizeReadSpaceSlug } from '@automattic/api-core';
 import { readSpaceBySlugQuery, readSpaceQuery, readSpacesQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { QueryClient } from '@tanstack/react-query';
@@ -97,23 +98,30 @@ const SPACE: ReadSpaceDetails = {
 // seeds the draft from that fresh detail, so the by-slug GET must resolve. Echo
 // the space's fields back in the wire (detail) shape.
 function mockSpaceBySlugEndpoint( space: ReadSpaceDetails = SPACE ) {
-	return nock( 'https://public-api.wordpress.com' )
-		.get( `/wpcom/v2/reader/spaces/slug/${ space.slug }` )
-		.reply( 200, {
-			id: Number( space.id ),
-			slug: space.slug,
-			title: space.name,
-			layout: space.layout,
-			tags: space.tags,
-			languages: space.languages,
-			follows: space.sources.map( ( source ) => ( {
-				feed_id: source.feedId,
-				feed_url: source.feedUrl,
-				blog_id: source.blogId,
-				name: source.name,
-				icon: source.siteIcon,
-			} ) ),
-		} );
+	return (
+		nock( 'https://public-api.wordpress.com' )
+			// Mirror the fetcher's path encoding so the matcher holds for any slug.
+			.get(
+				`/wpcom/v2/reader/spaces/slug/${ encodeURIComponent(
+					canonicalizeReadSpaceSlug( space.slug )
+				) }`
+			)
+			.reply( 200, {
+				id: Number( space.id ),
+				slug: space.slug,
+				title: space.name,
+				layout: space.layout,
+				tags: space.tags,
+				languages: space.languages,
+				follows: space.sources.map( ( source ) => ( {
+					feed_id: source.feedId,
+					feed_url: source.feedUrl,
+					blog_id: source.blogId,
+					name: source.name,
+					icon: source.siteIcon,
+				} ) ),
+			} )
+	);
 }
 
 // Echo the submitted fields back so the adapted detail reflects the edit.
@@ -152,7 +160,8 @@ function render( {
 	space?: ReadSpaceDetails;
 } = {} ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
-	const { sources, tags, ...summary } = space;
+	// The list endpoint returns the summary shape only (no sources/tags/languages).
+	const { sources, tags, languages, ...summary } = space;
 	queryClient.setQueryData( readSpacesQuery().queryKey, [ summary, ...others ] );
 	// The modal resolves the space by slug (sharing the view's cache); the id-keyed
 	// entry is what the mutations write back to.
@@ -242,7 +251,7 @@ describe( 'CustomizeModal', () => {
 	it( 'seeds saved tags from the fresh detail even when the cached snapshot has none', async () => {
 		const user = userEvent.setup();
 		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
-		const { sources, tags, ...summary } = SPACE;
+		const { sources, tags, languages, ...summary } = SPACE;
 		queryClient.setQueryData( readSpacesQuery().queryKey, [ summary ] );
 		// A create leaves a by-slug snapshot that can omit tags; seeding that would
 		// show empty tags on edit. The open-time refetch returns the real tags.

--- a/client/reader/spaces/customize-modal/test/index.test.tsx
+++ b/client/reader/spaces/customize-modal/test/index.test.tsx
@@ -93,6 +93,29 @@ const SPACE: ReadSpaceDetails = {
 	sources: [],
 };
 
+// The modal refetches the space by slug on open (`refetchOnMount: 'always'`) and
+// seeds the draft from that fresh detail, so the by-slug GET must resolve. Echo
+// the space's fields back in the wire (detail) shape.
+function mockSpaceBySlugEndpoint( space: ReadSpaceDetails = SPACE ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/reader/spaces/slug/${ space.slug }` )
+		.reply( 200, {
+			id: Number( space.id ),
+			slug: space.slug,
+			title: space.name,
+			layout: space.layout,
+			tags: space.tags,
+			languages: space.languages,
+			follows: space.sources.map( ( source ) => ( {
+				feed_id: source.feedId,
+				feed_url: source.feedUrl,
+				blog_id: source.blogId,
+				name: source.name,
+				icon: source.siteIcon,
+			} ) ),
+		} );
+}
+
 // Echo the submitted fields back so the adapted detail reflects the edit.
 function mockUpdateEndpoint( onBody?: ( body: Record< string, unknown > ) => void ) {
 	return nock( 'https://public-api.wordpress.com' )
@@ -135,6 +158,9 @@ function render( {
 	// entry is what the mutations write back to.
 	queryClient.setQueryData( readSpaceBySlugQuery( space.slug ).queryKey, space );
 	queryClient.setQueryData( readSpaceQuery( space.id ).queryKey, space );
+	// The modal seeds from the fresh by-slug refetch it triggers on open, not the
+	// cache above, so serve that request.
+	mockSpaceBySlugEndpoint( space );
 
 	const view = renderWithProvider(
 		<CustomizeModal isOpen slug={ space.slug } onClose={ onClose } />,
@@ -156,10 +182,10 @@ describe( 'CustomizeModal', () => {
 
 	afterEach( () => nock.cleanAll() );
 
-	it( 'seeds the identity fields from the space detail', () => {
+	it( 'seeds the identity fields from the space detail', async () => {
 		render();
 
-		expect( screen.getByLabelText( 'Name' ) ).toHaveValue( 'Work' );
+		expect( await screen.findByLabelText( 'Name' ) ).toHaveValue( 'Work' );
 		expect(
 			within( screen.getByRole( 'radiogroup', { name: 'Accent color' } ) ).getByRole( 'radio', {
 				name: 'Blue',
@@ -171,10 +197,10 @@ describe( 'CustomizeModal', () => {
 		expect( screen.getByRole( 'radio', { name: 'Inbox' } ) ).toBeChecked();
 	} );
 
-	it( 'shows the accent color picker after the icon controls', () => {
+	it( 'shows the accent color picker after the icon controls', async () => {
 		render();
 
-		const iconLabel = screen.getByText( 'Icon' );
+		const iconLabel = await screen.findByText( 'Icon' );
 		const iconColorLabel = screen.getByText( 'Icon color' );
 		const accentColorLabel = screen.getByText( 'Accent color' );
 
@@ -189,6 +215,8 @@ describe( 'CustomizeModal', () => {
 	it( 'switches between the Identity, Layout, Feeds, Topics and Delete tabs', async () => {
 		const user = userEvent.setup();
 		render();
+		// Wait for the open-time refetch to seed the draft before interacting.
+		await screen.findByLabelText( 'Name' );
 
 		expect( screen.getByRole( 'tab', { name: 'Delete' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'button', { name: 'Delete space' } ) ).not.toBeInTheDocument();
@@ -211,13 +239,37 @@ describe( 'CustomizeModal', () => {
 		expect( screen.getByRole( 'button', { name: 'Delete space' } ) ).toBeVisible();
 	} );
 
+	it( 'seeds saved tags from the fresh detail even when the cached snapshot has none', async () => {
+		const user = userEvent.setup();
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const { sources, tags, ...summary } = SPACE;
+		queryClient.setQueryData( readSpacesQuery().queryKey, [ summary ] );
+		// A create leaves a by-slug snapshot that can omit tags; seeding that would
+		// show empty tags on edit. The open-time refetch returns the real tags.
+		queryClient.setQueryData( readSpaceBySlugQuery( SPACE.slug ).queryKey, {
+			...SPACE,
+			tags: [],
+		} );
+		mockSpaceBySlugEndpoint( SPACE );
+
+		renderWithProvider( <CustomizeModal isOpen slug={ SPACE.slug } onClose={ jest.fn() } />, {
+			queryClient,
+			initialState: { currentUser: { id: 1 } },
+		} );
+
+		await screen.findByLabelText( 'Name' );
+		await user.click( screen.getByRole( 'tab', { name: 'Topics' } ) );
+		// The saved tag renders as a token in the Tags field.
+		expect( await screen.findByText( 'tech' ) ).toBeVisible();
+	} );
+
 	it( 'saves edited identity and layout, then closes', async () => {
 		const user = userEvent.setup();
 		const { queryClient, onClose } = render();
 		const onBody = jest.fn();
 		mockUpdateEndpoint( onBody );
 
-		const name = screen.getByLabelText( 'Name' );
+		const name = await screen.findByLabelText( 'Name' );
 		await user.clear( name );
 		await user.type( name, 'Reading' );
 		await user.click(
@@ -264,6 +316,7 @@ describe( 'CustomizeModal', () => {
 		const user = userEvent.setup();
 		const { onClose } = render();
 		mockUpdateEndpoint();
+		await screen.findByLabelText( 'Name' );
 
 		// Change only the accent colour; the name — and therefore the slug — is unchanged.
 		await user.click(
@@ -282,6 +335,7 @@ describe( 'CustomizeModal', () => {
 		const { onClose } = render();
 		const onBody = jest.fn();
 		mockUpdateEndpoint( onBody );
+		await screen.findByLabelText( 'Name' );
 
 		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
 
@@ -305,6 +359,7 @@ describe( 'CustomizeModal', () => {
 	it( 'seeds the width control from the stored layout width', async () => {
 		const user = userEvent.setup();
 		render( { space: { ...SPACE, layout: { ...SPACE.layout, width: 'regular' } } } );
+		await screen.findByLabelText( 'Name' );
 
 		await user.click( screen.getByRole( 'tab', { name: 'Layout' } ) );
 
@@ -331,6 +386,7 @@ describe( 'CustomizeModal', () => {
 		} );
 		const onBody = jest.fn();
 		mockUpdateEndpoint( onBody );
+		await screen.findByLabelText( 'Name' );
 
 		await user.click( screen.getByRole( 'tab', { name: 'Feeds' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Remove Existing Blog' } ) );
@@ -351,6 +407,7 @@ describe( 'CustomizeModal', () => {
 		const { onClose } = render();
 		const onBody = jest.fn();
 		mockUpdateEndpoint( onBody );
+		await screen.findByLabelText( 'Name' );
 
 		await user.click( screen.getByRole( 'tab', { name: 'Topics' } ) );
 		await user.type( screen.getByRole( 'combobox', { name: 'Tags' } ), 'design[Enter]' );
@@ -387,7 +444,7 @@ describe( 'CustomizeModal', () => {
 		mockUpdateEndpoint( onBody );
 
 		// Edit the name first...
-		const name = screen.getByLabelText( 'Name' );
+		const name = await screen.findByLabelText( 'Name' );
 		await user.clear( name );
 		await user.type( name, 'Reading' );
 
@@ -415,10 +472,10 @@ describe( 'CustomizeModal', () => {
 			],
 		} );
 
+		const name = await screen.findByLabelText( 'Name' );
 		// The unchanged own name is valid.
 		expect( screen.getByRole( 'button', { name: 'Save changes' } ) ).toBeEnabled();
 
-		const name = screen.getByLabelText( 'Name' );
 		await user.clear( name );
 		await user.type( name, 'Reading' );
 
@@ -430,6 +487,7 @@ describe( 'CustomizeModal', () => {
 		const user = userEvent.setup();
 		const { queryClient, onClose } = render();
 		mockDeleteEndpoint();
+		await screen.findByLabelText( 'Name' );
 
 		await user.click( screen.getByRole( 'tab', { name: 'Delete' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Delete space' } ) );

--- a/client/reader/spaces/test/view.test.tsx
+++ b/client/reader/spaces/test/view.test.tsx
@@ -46,9 +46,16 @@ jest.mock( 'calypso/reader/data/spaces', () => {
 		...actual,
 		useSpaceBySlug: ( ...args: Parameters< typeof actual.useSpaceBySlug > ) => {
 			const result = actual.useSpaceBySlug( ...args );
-			return mockSpaceError.current !== undefined
-				? { ...result, error: mockSpaceError.current }
-				: result;
+			if ( mockSpaceError.current !== undefined ) {
+				return { ...result, error: mockSpaceError.current };
+			}
+			// Tests seed the by-slug cache directly rather than serving the open-time
+			// refetch, so present that seeded detail as a settled successful fetch —
+			// the Customize modal only seeds its draft once the fetch has succeeded.
+			if ( result.data !== undefined ) {
+				return { ...result, isSuccess: true, isFetchedAfterMount: true };
+			}
+			return result;
 		},
 	};
 } );


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Seed the Customize modal draft once the open-time by-slug refetch has settled (via `isFetchedAfterMount`), instead of the immediately-returned cache snapshot — so saved tags (and every other field) reliably pre-fill on edit.
* Give `useSpaceBySlug` a second query-config argument (`enabled`, `refetchOnMount`) so callers gate/reload the query explicitly rather than passing a `null` slug.
* Document the "second argument = query config" convention for consumer read hooks in `client/reader/AGENTS.md`.

## Why are these changes being made?

After creating a space with tags, reopening it via **Customize → Topics** showed an empty Tags field. The one-shot seeding effect locked in whatever was in the by-slug cache on first render — a snapshot a create can leave without tags — before the fresh detail arrived. Waiting for the post-mount refetch makes the modal seed from authoritative server data every time it opens.

## Testing Instructions

### Scenario 1 - Saved tags pre-fill on edit:
- Go to `/reader` and create a Space, adding one or more tags in the Topics step.
- Open the new space, click **Customize**, and switch to the **Topics** tab.
- Check that the previously-added tags appear as tokens in the Tags field (not empty), and that Name, Languages, colors, icon, layout, and Feeds are also pre-filled.

### Scenario 2 - Create flow unaffected:
- Go to `/reader` and start creating a new Space.
- Check that the wizard opens immediately with empty tags and the account-language default, with no loading delay.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?