### PR TITLE
Pricing grid redesign: fix subheadings

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -58,6 +58,10 @@
 		font-weight: 500;
 		text-decoration: underline;
 
+		@media ( min-width: 960px ) {
+			padding: 1px 0;
+		}
+
 		&:hover,
 		&:focus {
 			color: inherit;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -47,6 +47,14 @@
 		--step-container-v2-content-inline-padding: clamp( 1rem, 2vw, 2rem );
 	}
 
+	.step-container-v2__content-wrapper.axis-vertical:has(
+		.plans-grid-next.is-plans-grid-redesign-experiment
+	) {
+		.step-container-v2__heading p {
+			letter-spacing: -0.32px;
+		}
+	}
+
 	// Style the inline `start with a free plan` CTA inside Step.Heading subText
 	// to look like a link instead of a default borderless button. The legacy
 	// <PlansPageSubheader> applied equivalent styles to the same button via its

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -53,6 +53,10 @@
 		.step-container-v2__heading p {
 			letter-spacing: -0.32px;
 		}
+
+		.plans-features-main__free-plan-cta {
+			font-weight: inherit;
+		}
 	}
 
 	// Style the inline `start with a free plan` CTA inside Step.Heading subText

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -50,10 +50,6 @@
 	.step-container-v2__content-wrapper.axis-vertical:has(
 		.plans-grid-next.is-plans-grid-redesign-experiment
 	) {
-		.step-container-v2__heading p {
-			letter-spacing: -0.32px;
-		}
-
 		.plans-features-main__free-plan-cta {
 			font-weight: inherit;
 		}

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -8,14 +8,25 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { SelectedFeatureData } from '../hooks/use-selected-feature';
 
-const Subheader = styled.p< { isUsingStepContainerV2?: boolean; isVisualSplitIntent?: boolean } >`
+const Subheader = styled.p< {
+	isPlansGridRedesign?: boolean;
+	isUsingStepContainerV2?: boolean;
+	isVisualSplitIntent?: boolean;
+} >`
 	${ ( props ) =>
 		props.isUsingStepContainerV2
 			? `
-				margin: -2.5rem 0 3rem;
+				margin: ${ props.isPlansGridRedesign ? '-3rem 0 3rem' : '-2.5rem 0 3rem' };
 				color: var( --color-text );
 				font-size: 0.875rem;
 				line-height: 1.5;
+				${
+					props.isPlansGridRedesign
+						? `
+							letter-spacing: -0.32px;
+						`
+						: ''
+				}
 				text-wrap: balance;
 				text-align: left;
 				button.is-borderless {
@@ -39,6 +50,13 @@ const Subheader = styled.p< { isUsingStepContainerV2?: boolean; isVisualSplitInt
 				margin: ${ props.isVisualSplitIntent ? '-40px 0 30px 0' : '-32px 0 40px 0' };
 				color: var( --studio-gray-60 );
 				font-size: 1rem;
+				${
+					props.isPlansGridRedesign
+						? `
+							letter-spacing: -0.32px;
+						`
+						: ''
+				}
 				text-align: center;
 				button.is-borderless {
 					font-weight: ${ props.isVisualSplitIntent ? 'inherit' : '500' };
@@ -323,6 +341,7 @@ const PlansPageSubheader = ( {
 	selectedFeature,
 	intent,
 	showDifferentiatorHeader,
+	isPlansGridRedesign,
 }: {
 	siteSlug?: string | null;
 	isDisplayingPlansNeededForFeature: boolean;
@@ -335,6 +354,7 @@ const PlansPageSubheader = ( {
 	selectedFeature: SelectedFeatureData | null;
 	intent?: string;
 	showDifferentiatorHeader?: boolean;
+	isPlansGridRedesign?: boolean;
 } ) => {
 	const translate = useTranslate();
 
@@ -346,6 +366,7 @@ const PlansPageSubheader = ( {
 		intent === 'plans-wordpress-hosting' || intent === 'plans-website-builder';
 
 	const subheaderCommonProps = {
+		isPlansGridRedesign,
 		isUsingStepContainerV2,
 		isVisualSplitIntent,
 	};

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -30,7 +30,7 @@ const Subheader = styled.p< {
 				text-wrap: balance;
 				text-align: left;
 				button.is-borderless {
-					font-weight: 500;
+					font-weight: ${ props.isPlansGridRedesign ? 'inherit' : '500' };
 					color: inherit;
 					text-decoration: underline;
 					font-size: inherit;
@@ -59,7 +59,7 @@ const Subheader = styled.p< {
 				}
 				text-align: center;
 				button.is-borderless {
-					font-weight: ${ props.isVisualSplitIntent ? 'inherit' : '500' };
+					font-weight: ${ props.isPlansGridRedesign || props.isVisualSplitIntent ? 'inherit' : '500' };
 					color: var( --studio-gray-90 );
 					text-decoration: underline;
 					font-size: 16px;

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -20,13 +20,6 @@ const Subheader = styled.p< {
 				color: var( --color-text );
 				font-size: 0.875rem;
 				line-height: 1.5;
-				${
-					props.isPlansGridRedesign
-						? `
-							letter-spacing: -0.32px;
-						`
-						: ''
-				}
 				text-wrap: balance;
 				text-align: left;
 				button.is-borderless {
@@ -50,13 +43,6 @@ const Subheader = styled.p< {
 				margin: ${ props.isVisualSplitIntent ? '-40px 0 30px 0' : '-32px 0 40px 0' };
 				color: var( --studio-gray-60 );
 				font-size: 1rem;
-				${
-					props.isPlansGridRedesign
-						? `
-							letter-spacing: -0.32px;
-						`
-						: ''
-				}
 				text-align: center;
 				button.is-borderless {
 					font-weight: ${ props.isPlansGridRedesign || props.isVisualSplitIntent ? 'inherit' : '500' };

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -30,6 +30,9 @@ const Subheader = styled.p< { isUsingStepContainerV2?: boolean; isVisualSplitInt
 				}
 				@media ( min-width: 960px ) {
 					font-size: 1rem;
+					button.is-borderless {
+						padding: 1px 0;
+					}
 				}
 			`
 			: `
@@ -49,6 +52,11 @@ const Subheader = styled.p< { isUsingStepContainerV2?: boolean; isVisualSplitInt
 				}
 				@media ( min-width: 600px ) {
 					text-align: center;
+				}
+				@media ( min-width: 960px ) {
+					button.is-borderless {
+						padding: 1px 0;
+					}
 				}
 			` }
 `;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1425,6 +1425,7 @@ const PlansFeaturesMain = ( {
 					renderFreePlanCtaInStepContainerV2={ renderFreePlanCtaInStepContainerV2 }
 					onFreePlanCTAClick={ onFreePlanCTAClick }
 					intent={ intent }
+					isPlansGridRedesign={ usePlansGridRedesign }
 					showDifferentiatorHeader={
 						showDifferentiatorHeader || showPlansGridRedesignDifferentiatorHeader
 					}


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17810

## Proposed Changes

* Move the 'start with a free plan' CTA to be in line with the text on existing/new design.
* Adjust the spacing between the top subheading and the next line to match the design.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a paid domain and test /setup/onboarding/plans.
* Check on control to confirm that the CTA is now aligned correctly, with no other changes.
* Check a treatment variant and compare to the Figma design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
