### PR TITLE
Scope query cache persistence to the current user

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -1,4 +1,4 @@
-import { persistQueryClientPromise } from '@automattic/api-queries';
+import { getPersistQueryClientPromise, queryClient } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { captureException, initSentry } from '@automattic/calypso-sentry';
 import { maybeInitializeSupportSession } from '@automattic/calypso-support-session';
@@ -7,6 +7,7 @@ import '@wordpress/components/build-style/style.css';
 import '@wordpress/commands/build-style/style.css';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import wpcom from 'calypso/lib/wp';
+import { AUTH_QUERY_KEY, initializeCurrentUser } from './auth';
 import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
@@ -48,9 +49,18 @@ function boot( config: AppConfig ) {
 			.catch( captureException );
 	}
 
-	persistQueryClientPromise.then( () => {
-		root.render( <Layout config={ config } /> );
-	} );
+	initializeCurrentUser()
+		.then( ( user ) => {
+			// Seed the query cache with the auth query result. Avoids
+			// redundant request by AuthProvider.
+			queryClient.setQueryData( AUTH_QUERY_KEY, user );
+			return user.ID;
+		} )
+		.catch( () => undefined )
+		.then( ( userId ) => getPersistQueryClientPromise( userId ) )
+		.then( () => {
+			root.render( <Layout config={ config } /> );
+		} );
 }
 
 export default boot;

