### PR TITLE
AGENTS: more assertive way to tell not to add verbose comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ yarn reformat-files   # Fix formatting with Prettier
 yarn typecheck-client # Type-check client
 ```
 
+## Conventions
+
+- Do NOT add any verbose code comments that narrate what the change does or why it was made (e.g. `// Added this to fix X`, `// Changed from Y to Z`, restating the code in prose). Such explanation belongs in the PR description, not the source. Only keep comments that a future reader genuinely needs — non-obvious rationale, gotchas, links to context — and match the comment density and style of the surrounding code.
+
 ## Pre-PR checks
 
 Before pushing a branch or running `gh pr create`, run the type-check that CI will run. PRs touching `client/` may fail the `type_check_client` CI check after opening, so verify locally first:
@@ -88,7 +92,6 @@ If it fails, fix the type errors at the source — do not silence them with `// 
 
 ## Creating Pull Requests
 
-- Before pushing the changes, remove any verbose code comments that narrate what the change does or why it was made (e.g. `// Added this to fix X`, `// Changed from Y to Z`, restating the code in prose). Such explanation belongs in the PR description, not the source. Only keep comments that a future reader genuinely needs — non-obvious rationale, gotchas, links to context — and match the comment density and style of the surrounding code.
 - Create PRs as draft. Follow the template in .github/PULL_REQUEST_TEMPLATE.md.
 - Follow the branch naming conventions in docs/git-workflow.md.
 - In the PR description:


### PR DESCRIPTION
## Proposed Changes

Move the "don't add verbose comments" instruction from "Pre-PR checks" section to "Conventions" section. With this we hope that this rule is being followed by agents early during the code generation phase. This is to avoid this rule from being looked at too late or even not followed at all if the devs use different ways of creating PRs.