### PR TITLE
Add /logout route that clears site data via Clear-Site-Data

### DIFF
--- a/client/document/logout.jsx
+++ b/client/document/logout.jsx
@@ -1,0 +1,75 @@
+function logoutFn( { redirectTo } ) {
+	function done() {
+		window.location.replace( redirectTo );
+	}
+
+	const iframe = document.getElementById( 'logout-clear-frame' );
+
+	if ( ! iframe ) {
+		done();
+		return;
+	}
+
+	// Redirect once the counterpart origin has been cleared, with a fallback in
+	// case its iframe never fires `load` (e.g. blocked by the browser).
+	const fallback = window.setTimeout( done, 2000 );
+	iframe.addEventListener( 'load', function () {
+		window.clearTimeout( fallback );
+		done();
+	} );
+}
+
+function Logout( { redirectTo = '/log-in', iframeSrc = null, embed = false } ) {
+	// The embed variant is loaded inside the counterpart origin's iframe. Its only
+	// job is to carry the `Clear-Site-Data` response header, so it renders nothing.
+	if ( embed ) {
+		return (
+			<html lang="en">
+				<body />
+			</html>
+		);
+	}
+
+	return (
+		<html lang="en">
+			<body>
+				{ /* eslint-disable react/no-danger */ }
+				<style
+					dangerouslySetInnerHTML={ {
+						__html: `
+							body {
+								margin: 0;
+								min-height: 100vh;
+								display: flex;
+								align-items: center;
+								justify-content: center;
+								font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+							}
+						`,
+					} }
+				/>
+				<p>Logging out…</p>
+				{ iframeSrc && (
+					<iframe
+						id="logout-clear-frame"
+						title="Signing out"
+						src={ iframeSrc }
+						style={ { display: 'none' } }
+					/>
+				) }
+				<script
+					dangerouslySetInnerHTML={ {
+						__html: `
+						const logoutFn = ${ logoutFn.toString() };
+
+						logoutFn( { redirectTo: "${ encodeURI( redirectTo ) }" } );
+						`,
+					} }
+				/>
+				{ /* eslint-enable react/no-danger */ }
+			</body>
+		</html>
+	);
+}
+
+export default Logout;

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -28,13 +28,17 @@ import {
 	CIAB_DASHBOARD_SECTION_DEFINITION,
 	CIAB_DASHBOARD_SECTION_PATHS,
 } from 'calypso/dashboard/app-ciab/section';
-import { isAllowedDotcomDashboardHostname } from 'calypso/dashboard/app-dotcom/routing';
+import {
+	buildDotcomDashboardLink,
+	isAllowedDotcomDashboardHostname,
+} from 'calypso/dashboard/app-dotcom/routing';
 import {
 	DOTCOM_DASHBOARD_SECTION_DEFINITION,
 	DOTCOM_DASHBOARD_SECTION_PATHS,
 } from 'calypso/dashboard/app-dotcom/section';
 import { A4A_SIGNUP_PATHS } from 'calypso/dashboard/section';
 import isDashboardEnv from 'calypso/dashboard/utils/is-dashboard-env';
+import { wpcomLink } from 'calypso/dashboard/utils/link';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
 import { SUBSCRIPTIONS_SECTION_DEFINITION } from 'calypso/landing/subscriptions/section';
@@ -1212,6 +1216,62 @@ function wpcomPages( app ) {
 	} );
 }
 