--- a/client/sites/v2/site-overview/index.tsx
+++ b/client/sites/v2/site-overview/index.tsx
@@ -1,4 +1,4 @@
-import { persistQueryClientPromise, queryClient } from '@automattic/api-queries';
+import { getPersistQueryClientPromise, queryClient } from '@automattic/api-queries';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
@@ -38,7 +38,7 @@ export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?
 		}
 
 		Promise.all( [
-			persistQueryClientPromise,
+			getPersistQueryClientPromise( user?.ID ),
 			router.preloadRoute( {
 				to: `/sites/${ siteSlug }`,
 			} ),

--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -1,4 +1,8 @@
-import { siteSettingsQuery, queryClient, persistQueryClientPromise } from '@automattic/api-queries';
+import {
+	siteSettingsQuery,
+	queryClient,
+	getPersistQueryClientPromise,
+} from '@automattic/api-queries';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
@@ -51,7 +55,7 @@ export default function DashboardBackportSiteSettingsRenderer( {
 		}
 
 		Promise.all( [
-			persistQueryClientPromise,
+			getPersistQueryClientPromise( user?.ID ),
 			router.preloadRoute( {
 				to: `/sites/${ siteSlug }/settings`,
 			} ),

--- a/client/sites/v2/sites-list/index.tsx
+++ b/client/sites/v2/sites-list/index.tsx
@@ -1,4 +1,4 @@
-import { queryClient, persistQueryClientPromise } from '@automattic/api-queries';
+import { queryClient, getPersistQueryClientPromise } from '@automattic/api-queries';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
@@ -38,14 +38,14 @@ export default function DashboardBackportSitesList() {
 		}
 
 		Promise.all( [
-			persistQueryClientPromise,
+			getPersistQueryClientPromise( user?.ID ),
 			router.preloadRoute( {
 				to: '/sites',
 			} ),
 		] ).then( () => {
 			rootInstanceRef.current?.render( <Layout analyticsClient={ analyticsClient } /> );
 		} );
-	}, [ analyticsClient ] );
+	}, [ analyticsClient, user ] );
 
 	// Use data already available in Redux to seed the React Query cache and avoid redundant data fetching.
 	useEffect( () => {

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -63,32 +63,53 @@ const persister = createSyncStoragePersister( {
 } );
 
 const maxAge = 1000 * 60 * 60 * 24; // 24 hours
+const cacheDataShapeVersion = 3; // Bump the numeric prefix when query data shape changes.
 
-const [ disablePersistQueryClient, persistQueryClientPromise ] = persistQueryClient( {
-	queryClient,
-	persister,
-	buster: '3', // Bump when query data shape changes.
-	maxAge,
-	dehydrateOptions: {
-		shouldRedactErrors: () => false,
-		shouldDehydrateQuery: ( query ) => {
-			const persist = query.meta?.persist;
-			if ( persist === false ) {
-				return false;
-			}
-			// Gate the predicate behind the default check so it is never handed the
-			// data of a query that hasn't succeeded.
-			if ( ! defaultShouldDehydrateQuery( query ) ) {
-				return false;
-			}
-			return typeof persist === 'function' ? persist( query.state.data ) : true;
-		},
-	},
-} );
+let disablePersist: ( () => void ) | undefined;
+let persistPromise: Promise< void > | undefined;
+
+/**
+ * Start restoring/persisting the query cache.
+ *
+ * Memoized: the first call starts persistence and every call returns the same
+ * promise, so callers can invoke it freely (e.g. from an effect).
+ */
+export function getPersistQueryClientPromise( userId?: number ): Promise< void > {
+	if ( ! persistPromise ) {
+		const [ disable, promise ] = persistQueryClient( {
+			queryClient,
+			persister,
+			buster: `${ cacheDataShapeVersion }-${ userId ?? 'anon' }`,
+			maxAge,
+			dehydrateOptions: {
+				shouldRedactErrors: () => false,
+				shouldDehydrateQuery: ( query ) => {
+					const persist = query.meta?.persist;
+					if ( persist === false ) {
+						return false;
+					}
+					// Gate the predicate behind the default check so it is never handed the
+					// data of a query that hasn't succeeded.
+					if ( ! defaultShouldDehydrateQuery( query ) ) {
+						return false;
+					}
+					return typeof persist === 'function' ? persist( query.state.data ) : true;
+				},
+			},
+		} );
+		disablePersist = disable;
+		persistPromise = promise;
+	}
+	return persistPromise;
+}
+
+export function disablePersistQueryClient() {
+	disablePersist?.();
+}
 
 startSiteCollisionListener( queryClient );
 
-export { queryClient, disablePersistQueryClient, persistQueryClientPromise };
+export { queryClient };
 
 export function clearQueryClient() {
 	if ( typeof window !== 'undefined' && ! isSupportSession() ) {

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -65,46 +65,53 @@ const persister = createSyncStoragePersister( {
 const maxAge = 1000 * 60 * 60 * 24; // 24 hours
 const cacheDataShapeVersion = 3; // Bump the numeric prefix when query data shape changes.
 
-let disablePersist: ( () => void ) | undefined;
-let persistPromise: Promise< void > | undefined;
+let persistence: { userId: number; promise: Promise< void >; disable: () => void } | undefined;
 
 /**
- * Start restoring/persisting the query cache.
+ * Start restoring/persisting the query cache, scoped to the given user.
  *
- * Memoized: the first call starts persistence and every call returns the same
- * promise, so callers can invoke it freely (e.g. from an effect).
+ * Memoized per user, so callers can invoke it freely (e.g. from an effect).
+ * While the user is unknown we neither restore nor persist.
  */
 export function getPersistQueryClientPromise( userId?: number ): Promise< void > {
-	if ( ! persistPromise ) {
-		const [ disable, promise ] = persistQueryClient( {
-			queryClient,
-			persister,
-			buster: `${ cacheDataShapeVersion }-${ userId ?? 'anon' }`,
-			maxAge,
-			dehydrateOptions: {
-				shouldRedactErrors: () => false,
-				shouldDehydrateQuery: ( query ) => {
-					const persist = query.meta?.persist;
-					if ( persist === false ) {
-						return false;
-					}
-					// Gate the predicate behind the default check so it is never handed the
-					// data of a query that hasn't succeeded.
-					if ( ! defaultShouldDehydrateQuery( query ) ) {
-						return false;
-					}
-					return typeof persist === 'function' ? persist( query.state.data ) : true;
-				},
-			},
-		} );
-		disablePersist = disable;
-		persistPromise = promise;
+	if ( userId === undefined ) {
+		return Promise.resolve();
 	}
-	return persistPromise;
+
+	if ( persistence?.userId === userId ) {
+		return persistence.promise;
+	}
+
+	persistence?.disable();
+
+	const [ disable, promise ] = persistQueryClient( {
+		queryClient,
+		persister,
+		buster: `${ cacheDataShapeVersion }-${ userId }`,
+		maxAge,
+		dehydrateOptions: {
+			shouldRedactErrors: () => false,
+			shouldDehydrateQuery: ( query ) => {
+				const persist = query.meta?.persist;
+				if ( persist === false ) {
+					return false;
+				}
+				// Gate the predicate behind the default check so it is never handed the
+				// data of a query that hasn't succeeded.
+				if ( ! defaultShouldDehydrateQuery( query ) ) {
+					return false;
+				}
+				return typeof persist === 'function' ? persist( query.state.data ) : true;
+			},
+		},
+	} );
+	persistence = { userId, promise, disable };
+
+	return promise;
 }
 
 export function disablePersistQueryClient() {
-	disablePersist?.();
+	persistence?.disable();
 }
 
 startSiteCollisionListener( queryClient );


### PR DESCRIPTION
Related to DOTMSD-1407

## Proposed Changes

* Scope the persisted React Query cache to the current user so a cache written by one user is never restored for another.
* Replace the eager `persistQueryClientPromise` with a memoized `getPersistQueryClientPromise( userId? )` that bakes the user ID into the persistence `buster` (`<shape-version>-<userId>`).
* While the user is unknown, neither restore nor persist. Persistence starts on the first call that knows who the user is.
* Dashboard `boot.tsx` now resolves `initializeCurrentUser()` before restoring, seeding the auth query to avoid a redundant fetch in `AuthProvider`. On failure it renders without persistence so `AuthProvider` can redirect to login.
* The Calypso v2 backport renderers (`sites-list`, `site-overview`, `site-settings`) pass their redux `user?.ID`.

## Why are these changes being made?

If user A and user B use the same browser, the query cache persisted by user A can be restored into user B's session on load, so user B briefly sees a flash of user A's data before it refetches. Scoping the persistence `buster` to the user ID makes that stale cache get discarded instead of restored. This is the passive backstop that complements the explicit cache clear on logout.

The buster is only consulted when the cache is **restored**, which was happening eagerly at module load — before the current user is known. Deferring restore until the caller has resolved the user closes that window.

## Considerations

An earlier revision fell back to a shared `anon` bucket when the user wasn't known yet, so that persistence could still start early. That reintroduces the leak it was meant to close: a logged-in user whose `/me` request fails on a network blip gets their data written under `anon`, and a later visitor who also passes through an unknown-user window hydrates it back. It also meant the first caller to arrive decided the bucket for the whole page load, so a caller that learned the user ID later was stuck writing to `anon`.

Skipping persistence entirely while the user is unknown avoids that: the `anon` entry is never written, so there is nothing to leak. Nothing is lost by it — a visitor with no resolved user is on their way to the login screen and has nothing worth caching.

The one cost: if `/me` fails at boot but the retry in `AuthProvider` succeeds, that page load runs without persistence and the next load starts from a cold cache. It self-heals, and it is preferable to writing that user's data to a shared bucket.

## Testing Instructions

* Log in as user A in the Dashboard, browse a few sites/settings pages (populates the persisted cache), then check `localStorage` `REACT_QUERY_OFFLINE_CACHE` — the stored `buster` should end in user A's ID.
* Log out via the Calypso v1 dashboard, log in as user B on the same browser, and confirm user B never sees a flash of user A's data — the old cache is discarded and data refetches.
* Confirm normal reloads for the same user still hydrate instantly from the persisted cache.
* Load the Dashboard logged out and confirm you are redirected to login and that no `REACT_QUERY_OFFLINE_CACHE` entry is written.
* Test both with `wpcom-user-bootstrap` enabled and disabled (the non-bootstrapped path fetches the user before restoring).
* Verify no redundant `/me` request fires on Dashboard boot (auth query is seeded).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
