### PR TITLE
E2E: reject throttled signup responses and harden account teardown

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -16,6 +16,56 @@ class TransientSignupError extends Error {}
 // matches (Bad Gateway / Service Unavailable / Gateway Timeout).
 const TRANSIENT_UPSTREAM_STATUSES = [ 502, 503, 504 ];
 
+/** Returns whether a value is a non-null object (arrays included). */
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Validates that a `/users/new` response created an account with the identity
+ * and bearer token required by subsequent authenticated setup calls.
+ *
+ * @param {unknown} response Raw JSON response from `/users/new`.
+ * @returns {NewUserResponse} Validated successful signup response.
+ */
+export function assertSuccessfulNewUserResponse( response: unknown ): NewUserResponse {
+	const responseBody = isRecord( response ) && isRecord( response.body ) ? response.body : null;
+	// `/users/new` is untyped JSON off the wire; user_id can arrive as a numeric
+	// string, so coerce before validating (mirrors the blogid handling below).
+	// Only a number or string coerces; a boolean/array must not slip through
+	// (`Number( true )` is 1, `Number( [ 123 ] )` is 123).
+	const rawUserID = responseBody?.user_id;
+	const userID =
+		typeof rawUserID === 'number' || typeof rawUserID === 'string' ? Number( rawUserID ) : NaN;
+	const username = responseBody?.username;
+	const bearerToken = responseBody?.bearer_token;
+
+	if (
+		responseBody &&
+		responseBody.success === true &&
+		Number.isInteger( userID ) &&
+		userID > 0 &&
+		typeof username === 'string' &&
+		username.trim() !== '' &&
+		typeof bearerToken === 'string' &&
+		bearerToken.trim() !== ''
+	) {
+		// Normalize a numeric-string user_id to a number so downstream integer
+		// checks (e.g. teardown's Number.isInteger) treat the account as closeable
+		// rather than ID-less (mirrors the blogid handling below).
+		responseBody.user_id = userID;
+		return response as NewUserResponse;
+	}
+
+	const details = [ responseBody?.error, responseBody?.message ]
+		.filter( ( value ): value is string => typeof value === 'string' && value.trim() !== '' )
+		.join( ': ' );
+
+	throw new Error(
+		`User signup did not create a usable account${ details ? `: ${ details }` : '.' }`
+	);
+}
+
 /**
  * This object represents multiple pages on WordPress.com:
  * 	- regular (/start/user)
@@ -182,7 +232,7 @@ export class UserSignupPage {
 				// exceed 10s on a slow CI runner.
 				{ timeout: 60_000 }
 			)
-			.then( ( response ) => response.json() );
+			.then( async ( response ) => assertSuccessfulNewUserResponse( await response.json() ) );
 	}
 
 	/**
@@ -476,7 +526,7 @@ export class UserSignupPage {
 			throw new Error( 'Failed to create new user at WooCommerce using WPCC.' );
 		}
 
-		return responseBody;
+		return assertSuccessfulNewUserResponse( responseBody );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -184,6 +184,25 @@ export async function closeAccountAndRecordLeak(
 	accountDetails: AccountDetails,
 	leakDir: string
 ): Promise< void > {
+	const hasUserID = Number.isInteger( accountDetails.userID ) && accountDetails.userID > 0;
+	const username =
+		typeof accountDetails.username === 'string' ? accountDetails.username.trim() : '';
+	const email = typeof accountDetails.email === 'string' ? accountDetails.email.trim() : '';
+
+	if ( ! hasUserID || ! username || ! email ) {
+		console.warn( 'Skipping remote account teardown: account identity is incomplete.' );
+		if ( hasUserID || email ) {
+			recordAccountLeak( leakDir, {
+				...( hasUserID ? { userID: accountDetails.userID } : {} ),
+				username,
+				email,
+				error:
+					'Remote teardown skipped because the signup response contained an incomplete account identity.',
+			} );
+		}
+		return;
+	}
+
 	console.log( `Closing account ${ accountDetails.userID }.` );
 
 	// Track the wait so the terminal `[atomic-teardown]` breadcrumb reports how

--- a/packages/calypso-e2e/src/test/lib/pages/user-signup-page.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/user-signup-page.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import {
+	assertSuccessfulNewUserResponse,
+	UserSignupPage,
+} from '../../../lib/pages/signup/user-signup-page';
+import type { Page } from 'playwright';
+
+const successfulResponse = {
+	code: 200,
+	body: {
+		success: true,
+		user_id: 123,
+		username: 'e2eflowtesting123',
+		bearer_token: 'token',
+	},
+};
+
+describe( 'assertSuccessfulNewUserResponse', () => {
+	test( 'returns a response containing a usable account identity', () => {
+		expect( assertSuccessfulNewUserResponse( successfulResponse ) ).toBe( successfulResponse );
+	} );
+
+	test( 'normalizes a numeric-string user_id to a number', () => {
+		const response = {
+			code: 200,
+			body: { ...successfulResponse.body, user_id: '123' },
+		};
+		expect( assertSuccessfulNewUserResponse( response ).body.user_id ).toBe( 123 );
+	} );
+
+	test( 'rejects an explicitly throttled signup response', () => {
+		expect( () =>
+			assertSuccessfulNewUserResponse( {
+				code: 200,
+				body: {
+					success: false,
+					error: 'throttled',
+					message: 'Limit reached.',
+				},
+			} )
+		).toThrow( 'User signup did not create a usable account: throttled: Limit reached.' );
+	} );
+
+	test.each( [
+		[ 'user ID', { ...successfulResponse.body, user_id: undefined } ],
+		[ 'boolean user ID', { ...successfulResponse.body, user_id: true } ],
+		[ 'array user ID', { ...successfulResponse.body, user_id: [ 123 ] } ],
+		[ 'non-numeric string user ID', { ...successfulResponse.body, user_id: 'abc' } ],
+		[ 'username', { ...successfulResponse.body, username: '' } ],
+		[ 'bearer token', { ...successfulResponse.body, bearer_token: '' } ],
+	] )( 'rejects a successful response without a usable %s', ( _field, body ) => {
+		expect( () => assertSuccessfulNewUserResponse( { code: 200, body } ) ).toThrow(
+			'User signup did not create a usable account.'
+		);
+	} );
+
+	test( 'rejects a malformed response', () => {
+		expect( () => assertSuccessfulNewUserResponse( null ) ).toThrow(
+			'User signup did not create a usable account.'
+		);
+	} );
+} );
+
+describe( 'UserSignupPage', () => {
+	test( 'returns a partial invite signup response so the caller can retain it for cleanup', async () => {
+		// Deliberately omits bearer_token: the invite path must return the raw
+		// response for cleanup and must NOT run assertSuccessfulNewUserResponse,
+		// which would throw here. This case fails if the guard is added to it.
+		const partialResponse = {
+			code: 200,
+			body: {
+				success: true,
+				user_id: 123,
+				username: 'e2eflowtesting123',
+			},
+		};
+		const locator = {
+			click: jest.fn( async () => undefined ),
+			fill: jest.fn( async () => undefined ),
+		};
+		const page = {
+			getByRole: jest.fn( () => locator ),
+			locator: jest.fn( () => locator ),
+			waitForResponse: jest.fn( async () => ( {
+				json: async () => partialResponse,
+			} ) ),
+		} as unknown as Page;
+
+		const signupPage = new UserSignupPage( page );
+
+		await expect( signupPage.signupThroughInvite( 'test@example.com' ) ).resolves.toBe(
+			partialResponse
+		);
+	} );
+} );

--- a/packages/calypso-e2e/src/test/teardown-markers.test.ts
+++ b/packages/calypso-e2e/src/test/teardown-markers.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
@@ -21,6 +21,8 @@ afterEach( () => {
 } );
 
 const markerFile = ( userID: number ): string => path.join( leakDir, `account-${ userID }.json` );
+const emailMarkerFile = ( email: string ): string =>
+	path.join( leakDir, `account-${ encodeURIComponent( email ) }.json` );
 
 const details = {
 	userID: 2001,
@@ -121,6 +123,68 @@ describe( 'teardown-markers: isAccountClosedError', () => {
 } );
 
 describe( 'closeAccountAndRecordLeak', () => {
+	test( 'no userID: records an email-keyed marker without accessing the account', async () => {
+		const closeAccount = jest.fn( async () => ( { success: true } ) );
+		const getMyAccountInformation = jest.fn( async () => ( {} ) );
+		const incompleteDetails = {
+			...details,
+			userID: undefined,
+		} as unknown as typeof details;
+
+		await closeAccountAndRecordLeak(
+			fakeClient( { closeAccount, getMyAccountInformation } ),
+			incompleteDetails,
+			leakDir
+		);
+
+		expect( closeAccount ).not.toHaveBeenCalled();
+		expect( getMyAccountInformation ).not.toHaveBeenCalled();
+		expect( existsSync( emailMarkerFile( details.email ) ) ).toBe( true );
+		const marker = JSON.parse( readFileSync( emailMarkerFile( details.email ), 'utf8' ) );
+		expect( marker.error ).toContain( 'incomplete account identity' );
+	} );
+
+	test( 'neither userID nor email: skips teardown and records nothing (no recordable key)', async () => {
+		const closeAccount = jest.fn( async () => ( { success: true } ) );
+		const getMyAccountInformation = jest.fn( async () => ( {} ) );
+		const unrecordableDetails = {
+			...details,
+			userID: undefined,
+			email: '',
+		} as unknown as typeof details;
+
+		await closeAccountAndRecordLeak(
+			fakeClient( { closeAccount, getMyAccountInformation } ),
+			unrecordableDetails,
+			leakDir
+		);
+
+		expect( closeAccount ).not.toHaveBeenCalled();
+		expect( getMyAccountInformation ).not.toHaveBeenCalled();
+		expect( readdirSync( leakDir ) ).toHaveLength( 0 );
+	} );
+
+	test( 'userID present but username/email missing: records a marker keyed by userID without accessing the account', async () => {
+		const closeAccount = jest.fn( async () => ( { success: true } ) );
+		const getMyAccountInformation = jest.fn( async () => ( {} ) );
+		const incompleteDetails = {
+			...details,
+			username: '',
+			email: '',
+		};
+
+		await closeAccountAndRecordLeak(
+			fakeClient( { closeAccount, getMyAccountInformation } ),
+			incompleteDetails,
+			leakDir
+		);
+
+		expect( closeAccount ).not.toHaveBeenCalled();
+		expect( getMyAccountInformation ).not.toHaveBeenCalled();
+		const marker = JSON.parse( readFileSync( markerFile( details.userID ), 'utf8' ) );
+		expect( marker.error ).toContain( 'incomplete account identity' );
+	} );
+
 	test( 'close succeeds: clears the marker and never probes', async () => {
 		const getMyAccountInformation = jest.fn( async () => ( {} ) );
 		await closeAccountAndRecordLeak(

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -141,12 +141,17 @@ test.describe(
 			} );
 
 			await test.step( 'Given I have a free site', async function () {
+				const accountToCleanup: ( typeof accountsToCleanup )[ number ] = {
+					testUser,
+					newUserDetails,
+				};
+				accountsToCleanup.push( accountToCleanup );
 				newSiteDetails = await apiCreateFreeSiteForUser(
 					testUser,
 					newUserDetails,
 					helperData.getBlogName()
 				);
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+				accountToCleanup.newSiteDetails = newSiteDetails;
 			} );
 
 			await test.step( 'And I enter the domain flow', async function () {
@@ -214,12 +219,17 @@ test.describe(
 			} );
 
 			await test.step( 'Given I have a free site', async function () {
+				const accountToCleanup: ( typeof accountsToCleanup )[ number ] = {
+					testUser,
+					newUserDetails,
+				};
+				accountsToCleanup.push( accountToCleanup );
 				newSiteDetails = await apiCreateFreeSiteForUser(
 					testUser,
 					newUserDetails,
 					helperData.getBlogName()
 				);
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+				accountToCleanup.newSiteDetails = newSiteDetails;
 			} );
 
 			await test.step( 'And I enter the domain flow', async function () {

--- a/test/e2e/specs/shared/api-create-free-site.ts
+++ b/test/e2e/specs/shared/api-create-free-site.ts
@@ -1,4 +1,4 @@
-import { RestAPIClient } from '@automattic/calypso-e2e';
+import { assertSuccessfulNewUserResponse, RestAPIClient } from '@automattic/calypso-e2e';
 import { apiWaitForBearerTokenAcceptance } from './api-wait-for-account-propagation';
 import type {
 	NewSiteParams,
@@ -18,6 +18,8 @@ export async function apiCreateFreeSiteForUser(
 	siteName: string,
 	siteParams: FreeSiteParams = {}
 ): Promise< NewSiteResponse > {
+	assertSuccessfulNewUserResponse( newUserDetails );
+
 	const restAPIClient = new RestAPIClient(
 		{
 			username: testUser.username,


### PR DESCRIPTION
Part of [TESTOPS-213](https://linear.app/a8c/issue/TESTOPS-213)

## Proposed Changes

- Add `assertSuccessfulNewUserResponse` to validate a `/users/new` response (`success`, integer `user_id`, non-empty `username` and `bearer_token`) and throw fast when a signup did not create a usable account. It normalizes a numeric-string `user_id` to a number so teardown can close the account.
- Wire the guard into the shared non-invite signup paths (`captureNewUserResponse`, covering `signup` / `signupWithEmail` / `signupSocialFirstWithEmail` / `signupWPCC`, plus `signupWoo`) and the free-site REST helper. The invite path (`signupThroughInvite`) intentionally stays raw and is pinned by a test.
- Skip the remote `closeAccount` call when the signup identity is incomplete and record a leak marker instead of proceeding blindly.
- In `setup-domain__flows.spec.ts`, queue account cleanup before free-site creation so a create failure still tears down the account.
- Unit tests for the validator (accept/reject cases, numeric-string normalization, malformed types) and the teardown identity branches.

## Why are these changes being made?

Under login/signup throttling, `/users/new` returns HTTP 200 with `{ success: false }` and no usable account. The suite treated that as success, fell back to a `wp-login.php` login attempt, and failed later with an opaque error that hid the real cause. Validating the response at the signup boundary fails fast with a clear message.

Separately, a throttled or partial signup could leave an account queued for teardown with no real identity, producing false leak markers that TeamCity treats as build problems. Failing fast on the bad response (so nothing is queued) plus queuing cleanup before site creation removes both the false markers and the real leaks on partial failure.

## Testing Instructions

- `yarn jest --config packages/calypso-e2e/jest.config.js user-signup-page.test teardown-markers.test` — validator and teardown unit tests (36 pass).
- Run the affected E2E specs against a Calypso instance: `test/e2e/specs/flows/setup-domain__flows.spec.ts` and the onboarding signup specs. A throttled `/users/new` should now fail the spec immediately at signup with "User signup did not create a usable account", rather than proceeding to a login fallback.
- Confirm no leak markers are written for a signup that returned `success: false`.
