### PR TITLE
Stats: hide pre-publish months on Post Details Months tab

### DIFF
--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -171,12 +171,17 @@ class StatsPostSummary extends Component {
 				}
 
 				// statsByMonth() expands every year in stats.years to a full
-				// 12 months, which for the current year includes months that
-				// haven't happened yet; drop those rather than paginating
-				// into fake future bars.
+				// 12 months: for the current year that includes months that
+				// haven't happened yet, and for the first year it includes
+				// months before the post was published. Drop both rather than
+				// paginating into fake empty bars; post-publish months with
+				// zero views are kept, consistent with Days/Weeks paging.
 				const today = moment();
-				return [ ...statsByMonth( stats, moment ) ].filter( ( record ) =>
-					moment( record.startDate ).isSameOrBefore( today, 'month' )
+				const publishDate = stats.post?.post_date ?? stats.post?.post_date_gmt;
+				return [ ...statsByMonth( stats, moment ) ].filter(
+					( record ) =>
+						moment( record.startDate ).isSameOrBefore( today, 'month' ) &&
+						( ! publishDate || ! moment( record.startDate ).isBefore( publishDate, 'month' ) )
 				);
 			}
 			default:

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -177,11 +177,19 @@ class StatsPostSummary extends Component {
 				// paginating into fake empty bars; post-publish months with
 				// zero views are kept, consistent with Days/Weeks paging.
 				const today = moment();
-				const publishDate = stats.post?.post_date ?? stats.post?.post_date_gmt;
+				// post_date is the post's site-local publish time, matching the
+				// site-local month buckets; the post_date_gmt fallback is GMT,
+				// so parse it as GMT rather than in the viewer's timezone.
+				// Comparing YYYY-MM keys keeps the trim independent of the
+				// viewer's zone either way.
+				const publishMoment = stats.post?.post_date
+					? moment( stats.post.post_date )
+					: moment.utc( stats.post?.post_date_gmt ?? null );
+				const publishMonth = publishMoment.isValid() ? publishMoment.format( 'YYYY-MM' ) : null;
 				return [ ...statsByMonth( stats, moment ) ].filter(
 					( record ) =>
 						moment( record.startDate ).isSameOrBefore( today, 'month' ) &&
-						( ! publishDate || ! moment( record.startDate ).isBefore( publishDate, 'month' ) )
+						( ! publishMonth || record.startDate.slice( 0, 7 ) >= publishMonth )
 				);
 			}
 			default:

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -9,11 +9,13 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPostStats, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { STATS_SUMMARY_MAX_BARS } from '../constants';
 import StatsModuleUTM from '../features/modules/stats-utm';
+import { getMomentSiteZone } from '../hooks/use-moment-site-zone';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
 import DatePicker from '../stats-date-label';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import SummaryChart from '../stats-summary';
+import { getPublishMonthKey } from './publish-month';
 
 import './style.scss';
 
