### PR TITLE
Stats: video details follow-ups — drop the media request, fix hours-watched formatting

### DIFF
--- a/client/my-sites/stats/stats-video-detail/index.tsx
+++ b/client/my-sites/stats/stats-video-detail/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, useMemo } from 'react';
 import titlecase from 'to-title-case';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import {
@@ -7,7 +7,10 @@ import {
 	recordCurrentScreen,
 } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import { useSelector } from 'calypso/state';
-import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+import {
+	getSiteStatsNormalizedData,
+	hasSiteStatsQueryFailed,
+} from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from '../stats-page-view-tracker';
 import VideoDetailsCard from './video-details-card';
@@ -38,13 +41,18 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 	// the statsVideo response — available in both Calypso and Odyssey (the
 	// stats-app proxy forwards stats routes). Mirrors VideoSummary's default
 	// Days/Weeks query, which is always fetched first.
+	const videoInfoQuery = useMemo(
+		() => ( { postId, statType: 'views', period: 'month' } ),
+		[ postId ]
+	);
 	const videoStatsData = useSelector(
 		( state ) =>
-			getSiteStatsNormalizedData( state, siteId, 'statsVideo', {
-				postId,
-				statType: 'views',
-				period: 'month',
-			} ) as { post?: VideoStatsPost | null } | null
+			getSiteStatsNormalizedData( state, siteId, 'statsVideo', videoInfoQuery ) as {
+				post?: VideoStatsPost | null;
+			} | null
+	);
+	const hasVideoInfoFailed = useSelector( ( state ) =>
+		siteId ? hasSiteStatsQueryFailed( state, siteId, 'statsVideo', videoInfoQuery ) : false
 	);
 	const videoStatsPost = videoStatsData?.post ?? null;
 	const breadcrumbTrail = useStatsBreadcrumbTrail();
@@ -66,9 +74,9 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 
 	const videoTitle = videoStatsPost?.post_title || null;
 	const videoDate = videoStatsPost?.post_date || null;
-	// Loading until statsVideo answers; a response without a post means there
-	// is genuinely no title and the card hides.
-	const isVideoInfoLoading = ! videoStatsData;
+	// Loading until statsVideo answers (success or failure); a response
+	// without a post means there is genuinely no title and the card hides.
+	const isVideoInfoLoading = ! videoStatsData && ! hasVideoInfoFailed;
 
 	return (
 		<Main

--- a/client/my-sites/stats/stats-video-detail/index.tsx
+++ b/client/my-sites/stats/stats-video-detail/index.tsx
@@ -1,14 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useLayoutEffect } from 'react';
 import titlecase from 'to-title-case';
-import QueryMedia from 'calypso/components/data/query-media';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import {
 	useStatsBreadcrumbTrail,
 	recordCurrentScreen,
 } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import { useSelector } from 'calypso/state';
-import getMediaItem from 'calypso/state/selectors/get-media-item';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from '../stats-page-view-tracker';
@@ -26,13 +24,6 @@ interface StatsVideoDetailProps {
 	context: {
 		query: Record< string, string >;
 	};
-}
-
-interface VideoMediaItem {
-	title?: string;
-	date?: string;
-	/** Video duration in seconds. */
-	length?: number;
 }
 
 interface VideoStatsPost {
@@ -56,12 +47,6 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 			} ) as { post?: VideoStatsPost | null } | null
 	);
 	const videoStatsPost = videoStatsData?.post ?? null;
-	// The media item is only needed for the video duration (retention rate);
-	// the request 404s harmlessly in Odyssey, where the stats-app proxy has no
-	// media route, and the retention card is simply omitted.
-	const media = useSelector(
-		( state ) => getMediaItem( state, siteId, postId ) as VideoMediaItem | null
-	);
 	const breadcrumbTrail = useStatsBreadcrumbTrail();
 	const statType = context.query.statType ?? null;
 
@@ -79,11 +64,11 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 		} );
 	}, [ context.query, period.period ] );
 
-	const videoTitle = videoStatsPost?.post_title || media?.title || null;
-	const videoDate = videoStatsPost?.post_date || media?.date || null;
-	// Loading = neither source has responded yet; once statsVideo answers, a
-	// missing post means there is genuinely no title and the card hides.
-	const isVideoInfoLoading = ! videoStatsData && ! media;
+	const videoTitle = videoStatsPost?.post_title || null;
+	const videoDate = videoStatsPost?.post_date || null;
+	// Loading until statsVideo answers; a response without a post means there
+	// is genuinely no title and the card hides.
+	const isVideoInfoLoading = ! videoStatsData;
 
 	return (
 		<Main
@@ -100,7 +85,6 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 				path={ `/stats/${ period.period }/videodetails/:site` }
 				title={ `Stats > ${ titlecase( period.period ) } > Videodetails` }
 			/>
-			{ siteId && <QueryMedia siteId={ siteId } mediaId={ postId } /> }
 			<div className="stats stats-summary-view">
 				<div
 					id="my-stats-content"

--- a/client/my-sites/stats/stats-video-detail/video-embeds-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-embeds-card.tsx
@@ -3,7 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useSelector } from 'calypso/state';
-import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+import {
+	getSiteStatsNormalizedData,
+	hasSiteStatsQueryFailed,
+} from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 
@@ -20,10 +23,13 @@ export default function VideoEmbedsCard( { postId }: { postId: number } ) {
 		( state ) =>
 			getSiteStatsNormalizedData( state, siteId, 'statsVideo', query ) as VideoEmbedsData | null
 	);
