### PR TITLE
Help Center: stamp Zendesk ticket fields on escalation to avoid blank Site URL

### DIFF
--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -36,6 +36,9 @@ jest.mock( '@automattic/zendesk-client', () => ( {
 		isPending: false,
 		mutateAsync: mockSubmitUserFields,
 	} ),
+	ZENDESK_CUSTOM_FIELD_AI_CHAT_ID: 33538949515668,
+	ZENDESK_CUSTOM_FIELD_WEBSITE_URL: 22054927,
+	ZENDESK_SOURCE_URL_TICKET_FIELD_ID: 23752099174548,
 } ) );
 
 jest.mock( '../../context', () => ( {
@@ -170,6 +173,26 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 		expect( error.smooch_waited_ms ).toBeLessThanOrEqual( 10_000 );
 		// The user is shown the try-again message.
 		expect( mockSetChat ).toHaveBeenCalled();
+	} );
+
+	it( 'duplicates the critical user fields as ticket-field metadata on the conversation', async () => {
+		smoochCreateConversation.mockResolvedValueOnce( { id: 'conv-1', metadata: {} } );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		await expect( result.current( { createdFrom: 'automatic_escalation' } ) ).resolves.toBe(
+			'conv-1'
+		);
+
+		expect( smoochCreateConversation ).toHaveBeenCalledWith( {
+			metadata: expect.objectContaining( {
+				supportInteractionId: 'int-1',
+				odieChatId: 'odie-1',
+				'zen:ticket_field:22054927': 'https://example.com',
+				'zen:ticket_field:23752099174548': window.location.href,
+				'zen:ticket_field:33538949515668': 'odie-1',
+			} ),
+		} );
 	} );
 
 	it( 'does not retry a non-transient error', async () => {

--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -184,13 +184,19 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 			'conv-1'
 		);
 
+		const {
+			ZENDESK_CUSTOM_FIELD_AI_CHAT_ID,
+			ZENDESK_CUSTOM_FIELD_WEBSITE_URL,
+			ZENDESK_SOURCE_URL_TICKET_FIELD_ID,
+		} = jest.requireMock( '@automattic/zendesk-client' );
+
 		expect( smoochCreateConversation ).toHaveBeenCalledWith( {
 			metadata: expect.objectContaining( {
 				supportInteractionId: 'int-1',
 				odieChatId: 'odie-1',
-				'zen:ticket_field:22054927': 'https://example.com',
-				'zen:ticket_field:23752099174548': window.location.href,
-				'zen:ticket_field:33538949515668': 'odie-1',
+				[ `zen:ticket_field:${ ZENDESK_CUSTOM_FIELD_WEBSITE_URL }` ]: 'https://example.com',
+				[ `zen:ticket_field:${ ZENDESK_SOURCE_URL_TICKET_FIELD_ID }` ]: window.location.href,
+				[ `zen:ticket_field:${ ZENDESK_CUSTOM_FIELD_AI_CHAT_ID }` ]: 'odie-1',
 			} ),
 		} );
 	} );

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -155,7 +155,7 @@ export const useCreateZendeskConversation = () => {
 				messaging_initial_message: userFieldMessage || undefined,
 				messaging_site_id: selectedSiteId || null,
 				messaging_ai_chat_id: chatId || undefined,
-				// messaging_url: selectedSiteURL || window.location.href,
+				messaging_url: selectedSiteURL || window.location.href,
 				messaging_flow: userFieldFlowName || null,
 				messaging_source: window.location.href,
 			} );

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,4 +1,10 @@
-import { useUpdateZendeskUserFields, type ZendeskConversation } from '@automattic/zendesk-client';
+import {
+	useUpdateZendeskUserFields,
+	ZENDESK_CUSTOM_FIELD_AI_CHAT_ID,
+	ZENDESK_CUSTOM_FIELD_WEBSITE_URL,
+	ZENDESK_SOURCE_URL_TICKET_FIELD_ID,
+	type ZendeskConversation,
+} from '@automattic/zendesk-client';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Smooch from 'smooch';
 import {
@@ -149,7 +155,7 @@ export const useCreateZendeskConversation = () => {
 				messaging_initial_message: userFieldMessage || undefined,
 				messaging_site_id: selectedSiteId || null,
 				messaging_ai_chat_id: chatId || undefined,
-				messaging_url: selectedSiteURL || window.location.href,
+				// messaging_url: selectedSiteURL || window.location.href,
 				messaging_flow: userFieldFlowName || null,
 				messaging_source: window.location.href,
 			} );
