### PR TITLE
Stats: Make bottom padding between content and footer consistent across tabs

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -98,13 +98,24 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 		@include apply-improved-classic-dark-colors();
 	}
 
-	// `admin-ui-page-layout` zeroes `.layout__primary .main`'s padding-bottom,
-	// leaving the footer flush against the content inside the Calypso shell
-	// (Simple sites). Restore a gap. Scoped to `.layout__primary`, which only
-	// exists in the shell — self-hosted wp-admin has none and gets its bottom
-	// spacing from the surrounding chrome, so this never doubles up there.
-	.layout__primary .main > .jetpack-footer {
-		margin-top: 32px;
+	// The stats layout zeroes the page padding-bottom, leaving content flush
+	// against the footer. Restore a page-controlled gap. Applies to both the
+	// Calypso shell (Simple) and Odyssey/wp-admin (self-hosted).
+	.layout__primary .main > .admin-ui-page {
+		padding-block-end: 32px;
+
+		// Stop the last section stacking its own trailing space on the page gap
+		// above (otherwise varies by tab and site).
+		.stats > :last-child {
+			margin-block-end: 0;
+			padding-block-end: 0;
+
+			// Drop the flexible-grid `::after` balancer, whose `gap` adds a
+			// trailing row (as already done for `.subscribers-page`).
+			&::after {
+				display: none;
+			}
+		}
 	}
 
 	.sticky-panel.is-sticky {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -102,7 +102,7 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	// against the footer. Restore a page-controlled gap. Applies to both the
 	// Calypso shell (Simple) and Odyssey/wp-admin (self-hosted).
 	.layout__primary .main > .admin-ui-page {
-		padding-block-end: 32px;
+		padding-block-end: $vertical-margin;
 
 		// Stop the last section stacking its own trailing space on the page gap
 		// above (otherwise varies by tab and site).

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -98,6 +98,15 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 		@include apply-improved-classic-dark-colors();
 	}
 
+	// `admin-ui-page-layout` zeroes `.layout__primary .main`'s padding-bottom,
+	// leaving the footer flush against the content inside the Calypso shell
+	// (Simple sites). Restore a gap. Scoped to `.layout__primary`, which only
+	// exists in the shell — self-hosted wp-admin has none and gets its bottom
+	// spacing from the surrounding chrome, so this never doubles up there.
+	.layout__primary .main > .jetpack-footer {
+		margin-top: 32px;
+	}
+
 	.sticky-panel.is-sticky {
 		padding: 0;
 	}


### PR DESCRIPTION
Fixes STATS-293

## Why are these changes being made?

Every Stats tab rendered its last module flush against the "Jetpack · Products · Help" footer. The `admin-ui-page-layout` mixin that Stats includes zeroes the page's `padding-bottom`, and nothing restored a gap — so the bottom spacing was effectively uncontrolled and varied tab to tab. Where a tab's last module carried its own trailing margin/padding (e.g. the Subscribers email module), the space ballooned to ~120px; elsewhere it sat flush at 0px.

This affects **both** WordPress.com Simple sites (Calypso shell) **and** self-hosted Jetpack (Odyssey in wp-admin) — both render the same `.layout__primary .main > .admin-ui-page` + `.jetpack-footer` structure. (An earlier revision of this PR assumed self-hosted lacked `.layout__primary` and scoped the fix to exclude it; that assumption was incorrect.)

## Proposed Changes

Make the page layout the single source of the bottom gap, in `client/my-sites/stats/style.scss`:

* Add `padding-block-end: 32px` to `.admin-ui-page`, so the gap belongs to the grey content area rather than a transparent margin above the footer.
* Zero the trailing `margin`/`padding` on the last section, so a module's own trailing space can't stack on top of the page gap.
* Drop the flexible-grid `::after` balancer on the last section (its `gap` otherwise appends a trailing row) — mirroring the treatment already applied to `.subscribers-page`.

Result: a consistent **32px** gap between content and footer on every tab, on both Simple and self-hosted.

## Screenshots

Before / after — content-to-footer spacing, viewport scrolled to the bottom of each page. (Click any image to view full size.)

| Tab / Site | Before | After |
| --- | --- | --- |
| **Traffic** — Simple free site | <img src="https://github.com/user-attachments/assets/90c79c76-b277-437a-a0fb-fbf8558b0294" width="360"> | <img src="https://github.com/user-attachments/assets/649edd7c-5acd-47c7-bfd0-e759109ce04f" width="360"> |
| **Traffic** — jetpack.com | <img src="https://github.com/user-attachments/assets/1aea0c2f-1bdc-4d27-80bf-4eb3bc842e49" width="360"> | <img src="https://github.com/user-attachments/assets/9f71bc07-e90c-4e00-a63c-d81c8bcd64b4" width="360"> |
| **Realtime** — Simple free site | <img src="https://github.com/user-attachments/assets/c66169ec-2e64-4aeb-b967-46faca00f255" width="360"> | <img src="https://github.com/user-attachments/assets/fa53af00-469a-4e1f-ab04-196bd5a43d7a" width="360"> |
| **Realtime** — jetpack.com | <img src="https://github.com/user-attachments/assets/91624fdf-acc2-4462-8da1-f87a7c355946" width="360"> | <img src="https://github.com/user-attachments/assets/60734147-dabf-4961-9cbd-330d89045cd6" width="360"> |
| **Insights** — Simple free site | <img src="https://github.com/user-attachments/assets/f0a1daef-6c0d-49b0-a006-66f11cb57cd4" width="360"> | <img src="https://github.com/user-attachments/assets/2043efdb-c7d4-4ba4-8511-87fa91ccd19b" width="360"> |
| **Insights** — jetpack.com | <img src="https://github.com/user-attachments/assets/dcd9fb7a-3d60-48f4-99f1-ecffa5001278" width="360"> | <img src="https://github.com/user-attachments/assets/a552dd7d-e992-48bc-89c5-a537c1db7eb7" width="360"> |
| **Subscribers** — Simple free site | <img src="https://github.com/user-attachments/assets/047305a3-12c8-4ba7-9576-e08c59238ab6" width="360"> | <img src="https://github.com/user-attachments/assets/aa663b4a-132a-4cc8-8bd3-6dbb1f32cb61" width="360"> |
| **Subscribers** — jetpack.com | <img src="https://github.com/user-attachments/assets/e0f0e122-8d4e-4efb-9cf0-1211f844ff2a" width="360"> | <img src="https://github.com/user-attachments/assets/e6599d01-8a17-4542-816e-54e08d36a7b7" width="360"> |

## Testing Instructions

1. Open **Stats** and visit the **Traffic**, **Realtime**, **Insights** and **Subscribers** tabs; scroll to the bottom of each.
2. **Before:** the gap between the last content and the footer is inconsistent — flush (0px) on some tabs, ~120px on others (e.g. Subscribers with an email list).
3. **After:** a consistent 32px gap on every tab.
4. Repeat on a **self-hosted Jetpack (Odyssey)** site — same result.

**What I verified:** Measured the content-to-footer gap in the browser across Traffic / Realtime / Insights / Subscribers on a Simple site and a self-hosted site — all land at 32px (previously flush to ~120px depending on tab). Confirmed the fix live on the self-hosted staging site by injecting the compiled CSS (Insights: 64px → 32px; Traffic unchanged at 32px). `stylelint` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — N/A, CSS-only spacing fix
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — Verified on Simple and self-hosted (Odyssey); Atomic renders in the same Calypso shell as Simple but was not exercised separately
- [ ] Have you checked for TypeScript, React or other console errors? — N/A, no JS/TS change
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)? — Spacing only; unaffected by color scheme
- [x] Have you tested accessibility for your changes? — Spacing-only change, no interaction/semantics affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
