### PR TITLE
Masterbar: point notifications link at the wpcom origin

### DIFF
--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { wpcomLink } from 'calypso/dashboard/utils/link';
 import { setUnseenCount } from 'calypso/state/notifications/actions';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
@@ -94,7 +95,7 @@ class MasterbarItemNotifications extends Component {
 		return (
 			<>
 				<MasterbarItem
-					url="/notifications"
+					url={ wpcomLink( '/notifications' ) }
 					icon={ <BellIcon newItems={ this.state.newNote } active={ this.props.isActive } /> }
 					onClick={ this.toggleNotesFrame }
 					isActive={ this.props.isActive }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -5,7 +5,7 @@ const selectors = {
 	mySiteButton: '[data-tip-target="my-sites"]',
 	mobileMenuButton: '[data-tip-target="mobile-menu"]',
 	editorBackButton: '[data-tip-target="back-home"]',
-	notificationsButton: 'a[href="/notifications"]',
+	notificationsButton: 'a.masterbar-notifications',
 	meButton: 'a[data-tip-target="me"]',
 };
 /**


### PR DESCRIPTION
## Proposed Changes

- Point the masterbar notifications bell at the WordPress.com origin via `wpcomLink( '/notifications' )` instead of a relative `/notifications` URL.

## Why are these changes being made?

The masterbar notifications button is also rendered on dashboard hosts (e.g. `my.wordpress.com`) through the interim omnibar. A relative `/notifications` resolves against the current origin, so on a dashboard host it points at `my.wordpress.com/notifications`, which does not serve the notifications app. `wpcomLink` resolves the link from the `wpcom_url` config, so it targets the classic Calypso origin that actually serves notifications (and remains the same destination on classic hosts).

The click handler still toggles the in-page notifications panel; the `url` mainly governs the href for middle-click / open-in-new-tab and accessibility, which now points to a working destination in both contexts.

## Testing Instructions

1. On a classic Calypso host, confirm the notifications bell still opens the panel and its href points at `/notifications` on the same origin.
2. On a dashboard host (interim omnibar), confirm the bell's href resolves to the WordPress.com origin (`…/notifications`) rather than the dashboard origin.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
