### PR TITLE
Dashboard: prevent cross-origin logout leaking cached user data

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -1,5 +1,9 @@
 import { fetchUser, isWpError, User } from '@automattic/api-core';
-import { clearQueryClient, disablePersistQueryClient } from '@automattic/api-queries';
+import {
+	clearQueryClient,
+	disablePersistQueryClient,
+	validateQueryCacheOwner,
+} from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { setUser } from '@automattic/calypso-sentry';
 import { isSupportUserSession } from '@automattic/calypso-support-session';
@@ -62,14 +66,18 @@ export async function initializeCurrentUser(): Promise< User > {
 	// sessions the server does bootstrap the correct `currentUser`.
 	const useBootstrap = ! isSupportUserSession() && config.isEnabled( 'wpcom-user-bootstrap' );
 
+	let user: User;
 	if ( useBootstrap ) {
-		if ( window.currentUser ) {
-			return window.currentUser;
+		if ( ! window.currentUser ) {
+			throw new Error( 'Failed to bootstrap user object' );
 		}
-		throw new Error( 'Failed to bootstrap user object' );
+		user = window.currentUser;
+	} else {
+		user = await fetchUser();
 	}
 
-	return fetchUser();
+	validateQueryCacheOwner( user.ID );
+	return user;
 }
 
 /**
@@ -115,6 +123,11 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		}
 
 		authErrorHandled.current = true;
+
+		// The session is gone, so treat this like a logout and leave no
+		// previous-user data behind before redirecting to login.
+		disablePersistQueryClient();
+		clearQueryClient();
 
 		if ( config.isEnabled( 'oauth' ) ) {
 			const state = crypto.randomUUID();

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -1,4 +1,4 @@
-import { persistQueryClientPromise } from '@automattic/api-queries';
+import { persistQueryClientPromise, validateQueryCacheOwner } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { captureException, initSentry } from '@automattic/calypso-sentry';
 import { maybeInitializeSupportSession } from '@automattic/calypso-support-session';
@@ -26,6 +26,12 @@ import '@automattic/omnibar/style.scss';
 function boot( config: AppConfig ) {
 	if ( handleOAuthCallback() ) {
 		return;
+	}
+
+	// Validate before anything renders; with user bootstrap the user is known
+	// synchronously. OAuth variants are covered by `initializeCurrentUser`.
+	if ( window.currentUser ) {
+		validateQueryCacheOwner( window.currentUser.ID );
 	}
 
 	maybeInitializeSupportSession( wpcom );

--- a/client/lib/user/clear-hosting-dashboard-storage.ts
+++ b/client/lib/user/clear-hosting-dashboard-storage.ts
@@ -1,0 +1,41 @@
+import config from '@automattic/calypso-config';
+
+/**
+ * The Hosting Dashboard lives on its own origin (e.g. my.wordpress.com), so
+ * logging out here can't clear its persisted caches directly. Instead, load
+ * its /clear-storage page in a hidden iframe (same-site, so not affected by
+ * storage partitioning) and wait for its completion message. Best effort:
+ * resolves after `timeout` ms no matter what, so logout is never blocked.
+ */
+export function clearHostingDashboardStorage( timeout = 2000 ): Promise< void > {
+	const url = config< string | false >( 'hosting_dashboard_clear_storage_url' );
+	if ( ! url || typeof document === 'undefined' || document.body === null ) {
+		return Promise.resolve();
+	}
+
+	return new Promise( ( resolve ) => {
+		const iframe = document.createElement( 'iframe' );
+		const listener = new AbortController();
+
+		const finish = () => {
+			listener.abort();
+			iframe.remove();
+			resolve();
+		};
+
+		window.addEventListener(
+			'message',
+			( event ) => {
+				if ( event.source === iframe.contentWindow && event.data === 'clear-storage:done' ) {
+					finish();
+				}
+			},
+			{ signal: listener.signal }
+		);
+		setTimeout( finish, timeout );
+
+		iframe.hidden = true;
+		iframe.src = url;
+		document.body.appendChild( iframe );
+	} );
+}

--- a/client/lib/user/test/clear-hosting-dashboard-storage.ts
+++ b/client/lib/user/test/clear-hosting-dashboard-storage.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { clearHostingDashboardStorage } from '../clear-hosting-dashboard-storage';
+
+jest.mock( '@automattic/calypso-config', () => jest.fn() );
+
+const mockConfig = config as unknown as jest.Mock;
+
+function getIframe(): HTMLIFrameElement | null {
+	return document.querySelector( 'iframe' );
+}
+
+describe( 'clearHostingDashboardStorage', () => {
+	afterEach( () => {
+		getIframe()?.remove();
+		jest.useRealTimers();
+	} );
+
+	it( 'resolves immediately when no URL is configured', async () => {
+		mockConfig.mockReturnValue( false );
+
+		await clearHostingDashboardStorage();
+
+		expect( getIframe() ).toBeNull();
+	} );
+
+	it( 'loads the configured URL in a hidden iframe and resolves on the done message', async () => {
+		mockConfig.mockReturnValue( 'https://my.wordpress.com/clear-storage' );
+
+		const promise = clearHostingDashboardStorage();
+		const iframe = getIframe();
+		expect( iframe ).not.toBeNull();
+		expect( iframe?.src ).toBe( 'https://my.wordpress.com/clear-storage' );
+		expect( iframe?.hidden ).toBe( true );
+
+		window.dispatchEvent(
+			new MessageEvent( 'message', {
+				data: 'clear-storage:done',
+				source: iframe?.contentWindow,
+			} )
+		);
+
+		await promise;
+		expect( getIframe() ).toBeNull();
+	} );
+
+	it( 'ignores messages from other sources', async () => {
+		jest.useFakeTimers();
+		mockConfig.mockReturnValue( 'https://my.wordpress.com/clear-storage' );
+
+		const promise = clearHostingDashboardStorage( 2000 );
+
+		window.dispatchEvent( new MessageEvent( 'message', { data: 'clear-storage:done' } ) );
+		expect( getIframe() ).not.toBeNull();
+
+		jest.advanceTimersByTime( 2000 );
+		await promise;
+		expect( getIframe() ).toBeNull();
+	} );
+
+	it( 'resolves after the timeout when no message arrives', async () => {
+		jest.useFakeTimers();
+		mockConfig.mockReturnValue( 'https://my.wordpress.com/clear-storage' );
+
+		const promise = clearHostingDashboardStorage( 500 );
+		expect( getIframe() ).not.toBeNull();
+
+		jest.advanceTimersByTime( 500 );
+		await promise;
+		expect( getIframe() ).toBeNull();
+	} );
+} );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -24,6 +24,7 @@ import SidebarFooter from 'calypso/layout/sidebar/footer';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
+import { clearHostingDashboardStorage } from 'calypso/lib/user/clear-hosting-dashboard-storage';
 import { clearStore, disablePersistence } from 'calypso/lib/user/store';
 import ProfileGravatar from 'calypso/me/profile-gravatar';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
@@ -75,7 +76,7 @@ class MeSidebar extends Component {
 		try {
 			const { redirect_to } = await this.props.logoutUser( redirectTo );
 			disablePersistence();
-			await clearStore();
+			await Promise.all( [ clearStore(), clearHostingDashboardStorage() ] );
 			window.location.href = redirect_to || '/';
 		} catch {
 			// The logout endpoint might fail if the nonce has expired.

--- a/client/server/pages/clear-storage.js
+++ b/client/server/pages/clear-storage.js
@@ -1,0 +1,54 @@
+/**
+ * Serves a minimal page that wipes this origin's browser storage and reports
+ * completion to its embedder. Logout flows on other wordpress.com origins load
+ * it in a hidden iframe, since they cannot clear this origin's storage
+ * themselves. It stays independent of the app bundles so the iframe loads fast.
+ */
+
+const CLEAR_STORAGE_HTML = `<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="robots" content="noindex" />
+		<title>Clear storage</title>
+	</head>
+	<body>
+		<script>
+			( function () {
+				var finished = false;
+				function done() {
+					if ( finished ) {
+						return;
+					}
+					finished = true;
+					if ( window.parent !== window ) {
+						window.parent.postMessage( 'clear-storage:done', '*' );
+					}
+				}
+				try {
+					window.localStorage.clear();
+					window.sessionStorage.clear();
+				} catch ( e ) {}
+				try {
+					var request = window.indexedDB.deleteDatabase( 'calypso' );
+					request.onsuccess = request.onerror = request.onblocked = done;
+					// deleteDatabase events may never fire (e.g. blocked by another tab).
+					setTimeout( done, 1000 );
+				} catch ( e ) {
+					done();
+				}
+			} )();
+		</script>
+	</body>
+</html>
+`;
+
+export function registerClearStorageRoute( app ) {
+	app.get( '/clear-storage', ( req, res ) => {
+		res.set( {
+			'Content-Security-Policy':
+				"frame-ancestors 'self' https://wordpress.com https://*.wordpress.com",
+			'Cache-Control': 'no-store',
+		} );
+		res.send( CLEAR_STORAGE_HTML );
+	} );
+}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -73,6 +73,7 @@ import middlewareAssets from '../middleware/assets.js';
 import middlewareCache from '../middleware/cache.js';
 import middlewareUnsupportedBrowser from '../middleware/unsupported-browser.js';
 import { logSectionResponse } from './analytics';
+import { registerClearStorageRoute } from './clear-storage';
 import { registerCspReportRoute } from './csp-report';
 const debug = debugFactory( 'calypso:pages' );
 
@@ -1234,6 +1235,8 @@ export default function pages() {
 
 	// Multi-site Dashboard routing.
 	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
+		registerClearStorageRoute( app );
+
 		const signupSectionDefinition = sections.find( ( s ) => s.name === 'signup' );
 		handleSectionPath( signupSectionDefinition, '/start', undefined, ( req ) =>
 			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )

--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -1,3 +1,4 @@
+import { clearHostingDashboardStorage } from 'calypso/lib/user/clear-hosting-dashboard-storage';
 import { filterUserObject, getLogoutUrl, rawCurrentUserFetch } from 'calypso/lib/user/shared-utils';
 import {
 	clearStore,
@@ -67,7 +68,7 @@ export function redirectToLogout( postLogoutRedirectUrl ) {
 
 		// Clear any data stored locally within the user data module or localStorage
 		disablePersistence();
-		await clearStore();
+		await Promise.all( [ clearStore(), clearHostingDashboardStorage() ] );
 
 		window.location.href = logoutUrl;
 	};

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -19,6 +19,7 @@
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,
 	"logout_url": false,
+	"hosting_dashboard_clear_storage_url": false,
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_signup_url": false,
 	"wpcom_login_url": false,

--- a/config/client.json
+++ b/config/client.json
@@ -7,6 +7,7 @@
 	"facebook_api_key",
 	"features",
 	"hostname",
+	"hosting_dashboard_clear_storage_url",
 	"hotjar_enabled",
 	"i18n_default_locale_slug",
 	"jetpack_support_blog",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -9,6 +9,7 @@
 	"wpcom_url": "https://horizon.wordpress.com",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"hosting_dashboard_clear_storage_url": "https://my.wordpress.com/clear-storage",
 	"facebook_api_key": "249643311490",
 	"features": {
 		"100-year-plan/vip": true,

--- a/config/production.json
+++ b/config/production.json
@@ -8,6 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"hosting_dashboard_clear_storage_url": "https://my.wordpress.com/clear-storage",
 	"facebook_api_key": "249643311490",
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",

--- a/config/stage.json
+++ b/config/stage.json
@@ -8,6 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"hosting_dashboard_clear_storage_url": "https://my.wordpress.com/clear-storage",
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -8,6 +8,7 @@
 	"wpcom_url": "https://wpcalypso.wordpress.com",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"hosting_dashboard_clear_storage_url": "https://my.wordpress.com/clear-storage",
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",

--- a/packages/api-queries/src/__tests__/query-client-owner.test.ts
+++ b/packages/api-queries/src/__tests__/query-client-owner.test.ts
@@ -1,0 +1,75 @@
+import { clearQueryClient, queryClient, validateQueryCacheOwner } from '../query-client';
+
+const CACHE_KEY = 'REACT_QUERY_OFFLINE_CACHE';
+const OWNER_KEY = 'REACT_QUERY_CACHE_OWNER';
+
+describe( 'validateQueryCacheOwner', () => {
+	beforeEach( () => {
+		localStorage.clear();
+		queryClient.getQueryCache().clear();
+		queryClient.getMutationCache().clear();
+	} );
+
+	it( 'stamps the owner and clears the cache on first run', () => {
+		localStorage.setItem( CACHE_KEY, 'stale-cache' );
+		queryClient.setQueryData( [ 'sites' ], [ { ID: 1 } ] );
+
+		validateQueryCacheOwner( 123 );
+
+		expect( localStorage.getItem( CACHE_KEY ) ).toBeNull();
+		expect( queryClient.getQueryData( [ 'sites' ] ) ).toBeUndefined();
+		expect( localStorage.getItem( OWNER_KEY ) ).toBe( '123' );
+	} );
+
+	it( 'keeps the cache when the owner matches', () => {
+		localStorage.setItem( OWNER_KEY, '123' );
+		localStorage.setItem( CACHE_KEY, 'own-cache' );
+		queryClient.setQueryData( [ 'sites' ], [ { ID: 1 } ] );
+
+		validateQueryCacheOwner( 123 );
+
+		expect( localStorage.getItem( CACHE_KEY ) ).toBe( 'own-cache' );
+		expect( queryClient.getQueryData( [ 'sites' ] ) ).toEqual( [ { ID: 1 } ] );
+	} );
+
+	it( 'clears the persisted and in-memory caches when the owner differs', () => {
+		localStorage.setItem( OWNER_KEY, '123' );
+		localStorage.setItem( CACHE_KEY, 'previous-user-cache' );
+		queryClient.setQueryData( [ 'sites' ], [ { ID: 1 } ] );
+
+		validateQueryCacheOwner( 456 );
+
+		expect( localStorage.getItem( CACHE_KEY ) ).toBeNull();
+		expect( queryClient.getQueryData( [ 'sites' ] ) ).toBeUndefined();
+		expect( localStorage.getItem( OWNER_KEY ) ).toBe( '456' );
+	} );
+
+	it( 'keeps pending queries when clearing', async () => {
+		localStorage.setItem( OWNER_KEY, '123' );
+		queryClient.setQueryData( [ 'sites' ], [ { ID: 1 } ] );
+		let resolveFetch: ( value: string ) => void = () => {};
+		const pending = queryClient.fetchQuery( {
+			queryKey: [ 'auth', 'user' ],
+			queryFn: () => new Promise< string >( ( resolve ) => ( resolveFetch = resolve ) ),
+		} );
+
+		validateQueryCacheOwner( 456 );
+
+		expect( queryClient.getQueryData( [ 'sites' ] ) ).toBeUndefined();
+		expect( queryClient.getQueryCache().find( { queryKey: [ 'auth', 'user' ] } ) ).toBeDefined();
+		resolveFetch( 'user' );
+		await expect( pending ).resolves.toBe( 'user' );
+	} );
+} );
+
+describe( 'clearQueryClient', () => {
+	it( 'removes the cache and the owner key', () => {
+		localStorage.setItem( CACHE_KEY, 'cache' );
+		localStorage.setItem( OWNER_KEY, '123' );
+
+		clearQueryClient();
+
+		expect( localStorage.getItem( CACHE_KEY ) ).toBeNull();
+		expect( localStorage.getItem( OWNER_KEY ) ).toBeNull();
+	} );
+} );

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -18,6 +18,11 @@ declare module '@tanstack/react-query' {
 // of breaking changes to the default key in the future.
 const reactQueryCacheKey = 'REACT_QUERY_OFFLINE_CACHE';
 
+// Tracks which user the persisted cache belongs to. Logout on another origin
+// (e.g. wordpress.com) can't clear this origin's storage, so ownership is
+// validated here at boot instead.
+const cacheOwnerKey = 'REACT_QUERY_CACHE_OWNER';
+
 const queryClient = new QueryClient( {
 	defaultOptions: {
 		queries: {
@@ -71,5 +76,28 @@ export { queryClient, disablePersistQueryClient, persistQueryClientPromise };
 export function clearQueryClient() {
 	if ( typeof window !== 'undefined' && ! isSupportSession() ) {
 		localStorage.removeItem( reactQueryCacheKey );
+		localStorage.removeItem( cacheOwnerKey );
 	}
+}
+
+/**
+ * Wipes the persisted and in-memory query caches unless they belong to the
+ * given user, then records that user as the cache owner. Pending queries are
+ * kept: they hold no previous-user data and removing in-flight queries (like
+ * the auth query calling this) would trigger refetch loops.
+ */
+export function validateQueryCacheOwner( userId: number ) {
+	if ( typeof window === 'undefined' || isSupportSession() ) {
+		return;
+	}
+
+	const owner = localStorage.getItem( cacheOwnerKey );
+	if ( owner === String( userId ) ) {
+		return;
+	}
+
+	localStorage.removeItem( reactQueryCacheKey );
+	queryClient.removeQueries( { predicate: ( query ) => query.state.status !== 'pending' } );
+	queryClient.getMutationCache().clear();
+	localStorage.setItem( cacheOwnerKey, String( userId ) );
 }


### PR DESCRIPTION
## Proposed Changes

* Stamp the Hosting Dashboard's persisted query cache with an owner user ID and wipe it (persisted + in-memory) at boot whenever the authenticated user doesn't match. Also wipe it when auth fails, before redirecting to login.
* Add a lightweight `/clear-storage` page on the dashboard hostnames that clears the origin's localStorage/sessionStorage/IndexedDB and reports completion to its embedder.
* On wordpress.com logout (masterbar and me-sidebar paths), load that page in a hidden same-site iframe (best effort, 2s timeout) so the dashboard origin's storage is also cleared at logout time.

## Why are these changes being made?

* Logging out from Calypso on wordpress.com clears that origin's storage only. The Hosting Dashboard's persisted query cache lives under the my.wordpress.com origin, which wordpress.com code cannot touch, so it survived logout.
* The cache was stored under a single fixed key with no user scoping, so the next user to log in on the same browser would restore — and briefly render — the previous user's sites, domains, billing, and email data.
* The owner check is the guarantee: it covers every path that ends a session (masterbar logout, wp-admin logout, session expiry), mirroring how classic Calypso validates its user-scoped `redux-state-<userId>` keys at boot. The iframe clear is defense in depth: it removes the data at rest at logout time instead of waiting for the next visit to the dashboard.

## Considerations

* User-scoping via the persister `buster` was rejected: the buster is fixed at module init, which only works where the user is bootstrapped synchronously (my.wordpress.com) and would leave the OAuth dashboard variants unprotected. The owner check covers all variants with one code path.
* A redirect hop through my.wordpress.com in the logout chain was rejected as more brittle (visible navigation, open-redirect surface) than a hidden same-site iframe.
* First run after deploy has no owner stamp, so every user's cache is cleared once. Data always refetches (staleTime 0), so the only cost is one slower paint.

## Testing Instructions

* `yarn test-packages packages/api-queries/src/__tests__/query-client-owner.test.ts`
* `yarn test-client client/lib/user/test/clear-hosting-dashboard-storage.ts`
* Layer 1: log in as user A, visit my.wordpress.com, log out from the wordpress.com masterbar, log in as user B, visit my.wordpress.com — no flash of user A's data, and `REACT_QUERY_OFFLINE_CACHE` in localStorage belongs to B.
* Layer 2: with user A on my.wordpress.com, log out from the wordpress.com masterbar and check my.wordpress.com localStorage in DevTools — it should be empty without revisiting the dashboard.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWgBXbtrwohs6xp1iMAWh1