### PR TITLE
Plugins "Upgrade and activate": open the plan upgrade flow instead of the Plans page

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
@@ -11,6 +11,7 @@ The plan upgrade flow is designed to provide a streamlined experience for existi
 - `siteSlug` - **Required** - The site slug for which to upgrade the plan
 - `redirect_to` - URL to redirect to after checkout completion
 - `feature` - Filter out all plans which don't provide this feature.
+- `products` - Comma-separated product slugs to check out alongside the selected plan, e.g. a paid plugin or theme. They go to checkout as given, on the term the caller chose: a marketplace subscription bills independently of the plan, so the grid's interval toggle governs the plan only.
 
 ### Flow Steps
 

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,4 +1,5 @@
 import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
+import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -10,6 +11,7 @@ import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getCurrentQueryParams } from 'calypso/landing/stepper/utils/get-current-query-params';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { isExternal } from 'calypso/lib/url';
+import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
 
@@ -99,6 +101,8 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 		const siteSlug = query.get( 'siteSlug' );
 		const redirectTo = query.get( 'redirect_to' );
 
+		const extraProducts = query.get( 'products' );
+
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 
@@ -108,14 +112,33 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 					if ( providedDependencies?.cartItems && providedDependencies.cartItems.length > 0 ) {
 						const selectedPlan = providedDependencies.cartItems[ 0 ]?.product_slug;
 						if ( selectedPlan && siteSlug ) {
-							const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ selectedPlan }`;
+							const extras = extraProducts?.split( ',' ).filter( Boolean ) ?? [];
+							// Checkout encodes slashes in a slug its own way; the router won't take a
+							// percent-encoded one.
+							const products = [ selectedPlan, ...extras ].map( encodeProductForUrl ).join( ',' );
+							const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ products }`;
 							const currentPath = window.location.href.replace( window.location.origin, '' );
+
+							// The user can drop a product at checkout and buy the plan alone, so only a
+							// plan-only cart has a destination we can name up front. Otherwise checkout derives
+							// it from what was bought — but reads two things first, so clear both.
+							const checkoutChoosesDestination = extras.length > 0 && ! redirectTo;
+
+							// Signup leaves the page it meant to end on in a cookie, good for a day. This
+							// purchase isn't that signup finishing.
+							if ( checkoutChoosesDestination ) {
+								clearSignupDestinationCookie();
+							}
 
 							// Build checkout URL with query params
 							// Note: Not using goToCheckout utility because it hardcodes signup=1
 							// Checkout validates redirect_to to prevent open redirects
 							const finalUrl = addQueryArgs( checkoutUrl, {
-								redirect_to: redirectTo || dashboardLink( '/sites' ),
+								...( checkoutChoosesDestination
+									? // Declines checkout's upsell, which if taken leaves it an email cart the
+									  // plugin can't be read from.
+									  { upgrade: 1 }
+									: { redirect_to: redirectTo || dashboardLink( '/sites' ) } ),
 								cancel_to: currentPath,
 							} );
 

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/test/plan-upgrade.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/test/plan-upgrade.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+import { STEPS } from '../../../internals/steps';
+import planUpgradeFlow from '../plan-upgrade';
+
+let mockQuery: Record< string, string > = {};
+
+jest.mock( '@automattic/onboarding', () => ( { PLAN_UPGRADE_FLOW: 'plan-upgrade' } ) );
+jest.mock( 'calypso/landing/stepper/stores', () => ( { SITE_STORE: 'SITE_STORE' } ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: () => ( { get: ( key: string ) => mockQuery[ key ] ?? null } ),
+} ) );
+
+const mockClearSignupDestination = jest.fn();
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	clearSignupDestinationCookie: () => mockClearSignupDestination(),
+} ) );
+
+const submitPlan = ( plan: string ) =>
+	planUpgradeFlow.useStepNavigation( STEPS.UNIFIED_PLANS.slug, jest.fn() ).submit( {
+		slug: STEPS.UNIFIED_PLANS.slug,
+		providedDependencies: { stepName: 'plans', cartItems: [ { product_slug: plan } ] },
+	} );
+
+const checkoutUrl = () => ( window.location.assign as jest.Mock ).mock.calls[ 0 ][ 0 ];
+
+describe( 'plan-upgrade flow', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockQuery = { siteSlug: 'example.wordpress.com' };
+		Object.defineProperty( window, 'location', {
+			value: { ...window.location, assign: jest.fn() },
+			writable: true,
+		} );
+	} );
+
+	it( 'checks out the products it was given alongside the plan', () => {
+		mockQuery.products = 'sensei_pro_monthly';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).toContain(
+			'/checkout/example.wordpress.com/personal-bundle,sensei_pro_monthly?'
+		);
+	} );
+
+	it( 'hands checkout a slug with a slash in the encoding it reads back', () => {
+		// The router won't take a percent-encoded slash, so checkout has an encoding of its own.
+		mockQuery.products = 'no-adverts/no-adverts.php';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).toContain(
+			'/checkout/example.wordpress.com/personal-bundle,no-adverts%25no-adverts.php?'
+		);
+	} );
+
+	it( 'leaves the destination to checkout when a product is in the cart', () => {
+		mockQuery.products = 'sensei_pro_monthly';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).not.toContain( 'redirect_to' );
+	} );
+
+	it( 'keeps checkout from offering an upsell that would swallow the cart destination', () => {
+		mockQuery.products = 'sensei_pro_monthly';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).toContain( 'upgrade=1' );
+	} );
+
+	it( 'lets checkout make its offer when it has a destination to come back to', () => {
+		mockQuery.redirect_to = '/plugins/givewp/example.wordpress.com';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).not.toContain( 'upgrade=1' );
+	} );
+
+	it( 'drops a recent signup destination, which checkout would take over the cart', () => {
+		// Checkout reads the cookie before the cart.
+		mockQuery.products = 'sensei_pro_monthly';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( mockClearSignupDestination ).toHaveBeenCalled();
+	} );
+
+	it( 'keeps the signup destination when the caller named a destination of its own', () => {
+		mockQuery.redirect_to = '/plugins/givewp/example.wordpress.com';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( mockClearSignupDestination ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends a plan-only purchase where the caller asked', () => {
+		mockQuery.redirect_to = '/plugins/givewp/example.wordpress.com';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).toContain(
+			`redirect_to=${ encodeURIComponent( '/plugins/givewp/example.wordpress.com' ) }`
+		);
+	} );
+
+	it( 'falls back to the sites dashboard when the caller asks for nowhere', () => {
+		mockQuery.redirect_to = '';
+
+		submitPlan( 'personal-bundle' );
+
+		expect( checkoutUrl() ).toContain( 'redirect_to=' );
+	} );
+} );

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -5,12 +5,15 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
+import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { ToggleControl, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import { navigate } from 'calypso/lib/navigate';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
+import { addQueryArgs } from 'calypso/lib/url';
 import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -244,7 +247,23 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	);
 }
 