+/**
+ * Resolve the counterpart origin's `/logout` URL for the cross-origin data clear.
+ *
+ * `Clear-Site-Data` for "storage"/"cache" is scoped to the origin that returns
+ * it, and the classic Calypso app and the Dashboard are served from separate
+ * origins (e.g. wordpress.com vs. my.wordpress.com). To clear both, `/logout`
+ * embeds the counterpart origin's `/logout?embed=1` in a hidden iframe. Returns
+ * `null` when there is no distinct counterpart (e.g. single-origin calypso.live).
+ */
+function getCounterpartLogoutUrl( req ) {
+	if ( req.hostname.endsWith( '.calypso.live' ) ) {
+		return null;
+	}
+
+	if ( isAllowedDotcomDashboardHostname( req.hostname ) ) {
+		// On the Dashboard host, the classic Calypso origin is the counterpart.
+		// `wpcomLink` resolves it from the `wpcom_url` config (wordpress.com in
+		// production, the local Calypso dev server in development).
+		return wpcomLink( '/logout?embed=1' );
+	}
+
+	if ( [ 'wordpress.com', 'calypso.localhost' ].includes( req.hostname ) ) {
+		return buildDotcomDashboardLink( '/logout?embed=1' );
+	}
+
+	return null;
+}
+
+/**
+ * Resolve the destination `/logout` sends the user to once data is cleared.
+ *
+ * Honors a `redirect_to` query param, but only for same-origin destinations —
+ * returned as a relative path so the client-side redirect can never leave this
+ * origin (guards against open redirects). Anything else falls back to `/log-in`.
+ */
+function getLogoutRedirectTo( req ) {
+	const target = req.query.redirect_to;
+	if ( typeof target !== 'string' || ! target ) {
+		return '/log-in';
+	}
+
+	const host = req.get( 'host' );
+	try {
+		const resolved = new URL( target, `https://${ host }` );
+		const destination = resolved.pathname + resolved.search + resolved.hash;
+		// Reject cross-origin and protocol-relative (`//host`) destinations.
+		if ( resolved.host === host && ! destination.startsWith( '//' ) ) {
+			return destination;
+		}
+	} catch {
+		// Fall through to the default.
+	}
+
+	return '/log-in';
+}
+
 export default function pages() {
 	const app = express();
 
@@ -1223,6 +1283,30 @@ export default function pages() {
 	app.use( middlewareCache() );
 	app.use( setupLoggedInContext );
 	app.use( middlewareUnsupportedBrowser() );
+
+	// `/logout` clears browser-stored site data for the current origin via the
+	// `Clear-Site-Data` response header, then best-effort clears the counterpart
+	// origin (classic Calypso <-> Dashboard) through a hidden iframe before
+	// redirecting to the login page. Actual session invalidation is handled by the
+	// client logout flow. Registered before section routing so it responds on both
+	// the classic Calypso and Dashboard hostnames.
+	app.get( '/logout', ( req, res ) => {
+		res.set( 'Clear-Site-Data', '"storage", "cache", "cookies"' );
+
+		if ( req.query.embed ) {
+			// Loaded inside the counterpart origin's iframe: this response only needs
+			// to carry the header, so render an empty page and stop here.
+			res.send( renderJsx( 'logout', { embed: true } ) );
+			return;
+		}
+
+		res.send(
+			renderJsx( 'logout', {
+				iframeSrc: getCounterpartLogoutUrl( req ),
+				redirectTo: getLogoutRedirectTo( req ),
+			} )
+		);
+	} );
 
 	if ( ! ( isJetpackCloud() || isA8CForAgencies() || isDashboardEnv() ) ) {
 		wpcomPages( app );


### PR DESCRIPTION
## Proposed Changes

- Add a server-side `/logout` route that returns `Clear-Site-Data: "storage", "cache", "cookies"` for the current origin.
- The route responds on both the classic Calypso host and the Dashboard host (registered before section routing and the dashboard early-return), so both experiences support the same path.
- Because `Clear-Site-Data` for `storage`/`cache` is scoped to the origin that returns it, and Calypso and the Dashboard live on separate origins (e.g. `wordpress.com` vs. `my.wordpress.com`), the top-level `/logout` page embeds the counterpart origin's `/logout?embed=1` in a hidden iframe to also clear it, then redirects onward.
- The redirect destination honors a `redirect_to` query param **only for same-origin destinations** (returned as a relative path), and defaults to `/log-in`. This lets callers preserve a post-logout destination without opening a redirect hole.
- Single-origin environments (`*.calypso.live`) and unrecognized hosts skip the iframe and just clear their own origin before redirecting.

Nothing routes through `/logout` yet — this PR only adds the route. Wiring up the existing logout flows is a follow-up in #113331.

## Why are these changes being made?

Logging out should drop browser-stored data (storage, cache, cookies), not only the session cookie. Clearing that data requires the one thing client JavaScript cannot do — set the `Clear-Site-Data` response header — so a server-emitted `/logout` route provides it, for both the classic Calypso and Dashboard origins from a single shared path.

The route is landed on its own first so it can be verified in isolation. It is inert until something links to it, which keeps the behavioral change to the live logout flows in a separate, revertable PR.

## Testing Instructions

Verified locally:

1. Start the dev server (`yarn start`).
2. `curl -D - http://calypso.localhost:3000/logout` — response carries `Clear-Site-Data: "storage", "cache", "cookies"`, the body contains a hidden iframe pointing at `http://my.localhost:3000/logout?embed=1`, and a script that redirects to `/log-in`.
3. `curl -D - http://my.localhost:3000/logout` — same header; the iframe points back at `http://calypso.localhost:3000/logout?embed=1` (symmetric).
4. `curl -D - 'http://calypso.localhost:3000/logout?embed=1'` — header-only response with an empty body (the variant loaded inside the iframe; no nested iframe, no redirect).
5. In a browser, visit `/logout` on either host and confirm it clears `localStorage`/cache/cookies (dev console logs the `Clear-Site-Data` clears for both origins) and lands on `/log-in`.
6. `redirect_to` handling: `/logout?redirect_to=/me/account` redirects to `/me/account`; a same-origin absolute URL is honored as its relative path; cross-origin, protocol-relative (`//host`), and `javascript:` values fall back to `/log-in`.
7. Confirm normal logout is unaffected — no existing flow routes through the new path yet.

## Considerations

- **Iframe vs. redirect chain for cross-origin clearing.** An iframe avoids extra full-page navigations, but the counterpart frame is cross-origin/third-party, so browser storage partitioning means its `Clear-Site-Data` clears the *partitioned* bucket rather than that origin's true first-party `storage`/`cache` (`cookies` still clear across the registrable domain). A multi-redirect chain would clear each origin as a first-party navigation and is more thorough; the iframe was chosen to keep logout a single top-level navigation.
- **Open-redirect protection.** `/logout` performs a client-side redirect, so it only honors a `redirect_to` whose host matches the request host, returned as a relative path; everything else defaults to `/log-in`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
