### PR TITLE
Emergency revert:  reverse MSD rollout in all environments

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -31,7 +31,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -27,7 +27,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -33,7 +33,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -32,7 +32,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,7 +44,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,7 +40,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,


### PR DESCRIPTION

## Why are these changes being made?

Prepared as an emergency rollback of the MSD percentage rollout. Merging this disables the auto-enrollment so users are no longer redirected to the hosting dashboard based on `userId % 100 < 50`.

Use this pre-made PR for a quicker revert experience.

## Proposed Changes

* Flip the `dashboard/enable-percentage-rollout` feature flag from `true` back to `false` in every environment config where it is defined (`config/development.json`, `horizon.json`, `stage.json`, `production.json`, `test.json`, `wpcalypso.json`, and the four `dashboard-*.json` variants).

This is a **partial revert of #112586** — it reverts only the `enable-percentage-rollout` flag flip, leaving the other changes from that PR in place.


## Testing Instructions

* Confirm the flag is `false` in the relevant environment config.
* For a user whose `userId % 100 < 50`, verify they are no longer auto-enrolled (not redirected to the hosting dashboard).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
