### PR TITLE
Pricing grid redesign: small CSS tweaks

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -309,6 +309,10 @@
 }
 
 .plans-grid-next.is-plans-grid-redesign-experiment {
+	.plans-grid-next-comparison-grid .plans-grid__plan-pill {
+		letter-spacing: 0.25px;
+	}
+
 	.plan-comparison-grid__available-checkmark {
 		color: var( --studio-green-60 );
 		fill: var( --studio-green-60 );

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -393,13 +393,6 @@ $redesign-table-cell-max-width: 280px;
 	&.is-reduced-feature-group-spacing > .plan-features-2023-grid__table-item {
 		padding-top: 0;
 	}
-
-	&.is-first-feature-group-row.is-reduced-feature-group-spacing
-		> .plan-features-2023-grid__table-item {
-		@include plans-grid-medium-large {
-			padding-top: 0;
-		}
-	}
 }
 
 .plan-features-2023-grid__item-info {
@@ -1312,6 +1305,11 @@ $redesign-table-cell-max-width: 280px;
 	&.is-xlarge {
 		.plan-features-2023-grid__table-item.is-top-buttons button {
 			margin-top: 0;
+		}
+
+		.plans-grid-next-features-grid__feature-group-row.is-first-feature-group-row.is-reduced-feature-group-spacing
+			> .plan-features-2023-grid__table-item {
+			padding-top: 0;
 		}
 
 		thead tr:first-child .plan-features-2023-grid__table-item.popular-plan-parent-class {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -1345,7 +1345,7 @@ $redesign-table-cell-max-width: 280px;
 					height: 24px;
 					justify-content: center;
 					left: 16px;
-					letter-spacing: 0;
+					letter-spacing: 0.25px;
 					line-height: 20px;
 					padding: 0 8px;
 					position: absolute;
@@ -1388,6 +1388,10 @@ $redesign-table-cell-max-width: 280px;
 			padding-block: 24px;
 
 			.plan-features-2023-grid__popular-badge {
+				.plans-grid__plan-pill {
+					letter-spacing: 0.25px;
+				}
+
 				&.is-premium-plan .plans-grid__plan-pill,
 				&.is-wooexpress-medium-plan .plans-grid__plan-pill {
 					background-color: var( --studio-white );

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -1303,7 +1303,7 @@ $redesign-table-cell-max-width: 280px;
 	&.is-medium,
 	&.is-large,
 	&.is-xlarge {
-		.plan-features-2023-grid__table-item.is-top-buttons button {
+		.plan-features-2023-grid__table-item.is-top-buttons .plan-features-2023-grid__actions-button {
 			margin-top: 0;
 		}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -393,6 +393,13 @@ $redesign-table-cell-max-width: 280px;
 	&.is-reduced-feature-group-spacing > .plan-features-2023-grid__table-item {
 		padding-top: 0;
 	}
+
+	&.is-first-feature-group-row.is-reduced-feature-group-spacing
+		> .plan-features-2023-grid__table-item {
+		@include plans-grid-medium-large {
+			padding-top: 0;
+		}
+	}
 }
 
 .plan-features-2023-grid__item-info {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -1303,6 +1303,10 @@ $redesign-table-cell-max-width: 280px;
 	&.is-medium,
 	&.is-large,
 	&.is-xlarge {
+		.plan-features-2023-grid__table-item.is-top-buttons button {
+			margin-top: 0;
+		}
+
 		thead tr:first-child .plan-features-2023-grid__table-item.popular-plan-parent-class {
 			height: 0;
 			padding: 0;


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adjust the margin/padding around the CTAs.
* Increase letter spacing on plan badges.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that there no regression issues in the control.
* Test with on of the variants.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
