### PR TITLE
E2E: pin signup lifecycle specs to classic purchases UI during dashboard rollout

### DIFF
--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -42,12 +42,19 @@ const WebpackBuildMonitor = lazy(
 const SLOW_THRESHOLD_MS = 100;
 const VERY_SLOW_THRESHOLD_MS = 6000;
 
+// E2E tests append this suffix to the browser user agent (see
+// test/e2e playwright.config.ts). Detecting it lets us suppress the welcome
+// modal so it doesn't interfere with unrelated tests.
+function isE2ETest(): boolean {
+	return typeof navigator !== 'undefined' && navigator.userAgent.includes( 'wp-e2e-tests' );
+}
+
 function Root() {
 	const isAccountRecoveryInterstitialEnabled = isEnabled(
 		'dashboard/account-recovery-interstitial'
 	);
 	const isOptInWelcomeModalEnabled =
-		! isDashboardBackport() && isEnabled( 'dashboard/opt-in-welcome-modal' );
+		! isDashboardBackport() && ! isE2ETest() && isEnabled( 'dashboard/opt-in-welcome-modal' );
 	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
 	const isFetching = useIsFetching();
 	const isMutating = useIsMutating();

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -1,9 +1,26 @@
 /**
  * @jest-environment jsdom
  */
+import { isEnabled } from '@automattic/calypso-config';
 import pageLibrary from '@automattic/calypso-router';
 import { waitFor } from '@testing-library/dom';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import initRootSection from '../root';
+
+const originalLocation = window.location;
+
+// Replaces `window.location` so we can assert on `assign()` for redirects to
+// the hosting dashboard (an absolute URL, so `root` uses `location.assign`
+// rather than the in-app router).
+function mockLocationAssign() {
+	const assign = jest.fn();
+	Object.defineProperty( window, 'location', { value: { assign }, configurable: true } );
+	return assign;
+}
+
+afterEach( () => {
+	Object.defineProperty( window, 'location', { value: originalLocation, configurable: true } );
+} );
 
 function initRouter( { state }: { state: any } ) {
 	const dispatch = jest.fn();
@@ -22,13 +39,26 @@ function initRouter( { state }: { state: any } ) {
 
 describe( 'Logged In Landing Page', () => {
 	test( 'user with no sites goes to Sites Dashboard', async () => {
-		const state = { currentUser: { id: 1 }, sites: { items: {} }, ui: {} };
+		const state = { currentUser: { id: 55 }, sites: { items: {} }, ui: {} };
 		const { page } = initRouter( { state } );
 
 		page( '/' );
 
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
+
+	if ( isEnabled( 'dashboard/enable-percentage-rollout' ) ) {
+		test( 'rollout cohort user with no sites goes to Sites Dashboard', async () => {
+			// User ID 1 will be allocated to the new dashboard rollout
+			const state = { currentUser: { id: 1 }, sites: { items: {} }, ui: {} };
+			const { page } = initRouter( { state } );
+			const assign = mockLocationAssign();
+
+			page( '/' );
+
+			await waitFor( () => expect( assign ).toHaveBeenCalledWith( dashboardLink( '/sites' ) ) );
+		} );
+	}
 
 	test( 'user with a primary site but no permissions goes to day stats', async () => {
 		const state = {
@@ -94,7 +124,7 @@ describe( 'Logged In Landing Page', () => {
 	test( 'user who opts in goes to sites page', async () => {
 		const state = {
 			currentUser: {
-				id: 1,
+				id: 55,
 				capabilities: { 1: { edit_posts: true } },
 				user: { primary_blog: 1, site_count: 2 },
 			},
@@ -125,6 +155,44 @@ describe( 'Logged In Landing Page', () => {
 
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
+
+	if ( isEnabled( 'add/dashboard-enable-percentage-rollout' ) ) {
+		test( 'rollout cohort user who opts in goes to sites page', async () => {
+			const state = {
+				currentUser: {
+					id: 1,
+					capabilities: { 1: { edit_posts: true } },
+					user: { primary_blog: 1, site_count: 2 },
+				},
+				preferences: {
+					localValues: {
+						'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
+						'reader-landing-page': { useReaderAsLandingPage: false, updatedAt: 1111 },
+					},
+				},
+				ui: {},
+				sites: {
+					items: {
+						1: {
+							ID: 1,
+							URL: 'https://test.wordpress.com',
+						},
+						2: {
+							ID: 2,
+							URL: 'https://test.jurassic.ninja',
+							jetpack: true,
+						},
+					},
+				},
+			};
+			const assign = mockLocationAssign();
+			const { page } = initRouter( { state } );
+
+			page( '/' );
+
+			await waitFor( () => expect( assign ).toHaveBeenCalledWith( dashboardLink( '/sites' ) ) );
+		} );
+	}
 
 	test( 'user who opts in goes to reader page', async () => {
 		const state = {

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -31,7 +31,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -34,7 +34,7 @@
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -28,7 +28,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -27,7 +27,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -33,7 +33,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -34,7 +34,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"domain-transfer-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -33,7 +33,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,
 		"dev/store-sandbox-helper": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -32,7 +32,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": false,

--- a/config/development.json
+++ b/config/development.json
@@ -74,7 +74,7 @@
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,7 +44,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/production.json
+++ b/config/production.json
@@ -45,7 +45,7 @@
 		"current-site/notice": true,
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/rollout-advance-notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/rollout-advance-notice": false,

--- a/config/test.json
+++ b/config/test.json
@@ -38,7 +38,7 @@
 		"current-site/notice": true,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": false,
 		"dashboard/simulate-full-rollout": false,
 		"emails/titan-tiers": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,7 +42,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/opt-in-welcome-modal": false,
+		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,7 +40,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": false,
 		"dashboard/plans": true,

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
@@ -21,7 +21,7 @@ import {
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, apiForceDashboardOptOut } from '../shared';
 
 /**
  * Checks the entire user lifecycle, from signup, onboarding, launch and plan cancellation.
@@ -204,6 +204,14 @@ test.describe(
 					return;
 				}
 				await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
+			} );
+
+			await test.step( 'When I opt out of the hosting dashboard rollout', async () => {
+				const restAPIClient = new RestAPIClient(
+					{ username: testUser.username, password: testUser.password },
+					newUserDetails!.body.bearer_token
+				);
+				await apiForceDashboardOptOut( restAPIClient );
 			} );
 
 			await test.step( 'When I navigate to Me > Purchases', async () => {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -14,7 +14,7 @@ import {
 	cancelSubscriptionFlow,
 } from '@automattic/calypso-e2e';
 import { tags, test } from '../../lib/pw-base';
-import { apiCancelAtomicPlan, apiCloseAccount } from '../shared';
+import { apiCancelAtomicPlan, apiCloseAccount, apiForceDashboardOptOut } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
@@ -110,6 +110,14 @@ test.describe(
 			await test.step( 'Then I am in WP Admin', async () => {
 				await page.waitForURL( /wp-admin/ );
 				siteSlug = new URL( page.url() ).hostname;
+			} );
+
+			await test.step( 'When I opt out of the hosting dashboard rollout', async () => {
+				const restAPIClient = new RestAPIClient(
+					{ username: testUser.username, password: testUser.password },
+					newUserDetails!.body.bearer_token
+				);
+				await apiForceDashboardOptOut( restAPIClient );
 			} );
 
 			await test.step( 'When I navigate to Me > Purchases to cancel add-on', async () => {

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -5,7 +5,7 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, apiForceDashboardOptOut } from '../shared';
 
 test.describe(
 	'Signup: Lifecycle: Logged Out Home Page, signup, onboard, launch and cancel subscription',
@@ -130,6 +130,17 @@ test.describe(
 				);
 				const theme = await restAPIClient.getActiveTheme( newSiteDetails.blog_details.blogid );
 				expect( theme ).toBe( `pub/${ themeSlug }` );
+			} );
+
+			await test.step( 'And I opt out of the hosting dashboard rollout', async function () {
+				const restAPIClient = new RestAPIClient(
+					{
+						username: testUserThemeSignup.username,
+						password: testUserThemeSignup.password,
+					},
+					newUserThemeSignup.body.bearer_token
+				);
+				await apiForceDashboardOptOut( restAPIClient );
 			} );
 
 			await test.step( 'When I cancel my plan from the purchases page', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
@@ -22,7 +22,7 @@ import {
 	cancelAtomicPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, apiForceDashboardOptOut } from '../shared';
 
 test.describe(
 	'Lifecycle: Premium theme signup, onboard, launch and cancel subscription',
@@ -128,6 +128,14 @@ test.describe(
 				);
 				const theme = await restAPIClient.getActiveTheme( newSiteDetails.blog_details.blogid );
 				expect( theme ).toContain( themeSlug );
+			} );
+
+			await test.step( 'Opt out of the hosting dashboard rollout', async () => {
+				const restAPIClient = new RestAPIClient(
+					{ username: testUser.username, password: testUser.password },
+					newUserDetails!.body.bearer_token
+				);
+				await apiForceDashboardOptOut( restAPIClient );
 			} );
 
 			await test.step( 'Navigate to Me > Purchases', async () => {

--- a/test/e2e/specs/published-content/reader__view.spec.ts
+++ b/test/e2e/specs/published-content/reader__view.spec.ts
@@ -17,7 +17,8 @@ test.describe(
 		test( 'As a user, I can view the Reader', async ( { page } ) => {
 			await test.step( 'Authenticate', async () => {
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				// No `waitForStability` needed because we will immediately navigate after authenticating.
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Visit the Reader', async () => {

--- a/test/e2e/specs/shared/api-force-dashboard-opt-out.ts
+++ b/test/e2e/specs/shared/api-force-dashboard-opt-out.ts
@@ -1,0 +1,22 @@
+import type { RestAPIClient } from '@automattic/calypso-e2e';
+
+/**
+ * Pins the user to the classic dashboard by setting the `hosting-dashboard-opt-in`
+ * preference to `forced-opt-out`, which wins over percentage-rollout enrollment
+ * (see `client/dashboard/utils/hosting-dashboard-enrollment.ts`).
+ *
+ * New users can land in the hosting dashboard rollout cohort, where classic
+ * purchase-management routes redirect to the dashboard billing pages. Specs that
+ * drive the classic purchases UI call this after signup so their coverage stays
+ * deterministic. Remove once those specs migrate to the dashboard billing UI.
+ *
+ * @param {RestAPIClient} client Client to interact with the WP REST API.
+ */
+export async function apiForceDashboardOptOut( client: RestAPIClient ): Promise< void > {
+	await client.setCalypsoPreferences( {
+		'hosting-dashboard-opt-in': {
+			value: 'forced-opt-out',
+			updated_at: new Date().toISOString(),
+		},
+	} );
+}

--- a/test/e2e/specs/shared/api-force-dashboard-opt-out.ts
+++ b/test/e2e/specs/shared/api-force-dashboard-opt-out.ts
@@ -1,5 +1,11 @@
 import type { RestAPIClient } from '@automattic/calypso-e2e';
 
+const PREFERENCE_KEY = 'hosting-dashboard-opt-in';
+
+interface HostingDashboardOptInPreference {
+	value?: string;
+}
+
 /**
  * Pins the user to the classic dashboard by setting the `hosting-dashboard-opt-in`
  * preference to `forced-opt-out`, which wins over percentage-rollout enrollment
@@ -10,13 +16,32 @@ import type { RestAPIClient } from '@automattic/calypso-e2e';
  * drive the classic purchases UI call this after signup so their coverage stays
  * deterministic. Remove once those specs migrate to the dashboard billing UI.
  *
+ * The write is verified with a read-back because `RestAPIClient.sendRequest`
+ * returns API error responses instead of throwing; without the check a rejected
+ * write would surface much later as an unrelated-looking redirect to the
+ * dashboard.
+ *
  * @param {RestAPIClient} client Client to interact with the WP REST API.
+ * @throws If the preference does not persist, with the API responses attached.
  */
 export async function apiForceDashboardOptOut( client: RestAPIClient ): Promise< void > {
-	await client.setCalypsoPreferences( {
-		'hosting-dashboard-opt-in': {
+	const setResponse = await client.setCalypsoPreferences( {
+		[ PREFERENCE_KEY ]: {
 			value: 'forced-opt-out',
 			updated_at: new Date().toISOString(),
 		},
 	} );
+
+	const readBack = await client.getCalypsoPreferences();
+	const saved = readBack?.calypso_preferences?.[ PREFERENCE_KEY ] as
+		| HostingDashboardOptInPreference
+		| undefined;
+
+	if ( saved?.value !== 'forced-opt-out' ) {
+		throw new Error(
+			`Failed to persist ${ PREFERENCE_KEY }=forced-opt-out.\n` +
+				`POST response: ${ JSON.stringify( setResponse ) }\n` +
+				`GET response: ${ JSON.stringify( readBack ) }`
+		);
+	}
 }

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,5 +1,6 @@
 export * from './api-cancel-atomic-plan';
 export * from './api-close-account';
+export * from './api-force-dashboard-opt-out';
 export * from './api-create-free-site';
 export * from './api-delete-site';
 export * from './api-wait-for-account-propagation';


### PR DESCRIPTION
Part of #112586

## Proposed Changes

* Add a shared e2e helper that sets the `hosting-dashboard-opt-in` preference to `forced-opt-out` via the REST API, which wins over percentage-rollout enrollment.
* Call it after checkout, before the purchases steps, in the four signup lifecycle specs that drive the classic purchases UI with freshly created users.

## Why are these changes being made?

* With `dashboard/enable-percentage-rollout` on, ~50% of new test users are enrolled in the hosting dashboard, so `/me/purchases` redirects to the new billing pages and the classic purchases steps time out (see the failing E2E check on #112586). Once the new-user threshold is set on release day, every run would fail.
* Pinning the test user to the classic dashboard keeps these specs deterministic and preserves coverage of the classic cancel flow, which still serves the non-enrolled half of users during the rollout window.
* This is a bridge, not the destination: the helper should be removed when these specs migrate to the new dashboard billing UI.

## Testing Instructions

* CI on this PR should pass the previously failing `E2E Tests (Playwright Test) (Web app)` check; the failing spec was `onboarding/signup__with-theme-LOHP.spec.ts` on [Mobile]. Since cohort assignment is a per-user coin flip, a few green runs are stronger signal than one.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?