### PR TITLE
Dashboard: open the Help Center for help-center deep links

### DIFF
--- a/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
@@ -6,6 +6,16 @@ import { useHelpCenter } from '../help-center';
 const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' ) );
 
 /**
+ * The `help-center` query param is acted on by `useActionHooks` inside the
+ * `HelpCenter` component itself, so the panel has to be mounted for a deep link
+ * to open it. Mount on load whenever the param is present, and leave it to
+ * `useActionHooks` to decide which values it recognizes.
+ */
+function hasHelpCenterQueryParam() {
+	return new URLSearchParams( window.location.search ).has( 'help-center' );
+}
+
+/**
  * Renders the floating Help Center panel when the omnibar is enabled.
  * The masterbar's help button handles toggling via the shared help center store.
  *
@@ -17,7 +27,7 @@ const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' 
 export default function OmnibarHelpCenter() {
 	const { user } = useAuth();
 	const { isShown, setShowHelpCenter } = useHelpCenter();
-	const [ hasBeenShown, setHasBeenShown ] = useState( false );
+	const [ shouldMount, setShouldMount ] = useState( hasHelpCenterQueryParam );
 
 	const handleClose = useCallback( () => {
 		setShowHelpCenter( false, undefined, true );
@@ -25,12 +35,12 @@ export default function OmnibarHelpCenter() {
 
 	// Latch to true the first time the panel is shown. React will re-render
 	// immediately and discard this render's output.
-	if ( isShown && ! hasBeenShown ) {
-		setHasBeenShown( true );
+	if ( isShown && ! shouldMount ) {
+		setShouldMount( true );
 	}
 
-	// Defer the lazy chunk download until the first time the panel is opened.
-	if ( ! hasBeenShown ) {
+	// Defer the lazy chunk download until the panel is opened or deep-linked to.
+	if ( ! shouldMount ) {
 		return null;
 	}
 

--- a/client/dashboard/app/interim-omnibar/test/omnibar-help-center.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-help-center.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import OmnibarHelpCenter from '../omnibar-help-center';
+
+jest.mock( '@automattic/help-center', () => ( {
+	__esModule: true,
+	default: () => <div role="region" aria-label="Help Center" />,
+} ) );
+
+describe( '<OmnibarHelpCenter />', () => {
+	afterEach( () => {
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	test( 'renders nothing when the Help Center is closed', () => {
+		const { container } = render( <OmnibarHelpCenter /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'mounts the Help Center when the URL asks for it', async () => {
+		window.history.replaceState( {}, '', '/sites?help-center=home' );
+
+		render( <OmnibarHelpCenter /> );
+
+		expect( await screen.findByRole( 'region', { name: 'Help Center' } ) ).toBeVisible();
+	} );
+
+	test( 'mounts the Help Center for every deep link value', async () => {
+		for ( const value of [ 'wapuu', 'subscribe-block', 'happiness-engineer' ] ) {
+			window.history.replaceState( {}, '', `/sites?help-center=${ value }` );
+
+			const { unmount } = render( <OmnibarHelpCenter /> );
+
+			expect( await screen.findByRole( 'region', { name: 'Help Center' } ) ).toBeVisible();
+
+			unmount();
+		}
+	} );
+
+	test( 'ignores unrelated query params', () => {
+		window.history.replaceState( {}, '', '/sites?from=email' );
+
+		const { container } = render( <OmnibarHelpCenter /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
Fixes DOTMSD-1409

## Proposed Changes

* Mount the Help Center panel on page load when the URL carries a `help-center` query param, so deep links like `?help-center=home` open it.

## Why are these changes being made?

* Links such as `/sites?help-center=home` are used in lifecycle and marketing emails. They work on the classic dashboard, but users in the multi-site dashboard rollout are redirected to the new dashboard, where the link silently does nothing.
* The query param is read by a hook that lives *inside* the Help Center component. The classic dashboard mounts that component on every page load, so the hook runs and opens the panel. The new dashboard defers mounting it until the panel is already open, to avoid pulling a large lazy chunk into every page load. The result is a deadlock: the code that opens the Help Center only runs after the Help Center has been opened.
* This will affect a growing share of email clicks as the rollout percentage increases.

## Considerations

Two approaches were viable:

1. **Mount the existing component when the param is present** (this PR). The existing hook then handles the param exactly as it does on the classic dashboard.
2. **Add a dashboard-side hook** that reads the param and opens the panel itself.

The second was rejected. It would duplicate the list of supported param values in a second place, and the dashboard's Help Center wrapper does not expose every action the values need. Worse, once it opened the panel, the component would mount and its own hook would read the still-present param and fire the action a second time.

The first approach keeps a single source of truth for which values mean what, so all four supported values (`home`, `wapuu`, `subscribe-block`, `happiness-engineer`) and their sibling params work with no new per-value code.

Deliberately not enumerating the valid values on the dashboard side: any `help-center` param mounts the panel, and the existing hook decides what to do with it. Enumerating them would silently break the next value someone adds.

### Out of scope

Users bucketed into the unified Agents Manager experience are still unaffected by these deep links. That app never implemented the param, and the legacy Help Center renders nothing for those users. That is a separate, pre-existing gap and is not addressed here.

## Testing Instructions

1. Run `yarn start-dashboard`.
2. Log in and visit `/sites?help-center=home` on the dashboard.
3. The Help Center panel opens, showing "Recommended guides".
4. Visit `/sites?help-center=wapuu`. The Support Assistant chat opens instead.
5. Visit `/sites` with no param. Nothing opens, and the Help Center chunk is not downloaded.
6. On trunk, steps 2-4 open nothing.

Automated coverage is included: the new tests fail without the change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
