### PR TITLE
Stats: fix video summary chart rendering for videos with no plays

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -19,8 +19,9 @@ const isTouch = hasTouch();
  */
 function getYAxisMax( values ) {
 	// Calculate max value in a dataset.
+	// `Math.max()` of an empty dataset is -Infinity, so guard against it too.
 	const max = Math.max.apply( null, values );
-	if ( 0 === max ) {
+	if ( ! Number.isFinite( max ) || max <= 0 ) {
 		return 2;
 	}
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -33,6 +33,11 @@
 	padding: 0;
 	margin-bottom: 10px;
 	overflow-x: auto;
+
+	// Give the summary chart's top y-axis label room from the card edge.
+	&.is-summary-chart {
+		padding-block-start: 16px;
+	}
 }
 // Site sections
 .stats__module-list {

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1636,6 +1636,30 @@ describe( 'utils', () => {
 				expect( normalizers.statsVideo() ).toBeNull();
 			} );
 
+			test( 'should return empty data when the endpoint reports an empty window', () => {
+				// With no rows in the requested window, the endpoint returns a
+				// single object instead of the usual [ date, value ] tuples.
+				expect(
+					normalizers.statsVideo( {
+						data: { date: '7-10', p: '0' },
+						pages: [],
+					} )
+				).toEqual( { pages: [], data: [], post: null } );
+			} );
+
+			test( 'should skip non-tuple entries in the data array', () => {
+				expect(
+					normalizers.statsVideo( {
+						data: [ [ '2016-11-12', 1 ], { date: '7-10', p: '0' } ],
+						pages: [],
+					} )
+				).toEqual( {
+					pages: [],
+					data: [ { period: '2016-11-12', value: 1 } ],
+					post: null,
+				} );
+			} );
+
 			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsVideo( {
@@ -1675,23 +1699,20 @@ describe( 'utils', () => {
 							link: 'http://www.themepremium.com/blog-with-the-speed-of-your-thought-with-the-p2-theme/',
 						},
 					],
+					post: null,
 				} );
 			} );
 
-			test( 'should drop the stub object row returned for videos with no plays', () => {
-				expect(
-					normalizers.statsVideo( {
-						data: [ { date: '7-10', p: '0' } ],
-						pages: [ 'https://vip.wordpress.com/category/themes/' ],
-					} )
-				).toEqual( {
+			test( 'should pass through the attachment post', () => {
+				const post = {
+					ID: 43948,
+					post_title: 'blank-canvas-split-screen',
+					post_date: '2021-02-08 13:53:37',
+				};
+				expect( normalizers.statsVideo( { data: [], pages: [], post } ) ).toEqual( {
+					pages: [],
 					data: [],
-					pages: [
-						{
-							label: 'https://vip.wordpress.com/category/themes/',
-							link: 'https://vip.wordpress.com/category/themes/',
-						},
-					],
+					post,
 				} );
 			} );
 		} );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1677,6 +1677,23 @@ describe( 'utils', () => {
 					],
 				} );
 			} );
+
+			test( 'should drop the stub object row returned for videos with no plays', () => {
+				expect(
+					normalizers.statsVideo( {
+						data: [ { date: '7-10', p: '0' } ],
+						pages: [ 'https://vip.wordpress.com/category/themes/' ],
+					} )
+				).toEqual( {
+					data: [],
+					pages: [
+						{
+							label: 'https://vip.wordpress.com/category/themes/',
+							link: 'https://vip.wordpress.com/category/themes/',
+						},
+					],
+				} );
+			} );
 		} );
 
 		describe( 'statsTopAuthors()', () => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -834,9 +834,9 @@ export const normalizers = {
 		}
 
 		let data = [];
-		if ( payload.data ) {
-			// When a video has no plays for the period, the API returns a stub object
-			// (e.g. `{ date: '7-10', p: '0' }`) instead of a `[ period, value ]` pair.
+		// When the requested window has no rows at all, the endpoint returns a single
+		// `{ date, p }` object instead of the usual `[ date, value ]` tuples.
+		if ( Array.isArray( payload.data ) ) {
 			data = payload.data
 				.filter( ( item ) => Array.isArray( item ) )
 				.map( ( item ) => {
@@ -854,7 +854,9 @@ export const normalizers = {
 			} );
 		}
 
-		return { pages, data };
+		// The endpoint also returns the video's attachment post, which carries
+		// the title and upload date.
+		return { pages, data, post: payload.post ?? null };
 	},
 
 	/**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -835,9 +835,13 @@ export const normalizers = {
 
 		let data = [];
 		if ( payload.data ) {
-			data = payload.data.map( ( item ) => {
-				return { period: item[ 0 ], value: item[ 1 ] };
-			} );
+			// When a video has no plays for the period, the API returns a stub object
+			// (e.g. `{ date: '7-10', p: '0' }`) instead of a `[ period, value ]` pair.
+			data = payload.data
+				.filter( ( item ) => Array.isArray( item ) )
+				.map( ( item ) => {
+					return { period: item[ 0 ], value: item[ 1 ] };
+				} );
 		}
 
 		let pages = [];


### PR DESCRIPTION
## Proposed Changes

* Filter out the stub object rows (e.g. `{ date: '7-10', p: '0' }`) that the stats API returns for periods with no plays in the `statsVideo` normalizer, keeping only `[ period, value ]` pairs.
* Guard `getYAxisMax()` in the chart component against empty datasets, where `Math.max()` returns `-Infinity`.
* Add a little top padding to the summary chart so the top y-axis label isn't clipped against the card edge.

### Before

<img width="2984" height="1336" alt="Google Chrome -2026-07-10 at 21 20 29@2x" src="https://github.com/user-attachments/assets/60f7bff7-e627-4738-a3e8-6f6f92a00f58" />


### After

<img width="2800" height="782" alt="Google Chrome -2026-07-10 at 21 19 57@2x" src="https://github.com/user-attachments/assets/8800423c-27d8-45da-b594-83edd080bf0d" />


## Why are these changes being made?

* Opening the stats summary page for a video with no plays in the selected period broke the chart: the API returns a stub object instead of a `[ period, value ]` pair for those periods, which produced `undefined` values and a `NaN`/`-Infinity` y-axis, so the chart failed to render correctly.

## Testing Instructions

* Go to Stats → Videos for a site with VideoPress, and open the summary page for a video that has no plays in the selected period (or switch to a period with no plays).
* Before this change the chart rendered broken (NaN y-axis); after, it renders an empty chart with a sane y-axis.
* Also check a video **with** plays to confirm the chart still renders as before.
* Before/after screenshots: _to be added_.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?