### PR TITLE
Setup Domain: skip paid-site cancel-plan E2E tests pending MSD flow migration

### DIFF
--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -272,7 +272,10 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a paid site, add a domain, then cancel the plan', async ( {
+		// Skipped for now; can be updated once we're sure all onboarding tests will go
+		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
+		// and https://github.com/Automattic/wp-calypso/pull/112587.
+		test.skip( 'As a new user, I can create a paid site, add a domain, then cancel the plan', async ( {
 			page,
 			componentDomainSearch,
 			componentSelectItems,
@@ -530,7 +533,10 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan', async ( {
+		// Skipped for now; can be updated once we're sure all onboarding tests will go
+		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
+		// and https://github.com/Automattic/wp-calypso/pull/112587.
+		test.skip( 'As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan', async ( {
 			page,
 			componentDomainSearch,
 			componentMeSidebar,


### PR DESCRIPTION
## Proposed Changes

* Skip two E2E tests in `flows/setup-domain__flows.spec.ts`:
  * `Setup Domain Flows › As a new user, I can create a paid site, add a domain, then cancel the plan`
  * `Setup Domain Flows › As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan`

## Why are these changes being made?

* Follow-up to #112586 and #112587. These onboarding-adjacent flows are unstable while onboarding migrates to the MSD flow. Skipping matches the approach taken for the other onboarding tests in #112586; they can be re-enabled once all onboarding tests reliably go through the MSD flow.

## Testing Instructions

* Confirm both tests are skipped in the E2E run (reported as skipped, not run).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
