### PR TITLE
A4A-3007: Use agency Lead Matching pilot flag

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility.ts
@@ -3,15 +3,6 @@ import { isEnabled } from '@automattic/calypso-config';
 export const A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG =
 	'a4a-partner-directory-lead-matching';
 
-export const A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS = new Set( [
-	234278359, 234036126, 232667176, 232640028, 251102500, 241918237, 235066401, 234595592, 232642471,
-	235867057, 234739905,
-] );
-
-export const isLeadMatchingPilotAgency = ( agencyId?: number ) =>
-	typeof agencyId === 'number' &&
-	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS.has( agencyId );
-
 export const isLeadMatchingSectionEnabled = () =>
 	isEnabled( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG );
 

--- a/client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts
@@ -3,11 +3,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 } ) );
 
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS,
-	isLeadMatchingPilotAgency,
-	isLeadMatchingSectionEnabled,
-} from '../lead-matching-visibility';
+import { isLeadMatchingSectionEnabled } from '../lead-matching-visibility';
 
 const mockedIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
@@ -22,17 +18,9 @@ describe( 'lead matching visibility', () => {
 		expect( isLeadMatchingSectionEnabled() ).toBe( true );
 	} );
 
-	it( 'returns true for pilot agencies', () => {
-		for ( const agencyId of A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS ) {
-			expect( isLeadMatchingPilotAgency( agencyId ) ).toBe( true );
-		}
-	} );
-
-	it( 'returns false for non-pilot agencies', () => {
+	it( 'returns false when the global feature flag is disabled', () => {
 		mockedIsEnabled.mockReturnValue( false );
 
-		expect( isLeadMatchingPilotAgency( 123 ) ).toBe( false );
-		expect( isLeadMatchingPilotAgency() ).toBe( false );
 		expect( isLeadMatchingSectionEnabled() ).toBe( false );
 	} );
 } );

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -2,10 +2,7 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import {
-	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG,
-	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS,
-} from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
+import { A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { NoticeActionOptions } from 'calypso/state/notices/types';
 import { APIError, Agency, AgencyThunkAction, UserBillingType } from '../types';
@@ -159,7 +156,7 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 
 			if (
 				! config.isEnabled( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG ) &&
-				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS.has( newAgency.id )
+				newAgency.lead_matching?.allowed === true
 			) {
 				config.enable( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG );
 			}

--- a/client/state/a8c-for-agencies/agency/test/actions.ts
+++ b/client/state/a8c-for-agencies/agency/test/actions.ts
@@ -17,9 +17,6 @@ jest.mock(
 	'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility',
 	() => ( {
 		A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG: 'a4a-partner-directory-lead-matching',
-		A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS: new Set( [
-			232667176, 251102500, 234036126, 234278359, 232640028,
-		] ),
 	} )
 );
 
@@ -339,7 +336,7 @@ describe( 'a8c-for-agencies agency actions', () => {
 	} );
 
 	describe( '#receiveAgencies()', () => {
-		test( 'enables the lead matching feature flag for pilot agencies', () => {
+		test( 'enables the lead matching feature flag for allowed agencies', () => {
 			let state = createState( createAgency() );
 			const getState = () => state;
 			const dispatch: jest.Mock = jest.fn( ( actionOrThunk: unknown ) => {
@@ -363,14 +360,23 @@ describe( 'a8c-for-agencies agency actions', () => {
 				return actionOrThunk;
 			} );
 
-			receiveAgencies( [ createAgency( { id: 232667176 } ) ] )( dispatch, getState, undefined );
+			receiveAgencies( [
+				createAgency( {
+					lead_matching: {
+						allowed: true,
+						draft: null,
+						profile: null,
+						sync: undefined,
+					},
+				} ),
+			] )( dispatch, getState, undefined );
 
 			expect( mockedConfig.enable ).toHaveBeenCalledWith(
 				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG
 			);
 		} );
 
-		test( 'does not enable the lead matching feature flag for non-pilot agencies', () => {
+		test( 'does not enable the lead matching feature flag when access is false', () => {
 			const getState = () => createState( createAgency() );
 			const dispatch: jest.Mock = jest.fn( ( actionOrThunk: unknown ) => {
 				if ( typeof actionOrThunk === 'function' ) {
@@ -380,7 +386,33 @@ describe( 'a8c-for-agencies agency actions', () => {
 				return actionOrThunk;
 			} );
 
-			receiveAgencies( [ createAgency( { id: 123 } ) ] )( dispatch, getState, undefined );
+			receiveAgencies( [
+				createAgency( {
+					lead_matching: {
+						allowed: false,
+						draft: null,
+						profile: null,
+						sync: undefined,
+					},
+				} ),
+			] )( dispatch, getState, undefined );
+
+			expect( mockedConfig.enable ).not.toHaveBeenCalledWith(
+				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG
+			);
+		} );
+
+		test( 'does not enable the lead matching feature flag when access is missing', () => {
+			const getState = () => createState( createAgency() );
+			const dispatch: jest.Mock = jest.fn( ( actionOrThunk: unknown ) => {
+				if ( typeof actionOrThunk === 'function' ) {
+					return actionOrThunk( dispatch, getState, undefined );
+				}
+
+				return actionOrThunk;
+			} );
+
+			receiveAgencies( [ createAgency() ] )( dispatch, getState, undefined );
 
 			expect( mockedConfig.enable ).not.toHaveBeenCalledWith(
 				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG


### PR DESCRIPTION
Part of A4A-3007

## Proposed Changes

This PR updates Lead Matching pilot visibility to use the agency API flag
instead of a hardcoded agency-ID allowlist.

## Why are these changes being made?

Pilot participation can now be managed through the agency backend, so Calypso
no longer needs code changes when agencies enter or leave the pilot.

## Testing Instructions

1. Open the Automattic for Agencies live preview.
2. Sign in with an agency whose Lead Matching pilot flag is enabled.
3. Confirm the Lead Matching section is visible.
4. Sign in with an agency whose pilot flag is disabled and confirm the section
   is hidden when the global feature flag is disabled.
5. Enable the global feature flag and confirm the section remains visible for
   either agency.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests][testing] for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic
  (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in
  [dark mode][dark-mode]?
- [ ] Have you tested accessibility for your changes? Ensure the feature
  remains usable with various user agents (e.g., browsers), interfaces
  (e.g., keyboard navigation), and assistive technologies
  (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in
  [Memoizing with create-selector][create-selector],
  [Using memoizing selectors][memoizing-selectors], and
  [Our Approach to Data][data].
- [ ] Have we added the "[Status] String Freeze" label as soon as any new
  strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have we tested the change in various languages
    (for example, ES, PT, FR, or DE)? The length of text and words vary
    significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the
  "[Status] Needs Privacy Updates" label if this pull request changes what
  data or activity we track or use (p4TIVU-aUh-p2)?

[testing]: https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md
[dark-mode]: https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md
[create-selector]: https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md
[memoizing-selectors]: https://react-redux.js.org/api/hooks#using-memoizing-selectors
[data]: https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md

*— ClemenAgent (Powered by Codex)*
