### PR TITLE
Shopping cart: retry the cart-key lookup when the request hangs

### DIFF
--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -361,14 +361,44 @@ export function doesResponseCartContainProductMatching(
 	} );
 }
 
+const timedOut = new Error( 'request timed out' );
+
 export async function findCartKeyFromSiteSlug(
 	slug: string,
 	getCart: GetCart
 ): Promise< CartKey > {
-	try {
-		const cart = await getCart( slug as CartKey );
-		return cart.cart_key;
-	} catch {
-		return 'no-site';
+	// The cart endpoint occasionally never responds when queried right after
+	// site creation, while re-issuing the identical request succeeds
+	// immediately. Try up to three sequential attempts, each capped at 1s.
+	// An abandoned attempt cannot be aborted (the transport exposes no abort
+	// API) and is left to idle out.
+	for ( let attempt = 1; attempt <= 3; attempt++ ) {
+		try {
+			const cart = await withTimeout( getCart( slug as CartKey ), 1000 );
+			return cart.cart_key;
+		} catch ( error ) {
+			if ( error !== timedOut ) {
+				// Same failure semantics as before the retry existed.
+				return 'no-site';
+			}
+			debug( `findCartKeyFromSiteSlug attempt ${ attempt } timed out` );
+		}
 	}
+	return 'no-site';
+}
+
+function withTimeout< T >( promise: Promise< T >, ms: number ): Promise< T > {
+	return new Promise< T >( ( resolve, reject ) => {
+		const timer = setTimeout( () => reject( timedOut ), ms );
+		promise.then(
+			( value ) => {
+				clearTimeout( timer );
+				resolve( value );
+			},
+			( error ) => {
+				clearTimeout( timer );
+				reject( error );
+			}
+		);
+	} );
 }

--- a/packages/shopping-cart/test/cart-functions.ts
+++ b/packages/shopping-cart/test/cart-functions.ts
@@ -1,0 +1,62 @@
+import { findCartKeyFromSiteSlug } from '../src/cart-functions';
+import type { ResponseCart } from '../src/types';
+
+jest.useFakeTimers();
+
+const cart = { cart_key: 12345 } as ResponseCart;
+const never = () => new Promise< ResponseCart >( () => {} );
+
+describe( 'findCartKeyFromSiteSlug', () => {
+	it( 'returns the cart key from the first attempt', async () => {
+		const getCart = jest.fn().mockResolvedValue( cart );
+		await expect( findCartKeyFromSiteSlug( 'example.wordpress.com', getCart ) ).resolves.toBe(
+			12345
+		);
+		expect( getCart ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'retries a hung request and returns the cart key from the next attempt', async () => {
+		const getCart = jest.fn().mockImplementationOnce( never ).mockResolvedValue( cart );
+		const promise = findCartKeyFromSiteSlug( 'example.wordpress.com', getCart );
+		await jest.advanceTimersByTimeAsync( 1000 );
+		await expect( promise ).resolves.toBe( 12345 );
+		expect( getCart ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'returns no-site after three timed-out attempts', async () => {
+		const getCart = jest.fn().mockImplementation( never );
+		const promise = findCartKeyFromSiteSlug( 'example.wordpress.com', getCart );
+		await jest.advanceTimersByTimeAsync( 3000 );
+		await expect( promise ).resolves.toBe( 'no-site' );
+		expect( getCart ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'returns no-site on a non-timeout error after a timeout without further retries', async () => {
+		const getCart = jest
+			.fn()
+			.mockImplementationOnce( never )
+			.mockRejectedValue( new Error( 'not found' ) );
+		const promise = findCartKeyFromSiteSlug( 'example.wordpress.com', getCart );
+		await jest.advanceTimersByTimeAsync( 1000 );
+		await expect( promise ).resolves.toBe( 'no-site' );
+		expect( getCart ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'returns no-site when getCart throws synchronously', async () => {
+		const getCart = jest.fn().mockImplementation( () => {
+			throw new Error( 'sync throw' );
+		} );
+		await expect( findCartKeyFromSiteSlug( 'example.wordpress.com', getCart ) ).resolves.toBe(
+			'no-site'
+		);
+		expect( getCart ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'returns no-site on a non-timeout error without retrying', async () => {
+		const getCart = jest.fn().mockRejectedValue( new Error( 'not found' ) );
+		await expect( findCartKeyFromSiteSlug( 'example.wordpress.com', getCart ) ).resolves.toBe(
+			'no-site'
+		);
+		expect( getCart ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
Related to [TESTOPS-108](https://linear.app/a8c/issue/TESTOPS-108) (recurrence of the same flake class).

## Proposed Changes

- Retry the cart-key lookup in `findCartKeyFromSiteSlug` (`packages/shopping-cart/src/cart-functions.ts`): up to three sequential attempts, each capped at 1s. Only timeouts retry; genuine API errors keep the previous immediate `'no-site'` behavior, and three timed-out attempts fall back to `'no-site'` as well. An abandoned attempt cannot be aborted (the transport exposes no abort API) and is left to idle out.
- Unit tests for the retry semantics (`packages/shopping-cart/test/cart-functions.ts`).

## Why are these changes being made?

`GET /rest/v1.1/me/shopping-cart/{siteSlug}` intermittently never responds when issued immediately after site creation. The request has no client-side timeout, so `getCartKeyForSiteSlug()` never settles, the stepper processing step never submits, and the user is parked indefinitely on `/setup/domain/processing` (or `/setup/onboarding/processing`) with a spinner. The same stall makes `setup-domain__flows.spec.ts` flaky in CI (desktop [18485399](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix_virtual_Batch_561411941_2/18485399), mobile [18485533](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix_virtual_Batch_583005117_2/18485533)).

Measurements against staging (Playwright network traces): the lookup either completes in 175-535ms or hangs indefinitely; there is no slow tail in between. When a hung request is re-issued, it succeeds in ~200ms. A capped retry therefore converts a guaranteed indefinite stall into ~1-2s of added latency, at the cost of an extra idempotent GET.

This mitigates the symptom client-side. The backend hang on the shopping-cart endpoint for freshly created sites, and the swallowed `ProcessingResult.FAILURE` in the domain flow (`client/landing/stepper/declarative-flow/flows/domain/domain.ts`), are separate follow-ups.

## Testing Instructions

- `yarn test-packages packages/shopping-cart` (102 tests, all passing; 6 new in `test/cart-functions.ts`).
- E2E (requires a local dev server so the modified bundle is served, secrets decrypted):

```
yarn start
cd test/e2e
BRANCH_NAME=trunk CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn playwright test specs/flows/setup-domain__flows.spec.ts --project=chrome --reporter=list -g "purchase a domain for a new site"
```

With `localStorage.debug = 'shopping-cart:*'`, a rescued hang logs `findCartKeyFromSiteSlug attempt N failed` before checkout loads.
