### PR TITLE
Theme sheet: fix preview padding and style variation spacing

### DIFF
--- a/client/my-sites/marketplace/components/reviews-summary/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-summary/styles.scss
@@ -2,7 +2,7 @@
 
 .reviews-summary__container {
 	display: flex;
-	padding-top: 1rem;
+	padding-top: 16px;
 	gap: 0.75rem;
 }
 .reviews-summary__number-reviews-link.is-link.button {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -175,6 +175,7 @@ $button-border: 4px;
 	.theme__sheet-demo-toggle {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		gap: 4px;
 	}
 }
@@ -364,6 +365,8 @@ $button-border: 4px;
 	$iframe-viewport-height: 1040px;
 	$iframe-viewport-height-scaled: calc( $iframe-viewport-height / 2 );
 	min-height: $iframe-viewport-height-scaled;
+	padding: 0 24px;
+	box-sizing: border-box;
 
 	.theme-preview__frame-wrapper {
 		max-height: 100vw;
@@ -374,6 +377,8 @@ $button-border: 4px;
 		}
 
 		@include breakpoint-deprecated( '>960px' ) {
+			padding: auto;
+
 			max-height: calc( 100vh - var( --masterbar-height ) );
 
 			.theme-preview__frame {

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -8,7 +8,6 @@
 	position: relative;
 
 	@include breakpoint-deprecated( "<960px" ) {
-		margin-bottom: -16px;
 		padding: 0 24px;
 
 		&::after {

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -9,10 +9,12 @@
 
 	@include breakpoint-deprecated( "<960px" ) {
 		margin-bottom: -16px;
-		padding: 0 0 0 24px;
+		padding: 0 24px;
 
 		&::after {
 			@include long-content-fade( $direction: right, $size: 24px );
+			// must equal padding.
+			margin-right: 24px;
 			height: 100%;
 		}
 	}


### PR DESCRIPTION
Fixes DSGCOM-683

## Proposed Changes

* Add horizontal padding to the theme preview frame container and set `box-sizing: border-box` so the preview no longer sits flush against the viewport edges on smaller screens.
* Reset the padding at the `>960px` breakpoint so the wider layout is unaffected.
* Align the theme demo toggle to `space-between`.
* Normalize the style-variations horizontal padding to `0 24px` and offset the fade `::after` by a matching `margin-right: 24px` so the long-content fade lines up with the new padding.

## Why are these changes being made?

The theme sheet preview and style-variations row had inconsistent horizontal spacing, causing content to touch the edges of the viewport on narrow screens and the long-content fade to misalign with the padding.

## Testing Instructions

* Open a theme sheet (e.g. `/theme/:slug/:site`).
* On a narrow viewport (<960px), confirm the preview frame has even 24px horizontal padding and the style-variations row's fade lines up with its padding.
* On a wide viewport (>960px), confirm the preview layout is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
