### PR TITLE
Stats: unify link colours, UTM outline, and interactive elements with the accent

### DIFF
--- a/client/blocks/stats-navigation/page-module-toggler.scss
+++ b/client/blocks/stats-navigation/page-module-toggler.scss
@@ -15,7 +15,7 @@
 	}
 
 	.page-modules-settings-action:focus {
-		box-shadow: 0 0 0 2px var(--color-primary-light);
+		box-shadow: 0 0 0 2px var(--color-accent-light);
 		z-index: 0; //fix for left box-shadow being cut off
 	}
 }

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -196,7 +196,7 @@
 					&:hover,
 					&:focus {
 						color: var(--color-text-inverted);
-						background-color: var(--color-primary);
+						background-color: var(--color-accent);
 						opacity: 0.65;
 					}
 				}
@@ -232,7 +232,7 @@
 				&:hover,
 				&:focus {
 					color: var(--color-text-inverted);
-					background-color: var(--color-primary);
+					background-color: var(--color-accent);
 					opacity: 0.65;
 
 					.button {

--- a/client/blocks/stats-sparkline/style.scss
+++ b/client/blocks/stats-sparkline/style.scss
@@ -9,7 +9,7 @@
 
 a:focus {
 	.stats-sparkline {
-		box-shadow: 0 0 0 2px var(--color-primary-light);
+		box-shadow: 0 0 0 2px var(--color-accent-light);
 		border-radius: 2px;
 		margin-left: 2px;
 	}

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -54,7 +54,7 @@
 		width: 100%;
 	}
 	&:hover {
-		background-color: var(--color-primary-0);
+		background-color: var(--color-accent-0);
 	}
 	& + & {
 		// Prevent overlap between outline and hover.

--- a/client/my-sites/stats/components/empty-state-action/styles.scss
+++ b/client/my-sites/stats/components/empty-state-action/styles.scss
@@ -24,7 +24,7 @@
 		}
 
 		&:focus {
-			border: 1px solid var( --color-primary-light );
+			border: 1px solid var( --color-accent-light );
 		}
 	}
 

--- a/client/my-sites/stats/components/highlight-cards/style.scss
+++ b/client/my-sites/stats/components/highlight-cards/style.scss
@@ -187,7 +187,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 			border-radius: 5px; // stylelint-disable-line scales/radii
 		}
 		button:focus {
-			box-shadow: 0 0 0 2px var(--color-primary-light);
+			box-shadow: 0 0 0 2px var(--color-accent-light);
 		}
 	}
 

--- a/client/my-sites/stats/components/stats-infotip/style.scss
+++ b/client/my-sites/stats/components/stats-infotip/style.scss
@@ -28,6 +28,11 @@
 	// No exact WPDS surface-width token for 280px (the scale steps 240px "xs" / 320px "sm");
 	// rounding up to "sm" avoids narrowing existing popup content.
 	max-width: 320px;
