### PR TITLE
Stats: make Post Details arrows page whole periods, not individual bars

### DIFF
--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -90,4 +90,8 @@ export const STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE = 'DoYouLoveJetpackStatsNoti
 
 export const DATE_FORMAT = 'YYYY-MM-DD';
 
+// Shared by the Post Details and Video Details summary charts so both show
+// the same amount of history per view (page or window) for a given period.
+export const STATS_SUMMARY_MAX_BARS = 10;
+
 export const NAVIGATION_METHOD_ARROW = 'arrow';

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -23,7 +23,7 @@ function* statsByMonth( stats, moment ) {
 			yield {
 				period: firstDayOfMonth.format( 'MMM YYYY' ),
 				periodLabel: firstDayOfMonth.format( 'MMMM YYYY' ),
-				startDate: firstDayOfMonth.format( 'YYYY/MM/DD' ),
+				startDate: firstDayOfMonth.format( 'YYYY-MM-DD' ),
 				value: stats.years[ year ]?.months[ month ] ?? 0,
 			};
 		}
@@ -100,7 +100,7 @@ class StatsPostSummary extends Component {
 					return {
 						period: year,
 						periodLabel: year,
-						startDate: moment( year, 'YYYY' ).startOf( 'year' ).format( 'YYYY/MM/DD' ),
+						startDate: moment( year, 'YYYY' ).startOf( 'year' ).format( 'YYYY-MM-DD' ),
 						value: stats.years[ year ].total,
 					};
 				} );
@@ -131,7 +131,7 @@ class StatsPostSummary extends Component {
 					return {
 						period: firstDay.format( 'MMM D' ),
 						periodLabel: firstDay.format( 'L' ) + ' - ' + firstDay.add( 6, 'days' ).format( 'L' ),
-						startDate: moment( week.days[ 0 ].day ).format( 'YYYY/MM/DD' ),
+						startDate: moment( week.days[ 0 ].day ).format( 'YYYY-MM-DD' ),
 						value: week.total,
 					};
 				} );
