### PR TITLE
calypso-e2e: fix typo in plugins-page comment

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -92,7 +92,7 @@ export class PluginsPage {
 	/**
 	 * Visit a specific page within the Plugins feature at `/plugins/page`.
 	 *
-	 * If optional paramter `site` is specified, this method will
+	 * If optional parameter `site` is specified, this method will
 	 * attempt to load `/plugins/<page>/<site>` endpoint.
 	 *
 	 * @param {string} page Sub-page to visit.


### PR DESCRIPTION
## Proposed Changes

* Fix a typo in a doc comment in `packages/calypso-e2e/src/lib/pages/plugins-page.ts` (`paramter` → `parameter`).

## Why are these changes being made?

* Comment-only spelling fix. Also serving as a small test PR to exercise the CI / merge-queue pipeline.

## Testing Instructions

* No behavioral change — comment-only edit. CI green is sufficient.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?