### PR TITLE
MSD: enroll all new users in rollout cohort

### DIFF
--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -5,8 +5,7 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 const ROLLOUT_PERCENTAGE = 50;
 
 // When rollout begins, users registered after this ID (i.e. new users) are enrolled.
-// TODO update on release day DOTMSD-1357
-const NEW_USER_ID_THRESHOLD = Infinity;
+const NEW_USER_ID_THRESHOLD = 282737579;
 
 /**
  * Whether the user belongs to the percentage-rollout cohort. Membership is

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -5,7 +5,7 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 const ROLLOUT_PERCENTAGE = 50;
 
 // When rollout begins, users registered after this ID (i.e. new users) are enrolled.
-const NEW_USER_ID_THRESHOLD = 282737579;
+const NEW_USER_ID_THRESHOLD = 282742932;
 
 /**
  * Whether the user belongs to the percentage-rollout cohort. Membership is


### PR DESCRIPTION
Closes DOTMSD-1357

## Proposed Changes

* Set `NEW_USER_ID_THRESHOLD` to the launch-day cutoff (`282737579`), replacing the placeholder `Infinity`.

> [!NOTE]
> We can keep updating this constant until we're ready to merge.
## Why are these changes being made?

* When the 50% MSD rollout starts, new signups would otherwise land on the legacy Calypso dashboard for ~50% of users, only to be switched over two weeks later. Enrolling all users registered after the launch-day cutoff in the rollout cohort avoids getting new users accustomed to the legacy dashboard first.

## Testing Instructions

* With the `dashboard/enable-percentage-rollout` feature flag enabled, confirm a user with an ID greater than `282737579` is treated as enrolled in the rollout cohort.
* Confirm users with an ID below the threshold still follow the existing percentage-based cohort logic.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
