### PR TITLE
Image Studio: track the limit-reached upgrade notice

### DIFF
--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -185,7 +185,7 @@ function ImageStudioAgentChat( {
 
 	const { error: agentError, ...agentUiProps } = agentChatProps;
 
-	useErrorNotice( agentError, addNotice );
+	useErrorNotice( agentError, addNotice, mode );
 
 	const isProcessing = agentChatProps.isProcessing || isAnnotationSaving;
 

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -27,8 +27,10 @@ function InlineNotice( { notice, onDismiss }: { notice: NoticeType; onDismiss?: 
 					onClick: () => {
 						try {
 							action.onClick?.();
-						} catch {
+						} catch ( err ) {
 							// The callback (e.g. tracking) must never block the action URL.
+							// eslint-disable-next-line no-console
+							console.warn( '[ImageStudioNotice] action onClick failed', err );
 						}
 						const newWindow = window.open( action.url, '_blank' );
 						if ( newWindow ) {
@@ -83,8 +85,10 @@ export function ImageStudioNotice() {
 								onClick: () => {
 									try {
 										action.onClick?.();
-									} catch {
+									} catch ( err ) {
 										// The callback (e.g. tracking) must never block the action URL.
+										// eslint-disable-next-line no-console
+										console.warn( '[ImageStudioNotice] action onClick failed', err );
 									}
 									const newWindow = window.open( action.url, '_blank' );
 									if ( newWindow ) {

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -25,6 +25,7 @@ function InlineNotice( { notice, onDismiss }: { notice: NoticeType; onDismiss?: 
 				notice.actions?.map( ( action ) => ( {
 					label: action.label,
 					onClick: () => {
+						action.onClick?.();
 						const newWindow = window.open( action.url, '_blank' );
 						if ( newWindow ) {
 							newWindow.opener = null;
@@ -76,6 +77,7 @@ export function ImageStudioNotice() {
 							actions: notice.actions.map( ( action ) => ( {
 								label: action.label,
 								onClick: () => {
+									action.onClick?.();
 									const newWindow = window.open( action.url, '_blank' );
 									if ( newWindow ) {
 										newWindow.opener = null;

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -25,7 +25,11 @@ function InlineNotice( { notice, onDismiss }: { notice: NoticeType; onDismiss?: 
 				notice.actions?.map( ( action ) => ( {
 					label: action.label,
 					onClick: () => {
-						action.onClick?.();
+						try {
+							action.onClick?.();
+						} catch {
+							// The callback (e.g. tracking) must never block the action URL.
+						}
 						const newWindow = window.open( action.url, '_blank' );
 						if ( newWindow ) {
 							newWindow.opener = null;
@@ -77,7 +81,11 @@ export function ImageStudioNotice() {
 							actions: notice.actions.map( ( action ) => ( {
 								label: action.label,
 								onClick: () => {
-									action.onClick?.();
+									try {
+										action.onClick?.();
+									} catch {
+										// The callback (e.g. tracking) must never block the action URL.
+									}
 									const newWindow = window.open( action.url, '_blank' );
 									if ( newWindow ) {
 										newWindow.opener = null;

--- a/packages/image-studio/src/components/sidebar/editable-field.tsx
+++ b/packages/image-studio/src/components/sidebar/editable-field.tsx
@@ -7,9 +7,9 @@ import { __ } from '@wordpress/i18n';
 import { useAgentConfig } from '../../hooks/use-agent-config';
 import { useErrorNotice } from '../../hooks/use-error-notice';
 import { store as imageStudioStore } from '../../store';
+import { ImageStudioMode, type MetadataField } from '../../types';
 import { defaultAgentConfigFactory } from '../../utils/agent-config';
 import { trackImageStudioGenAIButtonClick } from '../../utils/tracking';
-import type { MetadataField } from '../../types';
 import './editable-field.scss';
 
 interface GenAIButtonProps {
@@ -34,7 +34,8 @@ function GenAIButton( {
 		setProcessing( agentChatProps.isProcessing );
 	}, [ agentChatProps.isProcessing, setProcessing ] );
 
-	useErrorNotice( agentChatProps.error, addNotice );
+	// Metadata fields always operate on an existing attachment.
+	useErrorNotice( agentChatProps.error, addNotice, ImageStudioMode.Edit );
 
 	const handleClick = () => {
 		// Track the GenAI button click

--- a/packages/image-studio/src/hooks/use-error-notice.test.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.test.ts
@@ -8,6 +8,10 @@
  * - Upgrade URLs show persistent warning notice with correct label
  */
 import { renderHook } from '@testing-library/react';
+import {
+	trackImageStudioUpgradeNoticeShown,
+	trackImageStudioUpgradeNoticeClick,
+} from '../utils/tracking';
 import { useErrorNotice } from './use-error-notice';
 
 jest.mock( '@wordpress/element', () => ( {
@@ -18,11 +22,17 @@ jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str: string ) => str,
 } ) );
 
+jest.mock( '../utils/tracking', () => ( {
+	trackImageStudioUpgradeNoticeShown: jest.fn(),
+	trackImageStudioUpgradeNoticeClick: jest.fn(),
+} ) );
+
 describe( 'useErrorNotice', () => {
 	let mockAddNotice: jest.Mock;
 
 	beforeEach( () => {
 		mockAddNotice = jest.fn();
+		jest.clearAllMocks();
 	} );
 
 	describe( 'no error', () => {
@@ -121,6 +131,7 @@ describe( 'useErrorNotice', () => {
 					label: 'See plans',
 					url: 'https://wordpress.com/plans/example.com',
 					openInNewTab: true,
+					onClick: expect.any( Function ),
 				},
 			] );
 		} );
@@ -135,6 +146,7 @@ describe( 'useErrorNotice', () => {
 					label: 'Upgrade plan',
 					url: 'https://wordpress.com/upgrade/premium',
 					openInNewTab: true,
+					onClick: expect.any( Function ),
 				},
 			] );
 		} );
@@ -152,6 +164,7 @@ describe( 'useErrorNotice', () => {
 					label: 'Upgrade plan',
 					url: 'https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
 					openInNewTab: true,
+					onClick: expect.any( Function ),
 				},
 			] );
 		} );
@@ -176,6 +189,7 @@ describe( 'useErrorNotice', () => {
 						label: 'Upgrade plan',
 						url: 'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
 						openInNewTab: true,
+						onClick: expect.any( Function ),
 					},
 				] );
 			} finally {
@@ -202,6 +216,7 @@ describe( 'useErrorNotice', () => {
 						label: 'Upgrade plan',
 						url: 'https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
 						openInNewTab: true,
+						onClick: expect.any( Function ),
 					},
 				]
 			);
@@ -220,6 +235,7 @@ describe( 'useErrorNotice', () => {
 					label: 'See plans',
 					url: 'https://wordpress.com/plans/example.com',
 					openInNewTab: true,
+					onClick: expect.any( Function ),
 				},
 			] );
 		} );
@@ -229,6 +245,45 @@ describe( 'useErrorNotice', () => {
 			renderHook( () => useErrorNotice( error, mockAddNotice ) );
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Custom error object', 'error' );
+		} );
+	} );
+
+	describe( 'upgrade notice tracking', () => {
+		it( 'tracks the notice impression for upgrade URLs', () => {
+			renderHook( () =>
+				useErrorNotice(
+					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+					mockAddNotice
+				)
+			);
+
+			expect( trackImageStudioUpgradeNoticeShown ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'wires the click tracker as the action onClick', () => {
+			renderHook( () =>
+				useErrorNotice(
+					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+					mockAddNotice
+				)
+			);
+
+			const actions = mockAddNotice.mock.calls[ 0 ][ 2 ];
+			expect( actions[ 0 ].onClick ).toBe( trackImageStudioUpgradeNoticeClick );
+		} );
+
+		it( 'does not track impressions for plain errors', () => {
+			renderHook( () => useErrorNotice( 'Something went wrong', mockAddNotice ) );
+
+			expect( trackImageStudioUpgradeNoticeShown ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not track impressions for non-upgrade URL errors', () => {
+			renderHook( () =>
+				useErrorNotice( 'Visit https://jetpack.com/docs for help', mockAddNotice )
+			);
+
+			expect( trackImageStudioUpgradeNoticeShown ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/image-studio/src/hooks/use-error-notice.test.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.test.ts
@@ -8,6 +8,7 @@
  * - Upgrade URLs show persistent warning notice with correct label
  */
 import { renderHook } from '@testing-library/react';
+import { ImageStudioMode } from '../types';
 import {
 	trackImageStudioUpgradeNoticeShown,
 	trackImageStudioUpgradeNoticeClick,
@@ -38,43 +39,51 @@ describe( 'useErrorNotice', () => {
 
 	describe( 'no error', () => {
 		it( 'does not call addNotice when error is null', () => {
-			renderHook( () => useErrorNotice( null, mockAddNotice ) );
+			renderHook( () => useErrorNotice( null, mockAddNotice, ImageStudioMode.Generate ) );
 			expect( mockAddNotice ).not.toHaveBeenCalled();
 		} );
 
 		it( 'does not call addNotice when error is undefined', () => {
-			renderHook( () => useErrorNotice( undefined, mockAddNotice ) );
+			renderHook( () => useErrorNotice( undefined, mockAddNotice, ImageStudioMode.Generate ) );
 			expect( mockAddNotice ).not.toHaveBeenCalled();
 		} );
 
 		it( 'does not call addNotice when error is empty string', () => {
-			renderHook( () => useErrorNotice( '', mockAddNotice ) );
+			renderHook( () => useErrorNotice( '', mockAddNotice, ImageStudioMode.Generate ) );
 			expect( mockAddNotice ).not.toHaveBeenCalled();
 		} );
 	} );
 
 	describe( 'plain errors without URL', () => {
 		it( 'shows error snackbar for plain error message', () => {
-			renderHook( () => useErrorNotice( 'Something went wrong', mockAddNotice ) );
+			renderHook( () =>
+				useErrorNotice( 'Something went wrong', mockAddNotice, ImageStudioMode.Generate )
+			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Something went wrong', 'error' );
 		} );
 
 		it( 'extracts message from Error object', () => {
 			const error = new Error( 'Network failure' );
-			renderHook( () => useErrorNotice( error, mockAddNotice ) );
+			renderHook( () => useErrorNotice( error, mockAddNotice, ImageStudioMode.Generate ) );
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Network failure', 'error' );
 		} );
 
 		it( 'converts non-string errors to string', () => {
-			renderHook( () => useErrorNotice( 42, mockAddNotice ) );
+			renderHook( () => useErrorNotice( 42, mockAddNotice, ImageStudioMode.Generate ) );
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( '42', 'error' );
 		} );
 
 		it( 'strips "Streaming error:" prefix from message', () => {
-			renderHook( () => useErrorNotice( 'Streaming error: Connection lost', mockAddNotice ) );
+			renderHook( () =>
+				useErrorNotice(
+					'Streaming error: Connection lost',
+					mockAddNotice,
+					ImageStudioMode.Generate
+				)
+			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Connection lost', 'error' );
 		} );
@@ -85,7 +94,8 @@ describe( 'useErrorNotice', () => {
 			renderHook( () =>
 				useErrorNotice(
 					'Error occurred. See https://wordpress.com/help for details.',
-					mockAddNotice
+					mockAddNotice,
+					ImageStudioMode.Generate
 				)
 			);
 
@@ -100,7 +110,11 @@ describe( 'useErrorNotice', () => {
 
 		it( 'extracts URL from middle of message', () => {
 			renderHook( () =>
-				useErrorNotice( 'Visit https://jetpack.com/docs for help', mockAddNotice )
+				useErrorNotice(
+					'Visit https://jetpack.com/docs for help',
+					mockAddNotice,
+					ImageStudioMode.Generate
+				)
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Visit for help', 'error', [
@@ -114,7 +128,11 @@ describe( 'useErrorNotice', () => {
 
 		it( 'shows plain error when URL domain is not allowed', () => {
 			renderHook( () =>
-				useErrorNotice( 'Error occurred. See https://example.com/help for details.', mockAddNotice )
+				useErrorNotice(
+					'Error occurred. See https://example.com/help for details.',
+					mockAddNotice,
+					ImageStudioMode.Generate
+				)
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Error occurred. See for details.', 'error' );
@@ -124,7 +142,11 @@ describe( 'useErrorNotice', () => {
 	describe( 'errors with upgrade URLs', () => {
 		it( 'shows warning notice with "See plans" for /plans/ URL', () => {
 			renderHook( () =>
-				useErrorNotice( 'Upgrade required https://wordpress.com/plans/example.com', mockAddNotice )
+				useErrorNotice(
+					'Upgrade required https://wordpress.com/plans/example.com',
+					mockAddNotice,
+					ImageStudioMode.Generate
+				)
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Upgrade required', 'warning', [
@@ -139,7 +161,11 @@ describe( 'useErrorNotice', () => {
 
 		it( 'shows warning notice with "Upgrade plan" for /upgrade URL', () => {
 			renderHook( () =>
-				useErrorNotice( 'Upgrade required https://wordpress.com/upgrade/premium', mockAddNotice )
+				useErrorNotice(
+					'Upgrade required https://wordpress.com/upgrade/premium',
+					mockAddNotice,
+					ImageStudioMode.Generate
+				)
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Upgrade required', 'warning', [
@@ -156,7 +182,8 @@ describe( 'useErrorNotice', () => {
 			renderHook( () =>
 				useErrorNotice(
 					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
-					mockAddNotice
+					mockAddNotice,
+					ImageStudioMode.Generate
 				)
 			);
 
@@ -181,7 +208,8 @@ describe( 'useErrorNotice', () => {
 				renderHook( () =>
 					useErrorNotice(
 						'Please upgrade https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
-						mockAddNotice
+						mockAddNotice,
+						ImageStudioMode.Generate
 					)
 				);
 
@@ -205,7 +233,8 @@ describe( 'useErrorNotice', () => {
 			renderHook( () =>
 				useErrorNotice(
 					'Streaming error: Congratulations on exploring Image Studio and reaching the free requests limit! Upgrade now to keep using it. https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
-					mockAddNotice
+					mockAddNotice,
+					ImageStudioMode.Generate
 				)
 			);
 
@@ -229,7 +258,7 @@ describe( 'useErrorNotice', () => {
 			const error = new Error(
 				'Quota exceeded. Upgrade at https://wordpress.com/plans/example.com'
 			);
-			renderHook( () => useErrorNotice( error, mockAddNotice ) );
+			renderHook( () => useErrorNotice( error, mockAddNotice, ImageStudioMode.Generate ) );
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Quota exceeded. Upgrade at', 'warning', [
 				{
@@ -243,7 +272,7 @@ describe( 'useErrorNotice', () => {
 
 		it( 'handles object with message property', () => {
 			const error = { message: 'Custom error object' };
-			renderHook( () => useErrorNotice( error, mockAddNotice ) );
+			renderHook( () => useErrorNotice( error, mockAddNotice, ImageStudioMode.Generate ) );
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Custom error object', 'error' );
 		} );
@@ -254,39 +283,52 @@ describe( 'useErrorNotice', () => {
 			renderHook( () =>
 				useErrorNotice(
 					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
-					mockAddNotice
+					mockAddNotice,
+					ImageStudioMode.Generate
 				)
 			);
 
 			expect( trackImageStudioUpgradeNoticeShown ).toHaveBeenCalledTimes( 1 );
+			expect( trackImageStudioUpgradeNoticeShown ).toHaveBeenCalledWith( {
+				mode: ImageStudioMode.Generate,
+			} );
 		} );
 
 		it( 'wires the click tracker as the action onClick', () => {
 			renderHook( () =>
 				useErrorNotice(
 					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
-					mockAddNotice
+					mockAddNotice,
+					ImageStudioMode.Generate
 				)
 			);
 
 			const actions = mockAddNotice.mock.calls[ 0 ][ 2 ];
-			expect( actions[ 0 ].onClick ).toBe( trackImageStudioUpgradeNoticeClick );
+			actions[ 0 ].onClick();
+			expect( trackImageStudioUpgradeNoticeClick ).toHaveBeenCalledWith( {
+				mode: ImageStudioMode.Generate,
+			} );
 		} );
 
 		it( 'does not track impressions for plain errors', () => {
-			renderHook( () => useErrorNotice( 'Something went wrong', mockAddNotice ) );
+			renderHook( () =>
+				useErrorNotice( 'Something went wrong', mockAddNotice, ImageStudioMode.Generate )
+			);
 
 			expect( trackImageStudioUpgradeNoticeShown ).not.toHaveBeenCalled();
 		} );
 
 		it( 'tracks one impression per distinct message, not per repeated error', () => {
-			const { rerender } = renderHook( ( { error } ) => useErrorNotice( error, mockAddNotice ), {
-				initialProps: {
-					error: new Error(
-						'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
-					),
-				},
-			} );
+			const { rerender } = renderHook(
+				( { error } ) => useErrorNotice( error, mockAddNotice, ImageStudioMode.Generate ),
+				{
+					initialProps: {
+						error: new Error(
+							'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+						),
+					},
+				}
+			);
 			// A fresh error object with the same message re-runs the effect but,
 			// like the store's content de-dupe, must not count a new impression.
 			rerender( {
@@ -299,13 +341,16 @@ describe( 'useErrorNotice', () => {
 		} );
 
 		it( 'tracks a second impression when the message differs', () => {
-			const { rerender } = renderHook( ( { error } ) => useErrorNotice( error, mockAddNotice ), {
-				initialProps: {
-					error: new Error(
-						'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
-					),
-				},
-			} );
+			const { rerender } = renderHook(
+				( { error } ) => useErrorNotice( error, mockAddNotice, ImageStudioMode.Generate ),
+				{
+					initialProps: {
+						error: new Error(
+							'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+						),
+					},
+				}
+			);
 			rerender( {
 				error: new Error( 'Upgrade required https://wordpress.com/plans/example.com' ),
 			} );
@@ -315,7 +360,11 @@ describe( 'useErrorNotice', () => {
 
 		it( 'does not track impressions for non-upgrade URL errors', () => {
 			renderHook( () =>
-				useErrorNotice( 'Visit https://jetpack.com/docs for help', mockAddNotice )
+				useErrorNotice(
+					'Visit https://jetpack.com/docs for help',
+					mockAddNotice,
+					ImageStudioMode.Generate
+				)
 			);
 
 			expect( trackImageStudioUpgradeNoticeShown ).not.toHaveBeenCalled();

--- a/packages/image-studio/src/hooks/use-error-notice.test.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.test.ts
@@ -15,6 +15,7 @@ import {
 import { useErrorNotice } from './use-error-notice';
 
 jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
 	useEffect: ( fn: () => void ) => fn(),
 } ) );
 
@@ -276,6 +277,40 @@ describe( 'useErrorNotice', () => {
 			renderHook( () => useErrorNotice( 'Something went wrong', mockAddNotice ) );
 
 			expect( trackImageStudioUpgradeNoticeShown ).not.toHaveBeenCalled();
+		} );
+
+		it( 'tracks one impression per distinct message, not per repeated error', () => {
+			const { rerender } = renderHook( ( { error } ) => useErrorNotice( error, mockAddNotice ), {
+				initialProps: {
+					error: new Error(
+						'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+					),
+				},
+			} );
+			// A fresh error object with the same message re-runs the effect but,
+			// like the store's content de-dupe, must not count a new impression.
+			rerender( {
+				error: new Error(
+					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+				),
+			} );
+
+			expect( trackImageStudioUpgradeNoticeShown ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'tracks a second impression when the message differs', () => {
+			const { rerender } = renderHook( ( { error } ) => useErrorNotice( error, mockAddNotice ), {
+				initialProps: {
+					error: new Error(
+						'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+					),
+				},
+			} );
+			rerender( {
+				error: new Error( 'Upgrade required https://wordpress.com/plans/example.com' ),
+			} );
+
+			expect( trackImageStudioUpgradeNoticeShown ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'does not track impressions for non-upgrade URL errors', () => {

--- a/packages/image-studio/src/hooks/use-error-notice.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.ts
@@ -1,6 +1,10 @@
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { parseErrorUrl } from '../utils/parse-error-url';
+import {
+	trackImageStudioUpgradeNoticeShown,
+	trackImageStudioUpgradeNoticeClick,
+} from '../utils/tracking';
 import type { NoticeAction, NoticeType } from '../store';
 
 type AddNoticeFunc = ( content: string, type: NoticeType, actions?: NoticeAction[] ) => void;
@@ -27,6 +31,7 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 
 		if ( url && isUpgradeUrl ) {
 			// Show upgrade notices as persistent warning notices
+			trackImageStudioUpgradeNoticeShown();
 			addNotice( content, 'warning', [
 				{
 					label: isPlansPageUrl
@@ -34,6 +39,7 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 						: __( 'Upgrade plan', __i18n_text_domain__ ),
 					url,
 					openInNewTab: true,
+					onClick: trackImageStudioUpgradeNoticeClick,
 				},
 			] );
 		} else if ( url ) {

--- a/packages/image-studio/src/hooks/use-error-notice.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.ts
@@ -1,4 +1,4 @@
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { parseErrorUrl } from '../utils/parse-error-url';
 import {
@@ -17,6 +17,10 @@ type AddNoticeFunc = ( content: string, type: NoticeType, actions?: NoticeAction
  * @param addNotice - Function to add a notice to the store
  */
 export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void {
+	// The notice store dedupes by content, so repeated errors with the same
+	// message keep a single visible notice; mirror that here and count one
+	// impression per distinct message rather than one per error.
+	const trackedImpressions = useRef< Set< string > >( new Set() );
 	useEffect( () => {
 		if ( ! error ) {
 			return;
@@ -31,7 +35,10 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 
 		if ( url && isUpgradeUrl ) {
 			// Show upgrade notices as persistent warning notices
-			trackImageStudioUpgradeNoticeShown();
+			if ( ! trackedImpressions.current.has( content ) ) {
+				trackedImpressions.current.add( content );
+				trackImageStudioUpgradeNoticeShown();
+			}
 			addNotice( content, 'warning', [
 				{
 					label: isPlansPageUrl

--- a/packages/image-studio/src/hooks/use-error-notice.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.ts
@@ -6,6 +6,7 @@ import {
 	trackImageStudioUpgradeNoticeClick,
 } from '../utils/tracking';
 import type { NoticeAction, NoticeType } from '../store';
+import type { ImageStudioMode } from '../types';
 
 type AddNoticeFunc = ( content: string, type: NoticeType, actions?: NoticeAction[] ) => void;
 
@@ -15,8 +16,13 @@ type AddNoticeFunc = ( content: string, type: NoticeType, actions?: NoticeAction
  * Upgrade URLs show as persistent warning notices, other errors as snackbars.
  * @param error     - The error to display
  * @param addNotice - Function to add a notice to the store
+ * @param mode      - Image Studio mode ('edit' or 'generate') for tracking
  */
-export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void {
+export function useErrorNotice(
+	error: unknown,
+	addNotice: AddNoticeFunc,
+	mode: ImageStudioMode
+): void {
 	// The notice store dedupes by content, so repeated errors with the same
 	// message keep a single visible notice; mirror that here and count one
 	// impression per distinct message rather than one per error.
@@ -37,7 +43,7 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 			// Show upgrade notices as persistent warning notices
 			if ( ! trackedImpressions.current.has( content ) ) {
 				trackedImpressions.current.add( content );
-				trackImageStudioUpgradeNoticeShown();
+				trackImageStudioUpgradeNoticeShown( { mode } );
 			}
 			addNotice( content, 'warning', [
 				{
@@ -46,7 +52,7 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 						: __( 'Upgrade plan', __i18n_text_domain__ ),
 					url,
 					openInNewTab: true,
-					onClick: trackImageStudioUpgradeNoticeClick,
+					onClick: () => trackImageStudioUpgradeNoticeClick( { mode } ),
 				},
 			] );
 		} else if ( url ) {
@@ -62,5 +68,5 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 			// Plain errors show as snackbar
 			addNotice( content, 'error' );
 		}
-	}, [ error, addNotice ] );
+	}, [ error, addNotice, mode ] );
 }

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -32,6 +32,7 @@ export interface NoticeAction {
 	label: string;
 	url: string;
 	openInNewTab?: boolean;
+	onClick?: () => void;
 }
 export interface Notice {
 	id: string;

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -495,6 +495,25 @@ export function trackImageStudioError( {
 }
 
 /**
+ * Tracks when the limit-reached upgrade notice is shown
+ */
+export function trackImageStudioUpgradeNoticeShown(): void {
+	recordImageStudioEvent( 'image_studio_upgrade_notice_shown' );
+}
+
+/**
+ * Tracks a click on the upgrade notice action. Also fires the product-wide
+ * `jetpack_ai_upgrade_button` event so this surface appears in the same
+ * funnel as every other Jetpack AI upgrade button.
+ */
+export function trackImageStudioUpgradeNoticeClick(): void {
+	recordImageStudioEvent( 'image_studio_upgrade_notice_click' );
+	recordTracksEventBase( 'jetpack_ai_upgrade_button', {
+		placement: 'image-studio-limit-notice',
+	} );
+}
+
+/**
  * Tracks when a user provides thumbs up/down feedback on an image
  * @param options              - Tracking options
  * @param options.feedback     - User's feedback (up or down)

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -496,18 +496,22 @@ export function trackImageStudioError( {
 
 /**
  * Tracks when the limit-reached upgrade notice is shown
+ * @param options      - Tracking options
+ * @param options.mode - 'edit' or 'generate'
  */
-export function trackImageStudioUpgradeNoticeShown(): void {
-	recordImageStudioEvent( 'image_studio_upgrade_notice_shown' );
+export function trackImageStudioUpgradeNoticeShown( { mode }: { mode: ImageStudioMode } ): void {
+	recordImageStudioEvent( 'image_studio_upgrade_notice_shown', { mode } );
 }
 
 /**
  * Tracks a click on the upgrade notice action. Also fires the product-wide
  * `jetpack_ai_upgrade_button` event so this surface appears in the same
  * funnel as every other Jetpack AI upgrade button.
+ * @param options      - Tracking options
+ * @param options.mode - 'edit' or 'generate'
  */
-export function trackImageStudioUpgradeNoticeClick(): void {
-	recordImageStudioEvent( 'image_studio_upgrade_notice_click' );
+export function trackImageStudioUpgradeNoticeClick( { mode }: { mode: ImageStudioMode } ): void {
+	recordImageStudioEvent( 'image_studio_upgrade_notice_click', { mode } );
 	recordTracksEventBase( 'jetpack_ai_upgrade_button', {
 		placement: 'image-studio-limit-notice',
 	} );


### PR DESCRIPTION
## Proposed Changes

The upgrade notice Image Studio shows when a user exhausts their free requests was not instrumented: neither the impression nor the click fired any Tracks event, so the conversion path from that notice to checkout was invisible in our funnels.

This PR adds:

- `jetpack_big_sky_image_studio_upgrade_notice_shown` when the limit-reached notice renders (carries the usual Image Studio props: placement/entry point, site type, blog id, is_test).
- `jetpack_big_sky_image_studio_upgrade_notice_click` when the notice's action button is clicked.
- The product-wide `jetpack_ai_upgrade_button` event on the same click, with `placement: image-studio-limit-notice`, following the existing convention that every Jetpack AI upgrade button fires this shared funnel event.

To support this, `NoticeAction` gains an optional `onClick` callback which the notice component invokes before opening the action URL. No behavior change for existing notices.

## Why are these changes being made?

New Jetpack AI purchases increasingly arrive through the checkout destinations this notice links to, but nothing ties those purchases back to the notice itself. Instrumenting the impression and click makes the click-through and conversion measurable instead of inferred.

## Testing Instructions

1. On a test site with Image Studio enabled and the free request limit exhausted (or by forcing an upgrade-URL error), open Image Studio and trigger a generation.
2. When the persistent upgrade notice appears, verify `jetpack_big_sky_image_studio_upgrade_notice_shown` fires (Tracks debugger or network tab).
3. Click the notice's action button and verify both `jetpack_big_sky_image_studio_upgrade_notice_click` and `jetpack_ai_upgrade_button` (with `placement: image-studio-limit-notice`) fire, and the URL still opens in a new tab.
4. Trigger a plain error (no URL) and a non-upgrade URL error, and verify no upgrade-notice events fire.

Unit tests: `yarn test-packages packages/image-studio` (impression/click wiring covered in `use-error-notice.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)