### PR TITLE
Stats: Theme the form checkbox checked state

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -15,16 +15,26 @@
 		display: none;
 	}
 
-	.form-checkbox:checked::before {
-		// Increase Calypso styles specificity.
-		content: url(calypso/assets/images/checkbox-icons/checkmark-primary.svg);
-		width: 12px;
-		height: 12px;
-		margin: 3px auto;
-		display: inline-block;
+	// Checked: secondary-button-like outline style, matching the accent chain the
+	// @wordpress/components controls (e.g. the chart type toggle) already follow.
+	.form-checkbox:checked {
+		background-color: transparent;
+		border-color: var(--wp-components-color-accent, var(--color-accent));
 
-		// Override WP-Admin styles.
-		float: none;
+		&::before {
+			// Render the checkmark through an alpha mask so it takes a theme color;
+			// the base form-checkbox checkmark is an SVG with a hardcoded stroke
+			// that ignores color schemes. Also overrides WP-Admin core's checked
+			// styles (white checkmark content, float: left).
+			content: "";
+			mask: url(calypso/assets/images/checkbox-icons/checkmark-primary.svg) no-repeat center / contain;
+			background-color: var(--wp-components-color-accent, var(--color-accent));
+			width: 12px;
+			height: 12px;
+			margin: 3px auto;
+			display: inline-block;
+			float: none;
+		}
 	}
 
 	// Jetpack custom styles.

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -311,8 +311,24 @@ $y-axis-padding: 0 20px;
 		border-radius: 2px;
 		margin-right: 8px;
 
-		&:checked::before {
-			margin: 3px auto;
+		// Checked: secondary-button-like outline style, matching the chart type
+		// toggle (`.components-button.is-secondary`) next to the legend.
+		&:checked {
+			background-color: transparent;
+			border-color: var(--wp-components-color-accent, var(--color-accent));
+
+			&::before {
+				// Render the checkmark through an alpha mask so it takes a theme
+				// color; the base form-checkbox checkmark is an SVG with a
+				// hardcoded stroke that ignores color schemes.
+				content: "";
+				display: block;
+				width: 12px;
+				height: 12px;
+				margin: 3px auto;
+				mask: url(calypso/assets/images/checkbox-icons/checkmark-primary.svg) no-repeat center / contain;
+				background-color: var(--wp-components-color-accent, var(--color-accent));
+			}
 		}
 	}
 }


### PR DESCRIPTION
Part of STATS-305

## Proposed Changes

* Theme the checked state of Calypso `form-checkbox` inputs in Odyssey Stats (e.g. the chart legend’s Views/Visitors toggles). The checkmark was a hardcoded-color SVG (`checkmark-primary.svg`, stroke `#006088`) re-asserted by the `.wp-admin` override in `apps/odyssey-stats/src/app.scss`, so it ignored the user’s admin color scheme entirely.
* The checked state now uses a secondary-button-like outline style — transparent background, accent border, accent checkmark — mirroring the chart type toggle (`.components-button.is-secondary`) next to the legend, via the same variable chain (`--wp-components-color-accent`, falling back to `--color-accent`).
* The checkmark renders through an alpha mask of the existing SVG so it can take a theme color; no new image asset.
* The chart legend checkbox in `client/components/chart/style.scss` gets the same checked style, so the chart’s consumers outside wp-admin (Calypso Stats, customer-home, store stats, Jetpack Cloud) also follow their color scheme’s accent instead of the hardcoded checkmark.

## Why are these changes being made?

* In wp-admin (Odyssey), `@wordpress/components` controls follow the user’s admin color scheme through `--wp-components-color-accent` (mapped to `--color-accent` in the Odyssey theme), and since the WP core admin reskin the native wp-admin checkboxes do too — but Calypso `form-checkbox` inputs rendered a fixed dark-blue checkmark regardless of scheme. One of the surfaces reported under STATS-305.
* Editing the existing `.wp-admin .form-checkbox:checked::before` override in place fixes every Calypso checkbox rendered inside Odyssey at once and avoids a specificity contest with that override; the chart-scoped rule extends the same style to the legend checkbox everywhere else the chart renders. Both rules set identical declarations, so they can never fight where they overlap. The variable chain used here already resolves on trunk, independent of the broader `--color-primary` → `--color-accent` alignment in #112496.

## Testing Instructions

* In wp-admin (Odyssey Stats), open the Traffic chart and toggle the Views/Visitors legend checkboxes: the checked state should show a transparent box with an accent-colored border and checkmark, matching the line/bar chart type toggle next to it.
* Switch the admin color scheme (Users → Profile → Admin Color Scheme) and confirm the checked checkbox follows the scheme.
* In Calypso Stats, the legend checkboxes now use the same accent-outline checked style; switch the dashboard color scheme (Me → Account Settings → Dashboard color scheme) and confirm the checked state follows the scheme’s accent.

### Odyssey Stats

#### Simple sites
|Before|After|
|-|-|
|<img width="1255" height="713" alt="截圖 2026-07-13 下午1 42 21" src="https://github.com/user-attachments/assets/802270ba-141e-4ff5-8d1b-a391c5a75c41" />|<img width="1260" height="713" alt="截圖 2026-07-13 下午1 41 45" src="https://github.com/user-attachments/assets/cb02835b-0508-4221-a0b4-1096db07a35d" />|

#### Atomic sites
|Before|After|
|-|-|
|<img width="1258" height="859" alt="截圖 2026-07-13 下午1 25 38" src="https://github.com/user-attachments/assets/3b119e5b-9ca7-40b8-9602-ea60a502f7e9" />|<img width="1253" height="869" alt="截圖 2026-07-13 下午1 32 42" src="https://github.com/user-attachments/assets/d54769b9-35a6-433e-b0a3-843c34bb9f7a" />|

#### Self-hosted sites
|Before|After|
|-|-|
|<img width="1256" height="635" alt="截圖 2026-07-13 中午12 13 31" src="https://github.com/user-attachments/assets/99f1c8ee-9aaa-4c55-9032-82084c67c0f3" />|<img width="1254" height="636" alt="截圖 2026-07-13 中午12 13 05" src="https://github.com/user-attachments/assets/f761e99d-8d37-4782-aa55-403734242228" />|

### Calypso Stats

#### Simple sites
|Before|After|
|-|-|
|<img width="1249" height="710" alt="截圖 2026-07-13 下午2 32 23" src="https://github.com/user-attachments/assets/8530354a-aaf5-4763-871d-1b964723ee88" />|<img width="1256" height="723" alt="截圖 2026-07-13 下午2 32 33" src="https://github.com/user-attachments/assets/c68544e2-80e4-48b6-90b5-33a15fb34738" />|

#### Atomic sites
|Before|After|
|-|-|
|<img width="1258" height="714" alt="截圖 2026-07-13 下午2 33 34" src="https://github.com/user-attachments/assets/0797836a-eb0f-4889-80a1-7ee7f7b8fd2f" />|<img width="1256" height="712" alt="截圖 2026-07-13 下午2 33 13" src="https://github.com/user-attachments/assets/c0b370a5-8261-44b2-bdc1-ed63def19e5a" />|

#### Self-hosted sites
|Before|After|
|-|-|
|<img width="1138" height="716" alt="截圖 2026-07-13 下午2 42 05" src="https://github.com/user-attachments/assets/6495beb4-057d-483e-a2eb-d3ae1238a7e5" />|<img width="1138" height="714" alt="截圖 2026-07-13 下午2 41 39" src="https://github.com/user-attachments/assets/3967b7c5-e89a-4dca-b9f8-057f4dd02743" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


