### PR TITLE
Help Center: gate Zendesk escalation on Smooch readiness and cap automatic retries

### DIFF
--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,5 +1,6 @@
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { __, sprintf } from '@wordpress/i18n';
+import { ERROR_TRY_AGAIN_LATER_MESSAGE_ID } from './utils/chat-utils';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
 declare const __i18n_text_domain__: string;
 
@@ -289,6 +290,7 @@ export const getErrorTryAgainLaterMessage = (): Message => {
 		role: 'bot',
 		type: 'message',
 		message_id: Math.floor( Math.random() * 1000 ),
+		internal_message_id: ERROR_TRY_AGAIN_LATER_MESSAGE_ID,
 		context: {
 			site_id: null,
 			flags: {

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -9,6 +9,7 @@ import {
 	getOdieRateLimitMessage,
 	getOdieEmailFallbackMessage,
 	getOdieErrorMessageNonEligible,
+	getOdieZendeskConnectionErrorMessage,
 	getExistingConversationMessage,
 	getConversationLimitReachedMessage,
 	ODIE_DEFAULT_BOT_SLUG_LEGACY,
@@ -19,7 +20,11 @@ import { useCreateZendeskConversation } from '../hooks';
 import { useLoggedOutSession } from '../hooks/use-logged-out-session';
 import { useOpenInteractionStatusMap } from '../hooks/use-open-interaction-status-map';
 import { generateUUID, getOdieIdFromInteraction, getIsRequestingHumanSupport } from '../utils';
-import { hasRecentEscalationAttempt } from '../utils/chat-utils';
+import {
+	countFailedEscalationAttempts,
+	hasRecentEscalationAttempt,
+	MAX_AUTOMATIC_ESCALATION_ATTEMPTS,
+} from '../utils/chat-utils';
 import { getOpenLiveInteractions } from '../utils/get-open-live-interactions';
 import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import { useManageSupportInteraction, broadcastOdieMessage } from '.';
@@ -219,6 +224,21 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						...prevChat,
 						...props,
 						messages: [ ...prevChat.messages, getExistingConversationMessage() ],
+						status: 'loaded',
+					} ) );
+					broadcastOdieMessage( message, odieBroadcastClientId );
+					return;
+				} else if ( countFailedEscalationAttempts( chat ) >= MAX_AUTOMATIC_ESCALATION_ATTEMPTS ) {
+					// Repeated failures mean Zendesk/Smooch is not recovering; stop the
+					// escalate→fail→retry loop and route the user to email support instead.
+					trackEvent( 'automatic_escalation_capped', {
+						odie_id: chat?.odieId,
+						failed_attempts: countFailedEscalationAttempts( chat ),
+					} );
+					setChat( ( prevChat ) => ( {
+						...prevChat,
+						...props,
+						messages: [ ...prevChat.messages, getOdieZendeskConnectionErrorMessage() ],
 						status: 'loaded',
 					} ) );
 					broadcastOdieMessage( message, odieBroadcastClientId );

--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -16,6 +16,15 @@ const mockSubmitUserFields = jest.fn();
 const mockAddEventToInteraction = jest.fn();
 const mockStartNewInteraction = jest.fn();
 let mockHasReachedLimit = false;
+const mockGetIsChatLoaded = jest.fn( () => true );
+
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( { getIsChatLoaded: mockGetIsChatLoaded } ),
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	HelpCenter: { register: () => 'automattic/help-center' },
+} ) );
 
 jest.mock( 'smooch', () => ( {
 	__esModule: true,
@@ -85,6 +94,7 @@ beforeEach( () => {
 	jest.clearAllMocks();
 	jest.useFakeTimers();
 	mockHasReachedLimit = false;
+	mockGetIsChatLoaded.mockReturnValue( true );
 	mockSubmitUserFields.mockResolvedValue( undefined );
 	// activeInteractionId === interaction.uuid, so updateConversation is skipped.
 	mockAddEventToInteraction.mockResolvedValue( { uuid: 'int-1' } );
@@ -170,6 +180,45 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 		expect( error.smooch_waited_ms ).toBeLessThanOrEqual( 10_000 );
 		// The user is shown the try-again message.
 		expect( mockSetChat ).toHaveBeenCalled();
+	} );
+
+	it( 'does not submit user fields when Smooch never becomes ready', async () => {
+		mockGetIsChatLoaded.mockReturnValue( false );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		const promise = result.current( { createdFrom: 'automatic_escalation' } );
+
+		await jest.advanceTimersByTimeAsync( 10_500 );
+
+		await expect( promise ).resolves.toBeUndefined();
+
+		expect( mockSubmitUserFields ).not.toHaveBeenCalled();
+		expect( smoochCreateConversation ).not.toHaveBeenCalled();
+
+		const error = lastTrackedProps( 'error_creating_zendesk_conversation' );
+		expect( error ).toBeDefined();
+		// The user is shown the try-again message.
+		expect( mockSetChat ).toHaveBeenCalled();
+	} );
+
+	it( 'submits user fields only after Smooch becomes ready', async () => {
+		mockGetIsChatLoaded.mockReturnValue( false );
+		smoochCreateConversation.mockResolvedValueOnce( { id: 'conv-1', metadata: {} } );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		const promise = result.current( { createdFrom: 'automatic_escalation' } );
+
+		await jest.advanceTimersByTimeAsync( 0 );
+		expect( mockSubmitUserFields ).not.toHaveBeenCalled();
+
+		mockGetIsChatLoaded.mockReturnValue( true );
+		await jest.advanceTimersByTimeAsync( 250 );
+
+		await expect( promise ).resolves.toBe( 'conv-1' );
+		expect( mockSubmitUserFields ).toHaveBeenCalledTimes( 1 );
+		expect( smoochCreateConversation ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not retry a non-transient error', async () => {

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,4 +1,6 @@
+import { HelpCenter, type HelpCenterSelect } from '@automattic/data-stores';
 import { useUpdateZendeskUserFields, type ZendeskConversation } from '@automattic/zendesk-client';
+import { select } from '@wordpress/data';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Smooch from 'smooch';
 import {
@@ -11,6 +13,13 @@ import { useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
 import { getOpenLiveInteractions } from '../utils/get-open-live-interactions';
 import { useOpenInteractionStatusMap } from './use-open-interaction-status-map';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+// Fresh read of the store on every call: the async loops below outlive the
+// closure's `isChatLoaded` snapshot from the render that created them.
+const getIsSmoochLoaded = () =>
+	( select( HELP_CENTER_STORE ) as unknown as HelpCenterSelect ).getIsChatLoaded();
 
 export const useCreateZendeskConversation = () => {
 	const {
@@ -135,6 +144,29 @@ export const useCreateZendeskConversation = () => {
 			status: 'transfer',
 		} ) );
 
+		const SMOOCH_READY_TIMEOUT_MS = 10000;
+		const SMOOCH_RETRY_INTERVAL_MS = 250;
+		const smoochReadyDeadline = Date.now() + SMOOCH_READY_TIMEOUT_MS;
+
+		// Wait for Smooch before touching Zendesk: the user-fields call below hits
+		// Zendesk's create-or-update-user API (5 req/min per user), so an escalation
+		// doomed to fail on `createConversation` must bail out before writing anything.
+		// The fields must still be submitted BEFORE the conversation is created —
+		// Zendesk copies them from the user record onto the ticket at creation time.
+		while ( ! getIsSmoochLoaded() ) {
+			const remainingMs = smoochReadyDeadline - Date.now();
+			if ( remainingMs <= 0 ) {
+				handleErrorCreatingZendeskConversation(
+					'error_creating_zendesk_conversation',
+					new Error( 'Smooch did not become ready before submitting user fields' )
+				);
+				return;
+			}
+			const sleepMs = Math.min( SMOOCH_RETRY_INTERVAL_MS, remainingMs );
+			smoochWaitedMs += sleepMs;
+			await new Promise( ( resolve ) => setTimeout( resolve, sleepMs ) );
+		}
+
 		try {
 			trackEvent( 'submitting_zendesk_user_fields', {
 				messaging_initial_message: userFieldMessage || undefined,
@@ -162,10 +194,6 @@ export const useCreateZendeskConversation = () => {
 
 		let conversation: ZendeskConversation | null = null;
 		let interaction = null;
-
-		const SMOOCH_READY_TIMEOUT_MS = 10000;
-		const SMOOCH_RETRY_INTERVAL_MS = 250;
-		const smoochReadyDeadline = Date.now() + SMOOCH_READY_TIMEOUT_MS;
 
 		for (;;) {
 			try {

--- a/packages/odie-client/src/utils/chat-utils.ts
+++ b/packages/odie-client/src/utils/chat-utils.ts
@@ -3,6 +3,15 @@ import type { Chat, OdieChat, OdieMessage, Message, LoggedOutOdieConversation } 
 
 const MAX_ESCALATION_ATTEMPT_TIME = 3 * 24 * 60 * 60 * 1000; // three days
 
+export const ERROR_TRY_AGAIN_LATER_MESSAGE_ID = 'error-try-again-later-message';
+
+export const MAX_AUTOMATIC_ESCALATION_ATTEMPTS = 3;
+
+export const countFailedEscalationAttempts = ( chat: Chat ) =>
+	chat?.messages?.filter(
+		( message ) => message.internal_message_id === ERROR_TRY_AGAIN_LATER_MESSAGE_ID
+	).length ?? 0;
+
 export const hasRecentEscalationAttempt = ( chat: Chat ) => {
 	if ( ! chat?.messages?.length ) {
 		return false;

--- a/packages/odie-client/src/utils/test/chat-utils.test.ts
+++ b/packages/odie-client/src/utils/test/chat-utils.test.ts
@@ -1,5 +1,15 @@
+jest.mock( '@automattic/zendesk-client', () => ( {
+	isTestModeEnvironment: () => false,
+} ) );
+
+import { getErrorTryAgainLaterMessage } from '../../constants';
 import { Chat, OdieChat } from '../../types';
-import { convertOdieChatToOdieConversation, hasRecentEscalationAttempt } from '../chat-utils';
+import {
+	convertOdieChatToOdieConversation,
+	countFailedEscalationAttempts,
+	hasRecentEscalationAttempt,
+	ERROR_TRY_AGAIN_LATER_MESSAGE_ID,
+} from '../chat-utils';
 
 // Helper to create a date string in the format 'YYYY-MM-DD HH:MM:SS'
 const formatDate = ( date: Date ): string => {
@@ -99,6 +109,51 @@ describe( 'hasRecentEscalationAttempt', () => {
 		};
 
 		expect( hasRecentEscalationAttempt( chat ) ).toBe( false );
+	} );
+} );
+
+describe( 'countFailedEscalationAttempts', () => {
+	const baseChat: Chat = {
+		messages: [],
+		conversationId: null,
+		provider: 'odie',
+		status: 'loaded',
+	};
+
+	it( 'returns 0 when chat is undefined', () => {
+		expect( countFailedEscalationAttempts( undefined as unknown as Chat ) ).toBe( 0 );
+	} );
+
+	it( 'returns 0 when there are no failed escalation messages', () => {
+		const chat: Chat = {
+			...baseChat,
+			messages: [
+				{ content: 'Hello', role: 'user', type: 'message' },
+				{ content: 'Hi there', role: 'bot', type: 'message' },
+			],
+		};
+
+		expect( countFailedEscalationAttempts( chat ) ).toBe( 0 );
+	} );
+
+	it( 'counts each failed escalation error message', () => {
+		const chat: Chat = {
+			...baseChat,
+			messages: [
+				{ content: 'Hello', role: 'user', type: 'message' },
+				getErrorTryAgainLaterMessage(),
+				{ content: 'Try again?', role: 'user', type: 'message' },
+				getErrorTryAgainLaterMessage(),
+			],
+		};
+
+		expect( countFailedEscalationAttempts( chat ) ).toBe( 2 );
+	} );
+
+	it( 'identifies failed escalations via the stable internal message id', () => {
+		expect( getErrorTryAgainLaterMessage().internal_message_id ).toBe(
+			ERROR_TRY_AGAIN_LATER_MESSAGE_ID
+		);
 	} );
 } );
 


### PR DESCRIPTION
## Proposed Changes

**Escalations to Zendesk now wait for the chat SDK to be ready before writing anything to Zendesk, and stop retrying automatically after three failed attempts.**

- `useCreateZendeskConversation` polls the Help Center store’s `isChatLoaded` (250ms interval, 10s deadline) before submitting user fields. If Smooch never becomes ready, the escalation bails out with the existing “try again later” message without touching Zendesk. Fields are still submitted before the conversation is created, so they keep landing on the ticket.
- The “try again later” error message now carries a stable `internal_message_id`, and `useSendOdieMessage` counts those in the chat: after 3 failed attempts, `automatic_escalation` stops retrying and shows the connection-error message instead, whose button routes to email support while chat is down. A new `automatic_escalation_capped` Tracks event records when this happens.

## Why are these changes being made?

Over the weekend of July 12 we hit repeated Zendesk API rate-limit alerts. The bulk of the 429s came from a single user stuck in an escalation loop: the chat SDK (Smooch) never finished initializing in their browser, and every escalation attempt first wrote the user’s support fields to Zendesk — an API limited to 5 requests per minute per user — and then failed to create the conversation. The failure reset the chat, the next bot reply re-triggered the escalation, and the cycle repeated ~900 times over two days.

Two gaps made that possible: we wrote to Zendesk before knowing the escalation could succeed, and nothing capped how many times an automatic escalation could retry. This PR closes both.

## Testing Instructions

### Calypso

1. Run `yarn start` and log in as a user eligible for paid support.
2. In DevTools → Network, add a request-blocking rule for `*smooch.io*` and reload, so the chat SDK never initializes.
3. Open the Help Center, chat with the AI assistant, and ask for a human.
4. Verify the escalation fails with the “Sorry, I couldn’t connect you to our support team” message after ~10 seconds, and that the Network tab shows **no** request to `update-user-fields`.
5. Trigger the escalation twice more. On the next attempt, verify the assistant no longer retries and instead shows the message offering email support, and that its button opens the email contact form.
6. Unblock `*smooch.io*`, reload, and escalate again: verify the normal flow still works — fields submitted, conversation created, chat transferred.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Repeat the steps above from the Help Center there.
