### PR TITLE
Themes: open Customize site button in the current tab without external icon

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -7,7 +7,7 @@ import {
 	WPCOM_FEATURES_COMMUNITY_THEMES,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { getThemeIdFromStylesheet, Onboard } from '@automattic/data-stores';
 import {
 	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
@@ -919,12 +919,7 @@ class ThemeSheet extends Component {
 	getDefaultOptionLabel = () => {
 		const { defaultOption, isActive, isLoggedIn, siteId, translate } = this.props;
 		if ( isActive ) {
-			return (
-				<span className="theme__sheet-customize-button">
-					<Gridicon icon="external" />
-					{ translate( 'Customize site' ) }
-				</span>
-			);
+			return translate( 'Customize site' );
 		} else if ( isLoggedIn && siteId ) {
 			return translate( 'Activate' );
 		}
@@ -984,7 +979,6 @@ class ThemeSheet extends Component {
 				primary
 				busy={ this.isRequestingActivatingTheme() }
 				disabled={ this.isLoading() }
-				target={ isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
 			</Button>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -315,28 +315,6 @@ $button-border: 4px;
 	}
 }
 
-.theme__sheet-customize-button {
-	.gridicon {
-		margin-right: 4px;
-	}
-	&.spin {
-		.gridicons-sync > use:first-child,
-		.gridicons-sync > g:first-child {
-			animation: spinning-sync-icon linear 2s infinite;
-			transform-origin: center;
-		}
-	}
-}
-
-@keyframes spinning-sync-icon {
-	from {
-		transform: rotate( 0deg );
-	}
-	to {
-		transform: rotate( 360deg );
-	}
-}
-
 .theme__sheet-button-placeholder {
 	color: transparent;
 }


### PR DESCRIPTION
Fixes DSGCOM-684

## Proposed Changes

* On individual theme pages, the primary button for the active theme ("Customize site") no longer opens in a new tab: the `target="_blank"` attribute has been removed, so the site editor/customizer opens in the current tab.
* Removed the external-arrow icon from the button label, along with its now-unused wrapper span, `Gridicon` import, and dead CSS (`.theme__sheet-customize-button` block and the `spinning-sync-icon` keyframes only referenced there).

| Before | After |
|--------|--------|
| <img width="643" height="131" alt="Screenshot 2026-07-13 at 15 04 50" src="https://github.com/user-attachments/assets/80656f01-6d6e-4458-a490-b13299affa51" /> | <img width="643" height="131" alt="Screenshot 2026-07-13 at 15 05 01" src="https://github.com/user-attachments/assets/b3b50c16-8f02-42ed-a9cf-b76b98f8919f" /> | 

## Why are these changes being made?

* The customize button unnecessarily opened the editor in a new tab and showed an external-link icon, even though it's part of the same product flow. Opening it in the current tab is the expected navigation behavior.

## Testing Instructions

* Go to Appearance → Themes and open the details page of the currently active theme.
* Verify the primary button reads "Customize site" without an external-link icon.
* Click it and verify the editor opens in the same tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?