+	const hasFailed = useSelector( ( state ) =>
+		siteId ? hasSiteStatsQueryFailed( state, siteId, 'statsVideo', query ) : false
+	);
 	// QuerySiteStats defers its initial request, so the requesting flag can be
 	// false on first render; treat missing data as loading to avoid flashing
-	// the empty state.
-	const isLoading = ! data;
+	// the empty state. A failed request ends the loading state.
+	const isLoading = ! data && ! hasFailed;
 
 	const pages = data?.pages ?? [];
 

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -7,6 +7,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
 import {
 	getSiteStatsNormalizedData,
+	hasSiteStatsQueryFailed,
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -133,14 +134,21 @@ export default function VideoSummary( {
 			: false
 	);
 
+	const hasSelectedSeriesFailed = useSelector( ( state ) =>
+		siteId ? hasSiteStatsQueryFailed( state, siteId, 'statsVideo', queries[ statType ] ) : false
+	);
+
 	// QuerySiteStats defers its initial request, so the requesting flag is
 	// still false on the first render after switching windows; treat missing
 	// data as loading too, or the empty state flashes before the fetch starts.
-	const isSelectedSeriesLoaded = !! {
-		views: playsData,
-		impressions: impressionsData,
-		watch_time: watchTimeData,
-	}[ statType ];
+	// A failed request also ends the loading state (empty chart instead of an
+	// infinite placeholder).
+	const isSelectedSeriesLoaded =
+		!! {
+			views: playsData,
+			impressions: impressionsData,
+			watch_time: watchTimeData,
+		}[ statType ] || hasSelectedSeriesFailed;
 
 	// Group the fetched buckets (daily or monthly) into the buckets the UI
 	// period wants, summing values. Bucket keys are normalized ISO dates.

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -247,7 +247,7 @@ class VideoPressStatsModule extends Component {
 										tabIndex="0"
 										role="button"
 									>
-										{ row.watch_time > 1
+										{ row.watch_time === 0 || row.watch_time >= 1
 											? formatNumber( row.watch_time, { decimals: 1 } )
 											: `< ${ formatNumber( 1, { decimals: 1 } ) }` }
 									</span>


### PR DESCRIPTION
Follow-up to #112499.

## Proposed Changes

* **Stop fetching the media item on the video details page.** This commit was pushed to #112499 moments after the squash-merge snapshot was taken, so it never landed on trunk: the media request only remained as a title/date fallback after the retention card was removed, but the `stats/video` response's attachment post is the primary source for both in every environment — while the media request is a guaranteed 404 in Odyssey Stats (the stats-app proxy has no media route) and redundant on Calypso.
* **Fix the Hours Watched formatting on the All videos page grid** (`videopress-stats-module`), per [this #112499 review thread](https://github.com/Automattic/wp-calypso/pull/112499#discussion_r3560443563): `watch_time > 1` rendered both `0` and exactly `1` as `< 1.0` — zero hours reading as "less than one" is misleading. Values of exactly `0` and `>= 1` now render as numbers; `< 1.0` remains only for values strictly between zero and one, matching the video details metric cards.

## Why are these changes being made?

* One stranded commit from #112499's review cycle, and one formatting quirk the review agreed to clean up separately.

## Testing Instructions

* Open a video details page (`/stats/day/videodetails/:site?post=<id>`) with the network tab open — there should be no `/media/<id>` request (previously a v1.2 media request fired, and 404ed in Odyssey Stats); the header card title and published date still render.
* Open Stats → Videos (`/stats/day/videoplays/:site`): a video with zero watch time should show `0.0` (previously `< 1.0`), exactly 1 hour shows `1.0`, a fraction of an hour still shows `< 1.0`, larger values unchanged.

|Before|After|
|-|-|
|<img width="1215" height="121" alt="截圖 2026-07-11 凌晨2 08 17" src="https://github.com/user-attachments/assets/aaefe201-a63d-45dd-a21c-b2c3fa08b8ef" />|<img width="1193" height="121" alt="截圖 2026-07-11 凌晨2 08 23" src="https://github.com/user-attachments/assets/64c257eb-8eff-4c50-83f6-3fd1c611e6f0" />|

#### API response

<img width="226" height="101" alt="截圖 2026-07-11 凌晨2 09 57" src="https://github.com/user-attachments/assets/892781e0-a3a8-46eb-bc99-7cac1d408acf" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)