### PR TITLE
Stepper: let @wordpress/ui Button own trigger state styling

### DIFF
--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -20,13 +20,12 @@
 	justify-content: center;
 }
 
-// Background intentionally not suppressed: the minimal neutral Button's own
-// hover/press background is the non-color affordance for interactive states.
 .trigger {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	gap: var( --wpds-dimension-gap-sm );
+	background: none;
 	border: none;
 	padding: var( --wpds-dimension-padding-md );
 	height: auto;

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -20,16 +20,12 @@
 	justify-content: center;
 }
 
+// Base `.stepper` trigger styles (background/border suppression, height,
+// text-align, gap) also apply here via clsx; this block only adds the
+// horizontal-specific padding.
 .trigger {
-	display: flex;
 	flex-direction: row;
-	align-items: center;
-	gap: var( --wpds-dimension-gap-sm );
-	background: none;
-	border: none;
 	padding: var( --wpds-dimension-padding-md );
-	height: auto;
-	text-align: start;
 }
 
 .panel {

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -63,7 +63,7 @@
 			inset-inline-start: calc( 50% + var( --a8c-ui-stepper-indicator-size ) * 0.5 + var( --wpds-dimension-padding-md ) );
 			inset-inline-end: calc( -50% + var( --a8c-ui-stepper-indicator-size ) * 0.5 + var( --wpds-dimension-padding-md ) );
 			height: var( --wpds-border-width-xs );
-			background-color: var( --wpds-color-stroke-surface-neutral );
+			background-color: var( --wpds-color-stroke-surface-neutral-weak );
 		}
 	}
 

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -20,12 +20,13 @@
 	justify-content: center;
 }
 