@@ -163,6 +169,20 @@ export const useCreateZendeskConversation = () => {
 		let conversation: ZendeskConversation | null = null;
 		let interaction = null;
 
+		// The messaging user fields submitted above can take up to a minute to become
+		// visible to Zendesk's ticket-creation triggers, so tickets created within
+		// seconds of a user's first contact come out with blank Site URL / Started
+		// from. Ticket-field metadata travels atomically with the conversation, so
+		// duplicate the critical fields here. See DOTSUP-472.
+		const ticketFieldMetadata = {
+			[ `zen:ticket_field:${ ZENDESK_CUSTOM_FIELD_WEBSITE_URL }` ]:
+				selectedSiteURL || window.location.href,
+			[ `zen:ticket_field:${ ZENDESK_SOURCE_URL_TICKET_FIELD_ID }` ]: window.location.href,
+			...( chatId
+				? { [ `zen:ticket_field:${ ZENDESK_CUSTOM_FIELD_AI_CHAT_ID }` ]: String( chatId ) }
+				: {} ),
+		};
+
 		const SMOOCH_READY_TIMEOUT_MS = 10000;
 		const SMOOCH_RETRY_INTERVAL_MS = 250;
 		const smoochReadyDeadline = Date.now() + SMOOCH_READY_TIMEOUT_MS;
@@ -175,6 +195,7 @@ export const useCreateZendeskConversation = () => {
 						createdAt: Date.now(),
 						...( activeInteractionId ? { supportInteractionId: activeInteractionId } : {} ),
 						...( chatId ? { odieChatId: chatId } : {} ),
+						...ticketFieldMetadata,
 					},
 				} );
 				break;

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -16,6 +16,7 @@ export { calculateUnread } from './use-get-unread-conversations';
 export { isTestModeEnvironment, getBadRatingReasons } from './util';
 
 export {
+	ZENDESK_CUSTOM_FIELD_AI_CHAT_ID,
 	ZENDESK_CUSTOM_FIELD_PRODUCT,
 	ZENDESK_CUSTOM_FIELD_WEBSITE_URL,
 	ZENDESK_SOURCE_URL_TICKET_FIELD_ID,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-472/unified-ai-chat-escalations-miss-support-interaction-history

## Proposed Changes

**Classic Help Center escalations now stamp the critical support context (site URL, source URL, AI chat ID) directly onto the Zendesk ticket as ticket fields, instead of relying only on messaging user fields that may not have propagated yet.**

- `useCreateZendeskConversation` adds `zen:ticket_field:*` entries (website URL, source URL, AI chat ID) to the `Smooch.createConversation` metadata — the same mechanism the unified chat path already uses since #111878. Ticket-field metadata is applied atomically when Zendesk creates the ticket, so it can’t race.
- The `messaging_url` user field is no longer submitted to the user profile; the ticket field is now the source of truth for the site URL.
- Exports `ZENDESK_CUSTOM_FIELD_AI_CHAT_ID` from `@automattic/zendesk-client`.
- Adds a unit test asserting the new metadata on conversation creation.

## Why are these changes being made?

Happiness Engineers have been receiving chats with blank “Site URL” and “Started from” info (DOTSUP-472). Data analysis showed these tickets all come from users who escalate to a human within seconds of their first ever contact — mostly via the Big Sky “get human support” handoff, which jumps from the editor to a live chat in ~10 seconds.

The escalation flow writes the support context to the customer’s Zendesk *user profile* right before starting the chat, and a Zendesk automation copies it onto the ticket at creation. That write can take up to a minute to become visible to the automation. Repeat customers were masked by leftover values from their previous chats; first-time customers got blank tickets. Blank tickets ran at ~8–13/day (~2% of AI-chat escalations), and HEs had to ask users for basics the flow had already collected.

Attaching the same values as ticket-field metadata on the conversation itself makes them part of the ticket from the moment it exists, regardless of how fast the user escalated.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center, start a chat with the AI assistant, and ask to talk to a human until it escalates to Zendesk.
3. Send a message so the ticket is created.
4. In the Zendesk agent view for the new ticket, verify the “Website URL” and “Source URL” ticket fields are populated (and “AI Chat ID” when the escalation came from an AI chat).

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple or Atomic site (the site itself does not need sandboxing), open the Help Center from wp-admin, and repeat the escalation steps above.
4. Verify the same ticket fields are populated in the Zendesk agent view.
