### PR TITLE
Login: add Spacefast OAuth magic-code flow

### DIFF
--- a/client/assets/images/icons/spacefast-wordmark.svg
+++ b/client/assets/images/icons/spacefast-wordmark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 326 62">
+	<rect x="14" y="12" width="306" height="48" fill="#ff603d" />
+	<rect x="10" y="8" width="306" height="48" fill="#141419" stroke="#141419" stroke-width="1" />
+	<path
+		fill="#f4f0e6"
+		d="M22 19h24v7H29v7h17v20H22v-7h17v-7H22V19ZM53 19h24v18H60v16h-7V19Zm7 11h10v-4H60v4ZM85 19h24l9 34h-8l-2-8H86l-2 8h-8l9-34Zm3 19h18l-4-12H92l-4 12ZM152 26h-19v20h19v7h-26V19h26v7ZM158 19h26v7h-19v6h15v7h-15v7h19v7h-26V19ZM190 19h25v7h-18v6h15v7h-15v14h-7V19ZM220 19h24l9 34h-8l-2-8h-22l-2 8h-8l9-34Zm3 19h18l-4-12h-10l-4 12ZM259 19h24v7h-17v7h17v20h-24v-7h17v-7h-17V19ZM286 19h27v7h-10v27h-7V26h-10v-7Z"
+	/>
+</svg>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -17,6 +17,7 @@ import {
 	isBlazeProOAuth2Client,
 	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
+	isSpacefastOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import isPassportRedirect from 'calypso/lib/passport/is-passport-redirect';
 import { login } from 'calypso/lib/paths';
@@ -241,7 +242,11 @@ class Login extends Component {
 	handleTwoFactorRequested = ( authType ) => {
 		if ( this.props.onTwoFactorRequested ) {
 			this.props.onTwoFactorRequested( authType );
-		} else if ( this.props.isWCCOM || this.props.isGravPoweredClient ) {
+		} else if (
+			this.props.isWCCOM ||
+			this.props.isGravPoweredClient ||
+			isSpacefastOAuth2Client( this.props.oauth2Client )
+		) {
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -51,6 +51,10 @@ export const isGravPoweredOAuth2Client = ( oauth2Client ) => {
 	return isGravatarOAuth2Client( oauth2Client ) || isWPJobManagerOAuth2Client( oauth2Client );
 };
 
+export const isSpacefastOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 137504 || oauth2Client?.source === 'spacefast';
+};
+
 export const isWooOAuth2Client = ( oauth2Client ) => {
 	// 50019 => WooCommerce Dev, 50915 => WooCommerce Staging, 50916 => WooCommerce Production.
 	return oauth2Client && [ 50019, 50915, 50916 ].includes( oauth2Client.id );

--- a/client/lib/test/oauth2-clients.js
+++ b/client/lib/test/oauth2-clients.js
@@ -4,6 +4,7 @@ import {
 	isSharedMobileAppOAuth2Client,
 	getOAuth2RedirectUri,
 	isJetpackAppRedirectUri,
+	isSpacefastOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 
 describe( 'oauth2-clients mobile app helpers', () => {
@@ -48,6 +49,16 @@ describe( 'oauth2-clients mobile app helpers', () => {
 			expect( isSharedMobileAppOAuth2Client( { id: 1854 } ) ).toBe( false );
 			expect( isSharedMobileAppOAuth2Client( { id: 68663 } ) ).toBe( false );
 			expect( isSharedMobileAppOAuth2Client( null ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isSpacefastOAuth2Client', () => {
+		test( 'matches the production client ID or verified source metadata', () => {
+			expect( isSpacefastOAuth2Client( { id: 137504, source: 'spacefast' } ) ).toBe( true );
+			expect( isSpacefastOAuth2Client( { id: 137504 } ) ).toBe( true );
+			expect( isSpacefastOAuth2Client( { id: 200000, source: 'spacefast' } ) ).toBe( true );
+			expect( isSpacefastOAuth2Client( { id: 1854, source: 'gravatar' } ) ).toBe( false );
+			expect( isSpacefastOAuth2Client( null ) ).toBe( false );
 		} );
 	} );
 

--- a/client/login/controller.jsx
+++ b/client/login/controller.jsx
@@ -146,8 +146,7 @@ export async function magicLogin( context, next ) {
 		return login( context, next );
 	}
 
-	// For Gravatar-related OAuth2 clients, check the necessary URL parameters and fetch the client data if needed.
-	if ( gravatar_flow ) {
+	if ( client_id || gravatar_flow ) {
 		if ( ! client_id ) {
 			const error = new Error( 'The `client_id` query parameter is missing.' );
 			error.status = 401;
@@ -160,14 +159,25 @@ export async function magicLogin( context, next ) {
 			return next( error );
 		}
 
-		const oauth2Client = getOAuth2Client( context.store.getState(), client_id );
-		// Only fetch the data if it's not already in the store. This is to avoid unnecessary requests and re-renders.
-		if ( ! oauth2Client ) {
-			try {
-				await context.store.dispatch( fetchOAuth2ClientData( client_id ) );
-			} catch ( error ) {
-				return next( error );
-			}
+		const { searchParams: redirectParams } = getUrlParts( redirect_to );
+		const back = redirectParams.get( 'back' );
+		const redirectClientId =
+			redirectParams.get( 'client_id' ) ||
+			( back ? getUrlParts( back ).searchParams.get( 'client_id' ) : null );
+		if ( client_id !== redirectClientId ) {
+			const error = new Error(
+				'The `redirect_to` query parameter is invalid with the given `client_id`.'
+			);
+			error.status = 401;
+			return next( error );
+		}
+
+		try {
+			// Magic-login branding is derived from this server-owned response. Fetch it on every
+			// entry so persisted client state can never opt a request into a branded flow.
+			await context.store.dispatch( fetchOAuth2ClientData( client_id ) );
+		} catch ( error ) {
+			return next( error );
 		}
 	}
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -12,6 +12,7 @@ import {
 	isAndroidOAuth2Client,
 	isGravPoweredOAuth2Client,
 	isIosOAuth2Client,
+	isSpacefastOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { detectPartnerConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
@@ -46,6 +47,7 @@ import GravPoweredMagicLogin from './gravatar';
 import MainContentWooCoreProfiler from './main-content-woo-core-profiler';
 import RequestLoginCode from './request-login-code';
 import RequestLoginEmailForm from './request-login-email-form';
+import SpacefastMagicLogin from './spacefast';
 import {
 	getCheckYourEmailHeaders,
 	getEmailCodeHeaders,
@@ -280,6 +282,10 @@ export class MagicLogin extends Component {
 		} = this.props;
 		const { usernameOrEmail } = this.state;
 
+		if ( isSpacefastOAuth2Client( oauth2Client ) ) {
+			return <SpacefastMagicLogin />;
+		}
+
 		if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 			return <GravPoweredMagicLogin path={ this.props.path } />;
 		}
@@ -348,6 +354,13 @@ export class MagicLogin extends Component {
 }
 
 export const getMagicLoginInitialHeaders = ( props, translate ) => {
+	if ( isSpacefastOAuth2Client( props.oauth2Client ) ) {
+		return {
+			heading: translate( 'Log in or sign up for Spacefast' ),
+			subHeading: translate( 'Continue with your WordPress.com account.' ),
+		};
+	}
+
 	if ( isGravPoweredOAuth2Client( props.oauth2Client ) ) {
 		return {};
 	}

--- a/client/login/magic-login/spacefast/index.tsx
+++ b/client/login/magic-login/spacefast/index.tsx
@@ -1,0 +1,502 @@
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { FormLabel } from '@automattic/components';
+import { getLanguage, localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
+import emailValidator from 'email-validator';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
+import { ConsentText } from 'calypso/components/connect-screen/consent-text';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import { isSpacefastOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { login } from 'calypso/lib/paths';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
+import wpcom from 'calypso/lib/wp';
+import { useLoginContext } from 'calypso/login/login-context';
+import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
+import { useDispatch, useSelector } from 'calypso/state';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
+import { fetchMagicLoginAuthenticate } from 'calypso/state/login/magic-login/actions';
+import {
+	getLastCheckedUsernameOrEmail,
+	getRedirectToSanitized,
+	getTwoFactorNotificationSent,
+	isTwoFactorEnabled,
+} from 'calypso/state/login/selectors';
+import {
+	getCurrentOAuth2Client,
+	getCurrentOAuth2ClientId,
+} from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
+import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
+import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+
+type ApiError = {
+	error?: string;
+	code?: string | number;
+	message?: string;
+	status?: number;
+};
+
+type CodeResponse = {
+	public_token?: string;
+};
+
+export type SpacefastLoginStartResult =
+	| { status: 'needs-email'; username: string }
+	| { status: 'code-sent'; identifier: string; publicToken: string; createsAccount: boolean };
+
+interface BeginSpacefastLoginOptions {
+	identifier: string;
+	requestAuthOptions: ( identifier: string ) => Promise< unknown >;
+	sendLoginCode: ( identifier: string, createsAccount: boolean ) => Promise< CodeResponse >;
+}
+
+interface ContinueAfterSpacefastCodeOptions {
+	twoFactorEnabled: boolean;
+	twoFactorAuthType: string;
+	redirectTo: string;
+	oauth2ClientId: number;
+	locale: string;
+	reboot: () => void;
+	navigate: ( url: string ) => void;
+}
+
+export function continueAfterSpacefastCode( {
+	twoFactorEnabled,
+	twoFactorAuthType,
+	redirectTo,
+	oauth2ClientId,
+	locale,
+	reboot,
+	navigate,
+}: ContinueAfterSpacefastCodeOptions ) {
+	if ( ! twoFactorEnabled ) {
+		reboot();
+		return;
+	}
+
+	navigate(
+		login( {
+			twoFactorAuthType,
+			redirectTo,
+			oauth2ClientId,
+			locale,
+		} )
+	);
+}
+
+export async function beginSpacefastLogin( {
+	identifier,
+	requestAuthOptions,
+	sendLoginCode,
+}: BeginSpacefastLoginOptions ): Promise< SpacefastLoginStartResult > {
+	const normalizedIdentifier = identifier.trim();
+	const looksLikeEmail = normalizedIdentifier.includes( '@' );
+	const isEmail = emailValidator.validate( normalizedIdentifier );
+
+	if ( looksLikeEmail && ! isEmail ) {
+		throw new Error( 'invalid_email' );
+	}
+
+	let createsAccount = false;
+	try {
+		await requestAuthOptions( normalizedIdentifier );
+	} catch ( error ) {
+		const apiError = error as ApiError;
+		if ( ( apiError.error ?? apiError.code ) !== 'unknown_user' ) {
+			throw error;
+		}
+
+		if ( ! isEmail ) {
+			return { status: 'needs-email', username: normalizedIdentifier };
+		}
+
+		createsAccount = true;
+	}
+
+	const { public_token: publicToken } = await sendLoginCode( normalizedIdentifier, createsAccount );
+	if ( ! publicToken ) {
+		throw new Error( 'missing_public_token' );
+	}
+
+	return {
+		status: 'code-sent',
+		identifier: normalizedIdentifier,
+		publicToken,
+		createsAccount,
+	};
+}
+
+type LoginStep = 'identifier' | 'email' | 'code';
+
+interface SpacefastMagicLoginViewProps {
+	initialIdentifier?: string;
+	locale: string;
+	oauth2ClientId: number;
+	redirectTo: string;
+	isVerifyingCode: boolean;
+	verificationError?: ApiError | null;
+	beginLogin: ( identifier: string ) => Promise< SpacefastLoginStartResult >;
+	verifyCode: ( token: string ) => void;
+}
+
+const getRequestErrorMessage = ( error: unknown, translate: ReturnType< typeof useTranslate > ) => {
+	if ( error instanceof Error && error.message === 'invalid_email' ) {
+		return translate( 'Enter a valid email address.' );
+	}
+	const apiError = error as ApiError;
+	if ( apiError.message ) {
+		return apiError.message;
+	}
+	return translate( 'We couldn’t send a code. Please try again.' );
+};
+
+const getVerificationErrorMessage = (
+	error: ApiError | null | undefined,
+	translate: ReturnType< typeof useTranslate >
+) => {
+	if ( error?.status === 429 || error?.code === 429 ) {
+		return translate( 'Please wait a minute before trying again.' );
+	}
+	return translate( 'That code didn’t work. Check it and try again.' );
+};
+
+export function SpacefastMagicLoginView( {
+	initialIdentifier = '',
+	locale,
+	oauth2ClientId,
+	redirectTo,
+	isVerifyingCode,
+	verificationError,
+	beginLogin,
+	verifyCode,
+}: SpacefastMagicLoginViewProps ) {
+	const translate = useTranslate();
+	const { setHeaders } = useLoginContext();
+	const [ step, setStep ] = useState< LoginStep >( 'identifier' );
+	const [ identifier, setIdentifier ] = useState( initialIdentifier );
+	const [ unknownUsername, setUnknownUsername ] = useState( '' );
+	const [ publicToken, setPublicToken ] = useState( '' );
+	const [ verificationCode, setVerificationCode ] = useState( '' );
+	const [ isRequestingCode, setIsRequestingCode ] = useState( false );
+	const [ requestError, setRequestError ] = useState< string | null >( null );
+
+	useEffect( () => {
+		if ( step === 'email' ) {
+			setHeaders( {
+				heading: translate( 'Enter your email address' ),
+				subHeading: translate(
+					'We couldn’t find a WordPress.com account for “%(username)s”. Use an email address to continue.',
+					{ args: { username: unknownUsername } }
+				),
+			} );
+			return;
+		}
+
+		if ( step === 'code' ) {
+			setHeaders( {
+				heading: translate( 'Check your email' ),
+				subHeading: translate(
+					'Enter the six-character code sent to the email on your WordPress.com account.'
+				),
+			} );
+			return;
+		}
+
+		setHeaders( {
+			heading: translate( 'Log in or sign up for Spacefast' ),
+			subHeading: translate( 'Continue with your WordPress.com account.' ),
+		} );
+	}, [ setHeaders, step, translate, unknownUsername ] );
+
+	const requestCode = async () => {
+		if ( ! identifier.trim() ) {
+			return;
+		}
+
+		setIsRequestingCode( true );
+		setRequestError( null );
+		try {
+			const result = await beginLogin( identifier );
+			if ( result.status === 'needs-email' ) {
+				setUnknownUsername( result.username );
+				setIdentifier( '' );
+				setStep( 'email' );
+				return;
+			}
+
+			setIdentifier( result.identifier );
+			setPublicToken( result.publicToken );
+			setVerificationCode( '' );
+			setStep( 'code' );
+		} catch ( error ) {
+			setRequestError( getRequestErrorMessage( error, translate ) );
+		} finally {
+			setIsRequestingCode( false );
+		}
+	};
+
+	const onIdentifierSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		void requestCode();
+	};
+
+	const onCodeSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		if ( verificationCode.length !== 6 || ! publicToken ) {
+			return;
+		}
+		verifyCode( `${ publicToken }:${ btoa( verificationCode ) }` );
+	};
+
+	const passwordLoginUrl = login( {
+		locale,
+		redirectTo,
+		oauth2ClientId,
+		emailAddress: identifier || undefined,
+	} );
+
+	const terms = translate(
+		'By continuing, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}. If you don’t have a WordPress.com account, we’ll create one.',
+		{
+			components: {
+				tosLink: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				privacyLink: (
+					<a
+						href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
+
+	return (
+		<Main className="magic-login magic-login__request-link">
+			<div className="magic-login__form">
+				{ step === 'code' ? (
+					<LoggedOutForm className="magic-login__form-form" onSubmit={ onCodeSubmit }>
+						<FormLabel htmlFor="spacefast-verification-code">
+							{ translate( 'Verification code' ) }
+						</FormLabel>
+						<FormFieldset className="magic-login__email-fields">
+							<FormTextInput
+								id="spacefast-verification-code"
+								name="verificationCode"
+								value={ verificationCode }
+								onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+									setVerificationCode(
+										event.target.value
+											.toUpperCase()
+											.replace( /[^A-Z0-9]/g, '' )
+											.slice( 0, 6 )
+									)
+								}
+								autoComplete="one-time-code"
+								pattern="[A-Z0-9]*"
+								maxLength={ 6 }
+								disabled={ isVerifyingCode }
+								isError={ Boolean( verificationError ) }
+								autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+							/>
+							{ verificationError && (
+								<Notice
+									text={ getVerificationErrorMessage( verificationError, translate ) }
+									showDismiss={ false }
+									status="is-transparent-info"
+								/>
+							) }
+							{ requestError && (
+								<Notice text={ requestError } showDismiss={ false } status="is-transparent-info" />
+							) }
+							<div className="magic-login__form-action">
+								<ActionButtons
+									primaryLabel={ translate( 'Continue' ) }
+									primaryType="submit"
+									primaryDisabled={ verificationCode.length !== 6 }
+									primaryLoading={ isVerifyingCode }
+								/>
+							</div>
+						</FormFieldset>
+					</LoggedOutForm>
+				) : (
+					<LoggedOutForm className="magic-login__form-form" onSubmit={ onIdentifierSubmit }>
+						<FormLabel htmlFor="spacefast-identifier">
+							{ step === 'email'
+								? translate( 'Email address' )
+								: translate( 'Email address or username' ) }
+						</FormLabel>
+						<FormFieldset className="magic-login__email-fields">
+							<FormTextInput
+								id="spacefast-identifier"
+								name="usernameOrEmail"
+								value={ identifier }
+								onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) => {
+									setIdentifier( event.target.value );
+									setRequestError( null );
+								} }
+								type={ step === 'email' ? 'email' : 'text' }
+								autoComplete="username"
+								disabled={ isRequestingCode }
+								isError={ Boolean( requestError ) }
+								autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+							/>
+							<ConsentText className="magic-login__tos wp-login__one-login-layout-tos">
+								{ terms }
+							</ConsentText>
+							{ requestError && (
+								<Notice text={ requestError } showDismiss={ false } status="is-transparent-info" />
+							) }
+							<div className="magic-login__form-action">
+								<ActionButtons
+									primaryLabel={ translate( 'Email me a code' ) }
+									primaryType="submit"
+									primaryDisabled={ ! identifier.trim() }
+									primaryLoading={ isRequestingCode }
+								/>
+							</div>
+						</FormFieldset>
+					</LoggedOutForm>
+				) }
+			</div>
+			<div className="one-login__footer">
+				<div className="one-login__footer-links-wrapper">
+					{ step === 'code' && (
+						<>
+							<Button
+								variant="link"
+								onClick={ () => void requestCode() }
+								disabled={ isRequestingCode || isVerifyingCode }
+							>
+								{ translate( 'Send another code' ) }
+							</Button>
+							<Button
+								variant="link"
+								onClick={ () => {
+									setStep( 'identifier' );
+									setVerificationCode( '' );
+									setRequestError( null );
+								} }
+							>
+								{ translate( 'Use a different account' ) }
+							</Button>
+						</>
+					) }
+					<a className="one-login__footer-link" href={ passwordLoginUrl }>
+						{ translate( 'Use a password or another method' ) }
+					</a>
+				</div>
+			</div>
+		</Main>
+	);
+}
+
+const SpacefastMagicLogin = () => {
+	const dispatch = useDispatch();
+	const locale = useSelector( getCurrentLocaleSlug );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const oauth2ClientId = useSelector( getCurrentOAuth2ClientId );
+	const currentQuery = useSelector( getCurrentQueryArguments ) as
+		| Record< string, string >
+		| undefined;
+	const initialQuery = useSelector( getInitialQueryArguments );
+	const lastCheckedIdentifier = useSelector( getLastCheckedUsernameOrEmail ) as string | null;
+	const redirectToSanitized = useSelector( getRedirectToSanitized );
+	const twoFactorEnabled = useSelector( isTwoFactorEnabled );
+	const twoFactorNotificationSent = useSelector( getTwoFactorNotificationSent );
+	const isVerifyingCode = useSelector( isFetchingMagicLoginAuth );
+	const isCodeVerified = useSelector( getMagicLoginRequestedAuthSuccessfully );
+	const verificationError = useSelector( getMagicLoginRequestAuthError );
+	const redirectTo = currentQuery?.redirect_to ?? '';
+	const initialIdentifier =
+		lastCheckedIdentifier || currentQuery?.email_address || initialQuery?.email_address || '';
+
+	useEffect( () => {
+		if ( ! isCodeVerified || ! oauth2ClientId ) {
+			return;
+		}
+
+		continueAfterSpacefastCode( {
+			twoFactorEnabled,
+			twoFactorAuthType:
+				twoFactorNotificationSent?.replace( 'none', 'authenticator' ) ?? 'authenticator',
+			redirectTo: redirectToSanitized ?? redirectTo,
+			oauth2ClientId,
+			locale,
+			reboot: () => dispatch( rebootAfterLogin( { magic_login: 1 } ) ),
+			navigate: page,
+		} );
+	}, [
+		dispatch,
+		isCodeVerified,
+		locale,
+		oauth2ClientId,
+		redirectTo,
+		redirectToSanitized,
+		twoFactorEnabled,
+		twoFactorNotificationSent,
+	] );
+
+	if ( ! oauth2ClientId || ! isSpacefastOAuth2Client( oauth2Client ) ) {
+		return null;
+	}
+
+	const beginLogin = ( identifier: string ) =>
+		beginSpacefastLogin( {
+			identifier,
+			requestAuthOptions: ( value ) =>
+				wpcom.req.get( `/users/${ encodeURIComponent( value ) }/auth-options` ),
+			sendLoginCode: ( value, createsAccount ) =>
+				wpcom.req.post(
+					'/auth/send-login-email',
+					{ apiVersion: '1.3' },
+					{
+						client_id: config( 'wpcom_signup_id' ),
+						client_secret: config( 'wpcom_signup_key' ),
+						locale,
+						lang_id: getLanguage( locale )?.value,
+						email: value,
+						redirect_to: redirectTo,
+						flow: 'spacefast',
+						create_account: createsAccount,
+						tos: getToSAcceptancePayload(),
+						token_type: 'code',
+					}
+				),
+		} );
+
+	return (
+		<OneLoginLayout isJetpack={ false } isSectionSignup showLogo>
+			<SpacefastMagicLoginView
+				initialIdentifier={ initialIdentifier }
+				locale={ locale }
+				oauth2ClientId={ oauth2ClientId }
+				redirectTo={ redirectTo }
+				isVerifyingCode={ isVerifyingCode || isCodeVerified }
+				verificationError={ verificationError }
+				beginLogin={ beginLogin }
+				verifyCode={ ( token ) =>
+					dispatch( fetchMagicLoginAuthenticate( token, redirectTo, 'spacefast', true ) )
+				}
+			/>
+		</OneLoginLayout>
+	);
+};
+
+export default SpacefastMagicLogin;

--- a/client/login/magic-login/spacefast/test/index.test.tsx
+++ b/client/login/magic-login/spacefast/test/index.test.tsx
@@ -1,0 +1,238 @@
+/** @jest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoginContext } from 'calypso/login/login-context';
+import {
+	beginSpacefastLogin,
+	continueAfterSpacefastCode,
+	SpacefastMagicLoginView,
+	type SpacefastLoginStartResult,
+} from '../index';
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+const rejectUnknownUser = async () => {
+	throw Object.assign( new Error( 'Unknown user' ), { error: 'unknown_user' } );
+};
+
+describe( 'beginSpacefastLogin', () => {
+	it( 'emails a code to an existing username without creating an account', async () => {
+		const sentCodes: Array< [ string, boolean ] > = [];
+		const requestAuthOptions = async () => ( { passwordless: false } );
+		const sendLoginCode = async ( identifier: string, createsAccount: boolean ) => {
+			sentCodes.push( [ identifier, createsAccount ] );
+			return { public_token: 'public-token' };
+		};
+
+		await expect(
+			beginSpacefastLogin( { identifier: 'existing-user', requestAuthOptions, sendLoginCode } )
+		).resolves.toEqual( {
+			status: 'code-sent',
+			identifier: 'existing-user',
+			publicToken: 'public-token',
+			createsAccount: false,
+		} );
+		expect( sentCodes ).toEqual( [ [ 'existing-user', false ] ] );
+	} );
+
+	it( 'creates an account and emails a code for an unknown email in one submission', async () => {
+		const sentCodes: Array< [ string, boolean ] > = [];
+		const requestAuthOptions = rejectUnknownUser;
+		const sendLoginCode = async ( identifier: string, createsAccount: boolean ) => {
+			sentCodes.push( [ identifier, createsAccount ] );
+			return { public_token: 'new-user-token' };
+		};
+
+		await expect(
+			beginSpacefastLogin( {
+				identifier: 'new@example.com',
+				requestAuthOptions,
+				sendLoginCode,
+			} )
+		).resolves.toEqual( {
+			status: 'code-sent',
+			identifier: 'new@example.com',
+			publicToken: 'new-user-token',
+			createsAccount: true,
+		} );
+		expect( sentCodes ).toEqual( [ [ 'new@example.com', true ] ] );
+	} );
+
+	it( 'asks for an email instead of trying to register an unknown username', async () => {
+		const sentCodes: Array< [ string, boolean ] > = [];
+		const requestAuthOptions = rejectUnknownUser;
+		const sendLoginCode = async ( identifier: string, createsAccount: boolean ) => {
+			sentCodes.push( [ identifier, createsAccount ] );
+			return { public_token: 'unused' };
+		};
+
+		await expect(
+			beginSpacefastLogin( { identifier: 'new-user', requestAuthOptions, sendLoginCode } )
+		).resolves.toEqual( { status: 'needs-email', username: 'new-user' } );
+		expect( sentCodes ).toEqual( [] );
+	} );
+
+	it( 'rejects a malformed email before requesting account details', async () => {
+		let requestedIdentifier = '';
+		const requestAuthOptions = async ( identifier: string ) => {
+			requestedIdentifier = identifier;
+		};
+		const sendLoginCode = async () => ( { public_token: 'unused' } );
+
+		await expect(
+			beginSpacefastLogin( {
+				identifier: 'person@invalid',
+				requestAuthOptions,
+				sendLoginCode,
+			} )
+		).rejects.toThrow( 'invalid_email' );
+		expect( requestedIdentifier ).toBe( '' );
+	} );
+} );
+
+describe( 'continueAfterSpacefastCode', () => {
+	it( 'keeps the OAuth redirect in the native 2FA route without rebooting', () => {
+		let rebooted = false;
+		let navigatedTo = '';
+		continueAfterSpacefastCode( {
+			twoFactorEnabled: true,
+			twoFactorAuthType: 'authenticator',
+			redirectTo: 'https://public-api.wordpress.com/oauth2/authorize?client_id=137504&state=abc',
+			oauth2ClientId: 137504,
+			locale: 'en',
+			reboot: () => {
+				rebooted = true;
+			},
+			navigate: ( url ) => {
+				navigatedTo = url;
+			},
+		} );
+
+		const query = new URLSearchParams( navigatedTo.split( '?' )[ 1 ] );
+		expect( rebooted ).toBe( false );
+		expect( navigatedTo.startsWith( '/log-in/authenticator' ) ).toBe( true );
+		expect( query.get( 'client_id' ) ).toBe( '137504' );
+		expect( query.get( 'redirect_to' ) ).toContain( 'state=abc' );
+	} );
+
+	it( 'reboots into the authorization flow when no second factor is needed', () => {
+		let rebooted = false;
+		let navigatedTo = '';
+		continueAfterSpacefastCode( {
+			twoFactorEnabled: false,
+			twoFactorAuthType: 'authenticator',
+			redirectTo: 'https://public-api.wordpress.com/oauth2/authorize?client_id=137504',
+			oauth2ClientId: 137504,
+			locale: 'en',
+			reboot: () => {
+				rebooted = true;
+			},
+			navigate: ( url ) => {
+				navigatedTo = url;
+			},
+		} );
+
+		expect( rebooted ).toBe( true );
+		expect( navigatedTo ).toBe( '' );
+	} );
+} );
+
+describe( 'SpacefastMagicLoginView', () => {
+	const baseProps = {
+		locale: 'en',
+		oauth2ClientId: 137504,
+		redirectTo: 'https://public-api.wordpress.com/oauth2/authorize?client_id=137504',
+		isVerifyingCode: false,
+		verificationError: null,
+		verifyCode: () => {},
+	};
+
+	const renderView = (
+		beginLogin: ( identifier: string ) => Promise< SpacefastLoginStartResult >,
+		props = {}
+	) =>
+		render(
+			<LoginContext.Provider value={ { setHeaders: () => {} } }>
+				<SpacefastMagicLoginView { ...baseProps } { ...props } beginLogin={ beginLogin } />
+			</LoginContext.Provider>
+		);
+
+	it( 'prompts for an email after an unknown username', async () => {
+		const submittedIdentifiers: string[] = [];
+		const beginLogin = async ( identifier: string ) => {
+			submittedIdentifiers.push( identifier );
+			return { status: 'needs-email' as const, username: identifier };
+		};
+		renderView( beginLogin );
+
+		await userEvent.type( screen.getByLabelText( 'Email address or username' ), 'missing-user' );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Email me a code' } ) );
+
+		expect( await screen.findByLabelText( 'Email address' ) ).toBeVisible();
+		expect( submittedIdentifiers ).toEqual( [ 'missing-user' ] );
+	} );
+
+	it( 'keeps the OAuth client and redirect on the native login link', () => {
+		const beginLogin = async () => ( { status: 'needs-email', username: 'unused' } ) as const;
+		renderView( beginLogin, { initialIdentifier: 'person@example.com' } );
+
+		const href = screen
+			.getByRole( 'link', { name: 'Use a password or another method' } )
+			.getAttribute( 'href' );
+		const url = new URL( href ?? '', 'https://calypso.localhost:3000' );
+		expect( url.pathname ).toBe( '/log-in' );
+		expect( url.searchParams.get( 'client_id' ) ).toBe( '137504' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( baseProps.redirectTo );
+	} );
+
+	it( 'accepts a six-character code and authenticates with the public token', async () => {
+		const beginLogin = async () =>
+			( {
+				status: 'code-sent',
+				identifier: 'person@example.com',
+				publicToken: 'public-token',
+				createsAccount: false,
+			} ) as const;
+		const verifiedTokens: string[] = [];
+		const verifyCode = ( token: string ) => {
+			verifiedTokens.push( token );
+		};
+		renderView( beginLogin, { initialIdentifier: 'person@example.com', verifyCode } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Email me a code' } ) );
+		const codeInput = await screen.findByLabelText( 'Verification code' );
+		await userEvent.type( codeInput, '12a-34b' );
+		expect( codeInput ).toHaveValue( '12A34B' );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		await waitFor( () => expect( verifiedTokens ).toEqual( [ 'public-token:MTJBMzRC' ] ) );
+	} );
+
+	it( 'shows a resend failure while keeping the code form available', async () => {
+		let requestCount = 0;
+		const beginLogin = async () => {
+			requestCount += 1;
+			if ( requestCount > 1 ) {
+				throw new Error( 'Please wait before requesting another code.' );
+			}
+			return {
+				status: 'code-sent',
+				identifier: 'person@example.com',
+				publicToken: 'public-token',
+				createsAccount: false,
+			} as const;
+		};
+		renderView( beginLogin, { initialIdentifier: 'person@example.com' } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Email me a code' } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Send another code' } ) );
+
+		expect(
+			await screen.findByText( 'Please wait before requesting another code.' )
+		).toBeVisible();
+		expect( screen.getByLabelText( 'Verification code' ) ).toBeVisible();
+	} );
+} );

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { getConnectionFlowFromRedirectTo, getMagicLoginInitialHeaders, MagicLogin } from '../index';
+import SpacefastMagicLogin from '../spacefast';
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	detectPartnerConfig: jest.fn(),
@@ -124,6 +125,26 @@ describe( 'magic-login branding behavior', () => {
 				} ),
 			} )
 		);
+	} );
+
+	it( 'renders Spacefast login only for verified Spacefast client metadata', () => {
+		const instance = new MagicLogin( {
+			...baseProps,
+			query: { spacefast_flow: '1' },
+			oauth2Client: { id: 137504, source: 'spacefast', title: 'Spacefast' },
+		} );
+
+		expect( instance.render().type ).toBe( SpacefastMagicLogin );
+	} );
+
+	it( 'ignores a Spacefast-looking query flag without verified metadata', () => {
+		const instance = new MagicLogin( {
+			...baseProps,
+			query: { spacefast_flow: '1' },
+			oauth2Client: null,
+		} );
+
+		expect( instance.render().type ).not.toBe( SpacefastMagicLogin );
 	} );
 } );
 

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
+import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
-import { redirectJetpack, login } from '../controller';
+import { redirectJetpack, login, magicLogin } from '../controller';
 
 jest.mock( 'calypso/state/oauth2-clients/actions', () => ( {
 	...jest.requireActual( 'calypso/state/oauth2-clients/actions' ),
@@ -123,5 +124,69 @@ describe( 'login', () => {
 
 		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
 		expect( next ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'magicLogin', () => {
+	let context;
+	let next;
+	let nextArguments;
+	let fetchedClientIds;
+	let dispatchedActions;
+
+	beforeEach( () => {
+		nextArguments = [];
+		fetchedClientIds = [];
+		dispatchedActions = [];
+		context = {
+			path: '/log-in/link',
+			query: {},
+			store: {
+				getState: jest.fn().mockReturnValue( { currentUser: { id: null } } ),
+				dispatch: ( action ) => {
+					dispatchedActions.push( action );
+					return action;
+				},
+			},
+		};
+		next = ( ...args ) => nextArguments.push( args );
+		fetchOAuth2ClientData.mockImplementation( ( clientId ) => {
+			fetchedClientIds.push( clientId );
+			return { type: 'FETCH_CLIENT', clientId };
+		} );
+	} );
+
+	it( 'fetches OAuth client metadata before rendering a client magic-login flow', async () => {
+		context.query = {
+			client_id: '137504',
+			redirect_to: 'https://public-api.wordpress.com/oauth2/authorize?client_id=137504',
+		};
+
+		await magicLogin( context, next );
+
+		expect( fetchedClientIds ).toEqual( [ '137504' ] );
+		expect( dispatchedActions ).toEqual( [ { type: 'FETCH_CLIENT', clientId: '137504' } ] );
+		expect( nextArguments ).toEqual( [ [] ] );
+	} );
+
+	it( 'rejects a client ID that does not match the OAuth redirect', async () => {
+		context.query = {
+			client_id: '137504',
+			redirect_to: 'https://public-api.wordpress.com/oauth2/authorize?client_id=1854',
+		};
+
+		await magicLogin( context, next );
+
+		expect( fetchedClientIds ).toEqual( [] );
+		expect( nextArguments[ 0 ][ 0 ].status ).toBe( 401 );
+	} );
+
+	it( 'does not derive a branded flow from query flags without a client ID', async () => {
+		context.query = { spacefast_flow: '1' };
+
+		await magicLogin( context, next );
+
+		expect( fetchedClientIds ).toEqual( [] );
+		expect( nextArguments ).toEqual( [ [] ] );
 	} );
 } );

--- a/client/login/wp-login/components/heading-logo.tsx
+++ b/client/login/wp-login/components/heading-logo.tsx
@@ -5,6 +5,7 @@ import akismetLogo from 'calypso/assets/images/icons/akismet-logo.svg';
 import crowdsignalLogo from 'calypso/assets/images/icons/crowdsignal.svg';
 import gravatarLogo from 'calypso/assets/images/icons/gravatar.svg';
 import passportLogo from 'calypso/assets/images/icons/passport-icon-rounded.svg';
+import spacefastWordmark from 'calypso/assets/images/icons/spacefast-wordmark.svg';
 import studioAppLogo from 'calypso/assets/images/icons/studio-app-logo.svg';
 import wpJobManagerLogo from 'calypso/assets/images/icons/wp-job-manager.webp';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -23,6 +24,7 @@ import {
 	isPartnerPortalOAuth2Client,
 	isSharedMobileAppOAuth2Client,
 	isIosOAuth2Client,
+	isSpacefastOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useSelector } from 'calypso/state';
@@ -76,6 +78,10 @@ const HeadingLogo = ( { isJetpack, isFromJetpackConnector, connectorPlugins }: P
 	let logo = null;
 	if ( isPushTwoFactor ) {
 		logo = <img src={ JETPACK_PUSH_LOGO_URL } alt="Jetpack" />;
+	} else if ( isSpacefastOAuth2Client( oauth2Client ) ) {
+		logo = (
+			<img src={ spacefastWordmark } alt="Spacefast" className="wp-login__spacefast-wordmark" />
+		);
 	} else if ( isStudioAppOAuth2Client( oauth2Client ) ) {
 		logo = <img src={ studioAppLogo } alt="Studio App Logo" />;
 	} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import '@automattic/typography/styles/variables';
 
 .wp-login__one-login-layout-content-wrapper {
 	display: flex;
@@ -20,6 +20,11 @@
 	> img {
 		width: 64px;
 		height: 64px;
+	}
+
+	> .wp-login__spacefast-wordmark {
+		width: min( 244px, 100% );
+		height: auto;
 	}
 }
 

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -10,6 +10,7 @@ import {
 	isVIPOAuth2Client,
 	isSharedMobileAppOAuth2Client,
 	isIosOAuth2Client,
+	isSpacefastOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -175,6 +176,8 @@ export function getHeaderText( {
 				clientName = 'Woo';
 			} else if ( isVIPOAuth2Client( oauth2Client ) ) {
 				clientName = 'VIP';
+			} else if ( isSpacefastOAuth2Client( oauth2Client ) ) {
+				clientName = 'Spacefast';
 			}
 
 			/**


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Add a Spacefast-specific magic-code login view selected only from server-provided OAuth client metadata.
* Preserve OAuth redirect and two-factor state while supporting existing users and email-first account creation.
* Add the Spacefast wordmark and focused controller, client-classification, and UI tests.

## Why are these changes being made?

* Spacefast uses WordPress.com as its account identity provider. This gives that verified OAuth client a direct branded code flow without trusting caller-supplied branding flags.
* The corresponding WordPress.com OAuth routing and email-template change must land before this UI is enabled end to end.

## Testing Instructions

* Run `yarn test-client client/login/magic-login/spacefast/test/index.test.tsx client/lib/test/oauth2-clients.js client/login/magic-login/test/index.test.jsx client/login/test/controller.js --runInBand`.
* Run ESLint on the changed JavaScript and TypeScript files, Stylelint on `one-login-layout.scss`, and Prettier check on all changed files.
* Exercise `/log-in/link` with the verified Spacefast OAuth client and confirm unknown usernames request an email, codes preserve the OAuth redirect, and 2FA continues through the native route.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?