### PR TITLE
Dashboard: use isSupportSession in interim omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -11,8 +11,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		return;
 	}
 
-	// Recolor the masterbar for support "user" sessions. "Next" sessions already
-	// have their own indicator, so they're excluded.
+	// Recolor the masterbar for support sessions.
 	if ( isSupportSession() ) {
 		container.classList.add( 'is-support-user-session' );
 	}

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,4 @@
-import { isSupportUserSession } from '@automattic/calypso-support-session';
+import { isSupportSession } from '@automattic/calypso-support-session';
 // eslint-disable-next-line no-restricted-imports
 import { I18N, I18NContext } from 'i18n-calypso';
 import { hydrateRoot } from 'react-dom/client';
@@ -13,7 +13,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 
 	// Recolor the masterbar for support "user" sessions. "Next" sessions already
 	// have their own indicator, so they're excluded.
-	if ( isSupportUserSession() ) {
+	if ( isSupportSession() ) {
 		container.classList.add( 'is-support-user-session' );
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Replace `isSupportUserSession` with `isSupportSession` from `@automattic/calypso-support-session` in the interim omnibar loader.

## Why are these changes being made?

* The interim omnibar recolors the masterbar for support sessions. It was calling `isSupportUserSession`, which only matches the "user" session variety. Using `isSupportSession` correctly detects support sessions when deciding whether to apply the `is-support-user-session` indicator.

## Testing Instructions

* Load the Dashboard within a support session and confirm the masterbar receives the `is-support-user-session` styling.
* Load it in a normal session and confirm the styling is not applied.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)