### PR TITLE
Disable dashboard/account-recovery-interstitial feature flag

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -29,7 +29,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": true,
+		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -25,7 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": true,
+		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -31,7 +31,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": true,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": true,
+		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -30,7 +30,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": true,
+		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": false,


### PR DESCRIPTION
## Proposed Changes

Set the `dashboard/account-recovery-interstitial` feature flag to `false` across all dashboard environments (production, stage, horizon, development), turning off the account recovery interstitial modal in the Multi-site Dashboard.

## Why are these changes being made?

The MSD launch is happening now and its welcome modal would clash with the account recovery modal. Per the decision in the multi-site-dashboard channel, the MSD rollout takes priority, the account recovery experiment is being stopped, and the modal should be rolled back for now. Early experiment indications also showed reduced engagement and conversion (not yet conclusive).

## Testing Instructions

* Load a Multi-site Dashboard page as a user with incomplete account security setup.
* Confirm the account recovery interstitial modal no longer appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