+// Background intentionally not suppressed: the minimal neutral Button's own
+// hover/press background is the non-color affordance for interactive states.
 .trigger {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	gap: var( --wpds-dimension-gap-sm );
-	background: none;
 	border: none;
 	padding: var( --wpds-dimension-padding-md );
 	height: auto;

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -24,29 +24,29 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;
-	// The indicator is static status content, not an interactive control
-	// (the .trigger button is), so it reads from the content token family.
-	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-content-neutral );
+	// The indicator is part of the interactive .trigger button, so it reads
+	// from the fg-interactive token family (same as the Tabs component).
+	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
 	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
 // Current step
 .indicator.is-current {
-	border-color: var( --wpds-color-fg-content-neutral );
-	background: var( --wpds-color-fg-content-neutral );
+	border-color: var( --wpds-color-fg-interactive-neutral );
+	background: var( --wpds-color-fg-interactive-neutral );
 	color: var( --wpds-color-bg-surface-neutral-strong );
 	font-weight: 600;
 }
 
 // Completed step
 .indicator.is-completed {
-	border-color: var( --wpds-color-fg-content-neutral-weak );
+	border-color: var( --wpds-color-fg-interactive-neutral-weak );
 	background: transparent;
-	color: var( --wpds-color-fg-content-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 
 	svg {
 		stroke: currentColor;
@@ -66,8 +66,8 @@
 // Upcoming: dashed gray-700 circle, no icon
 .indicator[data-indicator-variant='bullet'] {
 	border-style: dashed;
-	border-color: var( --wpds-color-fg-content-neutral-weak );
-	color: var( --wpds-color-fg-content-neutral-weak );
+	border-color: var( --wpds-color-fg-interactive-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 }
 
 // Current: 16px solid gray-900 ring, transparent background + half-circle dome
@@ -78,9 +78,9 @@
 	height: var( --a8c-ui-stepper-indicator-size-sm );
 	margin: var( --a8c-ui-stepper-indicator-offset );
 	border-style: solid;
-	border-color: var( --wpds-color-fg-content-neutral );
+	border-color: var( --wpds-color-fg-interactive-neutral );
 	background: transparent;
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // Completed: 16px, solid border (color inherited from .indicator.is-completed)
@@ -91,19 +91,19 @@
 	border-style: solid;
 }
 
-// Upcoming step titles — de-emphasized static content
+// Upcoming step titles — de-emphasized (incomplete steps use the weak variant)
 [data-indicator-variant] .title {
-	color: var( --wpds-color-fg-content-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 }
 
 // Completed step titles — same weight as upcoming but full neutral (not weak)
 [data-indicator-variant] [data-status='completed'] .title {
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // Current/active step title — full neutral, bold (weight set on the trigger below)
 [data-indicator-variant] [data-current] .title {
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // ---------------------------------------------------------------------------
@@ -115,34 +115,39 @@
 	padding: 0;
 }
 
+// The trigger renders as a minimal neutral Button, whose own background
+// (transparent at rest, neutral-weak-active on hover/press/focus) provides the
+// extra, non-color-only affordance for interactive states. Only layout is
+// overridden here; the background is deliberately not suppressed.
 .trigger {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	gap: var( --wpds-dimension-gap-sm );
 	padding: 0;
-	background: none;
 	border: none;
 	height: auto;
 	text-align: start;
 	width: 100%;
 
+	// Hover/focus use the -active variant of the same neutral tone; WPDS
+	// tokens should not mix tones (no brand color on a neutral control).
 	&:hover:not( [aria-disabled='true'] ) {
 		.title {
-			color: var( --wpds-color-fg-interactive-brand );
+			color: var( --wpds-color-fg-interactive-neutral-active );
 		}
 
 		// Number-variant current step has a solid filled circle — skip border change
-		// to avoid an accent ring appearing against the dark background on hover.
+		// to avoid a ring appearing against the dark background on hover.
 		.indicator:not( .is-current[data-indicator-variant='number'] ) {
-			border-color: var( --wpds-color-fg-interactive-brand );
+			border-color: var( --wpds-color-fg-interactive-neutral-active );
 		}
 
 		// Pull icon color for completed and current steps (SVG/dome use currentColor).
 		// Number-variant current steps keep their original number color on hover.
 		.indicator.is-completed,
 		.indicator.is-current:not( [data-indicator-variant='number'] ) {
-			color: var( --wpds-color-fg-interactive-brand );
+			color: var( --wpds-color-fg-interactive-neutral-active );
 		}
 	}
 
@@ -199,6 +204,8 @@
 	font-weight: inherit;
 }
 
+// The description lives inside the interactive trigger, so it uses the weak
+// variant of the same interactive-neutral family as the rest of the trigger.
 .description {
-	color: var( --wpds-color-fg-content-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 }

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -48,12 +48,9 @@
 	color: var( --wpds-color-fg-interactive-neutral-strong );
 }
 
-// Completed step — the indicator is deliberately de-emphasized relative to
-// its title (per the Figma design), using the weak variant of the same
-// interactive-neutral family.
+// Completed step — the check icon and circle inherit the trigger's color,
+// so they always match the title text.
 .indicator.is-completed {
-	color: var( --wpds-color-fg-interactive-neutral-weak );
-
 	svg {
 		stroke: currentColor;
 		stroke-width: 1.5px;
@@ -85,7 +82,7 @@
 	border-style: solid;
 }
 
-// Completed: 16px, solid border (color inherited from .indicator.is-completed)
+// Completed: 16px, solid border (color inherited from the trigger)
 .indicator.is-completed[data-indicator-variant='bullet'] {
 	width: var( --a8c-ui-stepper-indicator-size-sm );
 	height: var( --a8c-ui-stepper-indicator-size-sm );
@@ -115,6 +112,9 @@
 	height: auto;
 	text-align: start;
 	width: 100%;
+	// Rest at regular weight (the Button default is medium); only the active
+	// step's title is bolded via the aria-expanded/aria-selected rule below.
+	font-weight: var( --wpds-typography-font-weight-regular );
 
 	// State text colors are set once here, on the button, and cascade to the
 	// title and description. Step state is read from the button's own

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -99,46 +99,37 @@
 	padding: 0;
 }
 
-// The trigger renders as a minimal neutral Button; its background is
-// suppressed per design (the steps read as plain labels, not pill buttons).
+// The trigger renders as a minimal neutral Button. Button owns the
+// interactive state styling: rest/hover/focus/active/disabled foreground
+// colours, the focus ring and the cursor. The rules here are layout/anatomy
+// plus the one state Button has no concept of: a step being "upcoming".
 .trigger {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	gap: var( --wpds-dimension-gap-sm );
 	padding: 0;
-	background: none;
-	border: none;
 	height: auto;
 	text-align: start;
 	width: 100%;
-	// Rest at regular weight (the Button default is medium); only the active
-	// step's title is bolded via the aria-expanded/aria-selected rule below.
+
+	// Steps read as plain labels, not pill buttons, so the minimal variant's
+	// weak background + border chrome is dropped. This is an anatomy choice,
+	// not a state override: Button still owns the foreground colours.
+	background: none;
+	border: none;
+
+	// Step labels read as text, so the rest weight is regular rather than
+	// Button's medium; only the active step's title is bolded (rule below).
 	font-weight: var( --wpds-typography-font-weight-regular );
 
-	// State text colors are set once here, on the button, and cascade to the
-	// title and description. Step state is read from the button's own
-	// attributes (data-status / aria-current / aria-disabled).
-	// Upcoming (incomplete) steps rest on the weak variant.
-	color: var( --wpds-color-fg-interactive-neutral-weak );
-
-	// Completed and current steps read at full neutral strength.
-	&[data-status='completed'],
-	&[aria-current='step'] {
-		color: var( --wpds-color-fg-interactive-neutral );
-	}
-
-	// Hover/focus use the -active variant of the same neutral tone; WPDS
-	// tokens should not mix tones (no brand color on a neutral control).
-	// The indicator border and glyph follow automatically via currentColor.
-	&:hover:not( [aria-disabled='true'] ),
-	&:focus-visible:not( [aria-disabled='true'] ) {
-		color: var( --wpds-color-fg-interactive-neutral-active );
-	}
-
-	&[aria-disabled='true'] {
-		cursor: default;
-		color: var( --wpds-color-fg-interactive-neutral-disabled );
+	// The only Stepper-specific colour state: steps that are neither completed
+	// nor current are de-emphasised. Feeding Button's own foreground custom
+	// property (rather than setting `color`) keeps Button in charge of every
+	// state: it reads this value for the rest state and still swaps in its
+	// -active / -disabled tokens for hover, focus and disabled on its own.
+	&:not( [data-status='completed'] ):not( [aria-current='step'] ) {
+		--wp-ui-button-foreground-color: var( --wpds-color-fg-interactive-neutral-weak );
 	}
 
 	&[aria-expanded='true'],
@@ -179,14 +170,15 @@
 // Title and Description
 // ---------------------------------------------------------------------------
 
-// Title color is inherited from the `.trigger` button, which owns the
-// per-state (upcoming/completed/current/hover/disabled) text colors.
+// Title and description both live inside the Button and inherit its per-state
+// foreground colour: Button sets `color` on the trigger, Text sets none, so it
+// cascades down. Neither sets its own colour, so hover/focus/disabled states
+// keep flowing from the Button. The size step (body-md title vs body-sm
+// description) is what visually separates them.
 .title {
 	font-weight: inherit;
 }
 
-// The description lives inside the interactive trigger, so it uses the weak
-// variant of the same interactive-neutral family as the rest of the trigger.
 .description {
-	color: var( --wpds-color-fg-interactive-neutral-weak );
+	color: inherit;
 }

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -102,16 +102,15 @@
 	padding: 0;
 }
 
-// The trigger renders as a minimal neutral Button, whose own background
-// (transparent at rest, neutral-weak-active on hover/press/focus) provides the
-// extra, non-color-only affordance for interactive states. Only layout is
-// overridden here; the background is deliberately not suppressed.
+// The trigger renders as a minimal neutral Button; its background is
+// suppressed per design (the steps read as plain labels, not pill buttons).
 .trigger {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	gap: var( --wpds-dimension-gap-sm );
 	padding: 0;
+	background: none;
 	border: none;
 	height: auto;
 	text-align: start;

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -91,21 +91,6 @@
 	border-style: solid;
 }
 
-// Upcoming step titles — de-emphasized (incomplete steps use the weak variant)
-[data-indicator-variant] .title {
-	color: var( --wpds-color-fg-interactive-neutral-weak );
-}
-
-// Completed step titles — same weight as upcoming but full neutral (not weak)
-[data-indicator-variant] [data-status='completed'] .title {
-	color: var( --wpds-color-fg-interactive-neutral );
-}
-
-// Current/active step title — full neutral, bold (weight set on the trigger below)
-[data-indicator-variant] [data-current] .title {
-	color: var( --wpds-color-fg-interactive-neutral );
-}
-
 // ---------------------------------------------------------------------------
 // Trigger
 // ---------------------------------------------------------------------------
@@ -130,12 +115,23 @@
 	text-align: start;
 	width: 100%;
 
+	// State text colors are set once here, on the button, and cascade to the
+	// title and description. Step state is read from the button's own
+	// attributes (data-status / aria-current / aria-disabled).
+	// Upcoming (incomplete) steps rest on the weak variant.
+	color: var( --wpds-color-fg-interactive-neutral-weak );
+
+	// Completed and current steps read at full neutral strength.
+	&[data-status='completed'],
+	&[aria-current='step'] {
+		color: var( --wpds-color-fg-interactive-neutral );
+	}
+
 	// Hover/focus use the -active variant of the same neutral tone; WPDS
 	// tokens should not mix tones (no brand color on a neutral control).
-	&:hover:not( [aria-disabled='true'] ) {
-		.title {
-			color: var( --wpds-color-fg-interactive-neutral-active );
-		}
+	&:hover:not( [aria-disabled='true'] ),
+	&:focus-visible:not( [aria-disabled='true'] ) {
+		color: var( --wpds-color-fg-interactive-neutral-active );
 
 		// Number-variant current step has a solid filled circle — skip border change
 		// to avoid a ring appearing against the dark background on hover.
@@ -153,11 +149,7 @@
 
 	&[aria-disabled='true'] {
 		cursor: default;
-
-		&,
-		.title {
-			color: var( --wpds-color-fg-interactive-neutral-disabled );
-		}
+		color: var( --wpds-color-fg-interactive-neutral-disabled );
 	}
 
 	&[aria-expanded='true'],
@@ -198,8 +190,8 @@
 // Title and Description
 // ---------------------------------------------------------------------------
 
-// Title color is set by the `[data-indicator-variant] … .title` rules above;
-// the root always renders `data-indicator-variant`, so no base color is needed.
+// Title color is inherited from the `.trigger` button, which owns the
+// per-state (upcoming/completed/current/hover/disabled) text colors.
 .title {
 	font-weight: inherit;
 }

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -24,28 +24,34 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;
-	// The indicator is part of the interactive .trigger button, so it reads
-	// from the fg-interactive token family (same as the Tabs component).
-	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
+	// No explicit color or background: the glyph color is inherited from the
+	// .trigger button (which owns the per-state colors), the border reads it
+	// via currentColor, and the background stays transparent.
+	border: var( --wpds-border-width-xs ) solid currentColor;
 	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-interactive-neutral );
-	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
 // Current step
 .indicator.is-current {
-	border-color: var( --wpds-color-fg-interactive-neutral );
-	background: var( --wpds-color-fg-interactive-neutral );
-	color: var( --wpds-color-bg-surface-neutral-strong );
 	font-weight: 600;
 }
 
-// Completed step
+// Current step, number variant — solid filled circle. Uses the strong
+// interactive pairing (dark fill, light glyph), like a solid neutral Button.
+// The explicit colors also keep the fill stable on hover, avoiding a ring
+// against the dark background.
+.indicator.is-current[data-indicator-variant='number'] {
+	border-color: var( --wpds-color-bg-interactive-neutral-strong );
+	background: var( --wpds-color-bg-interactive-neutral-strong );
+	color: var( --wpds-color-fg-interactive-neutral-strong );
+}
+
+// Completed step — the indicator is deliberately de-emphasized relative to
+// its title (per the Figma design), using the weak variant of the same
+// interactive-neutral family.
 .indicator.is-completed {
-	border-color: var( --wpds-color-fg-interactive-neutral-weak );
-	background: transparent;
 	color: var( --wpds-color-fg-interactive-neutral-weak );
 
 	svg {
@@ -63,14 +69,13 @@
 // Bullet indicator variant
 // ---------------------------------------------------------------------------
 
-// Upcoming: dashed gray-700 circle, no icon
+// Upcoming: dashed circle, no icon (weak color inherited from the trigger)
 .indicator[data-indicator-variant='bullet'] {
 	border-style: dashed;
-	border-color: var( --wpds-color-fg-interactive-neutral-weak );
-	color: var( --wpds-color-fg-interactive-neutral-weak );
 }
 
-// Current: 16px solid gray-900 ring, transparent background + half-circle dome
+// Current: smaller solid ring + half-circle dome (color inherited from the
+// trigger, which reads at full neutral strength for the current step).
 // The margin compensates for the size reduction vs upcoming (size → size-sm)
 // so the indicator centres stay aligned vertically across states.
 .indicator.is-current[data-indicator-variant='bullet'] {
@@ -78,9 +83,6 @@
 	height: var( --a8c-ui-stepper-indicator-size-sm );
 	margin: var( --a8c-ui-stepper-indicator-offset );
 	border-style: solid;
-	border-color: var( --wpds-color-fg-interactive-neutral );
-	background: transparent;
-	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // Completed: 16px, solid border (color inherited from .indicator.is-completed)
@@ -129,22 +131,10 @@
 
 	// Hover/focus use the -active variant of the same neutral tone; WPDS
 	// tokens should not mix tones (no brand color on a neutral control).
+	// The indicator border and glyph follow automatically via currentColor.
 	&:hover:not( [aria-disabled='true'] ),
 	&:focus-visible:not( [aria-disabled='true'] ) {
 		color: var( --wpds-color-fg-interactive-neutral-active );
-
-		// Number-variant current step has a solid filled circle — skip border change
-		// to avoid a ring appearing against the dark background on hover.
-		.indicator:not( .is-current[data-indicator-variant='number'] ) {
-			border-color: var( --wpds-color-fg-interactive-neutral-active );
-		}
-
-		// Pull icon color for completed and current steps (SVG/dome use currentColor).
-		// Number-variant current steps keep their original number color on hover.
-		.indicator.is-completed,
-		.indicator.is-current:not( [data-indicator-variant='number'] ) {
-			color: var( --wpds-color-fg-interactive-neutral-active );
-		}
 	}
 
 	&[aria-disabled='true'] {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -24,11 +24,13 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;
-	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
+	// The indicator is static status content, not an interactive control
+	// (the .trigger button is), so it reads from the content token family.
+	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-content-neutral );
 	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-interactive-neutral );
+	color: var( --wpds-color-fg-content-neutral );
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
@@ -89,19 +91,19 @@
 	border-style: solid;
 }
 
-// Upcoming step titles
+// Upcoming step titles — de-emphasized static content
 [data-indicator-variant] .title {
-	color: var( --wpds-color-fg-interactive-neutral );
+	color: var( --wpds-color-fg-content-neutral-weak );
 }
 
 // Completed step titles — same weight as upcoming but full neutral (not weak)
 [data-indicator-variant] [data-status='completed'] .title {
-	color: var( --wpds-color-fg-interactive-neutral-active );
+	color: var( --wpds-color-fg-content-neutral );
 }
 
 // Current/active step title — full neutral, bold (weight set on the trigger below)
 [data-indicator-variant] [data-current] .title {
-	color: var( --wpds-color-fg-interactive-neutral-active );
+	color: var( --wpds-color-fg-content-neutral );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -16,7 +16,7 @@ type StepperTriggerProps = ComponentProps< 'button' > & {
 export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 	function StepperTrigger( { children, className, ...props }, forwardedRef ) {
 		const { orientation, headingLevel, registerTriggerRef } = useStepperContext();
-		const { value, isCurrent, isDisabled } = useStepContext();
+		const { value, isCurrent, isDisabled, status } = useStepContext();
 
 		// Keep a stable ref to forwardedRef so callbackRef doesn't change
 		// identity when the parent passes an inline callback ref.
@@ -49,6 +49,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 						ref={ callbackRef as Ref< HTMLButtonElement > }
 						render={ <Button variant="minimal" tone="neutral" /> }
 						aria-current={ isCurrent ? 'step' : undefined }
+						data-status={ status }
 						className={ clsx( styles[ 'trigger' ], className ) }
 						{ ...props }
 						onClick={ ( e ) => {
@@ -78,6 +79,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				disabled={ isDisabled }
 				render={ <Button variant="minimal" tone="neutral" /> }
 				aria-current={ isCurrent ? 'step' : undefined }
+				data-status={ status }
 				className={ clsx( styles[ 'trigger' ], className ) }
 				{ ...props }
 			>

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -47,7 +47,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				<Accordion.Header render={ headerElement } className={ styles[ 'trigger-heading' ] }>
 					<Accordion.Trigger
 						ref={ callbackRef as Ref< HTMLButtonElement > }
-						render={ <Button variant="minimal" /> }
+						render={ <Button variant="minimal" tone="neutral" /> }
 						aria-current={ isCurrent ? 'step' : undefined }
 						className={ clsx( styles[ 'trigger' ], className ) }
 						{ ...props }
@@ -76,7 +76,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				ref={ callbackRef as Ref< HTMLButtonElement > }
 				value={ value }
 				disabled={ isDisabled }
-				render={ <Button variant="minimal" /> }
+				render={ <Button variant="minimal" tone="neutral" /> }
 				aria-current={ isCurrent ? 'step' : undefined }
 				className={ clsx( styles[ 'trigger' ], className ) }
 				{ ...props }


### PR DESCRIPTION
Part of #111809

This addresses the review concern on #111809 that the Stepper trigger renders through `@wordpress/ui` `Button` but then overrides enough of Button's styling that using `Button` becomes fragile/pointless.

<img width="1027" height="253" alt="Screenshot 2026-07-20 at 22 42 45" src="https://github.com/user-attachments/assets/d1f6bea0-03ee-40bc-9d9b-fc8a2919d58d" />

## Proposed Changes

The button-first delta (final commit):

* Remove the trigger overrides that duplicated Button's own state styling: hover/focus color, disabled color, disabled cursor, and the completed/current color (which already equals Button's `minimal`/`neutral` rest color).
* Keep the one state Button has no concept of, a step being "upcoming", by feeding Button's own `--wp-ui-button-foreground-color` custom property instead of setting `color`. Button then keeps ownership of hover/focus/active/disabled, reading its `-active`/`-disabled` tokens on its own.
* Let the description inherit the Button's per-state color instead of forcing its own weak color, so it no longer fights disabled/hover/focus states.
* Drop the `background`/`border`/`height` suppression that `horizontal-stepper` duplicated from the base `stepper` trigger (both classes land on the same element via `clsx`).
* Trigger rules that remain are layout/anatomy only (flex arrangement, width, `background: none`/`border: none` so steps read as labels not pills, regular font-weight, active-step bold) and are documented as such.

Earlier commits are the #111809 token-semantics work, included here only so the combined diff reviews in one place.

BaseUI still owns behavior/accessibility: vertical uses `Accordion.Trigger`, horizontal uses `Tabs.Tab`, both rendered as `Button` via the `render` prop. No nested buttons. Keyboard nav, ARIA state, focus handling and `data-disabled` are unchanged.

## Why are these changes being made?

So Button is unambiguously the styling source and the Stepper inherits Button's interactive states, staying aligned as Button evolves rather than re-implementing (and drifting from) them.

## Testing Instructions

* `yarn test-packages packages/ui/src/stepper packages/ui/src/vertical-stepper packages/ui/src/horizontal-stepper` (72/72 pass).
* In Storybook (`packages/ui`), open the Vertical and Horizontal Stepper stories and verify across states:
  * Upcoming steps rest on the muted/weak neutral color; completed and current steps read at full neutral strength.
  * Hover/focus on an enabled step brightens to the active neutral color (now via Button's `:focus`, so a mouse-clicked step shows the active color while focused).
  * Disabled steps use Button's disabled color and are not brightened on hover.
  * Title and description share the step's color; the description is distinguished by size (body-sm vs body-md), no longer by a separate weak color.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
