### PR TITLE
Agents Manager: Allow undocked chat resize

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.79",
+		"@automattic/agenttic-ui": "^0.1.80",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.79",
-		"@automattic/agenttic-ui": "^0.1.79",
+		"@automattic/agenttic-client": "^0.1.80",
+		"@automattic/agenttic-ui": "^0.1.80",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -178,10 +178,11 @@ export default function AgentChat( {
 	onContextCardAction,
 	onContextCardDismiss,
 }: Props ) {
-	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
+	const { setFloatingPosition, setFreeDragPosition, setFloatingSize } =
+		useDispatch( AGENTS_MANAGER_STORE );
 	const conversationViewRef = useRef< HTMLDivElement >( null );
 	const imageUploaderRef = useRef< ImageUploaderHandle >( null );
-	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
+	const { floatingPosition, freeDragPosition, floatingSize } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -272,6 +273,8 @@ export default function AgentChat( {
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
 			initialFreeDragPosition={ freeDragPosition ?? undefined }
 			onFreeDragEnd={ setFreeDragPosition }
+			defaultSize={ floatingSize ?? undefined }
+			onResizeEnd={ setFloatingSize }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ messages }
 			isProcessing={ isProcessing }
@@ -280,6 +283,7 @@ export default function AgentChat( {
 			onSubmit={ onSubmit }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			freeDrag={ ! isDocked }
+			resizable={ ! isDocked }
 			suggestions={ suggestions }
 			clearSuggestions={ clearSuggestions }
 			onSuggestionClick={ onSuggestionClick }

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -38,8 +38,9 @@ export default function AgentHistory( {
 }: Props ) {
 	const { resumeActiveChat } = useAgentsManagerContext();
 
-	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
-	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
+	const { setFloatingPosition, setFreeDragPosition, setFloatingSize } =
+		useDispatch( AGENTS_MANAGER_STORE );
+	const { floatingPosition, freeDragPosition, floatingSize } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -56,6 +57,8 @@ export default function AgentHistory( {
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
 			initialFreeDragPosition={ freeDragPosition ?? undefined }
 			onFreeDragEnd={ setFreeDragPosition }
+			defaultSize={ floatingSize ?? undefined }
+			onResizeEnd={ setFloatingSize }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }
@@ -63,6 +66,7 @@ export default function AgentHistory( {
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			freeDrag={ ! isDocked }
+			resizable={ ! isDocked }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			triggerTitle={ title }
 			onClose={ onClose }

--- a/packages/agents-manager/src/components/sources-display/style.scss
+++ b/packages/agents-manager/src/components/sources-display/style.scss
@@ -5,6 +5,7 @@
 .agents-manager-sources-display {
 	&.card {
 		width: 100%;
+		max-width: unset;
 		display: flex;
 		flex-direction: column;
 		background-color: transparent;

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -38,8 +38,9 @@ export default function SupportGuide( {
 	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
 	const navigate = useNavigate();
 	const { state } = useLocation();
-	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
-	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
+	const { setFloatingPosition, setFreeDragPosition, setFloatingSize } =
+		useDispatch( AGENTS_MANAGER_STORE );
+	const { floatingPosition, freeDragPosition, floatingSize } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -66,6 +67,8 @@ export default function SupportGuide( {
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
 			initialFreeDragPosition={ freeDragPosition ?? undefined }
 			onFreeDragEnd={ setFreeDragPosition }
+			defaultSize={ floatingSize ?? undefined }
+			onResizeEnd={ setFloatingSize }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }
@@ -73,6 +76,7 @@ export default function SupportGuide( {
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			freeDrag={ ! isDocked }
+			resizable={ ! isDocked }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			triggerTitle={ title }
 			onClose={ onClose }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -120,8 +120,9 @@ export default function SupportGuides( {
 	const [ searchInput, setSearchInput, debouncedSearchInput ] = useDebouncedInput(
 		state?.searchQuery ?? ''
 	);
-	const { setFloatingPosition, setFreeDragPosition } = useDispatch( AGENTS_MANAGER_STORE );
-	const { floatingPosition, freeDragPosition } = useSelect( ( select ) => {
+	const { setFloatingPosition, setFreeDragPosition, setFloatingSize } =
+		useDispatch( AGENTS_MANAGER_STORE );
+	const { floatingPosition, freeDragPosition, floatingSize } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
@@ -136,6 +137,8 @@ export default function SupportGuides( {
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
 			initialFreeDragPosition={ freeDragPosition ?? undefined }
 			onFreeDragEnd={ setFreeDragPosition }
+			defaultSize={ floatingSize ?? undefined }
+			onResizeEnd={ setFloatingSize }
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }
@@ -143,6 +146,7 @@ export default function SupportGuides( {
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			freeDrag={ ! isDocked }
+			resizable={ ! isDocked }
 			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			triggerTitle={ title }
 			onClose={ onClose }

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.79",
+		"@automattic/agenttic-client": "^0.1.80",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/data-stores/src/agents-manager/actions.ts
+++ b/packages/data-stores/src/agents-manager/actions.ts
@@ -118,6 +118,18 @@ export function setFreeDragPosition( freeDragPosition: { x: number; y: number } 
 	} as const;
 }
 
+/**
+ * Set the size of the resizable floating panel. Session-scoped —
+ * intentionally not persisted to the backend (unlike floatingPosition); it
+ * survives view switches via the in-memory store but resets on full reload.
+ */
+export function setFloatingSize( floatingSize: { width: number; height: number } | null ) {
+	return {
+		type: 'AGENTS_MANAGER_SET_FLOATING_SIZE',
+		floatingSize,
+	} as const;
+}
+
 export function setLastActivity( lastActivity: PerSiteLastActivity | undefined ) {
 	return {
 		type: 'AGENTS_MANAGER_SET_LAST_ACTIVITY',
@@ -158,6 +170,7 @@ export type AgentsManagerAction =
 	| ReturnType< typeof setHasLoaded >
 	| ReturnType< typeof setIsSplitScreen >
 	| ReturnType< typeof setFreeDragPosition >
+	| ReturnType< typeof setFloatingSize >
 	| GeneratorReturnType< typeof setIsOpen >
 	| GeneratorReturnType< typeof setIsDocked >
 	| GeneratorReturnType< typeof setIsMinimized >

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -87,6 +87,17 @@ const freeDragPosition: Reducer< { x: number; y: number } | null, AgentsManagerA
 	return state;
 };
 
+const floatingSize: Reducer< { width: number; height: number } | null, AgentsManagerAction > = (
+	state = null,
+	action
+) => {
+	switch ( action.type ) {
+		case 'AGENTS_MANAGER_SET_FLOATING_SIZE':
+			return action.floatingSize;
+	}
+	return state;
+};
+
 export const isSplitScreen: Reducer< boolean, AgentsManagerAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_SPLIT_SCREEN':
@@ -110,6 +121,7 @@ const reducer = combineReducers( {
 	hasLoaded,
 	floatingPosition,
 	freeDragPosition,
+	floatingSize,
 	isSplitScreen,
 } );
 

--- a/packages/data-stores/src/agents-manager/selectors.ts
+++ b/packages/data-stores/src/agents-manager/selectors.ts
@@ -10,6 +10,7 @@ export const getAgentsManagerState = ( state: State ) => ( {
 	hasLoaded: state.hasLoaded,
 	floatingPosition: state.floatingPosition,
 	freeDragPosition: state.freeDragPosition,
+	floatingSize: state.floatingSize,
 	isSplitScreen: state.isSplitScreen,
 } );
 export const getIsOpen = ( state: State ) => state.isOpen;
@@ -32,3 +33,4 @@ export const getIsLoading = ( state: State ) => state.isLoading;
 export const getHasLoaded = ( state: State ) => state.hasLoaded;
 export const getFloatingPosition = ( state: State ) => state.floatingPosition;
 export const getFreeDragPosition = ( state: State ) => state.freeDragPosition;
+export const getFloatingSize = ( state: State ) => state.floatingSize;

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.79",
-		"@automattic/agenttic-ui": "^0.1.79",
+		"@automattic/agenttic-client": "^0.1.80",
+		"@automattic/agenttic-ui": "^0.1.80",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.79",
+		"@automattic/agenttic-client": "^0.1.80",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.79",
+		"@automattic/agenttic-ui": "^0.1.80",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.79"
-    "@automattic/agenttic-ui": "npm:^0.1.79"
+    "@automattic/agenttic-client": "npm:^0.1.80"
+    "@automattic/agenttic-ui": "npm:^0.1.80"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,9 +180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.79":
-  version: 0.1.79
-  resolution: "@automattic/agenttic-client@npm:0.1.79"
+"@automattic/agenttic-client@npm:^0.1.80":
+  version: 0.1.80
+  resolution: "@automattic/agenttic-client@npm:0.1.80"
   dependencies:
     "@types/react": "npm:^18.0.0 || ^19.0.0"
     marked: "npm:^16.2.1"
@@ -195,13 +195,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 043a4ec8f0088fadff7023af4c012f5ae9ffb5655846143019d106faccd914dd5bad7ef490fe24317bed2ba65737e48b6523c8ab314d6ae3f3ff53ca43f1ace9
+  checksum: d4563b8c86a122c0e1a97fa7818facea3b101d5aaa6b8fcca8a41b6d0c874d2bf770151fd7ed4fddef24ffd3b2165aed0ca4e3938d48f0a135283f0e1c0934eb
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.79":
-  version: 0.1.79
-  resolution: "@automattic/agenttic-ui@npm:0.1.79"
+"@automattic/agenttic-ui@npm:^0.1.80":
+  version: 0.1.80
+  resolution: "@automattic/agenttic-ui@npm:0.1.80"
   dependencies:
     "@automattic/charts": "npm:^1.10.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -224,7 +224,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 573ce9d379923e72b2d48b341e29aafe33de6ab653af4459d401f9d21b8580821c4710bc7aae6e4fe71f2d7ea504dcd4dbaea92c34b73b1c000425e587f3ef21
+  checksum: 79e7244f760c8ffee08f6817ef8a9e89af74626a951fa1ca76c2077012920ef692b09c33d2d1ac3fffb57f561d69f9ad6db01b88bcb30136c52798ff3ecf5e9b
   languageName: node
   linkType: hard
 
@@ -340,7 +340,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.79"
+    "@automattic/agenttic-client": "npm:^0.1.80"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1476,8 +1476,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.79"
-    "@automattic/agenttic-ui": "npm:^0.1.79"
+    "@automattic/agenttic-client": "npm:^0.1.80"
+    "@automattic/agenttic-ui": "npm:^0.1.80"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1572,7 +1572,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.79"
+    "@automattic/agenttic-client": "npm:^0.1.80"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1839,7 +1839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.79"
+    "@automattic/agenttic-ui": "npm:^0.1.80"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14372,7 +14372,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.79"
+    "@automattic/agenttic-ui": "npm:^0.1.80"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes AI-1046

## Proposed Changes

Enable resizing of the **undocked (floating)** Agents Manager chat and keep the chosen size stable as the user moves between views.

* Enable `resizable` on the floating chat across all four `AgentUI.Container` views so the panel is consistently resizable and consistently sized in every view (docked/embedded is unchanged).
* Persist the size in a new **session-scoped** `floatingSize` field in the `@automattic/data-stores` Agents Manager store (reducer + action + selector), mirroring the existing `freeDragPosition`: it lives in the in-memory store, survives the component remount that happens on a view switch, and resets on a full page reload. It is intentionally **not** written to user preferences.
* Adjust `SourcesDisplay` styles so it renders correctly at wider panel widths.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

AI-1046 — experiment with more flexible undocked chat sizing. The floating chat was fixed-size, which is cramped for richer, component-heavy responses. This lets users resize the undocked panel to fit their work, and makes that size behave like the drag position already does — stable across view switches within a session — so the panel doesn't snap back to its default size every time the view remounts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!IMPORTANT]
> Pairs with Automattic/big-sky-plugin#6129

* Sync this branch with your sandbox
  * `WPCOM_SANDBOX=wordpress yarn dev --sync`
* Open the site editor and undock the AI Cha
* You should now be able to resize the chat while hovering the edges
* Play with the chat sizes and also trigger different flows to check the experience on a wider chat panel
  * `Show me color palettes for my site that are modern`
  *  `Show me new fonts for my site`
  * Try any other prompts you can remeber
* Enable the Unified Experience on https://wordpress.com/wp-admin/profile.php
* Ask a support question like: `How can I add a domain`
* The sources component should appear below the message -- check if it looks good on wider chat panels


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
