### PR TITLE
Pricing grid redesign: update layout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -40,6 +40,13 @@
 		padding: 0;
 	}
 
+	.step-container-v2__content-wrapper.axis-vertical:has(
+		.plans-grid-next.is-plans-grid-redesign-experiment
+			.plan-features-2023-grid__table:is( .has-4-cols, .has-5-cols, .has-6-cols )
+	) {
+		--step-container-v2-content-inline-padding: clamp( 1rem, 2vw, 2rem );
+	}
+
 	// Style the inline `start with a free plan` CTA inside Step.Heading subText
 	// to look like a link instead of a default borderless button. The legacy
 	// <PlansPageSubheader> applied equivalent styles to the same button via its

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -1,5 +1,7 @@
 @import "../../shared";
 
+$redesign-table-cell-max-width: 280px;
+
 .plan-features-2023-grid__header {
 	display: flex;
 	position: relative;
@@ -717,6 +719,26 @@
 		border-radius: 8px;
 		box-shadow: none;
 
+		&.has-1-cols {
+			max-width: $redesign-table-cell-max-width;
+		}
+
+		&.has-2-cols {
+			max-width: $redesign-table-cell-max-width * 2;
+		}
+
+		&.has-3-cols {
+			max-width: $redesign-table-cell-max-width * 3;
+		}
+
+		&.has-4-cols {
+			max-width: $redesign-table-cell-max-width * 4;
+		}
+
+		&.has-5-cols {
+			max-width: $redesign-table-cell-max-width * 5;
+		}
+
 		&.has-highlighted-plan {
 			margin-top: 12px;
 		}
@@ -726,19 +748,38 @@
 		}
 	}
 
+	.plan-features-2023-grid__desktop-view,
+	.plan-features-2023-grid__tablet-view {
+		.plan-features-2023-grid__table-item {
+			max-width: $redesign-table-cell-max-width;
+		}
+	}
+
 	.plan-features-2023-grid__content.has-bottom-plan-card .plan-features-2023-grid__table {
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;
 	}
 
-	&.is-large {
+	&:not(.is-small) {
 		.plan-features-2023-grid__content.has-bottom-plan-card {
+			&.has-1-cols .plans-grid-next-features-grid__bottom-plan-card {
+				max-width: $redesign-table-cell-max-width;
+			}
+
+			&.has-2-cols .plans-grid-next-features-grid__bottom-plan-card {
+				max-width: $redesign-table-cell-max-width * 2;
+			}
+
 			&.has-3-cols .plans-grid-next-features-grid__bottom-plan-card {
-				max-width: $table-cell-max-width * 3;
+				max-width: $redesign-table-cell-max-width * 3;
 			}
 
 			&.has-4-cols .plans-grid-next-features-grid__bottom-plan-card {
-				max-width: $table-cell-max-width * 4;
+				max-width: $redesign-table-cell-max-width * 4;
+			}
+
+			&.has-5-cols .plans-grid-next-features-grid__bottom-plan-card {
+				max-width: $redesign-table-cell-max-width * 5;
 			}
 		}
 	}
@@ -939,13 +980,6 @@
 		color: var( --studio-gray-100 );
 		font-size: 16px;
 		line-height: 20px;
-	}
-
-	.plan-features-2023-grid__table-top,
-	.plan-features-2023-grid__table-bottom {
-		.plan-features-2023-grid__table {
-			max-width: 100%;
-		}
 	}
 
 	.plan-features-2023-grid__table-item {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17848

## Proposed Changes

* Update the max-width for plan column to 280px.
* Reduce the padding on pricing grid to allow more space when 4-6 plans are displayed horizontally.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the design with variants with 6,5,4 plans in variety of viewports.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
