### PR TITLE
Emails: De-emphasize current plan button in Titan plan grid

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -180,6 +180,16 @@ export function TitanPlanGrid( {
 		  )
 		: plans;
 
+	// The tier that gets the emphasized (primary) button: the recommended plan when
+	// buying, or the recommended upgrade target when upgrading. The current plan is
+	// never emphasized because its button is disabled.
+	const primaryTier = ( () => {
+		const candidates = currentTier
+			? visiblePlans.filter( ( plan ) => plan.tier !== currentTier )
+			: visiblePlans;
+		return ( candidates.find( ( plan ) => plan.isPopular ) ?? candidates[ 0 ] )?.tier;
+	} )();
+
 	const getMonthlyPrice = ( product?: Product ) => {
 		if ( ! product?.cost ) {
 			return 0;
@@ -271,7 +281,7 @@ export function TitanPlanGrid( {
 						<Button
 							__next40pxDefaultSize
 							className="email-provider-action"
-							variant={ plan.isPopular ? 'primary' : 'secondary' }
+							variant={ plan.tier === primaryTier ? 'primary' : 'secondary' }
 							disabled={ ! available || isCurrentPlan }
 							onClick={ () => {
 								// Upgrade mode goes to checkout for the picked tier; otherwise the


### PR DESCRIPTION
Fixes #

## Proposed Changes

* In the Professional Email (Titan) plan grid, the emphasized (primary/blue) button was always tied to the "popular" tier (Premium). When upgrading from Premium, this put the blue fill on the disabled **Current plan** button while the actionable **Upgrade** button (Ultra) was only an outlined secondary.
* The grid now computes a single emphasized tier so the current plan is never primary:
  * **Buy mode**: the recommended (popular) plan stays primary, unchanged from before.
  * **Upgrade mode**: the current plan is excluded, and the recommended upgrade target gets the primary treatment (the popular upgrade if offered, otherwise the first available upgrade).

## Why are these changes being made?

* A disabled "Current plan" button should not be the loudest element on the page. The blue emphasis should sit on the actionable upgrade CTA so the upgrade path is clear.

## Testing Instructions

* Go to `/emails/choose-email-solution/<domain>` for a domain that already has a **Premium** Titan subscription (upgrade mode).
* Confirm the **Premium** card shows a de-emphasized (outlined/secondary) disabled "Current plan" button, and the **Ultra** card shows the primary/blue "Upgrade" button.
* Verify upgrade from **Pro** shows Premium as the primary "Upgrade" button, with Pro (current) and Ultra secondary.
* Verify the buy-new flow is unchanged: Premium remains the primary "Get Premium" button.

Before / After (upgrade from Premium):
* Before: blue fill on disabled "Current plan" (Premium), outlined "Upgrade" (Ultra).
* After: outlined disabled "Current plan" (Premium), blue "Upgrade" (Ultra).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
