### PR TITLE
Stats: don't re-ask for non-commercial trust pledge after commercial opt-out

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -55,6 +55,9 @@ const PersonalPurchase = ( {
 	const { data: connectionStatus } = useJetpackConnectionStatus( siteId, !! isSimpleSite );
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
+	// The opt-out form on the commercial page already collects this same pledge (and only lets the
+	// user through once all four boxes are checked), so don't make them repeat it here.
+	const hasConfirmedNonCommercialUsage = from === 'switch-from-commercial';
 
 	const continueButtonText = translate( 'Contribute now and continue' );
 
@@ -120,7 +123,7 @@ const PersonalPurchase = ( {
 				onSliderChange={ handleSliderChanged }
 			/>
 
-			{ subscriptionValue === 0 && (
+			{ subscriptionValue === 0 && ! hasConfirmedNonCommercialUsage && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist` }>
 					<p>
 						<strong>
@@ -178,7 +181,8 @@ const PersonalPurchase = ( {
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						disabled={
-							! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+							! hasConfirmedNonCommercialUsage &&
+							( ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked )
 						}
 						onClick={ () =>
 							gotoCheckoutPage( {


### PR DESCRIPTION
## Proposed Changes

* When a user opts out of the commercial Stats flow (checking the four non-commercial confirmation boxes on the commercial purchase page), don't re-show and re-require the same checklist on the personal purchase page they land on next.
* The personal purchase page now detects this specific transition (`from=switch-from-commercial`, which is only reachable after the opt-out form's boxes are already checked) and skips the redundant checklist, letting the user go straight to checkout when selecting $0.

## Why are these changes being made?

Users switching from the commercial to the personal (non-commercial) Stats purchase flow already confirm non-commercial usage by checking four boxes on the commercial page's opt-out form. Landing on the personal purchase page, selecting the $0 contribution tier showed the exact same four checkboxes again and blocked the "Continue with Jetpack Stats for free" button until they were re-checked — forcing users to make the same pledge twice in a single flow. This felt redundant and, per user feedback, made users feel untrusted.

## Testing Instructions

* On the Stats commercial purchase page (`/stats/purchase/:site`), check all four non-commercial confirmation boxes in the opt-out form and click Continue.
* On the resulting personal purchase page, move the contribution slider to $0.00.
* Before this change: the same four checkboxes reappear and the "Continue with Jetpack Stats for free" button stays disabled until they're re-checked.
* After this change: no checklist is shown and the button is immediately enabled, going straight to checkout.
* Confirm the checklist still appears normally when landing on the personal purchase page through any other entry point (e.g. directly, or via "Upgrade my Stats").

| Before | After |
|-|-|
| <img width="1184" height="1141" alt="image" src="https://github.com/user-attachments/assets/7113df23-f382-488a-927a-be11a1f8810c" /> | <img width="1171" height="986" alt="image" src="https://github.com/user-attachments/assets/6ee3dafb-85cd-4650-aa6d-bfae26dd45bf" /> | 


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?