### PR TITLE
Dashboard: increase page title spacing and align sidebar menu with content

### DIFF
--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -45,7 +45,9 @@
 	// Headings
 	--dashboard-h1__font-size: 32px;
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: normal;
+	// Fixed so the level-1 heading row is exactly 40px; `normal` renders
+	// Recoleta at ~43.5px, breaking the sidebar/content alignment.
+	--dashboard-h1__line-height: 40px;
 	--dashboard-h1__font-family: Recoleta, Georgia, "Times New Roman", Times, serif;
 
 	// Overview

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -45,9 +45,7 @@
 	// Headings
 	--dashboard-h1__font-size: 32px;
 	--dashboard-h1__font-weight: 400;
-	// Fixed so the level-1 heading row is exactly 40px; `normal` renders
-	// Recoleta at ~43.5px, breaking the sidebar/content alignment.
-	--dashboard-h1__line-height: 40px;
+	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, Georgia, "Times New Roman", Times, serif;
 
 	// Overview

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -30,7 +30,10 @@
 	padding-block-start: $grid-unit-30;
 }
 
+// Aligns the first menu item with the content area below the page title:
+// 24px top + logo button + 24px flex gap + 2px menu focus-ring padding,
+// matching the content column's 24px block padding + 40px level-1 heading
+// row + 24px page gap (88px total).
 .dashboard-responsive-sidebar__logo {
-	padding: $grid-unit-20 $grid-unit-30;
-	border-block-end: 1px solid var( --dashboard-header__border-color );
+	padding: $grid-unit-30 $grid-unit-30 0;
 }

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -32,8 +32,8 @@
 
 // Aligns the first menu item with the content area below the page title:
 // 24px top + logo button + 24px flex gap + 2px menu focus-ring padding,
-// matching the content column's 24px block padding + 40px level-1 heading
-// row + 24px page gap (88px total).
+// matching the content column's rhythm defined on .dashboard-page-layout
+// (block padding + page header row + header-to-content gap, 88px total).
 .dashboard-responsive-sidebar__logo {
 	padding: $grid-unit-30 $grid-unit-30 0;
 }

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -2,6 +2,7 @@ import { useMatches } from '@tanstack/react-router';
 import { isValidElement } from 'react';
 import { SectionHeader } from '../section-header';
 import type { PageHeaderProps } from './types';
+import './style.scss';
 
 const PageTitle = () => {
 	const title = useMatches( {

--- a/client/dashboard/components/page-header/style.scss
+++ b/client/dashboard/components/page-header/style.scss
@@ -1,0 +1,7 @@
+.dashboard-page-header {
+	// Pin the heading row and line-height to the page header row height so
+	// the offset to the content below is deterministic — with `line-height:
+	// normal` some heading fonts render taller than the row.
+	--dashboard-section-header__heading-row-min-height: var( --dashboard-page-header__row-height, 40px );
+	--dashboard-h1__line-height: var( --dashboard-page-header__row-height, 40px );
+}

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -20,7 +20,7 @@ function PageLayout( {
 } ) {
 	return (
 		<VStack
-			spacing={ 6 }
+			spacing="var(--dashboard-page-header__content-gap)"
 			className={ `dashboard-page-layout is-${ size }` }
 			style={ PAGE_LAYOUT_SIZES[ size ] as CSSProperties }
 		>

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -20,7 +20,7 @@ function PageLayout( {
 } ) {
 	return (
 		<VStack
-			spacing={ 3 }
+			spacing={ 6 }
 			className={ `dashboard-page-layout is-${ size }` }
 			style={ PAGE_LAYOUT_SIZES[ size ] as CSSProperties }
 		>

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -3,11 +3,11 @@
 @import '@wordpress/base-styles/mixins';
 
 .dashboard-page-layout {
-	--page-layout-block-padding: #{$grid-unit-20};
+	--page-layout-block-padding: #{$grid-unit-30};
 	--page-layout-inline-padding: #{$grid-unit-20};
 
 	@include break-medium {
-		--page-layout-block-padding: #{$grid-unit-20};
+		--page-layout-block-padding: #{$grid-unit-30};
 		--page-layout-inline-padding: #{$grid-unit-30};
 	}
 

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -3,6 +3,13 @@
 @import '@wordpress/base-styles/mixins';
 
 .dashboard-page-layout {
+	// Page-level rhythm. Together with the block padding these drive the
+	// sidebar/content cross-column alignment: block padding (24px) + page
+	// header row (40px) + header-to-content gap (24px) must equal the
+	// sidebar's offset to its first menu item (88px).
+	--dashboard-page-header__row-height: 40px;
+	--dashboard-page-header__content-gap: #{$grid-unit-30};
+
 	--page-layout-block-padding: #{$grid-unit-30};
 	--page-layout-inline-padding: #{$grid-unit-20};
 

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -10,6 +10,14 @@
 	.dashboard-section-header__heading-row {
 		min-height: 32px;
 	}
+
+	// Level-1 rows take part in the cross-column alignment: page block padding
+	// (24px) + this row (40px) + page gap (24px) must equal the sidebar's
+	// offset to its first menu item, so the first item lines up with the
+	// content below the page title.
+	&.is-level-1 .dashboard-section-header__heading-row {
+		min-height: 40px;
+	}
 }
 
 .dashboard-section-header__heading {

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -8,15 +8,7 @@
 	z-index: 1;
 
 	.dashboard-section-header__heading-row {
-		min-height: 32px;
-	}
-
-	// Level-1 rows take part in the cross-column alignment: page block padding
-	// (24px) + this row (40px) + page gap (24px) must equal the sidebar's
-	// offset to its first menu item, so the first item lines up with the
-	// content below the page title.
-	&.is-level-1 .dashboard-section-header__heading-row {
-		min-height: 40px;
+		min-height: var( --dashboard-section-header__heading-row-min-height, 32px );
 	}
 }
 


### PR DESCRIPTION
Part of DOTMSD-1272

## Proposed Changes

* Remove the divider line under the sidebar logo.
* Increase the page layout block padding from 16px to 24px, and the gap between the page header and the content from 12px to 24px.
* Rebalance the sidebar logo block padding (24px top, 0 bottom) so the first sidebar menu item aligns with the content area below the page title. Both columns now resolve to the same 88px top offset: `24px page padding + 40px heading row + 24px gap` on the content side, and `24px logo padding + 36px logo button + 24px flex gap + 2px menu focus-ring padding` on the sidebar side.

<img width="922" height="366" alt="image" src="https://github.com/user-attachments/assets/c9d9515b-ddcc-4622-a1cd-d8d18a370cbb" />

## Testing Instructions

* Open the Dashboard and go to Sites.
* Check that there is no divider under the logo in the sidebar.
* Check that the page title has 24px above it and 24px between it and the DataViews card.
* Check that the top of the first sidebar item (Sites) aligns with the top of the DataViews card. Repeat on Domains and Emails.
* Resize below the medium breakpoint and confirm the mobile layout still looks correct. 
