### PR TITLE
Stepper: fix typo in window locale effect comment

### DIFF
--- a/client/landing/stepper/utils/window-locale-effect-manager.tsx
+++ b/client/landing/stepper/utils/window-locale-effect-manager.tsx
@@ -21,7 +21,7 @@ export const WindowLocaleEffectManager: React.FunctionComponent = () => {
 	}, [ lang ] );
 
 	// This line is required to make `isRTL()` work as expected for chunked translations:
-	// The `./bin/build-languages.js` script scans our codebase for calls to __() and puts only the neccessary strings
+	// The `./bin/build-languages.js` script scans our codebase for calls to __() and puts only the necessary strings
 	// in `./public/calypso-strings.pot`. Internally, isRTL() uses the translation for `ltr` to determine the text direction.
 	// But because isRTL is defined in the `@wordpress/i18n` package, our `./bin/build-languages.js` script
 	// does not know to include `ltr` in `./public/calypso-strings.pot`.


### PR DESCRIPTION
## Proposed Changes

* Fix a typo in a code comment in `client/landing/stepper/utils/window-locale-effect-manager.tsx` (`neccessary` → `necessary`).

## Why are these changes being made?

* Comment-only spelling fix. Also serving as a small test PR to exercise the CI / merge-queue pipeline.

## Testing Instructions

* No behavioral change — comment-only edit. CI green is sufficient.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?