### PR TITLE
Smart Dictation: unpin editor sidebar from defaults

### DIFF
--- a/apps/wpcom-smart-dictation/wpcom-smart-dictation.jsx
+++ b/apps/wpcom-smart-dictation/wpcom-smart-dictation.jsx
@@ -21,6 +21,7 @@ function WpcomSmartDictationPlugin() {
 				name={ SMART_DICTATION_SIDEBAR_NAME }
 				title={ __( 'WP.com Smart Dictation', __i18n_text_domain__ ) }
 				icon={ MicrophoneIcon }
+				isPinnable={ false }
 			>
 				<div className="wpcom-smart-dictation-sidebar-root">
 					<LiveAIAssistant />


### PR DESCRIPTION
Fixes DOTPROD-85.

### Proposed Changes

The Smart Dictation editor plugin registers a `PluginSidebar`, which adds a pinnable mic icon to the editor header toolbar by default. That makes the feature ship on by default for everyone.

Per the issue ("remove smart dictation from the default menu … let people discover it on their own"), this passes `isPinnable={false}` to the `PluginSidebar`:

- The mic icon is no longer added to the editor header toolbar.
- The feature stays discoverable from the editor's **Options (⋮) → Plugins** menu via the existing `PluginSidebarMoreMenuItem`; selecting it opens the sidebar as before.

Note: `isPinnable={false}` means the sidebar can be opened from the Options menu but not pinned to the toolbar. If we'd rather it start unpinned yet still be pinnable, that requires changing the `core/preferences` pinned default instead — happy to switch if that's preferred.

### Testing Instructions

1. Build and deploy the app (`yarn dev` from `apps/wpcom-smart-dictation`).
2. Open the block editor on a site with Smart Dictation enabled.
3. Confirm the Smart Dictation mic icon is **not** in the header toolbar.
4. Open the Options (⋮) menu → confirm "WP.com Smart Dictation" is listed and opens the sidebar.

### Pre-merge Checklist

- [x] Has the app been built and verified? (`yarn calypso-build` passes; `dist/` is a deploy-time artifact and not committed.)
- [ ] Have you written new tests for your changes?
- [x] Have you tested it locally? (build + lint)
