### PR TITLE
Remove the unreachable start-writing flow-name branches

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,6 +1,5 @@
 import type { Design } from '@automattic/design-picker';
 
-// Changing this? Consider also updating DEFAULT_START_WRITING_THEME so the write *flow* matches the write intent.
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 	slug: 'poema',
 	title: 'Poema',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/test/index.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
@@ -36,6 +35,13 @@ const stepContentProps = {
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
 	useSite: () => mockSite,
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	useLaunchpad: () => ( {
+		data: { checklist_statuses: { first_post_published: true } },
+	} ),
 } ) );
 
 const user = {
@@ -77,11 +83,9 @@ function renderCelebrationScreen( flow ) {
 }
 
 describe( 'The celebration step', () => {
-	describe( `The ${ START_WRITING_FLOW } flow`, () => {
-		const flow = START_WRITING_FLOW;
-
+	describe( 'when the first post is published', () => {
 		it( 'renders correct content and CTAs', () => {
-			renderCelebrationScreen( flow );
+			renderCelebrationScreen( '' );
 
 			expect( screen.getByText( 'Your blog’s ready!' ) ).toBeInTheDocument();
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/test/use-celebration-data.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/test/use-celebration-data.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { renderHook } from '@testing-library/react';
 import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import useCelebrationData from '../use-celebration-data';
@@ -18,14 +17,12 @@ describe( 'The useCelebrationData hook', () => {
 		);
 	} );
 
-	describe( `The ${ START_WRITING_FLOW } flow`, () => {
-		const flow = START_WRITING_FLOW;
-
+	describe( 'when the first post is published', () => {
 		it( 'renders correct texts and links', () => {
 			const { result } = renderHook(
 				() =>
 					useCelebrationData( {
-						flow,
+						isFirstPostPublished: true,
 						siteSlug,
 					} ),
 				{ wrapper }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/use-celebration-data.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/use-celebration-data.tsx
@@ -1,4 +1,3 @@
-import { isStartWritingFlow } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 
 interface Props {
@@ -7,9 +6,8 @@ interface Props {
 	isFirstPostPublished?: boolean;
 }
 
-const useCelebrationData = ( { flow, siteSlug = '', isFirstPostPublished = false }: Props ) => {
+const useCelebrationData = ( { siteSlug = '', isFirstPostPublished = false }: Props ) => {
 	const translate = useTranslate();
-	const isStartWritingFlowOrFirstPostPublished = isStartWritingFlow( flow ) || isFirstPostPublished;
 	const defaultCelebrationData = {
 		dashboardCtaName: 'Go to dashboard',
 		dashboardCtaText: translate( 'Go to dashboard' ),
@@ -19,16 +17,14 @@ const useCelebrationData = ( { flow, siteSlug = '', isFirstPostPublished = false
 	return {
 		...defaultCelebrationData,
 		title: translate( 'Your blog’s ready!' ),
-		subTitle: isStartWritingFlowOrFirstPostPublished
+		subTitle: isFirstPostPublished
 			? translate( 'Now it’s time to connect your social accounts.' )
 			: translate( 'Now it’s time to start posting.' ),
-		primaryCtaName: isStartWritingFlowOrFirstPostPublished
-			? 'Connect to social'
-			: 'Write your first post',
-		primaryCtaText: isStartWritingFlowOrFirstPostPublished
+		primaryCtaName: isFirstPostPublished ? 'Connect to social' : 'Write your first post',
+		primaryCtaText: isFirstPostPublished
 			? translate( 'Connect to social' )
 			: translate( 'Write your first post' ),
-		primaryCtaLink: isStartWritingFlowOrFirstPostPublished
+		primaryCtaLink: isFirstPostPublished
 			? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-social`
 			: `/post/${ siteSlug }`,
 		secondaryCtaName: 'Visit your blog',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -13,7 +13,6 @@ import {
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,
 	isReadymadeFlow,
-	isStartWritingFlow,
 	isWriteOnFlow,
 	isOnboardingFlow,
 	Step,
@@ -49,8 +48,6 @@ import './styles.scss';
 const DEFAULT_SITE_MIGRATION_THEME = 'pub/zoologist';
 const DEFAULT_ENTREPRENEUR_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
-// Changing this? Consider also updating WRITE_INTENT_DEFAULT_DESIGN so the write *intent* matches the write flow
-const DEFAULT_START_WRITING_THEME = 'pub/poema';
 
 function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 	if ( data && ( data as { sourceSlug: string } ).sourceSlug ) {
@@ -153,8 +150,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		theme = DEFAULT_SITE_MIGRATION_THEME;
 	} else if ( isEntrepreneurFlow( flow ) ) {
 		theme = DEFAULT_ENTREPRENEUR_FLOW;
-	} else if ( isStartWritingFlow( flow ) ) {
-		theme = DEFAULT_START_WRITING_THEME;
 	} else if ( isNewsletterFlow( flow ) ) {
 		theme = DEFAULT_NEWSLETTER_THEME;
 	}
@@ -167,7 +162,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	if (
 		isOnboardingFlow( flow ) ||
 		isCopySiteFlow( flow ) ||
-		isStartWritingFlow( flow ) ||
 		isWriteOnFlow( flow ) ||
 		isNewHostedSiteCreationFlow( flow ) ||
 		isReadymadeFlow( flow ) ||
@@ -189,9 +183,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const urlQueryParams = useQuery();
 	const platform = urlQueryParams.get( 'platform' ) || '';
 	const useThemeHeadstart =
-		! isStartWritingFlow( flow ) &&
-		! isNewHostedSiteCreationFlow( flow ) &&
-		! isNewSiteMigrationFlow( flow );
+		! isNewHostedSiteCreationFlow( flow ) && ! isNewSiteMigrationFlow( flow );
 	const shouldGoToCheckout = Boolean( planCartItem );
 	const [ , isSimplifiedOnboarding ] = useSimplifiedOnboarding();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -3,7 +3,6 @@ import {
 	NEWSLETTER_FLOW,
 	BUILD_FLOW,
 	WRITE_FLOW,
-	START_WRITING_FLOW,
 	READYMADE_TEMPLATE_FLOW,
 } from '@automattic/onboarding';
 import SitePreview from '../../components/site-preview';
@@ -19,7 +18,6 @@ const LaunchpadSitePreview = ( { siteSlug, flow }: Props ) => {
 			case NEWSLETTER_FLOW:
 			case BUILD_FLOW:
 			case WRITE_FLOW:
-			case START_WRITING_FLOW:
 			case READYMADE_TEMPLATE_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			default:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -89,10 +89,6 @@ const Sidebar = ( {
 		getConnectUrlForSiteId( state, site?.ID ?? 0 )
 	);
 
-	const showDomain =
-		! isStartWritingFlow( flow ) ||
-		( checklistStatuses?.domain_upsell_deferred === true && selectedDomain );
-
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	const { title, launchTitle, subtitle } = getLaunchpadTranslations( flow, hasSkippedCheckout );
@@ -237,44 +233,42 @@ const Sidebar = ( {
 					{ showLaunchTitle && launchTitle ? launchTitle : title }
 				</h1>
 				<p className="launchpad__sidebar-description">{ subtitle }</p>
-				{ showDomain && (
-					<div className="launchpad__url-box">
-						{ /* Google Chrome is adding an extra space after highlighted text. This extra wrapping div prevents that */ }
-						<div className="launchpad__url-box-domain">
-							<div className="launchpad__url-box-domain-text">{ getDomainName() }</div>
-							{ showClipboardButton && (
-								<>
-									<ClipboardButton
-										aria-label={ translate( 'Copy URL' ) }
-										text={ siteSlug }
-										className="launchpad__clipboard-button"
-										borderless
-										compact
-										onCopy={ () => setClipboardCopied( true ) }
-										onMouseLeave={ () => setClipboardCopied( false ) }
-										ref={ clipboardButtonEl }
-									>
-										<Icon icon={ copy } size={ 18 } />
-									</ClipboardButton>
-									<Tooltip
-										context={ clipboardButtonEl.current }
-										isVisible={ clipboardCopied }
-										position="top"
-									>
-										{ translate( 'Copied to clipboard!' ) }
-									</Tooltip>
-								</>
-							) }
-						</div>
-						{ showDomainUpgradeBadge() && (
-							<a href={ getDomainUpgradeBadgeUrl() }>
-								<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
-									{ translate( 'Pick a custom domain' ) }
-								</Badge>
-							</a>
+				<div className="launchpad__url-box">
+					{ /* Google Chrome is adding an extra space after highlighted text. This extra wrapping div prevents that */ }
+					<div className="launchpad__url-box-domain">
+						<div className="launchpad__url-box-domain-text">{ getDomainName() }</div>
+						{ showClipboardButton && (
+							<>
+								<ClipboardButton
+									aria-label={ translate( 'Copy URL' ) }
+									text={ siteSlug }
+									className="launchpad__clipboard-button"
+									borderless
+									compact
+									onCopy={ () => setClipboardCopied( true ) }
+									onMouseLeave={ () => setClipboardCopied( false ) }
+									ref={ clipboardButtonEl }
+								>
+									<Icon icon={ copy } size={ 18 } />
+								</ClipboardButton>
+								<Tooltip
+									context={ clipboardButtonEl.current }
+									isVisible={ clipboardCopied }
+									position="top"
+								>
+									{ translate( 'Copied to clipboard!' ) }
+								</Tooltip>
+							</>
 						) }
 					</div>
-				) }
+					{ showDomainUpgradeBadge() && (
+						<a href={ getDomainUpgradeBadgeUrl() }>
+							<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
+								{ translate( 'Pick a custom domain' ) }
+							</Badge>
+						</a>
+					) }
+				</div>
 				{ isDomainSSLProcessing && (
 					<div className="launchpad__domain-notification">
 						<div className="launchpad__domain-notification-icon">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,9 +1,7 @@
 import { Task } from '@automattic/launchpad';
-import { isStartWritingFlow } from '@automattic/onboarding';
-import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
-import { getSiteIdOrSlug, isDomainUpsellCompleted } from '../../task-helper';
+import { isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction } from '../../types';
 
 export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => {
@@ -16,14 +14,6 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const getDestionationUrl = () => {
 		if ( ! siteSlug ) {
 			return '';
-		}
-
-		if ( isStartWritingFlow( flow ) ) {
-			return addQueryArgs( `/setup/${ flow }/domains`, {
-				...getSiteIdOrSlug( flow, site, siteSlug ),
-				flowToReturnTo: flow,
-				new: site?.name,
-			} );
 		}
 
 		// Users with a paid non-monthly plan already have a qualifying plan
@@ -56,10 +46,7 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 		...task,
 		completed: domainUpsellCompleted,
 		calypso_path: getDestionationUrl(),
-		badge_text:
-			domainUpsellCompleted || isStartWritingFlow( flow ) || hasPaidNonMonthlyPlan
-				? ''
-				: translate( 'Upgrade plan' ),
+		badge_text: domainUpsellCompleted || hasPaidNonMonthlyPlan ? '' : translate( 'Upgrade plan' ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { getDomainUpSellTask } from '../';
 import { buildSiteDetails, buildTask } from '../../../test/lib/fixtures';
 import { type TaskContext } from '../../../types';
@@ -19,17 +18,6 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, 'flowId', context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path: '/domains/manage/site.wordpress.com',
-		} );
-	} );
-
-	it( 'returns the setup domain page when the flow is blog onboarding', () => {
-		const site = buildSiteDetails( { name: 'site.wordpress.com' } );
-		const context = buildContext( { siteSlug: 'site.wordpress.com', site } );
-
-		expect( getDomainUpSellTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
-			useCalypsoPath: true,
-			calypso_path:
-				'/setup/start-writing/domains?siteId=211078228&flowToReturnTo=start-writing&new=site.wordpress.com',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -1,6 +1,5 @@
 import { Task } from '@automattic/launchpad';
-import { isNewsletterFlow, isStartWritingFlow } from '@automattic/onboarding';
-import { addQueryArgs } from '@wordpress/url';
+import { isNewsletterFlow } from '@automattic/onboarding';
 import { TaskAction } from '../../types';
 
 export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task => {
@@ -9,15 +8,8 @@ export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task =
 
 	return {
 		...task,
-		disabled:
-			mustVerifyEmailBeforePosting ||
-			( task.completed && isStartWritingFlow( flow || null ) ) ||
-			false,
-		calypso_path: ! isStartWritingFlow( flow || null )
-			? task.calypso_path
-			: addQueryArgs( task.calypso_path, {
-					origin: window.location.origin,
-			  } ),
+		disabled: mustVerifyEmailBeforePosting || false,
+		calypso_path: task.calypso_path,
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/test/index.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { getFirstPostPublished } from '../';
 import { buildTask } from '../../../test/lib/fixtures';
 import { type TaskContext } from '../../../types';
@@ -34,16 +34,6 @@ describe( 'getFirstPostPublished', () => {
 
 		expect( getFirstPostPublished( task, NEWSLETTER_FLOW, context ) ).toMatchObject( {
 			disabled: true,
-		} );
-	} );
-
-	it( 'appends an `origin` param to calypso_path when it is a blog onboarding flow', () => {
-		const context = buildContext( {
-			isEmailVerified: false,
-		} );
-
-		expect( getFirstPostPublished( task, START_WRITING_FLOW, context ) ).toMatchObject( {
-			calypso_path: `some-path?origin=${ encodeURIComponent( window.location.origin ) }`,
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -1,5 +1,4 @@
 import { type Task } from '@automattic/launchpad';
-import { isStartWritingFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { getSiteIdOrSlug } from '../../task-helper';
 import { type TaskAction } from '../../types';
@@ -22,7 +21,7 @@ export const getSetupBlogTask: TaskAction = ( task, flow, context ): Task => {
 	return {
 		...task,
 		calypso_path: addQueryArgs( task.calypso_path, { ...getSiteIdOrSlug( flow, site, siteSlug ) } ),
-		disabled: task.completed && ! isStartWritingFlow( flow ),
+		disabled: task.completed,
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -1,45 +1,12 @@
 import { OnboardActions, SiteActions } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
-import { isStartWritingFlow, replaceProductsInCart } from '@automattic/onboarding';
+import { replaceProductsInCart } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { translate } from 'i18n-calypso';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
-import { isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction, TaskContext } from '../../types';
-
-const getCompletedTasks = ( tasks: Task[] ): Record< string, boolean > =>
-	tasks.reduce(
-		( acc, cur ) => ( {
-			...acc,
-			[ cur.id ]: cur.completed,
-		} ),
-		{}
-	);
-
-const getCompletedInfo = ( tasks: Task[], flow: string ): Record< string, boolean > => {
-	const completedTasks = getCompletedTasks( tasks );
-	return {
-		firstPostPublished: completedTasks.first_post_published,
-		planCompleted: completedTasks.plan_completed,
-		setupBlogCompleted: completedTasks.setup_blog || ! isStartWritingFlow( flow ),
-	};
-};
-
-const getIsLaunchSiteTaskDisabled = ( flow: string, context: TaskContext ) => {
-	const { tasks, site, checklistStatuses } = context;
-	const { firstPostPublished, planCompleted, setupBlogCompleted } = getCompletedInfo( tasks, flow );
-
-	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses! );
-
-	if ( isStartWritingFlow( flow ) ) {
-		return ! ( firstPostPublished && planCompleted && domainUpsellCompleted && setupBlogCompleted );
-	}
-
-	return false;
-};
 
 const getOnboardingCartItems = ( context: TaskContext ) => {
 	const { planCartItem, domainCartItem, productCartItems } = context;
@@ -47,18 +14,6 @@ const getOnboardingCartItems = ( context: TaskContext ) => {
 	return [ planCartItem, domainCartItem, ...( productCartItems ?? [] ) ].filter(
 		Boolean
 	) as MinimalRequestCartProduct[];
-};
-
-const getLaunchSiteTaskTitle = ( task: Task, flow: string, context: TaskContext ) => {
-	const { tasks } = context;
-	const onboardingCartItems = getOnboardingCartItems( context );
-	const isSupportedFlow = isStartWritingFlow( flow );
-	const { planCompleted } = getCompletedInfo( tasks, flow );
-	if ( isSupportedFlow && planCompleted && onboardingCartItems.length ) {
-		return translate( 'Checkout and launch' );
-	}
-
-	return task.title;
 };
 
 const completeLaunchSiteTask = async ( task: Task, flow: string, context: TaskContext ) => {
@@ -111,8 +66,8 @@ export const getSiteLaunchedTask: TaskAction = ( task, flow, context ): Task => 
 	return {
 		...task,
 		isLaunchTask: true,
-		title: getLaunchSiteTaskTitle( task, flow, context ),
-		disabled: getIsLaunchSiteTaskDisabled( flow, context ),
+		title: task.title,
+		disabled: false,
 		actionDispatch: () => completeLaunchSiteTask( task, flow, context ),
 		useCalypsoPath: false,
 	};
@@ -122,8 +77,8 @@ export const getBlogLaunchedTask: TaskAction = ( task, flow, context ): Task => 
 	return {
 		...task,
 		isLaunchTask: true,
-		title: getLaunchSiteTaskTitle( task, flow, context ),
-		disabled: getIsLaunchSiteTaskDisabled( flow, context ),
+		title: task.title,
+		disabled: false,
 		actionDispatch: () => completeLaunchSiteTask( task, flow, context ),
 		useCalypsoPath: false,
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/test/index.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { getBlogLaunchedTask, getSiteLaunchedTask } from '../';
 import { buildTask } from '../../../test/lib/fixtures';
 import { type TaskContext } from '../../../types';
@@ -22,15 +21,6 @@ describe( 'getSiteLaunchedTask', () => {
 			useCalypsoPath: false,
 		} );
 	} );
-
-	it( 'returns disabled when is an blog onboarding flow', () => {
-		const siteSlug = 'site.wordpress.com';
-		const context = buildContext( { siteSlug } );
-
-		expect( getSiteLaunchedTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
-			disabled: true,
-		} );
-	} );
 } );
 
 describe( 'getBlogLaunchedTask', () => {
@@ -42,15 +32,6 @@ describe( 'getBlogLaunchedTask', () => {
 
 		expect( getBlogLaunchedTask( task, 'flowId', context ) ).toMatchObject( {
 			useCalypsoPath: false,
-		} );
-	} );
-
-	it( 'returns disabled when is an blog onboarding flow', () => {
-		const siteSlug = 'site.wordpress.com';
-		const context = buildContext( { siteSlug } );
-
-		expect( getBlogLaunchedTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
-			disabled: true,
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/test/index.ts
@@ -53,17 +53,4 @@ describe( 'getEnhancedTasks', () => {
 			} );
 		} );
 	} );
-	describe( 'when checking if the first post is published', () => {
-		describe( 'and the flow is start-writing', () => {
-			it( 'disable the click link so the user will not get distracted going back to the post', () => {
-				const fakeTasks = [ buildTask( { id: 'first_post_published', completed: true } ) ];
-				const enhancedTasks = getEnhancedTasks( {
-					...defaultProps,
-					tasks: fakeTasks,
-					flow: 'start-writing',
-				} );
-				expect( enhancedTasks[ 0 ].disabled ).toEqual( true );
-			} );
-		} );
-	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -1,5 +1,5 @@
 import { type SiteDetails, type ChecklistStatuses } from '@automattic/data-stores';
-import { isStartWritingFlow, isReadymadeFlow } from '@automattic/onboarding';
+import { isReadymadeFlow } from '@automattic/onboarding';
 import { LaunchpadChecklist } from './types';
 
 export function isDomainUpsellCompleted(
@@ -14,9 +14,7 @@ export const getSiteIdOrSlug = (
 	site: SiteDetails | null,
 	siteSlug?: string | null
 ) => {
-	return isStartWritingFlow( flow ) || isReadymadeFlow( flow )
-		? { siteId: site?.ID }
-		: { siteSlug };
+	return isReadymadeFlow( flow ) ? { siteId: site?.ID } : { siteSlug };
 };
 
 /*

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -166,18 +166,6 @@ describe( 'Sidebar', () => {
 		expect( renderedDomain ).toBeVisible();
 	} );
 
-	it( 'start-writing flow does not display the current site url', () => {
-		renderSidebar( {
-			...props,
-			flow: 'start-writing',
-		} );
-
-		const renderedDomain = screen.queryByText( ( content ) =>
-			content.includes( secondAndTopLevelDomain )
-		);
-		expect( renderedDomain ).toBeNull();
-	} );
-
 	it( 'displays customize badge for wpcom domains (free)', () => {
 		renderSidebar( props );
 		expect( screen.getByRole( 'link', { name: upgradeDomainBadgeText } ) ).toHaveAttribute(
@@ -198,7 +186,7 @@ describe( 'Sidebar', () => {
 			name: 'upgradeDomainBadgeText',
 		} );
 
-		expect( upgradeDomainBadgeElement ).not.toBeInTheDocument;
+		expect( upgradeDomainBadgeElement ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not display customize badge for a flow with a redundant domain upsell task', () => {
@@ -214,7 +202,7 @@ describe( 'Sidebar', () => {
 			name: 'upgradeDomainBadgeText',
 		} );
 
-		expect( upgradeDomainBadgeElement ).not.toBeInTheDocument;
+		expect( upgradeDomainBadgeElement ).not.toBeInTheDocument();
 	} );
 
 	it( 'displays a progress bar based off of task completion', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import nock from 'nock';
@@ -32,14 +32,6 @@ const stepContentProps = {
 	goNext: () => {},
 	goToStep: () => {},
 	/* eslint-enable @typescript-eslint/no-empty-function */
-};
-
-// completionStatuses is defined here so we can change it dynamically in tests
-// feel free to add more attributes as needed
-const completionStatuses = {
-	'start-writing': {
-		plan_completed: false,
-	},
 };
 
 jest.mock( '@automattic/data-stores/src/plugins', () => ( {
@@ -139,31 +131,6 @@ jest.mock( '@automattic/data-stores', () => ( {
 						completed: true,
 						disabled: true,
 						title: 'Start writing',
-					},
-				];
-				break;
-
-			case 'start-writing':
-				checklist = [
-					{
-						id: 'first_post_published',
-						completed: false,
-						disabled: false,
-						title: 'Write your first post',
-					},
-					{ id: 'setup_blog', completed: false, disabled: false, title: 'Name your blog' },
-					{ id: 'domain_upsell', completed: false, disabled: false, title: 'Choose a domain' },
-					{
-						id: 'plan_completed',
-						completed: completionStatuses[ 'start-writing' ][ 'plan_completed' ],
-						disabled: false,
-						title: 'Choose a plan',
-					},
-					{
-						id: 'blog_launched',
-						completed: false,
-						disabled: false,
-						title: 'Launch your blog',
 					},
 				];
 				break;
@@ -295,54 +262,6 @@ describe( 'StepContent', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
-		} );
-	} );
-
-	describe( 'when flow is Start writing', () => {
-		beforeEach( () => {
-			mockSite.options.site_intent = START_WRITING_FLOW;
-		} );
-		it( 'renders correct sidebar header content', () => {
-			renderStepContent( false, START_WRITING_FLOW );
-
-			expect( screen.getByText( "Your blog's almost ready!" ) ).toBeInTheDocument();
-			expect(
-				screen.getByText( 'Keep up the momentum with these final steps.' )
-			).toBeInTheDocument();
-		} );
-
-		it( 'renders correct sidebar tasks', () => {
-			renderStepContent( false, START_WRITING_FLOW );
-
-			expect( screen.getByText( 'Write your first post' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Name your blog' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Choose a domain' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Choose a plan' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Launch your blog' ) ).toBeInTheDocument();
-		} );
-
-		it( 'renders correct status for each task', () => {
-			renderStepContent( false, START_WRITING_FLOW );
-
-			const setupBlogListItem = screen.getByText( 'Name your blog' ).closest( 'li' );
-			expect( setupBlogListItem ).toHaveClass( 'pending' );
-
-			const choosePlanListItem = screen.getByText( 'Choose a plan' ).closest( 'li' );
-			expect( choosePlanListItem ).toHaveClass( 'pending' );
-		} );
-
-		it( 'renders web preview section', () => {
-			renderStepContent( false, START_WRITING_FLOW );
-
-			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
-		} );
-
-		it( 'renders correct launch CTA text when plan not free', () => {
-			completionStatuses[ 'start-writing' ][ 'plan_completed' ] = true;
-			renderStepContent( false, START_WRITING_FLOW );
-
-			expect( screen.getByText( 'Checkout and launch' ) ).toBeInTheDocument();
-			completionStatuses[ 'start-writing' ][ 'plan_completed' ] = false;
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -1,9 +1,4 @@
-import {
-	NEWSLETTER_FLOW,
-	WRITE_FLOW,
-	BUILD_FLOW,
-	START_WRITING_FLOW,
-} from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, WRITE_FLOW, BUILD_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
 
@@ -22,11 +17,6 @@ export function getLaunchpadTranslations(
 			translatedStrings.flowName = translate( 'Newsletter' );
 			translatedStrings.title = translate( "Your newsletter's ready!" );
 			translatedStrings.subtitle = translate( 'Now it’s time to let your readers know.' );
-			break;
-		case START_WRITING_FLOW:
-			translatedStrings.flowName = translate( 'Blog' );
-			translatedStrings.title = translate( "Your blog's almost ready!" );
-			translatedStrings.launchTitle = translate( "Your blog's almost ready!" );
 			break;
 		case WRITE_FLOW:
 		case BUILD_FLOW:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -7,8 +7,6 @@ import {
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
-	isStartWritingFlow,
-	START_WRITING_FLOW,
 	READYMADE_TEMPLATE_FLOW,
 	DOMAIN_FLOW,
 	Step,
@@ -88,7 +86,6 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 					actionText: translate( 'Start a new site' ),
 				},
 			];
-		case START_WRITING_FLOW:
 		case READYMADE_TEMPLATE_FLOW:
 			return [
 				{
@@ -174,9 +171,6 @@ const NewOrExistingSiteStep: StepType< { submits: { newExistingSiteChoice: Choic
 		};
 
 		const getHeaderText = () => {
-			if ( isStartWritingFlow( flow ) ) {
-				return translate( 'New or existing site' );
-			}
 			switch ( flow ) {
 				case HUNDRED_YEAR_PLAN_FLOW:
 				case HUNDRED_YEAR_DOMAIN_FLOW:
@@ -242,7 +236,7 @@ const NewOrExistingSiteStep: StepType< { submits: { newExistingSiteChoice: Choic
 				stepName="new-or-existing-site"
 				flowName={ flow }
 				recordTracksEvent={ recordTracksEvent }
-				hideBack={ isStartWritingFlow( flow ) }
+				hideBack={ false }
 			/>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,4 +1,4 @@
-import { isDomainAndPlanFlow, isStartWritingFlow, StepContainer } from '@automattic/onboarding';
+import { isDomainAndPlanFlow, StepContainer } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
@@ -24,7 +24,7 @@ const plans: Step< {
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
 		const providedDependencies = {
 			plan,
-			goToCheckout: isDomainAndPlanFlow( flow ) || isStartWritingFlow( flow ),
+			goToCheckout: isDomainAndPlanFlow( flow ),
 		};
 
 		submit?.( providedDependencies );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -7,7 +7,6 @@ import {
 	NEWSLETTER_FLOW,
 	NEW_HOSTED_SITE_FLOW,
 	isDomainAndPlanFlow,
-	isStartWritingFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -140,7 +139,9 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			( items ) => items.product_slug === PRODUCT_1GB_SPACE
 		);
 
-		cartItemForStorageAddOn && setProductCartItems( [ cartItemForStorageAddOn ] );
+		if ( cartItemForStorageAddOn ) {
+			setProductCartItems( [ cartItemForStorageAddOn ] );
+		}
 		setPlanCartItem( planCartItem );
 		props.onSubmit?.( planCartItem );
 	};
@@ -195,7 +196,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return __( 'Choose the perfect plan' );
 		}
 
-		if ( isNewsletterFlow( flowName ) || isStartWritingFlow( flowName ) ) {
+		if ( isNewsletterFlow( flowName ) ) {
 			return __( "There's a plan for you." );
 		}
 
@@ -211,7 +212,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			<Button onClick={ handleFreePlanButtonClick } className="is-borderless" />
 		);
 
-		if ( isStartWritingFlow( flowName ) || isNewsletterFlow( flowName ) ) {
+		if ( isNewsletterFlow( flowName ) ) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
@@ -1,5 +1,4 @@
-import { SiteDetails } from '@automattic/data-stores';
-import { StepContainer, isStartWritingFlow } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -19,7 +18,7 @@ const SitesChecker: Step< {
 	submits: {
 		filteredSitesCount: number;
 	};
-} > = function SitePicker( { navigation, flow } ) {
+} > = function SitePicker( { navigation } ) {
 	const { __ } = useI18n();
 	const { submit } = navigation;
 	const hasAllSitesFetched = useSelector( hasAllSitesList );
@@ -32,12 +31,7 @@ const SitesChecker: Step< {
 
 	useEffect( () => {
 		if ( hasAllSitesFetched ) {
-			const filteredSites = isStartWritingFlow( flow )
-				? allSites?.filter(
-						( site: SiteDetails | null | undefined ) => site?.launch_status === 'unlaunched'
-				  )
-				: allSites;
-			submit?.( { filteredSitesCount: filteredSites.length } );
+			submit?.( { filteredSitesCount: allSites.length } );
 			return;
 		}
 	}, [ hasAllSitesFetched, allSites ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,5 +1,5 @@
 import { HelpCenter } from '@automattic/data-stores';
-import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
+import { StepContainer, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -198,8 +198,6 @@ const UseMyDomain: StepType< {
 		);
 	};
 
-	const shouldHideButtons = isStartWritingFlow( flow );
-
 	if ( shouldUseStepContainerV2( flow ) ) {
 		let columnWidth;
 		let headingText;
@@ -216,10 +214,6 @@ const UseMyDomain: StepType< {
 		}
 
 		const getTopBarLeftElement = () => {
-			if ( shouldHideButtons ) {
-				return undefined;
-			}
-
 			if ( goBack ) {
 				return <Step.BackButton onClick={ handleGoBack } />;
 			}
@@ -285,7 +279,7 @@ const UseMyDomain: StepType< {
 			<QueryProductsList />
 			<StepContainer
 				stepName="useMyDomain"
-				shouldHideNavButtons={ shouldHideButtons }
+				shouldHideNavButtons={ false }
 				goBack={ handleGoBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }


### PR DESCRIPTION
Fixes # N/A

## Proposed Changes

* Remove every `isStartWritingFlow( flow )` / `START_WRITING_FLOW` branch that keys off the running flow name, across the launchpad task definitions, sidebar, translations, site preview, and the create-site, new-or-existing-site, sites-checker, use-my-domain, plans, and celebration steps. Each collapses to the value it already held for every live flow, so no live behavior changes.
* Update the tests that exercised the removed flow-name behavior. The celebration cases are re-pointed at `isFirstPostPublished`, which now drives that output, rather than dropping the coverage.
* Fix three pre-existing lint errors in files this change already touches: two no-op `.not.toBeInTheDocument` assertions that were missing their call, and a short-circuit expression statement rewritten as an `if`.

Two references are intentionally left in place:

* The launchpad sidebar still calls `isStartWritingFlow` on a site's stored intent (not the flow name), which existing sites can still carry until the backend clears it.
* The `START_WRITING_FLOW` to `plans-blog-onboarding` mappings in the plans steps stay with the intent they produce, to be removed alongside it in a later change.

## Why are these changes being made?

Now that the start-writing flow is unregistered, nothing can supply `start-writing` as a running flow name. Every branch that tested the flow name against it is therefore dead code that collapses to a constant. Removing it trims the special-casing that would otherwise mislead future readers into thinking the flow is still wired up.

## Testing Instructions

This removes unreachable branches without changing behavior for any live flow, so there is nothing new to exercise in the product. To confirm it is safe:

* `yarn test-client client/landing/stepper` passes (99 suites), as do the `@automattic/onboarding` package tests.
* `yarn typecheck-client` and `yarn typecheck-packages` both pass. The client type-check reports only pre-existing errors also present on trunk (`client/dashboard/*` and `client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx`).
* A repo-wide search confirms the only remaining `start-writing` flow references are the two intentional ones above and the shared `START_WRITING_FLOW` / `isStartWritingFlow` definitions.
* Optionally, load a live launchpad flow such as `/setup/write` and confirm the launchpad sidebar, tasks, and celebration screen render as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
