### PR TITLE
Pricing grid redesign: fix logos appearences

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -353,7 +353,6 @@ const FeaturesGrid = ( {
 	const tabletTopRowPlanCount = getTabletTopRowPlanCount( gridPlansWithoutSpotlightCount );
 	const hasTabletSplitRow =
 		'medium' === gridSize && gridPlansWithoutSpotlightCount > tabletTopRowPlanCount;
-	const tabletSplitRowWidthColumnCount = hasTabletSplitRow ? tabletTopRowPlanCount : 0;
 
 	return (
 		<div className="plans-grid-next-features-grid">
@@ -363,8 +362,7 @@ const FeaturesGrid = ( {
 					className={ clsx(
 						'plan-features-2023-grid__content',
 						`has-${ gridPlansWithoutSpotlightCount }-cols`,
-						hasTabletSplitRow &&
-							`has-tablet-split-row-width-${ tabletSplitRowWidthColumnCount }-cols`,
+						hasTabletSplitRow && `has-tablet-split-row-width-${ tabletTopRowPlanCount }-cols`,
 						{
 							'has-bottom-plan-card': bottomGridPlan,
 							'has-tablet-split-row': hasTabletSplitRow,

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -252,6 +252,8 @@ type TabletViewProps = {
 	stickyRowOffset: number;
 };
 
+const getTabletTopRowPlanCount = ( planCount: number ) => ( 4 === planCount ? 4 : 3 );
+
 const TabletView = ( {
 	currentSitePlanSlug,
 	generatedWPComSubdomain,
@@ -271,7 +273,7 @@ const TabletView = ( {
 	const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
 		? renderedGridPlans
 		: renderedGridPlans.filter( ( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug );
-	const numberOfPlansToShowOnTop = 4 === gridPlansWithoutSpotlight.length ? 4 : 3;
+	const numberOfPlansToShowOnTop = getTabletTopRowPlanCount( gridPlansWithoutSpotlight.length );
 	const plansForTopRow = gridPlansWithoutSpotlight.slice( 0, numberOfPlansToShowOnTop );
 	const plansForBottomRow = gridPlansWithoutSpotlight.slice( numberOfPlansToShowOnTop );
 	const tableProps = {
@@ -348,6 +350,10 @@ const FeaturesGrid = ( {
 	const gridPlansWithoutSpotlightCount = gridPlanForSpotlight
 		? gridPlans.filter( ( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug ).length
 		: gridPlans.length;
+	const tabletTopRowPlanCount = getTabletTopRowPlanCount( gridPlansWithoutSpotlightCount );
+	const hasTabletSplitRow =
+		'medium' === gridSize && gridPlansWithoutSpotlightCount > tabletTopRowPlanCount;
+	const tabletSplitRowWidthColumnCount = hasTabletSplitRow ? tabletTopRowPlanCount : 0;
 
 	return (
 		<div className="plans-grid-next-features-grid">
@@ -357,8 +363,11 @@ const FeaturesGrid = ( {
 					className={ clsx(
 						'plan-features-2023-grid__content',
 						`has-${ gridPlansWithoutSpotlightCount }-cols`,
+						hasTabletSplitRow &&
+							`has-tablet-split-row-width-${ tabletSplitRowWidthColumnCount }-cols`,
 						{
 							'has-bottom-plan-card': bottomGridPlan,
+							'has-tablet-split-row': hasTabletSplitRow,
 						}
 					) }
 				>

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -809,31 +809,10 @@ $redesign-table-cell-max-width: 280px;
 				}
 			}
 
-			&.has-tablet-split-row-width-1-cols {
-				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
-				.plans-grid-next-features-grid__bottom-plan-card {
-					max-width: $redesign-table-cell-max-width;
-				}
-			}
-
-			&.has-tablet-split-row-width-2-cols {
-				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
-				.plans-grid-next-features-grid__bottom-plan-card {
-					max-width: $redesign-table-cell-max-width * 2;
-				}
-			}
-
 			&.has-tablet-split-row-width-3-cols {
 				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
 				.plans-grid-next-features-grid__bottom-plan-card {
 					max-width: $redesign-table-cell-max-width * 3;
-				}
-			}
-
-			&.has-tablet-split-row-width-4-cols {
-				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
-				.plans-grid-next-features-grid__bottom-plan-card {
-					max-width: $redesign-table-cell-max-width * 4;
 				}
 			}
 		}

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -847,7 +847,7 @@ $redesign-table-cell-max-width: 280px;
 		border-top: 0;
 		box-sizing: border-box;
 		display: flex;
-		gap: 32px;
+		gap: 20px;
 		justify-content: space-between;
 		margin: 0 auto;
 		min-height: 136px;
@@ -939,6 +939,13 @@ $redesign-table-cell-max-width: 280px;
 
 		.plans-grid-next-client-logo-list__item {
 			--adjustment-unit: calc( var( --bottom-plan-card-logo-height ) / 60 );
+		}
+	}
+
+	&.is-smedium,
+	&.is-medium {
+		.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
+			--bottom-plan-card-logo-height: 32px;
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -802,6 +802,40 @@ $redesign-table-cell-max-width: 280px;
 			&.has-5-cols .plans-grid-next-features-grid__bottom-plan-card {
 				max-width: $redesign-table-cell-max-width * 5;
 			}
+
+			&.has-tablet-split-row {
+				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table-item {
+					max-width: none;
+				}
+			}
+
+			&.has-tablet-split-row-width-1-cols {
+				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
+				.plans-grid-next-features-grid__bottom-plan-card {
+					max-width: $redesign-table-cell-max-width;
+				}
+			}
+
+			&.has-tablet-split-row-width-2-cols {
+				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
+				.plans-grid-next-features-grid__bottom-plan-card {
+					max-width: $redesign-table-cell-max-width * 2;
+				}
+			}
+
+			&.has-tablet-split-row-width-3-cols {
+				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
+				.plans-grid-next-features-grid__bottom-plan-card {
+					max-width: $redesign-table-cell-max-width * 3;
+				}
+			}
+
+			&.has-tablet-split-row-width-4-cols {
+				.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table,
+				.plans-grid-next-features-grid__bottom-plan-card {
+					max-width: $redesign-table-cell-max-width * 4;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17847

## Proposed Changes

* Adjust the logos sizes and card width in tablet view

**Before**
<img width="766" height="466" alt="Screenshot 2026-07-13 at 01 07 37" src="https://github.com/user-attachments/assets/e0b86232-51a6-4f81-a9ae-31971269949d" />

**After**
<img width="875" height="419" alt="Screenshot 2026-07-13 at 01 06 54" src="https://github.com/user-attachments/assets/59df2b59-52f9-404e-922d-c5f635096305" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to five_plan_new_design variant and test the /setup/onboarding/plans page from full width to mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
