### PR TITLE
E2E: fix signupWoo response-body eviction race in Woo WPCC email signup

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -460,17 +460,22 @@ export class UserSignupPage {
 			this.page.on( 'framenavigated', handler );
 		} );
 
-		// Ensure response is captured correctly
-		const responsePromise = this.page.waitForResponse( /\/users\/new\?[^?]*$/ );
-		await this.submitButton.click();
+		// Read the response body as soon as it arrives; waiting for the redirect
+		// first lets the navigation evict the body from the browser cache.
+		const responseBodyPromise = this.page
+			.waitForResponse( /\/users\/new\?[^?]*$/ )
+			.then( ( response ): Promise< NewUserResponse > => response.json() );
 
-		const [ response ] = await Promise.all( [ responsePromise, redirectDetected ] );
+		const [ responseBody ] = await Promise.all( [
+			responseBodyPromise,
+			redirectDetected,
+			this.submitButton.click(),
+		] );
 
-		if ( ! response ) {
+		if ( ! responseBody ) {
 			throw new Error( 'Failed to create new user at WooCommerce using WPCC.' );
 		}
 
-		const responseBody: NewUserResponse = await response.json();
 		return responseBody;
 	}
 


### PR DESCRIPTION
Slack thread: p1783930807246679-slack-C0E1C5NCR (representative or other similar failures)

## Proposed Changes

* Fix a flaky failure in `specs/onboarding/signup__woo-email.spec.ts`: `Error: response.json: Protocol error (Network.getResponseBody): No resource with given identifier found` at `UserSignupPage.signupWoo`. [Example](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/18486549).
* `signupWoo` awaited both the `/users/new` response and the `framenavigated` redirect to woocommerce.com before calling `response.json()`. When the navigation committed first, Chrome evicted the response body from the network buffer and the body read failed. The failure reproduced on the initial run and retry, e.g. in the pre-release matrix.
* Chain `.json()` directly onto `waitForResponse` so the body is read the moment the response arrives, and move `submitButton.click()` into the same `Promise.all` so no promise is left without a handler while the click resolves.

## Why are these changes being made?

* Removes an intermittent failure from the pre-release E2E matrix. Instrumented runs against staging show the response body is now read ~7ms after the response arrives, ~700-880ms before the redirect navigation that previously evicted it.

## Testing Instructions

* `CALYPSO_BASE_URL=<STAGING_URL> yarn workspace wp-e2e-tests test:pw -- specs/onboarding/signup__woo-email.spec.ts --reporter=list`
* Verified locally against staging: 6/6 passing executions (chrome + pixel, including a `--repeat-each=3` run). Note a passing run cannot prove a rare race is gone; the probe timings above confirm the mechanism.