### PR TITLE
Jetpack plans: fix typo in purchase-url callback comment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -21,7 +21,7 @@ import type {
 } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 /**
- * build the URL to checkout page for the enviroment and products.
+ * build the URL to checkout page for the environment and products.
  * @param {string} siteSlug Selected site
  * @param {string | string[]} products Slugs of the products to add to the cart
  * @param {QueryArgs} urlQueryArgs Additional query params appended to url (ie. for affiliate tracking, or whatever)


### PR DESCRIPTION
## Proposed Changes

* Fix a typo in a code comment in `client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts` (`enviroment` → `environment`).

## Why are these changes being made?

* Comment-only spelling fix. Also serving as a small test PR to exercise the CI / merge-queue pipeline.

## Testing Instructions

* No behavioral change — comment-only edit. CI green is sufficient.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?