+
+	// The popup is portaled outside the .stats subtree, so it misses the Stats
+	// --color-link override; re-apply it so in-popup links follow the accent.
+	--color-link: var(--color-accent);
+	--color-link-dark: var(--color-accent-dark);
 }
 
 .stats-infotip__description {

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
@@ -41,7 +41,7 @@ $stats-utm-border: 1px solid var(--gray-gray-5, #dcdcde);
 
 	&:hover {
 		.components-button {
-			background-color: var(--color-primary-0);
+			background-color: var(--color-accent-0);
 		}
 	}
 

--- a/client/my-sites/stats/promo-cards/style.scss
+++ b/client/my-sites/stats/promo-cards/style.scss
@@ -39,6 +39,9 @@
 	a.app-promo-card__link {
 		color: var(--color-link);
 
+		// The compound `&.app-promo-card__jetpack-link:hover` isn't redundant: the
+		// plain `&:hover` only ties AppPromoCard's own jetpack-link hover rule on
+		// specificity, so it also needs the extra class to reliably win.
 		&:hover,
 		&.app-promo-card__jetpack-link:hover {
 			color: var(--color-link-dark);

--- a/client/my-sites/stats/promo-cards/style.scss
+++ b/client/my-sites/stats/promo-cards/style.scss
@@ -33,4 +33,15 @@
 .app-promo-card.stats__promo-card-apps {
 	// Overrides Mobile Apps banner styles.
 	border: none;
+
+	// The shared AppPromoCard hardcodes a Jetpack-green link; follow the themed
+	// Stats link colour here instead.
+	a.app-promo-card__link {
+		color: var(--color-link);
+
+		&:hover,
+		&.app-promo-card__jetpack-link:hover {
+			color: var(--color-link-dark);
+		}
+	}
 }

--- a/client/my-sites/stats/stats-download-csv/style.scss
+++ b/client/my-sites/stats/stats-download-csv/style.scss
@@ -8,7 +8,7 @@
 		gap: 4px;
 
 		@media (min-width: $break-mobile) {
-			color: var(--color-link)
+			color: var(--color-link);
 		}
 
 		&:disabled {

--- a/client/my-sites/stats/stats-download-csv/style.scss
+++ b/client/my-sites/stats/stats-download-csv/style.scss
@@ -8,7 +8,7 @@
 		gap: 4px;
 
 		@media (min-width: $break-mobile) {
-			color: var(--color-primary-50)
+			color: var(--color-link)
 		}
 
 		&:disabled {

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -20,6 +20,19 @@ $modal-content-padding: 32px;
 		}
 	}
 
+	// Follow the admin accent (not --color-primary from the shared form-input
+	// focus style) for the focused field's outline. The selector is scoped
+	// through the fields wrapper and `input` so it outranks the base
+	// `input[type].form-text-input:focus` rule.
+	.stats-utm-builder__fields input.form-text-input:focus {
+		border-color: var(--color-accent);
+		box-shadow: 0 0 0 2px var(--color-accent-10);
+
+		&:hover {
+			box-shadow: 0 0 0 2px var(--color-accent-20);
+		}
+	}
+
 	.components-modal__header {
 		font-family: $font-recoleta;
 	

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -20,19 +20,6 @@ $modal-content-padding: 32px;
 		}
 	}
 
-	// Follow the admin accent (not --color-primary from the shared form-input
-	// focus style) for the focused field's outline. The selector is scoped
-	// through the fields wrapper and `input` so it outranks the base
-	// `input[type].form-text-input:focus` rule.
-	.stats-utm-builder__fields input.form-text-input:focus {
-		border-color: var(--color-accent);
-		box-shadow: 0 0 0 2px var(--color-accent-10);
-
-		&:hover {
-			box-shadow: 0 0 0 2px var(--color-accent-20);
-		}
-	}
-
 	.components-modal__header {
 		font-family: $font-recoleta;
 	
@@ -51,6 +38,21 @@ $modal-content-padding: 32px;
 	@media (max-width: $break-small) {
 		flex-wrap: wrap;
 		gap: $stats-utm-builder-vertical-spacing;
+	}
+}
+
+// Focused-field outline follows the admin accent. Deliberately not nested
+// under `.stats-utm-builder__overlay`: that class is the Modal's portal root,
+// and Odyssey prefixes CSS with the portal root as an ancestor — nesting would
+// ask for the overlay inside itself and never match. Leading with the fields
+// wrapper keeps a valid descendant chain; `input[type="text"]` outranks the
+// base `.form-text-input:focus` rule.
+.stats-utm-builder__fields input[type="text"].form-text-input:focus {
+	border-color: var(--color-accent);
+	box-shadow: 0 0 0 2px var(--color-accent-10);
+
+	&:hover {
+		box-shadow: 0 0 0 2px var(--color-accent-20);
 	}
 }
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -454,12 +454,12 @@ ul.module-header-actions {
 		.stats-module & td.has-no-data:hover, // 1
 		tbody tr:hover td,
 		.stats-module & tbody tr:hover th:first-child {
-			background: var(--color-primary-0);
+			background: var(--color-accent-0);
 		}
 
 		.stats-module & td.highest-count:hover,
 		tbody tr td:hover {
-			background: var(--color-primary-0);
+			background: var(--color-accent-0);
 			color: var(--color-neutral-70);
 		}
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -230,7 +230,7 @@ ul.module-header-actions {
 	// Hover state
 	@include breakpoint-deprecated( ">480px" ) {
 		.stats-module:hover & .module-header-action-link {
-			color: var(--color-primary);
+			color: var(--color-link);
 		}
 
 		.module-header & .module-header-action-link:hover {

--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -214,7 +214,7 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 
 	&.is-selected {
 		background: var(--color-surface);
-		border-color: var(--color-primary);
+		border-color: var(--color-accent);
 
 		.stats-video-metric-tabs__header {
 			color: var(--studio-black);

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -8,7 +8,7 @@
 	.earnings_history td:hover,
 	.earnings_history tbody tr:hover td,
 	.earnings_history tbody tr:hover th:first-child {
-		background: var(--color-primary-0);
+		background: var(--color-accent-0);
 	}
 
 	.earnings_history tbody tr:nth-child(odd) {


### PR DESCRIPTION
Fixes STATS-335

## Why are these changes being made?

Follow-up to the Stats theme-integration work (STATS-321 / #112496). Review of that PR — and a pass over the rest of the Stats surface — surfaced colour-consistency gaps it didn't cover:

1. **Links didn't all follow the themed link colour.** The merged work points `--color-link` at `--color-accent` inside `.stats`, but several links missed it — the CSV-download and module-header action links used `--color-primary` directly, the shared mobile-app promo card hardcodes a Jetpack green, and the module info popover portals **outside** the `.stats` subtree so its in-popup link fell back to the global blue `--color-link`. The result was orange, blue, and green links side by side.
2. **The UTM "Generate URL" modal's focused field showed a non-accent outline** — blue on WordPress.com, green in Jetpack contexts — because the shared form-input focus style uses `--color-primary` and the portaled modal inherits it.
3. **Interactive elements were still hardcoded to the static brand blue.** A spread of focus rings, hover backgrounds and selected-state borders across Stats used `--color-primary*` directly, so they stayed blue on any non-default admin colour scheme while the charts and links around them followed `--color-accent`.

The common thread: content that lives outside the `.stats` DOM subtree (portaled popovers/modals), comes from shared components, or simply referenced `--color-primary` directly never picked up the Stats accent. These fixes re-apply the accent at each of those boundaries.

> Note: in self-hosted/Odyssey Stats, `--color-accent*` is currently force-mapped to Jetpack green (`apps/odyssey-stats/src/styles/variables.scss`); removing that override is tracked separately in STATS-322. This PR only makes elements follow whatever `--color-accent` resolves to, so the two are complementary — once STATS-322 lands, these elements pick up the admin theme in Odyssey automatically, with no further component-CSS changes.

## Proposed Changes

- **Unify link colours** on `--color-link`:
  - CSV-download link and module-header action link → `--color-link` (were `--color-primary*`);
  - re-scope the accent onto the shared `AppPromoCard` link within Stats (was hardcoded Jetpack green);
  - re-apply `--color-link` on the portaled `stats-infotip` popup so in-popup links follow the accent.
- **UTM builder outline:** scope an accent focus outline onto the builder's input fields. The selector leads with the `.stats-utm-builder__fields` wrapper (not the `.stats-utm-builder__overlay` modal-root class) and qualifies `input[type="text"]`, so it outranks the base `.form-text-input:focus` rule **and** survives Odyssey's portal-root CSS prefixing — working in both the WordPress.com (Calypso) and self-hosted (Odyssey) builds.
- **Theme the remaining interactive elements** (`--color-primary*` → matching `--color-accent*`):
  - **Focus rings:** page-modules settings toggler, sparkline, highlight-card tooltip button, and the empty-state action button (e.g. the UTM "Generate URL with codes" trigger).
  - **Hover backgrounds:** interval dropdown, UTM picker item, legacy module and ad-earnings table rows, and the mobile nav-tab / subscribers-count states.
  - **Selected metric-tab border** in the video detail view.

Purchase-flow pricing UI (wizard indicator, tier-upgrade slider) keeps `--color-primary` intentionally — that's the WPCOM brand blue, paired against Jetpack green — so it is left unchanged.

## Screenshots

Captured on a Jetpack site using the **Classic Bright** admin scheme (accent = pink `#c9356e`).

**Module info popover link — now follows the accent**

<img width="320" alt="Popover link after" src="https://github.com/user-attachments/assets/16c0e238-f441-4d2a-a6a0-a432d6aa1527" />

**Mobile-app promo link — now the accent (was Jetpack green)**

<img width="600" alt="Promo link after" src="https://github.com/user-attachments/assets/b8ab7f72-dce8-422c-8448-8b5c4364dfdb" />

**UTM "Generate URL" focused input — now the accent outline (was blue/green)**

<img width="620" alt="UTM outline after" src="https://github.com/user-attachments/assets/f4f03cd9-3c68-49aa-9694-eab0f11b4098" />

## Testing Instructions

1. Set an admin colour scheme where `--color-primary` and `--color-accent` diverge — e.g. **Classic Bright** (pink) — via wp-admin → Users → Profile → Admin Color Scheme.
2. **Links** — on **Stats → Traffic**:
   - hover a module's info (ⓘ) icon (e.g. "Most viewed") and confirm the link inside the popover is the accent, not blue;
   - scroll to the "Bring your stats with you…" mobile-app card and confirm the **wp.com/app** link is the accent, not green;
   - confirm the "Download data as CSV" link and the module-header action links use the accent.
3. **UTM outline** — open the UTM "Generate URL" builder (ⓘ builder trigger on the UTM module) and focus the **Destination URL** field — the focus outline should be the accent, not blue/green.
4. **Focus rings** — tab to / click these and confirm the focus ring is the accent, not blue:
   - the module-settings toggler (sliders icon by the period nav);
   - the "Generate URL with codes using our builder" empty-state button in the UTM module;
   - a sparkline link and a highlight-card tooltip button.
5. **Hover / selected states** — confirm the accent (not blue) on: interval-dropdown items on hover, UTM picker items on hover, module/ad-earnings table rows on hover, mobile nav-tab hover/focus, and the selected tab border on **Stats → a video's detail** view.
6. **Regression — default theme:** switch to the default **Fresh** scheme (where the two variables coincide) and re-check all of the above; everything should look unchanged (standard blue).
7. **Odyssey / self-hosted (optional):** with a self-hosted Jetpack Stats setup, open the UTM builder and focus a field. The outline should resolve through `--color-accent` — which renders **Jetpack green** there today because Odyssey force-maps the accent. That green (not blue `--color-primary`) is the expected result until STATS-322 removes the override; the point is that the outline now tracks `--color-accent` rather than the static brand colour.

