### PR TITLE
Reader: fix typo in discover helper comment

### DIFF
--- a/client/reader/discover/helper/index.ts
+++ b/client/reader/discover/helper/index.ts
@@ -6,7 +6,7 @@ export const TAGS_TAB = 'tags';
 
 /**
  * Filters tags data and returns the tags intended to be loaded by the discover pages recommended
- * section. If tags is null, we return an empty array as we have yet to recieve the users followed
+ * section. If tags is null, we return an empty array as we have yet to receive the users followed
  * tags list. If the users followed tags list is empty, we return a default array of tags used to
  * load the feed. Otherwise, load the feed based on the users follwed tags.
  * @param {Array | null} tags Array of tag slugs to evaluate


### PR DESCRIPTION
## Proposed Changes

* Fix a typo in a code comment in `client/reader/discover/helper/index.ts` (`recieve` → `receive`).

## Why are these changes being made?

* Comment-only spelling fix. Also serving as a small test PR to exercise the CI / merge-queue pipeline.

## Testing Instructions

* No behavioral change — comment-only edit. CI green is sufficient.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?