@@ -199,8 +199,8 @@ class StatsPostSummary extends Component {
 
 		return {
 			period: 'day',
-			start_date: dateRange.start.format( 'YYYY/MM/DD' ),
-			date: dateRange.end.format( 'YYYY/MM/DD' ),
+			start_date: dateRange.start.format( 'YYYY-MM-DD' ),
+			date: dateRange.end.format( 'YYYY-MM-DD' ),
 			summarize: 1,
 			max: 0,
 		};

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -23,6 +23,7 @@ function* statsByMonth( stats, moment ) {
 			yield {
 				period: firstDayOfMonth.format( 'MMM YYYY' ),
 				periodLabel: firstDayOfMonth.format( 'MMMM YYYY' ),
+				startDate: firstDayOfMonth.format( 'YYYY/MM/DD' ),
 				value: stats.years[ year ]?.months[ month ] ?? 0,
 			};
 		}
@@ -40,7 +41,6 @@ class StatsPostSummary extends Component {
 	static MAX_RECORDS_PER_PAGE = 10;
 
 	state = {
-		selectedRecord: null,
 		period: 'day',
 		page: 1,
 	};
@@ -48,24 +48,19 @@ class StatsPostSummary extends Component {
 	selectPeriod( period ) {
 		return () =>
 			this.setState( {
-				selectedRecord: null,
 				period,
 				page: 1,
 			} );
 	}
-
-	selectRecord = ( record ) => {
-		this.setState( { selectedRecord: record } );
-	};
 
 	// Arrows page the whole visible window of bars (like the Traffic chart's
 	// date-range navigation), they never step through individual bars.
 	onPeriodChange = ( { direction } ) => {
 		const maxPages = this.getMaxPages();
 		if ( 'previous' === direction && this.state.page < maxPages ) {
-			this.setState( { selectedRecord: null, page: this.state.page + 1 } );
+			this.setState( { page: this.state.page + 1 } );
 		} else if ( 'next' === direction && this.state.page > 1 ) {
-			this.setState( { selectedRecord: null, page: this.state.page - 1 } );
+			this.setState( { page: this.state.page - 1 } );
 		}
 	};
 
@@ -105,6 +100,7 @@ class StatsPostSummary extends Component {
 					return {
 						period: year,
 						periodLabel: year,
+						startDate: moment( year, 'YYYY' ).startOf( 'year' ).format( 'YYYY/MM/DD' ),
 						value: stats.years[ year ].total,
 					};
 				} );
@@ -162,45 +158,51 @@ class StatsPostSummary extends Component {
 		return allRecords.slice( dataStart, dataEnd );
 	}
 
-	getQuery() {
-		let selectedRecord = this.state.selectedRecord;
+	// The start/end of the currently displayed page of bars, used to keep the
+	// header label and the UTM breakdown showing the same range (mirrors the
+	// Traffic page's start_date/date/summarize query for its date-range UTM
+	// module) instead of a single selected bar.
+	getPageDateRange() {
 		const { period } = this.state;
 		const { moment } = this.props;
-		const query = {
-			period,
-			max: 0,
-		};
+		const chartData = this.getChartData();
 
-		if ( ! selectedRecord ) {
-			const chartData = this.getChartData();
-
-			if ( chartData.length ) {
-				selectedRecord = chartData[ chartData.length - 1 ];
-			} else {
-				return query;
-			}
+		if ( ! chartData.length ) {
+			return null;
 		}
 
-		let date = selectedRecord.startDate;
+		const start = moment( chartData[ 0 ].startDate );
+		const end = moment( chartData[ chartData.length - 1 ].startDate );
 
 		switch ( period ) {
 			case 'week':
-				date = moment( date ).add( 6, 'days' ).format( 'YYYY/MM/DD' );
+				end.add( 6, 'days' );
 				break;
 			case 'month':
-				date = moment( date ).endOf( 'month' ).format( 'YYYY/MM/DD' );
+				end.endOf( 'month' );
 				break;
 			case 'year':
-				date = moment( date ).endOf( 'year' ).format( 'YYYY/MM/DD' );
+				end.endOf( 'year' );
 				break;
-			case 'day':
 			default:
 				break;
 		}
 
+		return { start, end };
+	}
+
+	getQuery() {
+		const dateRange = this.getPageDateRange();
+		if ( ! dateRange ) {
+			return { period: 'day', max: 0, summarize: 1 };
+		}
+
 		return {
-			...query,
-			date,
+			period: 'day',
+			start_date: dateRange.start.format( 'YYYY/MM/DD' ),
+			date: dateRange.end.format( 'YYYY/MM/DD' ),
+			summarize: 1,
+			max: 0,
 		};
 	}
 
@@ -213,10 +215,7 @@ class StatsPostSummary extends Component {
 			{ id: 'year', label: translate( 'Years' ) },
 		];
 		const chartData = this.getChartData();
-		let selectedRecord = this.state.selectedRecord;
-		if ( ! this.state.selectedRecord && chartData.length ) {
-			selectedRecord = chartData[ chartData.length - 1 ];
-		}
+		const pageDateRange = this.getPageDateRange();
 
 		const disablePreviousArrow = this.state.page >= this.getMaxPages();
 		const disableNextArrow = this.state.page <= 1;
@@ -238,7 +237,18 @@ class StatsPostSummary extends Component {
 							disableNextArrow={ disableNextArrow }
 							date={ null }
 						>
-							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
+							<DatePicker
+								period={ this.state.period }
+								dateRange={
+									pageDateRange
+										? {
+												chartStart: pageDateRange.start.format( 'YYYY-MM-DD' ),
+												chartEnd: pageDateRange.end.format( 'YYYY-MM-DD' ),
+										  }
+										: undefined
+								}
+								isShort
+							/>
 						</StatsPeriodNavigation>
 						<SegmentedControl primary>
 							{ periods.map( ( { id, label } ) => (
@@ -261,8 +271,6 @@ class StatsPostSummary extends Component {
 						labelKey="periodLabel"
 						chartType="views"
 						sectionClass="is-views"
-						selected={ selectedRecord }
-						onClick={ this.selectRecord }
 						tabLabel={ translate( 'Views' ) }
 						type="post"
 					/>

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -37,7 +37,7 @@ class StatsPostSummary extends Component {
 		supportsUTMStats: PropTypes.bool,
 	};
 
-	static MAX_RECORDS_PER_DAY = 10;
+	static MAX_RECORDS_PER_PAGE = 10;
 
 	state = {
 		selectedRecord: null,
@@ -50,6 +50,7 @@ class StatsPostSummary extends Component {
 			this.setState( {
 				selectedRecord: null,
 				period,
+				page: 1,
 			} );
 	}
 
@@ -57,50 +58,26 @@ class StatsPostSummary extends Component {
 		this.setState( { selectedRecord: record } );
 	};
 
+	// Arrows page the whole visible window of bars (like the Traffic chart's
+	// date-range navigation), they never step through individual bars.
 	onPeriodChange = ( { direction } ) => {
-		let chartData = this.getChartData();
-		if ( ! chartData.length ) {
-			return;
-		}
-
-		let selectedRecord = this.state.selectedRecord;
-		if ( ! selectedRecord ) {
-			selectedRecord = chartData[ chartData.length - 1 ];
-		}
-
-		const recordIndex = chartData.findIndex( ( item ) => item.period === selectedRecord.period );
-
-		if ( 'previous' === direction ) {
-			if ( recordIndex > 0 ) {
-				this.setState( { selectedRecord: chartData[ recordIndex - 1 ] } );
-			} else {
-				const nextPage = this.state.page + 1;
-				chartData = this.getChartData( nextPage );
-				if ( chartData ) {
-					this.setState( { selectedRecord: chartData[ chartData.length - 1 ] } );
-				}
-			}
-		} else if ( 'next' === direction ) {
-			if ( recordIndex < chartData.length - 1 ) {
-				this.setState( { selectedRecord: chartData[ recordIndex + 1 ] } );
-			} else {
-				const nextPage = this.state.page - 1;
-				chartData = this.getChartData( nextPage );
-				this.setState( { selectedRecord: chartData[ 0 ] } );
-			}
+		const maxPages = this.getMaxPages();
+		if ( 'previous' === direction && this.state.page < maxPages ) {
+			this.setState( { selectedRecord: null, page: this.state.page + 1 } );
+		} else if ( 'next' === direction && this.state.page > 1 ) {
+			this.setState( { selectedRecord: null, page: this.state.page - 1 } );
 		}
 	};
 
-	getChartData( newPage = 0 ) {
+	getMaxPages() {
+		const totalRecords = this.getAllRecordsForPeriod().length;
+		return Math.max( Math.ceil( totalRecords / StatsPostSummary.MAX_RECORDS_PER_PAGE ), 1 );
+	}
+
+	getAllRecordsForPeriod() {
 		const { moment, stats } = this.props;
 		if ( ! stats ) {
 			return [];
-		}
-
-		let page = this.state.page;
-		if ( newPage ) {
-			page = newPage;
-			this.setState( { page: newPage } );
 		}
 
 		switch ( this.state.period ) {
@@ -109,15 +86,7 @@ class StatsPostSummary extends Component {
 					return [];
 				}
 
-				const dataStart = Math.max(
-					stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * page,
-					0
-				);
-				const dataEnd = Math.max(
-					stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * ( page - 1 ),
-					0
-				);
-				return stats.data.slice( dataStart, dataEnd ).map( ( [ date, value ] ) => {
+				return stats.data.map( ( [ date, value ] ) => {
 					const momentDate = moment( date );
 					return {
 						period: momentDate.format( 'MMM D' ),
@@ -175,6 +144,24 @@ class StatsPostSummary extends Component {
 		}
 	}
 
+	getChartData() {
+		const allRecords = this.getAllRecordsForPeriod();
+		if ( ! allRecords.length ) {
+			return [];
+		}
+
+		const { page } = this.state;
+		const dataStart = Math.max(
+			allRecords.length - StatsPostSummary.MAX_RECORDS_PER_PAGE * page,
+			0
+		);
+		const dataEnd = Math.max(
+			allRecords.length - StatsPostSummary.MAX_RECORDS_PER_PAGE * ( page - 1 ),
+			0
+		);
+		return allRecords.slice( dataStart, dataEnd );
+	}
+
 	getQuery() {
 		let selectedRecord = this.state.selectedRecord;
 		const { period } = this.state;
@@ -218,7 +205,7 @@ class StatsPostSummary extends Component {
 	}
 
 	render() {
-		const { isRequesting, postId, siteId, translate, stats } = this.props;
+		const { isRequesting, postId, siteId, translate } = this.props;
 		const periods = [
 			{ id: 'day', label: translate( 'Days' ) },
 			{ id: 'week', label: translate( 'Weeks' ) },
@@ -231,19 +218,8 @@ class StatsPostSummary extends Component {
 			selectedRecord = chartData[ chartData.length - 1 ];
 		}
 
-		let disablePreviousArrow = false;
-		let disableNextArrow = false;
-		const selectedRecordIndex = chartData.findIndex(
-			( item ) => item.period === selectedRecord.period
-		);
-		if ( 'day' === this.state.period && stats.data ) {
-			const maxPages = Math.ceil( stats.data.length / StatsPostSummary.MAX_RECORDS_PER_DAY );
-			disablePreviousArrow = this.state.page >= maxPages && selectedRecordIndex === 0;
-			disableNextArrow = 1 === this.state.page && selectedRecordIndex === chartData.length - 1;
-		} else {
-			disablePreviousArrow = selectedRecordIndex === 0;
-			disableNextArrow = selectedRecordIndex === chartData.length - 1;
-		}
+		const disablePreviousArrow = this.state.page >= this.getMaxPages();
+		const disableNextArrow = this.state.page <= 1;
 
 		const summaryWrapperClass = clsx( 'stats-post-summary', 'is-chart-tabs', {
 			'is-period-year': this.state.period === 'year',

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -64,13 +64,56 @@ class StatsPostSummary extends Component {
 	};
 
 	getMaxPages() {
-		// Avoid mapping the entire daily history into record objects (can be
-		// thousands of entries for an old post) just to count them.
-		const totalRecords =
-			this.state.period === 'day'
-				? this.props.stats?.data?.length ?? 0
-				: this.getAllRecordsForPeriod().length;
-		return Math.max( Math.ceil( totalRecords / STATS_SUMMARY_MAX_BARS ), 1 );
+		return Math.max( Math.ceil( this.getTotalRecordCount() / STATS_SUMMARY_MAX_BARS ), 1 );
+	}
+
+	// Days can run to thousands of entries for an old post, so their count is
+	// read directly off stats.data rather than built into record objects.
+	getTotalRecordCount() {
+		return this.state.period === 'day'
+			? this.props.stats?.data?.length ?? 0
+			: this.getAllRecordsForPeriod().length;
+	}
+
+	// [start, end) slice bounds for the current page within a period's full,
+	// most-recent-last record list.
+	getPageSliceBounds( totalCount ) {
+		const { page } = this.state;
+		const dataStart = Math.max( totalCount - STATS_SUMMARY_MAX_BARS * page, 0 );
+		const dataEnd = Math.max( totalCount - STATS_SUMMARY_MAX_BARS * ( page - 1 ), 0 );
+		return [ dataStart, dataEnd ];
+	}
+
+	// Days are paged directly off the raw stats.data pairs, formatting only
+	// the bars for the current page rather than the post's entire history.
+	getPagedDayRecords() {
+		const { moment, stats } = this.props;
+		const data = stats?.data ?? [];
+		const [ dataStart, dataEnd ] = this.getPageSliceBounds( data.length );
+
+		const records = data.slice( dataStart, dataEnd ).map( ( [ date, value ] ) => {
+			const momentDate = moment( date );
+			return {
+				period: momentDate.format( 'MMM D' ),
+				periodLabel: momentDate.format( 'LL' ),
+				startDate: date,
+				value,
+			};
+		} );
+
+		return { records, totalCount: data.length };
+	}
+
+	// The current page of bars for the active period, plus the total record
+	// count it was sliced from (used to compute max pages).
+	getPagedRecords() {
+		if ( this.state.period === 'day' ) {
+			return this.getPagedDayRecords();
+		}
+
+		const allRecords = this.getAllRecordsForPeriod();
+		const [ dataStart, dataEnd ] = this.getPageSliceBounds( allRecords.length );
+		return { records: allRecords.slice( dataStart, dataEnd ), totalCount: allRecords.length };
 	}
 
 	getAllRecordsForPeriod() {
@@ -80,21 +123,6 @@ class StatsPostSummary extends Component {
 		}
 
 		switch ( this.state.period ) {
-			case 'day': {
-				if ( ! stats.data ) {
-					return [];
-				}
-
-				return stats.data.map( ( [ date, value ] ) => {
-					const momentDate = moment( date );
-					return {
-						period: momentDate.format( 'MMM D' ),
-						periodLabel: momentDate.format( 'LL' ),
-						startDate: date,
-						value,
-					};
-				} );
-			}
 			// stats.weeks only ever covers a fixed recent 7-week window
 			// (hard-coded server-side; no request param widens it — see
 			// WPCOM_JSON_API_Stats_V1_1_Post_Views_Endpoint), so weeks are
@@ -156,26 +184,13 @@ class StatsPostSummary extends Component {
 		}
 	}
 
-	getChartData() {
-		const allRecords = this.getAllRecordsForPeriod();
-		if ( ! allRecords.length ) {
-			return [];
-		}
-
-		const { page } = this.state;
-		const dataStart = Math.max( allRecords.length - STATS_SUMMARY_MAX_BARS * page, 0 );
-		const dataEnd = Math.max( allRecords.length - STATS_SUMMARY_MAX_BARS * ( page - 1 ), 0 );
-		return allRecords.slice( dataStart, dataEnd );
-	}
-
-	// The start/end of the currently displayed page of bars, used to keep the
-	// header label and the UTM breakdown showing the same range (mirrors the
-	// Traffic page's start_date/date/summarize query for its date-range UTM
-	// module) instead of a single selected bar.
-	getPageDateRange() {
+	// The start/end of a page of bars, used to keep the header label and the
+	// UTM breakdown showing the same range (mirrors the Traffic page's
+	// start_date/date/summarize query for its date-range UTM module) instead
+	// of a single selected bar.
+	getPageDateRange( chartData ) {
 		const { period } = this.state;
 		const { moment } = this.props;
-		const chartData = this.getChartData();
 
 		if ( ! chartData.length ) {
 			return null;
@@ -208,16 +223,15 @@ class StatsPostSummary extends Component {
 		return { start, end };
 	}
 
-	getQuery() {
-		const dateRange = this.getPageDateRange();
-		if ( ! dateRange ) {
+	getQuery( pageDateRange ) {
+		if ( ! pageDateRange ) {
 			return { period: 'day', max: 0, summarize: 1 };
 		}
 
 		return {
 			period: 'day',
-			start_date: dateRange.start.format( 'YYYY-MM-DD' ),
-			date: dateRange.end.format( 'YYYY-MM-DD' ),
+			start_date: pageDateRange.start.format( 'YYYY-MM-DD' ),
+			date: pageDateRange.end.format( 'YYYY-MM-DD' ),
 			summarize: 1,
 			max: 0,
 		};
@@ -231,10 +245,11 @@ class StatsPostSummary extends Component {
 			{ id: 'month', label: translate( 'Months' ) },
 			{ id: 'year', label: translate( 'Years' ) },
 		];
-		const chartData = this.getChartData();
-		const pageDateRange = this.getPageDateRange();
+		const { records: chartData, totalCount } = this.getPagedRecords();
+		const pageDateRange = this.getPageDateRange( chartData );
 
-		const disablePreviousArrow = this.state.page >= this.getMaxPages();
+		const maxPages = Math.max( Math.ceil( totalCount / STATS_SUMMARY_MAX_BARS ), 1 );
+		const disablePreviousArrow = this.state.page >= maxPages;
 		const disableNextArrow = this.state.page <= 1;
 
 		const summaryWrapperClass = clsx( 'stats-post-summary', 'is-chart-tabs', {
@@ -301,7 +316,7 @@ class StatsPostSummary extends Component {
 									siteId={ siteId }
 									postId={ postId }
 									period={ this.state.period }
-									query={ this.getQuery() }
+									query={ this.getQuery( pageDateRange ) }
 									context={ this.props.context }
 								/>
 							</div>

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -16,20 +16,6 @@ import SummaryChart from '../stats-summary';
 
 import './style.scss';
 
-function* statsByMonth( stats, moment ) {
-	for ( const year of Object.keys( stats.years ) ) {
-		for ( let month = 1; month <= 12; month++ ) {
-			const firstDayOfMonth = moment( `1/${ month }/${ year }`, 'DD/MM/YYYY' );
-			yield {
-				period: firstDayOfMonth.format( 'MMM YYYY' ),
-				periodLabel: firstDayOfMonth.format( 'MMMM YYYY' ),
-				startDate: firstDayOfMonth.format( 'YYYY-MM-DD' ),
-				value: stats.years[ year ]?.months[ month ] ?? 0,
-			};
-		}
-	}
-}
-
 class StatsPostSummary extends Component {
 	static propTypes = {
 		postId: PropTypes.number,
@@ -69,75 +55,67 @@ class StatsPostSummary extends Component {
 		return Math.max( Math.ceil( totalRecords / StatsPostSummary.MAX_RECORDS_PER_PAGE ), 1 );
 	}
 
+	// Weeks/months/years are aggregated from the full daily history
+	// (stats.data) rather than the API's own weeks/years breakdowns, which
+	// only cover a recent trailing window (e.g. the last 7 weeks, or years
+	// since 2021 even for a post from 2009) instead of the post's full
+	// lifetime — which left paging with nowhere further to go.
 	getAllRecordsForPeriod() {
 		const { moment, stats } = this.props;
-		if ( ! stats ) {
+		if ( ! stats?.data ) {
 			return [];
 		}
 
-		switch ( this.state.period ) {
-			case 'day': {
-				if ( ! stats.data ) {
-					return [];
-				}
+		const { period } = this.state;
 
-				return stats.data.map( ( [ date, value ] ) => {
-					const momentDate = moment( date );
-					return {
-						period: momentDate.format( 'MMM D' ),
-						periodLabel: momentDate.format( 'LL' ),
-						startDate: date,
-						value,
-					};
-				} );
-			}
-			case 'year':
-				if ( ! stats.years ) {
-					return [];
-				}
-
-				return Object.keys( stats.years ).map( ( year ) => {
-					return {
-						period: year,
-						periodLabel: year,
-						startDate: moment( year, 'YYYY' ).startOf( 'year' ).format( 'YYYY-MM-DD' ),
-						value: stats.years[ year ].total,
-					};
-				} );
-			case 'month': {
-				if ( ! stats.years ) {
-					return [];
-				}
-
-				const months = [ ...statsByMonth( stats, moment ) ];
-				const firstNotEmpty = months.findIndex( ( item ) => item.value !== 0 );
-				const reverseLastNotEmpty = [ ...months ]
-					.reverse()
-					.findIndex( ( item ) => item.value !== 0 );
-				const lastNotEmpty =
-					reverseLastNotEmpty === -1
-						? reverseLastNotEmpty
-						: months.length - ( reverseLastNotEmpty + 1 );
-
-				return months.slice( firstNotEmpty, lastNotEmpty + 1 );
-			}
-			case 'week':
-				if ( ! stats.weeks ) {
-					return [];
-				}
-
-				return stats.weeks.map( ( week ) => {
-					const firstDay = moment( week.days[ 0 ].day );
-					return {
-						period: firstDay.format( 'MMM D' ),
-						periodLabel: firstDay.format( 'L' ) + ' - ' + firstDay.add( 6, 'days' ).format( 'L' ),
-						startDate: moment( week.days[ 0 ].day ).format( 'YYYY-MM-DD' ),
-						value: week.total,
-					};
-				} );
-			default:
-				return [];
+		if ( period === 'day' ) {
+			return stats.data.map( ( [ date, value ] ) => {
+				const momentDate = moment( date );
+				return {
+					period: momentDate.format( 'MMM D' ),
+					periodLabel: momentDate.format( 'LL' ),
+					startDate: date,
+					value,
+				};
+			} );
 		}
+
+		const unit = period === 'week' ? 'isoWeek' : period;
+		const totals = new Map();
+		for ( const [ date, value ] of stats.data ) {
+			const key = moment( date ).startOf( unit ).format( 'YYYY-MM-DD' );
+			totals.set( key, ( totals.get( key ) ?? 0 ) + value );
+		}
+
+		return Array.from( totals.entries() )
+			.sort( ( [ a ], [ b ] ) => ( a < b ? -1 : 1 ) )
+			.map( ( [ key, value ] ) => {
+				const start = moment( key );
+				switch ( period ) {
+					case 'week':
+						return {
+							period: start.format( 'MMM D' ),
+							periodLabel:
+								start.format( 'L' ) + ' - ' + moment( key ).add( 6, 'days' ).format( 'L' ),
+							startDate: key,
+							value,
+						};
+					case 'month':
+						return {
+							period: start.format( 'MMM YYYY' ),
+							periodLabel: start.format( 'MMMM YYYY' ),
+							startDate: key,
+							value,
+						};
+					default:
+						return {
+							period: start.format( 'YYYY' ),
+							periodLabel: start.format( 'YYYY' ),
+							startDate: key,
+							value,
+						};
+				}
+			} );
 	}
 
 	getChartData() {

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -143,20 +143,27 @@ class StatsPostSummary extends Component {
 		}
 
 		const start = moment( chartData[ 0 ].startDate );
-		const end = moment( chartData[ chartData.length - 1 ].startDate );
+		let end = moment( chartData[ chartData.length - 1 ].startDate );
 
 		switch ( period ) {
 			case 'week':
-				end.add( 6, 'days' );
+				end = end.add( 6, 'days' );
 				break;
 			case 'month':
-				end.endOf( 'month' );
+				end = end.endOf( 'month' );
 				break;
 			case 'year':
-				end.endOf( 'year' );
+				end = end.endOf( 'year' );
 				break;
 			default:
 				break;
+		}
+
+		// Don't extend the range into the future when the last bar is still
+		// the current, in-progress period (e.g. this month before it ends).
+		const today = moment();
+		if ( end.isAfter( today, 'day' ) ) {
+			end = today;
 		}
 
 		return { start, end };

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPostStats, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
+import { STATS_SUMMARY_MAX_BARS } from '../constants';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
 import DatePicker from '../stats-date-label';
@@ -23,8 +24,6 @@ class StatsPostSummary extends Component {
 		translate: PropTypes.func,
 		supportsUTMStats: PropTypes.bool,
 	};
-
-	static MAX_RECORDS_PER_PAGE = 10;
 
 	state = {
 		period: 'day',
@@ -52,7 +51,7 @@ class StatsPostSummary extends Component {
 
 	getMaxPages() {
 		const totalRecords = this.getAllRecordsForPeriod().length;
-		return Math.max( Math.ceil( totalRecords / StatsPostSummary.MAX_RECORDS_PER_PAGE ), 1 );
+		return Math.max( Math.ceil( totalRecords / STATS_SUMMARY_MAX_BARS ), 1 );
 	}
 
 	// Weeks/months/years are aggregated from the full daily history
@@ -125,14 +124,8 @@ class StatsPostSummary extends Component {
 		}
 
 		const { page } = this.state;
-		const dataStart = Math.max(
-			allRecords.length - StatsPostSummary.MAX_RECORDS_PER_PAGE * page,
-			0
-		);
-		const dataEnd = Math.max(
-			allRecords.length - StatsPostSummary.MAX_RECORDS_PER_PAGE * ( page - 1 ),
-			0
-		);
+		const dataStart = Math.max( allRecords.length - STATS_SUMMARY_MAX_BARS * page, 0 );
+		const dataEnd = Math.max( allRecords.length - STATS_SUMMARY_MAX_BARS * ( page - 1 ), 0 );
 		return allRecords.slice( dataStart, dataEnd );
 	}
 

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -17,6 +17,20 @@ import SummaryChart from '../stats-summary';
 
 import './style.scss';
 
+function* statsByMonth( stats, moment ) {
+	for ( const year of Object.keys( stats.years ) ) {
+		for ( let month = 1; month <= 12; month++ ) {
+			const firstDayOfMonth = moment( `1/${ month }/${ year }`, 'DD/MM/YYYY' );
+			yield {
+				period: firstDayOfMonth.format( 'MMM YYYY' ),
+				periodLabel: firstDayOfMonth.format( 'MMMM YYYY' ),
+				startDate: firstDayOfMonth.format( 'YYYY-MM-DD' ),
+				value: stats.years[ year ]?.months[ month ] ?? 0,
+			};
+		}
+	}
+}
+
 class StatsPostSummary extends Component {
 	static propTypes = {
 		postId: PropTypes.number,
@@ -50,48 +64,57 @@ class StatsPostSummary extends Component {
 	};
 
 	getMaxPages() {
-		const totalRecords = this.getAllRecordsForPeriod().length;
+		// Avoid mapping the entire daily history into record objects (can be
+		// thousands of entries for an old post) just to count them.
+		const totalRecords =
+			this.state.period === 'day'
+				? this.props.stats?.data?.length ?? 0
+				: this.getAllRecordsForPeriod().length;
 		return Math.max( Math.ceil( totalRecords / STATS_SUMMARY_MAX_BARS ), 1 );
 	}
 
-	// Weeks/months/years are aggregated from the full daily history
-	// (stats.data) rather than the API's own weeks/years breakdowns, which
-	// only cover a recent trailing window (e.g. the last 7 weeks, or years
-	// since 2021 even for a post from 2009) instead of the post's full
-	// lifetime — which left paging with nowhere further to go.
 	getAllRecordsForPeriod() {
 		const { moment, stats } = this.props;
-		if ( ! stats?.data ) {
+		if ( ! stats ) {
 			return [];
 		}
 
-		const { period } = this.state;
+		switch ( this.state.period ) {
+			case 'day': {
+				if ( ! stats.data ) {
+					return [];
+				}
 
-		if ( period === 'day' ) {
-			return stats.data.map( ( [ date, value ] ) => {
-				const momentDate = moment( date );
-				return {
-					period: momentDate.format( 'MMM D' ),
-					periodLabel: momentDate.format( 'LL' ),
-					startDate: date,
-					value,
-				};
-			} );
-		}
+				return stats.data.map( ( [ date, value ] ) => {
+					const momentDate = moment( date );
+					return {
+						period: momentDate.format( 'MMM D' ),
+						periodLabel: momentDate.format( 'LL' ),
+						startDate: date,
+						value,
+					};
+				} );
+			}
+			// stats.weeks only ever covers a fixed recent 7-week window
+			// (hard-coded server-side; no request param widens it — see
+			// WPCOM_JSON_API_Stats_V1_1_Post_Views_Endpoint), so weeks are
+			// aggregated from the full daily history instead, to allow
+			// paging back to the post's actual publish date.
+			case 'week': {
+				if ( ! stats.data ) {
+					return [];
+				}
 
-		const unit = period === 'week' ? 'isoWeek' : period;
-		const totals = new Map();
-		for ( const [ date, value ] of stats.data ) {
-			const key = moment( date ).startOf( unit ).format( 'YYYY-MM-DD' );
-			totals.set( key, ( totals.get( key ) ?? 0 ) + value );
-		}
+				const totals = new Map();
+				for ( const [ date, value ] of stats.data ) {
+					const key = moment( date ).startOf( 'isoWeek' ).format( 'YYYY-MM-DD' );
+					totals.set( key, ( totals.get( key ) ?? 0 ) + value );
+				}
 
-		return Array.from( totals.entries() )
-			.sort( ( [ a ], [ b ] ) => ( a < b ? -1 : 1 ) )
-			.map( ( [ key, value ] ) => {
-				const start = moment( key );
-				switch ( period ) {
-					case 'week':
+				return Array.from( totals.entries() )
+					.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+					.map( ( [ key, value ] ) => {
+						const start = moment( key );
 						return {
 							period: start.format( 'MMM D' ),
 							periodLabel:
@@ -99,22 +122,38 @@ class StatsPostSummary extends Component {
 							startDate: key,
 							value,
 						};
-					case 'month':
-						return {
-							period: start.format( 'MMM YYYY' ),
-							periodLabel: start.format( 'MMMM YYYY' ),
-							startDate: key,
-							value,
-						};
-					default:
-						return {
-							period: start.format( 'YYYY' ),
-							periodLabel: start.format( 'YYYY' ),
-							startDate: key,
-							value,
-						};
+					} );
+			}
+			case 'year':
+				if ( ! stats.years ) {
+					return [];
 				}
-			} );
+
+				return Object.keys( stats.years ).map( ( year ) => {
+					return {
+						period: year,
+						periodLabel: year,
+						startDate: moment( year, 'YYYY' ).startOf( 'year' ).format( 'YYYY-MM-DD' ),
+						value: stats.years[ year ].total,
+					};
+				} );
+			case 'month': {
+				if ( ! stats.years ) {
+					return [];
+				}
+
+				// statsByMonth() expands every year in stats.years to a full
+				// 12 months, which for the current year includes months that
+				// haven't happened yet; drop those rather than paginating
+				// into fake future bars.
+				const today = moment();
+				return [ ...statsByMonth( stats, moment ) ].filter( ( record ) =>
+					moment( record.startDate ).isSameOrBefore( today, 'month' )
+				);
+			}
+			default:
+				return [];
+		}
 	}
 
 	getChartData() {

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -242,8 +242,10 @@ export default function VideoSummary( {
 		[ buckets, statType, uiPeriod, moment ]
 	);
 
-	const selected =
-		selectedRecord ?? ( chartData.length ? chartData[ chartData.length - 1 ] : null );
+	// No bar is highlighted by default; the header shows the range instead of
+	// a single bar's date, so defaulting to the most recent bar would highlight
+	// it for no reason until the user actually clicks one.
+	const selected = selectedRecord;
 
 	// The header shows the fixed trailing window the chart actually covers
 	// (like the Traffic page's date-range header), rather than the period of

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -11,6 +11,7 @@ import {
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { STATS_SUMMARY_MAX_BARS } from '../constants';
 import DatePicker from '../stats-date-label';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
@@ -193,7 +194,14 @@ export default function VideoSummary( {
 			] )
 		).sort();
 
-		return keys.map( ( key ) => ( {
+		// Cap to the most recent STATS_SUMMARY_MAX_BARS buckets so this chart
+		// shows the same amount of history per view as the Post Details chart,
+		// which pages in chunks of the same size. Weeks/Years will still fall
+		// short of that cap: the endpoint's `month`/`year` windows only cover
+		// ~30 days / ~13 months of raw data, which bucket into fewer than 10
+		// weeks/years regardless of this cap — there's no more granular data
+		// to draw from without a backend change.
+		return keys.slice( -STATS_SUMMARY_MAX_BARS ).map( ( key ) => ( {
 			key,
 			plays: playsByBucket.get( key ) ?? 0,
 			impressions: impressionsByBucket.get( key ) ?? 0,
@@ -247,26 +255,36 @@ export default function VideoSummary( {
 	// it for no reason until the user actually clicks one.
 	const selected = selectedRecord;
 
-	// The header shows the fixed trailing window the chart actually covers
-	// (like the Traffic page's date-range header), rather than the period of
-	// whichever single bar is selected, so it reads the same across every
-	// Day/Week/Month/Year tab.
+	// The header shows the date range the visible bars cover (like the Post
+	// Details chart's page-range header), rather than the period of whichever
+	// single bar is selected, so it reads the same across every
+	// Day/Week/Month/Year tab and matches Post Details' behavior.
 	const chartDateRange = useMemo( () => {
-		const windowDates = [ playsData?.data, impressionsData?.data, watchTimeData?.data ]
-			.flatMap( ( data ) => trimToTrailingWindow( data ) ?? [] )
-			.map( ( { period } ) => period )
-			.filter( ( date ) => moment( date ).isValid() )
-			.sort();
-
-		if ( ! windowDates.length ) {
+		if ( ! buckets.length ) {
 			return undefined;
 		}
 
+		const start = moment( buckets[ 0 ].key );
+		const end = moment( buckets[ buckets.length - 1 ].key );
+		switch ( uiPeriod ) {
+			case 'week':
+				end.add( 6, 'days' );
+				break;
+			case 'month':
+				end.endOf( 'month' );
+				break;
+			case 'year':
+				end.endOf( 'year' );
+				break;
+			default:
+				break;
+		}
+
 		return {
-			chartStart: moment( windowDates[ 0 ] ).format( 'YYYY-MM-DD' ),
-			chartEnd: moment().format( 'YYYY-MM-DD' ),
+			chartStart: start.format( 'YYYY-MM-DD' ),
+			chartEnd: end.format( 'YYYY-MM-DD' ),
 		};
-	}, [ playsData, impressionsData, watchTimeData, trimToTrailingWindow, moment ] );
+	}, [ buckets, uiPeriod, moment ] );
 
 	// Card totals cover the whole window shown in the chart.
 	const metricValues: VideoMetricValues = useMemo( () => {

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -265,19 +265,26 @@ export default function VideoSummary( {
 		}
 
 		const start = moment( buckets[ 0 ].key );
-		const end = moment( buckets[ buckets.length - 1 ].key );
+		let end = moment( buckets[ buckets.length - 1 ].key );
 		switch ( uiPeriod ) {
 			case 'week':
-				end.add( 6, 'days' );
+				end = end.add( 6, 'days' );
 				break;
 			case 'month':
-				end.endOf( 'month' );
+				end = end.endOf( 'month' );
 				break;
 			case 'year':
-				end.endOf( 'year' );
+				end = end.endOf( 'year' );
 				break;
 			default:
 				break;
+		}
+
+		// Don't extend the range into the future when the last bucket is
+		// still the current, in-progress period.
+		const today = moment();
+		if ( end.isAfter( today, 'day' ) ) {
+			end = today;
 		}
 
 		return {

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -260,23 +260,6 @@ export default function VideoSummary( {
 		setSelectedRecord( null );
 	};
 
-	// Bucket labels can repeat across the window (e.g. two "Jul" months), so
-	// selection identity uses the unique startDate.
-	const selectedIndex = selected
-		? chartData.findIndex( ( record ) => record.startDate === selected.startDate )
-		: -1;
-
-	const handleArrows = ( { direction }: { direction: string } ) => {
-		if ( selectedIndex === -1 ) {
-			return;
-		}
-		if ( direction === 'previous' && selectedIndex > 0 ) {
-			setSelectedRecord( chartData[ selectedIndex - 1 ] );
-		} else if ( direction === 'next' && selectedIndex < chartData.length - 1 ) {
-			setSelectedRecord( chartData[ selectedIndex + 1 ] );
-		}
-	};
-
 	const tabLabels: Record< VideoStatType, string > = {
 		views: translate( 'Views', { textOnly: true } ),
 		impressions: translate( 'Impressions', { textOnly: true } ),
@@ -308,13 +291,10 @@ export default function VideoSummary( {
 				) ) }
 
 			<StatsPeriodHeader>
-				<StatsPeriodNavigation
-					showArrows
-					onPeriodChange={ handleArrows }
-					disablePreviousArrow={ selectedIndex <= 0 }
-					disableNextArrow={ selectedIndex === chartData.length - 1 }
-					date={ null }
-				>
+				{ /* The video stats endpoint only returns a fixed trailing window
+				ending "now" (no backend support yet for an older window), so
+				there's no previous/next period to navigate to. */ }
+				<StatsPeriodNavigation showArrows disablePreviousArrow disableNextArrow date={ null }>
 					<DatePicker period={ uiPeriod } date={ selected?.startDate } isShort />
 				</StatsPeriodNavigation>
 				<SegmentedControl primary>

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -1,7 +1,7 @@
 import { SegmentedControl } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
@@ -85,6 +85,18 @@ export default function VideoSummary( {
 
 	const apiPeriod: ApiPeriod = uiPeriod === 'day' || uiPeriod === 'week' ? 'month' : 'year';
 
+	// The endpoint's `month` window spans 31 days inclusive; trim to the
+	// trailing 30 so totals line up with the 30-day window the Videos module
+	// and the All videos page show by default. Shared by the bucketing below
+	// and by the header's date-range label, so both agree on the window.
+	const trimToTrailingWindow = useCallback(
+		(
+			data?: Array< { period: string; value: number } >
+		): Array< { period: string; value: number } > | undefined =>
+			apiPeriod === 'month' && data && data.length > 30 ? data.slice( -30 ) : data,
+		[ apiPeriod ]
+	);
+
 	const queries = useMemo(
 		() =>
 			Object.fromEntries(
@@ -154,14 +166,9 @@ export default function VideoSummary( {
 	// period wants, summing values. Bucket keys are normalized ISO dates.
 	const buckets: BucketRecord[] = useMemo( () => {
 		const unit = uiPeriod;
-		// The endpoint's `month` window spans 31 days inclusive; trim to the
-		// trailing 30 so totals line up with the 30-day window the Videos
-		// module and the All videos page show by default.
-		const trimToWindow = ( data?: Array< { period: string; value: number } > ) =>
-			apiPeriod === 'month' && data && data.length > 30 ? data.slice( -30 ) : data;
 		const toBucketMap = ( data?: Array< { period: string; value: number } > ) => {
 			const map = new Map< string, number >();
-			for ( const { period: date, value } of trimToWindow( data ) ?? [] ) {
+			for ( const { period: date, value } of trimToTrailingWindow( data ) ?? [] ) {
 				const parsed = moment( date );
 				if ( ! parsed.isValid() ) {
 					continue;
@@ -192,7 +199,7 @@ export default function VideoSummary( {
 			impressions: impressionsByBucket.get( key ) ?? 0,
 			watchTime: watchTimeByBucket.get( key ) ?? 0,
 		} ) );
-	}, [ playsData, impressionsData, watchTimeData, uiPeriod, apiPeriod, moment ] );
+	}, [ playsData, impressionsData, watchTimeData, uiPeriod, trimToTrailingWindow, moment ] );
 
 	const chartData: ChartRecord[] = useMemo(
 		() =>
@@ -237,6 +244,27 @@ export default function VideoSummary( {
 
 	const selected =
 		selectedRecord ?? ( chartData.length ? chartData[ chartData.length - 1 ] : null );
+
+	// The header shows the fixed trailing window the chart actually covers
+	// (like the Traffic page's date-range header), rather than the period of
+	// whichever single bar is selected, so it reads the same across every
+	// Day/Week/Month/Year tab.
+	const chartDateRange = useMemo( () => {
+		const windowDates = [ playsData?.data, impressionsData?.data, watchTimeData?.data ]
+			.flatMap( ( data ) => trimToTrailingWindow( data ) ?? [] )
+			.map( ( { period } ) => period )
+			.filter( ( date ) => moment( date ).isValid() )
+			.sort();
+
+		if ( ! windowDates.length ) {
+			return undefined;
+		}
+
+		return {
+			chartStart: moment( windowDates[ 0 ] ).format( 'YYYY-MM-DD' ),
+			chartEnd: moment().format( 'YYYY-MM-DD' ),
+		};
+	}, [ playsData, impressionsData, watchTimeData, trimToTrailingWindow, moment ] );
 
 	// Card totals cover the whole window shown in the chart.
 	const metricValues: VideoMetricValues = useMemo( () => {
@@ -293,9 +321,15 @@ export default function VideoSummary( {
 			<StatsPeriodHeader>
 				{ /* The video stats endpoint only returns a fixed trailing window
 				ending "now" (no backend support yet for an older window), so
-				there's no previous/next period to navigate to. */ }
-				<StatsPeriodNavigation showArrows disablePreviousArrow disableNextArrow date={ null }>
-					<DatePicker period={ uiPeriod } date={ selected?.startDate } isShort />
+				there's no previous/next period to navigate to; the arrows are
+				hidden rather than shown disabled. */ }
+				<StatsPeriodNavigation showArrows={ false } date={ null }>
+					<DatePicker
+						period={ uiPeriod }
+						date={ selected?.startDate }
+						dateRange={ chartDateRange }
+						isShort
+					/>
 				</StatsPeriodNavigation>
 				<SegmentedControl primary>
 					{ periods.map( ( { id, label } ) => (

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -49,6 +49,7 @@ interface BucketRecord {
 
 interface VideoSummaryData {
 	data?: Array< { period: string; value: number } >;
+	post?: { post_date?: string } | null;
 }
 
 const STAT_TYPES: VideoStatType[] = [ 'views', 'impressions', 'watch_time' ];
@@ -86,16 +87,48 @@ export default function VideoSummary( {
 
 	const apiPeriod: ApiPeriod = uiPeriod === 'day' || uiPeriod === 'week' ? 'month' : 'year';
 
+	// The video's publish date, so the chart never shows periods before the
+	// video existed. Always queried with period=month (rather than reusing
+	// `apiPeriod`, which can be 'year') to mirror the parent StatsVideoDetail
+	// component's videoInfoQuery, so this reuses the same cached response.
+	const videoInfoQuery = useMemo(
+		() => ( { postId, statType: 'views', period: 'month' as const } ),
+		[ postId ]
+	);
+	const videoPublishDate = useSelector(
+		( state ) =>
+			(
+				getSiteStatsNormalizedData(
+					state,
+					siteId,
+					'statsVideo',
+					videoInfoQuery
+				) as VideoSummaryData | null
+			 )?.post?.post_date ?? null
+	);
+
 	// The endpoint's `month` window spans 31 days inclusive; trim to the
 	// trailing 30 so totals line up with the 30-day window the Videos module
-	// and the All videos page show by default. Shared by the bucketing below
-	// and by the header's date-range label, so both agree on the window.
+	// and the All videos page show by default, and drop any raw entry before
+	// the video's publish date. Shared by the bucketing below and by the
+	// header's date-range label, so both agree on the window.
 	const trimToTrailingWindow = useCallback(
 		(
 			data?: Array< { period: string; value: number } >
-		): Array< { period: string; value: number } > | undefined =>
-			apiPeriod === 'month' && data && data.length > 30 ? data.slice( -30 ) : data,
-		[ apiPeriod ]
+		): Array< { period: string; value: number } > | undefined => {
+			const trimmed = apiPeriod === 'month' && data && data.length > 30 ? data.slice( -30 ) : data;
+			if ( ! trimmed || ! videoPublishDate ) {
+				return trimmed;
+			}
+			// apiPeriod === 'year' raw entries are whole months (e.g.
+			// '2026-07'); comparing those at day granularity would drop the
+			// publish month entirely for a video published mid-month.
+			const unit = apiPeriod === 'year' ? 'month' : 'day';
+			return trimmed.filter(
+				( { period } ) => ! moment( period ).isBefore( videoPublishDate, unit )
+			);
+		},
+		[ apiPeriod, videoPublishDate, moment ]
 	);
 
 	const queries = useMemo(
@@ -194,14 +227,17 @@ export default function VideoSummary( {
 			] )
 		).sort();
 
-		// Cap to the most recent STATS_SUMMARY_MAX_BARS buckets so this chart
-		// shows the same amount of history per view as the Post Details chart,
-		// which pages in chunks of the same size. Weeks/Years will still fall
-		// short of that cap: the endpoint's `month`/`year` windows only cover
-		// ~30 days / ~13 months of raw data, which bucket into fewer than 10
-		// weeks/years regardless of this cap — there's no more granular data
-		// to draw from without a backend change.
-		return keys.slice( -STATS_SUMMARY_MAX_BARS ).map( ( key ) => ( {
+		// Cap Weeks/Months/Years to the most recent STATS_SUMMARY_MAX_BARS
+		// buckets so they show the same amount of history per view as the
+		// Post Details chart, which pages in chunks of the same size. Weeks/
+		// Years will still fall short of that cap: the endpoint's `month`/
+		// `year` windows only cover ~30 days / ~13 months of raw data, which
+		// bucket into fewer than 10 weeks/years regardless of this cap —
+		// there's no more granular data to draw from without a backend
+		// change. Days aren't capped; there's no pagination for this chart,
+		// so it shows the full ~30-day window it always has.
+		const cappedKeys = uiPeriod === 'day' ? keys : keys.slice( -STATS_SUMMARY_MAX_BARS );
+		return cappedKeys.map( ( key ) => ( {
 			key,
 			plays: playsByBucket.get( key ) ?? 0,
 			impressions: impressionsByBucket.get( key ) ?? 0,
@@ -344,6 +380,17 @@ export default function VideoSummary( {
 						query={ queries[ type ] }
 					/>
 				) ) }
+			{ /* apiPeriod is already 'month' on the Days/Weeks tabs, so
+			queries.views above is this exact query already; only fetch it
+			separately when viewing Months/Years. */ }
+			{ siteId && apiPeriod !== 'month' && (
+				<QuerySiteStats
+					key="video-info"
+					siteId={ siteId }
+					statType="statsVideo"
+					query={ videoInfoQuery }
+				/>
+			) }
 
 			<StatsPeriodHeader>
 				{ /* The video stats endpoint only returns a fixed trailing window


### PR DESCRIPTION
Fixes STATS-318

## Proposed Changes

* Post Details summary chart (`stats-post-summary`):
  * Prev/next arrows now always page the whole visible window of bars (Day/Week/Month/Year), mirroring the Traffic page's chart date-range navigation, instead of stepping through individual bars and only jumping a full page at the edge of the loaded window.
  * **Data sourcing, per backend investigation** (see "Why" below): Days use `stats.data` (full daily history) directly. Weeks are aggregated client-side from that same daily history, since `stats.weeks` is hard-coded server-side to a rolling 7-week window with no request parameter able to widen it. Months/Years use the API's own `stats.years` field directly — it turned out **not** to be truncated the way `stats.weeks` is; its lower bound is simply the first year the post has any recorded views, so no client-side reconstruction is needed there.
  * The header date label now shows the date range covered by the current page of bars, instead of whichever single bar was last selected — consistent across all four tabs, clamped so it never extends into the future for the current in-progress period.
  * The UTM breakdown module now queries that same page range (`start_date`/`date`/`summarize`, matching the pattern the Traffic page's own UTM module already uses) instead of a single period ending at a selected bar.
  * Clicking a bar on the chart no longer does anything; the now-unused selection state and click handler were removed.
  * Dates sent to the backend now use the `YYYY-MM-DD` format the rest of the stats module uses, instead of `YYYY/MM/DD`.
* Video Details summary chart (`stats-video-detail`):
  * Prev/next arrows are hidden (not just disabled), since there's no other window to page to.
  * The header now shows the date range the visible bars cover, derived from the actual bucket data (not the browser's "today"), instead of the period of whichever single bar happens to be selected — clamped the same way as Post Details so it never extends into the future.
  * The chart no longer highlights the most recent bar by default; nothing is highlighted until a bar is clicked directly.
  * Weeks/Months/Years now share the same `STATS_SUMMARY_MAX_BARS` cap Post Details pages by (up to 10 bars), instead of an inconsistent, ad-hoc number per period. Weeks/Years still fall short of that cap — the endpoint's underlying data windows are inherently too small to bucket into 10 real weeks/years. Days are **not** capped — there's no pagination on this chart, so it shows its full ~30-day window as it always did.
  * The chart no longer shows periods that predate the video's actual publish date. Previously it bucketed whatever fixed trailing window the backend returned (~30 days / ~13 months, always ending "now") regardless of when the video was published, so a recently-uploaded video showed mostly-empty weeks/months/years reaching back before it existed. Now filters those out using the video's publish date (reusing the same query the page header already uses to display "Published …"), comparing at day granularity for the daily window and month granularity for the monthly window so a video published mid-month doesn't lose its whole publish month.

## Why are these changes being made?

The arrows on Post Details and Video Details stepped through individual bars on the chart one at a time. On the Traffic page, the equivalent arrows instead shift the whole visible date range (a set of days) forward/back. This PR brings Post Details in line with that model.

**Backend investigation for Weeks/Months/Years** (`GET /sites/%s/stats/post/%d`, `WPCOM_JSON_API_Stats_V1_1_Post_Views_Endpoint`):
- The endpoint takes no query parameters at all — `weeks`/`years` can't be widened by any request param, today or in principle without a code change.
- `weeks` is a hard-coded 7-iteration rolling window anchored to `last monday − 5 weeks`, always ending at "now." There is no way to get more than 7 weeks of real weekly-aggregate data from this endpoint for a single post.
- `years`, despite looking similarly limited in testing (a post from 2009 only showed years from 2021), is **not** an artificial window — its lower bound is `$first->year`, the year of the earliest day with a *non-zero* recorded view for that post. It already reflects the post's genuine traffic history, just not padded with meaningless all-zero years before the post's real popularity began.
- `data` (daily) is complete because it's built differently server-side — it zero-fills every day from the post's actual creation, independent of the non-zero-view filtering that bounds `weeks`/`years`.
- No other WPCOM endpoint exposes per-post weekly/yearly aggregates for an arbitrary historical range; that capability exists in the underlying `stats_get_postviews()` data layer but isn't surfaced through any REST route today.

Given that, Weeks are reconstructed from the daily data (the only way to get real historical weekly paging), while Months/Years use the API's own field directly (it's already correct and complete, so reconstructing it would just be redundant, riskier logic).

Restoring the API-backed month path reintroduced a regression the original trimming logic used to guard against: expanding every year in `stats.years` to 12 months includes the current year's not-yet-happened months as fake zero bars, which page-based pagination would surface ahead of real recent months. Fixed by filtering out months after the current one.

**Known follow-up (not addressed in this PR):** the "clamp to today" logic in `getPageDateRange()` (Post Details) and `chartDateRange` (Video Details) uses `moment()` (browser-local time) rather than a site-timezone-aware moment. This matches an existing pattern already in this file and is a narrow edge case (only matters right at a month/week boundary when the viewer's timezone differs from the site's), but a full fix would need wiring `getMomentSiteZone` through these class/function components — left as a separate follow-up rather than a broader refactor bundled into this PR.

Video Details can't get the same arrow-paging fix yet: the `statsVideo` REST endpoint (`GET /sites/%s/stats/video/%d`) only accepts `statType` and `period`, and hard-codes the returned window to always end at "now" — there's no `date`/`before` param, and the legacy JSON API base class strips any undeclared query param before it reaches the endpoint callback. A separate site-wide endpoint (`/stats/video-plays`) does support arbitrary historical ranges and could enable this in the future by filtering its per-video breakdown client-side, but that's a larger follow-up, not part of this PR.

## Testing Instructions

* Visit a post's Stats > Post Details page (ideally an older post with years of history).
* On the Day/Week/Month/Year tabs, click the prev/next arrows and confirm the whole set of bars shifts to the previous/next window, and that paging continues correctly all the way back to the post's publish date (not disabling early).
* Confirm the Months tab doesn't show any bars for months later than the current month.
* Confirm the header above the chart shows the date range of the currently displayed page, not a single day/week/month/year, and never a date in the future.
* Confirm the UTM module below the chart reflects that same page range.
* Click a bar directly and confirm nothing happens (no highlight, no header/UTM change).
* Visit a video's Stats > Video Details page and confirm the prev/next arrows are not rendered on any period tab, no bar is highlighted by default, and clicking a bar directly still selects it.
* On Video Details, confirm Days shows up to ~30 bars and Weeks/Months/Years show up to 10, with the header date range matching what's actually plotted.
* On a recently-published video (e.g. uploaded within the last 30 days), confirm the Weeks/Months/Years tabs don't show empty bars for periods before the video's publish date.


| Page details - BEFORE | Page details - AFTER |
|-|-|
| <video src="https://github.com/user-attachments/assets/83c78edb-8717-4333-b175-ae18c4e32864"> |  <video src="https://github.com/user-attachments/assets/535cf9f3-7a44-4f34-9c5d-35194a40954d"> |

| Video details - BEFORE | Video details - AFTER |
|-|-|
| <video src="https://github.com/user-attachments/assets/44e81680-0c9e-4940-af1f-b60d1f507dae"> |  <video src="https://github.com/user-attachments/assets/9afea8a4-482b-42f8-a100-3e5ab3123f8d"> |


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
