### PR TITLE
Account recovery interstitial: don't stack with the MSD welcome modal

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -9,11 +9,14 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useId, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Text } from '../../components/text';
+import { isWelcomeModalEligible } from '../../utils/hosting-dashboard-enrollment';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { useAnalytics } from '../analytics';
+import { useAuth } from '../auth';
 import { getInterstitialCopy } from './copy';
 import heroIllustration from './hero-illustration.png';
 import type { InterstitialCta, SecurityLevel } from './copy';
@@ -75,6 +78,7 @@ function getSecurityLevel(
 export default function AccountRecoveryInterstitial() {
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
+	const { user } = useAuth();
 	const titleId = useId();
 
 	const { data: accountRecovery, isSuccess: isAccountRecoveryLoaded } = useQuery(
@@ -83,6 +87,12 @@ export default function AccountRecoveryInterstitial() {
 	const { data: userSettings, isSuccess: isUserSettingsLoaded } = useQuery( userSettingsQuery() );
 	const { data: snoozeUntilPersisted, isSuccess: isSnoozeLoaded } = useQuery(
 		userPreferenceQuery( 'account-recovery-interstitial-snoozed-until' )
+	);
+	const { data: dashboardOptIn, isSuccess: isDashboardOptInLoaded } = useQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
+	const { data: welcomeModalDismissed, isSuccess: isWelcomeModalDismissedLoaded } = useQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in-welcome-modal-dismissed' )
 	);
 
 	const snoozeMutation = useMutation(
@@ -108,12 +118,28 @@ export default function AccountRecoveryInterstitial() {
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
 
+	// Suppress the interstitial while the dashboard welcome modal is still pending, so the two
+	// full-page modals don't stack on the first dashboard load. The welcome-modal state is latched
+	// at first load: once the user dismisses the welcome modal, the account recovery modal keeps
+	// waiting until their next page load instead of popping up right behind it.
+	const isWelcomeDataLoaded = isDashboardOptInLoaded && isWelcomeModalDismissedLoaded;
+	const welcomeModalPendingAtLoadRef = useRef< boolean | undefined >( undefined );
+	if ( welcomeModalPendingAtLoadRef.current === undefined && isWelcomeDataLoaded ) {
+		welcomeModalPendingAtLoadRef.current =
+			! isDashboardBackport() &&
+			isWelcomeModalEligible( dashboardOptIn, user.ID ) &&
+			! welcomeModalDismissed;
+	}
+	const isWelcomeModalPending = welcomeModalPendingAtLoadRef.current ?? true;
+
 	// Eligible once the data has loaded and the snooze (if any) has elapsed. Support sessions are
 	// skipped.
 	const isEligible =
 		isAccountRecoveryLoaded &&
 		isUserSettingsLoaded &&
 		isSnoozeLoaded &&
+		isWelcomeDataLoaded &&
+		! isWelcomeModalPending &&
 		! isSnoozed &&
 		! isSupportSession() &&
 		securityLevel !== 'strong';

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -78,6 +78,9 @@ function assignExperiment( variationName: string | null = null ) {
 describe( '<AccountRecoveryInterstitial>', () => {
 	beforeEach( () => {
 		assignExperiment();
+		// On in the test config by default; the non-welcome-modal tests expect it off so the nudge is
+		// not held back. Tests that need it explicitly enable it.
+		disable( 'dashboard/opt-in-welcome-modal' );
 	} );
 
 	afterEach( () => {

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -1,8 +1,11 @@
 /**
  * @jest-environment jsdom
+ * @jest-environment-options { "url": "https://my.localhost/" }
  */
 
-import { screen, waitFor } from '@testing-library/react';
+import { disable, enable } from '@automattic/calypso-config';
+import { QueryClient } from '@tanstack/react-query';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
@@ -32,21 +35,21 @@ const EMAIL_ONLY_RECOVERY = {
 } as AccountRecovery;
 
 function mockAccountRecovery( data: AccountRecovery ) {
-	nock( 'https://public-api.wordpress.com' )
+	return nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/account-recovery' )
 		.query( true )
 		.reply( 200, data );
 }
 
 function mockUserSettings( data: Partial< UserSettings > ) {
-	nock( 'https://public-api.wordpress.com' )
+	return nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/settings' )
 		.query( true )
 		.reply( 200, data );
 }
 
 function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} ) {
-	nock( 'https://public-api.wordpress.com' )
+	return nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/preferences' )
 		.query( true )
 		.reply( 200, { calypso_preferences } );
@@ -80,6 +83,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 	afterEach( () => {
 		window.localStorage.clear();
 		delete window.isSupportSession;
+		disable( 'dashboard/opt-in-welcome-modal' );
 	} );
 
 	test( 'shows the modal and records an impression for a user with no recovery method', async () => {
@@ -283,5 +287,82 @@ describe( '<AccountRecoveryInterstitial>', () => {
 			'calypso_account_recovery_nudge_interstitial_impression',
 			expect.anything()
 		);
+	} );
+
+	test( 'does not show (or record an impression) while the dashboard welcome modal is still pending', async () => {
+		// Flag on + a rollout-cohort user (default test user ID 1) who has not opted in and has not
+		// dismissed the welcome modal: the welcome modal would take the screen first, so the nudge
+		// must stay back.
+		enable( 'dashboard/opt-in-welcome-modal' );
+		const recoveryScope = mockAccountRecovery( NONE_RECOVERY );
+		const settingsScope = mockUserSettings( { two_step_enabled: false } );
+		const preferencesScope = mockPreferences();
+
+		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
+
+		// Wait for every input the nudge depends on to load, so "hidden" reflects the welcome-modal
+		// gate rather than data that simply hasn't arrived yet.
+		await waitFor( () => {
+			expect( recoveryScope.isDone() ).toBe( true );
+			expect( settingsScope.isDone() ).toBe( true );
+			expect( preferencesScope.isDone() ).toBe( true );
+		} );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			'calypso_account_recovery_nudge_interstitial_impression',
+			expect.anything()
+		);
+	} );
+
+	test( 'shows when the welcome modal has already been dismissed', async () => {
+		enable( 'dashboard/opt-in-welcome-modal' );
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences( {
+			'hosting-dashboard-opt-in-welcome-modal-dismissed': '2026-01-01T00:00:00.000Z',
+		} );
+
+		render( <AccountRecoveryInterstitial /> );
+
+		expect(
+			await screen.findByRole( 'dialog', { name: 'Add a way back into your account' } )
+		).toBeVisible();
+	} );
+
+	test( 'stays hidden for the rest of the session after the welcome modal is dismissed mid-session', async () => {
+		enable( 'dashboard/opt-in-welcome-modal' );
+		const recoveryScope = mockAccountRecovery( NONE_RECOVERY );
+		const settingsScope = mockUserSettings( { two_step_enabled: false } );
+		const preferencesScope = mockPreferences();
+
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false } },
+		} );
+
+		render( <AccountRecoveryInterstitial />, { queryClient } );
+
+		// All data loaded with the welcome modal still pending: the nudge is suppressed.
+		await waitFor( () => {
+			expect( recoveryScope.isDone() ).toBe( true );
+			expect( settingsScope.isDone() ).toBe( true );
+			expect( preferencesScope.isDone() ).toBe( true );
+		} );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+
+		// Dismissing the welcome modal now flips the preference the nudge reads. Because everything
+		// is already loaded, an un-latched nudge would render this same tick (see the
+		// dismissed-at-load test above) — so a still-empty screen proves the load-time latch holds.
+		act( () => {
+			queryClient.setQueryData(
+				[ 'me', 'preferences' ],
+				( old: Partial< UserPreferences > | undefined ) => ( {
+					...old,
+					'hosting-dashboard-opt-in-welcome-modal-dismissed': '2026-01-01T00:00:00.000Z',
+				} )
+			);
+		} );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

Hold the account recovery interstitial back while the MSD welcome modal is still pending, so the two full-page modals don't stack on the first dashboard load. The welcome-modal state is latched at load time, so dismissing it holds the nudge until the next page load instead of popping it up right behind. The gate sits upstream of the ExPlat exposure, so a user with a pending welcome modal isn't counted as exposed until they'd actually see the nudge.

## Why are these changes being made?

The account recovery interstitial and the MSD welcome modal are both full-page modals in the dashboard shell. A user eligible for both saw them stacked on first load.

## Testing Instructions

* `yarn test-client client/dashboard/app/account-recovery-interstitial/test/index.test.tsx`
* As a user in the welcome-modal rollout cohort with incomplete account security: load the dashboard for the first time — only the welcome modal shows. Dismiss it and keep navigating — the nudge stays hidden. Reload — the nudge appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
