### PR TITLE
Help Center: externalize react-dom/client to fix React internals crash

### DIFF
--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -63,11 +63,28 @@ function getIndividualConfig( options = {} ) {
 						return null;
 					}
 
+					// Externalize the `react-dom/client` subpath to WordPress's `ReactDOM`
+					// global so `createRoot` comes from the same React that WordPress provides.
+					// The default extraction only maps bare `react-dom`, so this subpath would
+					// otherwise bundle our own react-dom (React 19), which reads React internals
+					// off the host's React and throws ("Cannot read properties of undefined").
+					if ( request === 'react-dom/client' ) {
+						return 'ReactDOM';
+					}
+
 					// Bundle @wordpress/dataviews and @wordpress/ui instead of externalizing.
 					// These are only used by HelpCenterA4AContactForm which is lazy-loaded,
 					// so we don't want them listed as dependencies for the main entry point.
 					if ( request === '@wordpress/dataviews' || request === '@wordpress/ui' ) {
 						return null;
+					}
+				},
+				requestToHandle( request ) {
+					// `react-dom/client` is externalized to the `ReactDOM` global above; point its
+					// script dependency at the existing `react-dom` handle since the request name
+					// itself is not a registered handle.
+					if ( request === 'react-dom/client' ) {
+						return 'react-dom';
 					}
 				},
 			} ),


### PR DESCRIPTION
## Proposed Changes

* Externalize the `react-dom/client` subpath to WordPress's `ReactDOM` global in the Help Center app's webpack config (`requestToExternal` + `requestToHandle`), so `createRoot` resolves from the same React that WordPress provides at runtime instead of being bundled from `node_modules`.

## Why are these changes being made?

The `widgets.wp.com` Help Center build was throwing `Uncaught TypeError: Cannot read properties of undefined (reading 'S')` from `react-dom-client.development.js` during render, breaking the panel.

Root cause: the recent React 19 migration of `packages/` made `packages/components` import `createRoot` from the `react-dom/client` subpath (in `embed-container` and `image-carousel`). The Help Center's `DependencyExtractionWebpackPlugin` externalizes bare `react` → `window.React` and `react-dom` → `window.ReactDOM`, but the default extraction does **not** map the `react-dom/client` subpath. So webpack bundled React 19's `react-dom-client` from `node_modules`, while `react` stayed externalized to the WordPress host's React (18). At runtime the bundled react-dom-client@19 read `React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE` off the host's React 18 global (`undefined`) and threw on `.S`.

Externalizing the subpath to the host `ReactDOM` global (which exposes `createRoot` in both React 18 and 19) keeps React and ReactDOM on a single, matching instance. This is the same class of hazard already documented for `react/jsx-runtime` in `apps/wpcom-block-editor/webpack.config.js`.

Verified against the production build: `react-dom-client` is no longer bundled, `createRoot` resolves from `window.ReactDOM`, and each affected entry's `.asset.json` lists the valid `react-dom` script handle.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple and Atomic
4. Open the Help Center and verify it loads and functions correctly, with no `Cannot read properties of undefined (reading 'S')` error in the console.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
