### PR TITLE
Plugins: fix plugin details screen layout on mobile

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -22,7 +22,7 @@ $rating-star-color: #ffb514;
 
 	@include break-mobile {
 		flex-wrap: nowrap;
-		align-items: flex-start;
+		align-items: center;
 		justify-content: flex-start;
 		text-align: initial;
 	}
@@ -43,6 +43,7 @@ $rating-star-color: #ffb514;
 
 	.full-width-section & {
 		flex-wrap: nowrap;
+		align-items: flex-start;
 		.plugin-details-header__icon {
 			width: 80px;
 			height: 80px;
@@ -52,6 +53,30 @@ $rating-star-color: #ffb514;
 				width: 72px;
 				height: 72px;
 			}
+		}
+	}
+}
+
+// Below the mobile breakpoint, keep the classic (non-redesign) header inline —
+// icon beside a vertically-centered title — rather than stacking it centered.
+.is-plugin-details.is-wide-layout {
+	.plugin-details-header__main-info {
+		@include breakpoint-deprecated( "<480px" ) {
+			flex-wrap: nowrap;
+			align-items: center;
+			justify-content: flex-start;
+			text-align: initial;
+
+			.plugin-details-header__icon {
+				margin-right: 20px;
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	.plugin-details-header__title-container {
+		@include breakpoint-deprecated( "<480px" ) {
+			margin-top: 0;
 		}
 	}
 }
@@ -111,7 +136,7 @@ $rating-star-color: #ffb514;
 }
 
 .plugin-details-header__description {
-	font-size: $font-title-small;
+	font-size: $font-body;
 	color: var(--studio-gray-80);
 	padding: 24px 0;
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -359,14 +359,13 @@ $calypso-header-height: 31px;
 		margin-top: 24px;
 		gap: 16px;
 		display: flex;
+		align-items: center;
+		justify-content: space-between;
 		font-size: $font-body-extra-small;
 
-		@include breakpoint-deprecated( '<1280px' ) {
-			flex-direction: column;
-			gap: 10px;
-		}
-
 		.plugin-details__plugin-download-cta {
+			flex-shrink: 0;
+
 			a {
 				font-size: $font-body-extra-small;
 				padding: 6px 14px;
@@ -376,6 +375,8 @@ $calypso-header-height: 31px;
 		.full-width-section & {
 			font-size: $font-body-small;
 			flex-direction: column;
+			align-items: initial;
+			justify-content: initial;
 
 			border-top: 1px solid var(--studio-gray-5);
 			padding-top: 24px;


### PR DESCRIPTION
Part of DSGCOM-686

## Proposed Changes

Fix the classic plugin details screen on mobile:

* **Header alignment** — vertically center the plugin title/author block with the icon (was top-aligned).
* **Description size** — reduce from `$font-title-small` (1.25rem) to `$font-body` (1rem), so the long copy no longer pushes the CTA button down.
* **Download row** — keep the "available for download" text and the Download button on one row with the button to the right, instead of stacking the button beneath the text.
* Below the mobile breakpoint (`<480px`) the classic header previously fell back to a centered, stacked layout; it now stays inline (icon beside a vertically-centered title). This is scoped to `.is-plugin-details.is-wide-layout` so the marketplace redesign (`.is-full-width-layout`) is untouched.

## Why are these changes being made?

The plugin screen looked rough on mobile: mismatched margins, a misaligned title, oversized copy pushing the activate button down, and a Download button stacked below its text. This applies the design feedback from the issue.

## Testing Instructions

1. With a site selected, open a plugin details page, e.g. `/plugins/woocommerce/<your-site>`.
2. Narrow the viewport to a phone width (both below and above 480px).
3. Verify:
   * The title is vertically aligned with the plugin icon.
   * The description reads at 1rem and the CTA is not pushed far down.
   * The "This plugin is available for download…" text and the **Download** button sit on the same row, button on the right, with no horizontal overflow.
4. Confirm the marketplace redesign (logged-out `/plugins/woocommerce`, or dashboard opt-in with no site) is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
