### PR TITLE
Dashboard: hide welcome modal from new and opted-in users

### DIFF
--- a/client/dashboard/app/welcome-modal/index.tsx
+++ b/client/dashboard/app/welcome-modal/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import ComponentViewTracker from '../../components/component-view-tracker';
-import { getHostingDashboardEnrollment } from '../../utils/hosting-dashboard-enrollment';
+import { isWelcomeModalEligible } from '../../utils/hosting-dashboard-enrollment';
 import { useAnalytics } from '../analytics';
 import { useAuth } from '../auth';
 import { hostingDashboardRoute as hostingDashboardPreferencesRoute } from '../router/me';
@@ -50,9 +50,7 @@ export function OptInWelcomeModal() {
 		return null;
 	}
 
-	// Only users whose default experience is the dashboard should see the welcome pitch.
-	const dashboardEnrollment = getHostingDashboardEnrollment( dashboardOptIn, user.ID );
-	if ( ! dashboardEnrollment.enrolled ) {
+	if ( ! isWelcomeModalEligible( dashboardOptIn, user.ID ) ) {
 		return null;
 	}
 

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 
@@ -58,27 +58,27 @@ export function getHostingDashboardEnrollment(
 }
 
 /**
- * Whether the opt-in welcome modal should be shown. Gated by the
- * `dashboard/opt-in-welcome-modal` feature flag. The modal introduces the
+ * Whether the opt-in welcome modal should be shown. The modal introduces the
  * dashboard to existing users who were moved onto it by the rollout, so it is
- * limited to enrolled users whose enrollment was forced. New users (who start
- * on the dashboard by default) and users who explicitly opted in (who are
- * already acquainted with it) are both excluded.
+ * limited to enrolled users who did not earlier opt in. Can't use the existing
+ * `isInRolloutCohort` logic because semantics are slightly different: even
+ * users who have been "forced" do not see modal if they have previously opt'd in.
  */
 export function isWelcomeModalEligible(
 	preference: HostingDashboardOptIn | undefined,
 	userId: number | undefined
 ): boolean {
-	if ( ! config.isEnabled( 'dashboard/opt-in-welcome-modal' ) ) {
+	if (
+		! isEnabled( 'dashboard/opt-in-welcome-modal' ) ||
+		! userId ||
+		userId > NEW_USER_ID_THRESHOLD ||
+		preference?.value === 'opt-in' ||
+		isSupportSession()
+	) {
 		return false;
 	}
 
-	if ( ! userId || userId > NEW_USER_ID_THRESHOLD ) {
-		return false;
-	}
-
-	const enrollment = getHostingDashboardEnrollment( preference, userId );
-	return enrollment.enrolled && enrollment.reason === 'forced';
+	return userId % 100 < ROLLOUT_PERCENTAGE;
 }
 
 /**

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -58,6 +58,25 @@ export function getHostingDashboardEnrollment(
 }
 
 /**
+ * Whether the opt-in welcome modal should be shown. The modal introduces the
+ * dashboard to existing users who were moved onto it by the rollout, so it is
+ * limited to enrolled users whose enrollment was forced. New users (who start
+ * on the dashboard by default) and users who explicitly opted in (who are
+ * already acquainted with it) are both excluded.
+ */
+export function isWelcomeModalEligible(
+	preference: HostingDashboardOptIn | undefined,
+	userId: number | undefined
+): boolean {
+	if ( ! userId || userId > NEW_USER_ID_THRESHOLD ) {
+		return false;
+	}
+
+	const enrollment = getHostingDashboardEnrollment( preference, userId );
+	return enrollment.enrolled && enrollment.reason === 'forced';
+}
+
+/**
  * Whether the user-facing opt-in toggle should be shown. Hidden for the
  * rollout cohort (the choice no longer exists) and for escape-hatched
  * users (their enrollment changes only via support tooling).

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 
@@ -69,7 +69,7 @@ export function isWelcomeModalEligible(
 	userId: number | undefined
 ): boolean {
 	if (
-		! isEnabled( 'dashboard/opt-in-welcome-modal' ) ||
+		! config.isEnabled( 'dashboard/opt-in-welcome-modal' ) ||
 		! userId ||
 		userId > NEW_USER_ID_THRESHOLD ||
 		preference?.value === 'opt-in' ||

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -58,7 +58,8 @@ export function getHostingDashboardEnrollment(
 }
 
 /**
- * Whether the opt-in welcome modal should be shown. The modal introduces the
+ * Whether the opt-in welcome modal should be shown. Gated by the
+ * `dashboard/opt-in-welcome-modal` feature flag. The modal introduces the
  * dashboard to existing users who were moved onto it by the rollout, so it is
  * limited to enrolled users whose enrollment was forced. New users (who start
  * on the dashboard by default) and users who explicitly opted in (who are
@@ -68,6 +69,10 @@ export function isWelcomeModalEligible(
 	preference: HostingDashboardOptIn | undefined,
 	userId: number | undefined
 ): boolean {
+	if ( ! config.isEnabled( 'dashboard/opt-in-welcome-modal' ) ) {
+		return false;
+	}
+
 	if ( ! userId || userId > NEW_USER_ID_THRESHOLD ) {
 		return false;
 	}


### PR DESCRIPTION
## Proposed Changes

* Add an `isWelcomeModalEligible()` helper to `hosting-dashboard-enrollment.ts` that owns the show/hide logic for the MSD opt-in welcome modal, and gate it behind a new `dashboard/opt-in-welcome-modal` feature flag.
* The modal is now shown only to the **forced percentage-rollout cohort**, excluding three groups that the previous `enrolled` gate let through:
  * **New users** (`userId > NEW_USER_ID_THRESHOLD`) — they start on the dashboard by default, so there's no prior experience to introduce them away from.
  * **Users who explicitly opted in** (`preference === 'opt-in'`) — they chose the dashboard and already know it. Weird to re-welcome them.
  * **Support sessions** — an agent assisting a user shouldn't trigger the pitch.
* `isWelcomeModalEligible()` computes cohort membership **directly** rather than reusing `isInRolloutCohort()` / `getHostingDashboardEnrollment()`. The semantics are deliberately not the same:
  * `getHostingDashboardEnrollment()` checks the ID cohort *before* the opt-in preference, so an opt-in user who also happens to land in the ID cohort is reported as `enrolled` with reason `'forced'`. The old "enrolled && forced" gate would therefore have shown them the modal; computing directly lets us exclude them.
  * The helper also intentionally ignores `simulate-full-rollout` and the `forced-opt-in` / `forced-opt-out` escape-hatch preferences — the welcome pitch keys purely off the real ID cohort.

## Why are these changes being made?

Prompted by this discussion p1783619174076859/1782971852.527979-slack-C08JZTRS6NA — we're currently going to show the welcome to too many people.

The modal is a "meet your new Hosting Dashboard" message aimed at existing users who were moved onto the dashboard by the rollout. Before this change the only gate was `enrolled`, which is also true for new users (force-enrolled via the ID threshold) and for self-selected opt-in users — so both would have been pitched a dashboard they either never had an old version of, or already knew well.

Note: the new-user exclusion is dormant until `NEW_USER_ID_THRESHOLD` is set to a finite value on release day (existing `TODO DOTMSD-1357`).

## Testing Instructions

This requires some manual preference and feature-flag tweaking. With `dashboard/opt-in-welcome-modal` enabled and the `hosting-dashboard-opt-in-welcome-modal-dismissed` preference unset:

* As a percentage-cohort user (`userId % 100 < 50`) with no opt-in preference → load the dashboard → modal shows.
* Set the `hosting-dashboard-opt-in` preference to `opt-in` → modal does not show.
* In a support session → modal does not show.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
