### PR TITLE
Stats: align video details tabs styling with Traffic page tabs

### DIFF
--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -191,36 +191,45 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 
 .stats-video-metric-tabs__tab {
 	flex: 1;
-	background: var(--color-surface);
-	border: 1px solid var(--studio-gray-5);
-	border-radius: 5px; /* stylelint-disable-line scales/radii */
+	background: var(--color-neutral-0);
+	border: 1.5px solid transparent;
+	border-radius: 4px;
 	box-sizing: border-box;
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
 	font-family: $font-sf-pro-text;
-	gap: 12px;
-	padding: 16px 24px;
+	gap: 8px;
+	padding: 8px 16px;
 	text-align: start;
 	width: 100%;
 
 	&:hover {
-		border-color: var(--studio-gray-30);
+		border-color: var(--color-neutral-10);
+
+		.stats-video-metric-tabs__header {
+			color: var(--studio-black);
+		}
 	}
 
 	&.is-selected {
+		background: var(--color-surface);
 		border-color: var(--color-primary);
-		box-shadow: inset 0 0 0 1px var(--color-primary);
+
+		.stats-video-metric-tabs__header {
+			color: var(--studio-black);
+		}
 	}
 }
 
 .stats-video-metric-tabs__header {
 	align-items: center;
-	color: var(--studio-gray-100);
+	color: var(--color-neutral-60);
 	display: flex;
 	font-size: $font-body-small;
 	gap: 8px;
-	line-height: 1.5;
+	letter-spacing: -0.15px;
+	line-height: 20px;
 
 	svg {
 		fill: currentColor;
@@ -228,8 +237,10 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 }
 
 .stats-video-metric-tabs__value {
-	@include stats-section-header;
-	color: var(--studio-gray-100);
+	color: var(--studio-black);
+	font-size: $font-title-medium;
+	font-weight: 500;
+	line-height: 40px;
 }
 
 @media (max-width: $break-medium) {


### PR DESCRIPTION
Fixes STATS-324

## Proposed Changes

* Align the video details page's metric-selector tabs (`stats-video-metric-tabs__tab` — Views / Impressions / Hours watched) with the Traffic page's tabs styling (`client/my-sites/stats/modernized-chart-tabs-styles.scss`, the `.is-chart-tabs .stats-tabs .stats-tab` rules)
* Match label typography (no uppercase/serif treatment, `$font-body-small`, `var(--color-neutral-60)` idle / `var(--studio-black)` on hover and selected)
* Match value typography and color (`$font-title-medium`, weight 500, `var(--studio-black)`) instead of the previous large serif number in a muted gray
* Tighten tile padding/gap and switch to Traffic's rounded-rect treatment (`border-radius: 4px`, `1.5px` border, `var(--color-neutral-0)` idle background / `var(--color-surface)` selected)

## Why are these changes being made?

The video details page's tabs were built as an independent "card tile" component during the recent VideoPress details page rewrite and never adopted the Traffic page's tab styling, so the two read as visually inconsistent components within the same Stats product — different casing, a much larger serif number, a different value color, and noticeably bulkier padding. This change reuses Traffic's typography, color, and spacing values so the two tab components feel like the same design system, without restructuring either component's underlying layout (video tabs intentionally keep a 3-up card grid; Traffic tabs remain a segmented row — reconciling those layouts is out of scope).

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/971d9b5b-cb05-4eb2-8e2d-cdc6db545f2c) | ![after](https://github.com/user-attachments/assets/d0235ca6-6b79-433f-ad53-f12acb337dbb) |

## Testing Instructions

* Visit a video's details page (`/stats/day/videodetails/<site>?post=<id>`) and compare the Views / Impressions / Hours watched tabs against the Traffic page's tabs (`/stats/day/<site>`)
* Confirm: labels are non-uppercase at `$font-body-small`, the value number is black at `$font-title-medium`/weight 500, idle background is light gray with a transparent border, hover darkens the border and label, and the selected tab gets a white background with a primary-colored border
* Click between tabs and confirm the chart below still swaps correctly
* Verified with `yarn stylelint client/my-sites/stats/stats-video-detail/style.scss` (clean) and `yarn typecheck-client` (no new errors)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
