### PR TITLE
Dashboard: track mutation failures with a bumpStat counter

### DIFF
--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -3,7 +3,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useAnalytics } from '../analytics';
 
-// Keep the key's leading string segments; stop at the first non-string, which is a dynamic id.
 function getMutationKeyLabel( key: unknown ): string | undefined {
 	if ( ! Array.isArray( key ) ) {
 		return undefined;
@@ -18,15 +17,6 @@ function getMutationKeyLabel( key: unknown ): string | undefined {
 	return leading.length ? leading.join( ':' ) : undefined;
 }
 
-/**
- * Records a Tracks event for every failed mutation, from the one place they all
- * pass through — the mutation cache. This gives complete coverage of user-facing
- * action failures without per-feature instrumentation.
- *
- * Only stable, categorical fields are emitted (status, error code, mutation key,
- * whether a snackbar was shown). The error message is never sent — it is localized
- * and may contain customer data. `path` is added automatically by the analytics client.
- */
 export default function MutationErrorTracker() {
 	const queryClient = useQueryClient();
 	const { recordTracksEvent } = useAnalytics();

--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -3,9 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useAnalytics } from '../analytics';
 
-// Leading string segments of a mutation key form a stable, low-cardinality label.
-// Dynamic trailing parts (site/blog ids, slugs appended after the constant) are
-// dropped so the label aggregates cleanly and never carries identifying data.
+// Keep the key's leading string segments; stop at the first non-string, which is a dynamic id.
 function mutationKeyLabel( key: unknown ): string | undefined {
 	if ( ! Array.isArray( key ) ) {
 		return undefined;

--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -1,11 +1,11 @@
 import { isWpError } from '@automattic/api-core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import { useAnalytics } from '../analytics';
+import { bumpStat } from '../analytics';
 
-function getMutationKeyLabel( key: unknown ): string | undefined {
+function getMutationKeyLabel( key: unknown ): string {
 	if ( ! Array.isArray( key ) ) {
-		return undefined;
+		return 'unknown';
 	}
 	const leading: string[] = [];
 	for ( const part of key ) {
@@ -14,12 +14,11 @@ function getMutationKeyLabel( key: unknown ): string | undefined {
 		}
 		leading.push( part );
 	}
-	return leading.length ? leading.join( ':' ) : undefined;
+	return leading.length ? leading.join( ':' ) : 'unknown';
 }
 
 export default function MutationErrorTracker() {
 	const queryClient = useQueryClient();
-	const { recordTracksEvent } = useAnalytics();
 
 	useEffect( () => {
 		return queryClient.getMutationCache().subscribe( ( event ) => {
@@ -30,25 +29,12 @@ export default function MutationErrorTracker() {
 			const { mutation } = event;
 			const error = event.action.error;
 
-			const properties: Record< string, unknown > = {
-				has_snackbar: Boolean( mutation.meta?.snackbar?.error ),
-			};
-
 			const keyLabel = getMutationKeyLabel( mutation.options.mutationKey );
-			if ( keyLabel ) {
-				properties.mutation_key = keyLabel;
-			}
+			const name = isWpError( error ) ? `${ keyLabel }:${ error.status }` : keyLabel;
 
-			if ( isWpError( error ) ) {
-				properties.status = error.status;
-				if ( error.error ) {
-					properties.error_code = error.error;
-				}
-			}
-
-			recordTracksEvent( 'calypso_dashboard_mutation_error', properties );
+			bumpStat( 'hd-mutation-error', name );
 		} );
-	}, [ queryClient, recordTracksEvent ] );
+	}, [ queryClient ] );
 
 	return null;
 }

--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -1,0 +1,66 @@
+import { isWpError } from '@automattic/api-core';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useAnalytics } from '../analytics';
+
+// Leading string segments of a mutation key form a stable, low-cardinality label.
+// Dynamic trailing parts (site/blog ids, slugs appended after the constant) are
+// dropped so the label aggregates cleanly and never carries identifying data.
+function mutationKeyLabel( key: unknown ): string | undefined {
+	if ( ! Array.isArray( key ) ) {
+		return undefined;
+	}
+	const leading: string[] = [];
+	for ( const part of key ) {
+		if ( typeof part !== 'string' ) {
+			break;
+		}
+		leading.push( part );
+	}
+	return leading.length ? leading.join( ':' ) : undefined;
+}
+
+/**
+ * Records a Tracks event for every failed mutation, from the one place they all
+ * pass through — the mutation cache. This gives complete coverage of user-facing
+ * action failures without per-feature instrumentation.
+ *
+ * Only stable, categorical fields are emitted (status, error code, mutation key,
+ * whether a snackbar was shown). The error message is never sent — it is localized
+ * and may contain customer data. `path` is added automatically by the analytics client.
+ */
+export default function MutationErrorTracker() {
+	const queryClient = useQueryClient();
+	const { recordTracksEvent } = useAnalytics();
+
+	useEffect( () => {
+		return queryClient.getMutationCache().subscribe( ( event ) => {
+			if ( event.type !== 'updated' || event.action.type !== 'error' ) {
+				return;
+			}
+
+			const { mutation } = event;
+			const error = event.action.error;
+
+			const properties: Record< string, unknown > = {
+				has_snackbar: Boolean( mutation.meta?.snackbar?.error ),
+			};
+
+			const keyLabel = mutationKeyLabel( mutation.options.mutationKey );
+			if ( keyLabel ) {
+				properties.mutation_key = keyLabel;
+			}
+
+			if ( isWpError( error ) ) {
+				properties.status = error.status;
+				if ( error.error ) {
+					properties.error_code = error.error;
+				}
+			}
+
+			recordTracksEvent( 'calypso_dashboard_mutation_error', properties );
+		} );
+	}, [ queryClient, recordTracksEvent ] );
+
+	return null;
+}

--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useAnalytics } from '../analytics';
 
 // Keep the key's leading string segments; stop at the first non-string, which is a dynamic id.
-function mutationKeyLabel( key: unknown ): string | undefined {
+function getMutationKeyLabel( key: unknown ): string | undefined {
 	if ( ! Array.isArray( key ) ) {
 		return undefined;
 	}
@@ -44,7 +44,7 @@ export default function MutationErrorTracker() {
 				has_snackbar: Boolean( mutation.meta?.snackbar?.error ),
 			};
 
-			const keyLabel = mutationKeyLabel( mutation.options.mutationKey );
+			const keyLabel = getMutationKeyLabel( mutation.options.mutationKey );
 			if ( keyLabel ) {
 				properties.mutation_key = keyLabel;
 			}

--- a/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
+++ b/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
@@ -2,35 +2,37 @@
  * @jest-environment jsdom
  */
 import { render } from '../../../test-utils';
+import { bumpStat } from '../../analytics';
 import MutationErrorTracker from '../index';
+
+jest.mock( '../../analytics', () => ( {
+	...jest.requireActual( '../../analytics' ),
+	bumpStat: jest.fn(),
+} ) );
+
+const mockedBumpStat = jest.mocked( bumpStat );
 
 function wpError( fields: { status: number; statusCode: number; error?: string } ) {
 	return Object.assign( new Error( 'boom' ), fields );
 }
 
-describe( 'MutationErrorTracker', () => {
-	it( 'records categorical fields when a keyed WPError mutation fails', async () => {
-		const { recordTracksEvent, queryClient } = render( <MutationErrorTracker /> );
+describe( '<MutationErrorTracker>', () => {
+	test( 'bumps a KEY:status stat when a keyed WPError mutation fails', async () => {
+		const { queryClient } = render( <MutationErrorTracker /> );
 
 		const error = wpError( { status: 500, statusCode: 500, error: 'internal_server_error' } );
 		const mutation = queryClient.getMutationCache().build( queryClient, {
 			mutationKey: [ 'PULL_FROM_STAGING', 12345 ],
-			meta: { snackbar: { error: 'Failed to pull' } },
 			mutationFn: () => Promise.reject( error ),
 		} );
 
 		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
 
-		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_mutation_error', {
-			has_snackbar: true,
-			mutation_key: 'PULL_FROM_STAGING',
-			status: 500,
-			error_code: 'internal_server_error',
-		} );
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-mutation-error', 'PULL_FROM_STAGING:500' );
 	} );
 
-	it( 'omits the key and error fields for an unkeyed, non-WPError failure', async () => {
-		const { recordTracksEvent, queryClient } = render( <MutationErrorTracker /> );
+	test( 'bumps the key label alone for an unkeyed, non-WPError failure', async () => {
+		const { queryClient } = render( <MutationErrorTracker /> );
 
 		const error = new Error( 'plain' );
 		const mutation = queryClient.getMutationCache().build( queryClient, {
@@ -39,13 +41,11 @@ describe( 'MutationErrorTracker', () => {
 
 		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
 
-		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_mutation_error', {
-			has_snackbar: false,
-		} );
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-mutation-error', 'unknown' );
 	} );
 
-	it( 'does not record anything when a mutation succeeds', async () => {
-		const { recordTracksEvent, queryClient } = render( <MutationErrorTracker /> );
+	test( 'does not bump anything when a mutation succeeds', async () => {
+		const { queryClient } = render( <MutationErrorTracker /> );
 
 		const mutation = queryClient.getMutationCache().build( queryClient, {
 			mutationFn: () => Promise.resolve( 'ok' ),
@@ -53,6 +53,6 @@ describe( 'MutationErrorTracker', () => {
 
 		await mutation.execute( undefined );
 
-		expect( recordTracksEvent ).not.toHaveBeenCalled();
+		expect( mockedBumpStat ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
+++ b/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '../../../test-utils';
+import MutationErrorTracker from '../index';
+
+function wpError( fields: { status: number; statusCode: number; error?: string } ) {
+	return Object.assign( new Error( 'boom' ), fields );
+}
+
+describe( 'MutationErrorTracker', () => {
+	it( 'records categorical fields when a keyed WPError mutation fails', async () => {
+		const { recordTracksEvent, queryClient } = render( <MutationErrorTracker /> );
+
+		const error = wpError( { status: 500, statusCode: 500, error: 'internal_server_error' } );
+		const mutation = queryClient.getMutationCache().build( queryClient, {
+			mutationKey: [ 'PULL_FROM_STAGING', 12345 ],
+			meta: { snackbar: { error: 'Failed to pull' } },
+			mutationFn: () => Promise.reject( error ),
+		} );
+
+		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_mutation_error', {
+			has_snackbar: true,
+			mutation_key: 'PULL_FROM_STAGING',
+			status: 500,
+			error_code: 'internal_server_error',
+		} );
+	} );
+
+	it( 'omits the key and error fields for an unkeyed, non-WPError failure', async () => {
+		const { recordTracksEvent, queryClient } = render( <MutationErrorTracker /> );
+
+		const error = new Error( 'plain' );
+		const mutation = queryClient.getMutationCache().build( queryClient, {
+			mutationFn: () => Promise.reject( error ),
+		} );
+
+		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_mutation_error', {
+			has_snackbar: false,
+		} );
+	} );
+
+	it( 'does not record anything when a mutation succeeds', async () => {
+		const { recordTracksEvent, queryClient } = render( <MutationErrorTracker /> );
+
+		const mutation = queryClient.getMutationCache().build( queryClient, {
+			mutationFn: () => Promise.resolve( 'ok' ),
+		} );
+
+		await mutation.execute( undefined );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -21,6 +21,7 @@ import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import OmnibarAgentsManager from '../interim-omnibar/omnibar-agents-manager';
 import OmnibarHelpCenter from '../interim-omnibar/omnibar-help-center';
+import MutationErrorTracker from '../mutation-error-tracker';
 import { NavigationBlockerRegistry } from '../navigation-blocker';
 import Notifications from '../notifications';
 import { useOmnibarEvent } from '../omnibar/events';
@@ -189,6 +190,7 @@ function Root() {
 			{ isAccountRecoveryInterstitialEnabled && <AccountRecoveryInterstitial /> }
 			{ isOptInWelcomeModalEnabled && <OptInWelcomeModal /> }
 			<PageViewTracker />
+			<MutationErrorTracker />
 			<NavigationBlockerRegistry />
 			{ 'development' === process.env.NODE_ENV && (
 				<Suspense fallback={ null }>


### PR DESCRIPTION
Part of DOTMSD-1418.

## Proposed Changes

* Add `MutationErrorTracker`, which subscribes to the TanStack mutation cache and bumps a single stat for every failed mutation.
* Each failure bumps `hd-mutation-error` with a `KEY:status` name — the mutation-key label crossed with the HTTP status (e.g. `PULL_FROM_STAGING:500`). Non-`WPError` failures bump the key label alone; mutations without a key bump `unknown`.
* Mounted once at the app root, next to the page-view tracker.

## Why are these changes being made?

Today, dashboard failures are only tracked where a developer manually added a per-feature `_success`/`_failure` event. Coverage is partial, and failures that don't surface a snackbar aren't measured at all. This centralizes failure tracking at the one place every mutation outcome flows through, giving complete, trendable coverage of user-facing action failures.

`bumpStat` is used rather than a Tracks event because these are simple aggregate counts — "which action failed, and with what status" — and a lightweight stat pixel is enough. Crossing the key and status into one name (`KEY:status`) keeps the *which failed → why* correlation that separate counters would lose.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/app/mutation-error-tracker`
* Or in the running dashboard, trigger a failing action and confirm a `hd-mutation-error` stat is bumped (a `pixel.wp.com/g.gif?...x_hd-mutation-error=KEY:status` request) with no message or PII.

## Considerations

* **No PII on the wire** — only the leading *string* segments of the mutation key (constant identifiers today) plus the HTTP status are emitted. Numeric/dynamic key parts (site/blog ids) are dropped. A future mutation that puts a user-controlled string in a leading key position would leak it; keys are expected to keep dynamic data in non-leading positions.
* **Coarser than Tracks, by design** — `bumpStat` carries only a group + name, so the previous `has_snackbar` and `error_code` fields are gone. The two dimensions worth aggregating for triage (which action, what status) are retained; anything finer belongs in a Tracks event.
* **Cardinality is `key × status`** — acceptable since statuses are a small set (mostly 4xx/5xx), and it buys the per-mutation status breakdown.
* **Dedicated component, not folded into the snackbar UI**, to keep analytics decoupled from presentation.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
