### PR TITLE
Sites dashboard: Fix dead plugin column links in Jetpack Manage and A4A

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -259,7 +259,7 @@ describe( 'useRowMetadata', () => {
 		const expected = {
 			eventName: 'calypso_jetpack_agency_dashboard_update_plugins_click_small_screen',
 			isExternalLink: false,
-			link: `/plugins/updates/${ FAKE_SITE.url }`,
+			link: `/plugins/manage/${ FAKE_SITE.url }`,
 			isSupported: true,
 			row: rows.plugin,
 			siteDown: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { AllowedTypes } from '../../types';
 
@@ -67,11 +68,10 @@ const getLinks = (
 		case 'plugin': {
 			link = `${ siteUrlWithScheme }/wp-admin/plugins.php`;
 			isExternalLink = true;
-			if ( ! isAtomicSite ) {
-				link =
-					status === 'warning'
-						? `/plugins/updates/${ siteUrlWithMultiSiteSupport }`
-						: `/plugins/manage/${ siteUrlWithMultiSiteSupport }`;
+			// Only Jetpack Cloud routes plugin management in-app; A4A has no per-site
+			// plugins route and sends users to wp-admin, as its site preview pane does.
+			if ( ! isAtomicSite && ! isA8CForAgencies() ) {
+				link = `/plugins/manage/${ siteUrlWithMultiSiteSupport }`;
 				isExternalLink = false;
 			}
 			break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import getLinks from '../get-links';
+
+jest.mock( 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies' );
+
+const mockedIsA8CForAgencies = isA8CForAgencies as jest.MockedFunction< typeof isA8CForAgencies >;
+
+const SITE_URL = 'example.com';
+const SITE_URL_WITH_SCHEME = 'https://example.com';
+
+describe( 'getLinks', () => {
+	describe( 'plugin', () => {
+		it( 'links a non-Atomic site to plugin management in Jetpack Cloud', () => {
+			mockedIsA8CForAgencies.mockReturnValue( false );
+
+			expect( getLinks( 'plugin', 'warning', SITE_URL, SITE_URL_WITH_SCHEME, false ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }`,
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'links a non-Atomic site to wp-admin in A4A, which has no per-site plugins route', () => {
+			mockedIsA8CForAgencies.mockReturnValue( true );
+
+			expect( getLinks( 'plugin', 'warning', SITE_URL, SITE_URL_WITH_SCHEME, false ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+
+		it( 'links an Atomic site to wp-admin', () => {
+			mockedIsA8CForAgencies.mockReturnValue( false );
+
+			expect( getLinks( 'plugin', 'warning', SITE_URL, SITE_URL_WITH_SCHEME, true ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -190,7 +190,7 @@ describe( '<SiteTable>', () => {
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
-			`/plugins/updates/${ urlToSlug( siteUrl ) }`
+			`/plugins/manage/${ urlToSlug( siteUrl ) }`
 		);
 		expect( getByText( `${ pluginUpdates.length } Available` ) ).toBeInTheDocument();
 	} );


### PR DESCRIPTION
## Proposed Changes

* In the sites dashboard's Plugins column, link non-Atomic sites to `/plugins/manage/<site-slug>` in Jetpack Manage, and to the site's `wp-admin/plugins.php` in Automattic for Agencies.
* Remove the `/plugins/updates/<site-slug>` link, which no longer resolves to a route in either app.
* Add unit tests for `getLinks` covering the Jetpack Manage, A4A, and Atomic cases.

## Why are these changes being made?

The Plugins column of the sites dashboard (`getLinks` in `client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts`) is shared by Jetpack Manage and A4A, which renders it through `SiteStatusContent`. Until now it built the cell's link like this: Atomic sites got an external link to `wp-admin/plugins.php`, while non-Atomic (self-hosted, Jetpack-connected) sites got an internal link — `/plugins/updates/<slug>` when the site had pending plugin updates, and `/plugins/manage/<slug>` otherwise.

`/plugins/updates/<slug>` only exists as a route in Calypso's `plugins` section, which registers `/plugins/:pluginFilter(active|inactive|updates)/:site_id?`. That section is not enabled in either Jetpack Manage or A4A — both have `enable_all_sections: false` and no `plugins` key in their config, so `sections-filter.js` drops it and its page.js handlers are never registered. Jetpack Manage instead registers its own routes (`/plugins`, `/plugins/manage/sites`, `/plugins/manage/sites/:slug`, `/plugins/manage/:site`, `/plugins/:plugin`), none of which match a two-segment path like `/plugins/updates/example.com`.

The result is a dead link. Because the cell renders a same-origin `<a href>`, page.js intercepts the click and pushes the new URL, then finds no matching route. Its `unhandled()` fallback compares `window.location` against the context's canonical path, sees they already match (the push happened first), and returns without doing anything. So the address bar changes to `/plugins/updates/<slug>`, no route handler runs, `context.primary` is never set, and the previous view stays on screen. Clicking the Plugins cell on any self-hosted site with pending updates appears to do nothing.

A4A is worse: it registers no per-site plugins route at all (its `/plugins/manage/sites/:slug` takes a *plugin* slug, which `renderPluginsDashboard` passes through as `pluginSlug`), so both branches of the non-Atomic link are dead there.

This change points each app at a destination it can actually route, reusing the one each app's own site preview pane already uses. Jetpack Manage's preview pane links "Manage plugins" to `/plugins/manage/<site.url>`, so the Plugins cell now goes to the same place. A4A's preview panes deliberately link out to `wp-admin/plugins.php` ("we are currently working to make this section function from the Automattic for Agencies dashboard; in the meantime, you'll be taken to WP-Admin"), so the Plugins cell now does the same.

Note that `/plugins/manage/:site` in Jetpack Manage is not site-scoped today — `PluginsDashboard` never reads `params.site` and lists plugins across all sites. That is pre-existing behavior, identical to what the preview pane's "Manage plugins" button already does, and is left for a follow-up.

## Testing Instructions

Prerequisites: a local Calypso dev instance, and an agency account with at least one self-hosted (non-Atomic) Jetpack site that has one or more plugin updates available.

**Jetpack Manage**

1. Run `yarn start`.
2. Visit `http://jetpack.cloud.localhost:3000/dashboard`.
3. Find a self-hosted site whose Plugins column shows "N Available" (a pending-update warning), and click that cell.
4. Verify you land on `/plugins/manage/<site-slug>` and the plugin management page actually renders. Before this change the URL changed to `/plugins/updates/<site-slug>` and the page never updated.
5. Find a self-hosted site with no pending plugin updates and click its Plugins cell. Verify it still goes to `/plugins/manage/<site-slug>` and renders.
6. Click the Plugins cell for an Atomic site. Verify it still opens `https://<site>/wp-admin/plugins.php` in a new tab.

**Automattic for Agencies**

1. Run `yarn start-a8c-for-agencies`.
2. Visit the Sites dashboard and click the Plugins cell for a self-hosted site with pending updates.
3. Verify it opens `https://<site>/wp-admin/plugins.php` in a new tab, matching the "Manage Plugins in wp-admin" link in the site preview pane's Plugins tab. Before this change the URL changed to `/plugins/updates/<site-slug>` and the page never updated.

**Unit tests**

```
yarn test-client client/jetpack-cloud/sections/agency-dashboard/sites-overview
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
