### PR TITLE
E2E: skip auth stability wait when next step navigates by URL

### DIFF
--- a/test/e2e/specs/appearance/widgets__legacy-visibility.spec.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.spec.ts
@@ -18,7 +18,8 @@ test.describe(
 			);
 
 			await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
-				await accountGivenByEnvironment.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'And I have cleared all widgets on my site', async function () {

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -51,7 +51,8 @@ describe( 'CoBlocks: Blocks', function () {
 		testAccount = new TestAccount( accountName );
 		editorPage = new EditorPage( page );
 
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 	} );
 
 	it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -42,7 +42,8 @@ describe( 'CoBlocks: Extensions: Cover Styles', function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 
 		editorPage = new EditorPage( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -40,7 +40,8 @@ describe( 'CoBlocks: Extensions: Gutter Control', function () {
 		testAccount = new TestAccount( accountName );
 		editorPage = new EditorPage( page );
 
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 	} );
 
 	it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -45,7 +45,8 @@ describe( 'CoBlocks: Extensions: Replace Image', function () {
 		editorPage = new EditorPage( page );
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 	} );
 
 	it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/blocks/blocks__media.spec.ts
+++ b/test/e2e/specs/blocks/blocks__media.spec.ts
@@ -67,7 +67,8 @@ test.describe(
 				};
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Start new post', async () => {

--- a/test/e2e/specs/blocks/blocks__shallowly_smoke_test_popular_blocks.ts
+++ b/test/e2e/specs/blocks/blocks__shallowly_smoke_test_popular_blocks.ts
@@ -38,7 +38,8 @@ skipDescribeIf( ! isGutenbergSimpleEdgeEnvironment )(
 			page = await browser.newPage();
 
 			const testAccount = new TestAccount( testAccountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			const postURL = `https://wordpress.com/post/${ testAccount.getSiteURL( {
 				protocol: false,

--- a/test/e2e/specs/blocks/blocks__story.ts
+++ b/test/e2e/specs/blocks/blocks__story.ts
@@ -41,7 +41,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Jetpack Story' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 
 		for ( const path of [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] ) {
 			const testFile = await MediaHelper.createTestFile( path );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -43,7 +43,8 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 			page = await browser.newPage();
 			editorPage = new EditorPage( page );
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 			siteSlug = testAccount.getSiteURL( { protocol: false } );
 		} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -37,7 +37,8 @@ describe(
 				page = await browser.newPage();
 
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
@@ -145,7 +146,8 @@ describe(
 				page = await browser.newPage();
 
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
@@ -211,7 +213,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );

--- a/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
@@ -31,7 +31,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );
@@ -72,7 +73,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
@@ -123,7 +125,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
@@ -180,7 +183,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -35,7 +35,8 @@ describe(
 				const page = await browser.newPage();
 
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				const fullSiteEditorPage = new FullSiteEditorPage( page );
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
@@ -59,7 +60,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );
@@ -113,7 +115,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );
@@ -201,7 +204,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -30,7 +30,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			page = await browser.newPage();
 
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
 			fullSiteEditorPage = new FullSiteEditorPage( page );
@@ -92,7 +93,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			page = await browser.newPage();
 
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
 			fullSiteEditorPage = new FullSiteEditorPage( page );
@@ -162,7 +164,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			page = await browser.newPage();
 
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
 			fullSiteEditorPage = new FullSiteEditorPage( page );
@@ -282,7 +285,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			page = await browser.newPage();
 
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
 			fullSiteEditorPage = new FullSiteEditorPage( page );

--- a/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
@@ -32,7 +32,8 @@ describe(
 				page = await browser.newPage();
 
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
@@ -89,7 +90,8 @@ describe(
 				page = await browser.newPage();
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
@@ -29,7 +29,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events'
 			page = await browser.newPage();
 
 			const testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 			siteSlug = testAccount.getSiteURL( { protocol: false } );
 
 			eventManager = new EditorTracksEventManager( page );

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -35,7 +35,8 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 
 				const accountName = getTestAccountByFeature( features );
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
@@ -115,7 +116,8 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 
 				const accountName = getTestAccountByFeature( { ...features, variant: 'siteEditor' } );
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page );

--- a/test/e2e/specs/editor/editor__navbar.spec.ts
+++ b/test/e2e/specs/editor/editor__navbar.spec.ts
@@ -29,7 +29,8 @@ test.describe( 'Editor: Navbar', { tag: [ tags.GUTENBERG, tags.CALYPSO_PR ] }, (
 			editorPage = new EditorPage( page );
 
 			const testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 			siteSlug = testAccount.getSiteURL( { protocol: false } );
 		} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -46,7 +46,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), function () 
 		page = await browser.newPage();
 
 		const testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 		siteSlug = testAccount.getSiteURL( { protocol: false } );
 	} );
 

--- a/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
@@ -45,7 +45,8 @@ test.describe( 'Editor: Advanced Post Flow', { tag: [ tags.GUTENBERG, tags.CALYP
 
 		await test.step( 'Authenticate and setup the test', async () => {
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 			siteSlug = testAccount.getSiteURL( { protocol: false } );
 		} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -44,7 +44,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		editorPage = new EditorPage( page );
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 		siteSlug = testAccount.getSiteURL( { protocol: false } );
 	} );
 

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -38,7 +38,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Schedule' ), function () {
 		page = await context.newPage();
 
 		const testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 		siteSlug = testAccount.getSiteURL( { protocol: false } );
 	} );
 
@@ -155,7 +156,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Schedule' ), function () {
 			const tmpPage = await browser.newPage();
 
 			const testAccount = new TestAccount( 'defaultUser' );
-			await testAccount.authenticate( tmpPage );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( tmpPage, { waitUntilStable: false } );
 
 			await tmpPage.goto( postURL.href );
 			await new PublishedPostPage( tmpPage ).validateTextInPost( postContent );

--- a/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
+++ b/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
@@ -15,7 +15,8 @@ test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_RELEASE ] }, 
 		const siteId = accountAtomic.credentials.testSites?.primary?.id as number;
 
 		await test.step( `And I am authenticated as '${ accountAtomic.accountName }'`, async function () {
-			await accountAtomic.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await accountAtomic.authenticate( page, { waitUntilStable: false } );
 		} );
 
 		await test.step( 'Given I clear any stale cart items', async function () {

--- a/test/e2e/specs/help-center/help-center__wp-admin.ts
+++ b/test/e2e/specs/help-center/help-center__wp-admin.ts
@@ -26,7 +26,8 @@ describe.skip( 'Help Center in WP Admin', () => {
 		testAccount = new TestAccount( 'defaultUser' );
 		pageUrl = `${ testAccount.getSiteURL( { protocol: true } ) }wp-admin/`;
 
-		await testAccount.authenticate( page, { waitUntilStable: true } );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 		await page.goto( pageUrl );
 
 		helpCenterComponent = new HelpCenterComponent( page );

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -27,7 +27,8 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		editorPage = new EditorPage( page );
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 	} );
 
 	it( 'Go to the new post page', async function () {

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -36,7 +36,8 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 
 		beforeAll( async function () {
 			page = await browser.newPage();
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			jetpackDashboardPage = new JetpackDashboardPage( page );
 

--- a/test/e2e/specs/jetpack/social__editor-features.spec.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.spec.ts
@@ -108,7 +108,8 @@ test.describe(
 					const siteId = testAccount.credentials.testSites?.primary?.id || 0;
 					const siteSlug = testAccount.getSiteURL( { protocol: false } );
 					const socialConnectionsManager = new SocialConnectionsManager( page, siteId );
-					await testAccount.authenticate( page );
+					// We navigate immediately after, so no need to wait for stability.
+					await testAccount.authenticate( page, { waitUntilStable: false } );
 
 					if ( mockConnections ) {
 						await socialConnectionsManager.mockSocialConnections();

--- a/test/e2e/specs/jetpack/social__editor-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.spec.ts
@@ -30,7 +30,8 @@ test.describe(
 				const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 				const testAccount = new TestAccount( accountName );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Verify that Social UI is visible', async () => {

--- a/test/e2e/specs/me/me__smoke.spec.ts
+++ b/test/e2e/specs/me/me__smoke.spec.ts
@@ -9,7 +9,8 @@ import { expect, tags, test } from '../../lib/pw-base';
 test.describe( 'Me: Smoke Test', { tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE ] }, () => {
 	test( 'Navigate to Me pages', async ( { accountGivenByEnvironment, page } ) => {
 		await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
-			await accountGivenByEnvironment.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 		} );
 
 		await test.step( 'When I navigate to /me', async function () {

--- a/test/e2e/specs/p2/p2__post.spec.ts
+++ b/test/e2e/specs/p2/p2__post.spec.ts
@@ -20,7 +20,8 @@ test.describe( 'P2: Post', { tag: [ tags.P2 ] }, () => {
 		accountP2,
 	} ) => {
 		await test.step( 'Given I am authenticated as a P2 user', async function () {
-			await accountP2.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await accountP2.authenticate( page, { waitUntilStable: false } );
 			accountUsed = accountP2;
 		} );
 

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -26,7 +26,8 @@ test.describe(
 			pageSignupPickPlan,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accountPreRelease.accountName }'`, async function () {
-				await accountPreRelease.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await accountPreRelease.authenticate( page, { waitUntilStable: false } );
 				accountUsed = accountPreRelease;
 			} );
 

--- a/test/e2e/specs/plans/plans__upgrade.spec.ts
+++ b/test/e2e/specs/plans/plans__upgrade.spec.ts
@@ -101,7 +101,8 @@ test.describe(
 					uploadedMediaUrl = uploadedMedia.URL;
 
 					const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
-					await testAccount.authenticate( page );
+					// We navigate immediately after, so no need to wait for stability.
+					await testAccount.authenticate( page, { waitUntilStable: false } );
 				},
 				// Bound the API setup (createSite + posts + media) at 60s so a
 				// site-provisioning hang fails here, not as a generic test timeout.

--- a/test/e2e/specs/plugins/plugins__browse.spec.ts
+++ b/test/e2e/specs/plugins/plugins__browse.spec.ts
@@ -27,7 +27,8 @@ test.describe(
 					},
 				] );
 				const testAccount = new TestAccount( testUser );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				siteUrl = testAccount
 					.getSiteURL( { protocol: false } )

--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -53,7 +53,8 @@ test.describe(
 			test.setTimeout( 180 * 1000 );
 
 			await test.step( `Given I am authenticated as '${ accountPreRelease.accountName }'`, async () => {
-				await accountPreRelease.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await accountPreRelease.authenticate( page, { waitUntilStable: false } );
 				accountUsed = accountPreRelease;
 			} );
 

--- a/test/e2e/specs/plugins/plugins__install-remove.ts
+++ b/test/e2e/specs/plugins/plugins__install-remove.ts
@@ -41,7 +41,8 @@ describe( DataHelper.createSuiteTitle( 'Jetpack: Plugin' ), function () {
 		page = await browser.newPage();
 
 		const testAccount = new TestAccount( 'jetpackRemoteSiteUser' );
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 		siteURL = SecretsManager.secrets.testAccounts.jetpackRemoteSiteUser.testSites?.primary
 			.url as string;
 		pluginsPage = new PluginsPage( page );

--- a/test/e2e/specs/plugins/plugins__purchase.spec.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.spec.ts
@@ -26,7 +26,8 @@ test.describe( 'Plugins: Add multiple to cart', { tag: [ tags.CALYPSO_RELEASE ] 
 
 		await test.step( 'Setup: authenticate and clear cart', async () => {
 			testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			const restAPIClient = new RestAPIClient( testAccount.credentials );
 			await restAPIClient.clearShoppingCart(

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -235,7 +235,8 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		let isInSpam = false;
 
 		beforeAll( async function () {
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			// Atomic tests sites might have local users, so the Jetpack SSO login will
 			// show up when visiting the Jetpack dashboard directly. We can bypass it if

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -84,7 +84,8 @@ describe( 'Likes: Comment', function () {
 			}
 		}
 
-		await testAccount.authenticate( page );
+		// We navigate immediately after, so no need to wait for stability.
+		await testAccount.authenticate( page, { waitUntilStable: false } );
 	} );
 
 	it( 'View the post', async function () {

--- a/test/e2e/specs/published-content/likes__post.spec.ts
+++ b/test/e2e/specs/published-content/likes__post.spec.ts
@@ -54,7 +54,8 @@ test.describe(
 			let publishedPostPage: PublishedPostPage;
 
 			await test.step( 'Authenticate and setup the test', async () => {
-				await postingUser.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await postingUser.authenticate( page, { waitUntilStable: false } );
 				restAPIClient = new RestAPIClient( postingUser.credentials );
 				otherUserRestAPIClient = new RestAPIClient( otherUser.credentials );
 				siteID = postingUser.credentials.testSites?.primary.id as number;

--- a/test/e2e/specs/published-content/reader__view.spec.ts
+++ b/test/e2e/specs/published-content/reader__view.spec.ts
@@ -17,7 +17,8 @@ test.describe(
 		test( 'As a user, I can view the Reader', async ( { page } ) => {
 			await test.step( 'Authenticate', async () => {
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Visit the Reader', async () => {

--- a/test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts
+++ b/test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts
@@ -30,7 +30,8 @@ test.describe(
 
 			await test.step( 'Authenticate and setup the test', async () => {
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Navigate to Settings > Hosting Configuration', async () => {

--- a/test/e2e/specs/tools/advertising__promote.spec.ts
+++ b/test/e2e/specs/tools/advertising__promote.spec.ts
@@ -17,7 +17,8 @@ test.describe(
 			const snippet = Array( 2 ).fill( helperData.getRandomPhrase() ).toString();
 
 			await test.step( `Given I am authenticated as '${ accountSimpleSiteFreePlan.accountName }'`, async function () {
-				await accountSimpleSiteFreePlan.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await accountSimpleSiteFreePlan.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'And my site has a published post', async function () {

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -69,7 +69,8 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 				);
 			}
 
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			advertisingPage = new AdvertisingPage( page );
 		} );

--- a/test/e2e/specs/tools/marketing__seo.spec.ts
+++ b/test/e2e/specs/tools/marketing__seo.spec.ts
@@ -11,7 +11,8 @@ test.describe( 'Marketing: SEO', { tag: [ tags.CALYPSO_PR ] }, () => {
 		const externalPreviewText = helperData.getRandomPhrase();
 
 		await test.step( `Given I am authenticated as '${ accountAtomic.accountName }'`, async function () {
-			await accountAtomic.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await accountAtomic.authenticate( page, { waitUntilStable: false } );
 		} );
 
 		await test.step( 'When I visit the Tools > Marketing > Traffic page', async function () {
@@ -45,7 +46,8 @@ test.describe( 'Marketing: SEO', { tag: [ tags.CALYPSO_PR ] }, () => {
 		pageJetpackTraffic,
 	} ) => {
 		await test.step( `Given I am authenticated as '${ accountSimpleSiteFreePlan.accountName }'`, async function () {
-			await accountSimpleSiteFreePlan.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await accountSimpleSiteFreePlan.authenticate( page, { waitUntilStable: false } );
 		} );
 
 		await test.step( 'When I visit the Jetpack > Traffic page', async function () {

--- a/test/e2e/specs/tools/social-connections__tumblr.ts
+++ b/test/e2e/specs/tools/social-connections__tumblr.ts
@@ -40,7 +40,8 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 			const features = envToFeatureKey( envVariables );
 			const accountName = getTestAccountByFeature( features );
 			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+			// We navigate immediately after, so no need to wait for stability.
+			await testAccount.authenticate( page, { waitUntilStable: false } );
 
 			restAPIClient = new RestAPIClient( testAccount.credentials );
 

--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -102,7 +102,8 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 		describe( 'As publishing user', function () {
 			beforeAll( async function () {
 				// Authenticate as the publishing user.
-				await testAccount.authenticate( page );
+				// We navigate immediately after, so no need to wait for stability.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				subscribersPage = new SubscribersPage( page );
 			} );


### PR DESCRIPTION
## Proposed Changes

At E2E `authenticate()` call sites whose very next step is a direct URL navigation (`page.goto(...)` or a page-object `.visit*()`), now use a `{ waitUntilStable: false }` flag so that  `authenticate()` skips its post-login sidebar-stability wait. If the very next step after logging in is to go to a different page, then it doesn't need to wait for the sidebar to fully load.

- 60 call sites across 45 spec files updated.
- One site (`help-center__wp-admin.ts`) was explicitly passing `waitUntilStable: true` right before a `page.goto`; flipped to `false`.
- Left untouched: sites that interact with the current post-auth page instead of navigating by URL — sidebar navigations (`componentSidebar.navigate` in `theme__details-preview`, `invite__revoke`, `invite__new-user`, `plugins__search`, `fse__temp-smoke-test`, `stats`), current-page interactions (`help-center__calypso`, `notifications__general-interaction`, both keep `waitUntilStable: true`), and a same-page `page.reload` (`tos-screenshots__checkout`).

## Why are these changes being made?

This is a follow up to the MSD rollout (https://github.com/Automattic/wp-calypso/pull/112586), and is an attempt at addressing fallout in the e2e tests.

The "stability check" in `authenticate()` was all about making sure that the Calypso dashboard had finished loading. However it assumed that it would be the non-MSD dashboard that loaded.

We can make the stability check work for MSD too, but I think the more fundamental issue is that many of these stability checks are not actually needed. So best to address that first.

## Testing Instructions

* CI E2E runs for the affected specs should pass unchanged.
* Each modified spec still authenticates and reaches its target page via URL navigation as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
