### PR TITLE
CI: show Claude bot PR review output for easier debugging

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -130,6 +130,7 @@ jobs:
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          display_report: true
           prompt: |
             # Code Review Instructions
 
@@ -200,6 +201,7 @@ jobs:
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          display_report: true
           prompt: |
             # Code Review Instructions (A4A)
 
@@ -268,6 +270,7 @@ jobs:
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          display_report: true
           prompt: |
             # Code Review Instructions (General)
 


### PR DESCRIPTION

## Proposed Changes

We used to be able to see the output of Claude bot PR review in GH Actions. But it seems Claude recently turns that option off by default (https://github.com/anthropics/claude-code-action/pull/992), so this PR explicitly enables that option.

## Why are these changes being made?

Easier debugging if certain prompt is not being followed by the bot.