### PR TITLE
Stepper: style trigger as a custom Tabs-like control, not a Button

### DIFF
--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -20,13 +20,12 @@
 	justify-content: center;
 }
 
-// Background intentionally not suppressed: the minimal neutral Button's own
-// hover/press background is the non-color affordance for interactive states.
 .trigger {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	gap: var( --wpds-dimension-gap-sm );
+	background: none;
 	border: none;
 	padding: var( --wpds-dimension-padding-md );
 	height: auto;

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -20,16 +20,11 @@
 	justify-content: center;
 }
 
+// Orientation-specific layout only; the base .trigger (stepper/style.module.scss)
+// owns the reset, colors, and focus ring.
 .trigger {
-	display: flex;
 	flex-direction: row;
-	align-items: center;
-	gap: var( --wpds-dimension-gap-sm );
-	background: none;
-	border: none;
 	padding: var( --wpds-dimension-padding-md );
-	height: auto;
-	text-align: start;
 }
 
 .panel {

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -63,7 +63,7 @@
 			inset-inline-start: calc( 50% + var( --a8c-ui-stepper-indicator-size ) * 0.5 + var( --wpds-dimension-padding-md ) );
 			inset-inline-end: calc( -50% + var( --a8c-ui-stepper-indicator-size ) * 0.5 + var( --wpds-dimension-padding-md ) );
 			height: var( --wpds-border-width-xs );
-			background-color: var( --wpds-color-stroke-surface-neutral );
+			background-color: var( --wpds-color-stroke-surface-neutral-weak );
 		}
 	}
 

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -20,12 +20,13 @@
 	justify-content: center;
 }
 
