### PR TITLE
Notifications: add unread accent bar for light-mode contrast (DOTMSD-1321)

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -96,6 +96,11 @@
 
 		.dataviews-view-list__item-wrapper {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+			// DOTMSD-1321: the 0.1 tint alone measures 1.16:1 against read rows,
+			// so unread is hard to spot. Add the accent bar we already draw in dark
+			// mode. 72% (not the open-note bar's solid color below) keeps an open row
+			// ranking above a merely-unread one.
+			box-shadow: inset 3px 0 0 color-mix(in srgb, var(--wp-admin-theme-color) 72%, transparent);
 		}
 	}
 


### PR DESCRIPTION
Part of DOTMSD-1321

## Proposed Changes

* Add an inset 3px left accent bar to unread rows in the notifications panel in light mode. Dark mode already has this bar; this brings the same treatment to light mode.

## Why are these changes being made?

The unread row treatment relies on a background tint at 0.1 alpha of the admin theme color. Measured against a read row, that tint is only 1.16:1, effectively invisible, so unread notifications are hard to tell apart from read ones. This is the top contrast complaint on the redesigned panel.

We already draw this exact accent bar for unread rows in dark mode, so this mirrors it into light mode. It is kept at 72% of the theme color rather than solid, so an open note's solid bar still out-ranks a merely-unread row.

## Testing Instructions

* Build the notifications app and load the panel (or open the bell in the Multi-site Dashboard).
* With a mix of read and unread notifications, confirm unread rows now show a left accent bar and are easy to distinguish from read rows.
* Open a note and confirm its solid accent bar still reads as stronger than a merely-unread row.
* Confirm dark mode is unchanged (it already had the bar).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Before / After

Captured on the live MSD panel (my.wordpress.com) with real notifications — 16 genuinely unread rows. Same panel state in both shots; the only difference is this PR's CSS.

| Before (0.1 tint only, 1.16:1) | After (tint + inset accent bar) |
|---|---|
| <img src="https://raw.githubusercontent.com/adampickering/wp-calypso/assets/dotmsd-1321/screenshots/1321-before.png" width="380" /> | <img src="https://raw.githubusercontent.com/adampickering/wp-calypso/assets/dotmsd-1321/screenshots/1321-after.png" width="380" /> |
