### PR TITLE
Pricing grid redesign: fix alignment of feature descriptions with badges

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
@@ -68,6 +68,22 @@ const PlanFeaturesList = ( {
 			( gridPlan ) => ! isWpcomEnterpriseGridPlan( gridPlan.planSlug )
 		);
 	}, [ renderedGridPlans ] );
+	const featureBadgesBySlug = useMemo( () => {
+		const featureBadges = new Map<
+			string,
+			NonNullable< GridPlan[ 'features' ][ 'wpcomFeatures' ][ number ][ 'badgeText' ] >
+		>();
+
+		plansWithFeatures.forEach( ( { features: { wpcomFeatures, jetpackFeatures } } ) => {
+			[ ...wpcomFeatures, ...jetpackFeatures ].forEach( ( feature ) => {
+				if ( feature.badgeText && ! featureBadges.has( feature.getSlug() ) ) {
+					featureBadges.set( feature.getSlug(), feature.badgeText );
+				}
+			} );
+		} );
+
+		return featureBadges;
+	}, [ plansWithFeatures ] );
 
 	return plansWithFeatures.map(
 		( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
@@ -160,6 +176,7 @@ const PlanFeaturesList = ( {
 						hideUnavailableFeatures={ hideUnavailableFeatures }
 						selectedFeature={ selectedFeature }
 						isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+						featureBadgesBySlug={ featureBadgesBySlug }
 						setActiveTooltipId={ setActiveTooltipId }
 						activeTooltipId={ activeTooltipId }
 					/>
@@ -184,6 +201,7 @@ const PlanFeaturesList = ( {
 								generatedWPComSubdomain={ generatedWPComSubdomain }
 								hideUnavailableFeatures={ hideUnavailableFeatures }
 								isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+								featureBadgesBySlug={ featureBadgesBySlug }
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 							/>

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -503,6 +503,10 @@
 	visibility: hidden;
 }
 
+.plan-features-2023-grid__feature-badge.is-placeholder {
+	visibility: hidden;
+}
+
 .plan-features-2023-grid__content {
 	.plan-features-2023-grid__table-bottom {
 		margin-top: 54px;

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -499,6 +499,10 @@
 	}
 }
 
+.plan-features-2023-grid__item-checkmark.is-placeholder {
+	visibility: hidden;
+}
+
 .plan-features-2023-grid__content {
 	.plan-features-2023-grid__table-bottom {
 		margin-top: 54px;

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -13,6 +13,7 @@ import { usePlansGridContext } from '../grid-context';
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject, DataResponse } from '../types';
+import type { TranslateResult } from 'i18n-calypso';
 
 const SubdomainSuggestion = styled.div`
 	.is-domain-name {
@@ -88,7 +89,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 	isCustomDomainAllowedOnFreePlan?: boolean;
-	featureBadgesBySlug?: Map< string, React.ReactNode >;
+	featureBadgesBySlug?: ReadonlyMap< string, TranslateResult >;
 	activeTooltipId: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 } > = ( {

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -163,9 +163,11 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				return (
 					<div key={ key } className={ divClasses }>
 						<PlanFeaturesItem>
-							{ showFeatureCheckmarks && isFeatureAvailable && (
+							{ showFeatureCheckmarks && (
 								<Gridicon
-									className="plan-features-2023-grid__item-checkmark"
+									className={ clsx( 'plan-features-2023-grid__item-checkmark', {
+										'is-placeholder': ! isFeatureAvailable,
+									} ) }
 									icon="checkmark"
 									size={ 16 }
 									aria-hidden="true"

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -88,6 +88,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 	isCustomDomainAllowedOnFreePlan?: boolean;
+	featureBadgesBySlug?: Map< string, React.ReactNode >;
 	activeTooltipId: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 } > = ( {
@@ -98,6 +99,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	hideUnavailableFeatures,
 	selectedFeature,
 	isCustomDomainAllowedOnFreePlan,
+	featureBadgesBySlug,
 	activeTooltipId,
 	setActiveTooltipId,
 } ) => {
@@ -145,6 +147,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					isCustomDomainFeatureWithPaidDomain && isExperimentVariant;
 				const isFeatureAvailable =
 					isFreePlanAndCustomDomainFeature || currentFeature.availableForCurrentPlan;
+				const placeholderBadgeText = featureBadgesBySlug?.get( featureSlug );
+				const badgeText = currentFeature.badgeText ?? placeholderBadgeText;
 
 				const divClasses = clsx( '', getPlanClass( planSlug ), {
 					'is-last-feature': featureIndex + 1 === features.length,
@@ -211,9 +215,14 @@ const PlanFeatures2023GridFeatures: React.FC< {
 															domainName: paidDomainName,
 														} ) }
 													</span>
-													{ currentFeature.badgeText && (
-														<FeatureBadge className="plan-features-2023-grid__feature-badge">
-															{ currentFeature.badgeText }
+													{ badgeText && (
+														<FeatureBadge
+															className={ clsx( 'plan-features-2023-grid__feature-badge', {
+																'is-placeholder': ! currentFeature.badgeText,
+															} ) }
+															aria-hidden={ currentFeature.badgeText ? undefined : true }
+														>
+															{ badgeText }
 														</FeatureBadge>
 													) }
 												</span>


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-17809

## Proposed Changes

* Fix the alignment of crossed-out feature descriptions.
* Fix line wraps for features with badges across plans which don't have the badges.

**Before the fixes**
<img width="466" height="316" alt="Screenshot 2026-07-10 at 15 24 58" src="https://github.com/user-attachments/assets/9df176d1-d191-4f0b-a847-024baa6261fc" />
**After fixing the checkmarks**
<img width="466" height="316" alt="Screenshot 2026-07-10 at 15 25 23" src="https://github.com/user-attachments/assets/88aefb0f-24f7-49bd-ad98-1a99eee6dff3" />
**After fixing the badges**
<img width="466" height="316" alt="Screenshot 2026-07-10 at 15 49 37" src="https://github.com/user-attachments/assets/80176826-a6c9-4274-b78a-4fcc9f417c35" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to one of the experiment variants and check /setup/onboarding/plans with monthly/yearly intervals.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
