### PR TITLE
Migrate onboarding purchase-cancellation E2E tests to the dashboard

### DIFF
--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -14,6 +14,7 @@ export * from './domain-search-component';
 export * from './isolated-block-editor-component';
 export * from './block-widget-editor-component';
 export * from './notice-component';
+export * from './snackbar-component';
 export * from './react-modal-component';
 export * from './editor-component';
 export * from './editor-inline-block-inserter-component';

--- a/packages/calypso-e2e/src/lib/components/snackbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/snackbar-component.ts
@@ -1,11 +1,10 @@
 import { Page } from 'playwright';
 
 /**
- * Represents the transient snackbar notices shown by the Multi-site Dashboard.
+ * Represents the snackbar notices shown by the Multi-site Dashboard.
  *
- * The dashboard reports the outcome of an action through a `@wordpress/notices`
- * snackbar, rather than through the classic Calypso notice that
- * `NoticeComponent` covers.
+ * The dashboard uses these instead of the classic Calypso notices covered by
+ * `NoticeComponent`.
  */
 export class SnackbarComponent {
 	private page: Page;
@@ -22,8 +21,7 @@ export class SnackbarComponent {
 	/**
 	 * Verifies that a snackbar with the given text is shown.
 	 *
-	 * Snackbars auto-dismiss, so this must be awaited while the snackbar is still
-	 * on screen — that is, as soon as the action that triggers it has resolved.
+	 * Snackbars auto-dismiss, so await this as soon as the triggering action resolves.
 	 *
 	 * @param {string} text Full or partial text to validate on page.
 	 * @param param1 Optional parameters.

--- a/packages/calypso-e2e/src/lib/components/snackbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/snackbar-component.ts
@@ -1,0 +1,39 @@
+import { Page } from 'playwright';
+
+/**
+ * Represents the transient snackbar notices shown by the Multi-site Dashboard.
+ *
+ * The dashboard reports the outcome of an action through a `@wordpress/notices`
+ * snackbar, rather than through the classic Calypso notice that
+ * `NoticeComponent` covers.
+ */
+export class SnackbarComponent {
+	private page: Page;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Verifies that a snackbar with the given text is shown.
+	 *
+	 * Snackbars auto-dismiss, so this must be awaited while the snackbar is still
+	 * on screen — that is, as soon as the action that triggers it has resolved.
+	 *
+	 * @param {string} text Full or partial text to validate on page.
+	 * @param param1 Optional parameters.
+	 * @param {number} param1.timeout Custom timeout value.
+	 */
+	async snackbarShown( text: string, { timeout }: { timeout?: number } = {} ): Promise< void > {
+		await this.page
+			.locator( '.components-snackbar' )
+			.filter( { hasText: text } )
+			.first()
+			.waitFor( { state: 'visible', timeout } );
+	}
+}

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -5,14 +5,9 @@ type CancelReason = 'Another reason…';
 /**
  * Clicks a button locator once it is both visible and actually enabled.
  *
- * The cancellation survey renders its primary button with the
- * `@wordpress/components` "busy" state (`class="is-busy"` plus the `disabled`
- * attribute) while an async request is in flight, and keeps it disabled until
- * the current step's required answers are filled in. Such a button is visible
- * but not actionable, so `click()` alone can exhaust its action timeout before
- * the button settles. Waiting for the `disabled` attribute to be removed first
- * guarantees the subsequent click targets an enabled element. The button may
- * also re-render between states; polling the live locator rides that out.
+ * The survey's step button is disabled until the step's required answers are
+ * filled in, and again while the request is in flight. Waiting for the
+ * `disabled` attribute to clear guarantees the click lands on an enabled button.
  *
  * @param {Locator} button Button locator to wait on and click.
  * @param {number} timeout Maximum time, in milliseconds, to wait for the enabled state.
@@ -36,12 +31,9 @@ async function clickWhenEnabled( button: Locator, timeout = 30 * 1000 ): Promise
 }
 
 /**
- * Returns a locator matching the cancellation survey's primary step button.
+ * Returns a locator matching the survey's primary step button.
  *
- * Every step of the dashboard survey — including the last — advances with
- * "Continue". The "Complete" and "…removal" variants only render on the
- * intent-driven paths gated behind the `purchases/split-cancel-remove` feature
- * flag, which is off in every deployed environment.
+ * Every step, including the last, advances with "Continue".
  *
  * @param {Page} page Page object the survey is rendered on.
  * @returns {Locator} Locator matching the survey's primary step button.
@@ -53,28 +45,22 @@ function surveyStepButton( page: Page ): Locator {
 /**
  * Waits for the cancel-and-refund request fired by the final survey step.
  *
- * The dashboard cancels through `wpcom/v2/upgrades/<id>/cancel` (the classic UI
- * used `purchases/<id>/cancel`). Callers must start listening *before* the click
- * that fires it, so a fast response cannot be missed.
+ * Callers must start listening before the click that fires it.
  *
  * @param {Page} page Page object the survey is rendered on.
  * @returns {Promise} Promise resolving once the cancellation request resolves.
  */
 function waitForCancelResponse( page: Page ) {
 	return page.waitForResponse( ( response ) => /\/upgrades\/\d+\/cancel/.test( response.url() ), {
-		// A refund is a real server round-trip and can be slow, so allow a
-		// generous window.
+		// A refund is a real server round-trip, so allow a generous window.
 		timeout: 60 * 1000,
 	} );
 }
 
 /**
- * Completes the cancellation survey for a non-plan subscription (e.g. a storage
- * add-on).
+ * Completes the cancellation survey for a non-plan subscription (e.g. a storage add-on).
  *
- * Such purchases get a single survey step whose only field — "What's one thing
- * we could have done better?" — is optional, so submitting it immediately fires
- * the cancel-and-refund request.
+ * These get a single survey step whose only field is optional.
  */
 export async function cancelSubscriptionFlow( page: Page ) {
 	const cancelResponsePromise = waitForCancelResponse( page );
@@ -87,9 +73,8 @@ export async function cancelSubscriptionFlow( page: Page ) {
 /**
  * Completes the cancellation survey for a plan.
  *
- * A plan gets two survey steps: a reason for cancelling, then where the user is
- * headed next. Both are required, and the step button stays disabled until they
- * are answered.
+ * A plan gets two steps: why you are cancelling, then where you are going next.
+ * Both are required.
  */
 export async function cancelAtomicPurchaseFlow(
 	page: Page,
@@ -98,8 +83,7 @@ export async function cancelAtomicPurchaseFlow(
 		customReasonText: string;
 	}
 ) {
-	// Choosing "Another reason…" reveals a free-text field and, unlike most of
-	// the other reasons, routes past the upsell step straight to the next one.
+	// "Another reason…" reveals a free-text field and skips the upsell step.
 	await page.getByRole( 'radio', { name: feedback.reason } ).check();
 	await page
 		.getByRole( 'textbox', { name: 'Can you please specify?' } )
@@ -107,20 +91,14 @@ export async function cancelAtomicPurchaseFlow(
 
 	await clickWhenEnabled( surveyStepButton( page ) );
 
-	// The next (and final) step asks where the user is headed next. Selecting an
-	// answer enables the final step button.
 	await page.getByRole( 'radio', { name: "I'm staying here and using the free plan." } ).check();
 
-	// Submitting the final step fires the cancel-and-refund request. Listen for
-	// its response before clicking so a fast response cannot be missed.
+	// Listen before clicking so a fast response cannot be missed.
 	const cancelResponsePromise = waitForCancelResponse( page );
 
 	await clickWhenEnabled( surveyStepButton( page ) );
 
-	// Submitting only *fires* the survey's completion handler, which then awaits
-	// the cancel-and-refund request before showing the success snackbar and
-	// navigating away. The snackbar auto-dismisses, so returning right after the
-	// click would leave the caller's assertion racing the whole refund
-	// round-trip. Block until the request actually resolves.
+	// Block until the refund resolves, so the caller's snackbar assertion isn't
+	// racing the round-trip.
 	await cancelResponsePromise;
 }

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -5,11 +5,12 @@ type CancelReason = 'Another reason…';
 /**
  * Clicks a button locator once it is both visible and actually enabled.
  *
- * The cancellation flow renders its primary buttons with the
+ * The cancellation survey renders its primary button with the
  * `@wordpress/components` "busy" state (`class="is-busy"` plus the `disabled`
- * attribute) while an async request is in flight. Such a button is visible but
- * not actionable, so `click()` alone can exhaust its action timeout before the
- * button settles. Waiting for the `disabled` attribute to be removed first
+ * attribute) while an async request is in flight, and keeps it disabled until
+ * the current step's required answers are filled in. Such a button is visible
+ * but not actionable, so `click()` alone can exhaust its action timeout before
+ * the button settles. Waiting for the `disabled` attribute to be removed first
  * guarantees the subsequent click targets an enabled element. The button may
  * also re-render between states; polling the live locator rides that out.
  *
@@ -35,51 +36,60 @@ async function clickWhenEnabled( button: Locator, timeout = 30 * 1000 ): Promise
 }
 
 /**
- * Completes the cancellation survey for a non-plan subscription (e.g. a storage
- * add-on), whose survey is a single step.
+ * Returns a locator matching the cancellation survey's primary step button.
  *
- * On the refund-and-remove (`intent=remove`) path the step button reads "Complete
- * removal"; legacy/other variants read "Submit" or "Complete". `surveyStepButton`
- * (scoped to the survey form) matches whichever renders, and `clickWhenEnabled`
- * rides out the busy/disabled state while the request is in flight.
- */
-export async function cancelSubscriptionFlow( page: Page ) {
-	await clickWhenEnabled( surveyStepButton( page ) );
-}
-
-/**
- * Returns a locator that matches the cancellation survey's primary step button.
- *
- * The button's label depends on the survey step and the active intent/variant:
- * - Legacy / `intent=cancel`: non-final step renders "Continue", final step
- *   renders "Submit" (legacy) or "Complete" (split cancel/remove).
- * - `intent=remove` (the refund-and-remove path this flow now drives): non-final
- *   step renders "Continue removal", final step renders "Complete removal".
- *
- * Matching all of these keeps the flow robust regardless of which variant is
- * served. `exact: true` ensures "Continue" does not also resolve "Continue
- * removal" (and vice versa).
- *
- * The locator is scoped to the survey's `.cancel-purchase-form` container. The
- * survey renders as an overlay on top of the cancellation confirmation screen,
- * whose own primary button can share a label (e.g. "Continue removal"); scoping
- * avoids matching that underlying button and tripping strict-mode violations.
+ * Every step of the dashboard survey — including the last — advances with
+ * "Continue". The "Complete" and "…removal" variants only render on the
+ * intent-driven paths gated behind the `purchases/split-cancel-remove` feature
+ * flag, which is off in every deployed environment.
  *
  * @param {Page} page Page object the survey is rendered on.
  * @returns {Locator} Locator matching the survey's primary step button.
  */
 function surveyStepButton( page: Page ): Locator {
-	const surveyForm = page.locator( '.cancel-purchase-form' );
-	return surveyForm
-		.getByRole( 'button', { name: 'Submit', exact: true } )
-		.or( surveyForm.getByRole( 'button', { name: 'Continue', exact: true } ) )
-		.or( surveyForm.getByRole( 'button', { name: 'Complete', exact: true } ) )
-		.or( surveyForm.getByRole( 'button', { name: 'Continue removal', exact: true } ) )
-		.or( surveyForm.getByRole( 'button', { name: 'Complete removal', exact: true } ) );
+	return page.getByRole( 'button', { name: 'Continue', exact: true } );
 }
 
 /**
- * Cancels a purchased Atomic site.
+ * Waits for the cancel-and-refund request fired by the final survey step.
+ *
+ * The dashboard cancels through `wpcom/v2/upgrades/<id>/cancel` (the classic UI
+ * used `purchases/<id>/cancel`). Callers must start listening *before* the click
+ * that fires it, so a fast response cannot be missed.
+ *
+ * @param {Page} page Page object the survey is rendered on.
+ * @returns {Promise} Promise resolving once the cancellation request resolves.
+ */
+function waitForCancelResponse( page: Page ) {
+	return page.waitForResponse( ( response ) => /\/upgrades\/\d+\/cancel/.test( response.url() ), {
+		// A refund is a real server round-trip and can be slow, so allow a
+		// generous window.
+		timeout: 60 * 1000,
+	} );
+}
+
+/**
+ * Completes the cancellation survey for a non-plan subscription (e.g. a storage
+ * add-on).
+ *
+ * Such purchases get a single survey step whose only field — "What's one thing
+ * we could have done better?" — is optional, so submitting it immediately fires
+ * the cancel-and-refund request.
+ */
+export async function cancelSubscriptionFlow( page: Page ) {
+	const cancelResponsePromise = waitForCancelResponse( page );
+
+	await clickWhenEnabled( surveyStepButton( page ) );
+
+	await cancelResponsePromise;
+}
+
+/**
+ * Completes the cancellation survey for a plan.
+ *
+ * A plan gets two survey steps: a reason for cancelling, then where the user is
+ * headed next. Both are required, and the step button stays disabled until they
+ * are answered.
  */
 export async function cancelAtomicPurchaseFlow(
 	page: Page,
@@ -88,60 +98,29 @@ export async function cancelAtomicPurchaseFlow(
 		customReasonText: string;
 	}
 ) {
-	// The feedback question is worded by intent: "Why would you like to cancel?"
-	// on the cancel path and "Why would you like to remove?" on the refund-and-
-	// remove (`intent=remove`) path this flow now drives. Match either.
-	await page
-		.getByRole( 'combobox', { name: /Why would you like to (cancel|remove)\?/ } )
-		.selectOption( feedback.reason );
-
+	// Choosing "Another reason…" reveals a free-text field and, unlike most of
+	// the other reasons, routes past the upsell step straight to the next one.
+	await page.getByRole( 'radio', { name: feedback.reason } ).check();
 	await page
 		.getByRole( 'textbox', { name: 'Can you please specify?' } )
 		.fill( feedback.customReasonText );
 
-	// Submit the feedback step. This is not the final step, so under the
-	// refund-and-remove (`intent=remove`) path the button is labelled "Continue
-	// removal"; other variants label it "Continue". `surveyStepButton` matches
-	// whichever renders.
 	await clickWhenEnabled( surveyStepButton( page ) );
 
 	// The next (and final) step asks where the user is headed next. Selecting an
 	// answer enables the final step button.
-	await page
-		.getByRole( 'combobox', { name: 'Where is your next adventure taking you?' } )
-		.selectOption( "I'm staying here and using the free plan." );
+	await page.getByRole( 'radio', { name: "I'm staying here and using the free plan." } ).check();
 
-	// Submitting the final step fires the cancel-and-refund request. Start
-	// listening for its response *before* clicking so the listener cannot miss
-	// a fast response. The request hits `wpcom/v2/purchases/<id>/cancel`; the
-	// API proxy URL contains `purchases/<id>/cancel`.
-	const cancelResponsePromise = page.waitForResponse(
-		( response ) => /\/purchases\/\d+\/cancel/.test( response.url() ),
-		// A refund is a real server round-trip and can be slow in the test
-		// environment, so allow a generous window.
-		{ timeout: 60 * 1000 }
-	);
+	// Submitting the final step fires the cancel-and-refund request. Listen for
+	// its response before clicking so a fast response cannot be missed.
+	const cancelResponsePromise = waitForCancelResponse( page );
 
-	// Submit the final step. The survey for a plan cancellation only has these
-	// two steps, so there is no third button to click. The final button renders
-	// visible but `disabled`/`is-busy` while the cancellation request is in
-	// flight, so visibility alone is not enough to click it reliably — wait for
-	// it to become enabled first.
 	await clickWhenEnabled( surveyStepButton( page ) );
 
-	// Confirming the cancellation does not trigger a full-page navigation: the
-	// purchases view updates in place as a single-page-app state change. The
-	// previous `page.waitForNavigation()` therefore never resolved and hung
-	// until its timeout.
-	//
-	// Clicking the final button only *fires* the survey's `onSurveyComplete`
-	// handler, which then `await`s the cancel-and-refund API request before
-	// rendering the success notice. Returning right after the click left the
-	// caller's `noticeShown()` assertion racing the entire refund round-trip:
-	// the success notice is created with a 10s auto-dismiss `duration`, so a
-	// slow refund could push the notice's brief visible window outside the
-	// assertion's budget. Block here until the cancel request actually
-	// resolves so the caller's notice assertion only has to cover the notice
-	// render, not the full network round-trip.
+	// Submitting only *fires* the survey's completion handler, which then awaits
+	// the cancel-and-refund request before showing the success snackbar and
+	// navigating away. The snackbar auto-dismisses, so returning right after the
+	// click would leave the caller's assertion racing the whole refund
+	// round-trip. Block until the request actually resolves.
 	await cancelResponsePromise;
 }

--- a/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
@@ -7,9 +7,9 @@ import {
 	LoggedOutHomePage,
 	LoggedOutThemesPage,
 	MyHomePage,
-	NoticeComponent,
 	PurchasesPage,
 	SignupPickPlanPage,
+	SnackbarComponent,
 	ThemesDetailPage,
 	UserSignupPage,
 } from '../..';
@@ -28,7 +28,7 @@ export class LOHPThemeSignupFlow {
 	readonly themesDetailPage: ThemesDetailPage;
 	readonly myHomePage: MyHomePage;
 	readonly purchasesPage: PurchasesPage;
-	readonly noticeComponent: NoticeComponent;
+	readonly snackbarComponent: SnackbarComponent;
 
 	/**
 	 * Constructs an instance of the flow.
@@ -46,7 +46,7 @@ export class LOHPThemeSignupFlow {
 		this.themesDetailPage = new ThemesDetailPage( page );
 		this.myHomePage = new MyHomePage( page );
 		this.purchasesPage = new PurchasesPage( page );
-		this.noticeComponent = new NoticeComponent( page );
+		this.snackbarComponent = new SnackbarComponent( page );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -1,10 +1,13 @@
 import { Page } from 'playwright';
 import { getCalypsoURL } from '../../../data-helper';
 
-type PurchaseActions = 'Cancel plan' | 'Cancel subscription';
-
 /**
- * Represents the /me endpoint.
+ * Represents the Multi-site Dashboard's "Active upgrades" screens, rooted at
+ * `/me/billing/purchases`.
+ *
+ * Users enrolled in the hosting dashboard rollout — which now includes every
+ * newly registered user — are redirected here from the classic `/me/purchases`
+ * routes, so this is the only purchase management UI a new user can reach.
  */
 export class PurchasesPage {
 	private page: Page;
@@ -19,10 +22,16 @@ export class PurchasesPage {
 	}
 
 	/**
-	 * Visits the /me endpoint.
+	 * Visits the purchases list.
+	 *
+	 * Entered through the classic route so the app itself works out where the
+	 * dashboard lives: it is served from a different host, and which host that is
+	 * varies by environment. Following the redirect keeps this working everywhere
+	 * without the caller having to know the dashboard's origin.
 	 */
 	async visit() {
 		await this.page.goto( getCalypsoURL( 'me/purchases' ) );
+		await this.page.waitForURL( /\/me\/billing\/purchases/ );
 	}
 
 	/* Purchases list view */
@@ -30,62 +39,41 @@ export class PurchasesPage {
 	/**
 	 * Clicks on the matching purchase.
 	 *
+	 * The list renders as a DataViews table in which the product cell links to
+	 * the purchase and the description cell carries the site slug. Filtering the
+	 * row by slug and then matching the link by product name keeps the match
+	 * unambiguous for an account holding several purchases on the same site.
+	 *
 	 * @param {string} name Name of the purchased subscription.
 	 * @param {string} siteSlug Site slug.
 	 */
 	async clickOnPurchase( name: string, siteSlug: string ) {
 		await this.page
-			.locator( '#purchases-list .dataviews-view-table__row' )
-			.filter( { hasText: name } )
+			.getByRole( 'row' )
 			.filter( { hasText: siteSlug } )
-			.locator( '.purchase-item__title-link' )
+			.getByRole( 'link', { name } )
 			.click();
 	}
 
 	/* Purchase detail view */
 
 	/**
-	 * Clicks a cancellation action for the purchase and advances to its
-	 * cancellation survey via the refund-and-remove path.
+	 * Starts cancellation from the purchase detail view and confirms it, leaving
+	 * the page on the first step of the cancellation survey.
 	 *
-	 * "Cancel plan" / "Cancel subscription" lands on a cancellation confirmation
-	 * screen (`intent=cancel`) whose primary action only disables auto-renew — it
-	 * no longer issues a refund. To drive the immediate refund-and-remove path
-	 * (the one the cancellation specs assert), this follows the "Remove and claim
-	 * refund." notice link on that screen, which navigates to the same route under
-	 * `intent=remove` where the primary confirm button reads "Continue removal".
-	 * Confirming there begins the cancellation survey, which fires the refund on
-	 * completion.
-	 *
-	 * @param {PurchaseActions} action Action link to click on the purchase detail view.
+	 * The detail view lists the cancellation action under a "Cancel subscription"
+	 * heading whose button is labelled simply "Cancel" — for plans and add-ons
+	 * alike. Confirming lands on a screen whose primary button stays disabled
+	 * until the acknowledgement checkbox is ticked.
 	 */
-	async cancelPurchase( action: PurchaseActions ) {
-		await this.page.getByRole( 'link', { name: action } ).click();
+	async cancelPurchase() {
+		await this.page.getByRole( 'button', { name: 'Cancel', exact: true } ).click();
 
-		// Follow the refund-eligibility notice link to switch from the
-		// auto-renew-only `intent=cancel` screen to the refund-and-remove
-		// `intent=remove` screen. Matched by a copy-resilient pattern so wording
-		// tweaks to the notice don't break the flow.
-		await this.page.getByRole( 'button', { name: /claim refund/i } ).click();
+		// Matched on a copy-resilient fragment: the full label is the only checkbox
+		// on the confirmation screen for a plan or add-on, and its curly apostrophes
+		// are easy to mangle.
+		await this.page.getByRole( 'checkbox', { name: /reviewed what/i } ).check();
 
-		// The screen remounts under `intent=remove`. Wait for its primary
-		// "Continue removal" button before interacting.
-		const continueRemovalButton = this.page.getByRole( 'button', {
-			name: 'Continue removal',
-			exact: true,
-		} );
-		await continueRemovalButton.waitFor( { state: 'visible' } );
-
-		// Under the split-cancel-remove flag the confirm button is gated behind an
-		// "I've reviewed what I'll lose…" checkbox; without the flag there is no
-		// checkbox and the button is enabled immediately. Tick it only when present
-		// so the flow works regardless of the served variant.
-		const confirmCheckbox = this.page.locator( 'label.cancel-purchase__confirm-checkbox input' );
-		if ( ( await confirmCheckbox.count() ) > 0 ) {
-			await confirmCheckbox.check();
-		}
-
-		// Confirm. Clicking "Continue removal" begins the cancellation survey.
-		await continueRemovalButton.click();
+		await this.page.getByRole( 'button', { name: 'Cancel subscription', exact: true } ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -2,12 +2,11 @@ import { Page } from 'playwright';
 import { getCalypsoURL } from '../../../data-helper';
 
 /**
- * Represents the Multi-site Dashboard's "Active upgrades" screens, rooted at
+ * Represents the Multi-site Dashboard's "Active upgrades" screens, at
  * `/me/billing/purchases`.
  *
- * Users enrolled in the hosting dashboard rollout — which now includes every
- * newly registered user — are redirected here from the classic `/me/purchases`
- * routes, so this is the only purchase management UI a new user can reach.
+ * Every newly registered user is enrolled in the hosting dashboard rollout, so
+ * they are redirected here from the classic `/me/purchases` routes.
  */
 export class PurchasesPage {
 	private page: Page;
@@ -24,14 +23,23 @@ export class PurchasesPage {
 	/**
 	 * Visits the purchases list.
 	 *
-	 * Entered through the classic route so the app itself works out where the
-	 * dashboard lives: it is served from a different host, and which host that is
-	 * varies by environment. Following the redirect keeps this working everywhere
-	 * without the caller having to know the dashboard's origin.
+	 * Entered through the classic route and follows the redirect, because the
+	 * dashboard's host varies by environment.
 	 */
 	async visit() {
 		await this.page.goto( getCalypsoURL( 'me/purchases' ) );
-		await this.page.waitForURL( /\/me\/billing\/purchases/ );
+
+		try {
+			await this.page.waitForURL( /\/me\/billing\/purchases/ );
+		} catch {
+			throw new Error(
+				`Expected the classic purchases route to redirect to the dashboard, but landed on ${ this.page.url() }.\n` +
+					'The user this test signed up was not enrolled in the hosting dashboard rollout. ' +
+					'Check NEW_USER_ID_THRESHOLD and the dashboard/enable-percentage-rollout flag in ' +
+					'client/dashboard/utils/hosting-dashboard-enrollment.ts — if new users are no longer ' +
+					'enrolled by default, they fall back to a 50% cohort and this fails half the time.'
+			);
+		}
 	}
 
 	/* Purchases list view */
@@ -39,10 +47,8 @@ export class PurchasesPage {
 	/**
 	 * Clicks on the matching purchase.
 	 *
-	 * The list renders as a DataViews table in which the product cell links to
-	 * the purchase and the description cell carries the site slug. Filtering the
-	 * row by slug and then matching the link by product name keeps the match
-	 * unambiguous for an account holding several purchases on the same site.
+	 * The list is a DataViews table: the product cell links to the purchase and
+	 * the description cell carries the site slug.
 	 *
 	 * @param {string} name Name of the purchased subscription.
 	 * @param {string} siteSlug Site slug.
@@ -58,20 +64,16 @@ export class PurchasesPage {
 	/* Purchase detail view */
 
 	/**
-	 * Starts cancellation from the purchase detail view and confirms it, leaving
-	 * the page on the first step of the cancellation survey.
+	 * Cancels the purchase and confirms, leaving the page on the first step of
+	 * the cancellation survey.
 	 *
-	 * The detail view lists the cancellation action under a "Cancel subscription"
-	 * heading whose button is labelled simply "Cancel" — for plans and add-ons
-	 * alike. Confirming lands on a screen whose primary button stays disabled
-	 * until the acknowledgement checkbox is ticked.
+	 * The button is labelled "Cancel" for plans and add-ons alike.
 	 */
 	async cancelPurchase() {
 		await this.page.getByRole( 'button', { name: 'Cancel', exact: true } ).click();
 
-		// Matched on a copy-resilient fragment: the full label is the only checkbox
-		// on the confirmation screen for a plan or add-on, and its curly apostrophes
-		// are easy to mangle.
+		// The confirm button is disabled until this is ticked. Matched on a
+		// fragment to avoid the curly apostrophes in the full label.
 		await this.page.getByRole( 'checkbox', { name: /reviewed what/i } ).check();
 
 		await this.page.getByRole( 'button', { name: 'Cancel subscription', exact: true } ).click();

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -34,9 +34,8 @@ export class SiteSettingsPage {
 	 * Start the site launch process.
 	 * Must be on the "Site visibility" sub-page.
 	 *
-	 * The launch control usually carries an href and so renders as a link, but on
-	 * the immediate-launch path it only has a click handler and renders as a
-	 * button. Match either.
+	 * The launch control renders as a link or a button depending on the path, so
+	 * match either.
 	 */
 	async launchSite(): Promise< void > {
 		const name = 'Launch your site';

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -33,16 +33,9 @@ export class SiteSettingsPage {
 	/**
 	 * Start the site launch process.
 	 * Must be on the "Site visibility" sub-page.
-	 *
-	 * The launch control renders as a link or a button depending on the path, so
-	 * match either.
 	 */
 	async launchSite(): Promise< void > {
-		const name = 'Launch your site';
-		const launchSite = this.page
-			.getByRole( 'link', { name } )
-			.or( this.page.getByRole( 'button', { name } ) )
-			.first();
+		const launchSite = this.page.getByRole( 'link', { name: 'Launch your site' } ).first();
 		await launchSite.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -33,9 +33,17 @@ export class SiteSettingsPage {
 	/**
 	 * Start the site launch process.
 	 * Must be on the "Site visibility" sub-page.
+	 *
+	 * The launch control usually carries an href and so renders as a link, but on
+	 * the immediate-launch path it only has a click handler and renders as a
+	 * button. Match either.
 	 */
 	async launchSite(): Promise< void > {
-		const launchSite = this.page.getByRole( 'link', { name: 'Launch your site' } ).first();
+		const name = 'Launch your site';
+		const launchSite = this.page
+			.getByRole( 'link', { name } )
+			.or( this.page.getByRole( 'button', { name } ) )
+			.first();
 		await launchSite.click();
 	}
 

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -77,6 +77,7 @@ import {
 	SidebarComponent,
 	SiteSelectComponent,
 	SignupPickPlanPage,
+	SnackbarComponent,
 	TestAccount,
 	ThemesDetailPage,
 	ThemesPage,
@@ -178,6 +179,10 @@ export const test = base.extend<
 		 * Component for displaying notices (e.g., success/error messages).
 		 */
 		componentNotice: NoticeComponent;
+		/**
+		 * Component for the Dashboard's transient snackbar notices.
+		 */
+		componentSnackbar: SnackbarComponent;
 		/**
 		 * Component for selecting items in various flows.
 		 */
@@ -432,6 +437,10 @@ export const test = base.extend<
 	componentNotice: async ( { page }, use ) => {
 		const noticeComponent = new NoticeComponent( page );
 		await use( noticeComponent );
+	},
+	componentSnackbar: async ( { page }, use ) => {
+		const snackbarComponent = new SnackbarComponent( page );
+		await use( snackbarComponent );
 	},
 	componentPreview: async ( { page }, use ) => {
 		const previewComponent = new PreviewComponent( page );

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -272,22 +272,17 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'As a new user, I can create a paid site, add a domain, then cancel the plan', async ( {
+		test( 'As a new user, I can create a paid site, add a domain, then cancel the plan', async ( {
 			page,
 			componentDomainSearch,
 			componentSelectItems,
 			componentSiteSelect,
-			componentMeSidebar,
-			componentNotice,
+			componentSnackbar,
 			helperData,
 			pageCartCheckout,
 			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 			pageUserSignUp,
-			pageMyProfile,
 			pagePurchases,
 		} ) => {
 			// This test chains several genuinely slow flows end to end: creating a
@@ -385,10 +380,8 @@ test.describe(
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );
 
-			await test.step( 'And I navigate to Me > Purchases', async function () {
-				await pageMyProfile.visit();
-				await componentMeSidebar.openMobileMenu();
-				await componentMeSidebar.navigate( 'Purchases' );
+			await test.step( 'And I navigate to the purchases page', async function () {
+				await pagePurchases.visit();
 			} );
 
 			await test.step( 'And I view details of the purchased plan', async function () {
@@ -396,20 +389,20 @@ test.describe(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug as string
 				);
-				await pagePurchases.cancelPurchase( 'Cancel plan' );
+				await pagePurchases.cancelPurchase();
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
-				// cancelAtomicPurchaseFlow now blocks until the cancel-and-refund
-				// API request resolves, so by the time it returns the success
-				// notice is rendering. The notice still carries a 10s auto-dismiss
-				// duration, so keep a comfortable margin to observe it.
+				// cancelAtomicPurchaseFlow blocks until the cancel-and-refund API
+				// request resolves, so by the time it returns the success snackbar is
+				// rendering. The snackbar still auto-dismisses, so keep a comfortable
+				// margin to observe it.
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
 
-				await componentNotice.noticeShown(
+				await componentSnackbar.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{
 						timeout: 30 * 1000,
@@ -533,20 +526,15 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan', async ( {
+		test( 'As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan', async ( {
 			page,
 			componentDomainSearch,
-			componentMeSidebar,
-			componentNotice,
+			componentSnackbar,
 			helperData,
 			pageCartCheckout,
 			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 			pageUserSignUp,
-			pageMyProfile,
 			pagePurchases,
 		} ) => {
 			// This test chains several genuinely slow flows end to end: creating a
@@ -622,10 +610,8 @@ test.describe(
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );
 
-			await test.step( 'And I navigate to Me > Purchases', async function () {
-				await pageMyProfile.visit();
-				await componentMeSidebar.openMobileMenu();
-				await componentMeSidebar.navigate( 'Purchases' );
+			await test.step( 'And I navigate to the purchases page', async function () {
+				await pagePurchases.visit();
 			} );
 
 			await test.step( 'And I view details of the purchased plan', async function () {
@@ -633,20 +619,20 @@ test.describe(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug as string
 				);
-				await pagePurchases.cancelPurchase( 'Cancel plan' );
+				await pagePurchases.cancelPurchase();
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
-				// cancelAtomicPurchaseFlow now blocks until the cancel-and-refund
-				// API request resolves, so by the time it returns the success
-				// notice is rendering. The notice still carries a 10s auto-dismiss
-				// duration, so keep a comfortable margin to observe it.
+				// cancelAtomicPurchaseFlow blocks until the cancel-and-refund API
+				// request resolves, so by the time it returns the success snackbar is
+				// rendering. The snackbar still auto-dismisses, so keep a comfortable
+				// margin to observe it.
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
 
-				await componentNotice.noticeShown(
+				await componentSnackbar.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{
 						timeout: 30 * 1000,

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -393,10 +393,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
-				// cancelAtomicPurchaseFlow blocks until the cancel-and-refund API
-				// request resolves, so by the time it returns the success snackbar is
-				// rendering. The snackbar still auto-dismisses, so keep a comfortable
-				// margin to observe it.
+				// The snackbar auto-dismisses, so keep a comfortable margin to observe it.
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
@@ -623,10 +620,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
-				// cancelAtomicPurchaseFlow blocks until the cancel-and-refund API
-				// request resolves, so by the time it returns the success snackbar is
-				// rendering. The snackbar still auto-dismisses, so keep a comfortable
-				// margin to observe it.
+				// The snackbar auto-dismisses, so keep a comfortable margin to observe it.
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
@@ -5,20 +5,19 @@ import {
 	DataHelper,
 	DomainSearchComponent,
 	LoginPage,
-	MeSidebarComponent,
 	MyHomePage,
-	MyProfilePage,
 	NewSiteResponse,
 	NewUserResponse,
-	NoticeComponent,
 	PostCheckoutSetupSitePage,
 	PurchasesPage,
 	RestAPIClient,
 	SecretsManager,
 	SignupPickPlanPage,
 	SiteSettingsPage,
+	SnackbarComponent,
 	StartSiteFlow,
 	UserSignupPage,
+	cancelAtomicPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
@@ -57,10 +56,7 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'As a new user, I can sign up, onboard, launch, and cancel subscription', async ( {
+		test( 'As a new user, I can sign up, onboard, launch, and cancel subscription', async ( {
 			page,
 			browser,
 		} ) => {
@@ -209,12 +205,9 @@ test.describe(
 				await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
 			} );
 
-			await test.step( 'When I navigate to Me > Purchases', async () => {
-				const mePage = new MyProfilePage( page );
-				await mePage.visit();
-				const meSidebarComponent = new MeSidebarComponent( page );
-				await meSidebarComponent.openMobileMenu();
-				await meSidebarComponent.navigate( 'Purchases' );
+			await test.step( 'When I navigate to the purchases page', async () => {
+				const purchasesPage = new PurchasesPage( page );
+				await purchasesPage.visit();
 			} );
 
 			await test.step( 'When I view details of purchased plan', async () => {
@@ -227,16 +220,16 @@ test.describe(
 
 			await test.step( 'When I cancel plan renewal', async () => {
 				const purchasesPage = new PurchasesPage( page );
-				const noticeComponent = new NoticeComponent( page );
-				await purchasesPage.cancelPurchase( 'Cancel plan' );
-				try {
-					await noticeComponent.noticeShown(
-						'Your refund has been processed and your purchase removed.',
-						{ timeout: 30 * 1000 }
-					);
-				} catch {
-					// Alternate flows may show different confirmation messaging.
-				}
+				const snackbarComponent = new SnackbarComponent( page );
+				await purchasesPage.cancelPurchase();
+				await cancelAtomicPurchaseFlow( page, {
+					reason: 'Another reason…',
+					customReasonText: 'E2E TEST CANCELLATION',
+				} );
+				await snackbarComponent.snackbarShown(
+					'Your refund has been processed and your purchase removed.',
+					{ timeout: 30 * 1000 }
+				);
 			} );
 		} );
 	}

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
@@ -205,13 +205,14 @@ test.describe(
 				await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
 			} );
 
+			const purchasesPage = new PurchasesPage( page );
+			const snackbarComponent = new SnackbarComponent( page );
+
 			await test.step( 'When I navigate to the purchases page', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.visit();
 			} );
 
 			await test.step( 'When I view details of purchased plan', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.clickOnPurchase(
 					`WordPress.com ${ planName }`,
 					newSiteDetails!.blog_details.site_slug
@@ -219,8 +220,6 @@ test.describe(
 			} );
 
 			await test.step( 'When I cancel plan renewal', async () => {
-				const purchasesPage = new PurchasesPage( page );
-				const snackbarComponent = new SnackbarComponent( page );
 				await purchasesPage.cancelPurchase();
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -100,16 +100,17 @@ test.describe(
 				await cartCheckoutPage!.purchase( { timeout: 90 * 1000 } );
 			} );
 
-			await test.step( 'Then I wait for the Atomic transfer to complete', async () => {
+			const purchasesPage = new PurchasesPage( page );
+			const snackbarComponent = new SnackbarComponent( page );
+
+			await test.step( 'Then the Atomic transfer completes', async () => {
 				await page.waitForURL( /.*transferring-hosted-site.*/ );
 
 				// The transfer lands on wp-admin or on the dashboard's site overview,
 				// depending on a race over the site's admin-interface option. Either is
 				// fine here; this test is about the purchases that follow.
 				await page.waitForURL( /wp-admin|\/sites\/[^/?#]+/, { timeout: 180 * 1000 } );
-			} );
 
-			await test.step( 'Then I capture the slug of the transferred site', async () => {
 				// wp-admin: https://<slug>/wp-admin/
 				// Site overview: https://my.wordpress.com/sites/<slug>
 				const url = new URL( page.url() );
@@ -119,16 +120,13 @@ test.describe(
 			} );
 
 			await test.step( 'When I navigate to the purchases page to cancel the add-on', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.visit();
 			} );
 
 			await test.step( 'When I cancel storage add-on', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.clickOnPurchase( 'Storage Add-On Space Upgrade 50 GB', siteSlug! );
 				await purchasesPage.cancelPurchase();
 				await cancelSubscriptionFlow( page );
-				const snackbarComponent = new SnackbarComponent( page );
 				await snackbarComponent.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{ timeout: 30 * 1000 }
@@ -136,19 +134,16 @@ test.describe(
 			} );
 
 			await test.step( 'When I navigate to the purchases page to cancel the plan', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.visit();
 			} );
 
 			await test.step( 'When I cancel plan', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.clickOnPurchase( `WordPress.com ${ planName }`, siteSlug! );
 				await purchasesPage.cancelPurchase();
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
-				const snackbarComponent = new SnackbarComponent( page );
 				await snackbarComponent.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{ timeout: 30 * 1000 }

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -2,13 +2,11 @@ import {
 	BrowserManager,
 	CartCheckoutPage,
 	DataHelper,
-	MeSidebarComponent,
-	MyProfilePage,
 	NewUserResponse,
-	NoticeComponent,
 	PlansPage,
 	PurchasesPage,
 	RestAPIClient,
+	SnackbarComponent,
 	UserSignupPage,
 	cancelAtomicPurchaseFlow,
 	cancelSubscriptionFlow,
@@ -51,10 +49,7 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'As a new user, I can purchase a hosted site and cancel it', async ( { page } ) => {
+		test( 'As a new user, I can purchase a hosted site and cancel it', async ( { page } ) => {
 			// ~360s of dominant waits (90s purchase + 180s Atomic transfer + 30s
 			// checkout + two 30s refund notices) plus signup, billing and two
 			// cancellation navigations; 420s covers the worst case.
@@ -107,52 +102,55 @@ test.describe(
 
 			await test.step( 'Then I wait for the Atomic transfer to complete', async () => {
 				await page.waitForURL( /.*transferring-hosted-site.*/ );
-				await page.waitForURL( /wp-admin/, { timeout: 180 * 1000 } );
+
+				// The flow exits to wp-admin when the site's admin-interface option says
+				// so, and to the dashboard's site overview otherwise. Which one wins is
+				// a race on that option being loaded, so accept either: this test cares
+				// about the purchases that follow, not where the transfer lands.
+				await page.waitForURL( /wp-admin|\/sites\/[^/?#]+/, { timeout: 180 * 1000 } );
 			} );
 
-			await test.step( 'Then I am in WP Admin', async () => {
-				await page.waitForURL( /wp-admin/ );
-				siteSlug = new URL( page.url() ).hostname;
+			await test.step( 'Then I capture the slug of the transferred site', async () => {
+				// wp-admin: https://<slug>/wp-admin/
+				// Site overview: https://my.wordpress.com/sites/<slug>
+				const url = new URL( page.url() );
+				siteSlug = url.pathname.startsWith( '/sites/' )
+					? ( url.pathname.split( '/' ).pop() as string )
+					: url.hostname;
 			} );
 
-			await test.step( 'When I navigate to Me > Purchases to cancel add-on', async () => {
-				const mePage = new MyProfilePage( page );
-				await mePage.visit();
-				const meSidebarComponent = new MeSidebarComponent( page );
-				await meSidebarComponent.openMobileMenu();
-				await meSidebarComponent.navigate( 'Purchases' );
+			await test.step( 'When I navigate to the purchases page to cancel the add-on', async () => {
+				const purchasesPage = new PurchasesPage( page );
+				await purchasesPage.visit();
 			} );
 
 			await test.step( 'When I cancel storage add-on', async () => {
 				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.clickOnPurchase( 'Storage Add-On Space Upgrade 50 GB', siteSlug! );
-				await purchasesPage.cancelPurchase( 'Cancel subscription' );
+				await purchasesPage.cancelPurchase();
 				await cancelSubscriptionFlow( page );
-				const noticeComponent = new NoticeComponent( page );
-				await noticeComponent.noticeShown(
+				const snackbarComponent = new SnackbarComponent( page );
+				await snackbarComponent.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{ timeout: 30 * 1000 }
 				);
 			} );
 
-			await test.step( 'When I navigate to Me > Purchases to cancel plan', async () => {
-				const mePage = new MyProfilePage( page );
-				await mePage.visit();
-				const meSidebarComponent = new MeSidebarComponent( page );
-				await meSidebarComponent.openMobileMenu();
-				await meSidebarComponent.navigate( 'Purchases' );
+			await test.step( 'When I navigate to the purchases page to cancel the plan', async () => {
+				const purchasesPage = new PurchasesPage( page );
+				await purchasesPage.visit();
 			} );
 
 			await test.step( 'When I cancel plan', async () => {
 				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.clickOnPurchase( `WordPress.com ${ planName }`, siteSlug! );
-				await purchasesPage.cancelPurchase( 'Cancel plan' );
+				await purchasesPage.cancelPurchase();
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
-				const noticeComponent = new NoticeComponent( page );
-				await noticeComponent.noticeShown(
+				const snackbarComponent = new SnackbarComponent( page );
+				await snackbarComponent.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{ timeout: 30 * 1000 }
 				);

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -103,10 +103,9 @@ test.describe(
 			await test.step( 'Then I wait for the Atomic transfer to complete', async () => {
 				await page.waitForURL( /.*transferring-hosted-site.*/ );
 
-				// The flow exits to wp-admin when the site's admin-interface option says
-				// so, and to the dashboard's site overview otherwise. Which one wins is
-				// a race on that option being loaded, so accept either: this test cares
-				// about the purchases that follow, not where the transfer lands.
+				// The transfer lands on wp-admin or on the dashboard's site overview,
+				// depending on a race over the site's admin-interface option. Either is
+				// fine here; this test is about the purchases that follow.
 				await page.waitForURL( /wp-admin|\/sites\/[^/?#]+/, { timeout: 180 * 1000 } );
 			} );
 

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -22,10 +22,7 @@ test.describe(
 		let testUserThemeSignup: NewTestUserDetails;
 		let newSiteDetails: NewSiteResponse;
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page', async ( {
+		test( 'One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page', async ( {
 			flowLOHPThemeSignup,
 			helperData,
 			secrets,
@@ -142,7 +139,7 @@ test.describe(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug
 				);
-				await flowLOHPThemeSignup.purchasesPage.cancelPurchase( 'Cancel plan' );
+				await flowLOHPThemeSignup.purchasesPage.cancelPurchase();
 			} );
 
 			await test.step( 'And I confirm the cancellation', async function () {
@@ -150,7 +147,7 @@ test.describe(
 			} );
 
 			await test.step( 'Then I see a cancellation confirmation notice', async function () {
-				await flowLOHPThemeSignup.noticeComponent.noticeShown(
+				await flowLOHPThemeSignup.snackbarComponent.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{
 						timeout: 30000,

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
@@ -8,15 +8,13 @@ import {
 	DataHelper,
 	DomainSearchComponent,
 	LoggedOutThemesPage,
-	MeSidebarComponent,
-	MyProfilePage,
 	NewSiteResponse,
 	NewUserResponse,
-	NoticeComponent,
 	PurchasesPage,
 	RestAPIClient,
 	SecretsManager,
 	SignupPickPlanPage,
+	SnackbarComponent,
 	ThemesPage,
 	UserSignupPage,
 	cancelAtomicPurchaseFlow,
@@ -52,10 +50,7 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'Signup, purchase, and cancel a Premium theme plan', async ( { page } ) => {
+		test( 'Signup, purchase, and cancel a Premium theme plan', async ( { page } ) => {
 			// Signup + purchase + atomic cancel stacks a 90s purchase timeout
 			// with several 30s waits; the 120s config default is not enough.
 			test.setTimeout( 240 * 1000 );
@@ -133,13 +128,9 @@ test.describe(
 				expect( theme ).toContain( themeSlug );
 			} );
 
-			await test.step( 'Navigate to Me > Purchases', async () => {
-				const mePage = new MyProfilePage( page );
-				await mePage.visit();
-
-				const meSidebarComponent = new MeSidebarComponent( page );
-				await meSidebarComponent.openMobileMenu();
-				await meSidebarComponent.navigate( 'Purchases' );
+			await test.step( 'Navigate to the purchases page', async () => {
+				const purchasesPage = new PurchasesPage( page );
+				await purchasesPage.visit();
 			} );
 
 			await test.step( 'View details of purchased plan and cancel plan', async () => {
@@ -149,13 +140,13 @@ test.describe(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug
 				);
-				await purchasesPage.cancelPurchase( 'Cancel plan' );
+				await purchasesPage.cancelPurchase();
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
-				const noticeComponent = new NoticeComponent( page );
-				await noticeComponent.noticeShown(
+				const snackbarComponent = new SnackbarComponent( page );
+				await snackbarComponent.snackbarShown(
 					'Your refund has been processed and your purchase removed.',
 					{ timeout: 30 * 1000 }
 				);

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
@@ -128,14 +128,13 @@ test.describe(
 				expect( theme ).toContain( themeSlug );
 			} );
 
+			const purchasesPage = new PurchasesPage( page );
+
 			await test.step( 'Navigate to the purchases page', async () => {
-				const purchasesPage = new PurchasesPage( page );
 				await purchasesPage.visit();
 			} );
 
 			await test.step( 'View details of purchased plan and cancel plan', async () => {
-				const purchasesPage = new PurchasesPage( page );
-
 				await purchasesPage.clickOnPurchase(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug


### PR DESCRIPTION
## Proposed Changes

* Re-enable the six E2E tests skipped by #112586 and #112594, migrating their purchase-cancellation steps to the Multi-site Dashboard.
* Point the purchases page object at the dashboard's Active upgrades screens, and rewrite the cancellation survey flows for the dashboard's UI.
* Add a snackbar component, since the dashboard reports success through a snackbar rather than a classic Calypso notice.
* Fix the new-hosted-site test's post-transfer assertion, which no longer always lands on wp-admin.
* Fail with an explanatory error if a test's user turns out not to be enrolled in the rollout.

<img width="677" height="629" alt="image" src="https://github.com/user-attachments/assets/4974f5be-24d7-4aca-8946-dfb1ced4b2eb" />

## Why are these changes being made?

#112587 lowered the new-user threshold so that **every** newly registered user is force-enrolled in the hosting dashboard rollout. Every one of these tests signs up a new user, so they are all now redirected off the classic surfaces they were driving, and were skipped rather than fixed at the time.

The breakage is narrower than "onboarding". Signup, domain search, plan selection and checkout still run in classic Calypso and were unaffected. What broke is the "Me → Purchases → cancel the plan" tail that all six tests share: `/me`, `/me/purchases` and the purchase detail/cancel routes now redirect enrolled users to the dashboard.

The page objects for those classic screens were used by these five spec files and nothing else, so they could be moved to the dashboard outright rather than made to handle both worlds.

Two things would have silently broken a naive port:

* The dashboard cancels through a different endpoint than classic, so the flow's wait-for-response matcher never fired and would have hung until timeout.
* The success message is a snackbar, which the existing notice component cannot see.

Separately, the new-hosted-site test asserted it lands in wp-admin after the Atomic transfer. The transfer flow exits to wp-admin only when the site's admin-interface option says so, and to the dashboard's site overview otherwise — and which one wins is a race on that option being loaded. Observed both outcomes across runs, so the test now accepts either; it cares about the purchases that follow, not where the transfer lands.

Also worth flagging for review: the lifecycle test previously wrapped its cancellation assertion in a `try/catch` that swallowed failures, and never completed the cancellation survey — so it could not have been verifying cancellation at all. It now completes the survey and asserts the refund, and is correspondingly stricter.

## Testing Instructions

All six tests were run against production and pass:

* `specs/onboarding/signup__with-theme-premium.spec.ts`
* `specs/onboarding/signup__with-theme-LOHP.spec.ts`
* `specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts`
* `specs/onboarding/onboarding__new-hosted-site.spec.ts`
* `specs/flows/setup-domain__flows.spec.ts` (the two cancel-plan tests; the whole file passes)

```
cd test/e2e
CALYPSO_BASE_URL=https://wordpress.com yarn playwright test specs/onboarding --project=chrome --reporter=list
```

The setup-domain suite is gated on trunk, so it needs `BRANCH_NAME=trunk` to run locally.

## Considerations

The alternative was to opt these test users out of the rollout, leaving the tests exercising classic Calypso unchanged. That would have been a much smaller change, but it would test a cancellation path real new users can no longer reach, and would leave the dashboard's cancellation flow with no E2E coverage at all. Migrating matches the intent recorded on #112586.

The purchases page object deliberately enters through the classic URL and follows the redirect, rather than navigating straight to the dashboard host. The dashboard's origin varies by environment, and `DASHBOARD_BASE_URL` is not guaranteed to be set in every job that runs these tests; letting the app compute its own dashboard link avoids depending on it.

These tests only hold together because new users are enrolled *unconditionally* — a new signup's ID always clears the threshold, so the 50%-of-IDs cohort never comes into play for them. That is a load-bearing assumption living in a constant. If the threshold is ever raised past current signup IDs, or the rollout flag is turned off, new users fall back to the percentage cohort and these tests would fail roughly half the time — which reads as flakiness, not as a config regression. So a failure to redirect now throws a message naming the threshold and the flag, rather than timing out anonymously.

Worth noting as a consequence: since all six tests sign up new users, and new users no longer see classic Calypso, **the classic `/me/purchases` cancellation path is left with no E2E coverage**. Existing users outside the rollout cohort still use it. Happy to add a test pinned to a non-enrolled account if that surface is sticking around.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