-function onClickInstallPlugin( {
+/**
+ * The plan upgrade flow: the plans grid over the current page, then checkout.
+ */
+export function getPlanUpgradeUrl( { siteSlug, productSlug, intervalType, redirectTo, cancelTo } ) {
+	return addQueryArgs(
+		{
+			siteSlug,
+			products: productSlug,
+			intervalType,
+			redirect_to: redirectTo,
+			cancel_to: cancelTo,
+		},
+		`/setup/${ PLAN_UPGRADE_FLOW }`
+	);
+}
+
+export function onClickInstallPlugin( {
 	dispatch,
 	selectedSite,
 	plugin,
@@ -281,35 +300,59 @@ function onClickInstallPlugin( {
 
 	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
 
+	// We need to add the product to the cart.
+	// Plugin install is handled on the backend by activating the subscription.
+	const variationPeriod = getPeriodVariationValue( billingPeriod );
+	const variation = plugin?.variations?.[ variationPeriod ];
+	const productSlug = isMarketplaceProduct
+		? getProductSlugByPeriodVariation( variation, productsList )
+		: undefined;
+
+	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
+
+	// A preinstalled premium plugin buys its own product rather than a plan.
+	const shouldUseStepperPlans =
+		upgradeAndInstall && ! isPreinstalledPremiumPlugin && isEnabled( 'plugins/stepper-plans' );
+
+	if ( shouldUseStepperPlans ) {
+		return navigate(
+			getPlanUpgradeUrl( {
+				siteSlug: selectedSite.slug,
+				productSlug,
+				intervalType: ( isMarketplaceProduct && variationPeriod ) || 'yearly',
+				// A paid plugin is in the cart, so checkout works out where to land — even if the user
+				// removes it before paying. A free plugin isn't, so name its installation page, and
+				// directInstall it: the state that normally authorizes the install is lost on the way
+				// out of Calypso.
+				redirectTo: isMarketplaceProduct
+					? undefined
+					: addQueryArgs( { directInstall: 1 }, installPluginURL ),
+				cancelTo: window.location.pathname + window.location.search,
+			} ),
+			false,
+			true
+		);
+	}
+
 	if ( isMarketplaceProduct ) {
-		// We need to add the product to the  cart.
-		// Plugin install is handled on the backend by activating the subscription.
-		const variationPeriod = getPeriodVariationValue( billingPeriod );
-
-		const variation = plugin?.variations?.[ variationPeriod ];
-		const product_slug = getProductSlugByPeriodVariation( variation, productsList );
-
 		if ( upgradeAndInstall ) {
 			// Redirect to plans page to let user choose a plan, then checkout with plan + plugin
-			const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 			return page(
 				`/plans/${ selectedSite.slug }?plan=personal-bundle&plugin=${ encodeURIComponent(
-					product_slug
+					productSlug
 				) }&redirect_to=${ encodeURIComponent( installPluginURL ) }`
 			);
 		}
 
-		return page( `/checkout/${ selectedSite.slug }/${ product_slug }#step2` );
+		return page( `/checkout/${ selectedSite.slug }/${ productSlug }#step2` );
 	}
 
 	if ( isPreinstalledPremiumPlugin ) {
 		const checkoutUrl = `/checkout/${ selectedSite.slug }/${ preinstalledPremiumPluginProduct }`;
-		const installUrl = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
-		return page( `${ checkoutUrl }?redirect_to=${ installUrl }#step2` );
+		return page( `${ checkoutUrl }?redirect_to=${ installPluginURL }#step2` );
 	}
 
 	// After buying a plan we need to redirect to the plugin install page.
-	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 	if ( upgradeAndInstall ) {
 		// Redirect to plans page to let user choose a plan, then redirect to plugin install
 		return page(

--- a/client/my-sites/plugins/plugin-details-CTA/test/CTA-button.js
+++ b/client/my-sites/plugins/plugin-details-CTA/test/CTA-button.js
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { navigate } from 'calypso/lib/navigate';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { onClickInstallPlugin } from '../CTA-button';
+
+// The module is a callable config function carrying isEnabled; keep it callable.
+jest.mock( '@automattic/calypso-config', () => {
+	const actual = jest.requireActual( '@automattic/calypso-config' );
+	const config = ( key ) => actual( key );
+	config.isEnabled = jest.fn();
+	return config;
+} );
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+jest.mock( 'calypso/lib/navigate', () => ( { navigate: jest.fn() } ) );
+
+const selectedSite = { slug: 'example.wordpress.com' };
+const paidPlugin = {
+	slug: 'sensei-pro',
+	tags: {},
+	variations: { monthly: { product_slug: 'sensei_pro_monthly' } },
+};
+const freePlugin = { slug: 'givewp', tags: {} };
+
+const clickUpgradeAndActivate = ( plugin, isMarketplaceProduct = false ) =>
+	onClickInstallPlugin( {
+		dispatch: jest.fn(),
+		selectedSite,
+		plugin,
+		upgradeAndInstall: true,
+		isMarketplaceProduct,
+		billingPeriod: IntervalLength.MONTHLY,
+		productsList: {},
+	} );
+
+const upgradeFlowArgs = () =>
+	Object.fromEntries(
+		new URL( navigate.mock.calls[ 0 ][ 0 ], 'https://example.com' ).searchParams
+	);
+
+describe( 'onClickInstallPlugin', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.history.replaceState( {}, '', '/plugins/sensei-pro/example.wordpress.com' );
+	} );
+
+	describe( 'with the plan upgrade flow', () => {
+		beforeEach( () => isEnabled.mockReturnValue( true ) );
+
+		it( 'takes a paid plugin to the flow, leaving the destination to checkout', () => {
+			clickUpgradeAndActivate( paidPlugin, true );
+
+			expect( navigate ).toHaveBeenCalledWith(
+				expect.stringContaining( '/setup/plan-upgrade?' ),
+				false,
+				true
+			);
+			expect( upgradeFlowArgs() ).toEqual( {
+				siteSlug: 'example.wordpress.com',
+				products: 'sensei_pro_monthly',
+				intervalType: 'monthly',
+				cancel_to: '/plugins/sensei-pro/example.wordpress.com',
+			} );
+			expect( page ).not.toHaveBeenCalled();
+		} );
+
+		it( 'sends a free plugin back to an installation that can run without the queued state', () => {
+			clickUpgradeAndActivate( freePlugin );
+
+			expect( upgradeFlowArgs() ).toMatchObject( {
+				intervalType: 'yearly',
+				redirect_to: '/marketplace/plugin/givewp/install/example.wordpress.com?directInstall=1',
+			} );
+			expect( upgradeFlowArgs() ).not.toHaveProperty( 'products' );
+		} );
+	} );
+
+	describe( 'with the flag off', () => {
+		beforeEach( () => isEnabled.mockReturnValue( false ) );
+
+		it( 'takes a paid plugin to the site plans page', () => {
+			clickUpgradeAndActivate( paidPlugin, true );
+
+			expect( page ).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'/plans/example.wordpress.com?plan=personal-bundle&plugin=sensei_pro_monthly'
+				)
+			);
+			expect( navigate ).not.toHaveBeenCalled();
+		} );
+
+		it( 'takes a free plugin to the site plans page', () => {
+			clickUpgradeAndActivate( freePlugin );
+
+			expect( page ).toHaveBeenCalledWith(
+				expect.stringContaining( '/plans/example.wordpress.com?plan=personal-bundle&redirect_to=' )
+			);
+			expect( navigate ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -183,6 +183,7 @@
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,
+		"plugins/stepper-plans": true,
 		"plugins/universal-header": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,6 +106,7 @@
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,
+		"plugins/stepper-plans": false,
 		"plugins/universal-header": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": false,

--- a/config/production.json
+++ b/config/production.json
@@ -134,6 +134,7 @@
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": false,
+		"plugins/stepper-plans": false,
 		"plugins/universal-header": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -132,6 +132,7 @@
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,
+		"plugins/stepper-plans": false,
 		"plugins/universal-header": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,

--- a/config/test.json
+++ b/config/test.json
@@ -93,6 +93,7 @@
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
 		"plugins/plugin-compass": true,
+		"plugins/stepper-plans": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,6 +139,7 @@
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,
+		"plugins/stepper-plans": true,
 		"plugins/universal-header": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,


### PR DESCRIPTION
Related to DOTMKT-38.

## Proposed Changes

* "Upgrade and activate" now goes to the Stepper plan upgrade flow (`/setup/plan-upgrade`) instead of the site's Plans page. The user picks a plan there and continues to checkout, and going back returns them to the plugin page.
* A paid plugin travels with the plan into checkout. Where the user lands afterwards is left to checkout, which knows what was actually bought, so it stays right if they remove the plugin before paying. A free plugin instead returns to its installation.
* The plan upgrade flow can now buy products alongside the plan.
* Behind `plugins/stepper-plans`, on in development and wpcalypso, off elsewhere. It adds one branch to the CTA; with the flag off, behaviour is unchanged.

## Why are these changes being made?

Plugins are on all paid plans now, so the marketplace upgrade paths should offer any paid plan, and upgrading shouldn't strand users away from the plugin they came for. This is the logged-in half; the logged-out "Get started" path was done previously.

## Testing Instructions

The flag is on for Calypso Live. Add `?flags=-plugins/stepper-plans` to the plugin page URL to test the fallback.

1. On a Free-plan site, open `/plugins/givewp/<site>` and click "Upgrade and activate".
2. You should land on the plans step, offering every paid plan, rather than a forced Business upgrade or the Plans page. Going back should return you to the plugin page.
3. Buy a plan (test card). The plugin should install rather than hang on "Putting the pieces together".
4. Repeat with a paid plugin (e.g. Sensei Pro): checkout should hold the plan *and* the plugin, and the plugin page's monthly/yearly choice should carry into the plans step.
5. Remove the plugin from the cart before paying. The destination should follow the cart.
6. Repeat on a site created in the same session. It should land on what was bought, not back in onboarding.
7. With the flag off, the CTA should still go to the Plans page, carrying the plugin.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