+// Background intentionally not suppressed: the minimal neutral Button's own
+// hover/press background is the non-color affordance for interactive states.
 .trigger {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	gap: var( --wpds-dimension-gap-sm );
-	background: none;
 	border: none;
 	padding: var( --wpds-dimension-padding-md );
 	height: auto;

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -24,29 +24,29 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;
-	// The indicator is static status content, not an interactive control
-	// (the .trigger button is), so it reads from the content token family.
-	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-content-neutral );
+	// The indicator is part of the interactive .trigger button, so it reads
+	// from the fg-interactive token family (same as the Tabs component).
+	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
 	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
 // Current step
 .indicator.is-current {
-	border-color: var( --wpds-color-fg-content-neutral );
-	background: var( --wpds-color-fg-content-neutral );
+	border-color: var( --wpds-color-fg-interactive-neutral );
+	background: var( --wpds-color-fg-interactive-neutral );
 	color: var( --wpds-color-bg-surface-neutral-strong );
 	font-weight: 600;
 }
 
 // Completed step
 .indicator.is-completed {
-	border-color: var( --wpds-color-fg-content-neutral-weak );
+	border-color: var( --wpds-color-fg-interactive-neutral-weak );
 	background: transparent;
-	color: var( --wpds-color-fg-content-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 
 	svg {
 		stroke: currentColor;
@@ -66,8 +66,8 @@
 // Upcoming: dashed gray-700 circle, no icon
 .indicator[data-indicator-variant='bullet'] {
 	border-style: dashed;
-	border-color: var( --wpds-color-fg-content-neutral-weak );
-	color: var( --wpds-color-fg-content-neutral-weak );
+	border-color: var( --wpds-color-fg-interactive-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 }
 
 // Current: 16px solid gray-900 ring, transparent background + half-circle dome
@@ -78,9 +78,9 @@
 	height: var( --a8c-ui-stepper-indicator-size-sm );
 	margin: var( --a8c-ui-stepper-indicator-offset );
 	border-style: solid;
-	border-color: var( --wpds-color-fg-content-neutral );
+	border-color: var( --wpds-color-fg-interactive-neutral );
 	background: transparent;
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // Completed: 16px, solid border (color inherited from .indicator.is-completed)
@@ -91,19 +91,19 @@
 	border-style: solid;
 }
 
-// Upcoming step titles — de-emphasized static content
+// Upcoming step titles — de-emphasized (incomplete steps use the weak variant)
 [data-indicator-variant] .title {
-	color: var( --wpds-color-fg-content-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 }
 
 // Completed step titles — same weight as upcoming but full neutral (not weak)
 [data-indicator-variant] [data-status='completed'] .title {
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // Current/active step title — full neutral, bold (weight set on the trigger below)
 [data-indicator-variant] [data-current] .title {
-	color: var( --wpds-color-fg-content-neutral );
+	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // ---------------------------------------------------------------------------
@@ -115,34 +115,39 @@
 	padding: 0;
 }
 
+// The trigger renders as a minimal neutral Button, whose own background
+// (transparent at rest, neutral-weak-active on hover/press/focus) provides the
+// extra, non-color-only affordance for interactive states. Only layout is
+// overridden here; the background is deliberately not suppressed.
 .trigger {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	gap: var( --wpds-dimension-gap-sm );
 	padding: 0;
-	background: none;
 	border: none;
 	height: auto;
 	text-align: start;
 	width: 100%;
 
+	// Hover/focus use the -active variant of the same neutral tone; WPDS
+	// tokens should not mix tones (no brand color on a neutral control).
 	&:hover:not( [aria-disabled='true'] ) {
 		.title {
-			color: var( --wpds-color-fg-interactive-brand );
+			color: var( --wpds-color-fg-interactive-neutral-active );
 		}
 
 		// Number-variant current step has a solid filled circle — skip border change
-		// to avoid an accent ring appearing against the dark background on hover.
+		// to avoid a ring appearing against the dark background on hover.
 		.indicator:not( .is-current[data-indicator-variant='number'] ) {
-			border-color: var( --wpds-color-fg-interactive-brand );
+			border-color: var( --wpds-color-fg-interactive-neutral-active );
 		}
 
 		// Pull icon color for completed and current steps (SVG/dome use currentColor).
 		// Number-variant current steps keep their original number color on hover.
 		.indicator.is-completed,
 		.indicator.is-current:not( [data-indicator-variant='number'] ) {
-			color: var( --wpds-color-fg-interactive-brand );
+			color: var( --wpds-color-fg-interactive-neutral-active );
 		}
 	}
 
@@ -199,6 +204,8 @@
 	font-weight: inherit;
 }
 
+// The description lives inside the interactive trigger, so it uses the weak
+// variant of the same interactive-neutral family as the rest of the trigger.
 .description {
-	color: var( --wpds-color-fg-content-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral-weak );
 }

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -48,12 +48,9 @@
 	color: var( --wpds-color-fg-interactive-neutral-strong );
 }
 
-// Completed step — the indicator is deliberately de-emphasized relative to
-// its title (per the Figma design), using the weak variant of the same
-// interactive-neutral family.
+// Completed step — the check icon and circle inherit the trigger's color,
+// so they always match the title text.
 .indicator.is-completed {
-	color: var( --wpds-color-fg-interactive-neutral-weak );
-
 	svg {
 		stroke: currentColor;
 		stroke-width: 1.5px;
@@ -85,7 +82,7 @@
 	border-style: solid;
 }
 
-// Completed: 16px, solid border (color inherited from .indicator.is-completed)
+// Completed: 16px, solid border (color inherited from the trigger)
 .indicator.is-completed[data-indicator-variant='bullet'] {
 	width: var( --a8c-ui-stepper-indicator-size-sm );
 	height: var( --a8c-ui-stepper-indicator-size-sm );
@@ -115,6 +112,9 @@
 	height: auto;
 	text-align: start;
 	width: 100%;
+	// Rest at regular weight (the Button default is medium); only the active
+	// step's title is bolded via the aria-expanded/aria-selected rule below.
+	font-weight: var( --wpds-typography-font-weight-regular );
 
 	// State text colors are set once here, on the button, and cascade to the
 	// title and description. Step state is read from the button's own

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -39,9 +39,9 @@
 }
 
 // Current step, number variant — solid filled circle. Uses the strong
-// interactive pairing (dark fill, light glyph), like a solid neutral Button.
-// The explicit colors also keep the fill stable on hover, avoiding a ring
-// against the dark background.
+// interactive-neutral pairing (dark fill, light glyph). The explicit colors
+// also keep the fill stable on hover, avoiding a ring against the dark
+// background.
 .indicator.is-current[data-indicator-variant='number'] {
 	border-color: var( --wpds-color-bg-interactive-neutral-strong );
 	background: var( --wpds-color-bg-interactive-neutral-strong );
@@ -99,27 +99,41 @@
 	padding: 0;
 }
 
-// The trigger renders as a minimal neutral Button; its background is
-// suppressed per design (the steps read as plain labels, not pill buttons).
+// The trigger is a custom step-navigation control, not a Button. Base UI's
+// Accordion.Trigger (vertical) and Tabs.Tab (horizontal) render a native
+// <button>; these rules reset that native chrome and re-style it as a
+// tab-like label. Token usage and interaction states mirror the
+// @wordpress/ui Tabs primitive (packages/ui/src/tabs/style.module.css):
+// the steps read as plain labels, not pill buttons.
 .trigger {
+	// Reset native button chrome (the focus ring is drawn on ::after below).
+	appearance: none;
+	margin: 0;
+	padding: 0;
+	border: none;
+	border-radius: 0;
+	background: transparent;
+	box-shadow: none;
+	outline: none;
+
+	// Layout for the indicator + title/description.
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	gap: var( --wpds-dimension-gap-sm );
-	padding: 0;
-	background: none;
-	border: none;
-	height: auto;
-	text-align: start;
 	width: 100%;
-	// Rest at regular weight (the Button default is medium); only the active
-	// step's title is bolded via the aria-expanded/aria-selected rule below.
+	text-align: start;
+
+	// Rest at regular weight (Tabs.Tab is 400 too); only the current step's
+	// title is bolded, via the aria-expanded/aria-selected rule below.
+	cursor: var( --wpds-cursor-control );
 	font-weight: var( --wpds-typography-font-weight-regular );
 
-	// State text colors are set once here, on the button, and cascade to the
-	// title and description. Step state is read from the button's own
-	// attributes (data-status / aria-current / aria-disabled).
-	// Upcoming (incomplete) steps rest on the weak variant.
+	// State text color is set once here, on the button, and cascades to the
+	// title and description via currentColor. All colors stay within the
+	// interactive-neutral family used by Tabs. Upcoming (not yet reached) steps
+	// rest on the weak variant.
 	color: var( --wpds-color-fg-interactive-neutral-weak );
 
 	// Completed and current steps read at full neutral strength.
@@ -128,17 +142,44 @@
 		color: var( --wpds-color-fg-interactive-neutral );
 	}
 
-	// Hover/focus use the -active variant of the same neutral tone; WPDS
-	// tokens should not mix tones (no brand color on a neutral control).
-	// The indicator border and glyph follow automatically via currentColor.
-	&:hover:not( [aria-disabled='true'] ),
-	&:focus-visible:not( [aria-disabled='true'] ) {
+	// Disabled steps stay focusable (Base UI sets focusableWhenDisabled on both
+	// Accordion.Trigger and Tabs.Tab, so they emit data-disabled + aria-disabled
+	// rather than the native attribute).
+	&[data-disabled] {
+		cursor: default;
+		color: var( --wpds-color-fg-interactive-neutral-disabled );
+
+		@media ( forced-colors: active ) {
+			color: GrayText;
+		}
+	}
+
+	// Hover/keyboard focus use the -active variant of the same neutral tone;
+	// the indicator border and glyph follow automatically via currentColor.
+	&:not( [data-disabled] ):is( :hover, :focus-visible ) {
 		color: var( --wpds-color-fg-interactive-neutral-active );
 	}
 
-	&[aria-disabled='true'] {
-		cursor: default;
-		color: var( --wpds-color-fg-interactive-neutral-disabled );
+	// Focus ring drawn on a dedicated ::after box (mirrors Tabs.Tab), so the
+	// native outline reset above does not remove keyboard focus visibility. The
+	// ring is a thin outline at the trigger edge over a transparent background,
+	// so it never covers the label/indicator.
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		border-radius: var( --wpds-border-radius-sm );
+		outline: var( --wpds-border-width-focus ) solid var( --wpds-color-stroke-focus-brand );
+		opacity: 0;
+
+		@media ( prefers-reduced-motion: no-preference ) {
+			transition: opacity 0.1s linear;
+		}
+	}
+
+	&:focus-visible::after {
+		opacity: 1;
 	}
 
 	&[aria-expanded='true'],
@@ -185,8 +226,10 @@
 	font-weight: inherit;
 }
 
-// The description lives inside the interactive trigger, so it uses the weak
-// variant of the same interactive-neutral family as the rest of the trigger.
+// The description lives inside the interactive trigger and stays subordinate
+// to the title, so it uses the weak variant of the same interactive-neutral
+// family (which also keeps it dimmer than the title once a reached step's
+// trigger brightens to the full neutral tone).
 .description {
 	color: var( --wpds-color-fg-interactive-neutral-weak );
 }

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -102,16 +102,15 @@
 	padding: 0;
 }
 
-// The trigger renders as a minimal neutral Button, whose own background
-// (transparent at rest, neutral-weak-active on hover/press/focus) provides the
-// extra, non-color-only affordance for interactive states. Only layout is
-// overridden here; the background is deliberately not suppressed.
+// The trigger renders as a minimal neutral Button; its background is
+// suppressed per design (the steps read as plain labels, not pill buttons).
 .trigger {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	gap: var( --wpds-dimension-gap-sm );
 	padding: 0;
+	background: none;
 	border: none;
 	height: auto;
 	text-align: start;

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -91,21 +91,6 @@
 	border-style: solid;
 }
 
-// Upcoming step titles — de-emphasized (incomplete steps use the weak variant)
-[data-indicator-variant] .title {
-	color: var( --wpds-color-fg-interactive-neutral-weak );
-}
-
-// Completed step titles — same weight as upcoming but full neutral (not weak)
-[data-indicator-variant] [data-status='completed'] .title {
-	color: var( --wpds-color-fg-interactive-neutral );
-}
-
-// Current/active step title — full neutral, bold (weight set on the trigger below)
-[data-indicator-variant] [data-current] .title {
-	color: var( --wpds-color-fg-interactive-neutral );
-}
-
 // ---------------------------------------------------------------------------
 // Trigger
 // ---------------------------------------------------------------------------
@@ -130,12 +115,23 @@
 	text-align: start;
 	width: 100%;
 
+	// State text colors are set once here, on the button, and cascade to the
+	// title and description. Step state is read from the button's own
+	// attributes (data-status / aria-current / aria-disabled).
+	// Upcoming (incomplete) steps rest on the weak variant.
+	color: var( --wpds-color-fg-interactive-neutral-weak );
+
+	// Completed and current steps read at full neutral strength.
+	&[data-status='completed'],
+	&[aria-current='step'] {
+		color: var( --wpds-color-fg-interactive-neutral );
+	}
+
 	// Hover/focus use the -active variant of the same neutral tone; WPDS
 	// tokens should not mix tones (no brand color on a neutral control).
-	&:hover:not( [aria-disabled='true'] ) {
-		.title {
-			color: var( --wpds-color-fg-interactive-neutral-active );
-		}
+	&:hover:not( [aria-disabled='true'] ),
+	&:focus-visible:not( [aria-disabled='true'] ) {
+		color: var( --wpds-color-fg-interactive-neutral-active );
 
 		// Number-variant current step has a solid filled circle — skip border change
 		// to avoid a ring appearing against the dark background on hover.
@@ -153,11 +149,7 @@
 
 	&[aria-disabled='true'] {
 		cursor: default;
-
-		&,
-		.title {
-			color: var( --wpds-color-fg-interactive-neutral-disabled );
-		}
+		color: var( --wpds-color-fg-interactive-neutral-disabled );
 	}
 
 	&[aria-expanded='true'],
@@ -198,8 +190,8 @@
 // Title and Description
 // ---------------------------------------------------------------------------
 
-// Title color is set by the `[data-indicator-variant] … .title` rules above;
-// the root always renders `data-indicator-variant`, so no base color is needed.
+// Title color is inherited from the `.trigger` button, which owns the
+// per-state (upcoming/completed/current/hover/disabled) text colors.
 .title {
 	font-weight: inherit;
 }

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -24,28 +24,34 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;
-	// The indicator is part of the interactive .trigger button, so it reads
-	// from the fg-interactive token family (same as the Tabs component).
-	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
+	// No explicit color or background: the glyph color is inherited from the
+	// .trigger button (which owns the per-state colors), the border reads it
+	// via currentColor, and the background stays transparent.
+	border: var( --wpds-border-width-xs ) solid currentColor;
 	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-interactive-neutral );
-	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
 // Current step
 .indicator.is-current {
-	border-color: var( --wpds-color-fg-interactive-neutral );
-	background: var( --wpds-color-fg-interactive-neutral );
-	color: var( --wpds-color-bg-surface-neutral-strong );
 	font-weight: 600;
 }
 
-// Completed step
+// Current step, number variant — solid filled circle. Uses the strong
+// interactive pairing (dark fill, light glyph), like a solid neutral Button.
+// The explicit colors also keep the fill stable on hover, avoiding a ring
+// against the dark background.
+.indicator.is-current[data-indicator-variant='number'] {
+	border-color: var( --wpds-color-bg-interactive-neutral-strong );
+	background: var( --wpds-color-bg-interactive-neutral-strong );
+	color: var( --wpds-color-fg-interactive-neutral-strong );
+}
+
+// Completed step — the indicator is deliberately de-emphasized relative to
+// its title (per the Figma design), using the weak variant of the same
+// interactive-neutral family.
 .indicator.is-completed {
-	border-color: var( --wpds-color-fg-interactive-neutral-weak );
-	background: transparent;
 	color: var( --wpds-color-fg-interactive-neutral-weak );
 
 	svg {
@@ -63,14 +69,13 @@
 // Bullet indicator variant
 // ---------------------------------------------------------------------------
 
-// Upcoming: dashed gray-700 circle, no icon
+// Upcoming: dashed circle, no icon (weak color inherited from the trigger)
 .indicator[data-indicator-variant='bullet'] {
 	border-style: dashed;
-	border-color: var( --wpds-color-fg-interactive-neutral-weak );
-	color: var( --wpds-color-fg-interactive-neutral-weak );
 }
 
-// Current: 16px solid gray-900 ring, transparent background + half-circle dome
+// Current: smaller solid ring + half-circle dome (color inherited from the
+// trigger, which reads at full neutral strength for the current step).
 // The margin compensates for the size reduction vs upcoming (size → size-sm)
 // so the indicator centres stay aligned vertically across states.
 .indicator.is-current[data-indicator-variant='bullet'] {
@@ -78,9 +83,6 @@
 	height: var( --a8c-ui-stepper-indicator-size-sm );
 	margin: var( --a8c-ui-stepper-indicator-offset );
 	border-style: solid;
-	border-color: var( --wpds-color-fg-interactive-neutral );
-	background: transparent;
-	color: var( --wpds-color-fg-interactive-neutral );
 }
 
 // Completed: 16px, solid border (color inherited from .indicator.is-completed)
@@ -129,22 +131,10 @@
 
 	// Hover/focus use the -active variant of the same neutral tone; WPDS
 	// tokens should not mix tones (no brand color on a neutral control).
+	// The indicator border and glyph follow automatically via currentColor.
 	&:hover:not( [aria-disabled='true'] ),
 	&:focus-visible:not( [aria-disabled='true'] ) {
 		color: var( --wpds-color-fg-interactive-neutral-active );
-
-		// Number-variant current step has a solid filled circle — skip border change
-		// to avoid a ring appearing against the dark background on hover.
-		.indicator:not( .is-current[data-indicator-variant='number'] ) {
-			border-color: var( --wpds-color-fg-interactive-neutral-active );
-		}
-
-		// Pull icon color for completed and current steps (SVG/dome use currentColor).
-		// Number-variant current steps keep their original number color on hover.
-		.indicator.is-completed,
-		.indicator.is-current:not( [data-indicator-variant='number'] ) {
-			color: var( --wpds-color-fg-interactive-neutral-active );
-		}
 	}
 
 	&[aria-disabled='true'] {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -21,6 +21,7 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	box-sizing: border-box;
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -24,11 +24,13 @@
 	width: var( --a8c-ui-stepper-indicator-size );
 	height: var( --a8c-ui-stepper-indicator-size );
 	border-radius: 50%;
-	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-interactive-neutral );
+	// The indicator is static status content, not an interactive control
+	// (the .trigger button is), so it reads from the content token family.
+	border: var( --wpds-border-width-xs ) solid var( --wpds-color-fg-content-neutral );
 	flex-shrink: 0;
 	font-size: var( --wpds-typography-font-size-sm );
 	font-weight: 400;
-	color: var( --wpds-color-fg-interactive-neutral );
+	color: var( --wpds-color-fg-content-neutral );
 	background: var( --wpds-color-bg-surface-neutral-strong );
 }
 
@@ -89,19 +91,19 @@
 	border-style: solid;
 }
 
-// Upcoming step titles
+// Upcoming step titles — de-emphasized static content
 [data-indicator-variant] .title {
-	color: var( --wpds-color-fg-interactive-neutral );
+	color: var( --wpds-color-fg-content-neutral-weak );
 }
 
 // Completed step titles — same weight as upcoming but full neutral (not weak)
 [data-indicator-variant] [data-status='completed'] .title {
-	color: var( --wpds-color-fg-interactive-neutral-active );
+	color: var( --wpds-color-fg-content-neutral );
 }
 
 // Current/active step title — full neutral, bold (weight set on the trigger below)
 [data-indicator-variant] [data-current] .title {
-	color: var( --wpds-color-fg-interactive-neutral-active );
+	color: var( --wpds-color-fg-content-neutral );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -16,7 +16,7 @@ type StepperTriggerProps = ComponentProps< 'button' > & {
 export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 	function StepperTrigger( { children, className, ...props }, forwardedRef ) {
 		const { orientation, headingLevel, registerTriggerRef } = useStepperContext();
-		const { value, isCurrent, isDisabled } = useStepContext();
+		const { value, isCurrent, isDisabled, status } = useStepContext();
 
 		// Keep a stable ref to forwardedRef so callbackRef doesn't change
 		// identity when the parent passes an inline callback ref.
@@ -49,6 +49,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 						ref={ callbackRef as Ref< HTMLButtonElement > }
 						render={ <Button variant="minimal" tone="neutral" /> }
 						aria-current={ isCurrent ? 'step' : undefined }
+						data-status={ status }
 						className={ clsx( styles[ 'trigger' ], className ) }
 						{ ...props }
 						onClick={ ( e ) => {
@@ -78,6 +79,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				disabled={ isDisabled }
 				render={ <Button variant="minimal" tone="neutral" /> }
 				aria-current={ isCurrent ? 'step' : undefined }
+				data-status={ status }
 				className={ clsx( styles[ 'trigger' ], className ) }
 				{ ...props }
 			>

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -47,7 +47,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				<Accordion.Header render={ headerElement } className={ styles[ 'trigger-heading' ] }>
 					<Accordion.Trigger
 						ref={ callbackRef as Ref< HTMLButtonElement > }
-						render={ <Button variant="minimal" /> }
+						render={ <Button variant="minimal" tone="neutral" /> }
 						aria-current={ isCurrent ? 'step' : undefined }
 						className={ clsx( styles[ 'trigger' ], className ) }
 						{ ...props }
@@ -76,7 +76,7 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				ref={ callbackRef as Ref< HTMLButtonElement > }
 				value={ value }
 				disabled={ isDisabled }
-				render={ <Button variant="minimal" /> }
+				render={ <Button variant="minimal" tone="neutral" /> }
 				aria-current={ isCurrent ? 'step' : undefined }
 				className={ clsx( styles[ 'trigger' ], className ) }
 				{ ...props }

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -2,7 +2,6 @@
 import { Accordion } from '@base-ui/react/accordion';
 import { Tabs } from '@base-ui/react/tabs';
 import { createElement, forwardRef, useCallback, useMemo, useRef } from '@wordpress/element';
-import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useStepContext, useStepperContext } from './context';
 import styles from './style.module.scss';
@@ -42,12 +41,15 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 		// Stable reference so Accordion.Header does not remount on every render
 		const headerElement = useMemo( () => createElement( `h${ headingLevel }` ), [ headingLevel ] );
 
+		// Both branches render Base UI's default native <button> (no render prop).
+		// It is styled as a custom step-navigation control modelled on
+		// @wordpress/ui Tabs — see the `.trigger` rules in style.module.scss —
+		// rather than through @wordpress/ui Button.
 		if ( orientation === 'vertical' ) {
 			return (
 				<Accordion.Header render={ headerElement } className={ styles[ 'trigger-heading' ] }>
 					<Accordion.Trigger
 						ref={ callbackRef as Ref< HTMLButtonElement > }
-						render={ <Button variant="minimal" tone="neutral" /> }
 						aria-current={ isCurrent ? 'step' : undefined }
 						data-status={ status }
 						className={ clsx( styles[ 'trigger' ], className ) }
@@ -77,7 +79,6 @@ export const StepperTrigger = forwardRef< HTMLElement, StepperTriggerProps >(
 				ref={ callbackRef as Ref< HTMLButtonElement > }
 				value={ value }
 				disabled={ isDisabled }
-				render={ <Button variant="minimal" tone="neutral" /> }
 				aria-current={ isCurrent ? 'step' : undefined }
 				data-status={ status }
 				className={ clsx( styles[ 'trigger' ], className ) }


### PR DESCRIPTION
<img width="1029" height="258" alt="Screenshot 2026-07-20 at 22 43 23" src="https://github.com/user-attachments/assets/81bdcc83-7089-4fc7-a1d8-a32681b88aca" />

## Proposed Changes

Explores the "custom / Tabs-like" direction for the Stepper trigger raised in review on #111809: stop treating `@wordpress/ui` Button as the styling source and style a custom Base UI trigger after `@wordpress/ui` Tabs, since Stepper behaves more like step/tab navigation than a regular button.

* `stepper/trigger.tsx`: drop the `Button` import and the `render={ <Button variant="minimal" tone="neutral" /> }` prop on both `Accordion.Trigger` (vertical) and `Tabs.Tab` (horizontal). Base UI now renders its default native `<button>`. `className`, ref composition, `aria-current`, `data-status`, `disabled`, and the current-step `preventDefault` click guard are unchanged.
* `stepper/style.module.scss`: reframe `.trigger` as the canonical custom control instead of a Button override. Reset native button chrome, `cursor: var(--wpds-cursor-control)`, and a Tabs-style focus ring drawn on `::after` (opacity 0→1 on `:focus-visible`, using `--wpds-border-width-focus` / `--wpds-color-stroke-focus-brand` / `--wpds-border-radius-sm`) that replaces the focus affordance Button previously provided. Disabled is keyed on `[data-disabled]` to match Tabs (Base UI sets `focusableWhenDisabled` on both primitives). The interactive-neutral state colours are preserved: upcoming weak, completed/current full, hover/focus active, disabled disabled.
* `horizontal-stepper/style.module.scss`: drop the now-redundant Button-reset lines; keep only orientation layout.

## Why are these changes being made?

Follow-up to #111036 and a response to review feedback on #111809: the trigger rendered through Button but then reset enough Button styling that the result was effectively a custom control. Rather than sit between the two, this treats Tabs as the reference implementation and removes Button-specific assumptions from the styling. Selected/current state stays clear via the indicator (fill/check) and the bold current title, matching how Tabs signals selection.

## Testing Instructions

* `yarn test-packages packages/ui/src/stepper packages/ui/src/vertical-stepper packages/ui/src/horizontal-stepper` (72 passing).
* In Storybook (`packages/ui`), open UI/Stepper/Vertical and UI/Stepper/Horizontal stories. Verify: reached steps read dark, upcoming steps and descriptions read weak, disabled steps are dimmed, the current step's title is bold with a filled/dome indicator, tabbing to a step shows a rounded brand focus ring around the whole trigger, and keyboard navigation / arrow keys still work.
* Confirm no `@wordpress/ui` Button chrome remains (steps read as labels, not pill buttons).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
