### PR TITLE
Pricing grid redesign: fix colors and position on plan badges on mobile

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -1325,13 +1325,6 @@ $redesign-table-cell-max-width: 280px;
 					width: auto;
 				}
 
-				&.is-premium-plan .plans-grid__plan-pill,
-				&.is-wooexpress-medium-plan .plans-grid__plan-pill {
-					background-color: var( --studio-white );
-					border-color: #e0e0e0;
-					color: var( --studio-gray-100 );
-				}
-
 				&.is-business-plan .plans-grid__plan-pill,
 				&.is-ecommerce-plan .plans-grid__plan-pill {
 					background-color: var( --studio-gray-100 );
@@ -1372,12 +1365,14 @@ $redesign-table-cell-max-width: 280px;
 				}
 			}
 
-			.plan-features-2023-grid__table-item.is-current-plan
-			.plan-features-2023-grid__popular-badge
-			.plans-grid__plan-pill {
-				background-color: var( --color-neutral-0 );
-				border: 1px solid #e0e0e0;
-				color: var( --color-neutral-80 );
+			.plan-features-2023-grid__table-item.is-current-plan {
+				.plan-features-2023-grid__popular-badge {
+					.plans-grid__plan-pill {
+						background-color: var( --color-neutral-0 );
+						border: 1px solid #e0e0e0;
+						color: var( --color-neutral-80 );
+					}
+				}
 			}
 		}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -707,6 +707,27 @@ $redesign-table-cell-max-width: 280px;
 }
 
 .plans-grid-next.is-plans-grid-redesign-experiment {
+	.plan-features-2023-grid__table-item.popular-plan-parent-class {
+		.plan-features-2023-grid__popular-badge {
+			&.is-premium-plan,
+			&.is-wooexpress-medium-plan {
+				.plans-grid__plan-pill {
+					background-color: var(--studio-white);
+					border: 1px solid #e0e0e0;
+					color: var(--studio-gray-100);
+					transform: translate(20px, 0);
+				}
+			}
+
+			&.is-business-plan,
+			&.is-ecommerce-plan {
+				.plans-grid__plan-pill {
+					transform: translate(20px, 0);
+				}
+			}
+		}
+	}
+
 	.plan-features-2023-grid__content,
 	.plan-features-2023-grid__desktop-view,
 	.plan-features-2023-grid__tablet-view {
@@ -1304,7 +1325,15 @@ $redesign-table-cell-max-width: 280px;
 					width: auto;
 				}
 
-				&.is-business-plan .plans-grid__plan-pill {
+				&.is-premium-plan .plans-grid__plan-pill,
+				&.is-wooexpress-medium-plan .plans-grid__plan-pill {
+					background-color: var( --studio-white );
+					border-color: #e0e0e0;
+					color: var( --studio-gray-100 );
+				}
+
+				&.is-business-plan .plans-grid__plan-pill,
+				&.is-ecommerce-plan .plans-grid__plan-pill {
 					background-color: var( --studio-gray-100 );
 					border-color: var( --studio-gray-100 );
 					color: var( --studio-white );
@@ -1333,6 +1362,23 @@ $redesign-table-cell-max-width: 280px;
 		.plans-grid-next-features-grid__mobile-plan-card {
 			border-radius: 8px;
 			padding-block: 24px;
+
+			.plan-features-2023-grid__popular-badge {
+				&.is-premium-plan .plans-grid__plan-pill,
+				&.is-wooexpress-medium-plan .plans-grid__plan-pill {
+					background-color: var( --studio-white );
+					border: 1px solid #e0e0e0;
+					color: var( --studio-gray-100 );
+				}
+			}
+
+			.plan-features-2023-grid__table-item.is-current-plan
+			.plan-features-2023-grid__popular-badge
+			.plans-grid__plan-pill {
+				background-color: var( --color-neutral-0 );
+				border: 1px solid #e0e0e0;
+				color: var( --color-neutral-80 );
+			}
 		}
 
 		.plan-features-2023-grid__header {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17846

## Proposed Changes

* Fix the position of the plan badges on mobile and their colors.

|**Before**|**After**|
|---|---|
|<img width="466" height="755" alt="Screenshot 2026-07-10 at 22 38 15" src="https://github.com/user-attachments/assets/9404107d-3bbc-4723-adc0-f798c016df91" />|<img width="466" height="755" alt="Screenshot 2026-07-10 at 22 38 30" src="https://github.com/user-attachments/assets/be11878d-5794-4e81-bcbb-ec1c8b391d14" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to any of the experiment variants and test the pricing grid on mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
