### PR TITLE
Dashboard: add blog post link to the welcome modal

### DIFF
--- a/client/dashboard/app/welcome-modal/index.tsx
+++ b/client/dashboard/app/welcome-modal/index.tsx
@@ -1,4 +1,5 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useMatch } from '@tanstack/react-router';
 import {
@@ -6,6 +7,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	Button,
+	ExternalLink,
 	Guide,
 } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
@@ -92,6 +94,16 @@ export function OptInWelcomeModal() {
 										'It’s built to make everyday management tasks faster and easier across your sites, domains, plugins and account.'
 									) }
 								</Text>
+								<ExternalLink
+									href={ localizeUrl( 'https://wordpress.com/support/navigate-wordpress-com/' ) }
+									onClick={ () => {
+										recordTracksEvent(
+											'calypso_dashboard_opt_in_welcome_modal_blog_post_link_click'
+										);
+									} }
+								>
+									{ __( 'Learn more' ) }
+								</ExternalLink>
 							</VStack>
 							<HStack justify="end">
 								<Button variant="primary" __next40pxDefaultSize onClick={ handleDismiss }>


### PR DESCRIPTION
Fixes DOTMSD-1412

## Proposed Changes

This is basically reverting @p-jackson's previous commit https://github.com/Automattic/wp-calypso/pull/112147/changes/182117faff3f33536092fd3d984f936b77735327.

This PR adds a `Learn more` link in the MSD welcome modal, pointing to https://wordpress.com/support/navigate-wordpress-com/ .

<img width="350" alt="image" src="https://github.com/user-attachments/assets/ce5f0cdc-816d-4599-ada6-5c0cc06c24e4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1. Check out this PR locally
2. Force-show the modal

```diff
diff --git i/client/dashboard/utils/hosting-dashboard-enrollment.ts w/client/dashboard/utils/hosting-dashboard-enrollment.ts
index 8d5175dd743..fe59a58ebb6 100644
--- i/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ w/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -68,17 +68,7 @@ export function isWelcomeModalEligible(
        preference: HostingDashboardOptIn | undefined,
        userId: number | undefined
 ): boolean {
-       if (
-               ! config.isEnabled( 'dashboard/opt-in-welcome-modal' ) ||
-               ! userId ||
-               userId > NEW_USER_ID_THRESHOLD ||
-               preference?.value === 'opt-in' ||
-               isSupportSession()
-       ) {
-               return false;
-       }
-
-       return userId % 100 < ROLLOUT_PERCENTAGE;
+       return true;
 }

 /**
```

3. Go to MSD /sites
4. Verify the link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