@@ -37,6 +39,7 @@ class StatsPostSummary extends Component {
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
 		supportsUTMStats: PropTypes.bool,
+		momentSiteZone: PropTypes.func,
 	};
 
 	state = {
@@ -177,15 +180,11 @@ class StatsPostSummary extends Component {
 				// paginating into fake empty bars; post-publish months with
 				// zero views are kept, consistent with Days/Weeks paging.
 				const today = moment();
-				// post_date is the post's site-local publish time, matching the
-				// site-local month buckets; the post_date_gmt fallback is GMT,
-				// so parse it as GMT rather than in the viewer's timezone.
-				// Comparing YYYY-MM keys keeps the trim independent of the
-				// viewer's zone either way.
-				const publishMoment = stats.post?.post_date
-					? moment( stats.post.post_date )
-					: moment.utc( stats.post?.post_date_gmt ?? null );
-				const publishMonth = publishMoment.isValid() ? publishMoment.format( 'YYYY-MM' ) : null;
+				// The month buckets are site-local, so the publish boundary is
+				// resolved in the site's timezone too (see getPublishMonthKey);
+				// comparing YYYY-MM keys keeps the trim independent of the
+				// viewer's zone.
+				const publishMonth = getPublishMonthKey( stats.post, this.props.momentSiteZone );
 				return [ ...statsByMonth( stats, moment ) ].filter(
 					( record ) =>
 						moment( record.startDate ).isSameOrBefore( today, 'month' ) &&
@@ -344,4 +343,5 @@ class StatsPostSummary extends Component {
 export default connect( ( state, { siteId, postId } ) => ( {
 	stats: getPostStats( state, siteId, postId ),
 	isRequesting: isRequestingPostStats( state, siteId, postId ),
+	momentSiteZone: getMomentSiteZone( state, siteId ),
 } ) )( localize( withLocalizedMoment( StatsPostSummary ) ) );

--- a/client/my-sites/stats/stats-post-summary/publish-month.js
+++ b/client/my-sites/stats/stats-post-summary/publish-month.js
@@ -1,0 +1,23 @@
+import moment from 'moment';
+
+/**
+ * The YYYY-MM key, in the site's timezone, of the month the post was
+ * published — the month buckets the Months tab renders are site-local, so
+ * the publish boundary must be too.
+ *
+ * `post_date` is a naive site-local timestamp: `momentSiteZone` interprets
+ * it as site wall time directly. The `post_date_gmt` fallback is GMT, so it
+ * is parsed as an absolute time first and then converted into the site's
+ * zone (a GMT timestamp near midnight can belong to a different site-local
+ * month). Returns null when both are missing or unparsable, so callers can
+ * skip trimming.
+ * @param {Object} post - the stats response's `post` object.
+ * @param {Function} momentSiteZone - the factory from `getMomentSiteZone`.
+ * @returns {?string} the publish month key, e.g. '2024-05'.
+ */
+export function getPublishMonthKey( post, momentSiteZone ) {
+	const publishMoment = post?.post_date
+		? momentSiteZone( post.post_date )
+		: post?.post_date_gmt && momentSiteZone( moment.utc( post.post_date_gmt ) );
+	return publishMoment && publishMoment.isValid() ? publishMoment.format( 'YYYY-MM' ) : null;
+}

--- a/client/my-sites/stats/stats-post-summary/test/publish-month.js
+++ b/client/my-sites/stats/stats-post-summary/test/publish-month.js
@@ -1,0 +1,50 @@
+import moment from 'moment-timezone';
+import { getPublishMonthKey } from '../publish-month';
+
+// Mirrors getMomentSiteZone's IANA-timezone case: naive strings are
+// interpreted as site wall time, absolute inputs are converted into the zone.
+const siteZone = ( timezone ) => ( dateInput ) => moment.tz( dateInput, timezone );
+
+describe( 'getPublishMonthKey', () => {
+	test( 'reads post_date as site wall time', () => {
+		expect(
+			getPublishMonthKey( { post_date: '2024-05-01 00:30:00' }, siteZone( 'Pacific/Kiritimati' ) )
+		).toBe( '2024-05' );
+	} );
+
+	test( 'converts the GMT fallback into the site zone across a month boundary (site ahead of GMT)', () => {
+		// Site is UTC+14: 2024-04-30 10:30 GMT is 2024-05-01 00:30 site time,
+		// so the publish month is May, not April.
+		expect(
+			getPublishMonthKey(
+				{ post_date_gmt: '2024-04-30 10:30:00' },
+				siteZone( 'Pacific/Kiritimati' )
+			)
+		).toBe( '2024-05' );
+	} );
+
+	test( 'converts the GMT fallback into the site zone across a month boundary (site behind GMT)', () => {
+		// Site is UTC-10: 2024-05-01 05:00 GMT is 2024-04-30 19:00 site time,
+		// so the publish month is April, not May.
+		expect(
+			getPublishMonthKey( { post_date_gmt: '2024-05-01 05:00:00' }, siteZone( 'Pacific/Honolulu' ) )
+		).toBe( '2024-04' );
+	} );
+
+	test( 'prefers post_date over post_date_gmt', () => {
+		expect(
+			getPublishMonthKey(
+				{ post_date: '2024-05-01 00:30:00', post_date_gmt: '2024-04-30 10:30:00' },
+				siteZone( 'Pacific/Kiritimati' )
+			)
+		).toBe( '2024-05' );
+	} );
+
+	test( 'returns null when the publish date is missing or unparsable', () => {
+		const zone = siteZone( 'Pacific/Kiritimati' );
+		expect( getPublishMonthKey( undefined, zone ) ).toBeNull();
+		expect( getPublishMonthKey( {}, zone ) ).toBeNull();
+		expect( getPublishMonthKey( { post_date: 'not-a-date' }, zone ) ).toBeNull();
+		expect( getPublishMonthKey( { post_date_gmt: 'not-a-date' }, zone ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Fixes STATS-333 (follow-up to #112548)

## Proposed Changes

* On Stats > Post Details > **Months** tab, stop rendering empty bars for months **before the post was published** when paging back with the prev arrow.
* `statsByMonth()` expands every year in `stats.years` to a full 12 months, and `stats.years` starts at the first year with recorded views. The old `firstNotEmpty` trimming hid those leading zero months; #112548 replaced it with a future-months-only filter, so months of the first year that precede the post's publish date were rendered as fake empty bars (at most 11, since earlier years aren't in `stats.years` at all).
* The filter now also drops months before the post's publish date, read from the stats response's own `post` object (`stats.post.post_date`, falling back to `post_date_gmt` — both fields are already relied on elsewhere against this endpoint) at month granularity. The Video Details chart took a similar publish-date trim in #112548 (`trimToTrailingWindow`), though not identical: that implementation compared in the viewer's local timezone, while this PR resolves the publish month in the site's timezone (see below). #112548's client-side trim has since been superseded entirely by #112969, where the API windows the series from the publish date server-side.
* The publish month is resolved in the **site's timezone** via `getMomentSiteZone` (`getPublishMonthKey` helper): `post_date` is site-local wall time already, and the `post_date_gmt` fallback is parsed as GMT and converted into the site zone — the month buckets are site-local, so a GMT timestamp near a month boundary (e.g. a UTC+14 site publishing 5/1 00:30 site time = 4/30 10:30 GMT) must not trim against the GMT month. The comparison uses `YYYY-MM` keys, so it never depends on the viewer's timezone.
* Post-publish months with zero views still show, consistent with Days/Weeks paging. The header date range also no longer starts before the post existed, since it is derived from the filtered records.
* If the publish date is missing or unparsable, the filter degrades to the current behavior (no leading trim).

## Why are these changes being made?

* Paging back on the Months tab showed bars for months in which the post did not exist (e.g. a post published 2024-05-07 showed empty Jan–Apr 2024 bars, with the header range starting "Feb 1"), which misrepresents the post's history and adds a meaningless extra page.

## Testing Instructions

1. Open Stats > Posts & pages and click a post that was published mid-year a few years back (so its first-view year has months before the publish month).
2. Switch to the **Months** tab and page back with the prev arrow to the oldest page.
3. Verify the oldest bar is the post's publish month — no empty bars for earlier months of that year, and the header date range starts at the publish month.
4. Verify post-publish months with zero views still render as empty bars, and that Days/Weeks/Years tabs behave as before.
5. `yarn test-client client/my-sites/stats/stats-post-summary/test/publish-month.js` — 5 tests green (site-local `post_date`, GMT fallback crossing a site month boundary in both directions, missing/unparsable dates).

|Before|After|
|-|-|
|<img width="1285" height="516" alt="截圖 2026-07-29 凌晨1 46 55" src="https://github.com/user-attachments/assets/28c3117d-f9fb-46b1-8c4a-fdf252c8e853" />|<img width="1304" height="526" alt="截圖 2026-07-29 凌晨1 53 30" src="https://github.com/user-attachments/assets/00724ad1-e6c1-4c2d-8f41-6060f9738fad" />|

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


