### PR TITLE
Marketplace: activate a plugin the atomic transfer installed

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -124,27 +124,24 @@ const MarketplaceProductInstall = ( {
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
 
-	// Guards the one activation this page dispatches. Also scopes the failure below to that attempt:
-	// the status persists by plugin id across the session, so a stale error from an earlier install
-	// must not count here — the checkout-driven flow, which never dispatches its own activation,
-	// would otherwise pick up someone else's failure.
-	const activationAttempted = useRef( false );
+	// The plugin this page activated, if any. Reading the activation status by this captured id keeps
+	// the failure stable while a poll is in flight (the installed-plugin selectors drop a site while
+	// its list is being fetched, so installedPlugin blinks out), and scopes it to our own attempt — a
+	// stale error from an earlier install, or the checkout-driven flow that never activates here, has
+	// no captured plugin and so does not count. The slug also survives the blink for the recovery link.
+	const activatedPlugin = useRef< { id: string; slug: string } | null >( null );
 
-	// Activation records a terminal status under the installed plugin's id. An activation_error just
-	// means the plugin was already active, so keep waiting for the refreshed active state; any other
-	// error is a real failure of our own attempt.
 	const activationStatus = useSelector( ( state ) =>
-		installedPlugin ? getStatusForPlugin( state, siteId, installedPlugin.id ) : undefined
+		activatedPlugin.current
+			? getStatusForPlugin( state, siteId, activatedPlugin.current.id )
+			: undefined
 	);
-	// The declared error type is a string, but a failed activation stores the raw error object.
-	const activationError = activationStatus?.error as string | { error?: string } | undefined;
-	const activationErrorCode =
-		typeof activationError === 'object' ? activationError?.error : activationError;
+	// Every terminal activation error is surfaced: activation_error is not reliably "already active"
+	// (the API returns it for a missing plugin file too), and polling continues regardless, so an
+	// already-active plugin still redirects once the refreshed list confirms it.
 	const activationFailed =
-		activationAttempted.current &&
 		activationStatus?.status === PLUGIN_INSTALLATION_ERROR &&
-		activationStatus.action === ACTIVATE_PLUGIN &&
-		activationErrorCode !== 'activation_error';
+		activationStatus.action === ACTIVATE_PLUGIN;
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -356,21 +353,21 @@ const MarketplaceProductInstall = ( {
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
 	// A transfer leaves the plugin installed but inactive, and it only turns up here once polling has
-	// fetched it. The ref (above) dispatches activation once, whatever the plugin state does between
-	// renders.
+	// fetched it. Capturing the id (above) both guards against a second dispatch and records which
+	// plugin we activated.
 	useEffect( () => {
 		if (
 			! canReconcilePlugin ||
 			currentStep !== 1 ||
 			! installedPlugin ||
 			installedPlugin.active ||
-			activationAttempted.current ||
+			activatedPlugin.current !== null ||
 			( isPluginUploadFlow && ! pluginUploadComplete )
 		) {
 			return;
 		}
 
-		activationAttempted.current = true;
+		activatedPlugin.current = { id: installedPlugin.id, slug: installedPlugin.slug };
 		setCurrentStep( 2 );
 		dispatch( activatePlugin( siteId, installedPlugin ) );
 	}, [
@@ -567,14 +564,15 @@ const MarketplaceProductInstall = ( {
 			);
 		}
 		// The plugin is installed, so the generic "upload it again" recovery below does not apply. Point
-		// at the plugin's own page, where it can be activated by hand.
-		if ( activationFailed ) {
+		// at the plugin's own page, where it can be activated by hand. Skip this once it reports active,
+		// which redirects instead — an already-active plugin can report a terminal error first.
+		if ( activationFailed && ! pluginActive ) {
 			return (
 				<EmptyContent
 					title={ null }
 					line={ translate( 'We installed the plugin, but could not activate it.' ) }
 					action={ translate( 'View plugin' ) }
-					actionURL={ `/plugins/${ pluginSlug }/${ selectedSiteSlug }` }
+					actionURL={ `/plugins/${ activatedPlugin.current?.slug }/${ selectedSiteSlug }` }
 				/>
 			);
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -322,6 +322,13 @@ const MarketplaceProductInstall = ( {
 		!! freshSite?.is_wpcom_atomic &&
 		wporgPlugin?.wporg === false;
 
+	// Unlike the theme flow, which only observes backend-owned activation, reconciling a plugin means
+	// dispatching activation and then leaving for a freshly discovered WP Admin URL. Gate both on the
+	// atomic site being ready, so we neither act nor redirect before that URL is real.
+	const canReconcilePlugin =
+		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
+		( ! ( atomicFlow || isMarketplacePluginFlow ) || isAtomicTransferReady );
+
 	// Poll the site plugins for the active state the same way the theme flow polls the active theme:
 	// once the flow is under way, until the server reports it active. The paid marketplace install is
 	// kicked off by checkout, so its step can still be 0 — cover it by its atomic-plugin shape too.
@@ -329,6 +336,7 @@ const MarketplaceProductInstall = ( {
 		!! pluginSlug &&
 		! pluginActive &&
 		! isFetchingSitePlugins &&
+		canReconcilePlugin &&
 		( currentStep !== 0 || isMarketplacePluginFlow );
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
@@ -343,10 +351,10 @@ const MarketplaceProductInstall = ( {
 			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
-			// A transferred plugin lands here once the refreshed site plugins report it active. It must be
-			// active first: the page this leaves for lists active plugins, and would not show an inactive
-			// one.
-			installedPlugin?.active ||
+			// A transferred plugin lands here once the refreshed site plugins report it active, and the
+			// site is ready for the WP Admin URL below. It must be active first: the page this leaves for
+			// lists active plugins, and would not show an inactive one.
+			( installedPlugin?.active && canReconcilePlugin ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
@@ -373,6 +381,7 @@ const MarketplaceProductInstall = ( {
 		uploadedPluginSlug,
 		pluginsUrlFinal,
 		isAtomicTransferReady,
+		canReconcilePlugin,
 	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	// Validate theme is already active

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -124,9 +124,15 @@ const MarketplaceProductInstall = ( {
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
 
+	// Guards the one activation this page dispatches. Also scopes the failure below to that attempt:
+	// the status persists by plugin id across the session, so a stale error from an earlier install
+	// must not count here — the checkout-driven flow, which never dispatches its own activation,
+	// would otherwise pick up someone else's failure.
+	const activationAttempted = useRef( false );
+
 	// Activation records a terminal status under the installed plugin's id. An activation_error just
 	// means the plugin was already active, so keep waiting for the refreshed active state; any other
-	// error is a real failure with no automatic recovery.
+	// error is a real failure of our own attempt.
 	const activationStatus = useSelector( ( state ) =>
 		installedPlugin ? getStatusForPlugin( state, siteId, installedPlugin.id ) : undefined
 	);
@@ -135,6 +141,7 @@ const MarketplaceProductInstall = ( {
 	const activationErrorCode =
 		typeof activationError === 'object' ? activationError?.error : activationError;
 	const activationFailed =
+		activationAttempted.current &&
 		activationStatus?.status === PLUGIN_INSTALLATION_ERROR &&
 		activationStatus.action === ACTIVATE_PLUGIN &&
 		activationErrorCode !== 'activation_error';
@@ -337,12 +344,11 @@ const MarketplaceProductInstall = ( {
 		( ! siteJustTransferred || ( isAtomicTransferReady && canManagePlugins ) );
 
 	// Poll for the active state like the theme flow polls the active theme: once the flow is under
-	// way, until the server reports it active. Stop on a genuine activation failure, which the error
-	// screen surfaces instead.
+	// way, until the server reports it active. Keep polling even after a reported activation failure:
+	// a lost response can follow a server-side success, and the refreshed list is what confirms it.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
 		! pluginActive &&
-		! activationFailed &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
 		installUnderway;
@@ -350,8 +356,8 @@ const MarketplaceProductInstall = ( {
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
 	// A transfer leaves the plugin installed but inactive, and it only turns up here once polling has
-	// fetched it. The ref dispatches activation once, whatever the plugin state does between renders.
-	const activationAttempted = useRef( false );
+	// fetched it. The ref (above) dispatches activation once, whatever the plugin state does between
+	// renders.
 	useEffect( () => {
 		if (
 			! canReconcilePlugin ||

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -71,9 +71,6 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
-// How long to wait for the plugin to install, and then for it to activate, before offering a way out.
-const RECONCILIATION_TIMEOUT = 60 * 1000;
-
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -334,41 +331,13 @@ const MarketplaceProductInstall = ( {
 	const isTransferredPluginFlow =
 		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	// An inactive plugin is missing from the active-only list the flow normally ends on.
-	const allPluginsUrl = freshAdminUrl ? `${ freshAdminUrl }plugins.php?plugin_status=all` : null;
-
 	const shouldReconcilePlugin = isTransferredPluginFlow || isMarketplacePluginFlow;
 
-	// The progress step is the stable phase signal: step 1 is installing, step 2 activating. Unlike
-	// whether the plugin is momentarily visible, it does not flicker between polls.
-	const setupPhase = currentStep === 2 ? 'activation' : 'installation';
-
-	const [ timedOutPhase, setTimedOutPhase ] = useState< 'installation' | 'activation' | null >(
-		null
-	);
-
 	// Poll until the plugin is active, not just present: an activation can be reported ambiguously, so
-	// only a refreshed active state ends the wait. Stop while this phase is timed out, and skip a tick
-	// while a request is already in flight.
-	const shouldFetchPlugin =
-		shouldReconcilePlugin &&
-		! pluginActive &&
-		timedOutPhase !== setupPhase &&
-		! isFetchingSitePlugins;
+	// only a refreshed active state ends the wait. Skip a tick while a request is already in flight.
+	const shouldFetchPlugin = shouldReconcilePlugin && ! pluginActive && ! isFetchingSitePlugins;
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
-
-	// Each phase gets its own deadline: when the step advances the phase changes, discarding the
-	// install timer so activation gets a fresh window. Timing out offers a way out, not a dead end.
-	useEffect( () => {
-		if ( ! shouldReconcilePlugin || pluginActive || timedOutPhase === setupPhase ) {
-			return;
-		}
-
-		const timeout = setTimeout( () => setTimedOutPhase( setupPhase ), RECONCILIATION_TIMEOUT );
-
-		return () => clearTimeout( timeout );
-	}, [ shouldReconcilePlugin, pluginActive, setupPhase, timedOutPhase ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
@@ -446,39 +415,8 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	// Restart the wait. Clearing the phase resumes polling; a timed-out activation is dispatched
-	// again directly, since the step has already advanced past the effect that would do it.
-	const retryPluginSetup = () => {
-		const phase = timedOutPhase;
-		setTimedOutPhase( null );
-
-		if ( phase === 'activation' && installedPlugin ) {
-			dispatch( activatePlugin( siteId, installedPlugin ) );
-		}
-	};
-
 	const renderError = () => {
 		// Evaluate error causes in priority order
-		if ( timedOutPhase && ! pluginActive ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={
-						timedOutPhase === 'activation'
-							? translate(
-									'The plugin was installed, but we could not activate it. You can activate it yourself from your plugins.'
-							  )
-							: translate(
-									'The plugin is taking longer than expected to install. You can check your plugins to see whether it arrived.'
-							  )
-					}
-					action={ translate( 'Try again' ) }
-					actionCallback={ retryPluginSetup }
-					secondaryAction={ translate( 'View all plugins' ) }
-					secondaryActionURL={ allPluginsUrl ?? undefined }
-				/>
-			);
-		}
 		if ( nonInstallablePlanError ) {
 			return (
 				<EmptyContent

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -71,6 +71,9 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
+// 3s polls, so a minute of waiting for the transferred plugin to be activated.
+const MAX_ACTIVATION_POLLS = 20;
+
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -327,9 +330,30 @@ const MarketplaceProductInstall = ( {
 		!! freshSite?.is_wpcom_atomic &&
 		wporgPlugin?.wporg === false;
 
+	// The transfer installs the plugin but leaves it inactive, and the effect above only activates a
+	// plugin this component can see. Poll once the transfer is done so the plugin reaches the store
+	// and that effect can fire.
+	const [ activationPolls, setActivationPolls ] = useState( 0 );
+	const gaveUpOnActivation = activationPolls >= MAX_ACTIVATION_POLLS;
+
+	const isAwaitingTransferredPlugin =
+		atomicFlow &&
+		! isPluginUploadFlow &&
+		!! pluginSlug &&
+		transferStates.COMPLETE === automatedTransferStatus;
+
 	useInterval(
-		() => dispatch( fetchSitePlugins( siteId ) ),
-		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
+		() => {
+			dispatch( fetchSitePlugins( siteId ) );
+
+			if ( isAwaitingTransferredPlugin ) {
+				setActivationPolls( ( polls ) => polls + 1 );
+			}
+		},
+		( isMarketplacePluginFlow && ! pluginActive ) ||
+			( isAwaitingTransferredPlugin && ! pluginActive && ! gaveUpOnActivation )
+			? 3000
+			: null
 	);
 
 	const canManagePlugins = useSelector( ( state ) => {
@@ -343,11 +367,13 @@ const MarketplaceProductInstall = ( {
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
 			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic using a marketplace plugin
+			// Transfer to atomic using a marketplace plugin. A plugin waits to be activated first: the
+			// page it lands on lists active plugins, and wouldn't hold the one just installed.
 			( atomicFlow &&
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins &&
-				isAtomicTransferReady ) ||
+				isAtomicTransferReady &&
+				( ! pluginSlug || pluginActive || gaveUpOnActivation ) ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
@@ -375,6 +401,8 @@ const MarketplaceProductInstall = ( {
 		uploadedPluginSlug,
 		pluginsUrlFinal,
 		isAtomicTransferReady,
+		pluginSlug,
+		gaveUpOnActivation,
 	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	// Validate theme is already active

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -71,10 +71,6 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
-// How long after activation begins before offering a manual way to the plugins list. Not a failure
-// point: polling carries on, and this only appears for someone who does not want to keep waiting.
-const MANUAL_ESCAPE_DELAY = 5 * 60 * 1000;
-
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -295,9 +291,6 @@ const MarketplaceProductInstall = ( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
-	// The unfiltered list, so an inactive plugin is still visible, for the manual escape below.
-	const allPluginsUrl = freshAdminUrl ? `${ freshAdminUrl }plugins.php?plugin_status=all` : null;
-
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
@@ -399,21 +392,6 @@ const MarketplaceProductInstall = ( {
 		isAtomicTransferReady,
 		canReconcilePlugin,
 	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
-
-	// Five minutes after activation is dispatched — the step advances to activating — reveal a manual
-	// way out. Clears itself if the plugin goes active first, which redirects instead.
-	const [ manualEscapeVisible, setManualEscapeVisible ] = useState( false );
-	useEffect( () => {
-		if ( currentStep !== 2 || pluginActive ) {
-			return;
-		}
-
-		const timer = setTimeout( () => setManualEscapeVisible( true ), MANUAL_ESCAPE_DELAY );
-
-		return () => clearTimeout( timer );
-	}, [ currentStep, pluginActive ] );
-
-	const showManualEscape = manualEscapeVisible && ! pluginActive && !! allPluginsUrl;
 
 	// Validate theme is already active
 	useEffect( () => {
@@ -605,22 +583,11 @@ const MarketplaceProductInstall = ( {
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
 				{ renderError() || (
-					<div className="marketplace-plugin-install__progress">
-						<MarketplaceProgressBar
-							steps={ steps }
-							currentStep={ currentStep }
-							additionalSteps={ additionalSteps }
-						/>
-						{ showManualEscape && (
-							<Button
-								plain
-								className="marketplace-plugin-install__manual-escape"
-								href={ allPluginsUrl ?? undefined }
-							>
-								{ translate( 'This is taking a while. View all plugins' ) }
-							</Button>
-						) }
-					</div>
+					<MarketplaceProgressBar
+						steps={ steps }
+						currentStep={ currentStep }
+						additionalSteps={ additionalSteps }
+					/>
 				) }
 			</div>
 		</ThemeProvider>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -71,6 +71,10 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
+// How long after activation begins before offering a manual way to the plugins list. Not a failure
+// point: polling carries on, and this only appears for someone who does not want to keep waiting.
+const MANUAL_ESCAPE_DELAY = 5 * 60 * 1000;
+
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -291,6 +295,9 @@ const MarketplaceProductInstall = ( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
+	// The unfiltered list, so an inactive plugin is still visible, for the manual escape below.
+	const allPluginsUrl = freshAdminUrl ? `${ freshAdminUrl }plugins.php?plugin_status=all` : null;
+
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
@@ -392,6 +399,21 @@ const MarketplaceProductInstall = ( {
 		isAtomicTransferReady,
 		canReconcilePlugin,
 	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
+
+	// Five minutes after activation is dispatched — the step advances to activating — reveal a manual
+	// way out. Clears itself if the plugin goes active first, which redirects instead.
+	const [ manualEscapeVisible, setManualEscapeVisible ] = useState( false );
+	useEffect( () => {
+		if ( currentStep !== 2 || pluginActive ) {
+			return;
+		}
+
+		const timer = setTimeout( () => setManualEscapeVisible( true ), MANUAL_ESCAPE_DELAY );
+
+		return () => clearTimeout( timer );
+	}, [ currentStep, pluginActive ] );
+
+	const showManualEscape = manualEscapeVisible && ! pluginActive && !! allPluginsUrl;
 
 	// Validate theme is already active
 	useEffect( () => {
@@ -583,11 +605,22 @@ const MarketplaceProductInstall = ( {
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
 				{ renderError() || (
-					<MarketplaceProgressBar
-						steps={ steps }
-						currentStep={ currentStep }
-						additionalSteps={ additionalSteps }
-					/>
+					<div className="marketplace-plugin-install__progress">
+						<MarketplaceProgressBar
+							steps={ steps }
+							currentStep={ currentStep }
+							additionalSteps={ additionalSteps }
+						/>
+						{ showManualEscape && (
+							<Button
+								plain
+								className="marketplace-plugin-install__manual-escape"
+								href={ allPluginsUrl ?? undefined }
+							>
+								{ translate( 'This is taking a while. View all plugins' ) }
+							</Button>
+						) }
+					</div>
 				) }
 			</div>
 		</ThemeProvider>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -268,26 +268,6 @@ const MarketplaceProductInstall = ( {
 		isJetpack,
 	] );
 
-	// A completed transfer is not a finished installation: it leaves the plugin inactive, and the
-	// plugin only turns up here once polling below has fetched it. Finding it ends the install step.
-	// The ref makes the activation happen once, whatever the plugin state does between renders.
-	const activationAttempted = useRef( false );
-	useEffect( () => {
-		if (
-			currentStep !== 1 ||
-			! installedPlugin ||
-			installedPlugin.active ||
-			activationAttempted.current ||
-			( isPluginUploadFlow && ! pluginUploadComplete )
-		) {
-			return;
-		}
-
-		activationAttempted.current = true;
-		setCurrentStep( 2 );
-		dispatch( activatePlugin( siteId, installedPlugin ) );
-	}, [ currentStep, installedPlugin, isPluginUploadFlow, pluginUploadComplete, dispatch, siteId ] );
-
 	// Fetch fresh site data (including admin_url) post-transfer
 	const { data: freshSite } = useQuery( {
 		...siteByIdQuery( siteId ?? 0 ),
@@ -340,6 +320,35 @@ const MarketplaceProductInstall = ( {
 		( currentStep !== 0 || isMarketplacePluginFlow );
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
+
+	// A completed transfer is not a finished installation: it leaves the plugin inactive, and the
+	// plugin only turns up here once polling above has fetched it. Finding it ends the install step.
+	// The ref makes the activation happen once, whatever the plugin state does between renders.
+	const activationAttempted = useRef( false );
+	useEffect( () => {
+		if (
+			! canReconcilePlugin ||
+			currentStep !== 1 ||
+			! installedPlugin ||
+			installedPlugin.active ||
+			activationAttempted.current ||
+			( isPluginUploadFlow && ! pluginUploadComplete )
+		) {
+			return;
+		}
+
+		activationAttempted.current = true;
+		setCurrentStep( 2 );
+		dispatch( activatePlugin( siteId, installedPlugin ) );
+	}, [
+		canReconcilePlugin,
+		currentStep,
+		installedPlugin,
+		isPluginUploadFlow,
+		pluginUploadComplete,
+		dispatch,
+		siteId,
+	] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,6 +21,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
+import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -42,6 +43,7 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -309,16 +311,26 @@ const MarketplaceProductInstall = ( {
 		!! freshSite?.is_wpcom_atomic &&
 		wporgPlugin?.wporg === false;
 
+	const canManagePlugins = useSelector( ( state ) =>
+		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
+	);
+
 	// Unlike the theme flow, which only observes backend-owned activation, reconciling a plugin means
 	// dispatching activation and then leaving for a freshly discovered WP Admin URL. Gate both on the
-	// atomic site being ready, so we neither act nor redirect before that URL is real.
+	// atomic site being ready, and its manage-plugins capability having propagated, so we neither act
+	// nor redirect before that is true — a rejected one-shot activation would never be retried.
 	const canReconcilePlugin =
 		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
-		( ! ( atomicFlow || isMarketplacePluginFlow ) || isAtomicTransferReady );
+		( ! ( atomicFlow || isMarketplacePluginFlow ) ||
+			( isAtomicTransferReady && canManagePlugins ) );
 
 	// A failed install with nothing installed is terminal — the error screen shows it, so stop
-	// polling. A failure that still left a plugin behind is a partial success worth reconciling.
-	const installFailed = !! pluginInstallStatus?.error && ! installedPlugin;
+	// polling. Read the current status, not a lingering error field the reducer keeps across a retry.
+	// A failure that still left a plugin behind is a partial success worth reconciling.
+	const installFailed =
+		pluginInstallStatus?.status === PLUGIN_INSTALLATION_ERROR &&
+		pluginInstallStatus.action === INSTALL_PLUGIN &&
+		! installedPlugin;
 
 	// Poll the site plugins for the active state the same way the theme flow polls the active theme:
 	// once the flow is under way, until the server reports it active. The paid marketplace install is
@@ -362,9 +374,6 @@ const MarketplaceProductInstall = ( {
 		siteId,
 	] );
 
-	const canManagePlugins = useSelector( ( state ) => {
-		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
-	} );
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -74,8 +74,13 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
-// How long to wait for the plugin to install, and then for it to activate.
+// How long to wait for the plugin to install, and then for it to activate, before saying it is
+// taking too long. Waiting carries on after that, more slowly.
 const SETUP_TIMEOUT = 60 * 1000;
+const POLL_INTERVAL = 3 * 1000;
+const SLOW_POLL_INTERVAL = 15 * 1000;
+
+type SetupStage = 'installation' | 'activation';
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -339,8 +344,13 @@ const MarketplaceProductInstall = ( {
 	const isTransferredPluginFlow =
 		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	const [ setupTimedOut, setSetupTimedOut ] = useState( false );
-	const setupStage = installedPlugin ? 'activation' : 'installation';
+	// The plugin has to be installed before it can be activated, and either one can be what the page
+	// is still waiting on.
+	const setupStage: SetupStage | null = pluginActive
+		? null
+		: ( installedPlugin && 'activation' ) || 'installation';
+
+	const isSetupPending = ( isTransferredPluginFlow || isMarketplacePluginFlow ) && !! setupStage;
 
 	const activationFailed = useSelector(
 		( state ) =>
@@ -354,23 +364,27 @@ const MarketplaceProductInstall = ( {
 			)
 	);
 
-	const isAwaitingPlugin =
-		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! pluginActive && ! setupTimedOut;
+	const [ timedOutStage, setTimedOutStage ] = useState< SetupStage | null >( null );
+	const [ retries, setRetries ] = useState( 0 );
 
-	// Poll until the plugin turns up, which is what lets the activation effect above run.
-	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), isAwaitingPlugin ? 3000 : null );
-
-	// Installing and activating are timed one after the other, so a slow install does not eat the
-	// time the activation that follows it gets.
+	// Each stage gets its own time, so a slow install does not eat the time the activation that
+	// follows it gets. Running out of it says so and keeps waiting, since the work is the backend's
+	// and a late plugin should still land on its own.
 	useEffect( () => {
-		if ( ! isAwaitingPlugin ) {
+		setTimedOutStage( null );
+
+		if ( ! isSetupPending || ! setupStage ) {
 			return;
 		}
 
-		const timeout = setTimeout( () => setSetupTimedOut( true ), SETUP_TIMEOUT );
+		const timeout = setTimeout( () => setTimedOutStage( setupStage ), SETUP_TIMEOUT );
 
 		return () => clearTimeout( timeout );
-	}, [ isAwaitingPlugin, setupStage ] );
+	}, [ isSetupPending, setupStage, retries ] );
+
+	// Poll until the plugin turns up, which is what lets the activation effect above run.
+	const pollInterval = timedOutStage ? SLOW_POLL_INTERVAL : POLL_INTERVAL;
+	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), isSetupPending ? pollInterval : null );
 
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
@@ -444,34 +458,38 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	// A plugin that never turned up is looked for again. One that did turn up is past its activation
-	// step, so activate it again by hand.
+	// A plugin that did turn up is past its activation step, so activate it again by hand. One that
+	// never turned up is only looked for again: finishing the install is the backend's to do, not
+	// this page's to ask for twice.
 	const retryPluginSetup = () => {
-		setSetupTimedOut( false );
+		setRetries( ( count ) => count + 1 );
 
 		if ( installedPlugin ) {
 			dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) );
-		} else {
-			dispatch( fetchSitePlugins( siteId ) );
+			return;
 		}
+
+		dispatch( fetchSitePlugins( siteId ) );
 	};
 
 	const renderError = () => {
 		// Evaluate error causes in priority order
-		if ( ( setupTimedOut || activationFailed ) && ! pluginActive ) {
+		if ( timedOutStage || activationFailed ) {
 			return (
 				<EmptyContent
 					title={ null }
 					line={
 						installedPlugin
 							? translate(
-									'We installed the plugin, but we could not activate it. You can activate it yourself from your plugins.'
+									'We installed the plugin, but we could not activate it. We are still trying, and you can activate it yourself from your plugins.'
 							  )
 							: translate(
-									'The plugin is taking longer than expected to install. You can check your plugins to see whether it arrived.'
+									'The plugin is taking longer than expected to install. We are still waiting for it, and you can check your plugins to see whether it arrived.'
 							  )
 					}
-					action={ translate( 'Try again' ) }
+					action={
+						installedPlugin ? translate( 'Try activating again' ) : translate( 'Check again' )
+					}
 					actionCallback={ retryPluginSetup }
 					secondaryAction={ translate( 'View all plugins' ) }
 					secondaryActionURL={ allPluginsUrl ?? undefined }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -566,14 +566,15 @@ const MarketplaceProductInstall = ( {
 				/>
 			);
 		}
-		// The plugin is installed, so the generic "upload it again" recovery below does not apply.
+		// The plugin is installed, so the generic "upload it again" recovery below does not apply. Point
+		// at the plugin's own page, where it can be activated by hand.
 		if ( activationFailed ) {
 			return (
 				<EmptyContent
 					title={ null }
-					line={ translate(
-						'We installed the plugin, but could not activate it. You can activate it yourself from your plugins.'
-					) }
+					line={ translate( 'We installed the plugin, but could not activate it.' ) }
+					action={ translate( 'View plugin' ) }
+					actionURL={ `/plugins/${ pluginSlug }/${ selectedSiteSlug }` }
 				/>
 			);
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,7 +21,6 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
-import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -41,10 +40,8 @@ import {
 import {
 	getPluginOnSite,
 	getStatusForPlugin,
-	isPluginActionStatus,
 	isPluginActive,
 } from 'calypso/state/plugins/installed/selectors-ts';
-import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -73,14 +70,6 @@ import {
 import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
-
-// How long to wait for the plugin to install, and then for it to activate, before saying it is
-// taking too long. Waiting carries on after that, more slowly.
-const SETUP_TIMEOUT = 60 * 1000;
-const POLL_INTERVAL = 3 * 1000;
-const SLOW_POLL_INTERVAL = 15 * 1000;
-
-type SetupStage = 'installation' | 'activation';
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -321,9 +310,6 @@ const MarketplaceProductInstall = ( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
-	// An inactive plugin is missing from the active-only list the flow normally ends on.
-	const allPluginsUrl = freshAdminUrl ? `${ freshAdminUrl }plugins.php?plugin_status=all` : null;
-
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
@@ -335,57 +321,20 @@ const MarketplaceProductInstall = ( {
 		!! freshSite?.is_wpcom_atomic &&
 		wporgPlugin?.wporg === false;
 
-	const canManagePlugins = useSelector( ( state ) => {
-		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
-	} );
-
 	// The transfer installs the plugin itself, so the site comes back with a plugin nothing here has
 	// fetched yet.
 	const isTransferredPluginFlow =
 		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	// The plugin has to be installed before it can be activated, and either one can be what the page
-	// is still waiting on.
-	const setupStage: SetupStage | null = pluginActive
-		? null
-		: ( installedPlugin && 'activation' ) || 'installation';
-
-	const isSetupPending = ( isTransferredPluginFlow || isMarketplacePluginFlow ) && !! setupStage;
-
-	const activationFailed = useSelector(
-		( state ) =>
-			!! installedPlugin &&
-			isPluginActionStatus(
-				state,
-				siteId,
-				installedPlugin.id,
-				ACTIVATE_PLUGIN,
-				PLUGIN_INSTALLATION_ERROR
-			)
+	// Poll until the plugin turns up, which is what lets the activation effect above run.
+	useInterval(
+		() => dispatch( fetchSitePlugins( siteId ) ),
+		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! pluginActive ? 3000 : null
 	);
 
-	const [ timedOutStage, setTimedOutStage ] = useState< SetupStage | null >( null );
-	const [ retries, setRetries ] = useState( 0 );
-
-	// Each stage gets its own time, so a slow install does not eat the time the activation that
-	// follows it gets. Running out of it says so and keeps waiting, since the work is the backend's
-	// and a late plugin should still land on its own.
-	useEffect( () => {
-		setTimedOutStage( null );
-
-		if ( ! isSetupPending || ! setupStage ) {
-			return;
-		}
-
-		const timeout = setTimeout( () => setTimedOutStage( setupStage ), SETUP_TIMEOUT );
-
-		return () => clearTimeout( timeout );
-	}, [ isSetupPending, setupStage, retries ] );
-
-	// Poll until the plugin turns up, which is what lets the activation effect above run.
-	const pollInterval = timedOutStage ? SLOW_POLL_INTERVAL : POLL_INTERVAL;
-	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), isSetupPending ? pollInterval : null );
-
+	const canManagePlugins = useSelector( ( state ) => {
+		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+	} );
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
@@ -458,44 +407,8 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	// A plugin that did turn up is past its activation step, so activate it again by hand. One that
-	// never turned up is only looked for again: finishing the install is the backend's to do, not
-	// this page's to ask for twice.
-	const retryPluginSetup = () => {
-		setRetries( ( count ) => count + 1 );
-
-		if ( installedPlugin ) {
-			dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) );
-			return;
-		}
-
-		dispatch( fetchSitePlugins( siteId ) );
-	};
-
 	const renderError = () => {
 		// Evaluate error causes in priority order
-		if ( timedOutStage || activationFailed ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={
-						installedPlugin
-							? translate(
-									'We installed the plugin, but we could not activate it. We are still trying, and you can activate it yourself from your plugins.'
-							  )
-							: translate(
-									'The plugin is taking longer than expected to install. We are still waiting for it, and you can check your plugins to see whether it arrived.'
-							  )
-					}
-					action={
-						installedPlugin ? translate( 'Try activating again' ) : translate( 'Check again' )
-					}
-					actionCallback={ retryPluginSetup }
-					secondaryAction={ translate( 'View all plugins' ) }
-					secondaryActionURL={ allPluginsUrl ?? undefined }
-				/>
-			);
-		}
 		if ( nonInstallablePlanError ) {
 			return (
 				<EmptyContent

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -71,8 +71,8 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
-// 3s polls, so a minute of waiting for the transferred plugin to be activated.
-const MAX_ACTIVATION_POLLS = 20;
+// How long to keep waiting for a transferred plugin to install and activate.
+const ACTIVATION_TIMEOUT = 60 * 1000;
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -271,14 +271,9 @@ const MarketplaceProductInstall = ( {
 		isJetpack,
 	] );
 
-	// Validate completion of atomic transfer flow
-	useEffect( () => {
-		if ( atomicFlow && currentStep === 1 && transferStates.COMPLETE === automatedTransferStatus ) {
-			setCurrentStep( 2 );
-		}
-	}, [ atomicFlow, automatedTransferStatus, currentStep ] );
-
-	// Validate plugin is already installed and activate
+	// Validate plugin is already installed and activate. A transfer installs the plugin without
+	// activating it, and the plugin only turns up here once polling below has fetched it, so this is
+	// what ends the install step: a completed transfer is not a finished installation.
 	useEffect( () => {
 		if (
 			installedPlugin &&
@@ -293,8 +288,7 @@ const MarketplaceProductInstall = ( {
 			);
 			setCurrentStep( 2 );
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
+	}, [ pluginUploadComplete, installedPlugin, currentStep, isPluginUploadFlow, dispatch, siteId ] );
 
 	// Fetch fresh site data (including admin_url) post-transfer
 	const { data: freshSite } = useQuery( {
@@ -319,6 +313,9 @@ const MarketplaceProductInstall = ( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
+	// An inactive plugin is missing from the active-only list the flow normally ends on.
+	const allPluginsUrl = freshAdminUrl ? `${ freshAdminUrl }plugins.php?plugin_status=all` : null;
+
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
@@ -330,35 +327,39 @@ const MarketplaceProductInstall = ( {
 		!! freshSite?.is_wpcom_atomic &&
 		wporgPlugin?.wporg === false;
 
-	// The transfer installs the plugin but leaves it inactive, and the effect above only activates a
-	// plugin this component can see. Poll once the transfer is done so the plugin reaches the store
-	// and that effect can fire.
-	const [ activationPolls, setActivationPolls ] = useState( 0 );
-	const gaveUpOnActivation = activationPolls >= MAX_ACTIVATION_POLLS;
+	const canManagePlugins = useSelector( ( state ) => {
+		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+	} );
 
-	const isAwaitingTransferredPlugin =
+	// The transfer installs the plugin on its own, so the site comes back with a plugin nothing here
+	// has fetched yet.
+	const isTransferredPluginFlow =
 		atomicFlow &&
-		! isPluginUploadFlow &&
-		!! pluginSlug &&
-		transferStates.COMPLETE === automatedTransferStatus;
+		transferStates.COMPLETE === automatedTransferStatus &&
+		isAtomicTransferReady &&
+		canManagePlugins;
 
+	const [ activationTimedOut, setActivationTimedOut ] = useState( false );
+
+	// Poll until the plugin turns up, which is what lets the activation effect above run.
 	useInterval(
-		() => {
-			dispatch( fetchSitePlugins( siteId ) );
-
-			if ( isAwaitingTransferredPlugin ) {
-				setActivationPolls( ( polls ) => polls + 1 );
-			}
-		},
-		( isMarketplacePluginFlow && ! pluginActive ) ||
-			( isAwaitingTransferredPlugin && ! pluginActive && ! gaveUpOnActivation )
+		() => dispatch( fetchSitePlugins( siteId ) ),
+		( isMarketplacePluginFlow || ( isTransferredPluginFlow && ! activationTimedOut ) ) &&
+			! pluginActive
 			? 3000
 			: null
 	);
 
-	const canManagePlugins = useSelector( ( state ) => {
-		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
-	} );
+	useEffect( () => {
+		if ( ! isTransferredPluginFlow || pluginActive || activationTimedOut ) {
+			return;
+		}
+
+		const timeout = setTimeout( () => setActivationTimedOut( true ), ACTIVATION_TIMEOUT );
+
+		return () => clearTimeout( timeout );
+	}, [ isTransferredPluginFlow, pluginActive, activationTimedOut ] );
+
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
@@ -367,13 +368,9 @@ const MarketplaceProductInstall = ( {
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
 			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic using a marketplace plugin. A plugin waits to be activated first: the
-			// page it lands on lists active plugins, and wouldn't hold the one just installed.
-			( atomicFlow &&
-				transferStates.COMPLETE === automatedTransferStatus &&
-				canManagePlugins &&
-				isAtomicTransferReady &&
-				( ! pluginSlug || pluginActive || gaveUpOnActivation ) ) ||
+			// Transfer to atomic using a marketplace plugin. The plugin has to be active first: the page
+			// this lands on lists active plugins, and would not show the one just installed.
+			( isTransferredPluginFlow && pluginActive ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
@@ -401,8 +398,7 @@ const MarketplaceProductInstall = ( {
 		uploadedPluginSlug,
 		pluginsUrlFinal,
 		isAtomicTransferReady,
-		pluginSlug,
-		gaveUpOnActivation,
+		isTransferredPluginFlow,
 	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	// Validate theme is already active
@@ -439,8 +435,32 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
+	// Resuming the poll is enough to install a plugin that never turned up. One that did turn up is
+	// past its activation step, so activate it again by hand.
+	const retryActivation = () => {
+		setActivationTimedOut( false );
+
+		if ( installedPlugin ) {
+			dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) );
+		}
+	};
+
 	const renderError = () => {
 		// Evaluate error causes in priority order
+		if ( activationTimedOut && ! pluginActive ) {
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						'We installed the plugin, but we could not activate it. You can activate it yourself from your plugins.'
+					) }
+					action={ translate( 'Try again' ) }
+					actionCallback={ retryActivation }
+					secondaryAction={ translate( 'View all plugins' ) }
+					secondaryActionURL={ allPluginsUrl ?? undefined }
+				/>
+			);
+		}
 		if ( nonInstallablePlanError ) {
 			return (
 				<EmptyContent

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,6 +21,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
+import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -42,6 +43,7 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -121,6 +123,21 @@ const MarketplaceProductInstall = ( {
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
+
+	// Activation records a terminal status under the installed plugin's id. An activation_error just
+	// means the plugin was already active, so keep waiting for the refreshed active state; any other
+	// error is a real failure with no automatic recovery.
+	const activationStatus = useSelector( ( state ) =>
+		installedPlugin ? getStatusForPlugin( state, siteId, installedPlugin.id ) : undefined
+	);
+	// The declared error type is a string, but a failed activation stores the raw error object.
+	const activationError = activationStatus?.error as string | { error?: string } | undefined;
+	const activationErrorCode =
+		typeof activationError === 'object' ? activationError?.error : activationError;
+	const activationFailed =
+		activationStatus?.status === PLUGIN_INSTALLATION_ERROR &&
+		activationStatus.action === ACTIVATE_PLUGIN &&
+		activationErrorCode !== 'activation_error';
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -320,10 +337,12 @@ const MarketplaceProductInstall = ( {
 		( ! siteJustTransferred || ( isAtomicTransferReady && canManagePlugins ) );
 
 	// Poll for the active state like the theme flow polls the active theme: once the flow is under
-	// way, until the server reports it active.
+	// way, until the server reports it active. Stop on a genuine activation failure, which the error
+	// screen surfaces instead.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
 		! pluginActive &&
+		! activationFailed &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
 		installUnderway;
@@ -545,6 +564,7 @@ const MarketplaceProductInstall = ( {
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
+			activationFailed ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,7 +21,6 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
-import { ACTIVATE_PLUGIN, INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -40,10 +39,9 @@ import {
 } from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
-	isPluginActionStatus,
+	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
-import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -72,6 +70,9 @@ import {
 import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
+
+// How long to wait for the plugin to install, and then for it to activate, before offering a way out.
+const RECONCILIATION_TIMEOUT = 60 * 1000;
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -120,27 +121,8 @@ const MarketplaceProductInstall = ( {
 
 	const isFetchingSitePlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
-	// Installing keys its status by the wporg id, activating by the installed plugin's, so each
-	// failure is read under its own id and action rather than one guessed from the current step.
-	const installFailed = useSelector( ( state ) =>
-		isPluginActionStatus(
-			state,
-			siteId,
-			wporgPlugin?.id ?? pluginSlug,
-			INSTALL_PLUGIN,
-			PLUGIN_INSTALLATION_ERROR
-		)
-	);
-	const activationFailed = useSelector(
-		( state ) =>
-			!! installedPlugin &&
-			isPluginActionStatus(
-				state,
-				siteId,
-				installedPlugin.id,
-				ACTIVATE_PLUGIN,
-				PLUGIN_INSTALLATION_ERROR
-			)
+	const pluginInstallStatus = useSelector( ( state ) =>
+		getStatusForPlugin( state, siteId, pluginSlug )
 	);
 
 	const productsList = useSelector( getProductsList );
@@ -292,19 +274,17 @@ const MarketplaceProductInstall = ( {
 	// A completed transfer is not a finished installation: it leaves the plugin inactive, and the
 	// plugin only turns up here once polling below has fetched it. Finding it ends the install step.
 	useEffect( () => {
-		const pluginReady =
-			installedPlugin && currentStep === 1 && ( ! isPluginUploadFlow || pluginUploadComplete );
-
-		if ( ! pluginReady ) {
+		if (
+			! installedPlugin ||
+			pluginActive ||
+			currentStep !== 1 ||
+			( isPluginUploadFlow && ! pluginUploadComplete )
+		) {
 			return;
 		}
 
 		setCurrentStep( 2 );
-
-		// A plugin that arrived already active needs no activation request.
-		if ( ! pluginActive ) {
-			dispatch( activatePlugin( siteId, installedPlugin ) );
-		}
+		dispatch( activatePlugin( siteId, installedPlugin ) );
 	}, [
 		installedPlugin,
 		pluginActive,
@@ -354,14 +334,35 @@ const MarketplaceProductInstall = ( {
 	const isTransferredPluginFlow =
 		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	const isWaitingForPlugin =
-		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! installedPlugin;
+	// An inactive plugin is missing from the active-only list the flow normally ends on.
+	const allPluginsUrl = freshAdminUrl ? `${ freshAdminUrl }plugins.php?plugin_status=all` : null;
 
-	// Poll until the plugin turns up, which lets the activation effect above run; activating it
-	// updates the store, so nothing is left to poll for. The fetch flag avoids overlapping requests.
-	const shouldFetchPlugin = isWaitingForPlugin && ! isFetchingSitePlugins;
+	const shouldReconcilePlugin = isTransferredPluginFlow || isMarketplacePluginFlow;
+
+	// Two phases with one poll: find the plugin, then wait for it to be active. Its active state comes
+	// from the refreshed site plugins, which is authoritative in a way an activation response is not.
+	const reconciliationPhase = installedPlugin ? 'activation' : 'installation';
+
+	const [ reconciliationTimedOut, setReconciliationTimedOut ] = useState( false );
+
+	// Poll until the plugin is active, not just present: an activation can be reported ambiguously, so
+	// only a refreshed active state ends the wait. The fetch flag avoids overlapping requests.
+	const shouldFetchPlugin =
+		shouldReconcilePlugin && ! pluginActive && ! reconciliationTimedOut && ! isFetchingSitePlugins;
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
+
+	// Each phase gets its own deadline: when the plugin appears the phase changes, discarding the
+	// install timer so activation gets a fresh window. Timing out offers a way out, not a dead end.
+	useEffect( () => {
+		if ( ! shouldReconcilePlugin || pluginActive || reconciliationTimedOut ) {
+			return;
+		}
+
+		const timeout = setTimeout( () => setReconciliationTimedOut( true ), RECONCILIATION_TIMEOUT );
+
+		return () => clearTimeout( timeout );
+	}, [ shouldReconcilePlugin, pluginActive, reconciliationPhase, reconciliationTimedOut ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
@@ -373,9 +374,10 @@ const MarketplaceProductInstall = ( {
 			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
-			// A transferred plugin lands here once polling has found and activated it. It must be active
-			// first: the page this leaves for lists active plugins, and would not show an inactive one.
-			( installedPlugin && pluginActive ) ||
+			// A transferred plugin lands here once the refreshed site plugins report it active. It must be
+			// active first: the page this leaves for lists active plugins, and would not show an inactive
+			// one.
+			installedPlugin?.active ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
@@ -438,10 +440,38 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	const pluginSetupFailed = installFailed || activationFailed;
+	// Restart the wait. A found-but-inactive plugin is sent back to the activation step so the effect
+	// runs again; a missing one just resumes polling once the deadline is cleared.
+	const retryPluginSetup = () => {
+		setReconciliationTimedOut( false );
+
+		if ( installedPlugin && ! pluginActive ) {
+			setCurrentStep( 1 );
+		}
+	};
 
 	const renderError = () => {
 		// Evaluate error causes in priority order
+		if ( reconciliationTimedOut && ! pluginActive ) {
+			return (
+				<EmptyContent
+					title={ null }
+					line={
+						installedPlugin
+							? translate(
+									'The plugin was installed, but we could not activate it. You can activate it yourself from your plugins.'
+							  )
+							: translate(
+									'The plugin is taking longer than expected to install. You can check your plugins to see whether it arrived.'
+							  )
+					}
+					action={ translate( 'Try again' ) }
+					actionCallback={ retryPluginSetup }
+					secondaryAction={ translate( 'View all plugins' ) }
+					secondaryActionURL={ allPluginsUrl ?? undefined }
+				/>
+			);
+		}
 		if ( nonInstallablePlanError ) {
 			return (
 				<EmptyContent
@@ -554,7 +584,7 @@ const MarketplaceProductInstall = ( {
 		// Catch the rest of the error cases.
 		if (
 			pluginUploadError ||
-			pluginSetupFailed ||
+			pluginInstallStatus?.error ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,6 +21,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
+import { ACTIVATE_PLUGIN, INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -43,6 +44,7 @@ import {
 	isPluginActive,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -277,15 +279,28 @@ const MarketplaceProductInstall = ( {
 	// activating it, and the plugin only turns up here once polling below has fetched it, so this is
 	// what ends the install step: a completed transfer is not a finished installation.
 	useEffect( () => {
-		if (
-			installedPlugin &&
-			currentStep === 1 &&
-			( ! isPluginUploadFlow || ( isPluginUploadFlow && pluginUploadComplete ) )
-		) {
-			dispatch( activatePlugin( siteId, installedPlugin ) );
-			setCurrentStep( 2 );
+		const pluginReady =
+			installedPlugin && currentStep === 1 && ( ! isPluginUploadFlow || pluginUploadComplete );
+
+		if ( ! pluginReady ) {
+			return;
 		}
-	}, [ pluginUploadComplete, installedPlugin, currentStep, isPluginUploadFlow, dispatch, siteId ] );
+
+		setCurrentStep( 2 );
+
+		// A plugin that arrived already active needs no activation request.
+		if ( ! pluginActive ) {
+			dispatch( activatePlugin( siteId, installedPlugin ) );
+		}
+	}, [
+		installedPlugin,
+		pluginActive,
+		currentStep,
+		isPluginUploadFlow,
+		pluginUploadComplete,
+		dispatch,
+		siteId,
+	] );
 
 	// Fetch fresh site data (including admin_url) post-transfer
 	const { data: freshSite } = useQuery( {
@@ -326,14 +341,15 @@ const MarketplaceProductInstall = ( {
 	const isTransferredPluginFlow =
 		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	// Poll until the plugin turns up, which is what lets the activation effect above run. Activating
-	// it updates the store itself, so there is nothing left to poll for after that.
-	const shouldPollForPlugin =
-		( isTransferredPluginFlow || isMarketplacePluginFlow ) &&
-		! installedPlugin &&
-		! isFetchingSitePlugins;
+	const isWaitingForPlugin =
+		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! installedPlugin;
 
-	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldPollForPlugin ? 3000 : null );
+	// Poll until the plugin turns up, which is what lets the activation effect above run. Activating
+	// it updates the store itself, so there is nothing left to poll for after that. The fetch flag
+	// keeps a slow request from overlapping the next tick.
+	const shouldFetchPlugin = isWaitingForPlugin && ! isFetchingSitePlugins;
+
+	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
@@ -409,6 +425,13 @@ const MarketplaceProductInstall = ( {
 		];
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
+
+	// A retained error from an unrelated action should not surface, so match the failure to the step
+	// the page is on: installing on step 1, activating on step 2.
+	const pluginSetupFailed =
+		pluginInstallStatus?.status === PLUGIN_INSTALLATION_ERROR &&
+		( ( currentStep === 1 && pluginInstallStatus.action === INSTALL_PLUGIN ) ||
+			( currentStep === 2 && pluginInstallStatus.action === ACTIVATE_PLUGIN ) );
 
 	const renderError = () => {
 		// Evaluate error causes in priority order
@@ -524,7 +547,7 @@ const MarketplaceProductInstall = ( {
 		// Catch the rest of the error cases.
 		if (
 			pluginUploadError ||
-			pluginInstallStatus?.error ||
+			pluginSetupFailed ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -41,6 +41,7 @@ import {
 	getPluginOnSite,
 	getStatusForPlugin,
 	isPluginActive,
+	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
@@ -118,9 +119,13 @@ const MarketplaceProductInstall = ( {
 		getAutomatedTransferStatus( state, siteId )
 	);
 
+	// Installing keys the status by the wporg plugin's id, activating by the installed plugin's, so
+	// the id to read a status under changes once the plugin is on the site.
+	const pluginStatusId = installedPlugin?.id ?? wporgPlugin?.id ?? pluginSlug;
 	const pluginInstallStatus = useSelector( ( state ) =>
-		getStatusForPlugin( state, siteId, pluginSlug )
+		getStatusForPlugin( state, siteId, pluginStatusId )
 	);
+	const isFetchingSitePlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -277,12 +282,7 @@ const MarketplaceProductInstall = ( {
 			currentStep === 1 &&
 			( ! isPluginUploadFlow || ( isPluginUploadFlow && pluginUploadComplete ) )
 		) {
-			dispatch(
-				activatePlugin( siteId, {
-					slug: installedPlugin?.slug,
-					id: installedPlugin?.id,
-				} )
-			);
+			dispatch( activatePlugin( siteId, installedPlugin ) );
 			setCurrentStep( 2 );
 		}
 	}, [ pluginUploadComplete, installedPlugin, currentStep, isPluginUploadFlow, dispatch, siteId ] );
@@ -326,11 +326,14 @@ const MarketplaceProductInstall = ( {
 	const isTransferredPluginFlow =
 		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	// Poll until the plugin turns up, which is what lets the activation effect above run.
-	useInterval(
-		() => dispatch( fetchSitePlugins( siteId ) ),
-		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! pluginActive ? 3000 : null
-	);
+	// Poll until the plugin turns up, which is what lets the activation effect above run. Activating
+	// it updates the store itself, so there is nothing left to poll for after that.
+	const shouldPollForPlugin =
+		( isTransferredPluginFlow || isMarketplacePluginFlow ) &&
+		! installedPlugin &&
+		! isFetchingSitePlugins;
+
+	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldPollForPlugin ? 3000 : null );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,6 +21,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
+import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -42,6 +43,7 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -121,6 +123,23 @@ const MarketplaceProductInstall = ( {
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
+
+	// Activation status is recorded under the installed plugin's id, not the slug.
+	const activationStatus = useSelector( ( state ) =>
+		installedPlugin ? getStatusForPlugin( state, siteId, installedPlugin.id ) : undefined
+	);
+
+	// The declared error type is a string, but a failed activation stores the raw error object.
+	const activationError = activationStatus?.error as string | { error?: string } | undefined;
+	const activationErrorCode =
+		typeof activationError === 'object' ? activationError?.error : activationError;
+
+	// An activation_error means the plugin was already active, so it is not a failure: keep waiting
+	// for the refreshed active state. Any other activation error is real.
+	const activationFailed =
+		activationStatus?.action === ACTIVATE_PLUGIN &&
+		activationStatus.status === PLUGIN_INSTALLATION_ERROR &&
+		activationErrorCode !== 'activation_error';
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -270,27 +289,23 @@ const MarketplaceProductInstall = ( {
 
 	// A completed transfer is not a finished installation: it leaves the plugin inactive, and the
 	// plugin only turns up here once polling below has fetched it. Finding it ends the install step.
+	// The ref makes the activation happen once, whatever the plugin state does between renders.
+	const activationAttempted = useRef( false );
 	useEffect( () => {
 		if (
-			! installedPlugin ||
-			pluginActive ||
 			currentStep !== 1 ||
+			! installedPlugin ||
+			installedPlugin.active ||
+			activationAttempted.current ||
 			( isPluginUploadFlow && ! pluginUploadComplete )
 		) {
 			return;
 		}
 
+		activationAttempted.current = true;
 		setCurrentStep( 2 );
 		dispatch( activatePlugin( siteId, installedPlugin ) );
-	}, [
-		installedPlugin,
-		pluginActive,
-		currentStep,
-		isPluginUploadFlow,
-		pluginUploadComplete,
-		dispatch,
-		siteId,
-	] );
+	}, [ currentStep, installedPlugin, isPluginUploadFlow, pluginUploadComplete, dispatch, siteId ] );
 
 	// Fetch fresh site data (including admin_url) post-transfer
 	const { data: freshSite } = useQuery( {
@@ -334,8 +349,10 @@ const MarketplaceProductInstall = ( {
 	const shouldReconcilePlugin = isTransferredPluginFlow || isMarketplacePluginFlow;
 
 	// Poll until the plugin is active, not just present: an activation can be reported ambiguously, so
-	// only a refreshed active state ends the wait. Skip a tick while a request is already in flight.
-	const shouldFetchPlugin = shouldReconcilePlugin && ! pluginActive && ! isFetchingSitePlugins;
+	// a refreshed active state settles it. Stop on a genuine failure, and skip a tick while a request
+	// is already in flight.
+	const shouldFetchPlugin =
+		shouldReconcilePlugin && ! pluginActive && ! activationFailed && ! isFetchingSitePlugins;
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
@@ -530,6 +547,7 @@ const MarketplaceProductInstall = ( {
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
+			activationFailed ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -566,11 +566,21 @@ const MarketplaceProductInstall = ( {
 				/>
 			);
 		}
+		// The plugin is installed, so the generic "upload it again" recovery below does not apply.
+		if ( activationFailed ) {
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						'We installed the plugin, but could not activate it. You can activate it yourself from your plugins.'
+					) }
+				/>
+			);
+		}
 		// Catch the rest of the error cases.
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
-			activationFailed ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -306,23 +306,27 @@ const MarketplaceProductInstall = ( {
 		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
 	);
 
+	// A checkout-driven marketplace install reaches this page on an already-transferred site without
+	// advancing the step machine, so it stands in for both "the site just transferred" and "the flow
+	// is under way" that the other flows express through atomicFlow and currentStep.
+	const siteJustTransferred = atomicFlow || isMarketplacePluginFlow;
+	const installUnderway = currentStep !== 0 || isMarketplacePluginFlow;
+
 	// Reconciling dispatches activation and then leaves for a freshly discovered WP Admin URL, so gate
-	// on the atomic site being ready and its manage-plugins capability having propagated: a rejected
-	// one-shot activation would never be retried.
+	// on the transferred site being ready and its manage-plugins capability having propagated: a
+	// rejected one-shot activation would never be retried.
 	const canReconcilePlugin =
 		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
-		( ! ( atomicFlow || isMarketplacePluginFlow ) ||
-			( isAtomicTransferReady && canManagePlugins ) );
+		( ! siteJustTransferred || ( isAtomicTransferReady && canManagePlugins ) );
 
 	// Poll for the active state like the theme flow polls the active theme: once the flow is under
-	// way, until the server reports it active. A checkout-driven marketplace install can sit at step 0,
-	// so cover it by its atomic-plugin shape too.
+	// way, until the server reports it active.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
 		! pluginActive &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
-		( currentStep !== 0 || isMarketplacePluginFlow );
+		installUnderway;
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
@@ -381,7 +385,6 @@ const MarketplaceProductInstall = ( {
 			} );
 		}
 	}, [
-		pluginActive,
 		automatedTransferStatus,
 		isPluginUploadFlow,
 		isAtomic,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -40,8 +40,7 @@ import {
 } from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
-	getStatusForPlugin,
-	isPluginActive,
+	isPluginActionStatus,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
 import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
@@ -114,20 +113,35 @@ const MarketplaceProductInstall = ( {
 	const installedPlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, siteId, isPluginUploadFlow ? uploadedPluginSlug : pluginSlug )
 	);
-	const pluginActive = useSelector( ( state ) =>
-		isPluginActive( state, siteId, isPluginUploadFlow ? uploadedPluginSlug : pluginSlug )
-	);
+	const pluginActive = !! installedPlugin?.active;
 	const automatedTransferStatus = useSelector( ( state ) =>
 		getAutomatedTransferStatus( state, siteId )
 	);
 
-	// Installing keys the status by the wporg plugin's id, activating by the installed plugin's, so
-	// the id to read a status under changes once the plugin is on the site.
-	const pluginStatusId = installedPlugin?.id ?? wporgPlugin?.id ?? pluginSlug;
-	const pluginInstallStatus = useSelector( ( state ) =>
-		getStatusForPlugin( state, siteId, pluginStatusId )
-	);
 	const isFetchingSitePlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
+
+	// Installing keys its status by the wporg id, activating by the installed plugin's, so each
+	// failure is read under its own id and action rather than one guessed from the current step.
+	const installFailed = useSelector( ( state ) =>
+		isPluginActionStatus(
+			state,
+			siteId,
+			wporgPlugin?.id ?? pluginSlug,
+			INSTALL_PLUGIN,
+			PLUGIN_INSTALLATION_ERROR
+		)
+	);
+	const activationFailed = useSelector(
+		( state ) =>
+			!! installedPlugin &&
+			isPluginActionStatus(
+				state,
+				siteId,
+				installedPlugin.id,
+				ACTIVATE_PLUGIN,
+				PLUGIN_INSTALLATION_ERROR
+			)
+	);
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -275,9 +289,8 @@ const MarketplaceProductInstall = ( {
 		isJetpack,
 	] );
 
-	// Validate plugin is already installed and activate. A transfer installs the plugin without
-	// activating it, and the plugin only turns up here once polling below has fetched it, so this is
-	// what ends the install step: a completed transfer is not a finished installation.
+	// A completed transfer is not a finished installation: it leaves the plugin inactive, and the
+	// plugin only turns up here once polling below has fetched it. Finding it ends the install step.
 	useEffect( () => {
 		const pluginReady =
 			installedPlugin && currentStep === 1 && ( ! isPluginUploadFlow || pluginUploadComplete );
@@ -344,9 +357,8 @@ const MarketplaceProductInstall = ( {
 	const isWaitingForPlugin =
 		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! installedPlugin;
 
-	// Poll until the plugin turns up, which is what lets the activation effect above run. Activating
-	// it updates the store itself, so there is nothing left to poll for after that. The fetch flag
-	// keeps a slow request from overlapping the next tick.
+	// Poll until the plugin turns up, which lets the activation effect above run; activating it
+	// updates the store, so nothing is left to poll for. The fetch flag avoids overlapping requests.
 	const shouldFetchPlugin = isWaitingForPlugin && ! isFetchingSitePlugins;
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
@@ -361,8 +373,8 @@ const MarketplaceProductInstall = ( {
 			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
-			// A transferred plugin also lands here, once polling has found it and activated it. It has to
-			// be active first: the page this leaves for lists active plugins, and would not show it.
+			// A transferred plugin lands here once polling has found and activated it. It must be active
+			// first: the page this leaves for lists active plugins, and would not show an inactive one.
 			( installedPlugin && pluginActive ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
@@ -426,12 +438,7 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	// A retained error from an unrelated action should not surface, so match the failure to the step
-	// the page is on: installing on step 1, activating on step 2.
-	const pluginSetupFailed =
-		pluginInstallStatus?.status === PLUGIN_INSTALLATION_ERROR &&
-		( ( currentStep === 1 && pluginInstallStatus.action === INSTALL_PLUGIN ) ||
-			( currentStep === 2 && pluginInstallStatus.action === ACTIVATE_PLUGIN ) );
+	const pluginSetupFailed = installFailed || activationFailed;
 
 	const renderError = () => {
 		// Evaluate error causes in priority order

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -1,4 +1,4 @@
-import { siteByIdQuery } from '@automattic/api-queries';
+import { siteByIdQuery, sitePluginActiveQuery } from '@automattic/api-queries';
 import {
 	PLAN_BUSINESS,
 	WPCOM_FEATURES_ATOMIC,
@@ -33,16 +33,8 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getPurchaseFlowState } from 'calypso/state/marketplace/purchase-flow/selectors';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
-import {
-	installPlugin,
-	activatePlugin,
-	fetchSitePlugins,
-} from 'calypso/state/plugins/installed/actions';
-import {
-	getPluginOnSite,
-	getStatusForPlugin,
-	isRequesting,
-} from 'calypso/state/plugins/installed/selectors-ts';
+import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
+import { getPluginOnSite, getStatusForPlugin } from 'calypso/state/plugins/installed/selectors-ts';
 import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
@@ -72,6 +64,17 @@ import {
 import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
+
+// The plugin-active endpoint returns 503 for a transient read failure (keep polling) and 502/other
+// for a terminal one (stop and surface it).
+function isTerminalPluginActiveError( error: unknown ): boolean {
+	const status = ( error as { status?: number } | null | undefined )?.status;
+	return status != null && status !== 503;
+}
+
+// How many times to (re)dispatch activation while the endpoint keeps reporting the plugin inactive
+// before treating it as a failed activation. The poll interval spaces the attempts out.
+const MAX_ACTIVATION_ATTEMPTS = 3;
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -117,8 +120,6 @@ const MarketplaceProductInstall = ( {
 		getAutomatedTransferStatus( state, siteId )
 	);
 
-	const isFetchingSitePlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
-
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
@@ -155,6 +156,15 @@ const MarketplaceProductInstall = ( {
 			productSlugInstalled &&
 			[ pluginSlug, themeSlug ].includes( productSlugInstalled ) &&
 			primaryDomain === selectedSiteSlug
+		);
+	} );
+
+	// A checkout handed this plugin off to this page for installation, whether that install is still
+	// in progress or already completed (so it is broader than marketplaceInstallationInProgress).
+	const marketplacePluginHandoff = useSelector( ( state ) => {
+		const { productSlugInstalled, primaryDomain } = getPurchaseFlowState( state as IAppState );
+		return (
+			!! pluginSlug && productSlugInstalled === pluginSlug && primaryDomain === selectedSiteSlug
 		);
 	} );
 
@@ -295,65 +305,98 @@ const MarketplaceProductInstall = ( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
-	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
-	// is initiated during checkout, not by this component. The wporg data is unavailable,
-	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// so that the existing redirect (installedPlugin?.active) fires.
-	const isMarketplacePluginFlow =
-		! atomicFlow &&
-		! isPluginUploadFlow &&
-		!! pluginSlug &&
-		!! freshSite?.is_wpcom_atomic &&
-		wporgPlugin?.wporg === false;
-
 	const canManagePlugins = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
 	);
 
-	// A checkout-driven marketplace install reaches this page on an already-transferred site without
-	// advancing the step machine, so it stands in for both "the site just transferred" and "the flow
-	// is under way" that the other flows express through atomicFlow and currentStep.
-	const siteJustTransferred = atomicFlow || isMarketplacePluginFlow;
-	const installUnderway = currentStep !== 0 || isMarketplacePluginFlow;
+	// An install was actually requested through this page — it started one (so the step left 0), or a
+	// checkout handed one off — rather than the user simply opening the install URL.
+	const installationRequested = currentStep !== 0 || marketplacePluginHandoff;
 
-	// Reconciling dispatches activation and then leaves for a freshly discovered WP Admin URL, so gate
-	// on the transferred site being ready and its manage-plugins capability having propagated: a
-	// rejected one-shot activation would never be retried.
-	const canReconcilePlugin =
-		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
-		( ! siteJustTransferred || ( isAtomicTransferReady && canManagePlugins ) );
+	// The transferred site is ready for its WP Admin URL and can manage plugins. Stronger than
+	// is_wpcom_atomic: isAtomicTransferReady also requires the manage_options capability to have
+	// propagated, so we neither activate nor redirect before WP Admin is usable.
+	const canReconcilePlugin = isAtomicTransferReady && canManagePlugins;
 
-	// A local install this page started (not a transfer or checkout-driven one) that terminally failed
-	// with no plugin to show for it. Read the current status and action, not the error field the
-	// reducer keeps across retries, and scope it to our own attempt so a stale error elsewhere does
-	// not count. A partial success — a plugin exists and may still activate — is not a failure.
+	// A local install this page started that terminally failed with no plugin to reconcile. Read the
+	// current status and action, not the error field the reducer keeps across retries.
 	const localInstallFailed =
 		installFlowInitiatedRef.current &&
-		! atomicFlow &&
-		! isMarketplacePluginFlow &&
 		! installedPlugin &&
 		pluginInstallStatus?.status === PLUGIN_INSTALLATION_ERROR &&
 		pluginInstallStatus.action === INSTALL_PLUGIN;
 
-	// Poll for the active state like the theme flow polls the active theme: once the flow is under
-	// way, until the server reports it active. Keep polling even after a reported activation failure:
-	// a lost response can follow a server-side success, and the refreshed list is what confirms it.
-	const shouldFetchPlugin =
+	// Activation retries are bounded (below); once exhausted, stop polling and show the failure.
+	const [ activationFailed, setActivationFailed ] = useState( false );
+
+	// Poll the read-only active-status endpoint to learn when the plugin is on, for the Atomic
+	// wp.org-slug flows. It never installs or activates — the transfer-with-software step does — so
+	// this replaces inferring state from the plugin list. The query itself is ephemeral so a stale
+	// `complete` from an earlier install can't drive an immediate redirect.
+	const shouldPollPluginActive =
 		!! pluginSlug &&
-		! installedPlugin?.active &&
-		! localInstallFailed &&
-		! isFetchingSitePlugins &&
+		! isPluginUploadFlow &&
+		installationRequested &&
 		canReconcilePlugin &&
-		installUnderway;
+		! localInstallFailed &&
+		! activationFailed;
 
-	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
+	const {
+		data: pluginActiveState,
+		error: pluginActiveError,
+		dataUpdatedAt: pluginActiveUpdatedAt,
+	} = useQuery( {
+		...sitePluginActiveQuery( siteId, pluginSlug ),
+		enabled: shouldPollPluginActive,
+		refetchInterval: ( query ) => {
+			// Stop once active or on a terminal read error; keep polling otherwise (incl. a transient 503).
+			if (
+				query.state.data?.status === 'complete' ||
+				isTerminalPluginActiveError( query.state.error )
+			) {
+				return false;
+			}
+			return 3000;
+		},
+		retry: false,
+	} );
 
-	// A transfer leaves the plugin installed but inactive, and it only turns up here once polling has
-	// fetched it. The ref (above) dispatches activation once, whatever the plugin state does between
-	// renders.
+	const pluginActiveStatus = pluginActiveState?.status;
+	const pluginReconcileFailed = isTerminalPluginActiveError( pluginActiveError );
+
+	// `inactive` means installed but not active: dispatch the targeted activation the page always
+	// used, with the id the endpoint returns. Each poll that still reports inactive retries it, up to
+	// a cap; after that it's a failed activation, not an endless spinner. Keyed on dataUpdatedAt so a
+	// fresh inactive result — not just a re-render — drives each retry.
+	const activationAttemptsRef = useRef( 0 );
+	useEffect( () => {
+		const installedId = pluginActiveState?.plugin?.id;
+		if ( pluginActiveStatus !== 'inactive' || ! installedId || activationFailed ) {
+			return;
+		}
+		if ( activationAttemptsRef.current >= MAX_ACTIVATION_ATTEMPTS ) {
+			setActivationFailed( true );
+			return;
+		}
+		activationAttemptsRef.current += 1;
+		setCurrentStep( 2 );
+		dispatch( activatePlugin( siteId, { id: installedId, slug: pluginSlug } ) );
+	}, [
+		pluginActiveUpdatedAt,
+		pluginActiveStatus,
+		pluginActiveState,
+		activationFailed,
+		dispatch,
+		siteId,
+		pluginSlug,
+	] );
+
+	// For flows the active-status endpoint can't reach — self-hosted Jetpack sites (not Atomic) and
+	// zip uploads (no wp.org slug) — keep the page's existing plugin-list activation: activate the
+	// installed plugin once it turns up.
 	useEffect( () => {
 		if (
-			! canReconcilePlugin ||
+			shouldPollPluginActive ||
 			currentStep !== 1 ||
 			! installedPlugin ||
 			installedPlugin.active ||
@@ -365,9 +408,9 @@ const MarketplaceProductInstall = ( {
 
 		activationAttempted.current = true;
 		setCurrentStep( 2 );
-		dispatch( activatePlugin( siteId, installedPlugin ) );
+		dispatch( activatePlugin( siteId, { id: installedPlugin.id, slug: installedPlugin.slug } ) );
 	}, [
-		canReconcilePlugin,
+		shouldPollPluginActive,
 		currentStep,
 		installedPlugin,
 		isPluginUploadFlow,
@@ -376,43 +419,49 @@ const MarketplaceProductInstall = ( {
 		siteId,
 	] );
 
-	// Check completition of all flows and redirect to thank you page
+	// Redirect once the plugin is active, or once a zip-upload transfer completes.
 	useEffect( () => {
-		if (
-			// Happens in 3 cases:
-			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
-			// - Install with the help of uploading archive of a plugins
-			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
-			// A transferred plugin lands here once it reports active and the site is ready for the WP
-			// Admin URL below — active first, since that page lists only active plugins.
-			( installedPlugin?.active && canReconcilePlugin ) ||
-			// Transfer to atomic uploading a zip plugin
-			( uploadedPluginSlug &&
-				isPluginUploadFlow &&
-				! isAtomic &&
-				transferStates.COMPLETE === automatedTransferStatus &&
-				canManagePlugins &&
-				isAtomicTransferReady )
-		) {
-			// Require a resolved pluginsUrlFinal before redirecting
-			if ( ! pluginsUrlFinal ) {
-				return;
-			}
-			waitFor( 1 ).then( () => {
-				window.location.href = pluginsUrlFinal as string;
-			} );
+		const active =
+			// The active-status endpoint reports the plugin on (Atomic wp.org flow, readiness already
+			// gated by the query being enabled).
+			pluginActiveStatus === 'complete' ||
+			// Flows the endpoint can't reach: the plugin list reports it active.
+			( ! shouldPollPluginActive && installedPlugin?.active );
+		const zipUploadTransferred =
+			uploadedPluginSlug &&
+			isPluginUploadFlow &&
+			! isAtomic &&
+			transferStates.COMPLETE === automatedTransferStatus &&
+			canManagePlugins &&
+			isAtomicTransferReady;
+
+		if ( ( ! active && ! zipUploadTransferred ) || ! pluginsUrlFinal ) {
+			return;
 		}
+
+		// A short delay lets the final progress render before navigating; cancel it if this effect
+		// re-runs (e.g. a fresh fetch supersedes a stale result) before it fires.
+		let cancelled = false;
+		waitFor( 1 ).then( () => {
+			if ( ! cancelled ) {
+				window.location.href = pluginsUrlFinal as string;
+			}
+		} );
+		return () => {
+			cancelled = true;
+		};
 	}, [
+		pluginActiveStatus,
+		shouldPollPluginActive,
+		installedPlugin,
 		automatedTransferStatus,
 		isPluginUploadFlow,
 		isAtomic,
 		canManagePlugins,
-		installedPlugin,
 		uploadedPluginSlug,
 		pluginsUrlFinal,
 		isAtomicTransferReady,
-		canReconcilePlugin,
-	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
+	] );
 
 	// Validate theme is already active
 	useEffect( () => {
@@ -556,6 +605,32 @@ const MarketplaceProductInstall = ( {
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
 					action={ translate( 'Re-upload plugin' ) }
 					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
+				/>
+			);
+		}
+		// Activation was retried and never took. The plugin is installed, so point at its page to
+		// activate it by hand rather than telling the user to re-upload.
+		if ( activationFailed ) {
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate( 'We installed the plugin, but could not activate it.' ) }
+					action={ translate( 'View plugin' ) }
+					actionURL={ `/plugins/${ pluginSlug }/${ selectedSiteSlug }` }
+				/>
+			);
+		}
+		// The active-status read failed terminally. The plugin may already be installed or active, so
+		// this is not an install failure — point at its page rather than telling the user to re-upload.
+		if ( pluginReconcileFailed ) {
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						'We could not verify the plugin’s status. Check it from your plugins.'
+					) }
+					action={ translate( 'View plugin' ) }
+					actionURL={ `/plugins/${ pluginSlug }/${ selectedSiteSlug }` }
 				/>
 			);
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,7 +21,6 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
-import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -43,7 +42,6 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
-import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -124,24 +122,8 @@ const MarketplaceProductInstall = ( {
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
 
-	// The plugin this page activated, if any. Reading the activation status by this captured id keeps
-	// the failure stable while a poll is in flight (the installed-plugin selectors drop a site while
-	// its list is being fetched, so installedPlugin blinks out), and scopes it to our own attempt — a
-	// stale error from an earlier install, or the checkout-driven flow that never activates here, has
-	// no captured plugin and so does not count. The slug also survives the blink for the recovery link.
-	const activatedPlugin = useRef< { id: string; slug: string } | null >( null );
-
-	const activationStatus = useSelector( ( state ) =>
-		activatedPlugin.current
-			? getStatusForPlugin( state, siteId, activatedPlugin.current.id )
-			: undefined
-	);
-	// Every terminal activation error is surfaced: activation_error is not reliably "already active"
-	// (the API returns it for a missing plugin file too), and polling continues regardless, so an
-	// already-active plugin still redirects once the refreshed list confirms it.
-	const activationFailed =
-		activationStatus?.status === PLUGIN_INSTALLATION_ERROR &&
-		activationStatus.action === ACTIVATE_PLUGIN;
+	// Guards the one activation this page dispatches.
+	const activationAttempted = useRef( false );
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -353,21 +335,21 @@ const MarketplaceProductInstall = ( {
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
 	// A transfer leaves the plugin installed but inactive, and it only turns up here once polling has
-	// fetched it. Capturing the id (above) both guards against a second dispatch and records which
-	// plugin we activated.
+	// fetched it. The ref (above) dispatches activation once, whatever the plugin state does between
+	// renders.
 	useEffect( () => {
 		if (
 			! canReconcilePlugin ||
 			currentStep !== 1 ||
 			! installedPlugin ||
 			installedPlugin.active ||
-			activatedPlugin.current !== null ||
+			activationAttempted.current ||
 			( isPluginUploadFlow && ! pluginUploadComplete )
 		) {
 			return;
 		}
 
-		activatedPlugin.current = { id: installedPlugin.id, slug: installedPlugin.slug };
+		activationAttempted.current = true;
 		setCurrentStep( 2 );
 		dispatch( activatePlugin( siteId, installedPlugin ) );
 	}, [
@@ -560,19 +542,6 @@ const MarketplaceProductInstall = ( {
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
 					action={ translate( 'Re-upload plugin' ) }
 					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
-				/>
-			);
-		}
-		// The plugin is installed, so the generic "upload it again" recovery below does not apply. Point
-		// at the plugin's own page, where it can be activated by hand. Skip this once it reports active,
-		// which redirects instead — an already-active plugin can report a terminal error first.
-		if ( activationFailed && ! pluginActive ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={ translate( 'We installed the plugin, but could not activate it.' ) }
-					action={ translate( 'View plugin' ) }
-					actionURL={ `/plugins/${ activatedPlugin.current?.slug }/${ selectedSiteSlug }` }
 				/>
 			);
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,7 +21,6 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
-import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -43,7 +42,6 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
-import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -315,39 +313,28 @@ const MarketplaceProductInstall = ( {
 		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
 	);
 
-	// Unlike the theme flow, which only observes backend-owned activation, reconciling a plugin means
-	// dispatching activation and then leaving for a freshly discovered WP Admin URL. Gate both on the
-	// atomic site being ready, and its manage-plugins capability having propagated, so we neither act
-	// nor redirect before that is true — a rejected one-shot activation would never be retried.
+	// Reconciling dispatches activation and then leaves for a freshly discovered WP Admin URL, so gate
+	// on the atomic site being ready and its manage-plugins capability having propagated: a rejected
+	// one-shot activation would never be retried.
 	const canReconcilePlugin =
 		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
 		( ! ( atomicFlow || isMarketplacePluginFlow ) ||
 			( isAtomicTransferReady && canManagePlugins ) );
 
-	// A failed install with nothing installed is terminal — the error screen shows it, so stop
-	// polling. Read the current status, not a lingering error field the reducer keeps across a retry.
-	// A failure that still left a plugin behind is a partial success worth reconciling.
-	const installFailed =
-		pluginInstallStatus?.status === PLUGIN_INSTALLATION_ERROR &&
-		pluginInstallStatus.action === INSTALL_PLUGIN &&
-		! installedPlugin;
-
-	// Poll the site plugins for the active state the same way the theme flow polls the active theme:
-	// once the flow is under way, until the server reports it active. The paid marketplace install is
-	// kicked off by checkout, so its step can still be 0 — cover it by its atomic-plugin shape too.
+	// Poll for the active state like the theme flow polls the active theme: once the flow is under
+	// way, until the server reports it active. A checkout-driven marketplace install can sit at step 0,
+	// so cover it by its atomic-plugin shape too.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
 		! pluginActive &&
-		! installFailed &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
 		( currentStep !== 0 || isMarketplacePluginFlow );
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
-	// A completed transfer is not a finished installation: it leaves the plugin inactive, and the
-	// plugin only turns up here once polling above has fetched it. Finding it ends the install step.
-	// The ref makes the activation happen once, whatever the plugin state does between renders.
+	// A transfer leaves the plugin installed but inactive, and it only turns up here once polling has
+	// fetched it. The ref dispatches activation once, whatever the plugin state does between renders.
 	const activationAttempted = useRef( false );
 	useEffect( () => {
 		if (
@@ -381,9 +368,8 @@ const MarketplaceProductInstall = ( {
 			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
-			// A transferred plugin lands here once the refreshed site plugins report it active, and the
-			// site is ready for the WP Admin URL below. It must be active first: the page this leaves for
-			// lists active plugins, and would not show an inactive one.
+			// A transferred plugin lands here once it reports active and the site is ready for the WP
+			// Admin URL below — active first, since that page lists only active plugins.
 			( installedPlugin?.active && canReconcilePlugin ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,6 +21,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
+import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -42,6 +43,7 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -321,12 +323,25 @@ const MarketplaceProductInstall = ( {
 		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
 		( ! siteJustTransferred || ( isAtomicTransferReady && canManagePlugins ) );
 
+	// A local install this page started (not a transfer or checkout-driven one) that terminally failed
+	// with no plugin to show for it. Read the current status and action, not the error field the
+	// reducer keeps across retries, and scope it to our own attempt so a stale error elsewhere does
+	// not count. A partial success — a plugin exists and may still activate — is not a failure.
+	const localInstallFailed =
+		installFlowInitiatedRef.current &&
+		! atomicFlow &&
+		! isMarketplacePluginFlow &&
+		! installedPlugin &&
+		pluginInstallStatus?.status === PLUGIN_INSTALLATION_ERROR &&
+		pluginInstallStatus.action === INSTALL_PLUGIN;
+
 	// Poll for the active state like the theme flow polls the active theme: once the flow is under
 	// way, until the server reports it active. Keep polling even after a reported activation failure:
 	// a lost response can follow a server-side success, and the refreshed list is what confirms it.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
 		! installedPlugin?.active &&
+		! localInstallFailed &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
 		installUnderway;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -111,7 +111,6 @@ const MarketplaceProductInstall = ( {
 	const installedPlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, siteId, isPluginUploadFlow ? uploadedPluginSlug : pluginSlug )
 	);
-	const pluginActive = !! installedPlugin?.active;
 	const automatedTransferStatus = useSelector( ( state ) =>
 		getAutomatedTransferStatus( state, siteId )
 	);
@@ -297,7 +296,7 @@ const MarketplaceProductInstall = ( {
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// so that the existing redirect (installedPlugin && pluginActive) fires.
+	// so that the existing redirect (installedPlugin?.active) fires.
 	const isMarketplacePluginFlow =
 		! atomicFlow &&
 		! isPluginUploadFlow &&
@@ -327,7 +326,7 @@ const MarketplaceProductInstall = ( {
 	// a lost response can follow a server-side success, and the refreshed list is what confirms it.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
-		! pluginActive &&
+		! installedPlugin?.active &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
 		installUnderway;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,7 +21,6 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
-import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -43,7 +42,6 @@ import {
 	getStatusForPlugin,
 	isRequesting,
 } from 'calypso/state/plugins/installed/selectors-ts';
-import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -123,23 +121,6 @@ const MarketplaceProductInstall = ( {
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
-
-	// Activation status is recorded under the installed plugin's id, not the slug.
-	const activationStatus = useSelector( ( state ) =>
-		installedPlugin ? getStatusForPlugin( state, siteId, installedPlugin.id ) : undefined
-	);
-
-	// The declared error type is a string, but a failed activation stores the raw error object.
-	const activationError = activationStatus?.error as string | { error?: string } | undefined;
-	const activationErrorCode =
-		typeof activationError === 'object' ? activationError?.error : activationError;
-
-	// An activation_error means the plugin was already active, so it is not a failure: keep waiting
-	// for the refreshed active state. Any other activation error is real.
-	const activationFailed =
-		activationStatus?.action === ACTIVATE_PLUGIN &&
-		activationStatus.status === PLUGIN_INSTALLATION_ERROR &&
-		activationErrorCode !== 'activation_error';
 
 	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
@@ -341,18 +322,14 @@ const MarketplaceProductInstall = ( {
 		!! freshSite?.is_wpcom_atomic &&
 		wporgPlugin?.wporg === false;
 
-	// The transfer installs the plugin itself, so the site comes back with a plugin nothing here has
-	// fetched yet.
-	const isTransferredPluginFlow =
-		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
-
-	const shouldReconcilePlugin = isTransferredPluginFlow || isMarketplacePluginFlow;
-
-	// Poll until the plugin is active, not just present: an activation can be reported ambiguously, so
-	// a refreshed active state settles it. Stop on a genuine failure, and skip a tick while a request
-	// is already in flight.
+	// Poll the site plugins for the active state the same way the theme flow polls the active theme:
+	// once the flow is under way, until the server reports it active. The paid marketplace install is
+	// kicked off by checkout, so its step can still be 0 — cover it by its atomic-plugin shape too.
 	const shouldFetchPlugin =
-		shouldReconcilePlugin && ! pluginActive && ! activationFailed && ! isFetchingSitePlugins;
+		!! pluginSlug &&
+		! pluginActive &&
+		! isFetchingSitePlugins &&
+		( currentStep !== 0 || isMarketplacePluginFlow );
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
@@ -547,7 +524,6 @@ const MarketplaceProductInstall = ( {
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
-			activationFailed ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -339,30 +339,36 @@ const MarketplaceProductInstall = ( {
 
 	const shouldReconcilePlugin = isTransferredPluginFlow || isMarketplacePluginFlow;
 
-	// Two phases with one poll: find the plugin, then wait for it to be active. Its active state comes
-	// from the refreshed site plugins, which is authoritative in a way an activation response is not.
-	const reconciliationPhase = installedPlugin ? 'activation' : 'installation';
+	// The progress step is the stable phase signal: step 1 is installing, step 2 activating. Unlike
+	// whether the plugin is momentarily visible, it does not flicker between polls.
+	const setupPhase = currentStep === 2 ? 'activation' : 'installation';
 
-	const [ reconciliationTimedOut, setReconciliationTimedOut ] = useState( false );
+	const [ timedOutPhase, setTimedOutPhase ] = useState< 'installation' | 'activation' | null >(
+		null
+	);
 
 	// Poll until the plugin is active, not just present: an activation can be reported ambiguously, so
-	// only a refreshed active state ends the wait. The fetch flag avoids overlapping requests.
+	// only a refreshed active state ends the wait. Stop while this phase is timed out, and skip a tick
+	// while a request is already in flight.
 	const shouldFetchPlugin =
-		shouldReconcilePlugin && ! pluginActive && ! reconciliationTimedOut && ! isFetchingSitePlugins;
+		shouldReconcilePlugin &&
+		! pluginActive &&
+		timedOutPhase !== setupPhase &&
+		! isFetchingSitePlugins;
 
 	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), shouldFetchPlugin ? 3000 : null );
 
-	// Each phase gets its own deadline: when the plugin appears the phase changes, discarding the
+	// Each phase gets its own deadline: when the step advances the phase changes, discarding the
 	// install timer so activation gets a fresh window. Timing out offers a way out, not a dead end.
 	useEffect( () => {
-		if ( ! shouldReconcilePlugin || pluginActive || reconciliationTimedOut ) {
+		if ( ! shouldReconcilePlugin || pluginActive || timedOutPhase === setupPhase ) {
 			return;
 		}
 
-		const timeout = setTimeout( () => setReconciliationTimedOut( true ), RECONCILIATION_TIMEOUT );
+		const timeout = setTimeout( () => setTimedOutPhase( setupPhase ), RECONCILIATION_TIMEOUT );
 
 		return () => clearTimeout( timeout );
-	}, [ shouldReconcilePlugin, pluginActive, reconciliationPhase, reconciliationTimedOut ] );
+	}, [ shouldReconcilePlugin, pluginActive, setupPhase, timedOutPhase ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
@@ -440,24 +446,25 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	// Restart the wait. A found-but-inactive plugin is sent back to the activation step so the effect
-	// runs again; a missing one just resumes polling once the deadline is cleared.
+	// Restart the wait. Clearing the phase resumes polling; a timed-out activation is dispatched
+	// again directly, since the step has already advanced past the effect that would do it.
 	const retryPluginSetup = () => {
-		setReconciliationTimedOut( false );
+		const phase = timedOutPhase;
+		setTimedOutPhase( null );
 
-		if ( installedPlugin && ! pluginActive ) {
-			setCurrentStep( 1 );
+		if ( phase === 'activation' && installedPlugin ) {
+			dispatch( activatePlugin( siteId, installedPlugin ) );
 		}
 	};
 
 	const renderError = () => {
 		// Evaluate error causes in priority order
-		if ( reconciliationTimedOut && ! pluginActive ) {
+		if ( timedOutPhase && ! pluginActive ) {
 			return (
 				<EmptyContent
 					title={ null }
 					line={
-						installedPlugin
+						timedOutPhase === 'activation'
 							? translate(
 									'The plugin was installed, but we could not activate it. You can activate it yourself from your plugins.'
 							  )

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -316,12 +316,17 @@ const MarketplaceProductInstall = ( {
 		( ! atomicFlow || transferStates.COMPLETE === automatedTransferStatus ) &&
 		( ! ( atomicFlow || isMarketplacePluginFlow ) || isAtomicTransferReady );
 
+	// A failed install with nothing installed is terminal — the error screen shows it, so stop
+	// polling. A failure that still left a plugin behind is a partial success worth reconciling.
+	const installFailed = !! pluginInstallStatus?.error && ! installedPlugin;
+
 	// Poll the site plugins for the active state the same way the theme flow polls the active theme:
 	// once the flow is under way, until the server reports it active. The paid marketplace install is
 	// kicked off by checkout, so its step can still be 0 — cover it by its atomic-plugin shape too.
 	const shouldFetchPlugin =
 		!! pluginSlug &&
 		! pluginActive &&
+		! installFailed &&
 		! isFetchingSitePlugins &&
 		canReconcilePlugin &&
 		( currentStep !== 0 || isMarketplacePluginFlow );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -21,6 +21,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
+import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
@@ -40,8 +41,10 @@ import {
 import {
 	getPluginOnSite,
 	getStatusForPlugin,
+	isPluginActionStatus,
 	isPluginActive,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import { PLUGIN_INSTALLATION_ERROR } from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -71,8 +74,8 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
-// How long to keep waiting for a transferred plugin to install and activate.
-const ACTIVATION_TIMEOUT = 60 * 1000;
+// How long to wait for the plugin to install, and then for it to activate.
+const SETUP_TIMEOUT = 60 * 1000;
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -331,34 +334,43 @@ const MarketplaceProductInstall = ( {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
 	} );
 
-	// The transfer installs the plugin on its own, so the site comes back with a plugin nothing here
-	// has fetched yet.
+	// The transfer installs the plugin itself, so the site comes back with a plugin nothing here has
+	// fetched yet.
 	const isTransferredPluginFlow =
-		atomicFlow &&
-		transferStates.COMPLETE === automatedTransferStatus &&
-		isAtomicTransferReady &&
-		canManagePlugins;
+		atomicFlow && transferStates.COMPLETE === automatedTransferStatus && isAtomicTransferReady;
 
-	const [ activationTimedOut, setActivationTimedOut ] = useState( false );
+	const [ setupTimedOut, setSetupTimedOut ] = useState( false );
+	const setupStage = installedPlugin ? 'activation' : 'installation';
 
-	// Poll until the plugin turns up, which is what lets the activation effect above run.
-	useInterval(
-		() => dispatch( fetchSitePlugins( siteId ) ),
-		( isMarketplacePluginFlow || ( isTransferredPluginFlow && ! activationTimedOut ) ) &&
-			! pluginActive
-			? 3000
-			: null
+	const activationFailed = useSelector(
+		( state ) =>
+			!! installedPlugin &&
+			isPluginActionStatus(
+				state,
+				siteId,
+				installedPlugin.id,
+				ACTIVATE_PLUGIN,
+				PLUGIN_INSTALLATION_ERROR
+			)
 	);
 
+	const isAwaitingPlugin =
+		( isTransferredPluginFlow || isMarketplacePluginFlow ) && ! pluginActive && ! setupTimedOut;
+
+	// Poll until the plugin turns up, which is what lets the activation effect above run.
+	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), isAwaitingPlugin ? 3000 : null );
+
+	// Installing and activating are timed one after the other, so a slow install does not eat the
+	// time the activation that follows it gets.
 	useEffect( () => {
-		if ( ! isTransferredPluginFlow || pluginActive || activationTimedOut ) {
+		if ( ! isAwaitingPlugin ) {
 			return;
 		}
 
-		const timeout = setTimeout( () => setActivationTimedOut( true ), ACTIVATION_TIMEOUT );
+		const timeout = setTimeout( () => setSetupTimedOut( true ), SETUP_TIMEOUT );
 
 		return () => clearTimeout( timeout );
-	}, [ isTransferredPluginFlow, pluginActive, activationTimedOut ] );
+	}, [ isAwaitingPlugin, setupStage ] );
 
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
@@ -367,10 +379,9 @@ const MarketplaceProductInstall = ( {
 			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
+			// A transferred plugin also lands here, once polling has found it and activated it. It has to
+			// be active first: the page this leaves for lists active plugins, and would not show it.
 			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic using a marketplace plugin. The plugin has to be active first: the page
-			// this lands on lists active plugins, and would not show the one just installed.
-			( isTransferredPluginFlow && pluginActive ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
@@ -390,7 +401,6 @@ const MarketplaceProductInstall = ( {
 	}, [
 		pluginActive,
 		automatedTransferStatus,
-		atomicFlow,
 		isPluginUploadFlow,
 		isAtomic,
 		canManagePlugins,
@@ -398,7 +408,6 @@ const MarketplaceProductInstall = ( {
 		uploadedPluginSlug,
 		pluginsUrlFinal,
 		isAtomicTransferReady,
-		isTransferredPluginFlow,
 	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	// Validate theme is already active
@@ -435,27 +444,35 @@ const MarketplaceProductInstall = ( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	// Resuming the poll is enough to install a plugin that never turned up. One that did turn up is
-	// past its activation step, so activate it again by hand.
-	const retryActivation = () => {
-		setActivationTimedOut( false );
+	// A plugin that never turned up is looked for again. One that did turn up is past its activation
+	// step, so activate it again by hand.
+	const retryPluginSetup = () => {
+		setSetupTimedOut( false );
 
 		if ( installedPlugin ) {
 			dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) );
+		} else {
+			dispatch( fetchSitePlugins( siteId ) );
 		}
 	};
 
 	const renderError = () => {
 		// Evaluate error causes in priority order
-		if ( activationTimedOut && ! pluginActive ) {
+		if ( ( setupTimedOut || activationFailed ) && ! pluginActive ) {
 			return (
 				<EmptyContent
 					title={ null }
-					line={ translate(
-						'We installed the plugin, but we could not activate it. You can activate it yourself from your plugins.'
-					) }
+					line={
+						installedPlugin
+							? translate(
+									'We installed the plugin, but we could not activate it. You can activate it yourself from your plugins.'
+							  )
+							: translate(
+									'The plugin is taking longer than expected to install. You can check your plugins to see whether it arrived.'
+							  )
+					}
 					action={ translate( 'Try again' ) }
-					actionCallback={ retryActivation }
+					actionCallback={ retryPluginSetup }
 					secondaryAction={ translate( 'View all plugins' ) }
 					secondaryActionURL={ allPluginsUrl ?? undefined }
 				/>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -1,17 +1,17 @@
 body.is-section-marketplace.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
+	--color-surface-backdrop: var(--studio-white);
 }
 
 .marketplace-plugin-install__masterbar {
-	--color-masterbar-background: var( --studio-white );
-	--color-masterbar-text: var( --studio-gray-60 );
+	--color-masterbar-background: var(--studio-white);
+	--color-masterbar-text: var(--studio-gray-60);
 	padding-right: 24px;
 	border-bottom: 0;
 
 	.marketplace-plugin-install__logo {
-		fill: rgb( 54, 54, 54 );
+		fill: rgb(54, 54, 54);
 		margin: 24px 12px 24px 24px;
-		@media ( min-width: 480px ) {
+		@media (min-width: 480px) {
 			margin: 24px;
 		}
 	}
@@ -59,14 +59,4 @@ body.is-section-marketplace {
 			margin-left: 10px;
 		}
 	}
-}
-
-.marketplace-plugin-install__progress {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-}
-
-.marketplace-plugin-install__manual-escape {
-	margin-top: 24px;
 }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -1,17 +1,17 @@
 body.is-section-marketplace.theme-default.color-scheme {
-	--color-surface-backdrop: var(--studio-white);
+	--color-surface-backdrop: var( --studio-white );
 }
 
 .marketplace-plugin-install__masterbar {
-	--color-masterbar-background: var(--studio-white);
-	--color-masterbar-text: var(--studio-gray-60);
+	--color-masterbar-background: var( --studio-white );
+	--color-masterbar-text: var( --studio-gray-60 );
 	padding-right: 24px;
 	border-bottom: 0;
 
 	.marketplace-plugin-install__logo {
-		fill: rgb(54, 54, 54);
+		fill: rgb( 54, 54, 54 );
 		margin: 24px 12px 24px 24px;
-		@media (min-width: 480px) {
+		@media ( min-width: 480px ) {
 			margin: 24px;
 		}
 	}
@@ -59,4 +59,14 @@ body.is-section-marketplace {
 			margin-left: 10px;
 		}
 	}
+}
+
+.marketplace-plugin-install__progress {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+.marketplace-plugin-install__manual-escape {
+	margin-top: 24px;
 }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,0 +1,220 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import MarketplaceProductInstall from '../index';
+
+const PLUGIN_SLUG = 'give';
+const SITE = { ID: 1, slug: 'example.wordpress.com' };
+const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
+
+// The state the component reads, as the mocked selectors below see it. A test moves the flow along
+// by changing this and re-rendering.
+const mockSite = {
+	transferStatus: transferStates.COMPLETE,
+	installedPlugin: null as { slug: string; id: string } | null,
+	pluginActive: false,
+};
+
+const mockDispatch = jest.fn();
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( {} ),
+} ) );
+
+jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
+	installPlugin: jest.fn( () => ( { type: 'INSTALL_PLUGIN' } ) ),
+	activatePlugin: jest.fn( () => ( { type: 'ACTIVATE_PLUGIN' } ) ),
+	fetchSitePlugins: jest.fn( () => ( { type: 'FETCH_SITE_PLUGINS' } ) ),
+} ) );
+jest.mock( 'calypso/state/themes/actions', () => ( {
+	initiateThemeTransfer: jest.fn( () => ( { type: 'INITIATE_TRANSFER' } ) ),
+	installAndActivateTheme: jest.fn( () => ( { type: 'INSTALL_THEME' } ) ),
+	requestActiveTheme: jest.fn( () => ( { type: 'REQUEST_ACTIVE_THEME' } ) ),
+} ) );
+jest.mock( 'calypso/state/atomic/transfers/actions', () => ( {
+	initiateAtomicTransfer: jest.fn( () => ( { type: 'INITIATE_ATOMIC_TRANSFER' } ) ),
+} ) );
+jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
+	fetchPluginData: jest.fn( () => ( { type: 'FETCH_PLUGIN_DATA' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
+	getPlugin: () => ( { slug: 'give', wporg: true } ),
+	isFetched: () => true,
+} ) );
+jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
+	getPluginOnSite: () => mockSite.installedPlugin,
+	getStatusForPlugin: () => null,
+	isPluginActive: () => mockSite.pluginActive,
+} ) );
+jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
+	getAutomatedTransferStatus: () => mockSite.transferStatus,
+} ) );
+jest.mock( 'calypso/state/marketplace/purchase-flow/selectors', () => ( {
+	getPurchaseFlowState: () => ( {
+		pluginInstallationStatus: 'PENDING',
+		productSlugInstalled: 'give',
+		primaryDomain: 'example.wordpress.com',
+	} ),
+} ) );
+jest.mock( 'calypso/state/products-list/selectors', () => ( {
+	getProductsList: () => ( {} ),
+	isMarketplaceProduct: () => false,
+} ) );
+jest.mock( 'calypso/state/themes/selectors', () => ( {
+	getTheme: () => null,
+	isThemeActive: () => false,
+} ) );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isJetpackSite: () => false,
+	getSiteAdminUrl: () => null,
+} ) );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/selectors/site-has-feature', () => ( {
+	__esModule: true,
+	default: () => true,
+} ) );
+jest.mock( 'calypso/state/selectors/get-current-query-arguments', () => ( {
+	getCurrentQueryArguments: () => ( {} ),
+} ) );
+jest.mock( 'calypso/state/selectors/get-plugin-upload-error', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( 'calypso/state/selectors/get-plugin-upload-progress', () => ( {
+	__esModule: true,
+	default: () => 0,
+} ) );
+jest.mock( 'calypso/state/selectors/get-uploaded-plugin-id', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( 'calypso/state/selectors/is-plugin-upload-complete', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSite: () => ( { ID: 1, slug: 'example.wordpress.com' } ),
+	getSelectedSiteId: () => 1,
+	getSelectedSiteSlug: () => 'example.wordpress.com',
+} ) );
+
+// The site the transfer hands back: atomic, with an admin URL to redirect to.
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: () => ( {
+		data: {
+			ID: 1,
+			is_wpcom_atomic: true,
+			options: { admin_url: 'https://example.wordpress.com/wp-admin/' },
+		},
+	} ),
+} ) );
+jest.mock( 'calypso/dashboard/utils/site-atomic-transfers', () => ( {
+	isAtomicTransferredSite: () => true,
+} ) );
+jest.mock( '@automattic/api-queries', () => ( {
+	siteByIdQuery: () => ( { queryKey: [ 'site' ] } ),
+} ) );
+jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
+	useWPCOMPlugin: () => ( { data: null } ),
+} ) );
+jest.mock( 'calypso/components/data/query-theme', () => ( { useQueryTheme: () => null } ) );
+jest.mock( 'calypso/components/data/query-active-theme', () => () => null );
+jest.mock( 'calypso/components/data/query-jetpack-plugins', () => () => null );
+jest.mock( 'calypso/components/data/query-products-list', () => () => null );
+jest.mock( 'calypso/layout/masterbar/masterbar', () => () => null );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+jest.mock( 'calypso/my-sites/marketplace/util', () => ( { waitFor: () => Promise.resolve() } ) );
+jest.mock( 'calypso/my-sites/marketplace/components/progressbar', () => ( {
+	__esModule: true,
+	default: ( { currentStep }: { currentStep: number } ) => (
+		<div data-testid="progress">{ currentStep }</div>
+	),
+} ) );
+
+const { activatePlugin, fetchSitePlugins } = jest.requireMock(
+	'calypso/state/plugins/installed/actions'
+);
+
+const renderInstallPage = () => render( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
+
+// The install page starts the transfer, then hands over to the effects that wait on it. Getting to
+// that point takes a render and a resolved promise, so let both settle.
+const startTransfer = async ( rendered: ReturnType< typeof renderInstallPage > ) => {
+	await act( async () => {} );
+	rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
+	await act( async () => {} );
+};
+
+describe( 'MarketplaceProductInstall', () => {
+	let originalLocation: Location;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.clearAllMocks();
+		mockSite.transferStatus = transferStates.COMPLETE;
+		mockSite.installedPlugin = null;
+		mockSite.pluginActive = false;
+		originalLocation = window.location;
+		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		Object.defineProperty( window, 'location', { value: originalLocation, writable: true } );
+	} );
+
+	it( 'activates a plugin the transfer installed, and only then leaves the page', async () => {
+		const rendered = renderInstallPage();
+		await startTransfer( rendered );
+
+		// The transfer is done but the plugin has not been fetched yet, which is the whole bug: the
+		// page must not call this an install and leave for a list the plugin is missing from.
+		expect( window.location.href ).toBe( '' );
+		expect( activatePlugin ).not.toHaveBeenCalled();
+
+		// It polls for the plugin instead.
+		await act( async () => {
+			jest.advanceTimersByTime( 3000 );
+		} );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE.ID );
+		expect( window.location.href ).toBe( '' );
+
+		// A later poll finds it, so it is activated.
+		mockSite.installedPlugin = { slug: PLUGIN_SLUG, id: 'give/give' };
+		await act( async () => {
+			rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
+		} );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE.ID, {
+			slug: PLUGIN_SLUG,
+			id: 'give/give',
+		} );
+		expect( window.location.href ).toBe( '' );
+
+		mockSite.pluginActive = true;
+		await act( async () => {
+			rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
+		} );
+		expect( window.location.href ).toBe(
+			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
+		);
+	} );
+
+	it( 'stops waiting for an activation that never happens', async () => {
+		const rendered = renderInstallPage();
+		await startTransfer( rendered );
+
+		await act( async () => {
+			jest.advanceTimersByTime( 60 * 1000 );
+		} );
+
+		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -252,22 +252,27 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'does not act or redirect before the transferred atomic site is ready', async () => {
+	it( 'does not activate or redirect before the transferred atomic site is ready', async () => {
 		mockSite.isReady = false;
 		const rendered = install();
 		await start( rendered );
 
-		// The plugin already reads active, but the site is not ready, so it must not poll, activate, or
+		// The plugin has turned up, but the site is not ready, so it must not activate it, poll, or
 		// send the user to a WP Admin URL that is not there yet.
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
+		mockSite.installedPlugin = PLUGIN;
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 6000 );
+		expect( activatePlugin ).not.toHaveBeenCalled();
 		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 		expect( window.location.href ).toBe( '' );
 
-		// Once the site is ready, it redirects.
+		// Once the site is ready, it activates the plugin and, once active, redirects.
 		mockSite.isReady = true;
 		await advance( rendered, 3000 );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
+		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -21,6 +21,8 @@ const mockSite = {
 	isWporgPlugin: true,
 	// Whether a site-plugins request is in flight, so a test can hold off the next poll.
 	isFetching: false,
+	// Whether the transferred atomic site is ready for its WP Admin URL.
+	isReady: true,
 };
 
 const mockDispatch = jest.fn();
@@ -122,7 +124,7 @@ jest.mock( '@tanstack/react-query', () => ( {
 	} ),
 } ) );
 jest.mock( 'calypso/dashboard/utils/site-atomic-transfers', () => ( {
-	isAtomicTransferredSite: () => true,
+	isAtomicTransferredSite: () => mockSite.isReady,
 } ) );
 jest.mock( '@automattic/api-queries', () => ( {
 	siteByIdQuery: () => ( { queryKey: [ 'site' ] } ),
@@ -177,6 +179,7 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
 		mockSite.isFetching = false;
+		mockSite.isReady = true;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -246,6 +249,25 @@ describe( 'MarketplaceProductInstall', () => {
 
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'does not act or redirect before the transferred atomic site is ready', async () => {
+		mockSite.isReady = false;
+		const rendered = install();
+		await start( rendered );
+
+		// The plugin already reads active, but the site is not ready, so it must not poll, activate, or
+		// send the user to a WP Admin URL that is not there yet.
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 6000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		expect( window.location.href ).toBe( '' );
+
+		// Once the site is ready, it redirects.
+		mockSite.isReady = true;
+		await advance( rendered, 3000 );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -326,6 +326,12 @@ describe( 'MarketplaceProductInstall', () => {
 		};
 		await settle( rendered );
 		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
+		// The message points at the plugin's own page rather than stranding the user or telling them to
+		// re-upload an already-installed plugin.
+		expect( screen.getByRole( 'link', { name: 'View plugin' } ) ).toHaveAttribute(
+			'href',
+			'/plugins/give/example.wordpress.com'
+		);
 
 		// A lost response can follow a server-side success, so polling continues and a later active
 		// refresh still redirects.

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, act } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -275,31 +275,6 @@ describe( 'MarketplaceProductInstall', () => {
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
-		await settle( rendered );
-		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
-	} );
-
-	it( 'offers a plugins-list escape five minutes after activation begins', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		// The plugin appears and is activated, which advances to the activating step.
-		mockSite.installedPlugin = PLUGIN;
-		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		// Before five minutes there is no escape, and the flow is still going.
-		await advance( rendered, 4 * 60 * 1000 );
-		expect( screen.queryByText( /View all plugins/ ) ).toBeNull();
-
-		// After five minutes it offers the unfiltered plugins list, without stopping the progress.
-		await advance( rendered, 60 * 1000 );
-		const link = screen.getByRole( 'link', { name: /View all plugins/ } );
-		expect( link ).toHaveAttribute( 'href', `${ ADMIN_URL }plugins.php?plugin_status=all` );
-		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
-
-		// If the plugin goes active, it redirects and the escape is moot.
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -25,6 +25,9 @@ const mockSite = {
 	isReady: true,
 	// Whether the site's manage-plugins capability has propagated.
 	canManage: true,
+	// The checkout install status. COMPLETED means checkout finished the install, so this page does
+	// not start one and stays at step 0 — the marketplace poll path.
+	purchaseStatus: 'PENDING',
 };
 
 const mockDispatch = jest.fn();
@@ -65,7 +68,7 @@ jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/marketplace/purchase-flow/selectors', () => ( {
 	getPurchaseFlowState: () => ( {
-		pluginInstallationStatus: 'PENDING',
+		pluginInstallationStatus: mockSite.purchaseStatus,
 		productSlugInstalled: 'give',
 		primaryDomain: 'example.wordpress.com',
 	} ),
@@ -147,7 +150,7 @@ jest.mock( 'calypso/my-sites/marketplace/components/progressbar', () => ( {
 	default: () => <div>Installing plugin</div>,
 } ) );
 
-const { activatePlugin, fetchSitePlugins } = jest.requireMock(
+const { installPlugin, activatePlugin, fetchSitePlugins } = jest.requireMock(
 	'calypso/state/plugins/installed/actions'
 );
 
@@ -184,6 +187,7 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isFetching = false;
 		mockSite.isReady = true;
 		mockSite.canManage = true;
+		mockSite.purchaseStatus = 'PENDING';
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -217,11 +221,16 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'keeps polling a paid plugin until it is externally activated', async () => {
+	it( 'polls a paid plugin that checkout installed, without starting its own install', async () => {
 		mockSite.isAtomic = true;
 		mockSite.isWporgPlugin = false;
+		// Checkout finished the install, so this page starts none and stays at step 0. Polling then
+		// happens only through the marketplace path, which is what this exercises.
+		mockSite.purchaseStatus = 'COMPLETED';
 		const rendered = install();
 		await start( rendered );
+
+		expect( installPlugin ).not.toHaveBeenCalled();
 
 		// The plugin is present but inactive. Checkout activates it out of band, so the page must keep
 		// polling rather than leaving as soon as it appears.
@@ -229,6 +238,7 @@ describe( 'MarketplaceProductInstall', () => {
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+		expect( installPlugin ).not.toHaveBeenCalled();
 		expect( window.location.href ).toBe( '' );
 
 		mockSite.installedPlugin = ACTIVE_PLUGIN;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -14,6 +14,8 @@ const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
 const mockSite = {
 	installedPlugin: null as typeof PLUGIN | null,
 	pluginActive: false,
+	// Redux keys a plugin's status by its id, which is what an activation error comes back under.
+	failedPluginId: null as string | null,
 	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
 	// transferred it and started the install.
 	isAtomic: false,
@@ -50,8 +52,10 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => null,
+	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
+		pluginId === mockSite.failedPluginId ? { error: { message: 'Activation failed' } } : null,
 	isPluginActive: () => mockSite.pluginActive,
+	isRequesting: () => false,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
 	getAutomatedTransferStatus: () => 'complete',
@@ -171,6 +175,7 @@ describe( 'MarketplaceProductInstall', () => {
 		jest.clearAllMocks();
 		mockSite.installedPlugin = null;
 		mockSite.pluginActive = false;
+		mockSite.failedPluginId = null;
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
 		originalLocation = window.location;
@@ -206,6 +211,27 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe(
 			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
 		);
+	} );
+
+	it( 'stops polling once the plugin is found, and reports an activation that fails', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		await advance( 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+
+		// Polling was only ever about finding the plugin. Activating it updates the store itself.
+		mockSite.installedPlugin = PLUGIN;
+		mockSite.failedPluginId = PLUGIN.id;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+
+		fetchSitePlugins.mockClear();
+		await advance( 10 * 1000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+
+		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
 	} );
 
 	it( 'keeps polling for a paid plugin, which checkout installs', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -325,7 +325,7 @@ describe( 'MarketplaceProductInstall', () => {
 			error: { error: 'some_failure' },
 		};
 		await settle( rendered );
-		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
+		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
 
 		// A lost response can follow a server-side success, so polling continues and a later active
 		// refresh still redirects.
@@ -353,7 +353,7 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = PLUGIN;
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 3000 );
-		expect( screen.queryByText( /An error occurred/ ) ).toBeNull();
+		expect( screen.queryByText( /could not activate it/ ) ).toBeNull();
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		await expectRedirectsOnceActive( rendered );
 	} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen, act } from '@testing-library/react';
-import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
-import { PLUGIN_INSTALL_REQUEST, PLUGIN_INSTALL_REQUEST_FAILURE } from 'calypso/state/action-types';
-import statusReducer from 'calypso/state/plugins/installed/status/reducer';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -28,8 +25,6 @@ const mockSite = {
 	isReady: true,
 	// Whether the site's manage-plugins capability has propagated.
 	canManage: true,
-	// The install status the store reports, built from real reducer transitions.
-	installStatus: null as { status: string; action: string; error?: unknown } | null,
 };
 
 const mockDispatch = jest.fn();
@@ -62,7 +57,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => mockSite.installStatus,
+	getStatusForPlugin: () => null,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -189,7 +184,6 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isFetching = false;
 		mockSite.isReady = true;
 		mockSite.canManage = true;
-		mockSite.installStatus = null;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -309,46 +303,6 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
-	} );
-
-	it( 'stops polling on a terminal install failure, and resumes when a retry begins', async () => {
-		mockSite.isAtomic = true; // existing-plan site, so the install runs through this page
-		mockSite.isWporgPlugin = true;
-		const rendered = install();
-		await start( rendered );
-
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-
-		// A real install failure with no plugin installed is terminal: the error shows, polling stops.
-		let statusState = statusReducer( undefined, {
-			type: PLUGIN_INSTALL_REQUEST_FAILURE,
-			siteId: SITE_ID,
-			pluginId: PLUGIN_SLUG,
-			action: INSTALL_PLUGIN,
-			error: { error: 'no_package' },
-		} );
-		mockSite.installStatus = statusState[ SITE_ID ][ PLUGIN_SLUG ];
-		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 9000 );
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
-		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
-
-		// A retry moves the status back to in progress. The reducer keeps the old error field, so a
-		// check on error-presence would stay stuck — the current status must drive the decision.
-		statusState = statusReducer( statusState, {
-			type: PLUGIN_INSTALL_REQUEST,
-			siteId: SITE_ID,
-			pluginId: PLUGIN_SLUG,
-			action: INSTALL_PLUGIN,
-		} );
-		expect( statusState[ SITE_ID ][ PLUGIN_SLUG ].error ).toBeTruthy();
-		mockSite.installStatus = statusState[ SITE_ID ][ PLUGIN_SLUG ];
-		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 	} );
 
 	it( 'waits for the manage-plugins capability before activating or redirecting', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -262,13 +262,18 @@ describe( 'MarketplaceProductInstall', () => {
 		await expectRedirectsOnceActive( rendered );
 	} );
 
-	it( 'does not activate or redirect before the transferred atomic site is ready', async () => {
-		mockSite.isReady = false;
+	// A transferred plugin must wait on two readiness signals before this page acts: the atomic site
+	// being ready for its WP Admin URL, and the manage-plugins capability having propagated.
+	it.each( [
+		[ 'the transferred atomic site is ready', 'isReady' as const ],
+		[ 'the manage-plugins capability propagates', 'canManage' as const ],
+	] )( 'does not activate or redirect before %s', async ( _label, gate ) => {
+		mockSite[ gate ] = false;
 		const rendered = install();
 		await start( rendered );
 
-		// The plugin has turned up, but the site is not ready, so it must not activate it, poll, or
-		// send the user to a WP Admin URL that is not there yet.
+		// The plugin has turned up, but the gate is not open, so it must not activate it, poll, or send
+		// the user to a WP Admin URL that is not there yet.
 		mockSite.installedPlugin = PLUGIN;
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 6000 );
@@ -276,30 +281,8 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 		expect( window.location.href ).toBe( '' );
 
-		// Once the site is ready, it activates the plugin and, once active, redirects.
-		mockSite.isReady = true;
-		await advance( rendered, 3000 );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		await expectRedirectsOnceActive( rendered );
-	} );
-
-	it( 'waits for the manage-plugins capability before activating or redirecting', async () => {
-		mockSite.canManage = false; // still propagating after the transfer
-		const rendered = install();
-		await start( rendered );
-
-		// Transfer complete and the site atomic-ready, but the capability has not propagated: the
-		// one-shot activation must not fire yet, and nothing should redirect.
-		mockSite.installedPlugin = PLUGIN;
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 6000 );
-		expect( activatePlugin ).not.toHaveBeenCalled();
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
-		expect( window.location.href ).toBe( '' );
-
-		// Once it propagates, it activates and, once active, redirects.
-		mockSite.canManage = true;
+		// Once the gate opens, it activates the plugin and, once active, redirects.
+		mockSite[ gate ] = true;
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -9,13 +10,12 @@ const PLUGIN = { slug: PLUGIN_SLUG, id: 'give/give' };
 const ACTIVE_PLUGIN = { ...PLUGIN, active: true };
 const SITE_ID = 1;
 const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
+const ACTIVE_LIST_URL = `${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`;
 
 // The state the component reads, as the mocked selectors below see it. A test moves the flow along
 // by changing this and re-rendering.
 const mockSite = {
 	installedPlugin: null as ( typeof PLUGIN & { active?: boolean } ) | null,
-	// The id an install or activation failure is recorded under.
-	failedPluginId: null as string | null,
 	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
 	// transferred it and started the install.
 	isAtomic: false,
@@ -52,8 +52,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	isPluginActionStatus: ( _state: unknown, _siteId: number, pluginId: string ) =>
-		pluginId === mockSite.failedPluginId,
+	getStatusForPlugin: () => null,
 	isRequesting: () => false,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -160,20 +159,22 @@ const start = async ( rendered: ReturnType< typeof install > ) => {
 	await settle( rendered );
 };
 
-const advance = async ( ms: number ) => {
+const advance = async ( rendered: ReturnType< typeof install >, ms: number ) => {
 	await act( async () => {
 		jest.advanceTimersByTime( ms );
 	} );
+	await settle( rendered );
 };
 
 describe( 'MarketplaceProductInstall', () => {
 	let originalLocation: Location;
+	let user: ReturnType< typeof userEvent.setup >;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
+		user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		jest.clearAllMocks();
 		mockSite.installedPlugin = null;
-		mockSite.failedPluginId = null;
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
 		originalLocation = window.location;
@@ -185,17 +186,16 @@ describe( 'MarketplaceProductInstall', () => {
 		Object.defineProperty( window, 'location', { value: originalLocation, writable: true } );
 	} );
 
-	it( 'activates a plugin the transfer installed, and only then leaves the page', async () => {
+	it( 'finds a transferred plugin, activates it, and redirects once it is active', async () => {
 		const rendered = install();
 		await start( rendered );
 
 		// The transfer is done but the plugin has not been fetched yet, which is the bug this guards
 		// against: the page must not call that an install and leave for a list the plugin is missing
 		// from. It polls for the plugin instead.
-		await advance( 3000 );
+		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		expect( activatePlugin ).not.toHaveBeenCalled();
-		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
 		expect( window.location.href ).toBe( '' );
 
 		// A later poll finds it, so it is activated.
@@ -204,66 +204,80 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 		expect( window.location.href ).toBe( '' );
 
+		// Only the refreshed active state, not the activation call, ends the wait.
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
-		expect( window.location.href ).toBe(
-			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
-		);
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'stops polling once the plugin is found, and reports an activation that fails', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		await advance( 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-
-		// Polling was only ever about finding the plugin. Activating it updates the store itself.
-		mockSite.installedPlugin = PLUGIN;
-		mockSite.failedPluginId = PLUGIN.id;
-		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		fetchSitePlugins.mockClear();
-		await advance( 10 * 1000 );
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
-
-		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
-	} );
-
-	it( 'shows an install failure keyed by slug even after the plugin exists', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		// An existing but inactive plugin can fail a slow update after activation begins. Its install
-		// status lives under the slug, not the installed id, so it still has to surface.
-		mockSite.installedPlugin = PLUGIN;
-		mockSite.failedPluginId = PLUGIN_SLUG;
-		await settle( rendered );
-
-		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
-	} );
-
-	it( 'keeps polling for a paid plugin, which checkout installs', async () => {
+	it( 'keeps polling a paid plugin until it is externally activated', async () => {
 		mockSite.isAtomic = true;
 		mockSite.isWporgPlugin = false;
 		const rendered = install();
 		await start( rendered );
 
-		await advance( 3000 );
+		// The plugin is present but inactive. Checkout activates it out of band, so the page must keep
+		// polling rather than leaving as soon as it appears.
+		mockSite.installedPlugin = PLUGIN;
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		expect( window.location.href ).toBe( '' );
 
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
+		await settle( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'redirects on a later active refresh even if activation looked like it failed', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		// Activation is dispatched, but the store still reports the plugin inactive: an activation
+		// response is not authoritative. The page waits for the refreshed active state, not the action.
 		mockSite.installedPlugin = PLUGIN;
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+		expect( window.location.href ).toBe( '' );
+
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
-		expect( window.location.href ).toBe(
-			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
-		);
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'times out installation and activation on their own deadlines, and retry resumes each', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		// Installation runs long. The page says so and offers a way out, without redirecting.
+		await advance( rendered, 60 * 1000 );
+		expect( screen.getByText( /taking longer than expected to install/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
+
+		// Retrying resumes polling.
+		fetchSitePlugins.mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+
+		// The plugin appears and is activated, and the deadline resets for the activation phase.
+		mockSite.installedPlugin = PLUGIN;
+		await advance( rendered, 3000 );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
+
+		// Activation gets its own full window rather than what a long install left over.
+		await advance( rendered, 60 * 1000 );
+		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
+
+		// Retrying an inactive plugin re-enters the activation step.
+		activatePlugin.mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, act } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -28,8 +28,6 @@ const DEFAULT_SITE = {
 	// The checkout install status. COMPLETED means checkout finished the install, so this page does
 	// not start one and stays at step 0 — the marketplace poll path.
 	purchaseStatus: 'PENDING',
-	// The status the store reports for the installed plugin's id, e.g. a failed activation.
-	activationStatus: null as { status: string; action: string; error?: unknown } | null,
 };
 const mockSite = { ...DEFAULT_SITE };
 
@@ -63,9 +61,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	// Install status is keyed by slug; activation status by the installed plugin's id (PLUGIN.id).
-	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
-		pluginId === 'give/give' ? mockSite.activationStatus : null,
+	getStatusForPlugin: () => null,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -307,92 +303,6 @@ describe( 'MarketplaceProductInstall', () => {
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		await expectRedirectsOnceActive( rendered );
-	} );
-
-	it( 'shows an error on a genuine activation failure, but keeps reconciling', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		mockSite.installedPlugin = PLUGIN;
-		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		// Activation reports a real failure, so the page surfaces the error.
-		mockSite.activationStatus = {
-			status: 'error',
-			action: 'ACTIVATE_PLUGIN',
-			error: { error: 'some_failure' },
-		};
-		await settle( rendered );
-		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
-		// The message points at the plugin's own page rather than stranding the user or telling them to
-		// re-upload an already-installed plugin.
-		expect( screen.getByRole( 'link', { name: 'View plugin' } ) ).toHaveAttribute(
-			'href',
-			'/plugins/give/example.wordpress.com'
-		);
-
-		// The next poll drops the plugin from the installed-plugin selector, but the error must not
-		// flip back to the progress screen — it is read from the captured id, not the live plugin.
-		mockSite.installedPlugin = null;
-		mockSite.isFetching = true;
-		await settle( rendered );
-		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
-		expect( screen.queryByText( /Installing plugin/ ) ).toBeNull();
-		mockSite.isFetching = false;
-
-		// A lost response can follow a server-side success, so polling continues and a later active
-		// refresh still redirects.
-		mockSite.installedPlugin = PLUGIN;
-		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-		await expectRedirectsOnceActive( rendered );
-	} );
-
-	it( 'ignores a stale activation error when checkout drives the install', async () => {
-		mockSite.isAtomic = true;
-		mockSite.isWporgPlugin = false;
-		mockSite.purchaseStatus = 'COMPLETED';
-		// A failure left over from an earlier attempt on the same plugin id, in the same session.
-		mockSite.activationStatus = {
-			status: 'error',
-			action: 'ACTIVATE_PLUGIN',
-			error: { error: 'some_failure' },
-		};
-		const rendered = install();
-		await start( rendered );
-
-		// This flow never dispatches its own activation, so the stale error is not ours: no error
-		// screen, and polling continues until the plugin is active.
-		mockSite.installedPlugin = PLUGIN;
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 3000 );
-		expect( screen.queryByText( /could not activate it/ ) ).toBeNull();
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-		await expectRedirectsOnceActive( rendered );
-	} );
-
-	it( 'surfaces an activation_error, which the API also uses for a missing plugin file', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		mockSite.installedPlugin = PLUGIN;
-		mockSite.activationStatus = {
-			status: 'error',
-			action: 'ACTIVATE_PLUGIN',
-			error: { error: 'activation_error' },
-		};
-		await settle( rendered );
-
-		// activation_error is not reliably "already active", so it is surfaced rather than left to poll
-		// forever. Polling still continues, so a genuinely-active plugin redirects on the next refresh.
-		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		await expectRedirectsOnceActive( rendered );
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -2,6 +2,9 @@
  * @jest-environment jsdom
  */
 import { render, screen, act } from '@testing-library/react';
+import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
+import { PLUGIN_INSTALL_REQUEST, PLUGIN_INSTALL_REQUEST_FAILURE } from 'calypso/state/action-types';
+import statusReducer from 'calypso/state/plugins/installed/status/reducer';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -23,8 +26,10 @@ const mockSite = {
 	isFetching: false,
 	// Whether the transferred atomic site is ready for its WP Admin URL.
 	isReady: true,
-	// Whether the install status reports a terminal error.
-	installError: false,
+	// Whether the site's manage-plugins capability has propagated.
+	canManage: true,
+	// The install status the store reports, built from real reducer transitions.
+	installStatus: null as { status: string; action: string; error?: unknown } | null,
 };
 
 const mockDispatch = jest.fn();
@@ -57,7 +62,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => ( mockSite.installError ? { error: 'install failed' } : null ),
+	getStatusForPlugin: () => mockSite.installStatus,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -88,7 +93,8 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 } ) );
 jest.mock( 'calypso/state/selectors/site-has-feature', () => ( {
 	__esModule: true,
-	default: () => true,
+	default: ( _state: unknown, _siteId: number, feature: string ) =>
+		feature === 'manage-plugins' ? mockSite.canManage : true,
 } ) );
 jest.mock( 'calypso/state/selectors/get-current-query-arguments', () => ( {
 	getCurrentQueryArguments: () => ( {} ),
@@ -182,7 +188,8 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isWporgPlugin = true;
 		mockSite.isFetching = false;
 		mockSite.isReady = true;
-		mockSite.installError = false;
+		mockSite.canManage = true;
+		mockSite.installStatus = null;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -304,23 +311,68 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'stops polling when installation fails with nothing installed', async () => {
+	it( 'stops polling on a terminal install failure, and resumes when a retry begins', async () => {
 		mockSite.isAtomic = true; // existing-plan site, so the install runs through this page
 		mockSite.isWporgPlugin = true;
 		const rendered = install();
 		await start( rendered );
 
-		// It polls while the install is under way.
 		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 
-		// The install fails and leaves no plugin. That is terminal: the error shows and polling stops.
-		mockSite.installError = true;
+		// A real install failure with no plugin installed is terminal: the error shows, polling stops.
+		let statusState = statusReducer( undefined, {
+			type: PLUGIN_INSTALL_REQUEST_FAILURE,
+			siteId: SITE_ID,
+			pluginId: PLUGIN_SLUG,
+			action: INSTALL_PLUGIN,
+			error: { error: 'no_package' },
+		} );
+		mockSite.installStatus = statusState[ SITE_ID ][ PLUGIN_SLUG ];
 		await settle( rendered );
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 9000 );
 		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
+
+		// A retry moves the status back to in progress. The reducer keeps the old error field, so a
+		// check on error-presence would stay stuck — the current status must drive the decision.
+		statusState = statusReducer( statusState, {
+			type: PLUGIN_INSTALL_REQUEST,
+			siteId: SITE_ID,
+			pluginId: PLUGIN_SLUG,
+			action: INSTALL_PLUGIN,
+		} );
+		expect( statusState[ SITE_ID ][ PLUGIN_SLUG ].error ).toBeTruthy();
+		mockSite.installStatus = statusState[ SITE_ID ][ PLUGIN_SLUG ];
+		await settle( rendered );
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+	} );
+
+	it( 'waits for the manage-plugins capability before activating or redirecting', async () => {
+		mockSite.canManage = false; // still propagating after the transfer
+		const rendered = install();
+		await start( rendered );
+
+		// Transfer complete and the site atomic-ready, but the capability has not propagated: the
+		// one-shot activation must not fire yet, and nothing should redirect.
+		mockSite.installedPlugin = PLUGIN;
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 6000 );
+		expect( activatePlugin ).not.toHaveBeenCalled();
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		expect( window.location.href ).toBe( '' );
+
+		// Once it propagates, it activates and, once active, redirects.
+		mockSite.canManage = true;
+		await advance( rendered, 3000 );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
+		await settle( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
 	it( 'does not start a new plugin fetch while one is already in flight', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -310,7 +310,7 @@ describe( 'MarketplaceProductInstall', () => {
 		await expectRedirectsOnceActive( rendered );
 	} );
 
-	it( 'shows an error and stops polling on a genuine activation failure', async () => {
+	it( 'shows an error on a genuine activation failure, but keeps reconciling', async () => {
 		const rendered = install();
 		await start( rendered );
 
@@ -318,18 +318,44 @@ describe( 'MarketplaceProductInstall', () => {
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		// Activation comes back with a real failure, so the page stops polling and shows the error.
+		// Activation reports a real failure, so the page surfaces the error.
 		mockSite.activationStatus = {
 			status: 'error',
 			action: 'ACTIVATE_PLUGIN',
 			error: { error: 'some_failure' },
 		};
 		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 9000 );
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
+
+		// A lost response can follow a server-side success, so polling continues and a later active
+		// refresh still redirects.
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+		await expectRedirectsOnceActive( rendered );
+	} );
+
+	it( 'ignores a stale activation error when checkout drives the install', async () => {
+		mockSite.isAtomic = true;
+		mockSite.isWporgPlugin = false;
+		mockSite.purchaseStatus = 'COMPLETED';
+		// A failure left over from an earlier attempt on the same plugin id, in the same session.
+		mockSite.activationStatus = {
+			status: 'error',
+			action: 'ACTIVATE_PLUGIN',
+			error: { error: 'some_failure' },
+		};
+		const rendered = install();
+		await start( rendered );
+
+		// This flow never dispatches its own activation, so the stale error is not ours: no error
+		// screen, and polling continues until the plugin is active.
+		mockSite.installedPlugin = PLUGIN;
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 3000 );
+		expect( screen.queryByText( /An error occurred/ ) ).toBeNull();
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+		await expectRedirectsOnceActive( rendered );
 	} );
 
 	it( 'keeps polling on an activation_error, which just means already active', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -271,6 +271,31 @@ describe( 'MarketplaceProductInstall', () => {
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
+		await settle( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'offers a plugins-list escape five minutes after activation begins', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		// The plugin appears and is activated, which advances to the activating step.
+		mockSite.installedPlugin = PLUGIN;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+
+		// Before five minutes there is no escape, and the flow is still going.
+		await advance( rendered, 4 * 60 * 1000 );
+		expect( screen.queryByText( /View all plugins/ ) ).toBeNull();
+
+		// After five minutes it offers the unfiltered plugins list, without stopping the progress.
+		await advance( rendered, 60 * 1000 );
+		const link = screen.getByRole( 'link', { name: /View all plugins/ } );
+		expect( link ).toHaveAttribute( 'href', `${ ADMIN_URL }plugins.php?plugin_status=all` );
+		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
+
+		// If the plugin goes active, it redirects and the escape is moot.
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -170,11 +169,9 @@ const advance = async ( rendered: ReturnType< typeof install >, ms: number ) => 
 
 describe( 'MarketplaceProductInstall', () => {
 	let originalLocation: Location;
-	let user: ReturnType< typeof userEvent.setup >;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
-		user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		jest.clearAllMocks();
 		mockSite.installedPlugin = null;
 		mockSite.isAtomic = false;
@@ -189,14 +186,14 @@ describe( 'MarketplaceProductInstall', () => {
 		Object.defineProperty( window, 'location', { value: originalLocation, writable: true } );
 	} );
 
-	it( 'finds a transferred plugin, activates it, and redirects once it is active', async () => {
+	it( 'activates a transferred plugin that appears after a minute, and redirects once active', async () => {
 		const rendered = install();
 		await start( rendered );
 
 		// The transfer is done but the plugin has not been fetched yet, which is the bug this guards
 		// against: the page must not call that an install and leave for a list the plugin is missing
-		// from. It polls for the plugin instead.
-		await advance( rendered, 3000 );
+		// from. It keeps polling however long the install takes, with no cutoff.
+		await advance( rendered, 90 * 1000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		expect( activatePlugin ).not.toHaveBeenCalled();
 		expect( window.location.href ).toBe( '' );
@@ -268,37 +265,5 @@ describe( 'MarketplaceProductInstall', () => {
 		await settle( rendered );
 		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-	} );
-
-	it( 'times out installation and activation on their own deadlines, and retry resumes each', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		// Installation runs long. The page says so and offers a way out, without redirecting.
-		await advance( rendered, 60 * 1000 );
-		expect( screen.getByText( /taking longer than expected to install/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
-
-		// Retrying resumes polling.
-		fetchSitePlugins.mockClear();
-		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-
-		// The plugin appears and is activated, and the deadline resets for the activation phase.
-		mockSite.installedPlugin = PLUGIN;
-		await advance( rendered, 3000 );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
-
-		// Activation gets its own full window rather than what a long install left over.
-		await advance( rendered, 60 * 1000 );
-		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
-
-		// Retrying an inactive plugin re-enters the activation step.
-		activatePlugin.mockClear();
-		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
-		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -15,7 +14,6 @@ const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
 const mockSite = {
 	installedPlugin: null as typeof PLUGIN | null,
 	pluginActive: false,
-	activationFailed: false,
 	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
 	// transferred it and started the install.
 	isAtomic: false,
@@ -53,7 +51,6 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
 	getStatusForPlugin: () => null,
-	isPluginActionStatus: () => mockSite.activationFailed,
 	isPluginActive: () => mockSite.pluginActive,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -168,15 +165,12 @@ const advance = async ( ms: number ) => {
 
 describe( 'MarketplaceProductInstall', () => {
 	let originalLocation: Location;
-	let user: ReturnType< typeof userEvent.setup >;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
-		user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		jest.clearAllMocks();
 		mockSite.installedPlugin = null;
 		mockSite.pluginActive = false;
-		mockSite.activationFailed = false;
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
 		originalLocation = window.location;
@@ -195,20 +189,17 @@ describe( 'MarketplaceProductInstall', () => {
 		// The transfer is done but the plugin has not been fetched yet, which is the bug this guards
 		// against: the page must not call that an install and leave for a list the plugin is missing
 		// from. It polls for the plugin instead.
-		await advance( 50 * 1000 );
+		await advance( 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		expect( activatePlugin ).not.toHaveBeenCalled();
+		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
 		expect( window.location.href ).toBe( '' );
 
-		// A late poll finds it, so it is activated.
+		// A later poll finds it, so it is activated.
 		mockSite.installedPlugin = PLUGIN;
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 		expect( window.location.href ).toBe( '' );
-
-		// Activating gets its own time to run, rather than what a slow install left over.
-		await advance( 30 * 1000 );
-		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
 
 		mockSite.pluginActive = true;
 		await settle( rendered );
@@ -217,55 +208,24 @@ describe( 'MarketplaceProductInstall', () => {
 		);
 	} );
 
-	it( 'says an install is taking too long, and keeps waiting for it anyway', async () => {
+	it( 'keeps polling for a paid plugin, which checkout installs', async () => {
 		mockSite.isAtomic = true;
 		mockSite.isWporgPlugin = false;
 		const rendered = install();
 		await start( rendered );
 
-		await advance( 61 * 1000 );
-		expect( screen.getByText( /taking longer than expected to install/ ) ).toBeVisible();
-
-		// A paid plugin is installed by checkout, so a late one is still on its way. Keep polling.
-		fetchSitePlugins.mockClear();
-		await advance( 15 * 1000 );
+		await advance( 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+		expect( window.location.href ).toBe( '' );
 
-		// It turns up, and is activated without the user having to do anything.
 		mockSite.installedPlugin = PLUGIN;
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
 
 		mockSite.pluginActive = true;
 		await settle( rendered );
 		expect( window.location.href ).toBe(
 			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
 		);
-	} );
-
-	it( 'looks for a missing plugin again on retry', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		await advance( 61 * 1000 );
-		fetchSitePlugins.mockClear();
-		await user.click( screen.getByRole( 'button', { name: 'Check again' } ) );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-	} );
-
-	it( 'reports a failed activation, and activates again on retry', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		mockSite.installedPlugin = PLUGIN;
-		mockSite.activationFailed = true;
-		await settle( rendered );
-		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
-
-		activatePlugin.mockClear();
-		await user.click( screen.getByRole( 'button', { name: 'Try activating again' } ) );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -28,6 +28,8 @@ const DEFAULT_SITE = {
 	// The checkout install status. COMPLETED means checkout finished the install, so this page does
 	// not start one and stays at step 0 — the marketplace poll path.
 	purchaseStatus: 'PENDING',
+	// The install status the store reports for the plugin slug, e.g. a terminal install failure.
+	installStatus: null as { status: string; action: string } | null,
 };
 const mockSite = { ...DEFAULT_SITE };
 
@@ -61,7 +63,9 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => null,
+	// Install status is keyed by the plugin slug.
+	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
+		pluginId === PLUGIN_SLUG ? mockSite.installStatus : null,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -287,6 +291,25 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
 		await expectRedirectsOnceActive( rendered );
+	} );
+
+	it( 'stops polling when a local install fails with no plugin installed', async () => {
+		mockSite.isAtomic = true; // existing-plan site, so this page runs the install itself
+		mockSite.isWporgPlugin = true; // a free wp.org plugin, not a marketplace product
+		const rendered = install();
+		await start( rendered );
+
+		// It polls while the install is under way.
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+
+		// The install fails and leaves no plugin. That is terminal, so polling stops rather than
+		// requesting the list forever behind the error screen.
+		mockSite.installStatus = { status: 'error', action: 'INSTALL_PLUGIN' };
+		await settle( rendered );
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 9000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not start a new plugin fetch while one is already in flight', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -16,6 +16,10 @@ const mockSite = {
 	installedPlugin: null as typeof PLUGIN | null,
 	pluginActive: false,
 	activationFailed: false,
+	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
+	// transferred it and started the install.
+	isAtomic: false,
+	isWporgPlugin: true,
 };
 
 const mockDispatch = jest.fn();
@@ -43,7 +47,7 @@ jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
 } ) );
 
 jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
-	getPlugin: () => ( { slug: 'give', wporg: true } ),
+	getPlugin: () => ( { slug: 'give', wporg: mockSite.isWporgPlugin } ),
 	isFetched: () => true,
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
@@ -76,7 +80,7 @@ jest.mock( 'calypso/state/sites/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	__esModule: true,
-	default: () => false,
+	default: () => mockSite.isAtomic,
 } ) );
 jest.mock( 'calypso/state/selectors/site-has-feature', () => ( {
 	__esModule: true,
@@ -150,8 +154,8 @@ const settle = async ( rendered: ReturnType< typeof install > ) => {
 	await act( async () => {} );
 };
 
-// Getting the transfer under way takes a render and a resolved promise, so let both settle.
-const startTransfer = async ( rendered: ReturnType< typeof install > ) => {
+// Getting the install under way takes a render and a resolved promise, so let both settle.
+const start = async ( rendered: ReturnType< typeof install > ) => {
 	await act( async () => {} );
 	await settle( rendered );
 };
@@ -173,6 +177,8 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = null;
 		mockSite.pluginActive = false;
 		mockSite.activationFailed = false;
+		mockSite.isAtomic = false;
+		mockSite.isWporgPlugin = true;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -184,7 +190,7 @@ describe( 'MarketplaceProductInstall', () => {
 
 	it( 'activates a plugin the transfer installed, and only then leaves the page', async () => {
 		const rendered = install();
-		await startTransfer( rendered );
+		await start( rendered );
 
 		// The transfer is done but the plugin has not been fetched yet, which is the bug this guards
 		// against: the page must not call that an install and leave for a list the plugin is missing
@@ -211,22 +217,46 @@ describe( 'MarketplaceProductInstall', () => {
 		);
 	} );
 
-	it( 'stops waiting for a plugin that never installs, and looks for it again on retry', async () => {
+	it( 'says an install is taking too long, and keeps waiting for it anyway', async () => {
+		mockSite.isAtomic = true;
+		mockSite.isWporgPlugin = false;
 		const rendered = install();
-		await startTransfer( rendered );
+		await start( rendered );
 
-		await advance( 60 * 1000 );
+		await advance( 61 * 1000 );
 		expect( screen.getByText( /taking longer than expected to install/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
 
+		// A paid plugin is installed by checkout, so a late one is still on its way. Keep polling.
 		fetchSitePlugins.mockClear();
-		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		await advance( 15 * 1000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+
+		// It turns up, and is activated without the user having to do anything.
+		mockSite.installedPlugin = PLUGIN;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
+
+		mockSite.pluginActive = true;
+		await settle( rendered );
+		expect( window.location.href ).toBe(
+			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
+		);
+	} );
+
+	it( 'looks for a missing plugin again on retry', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		await advance( 61 * 1000 );
+		fetchSitePlugins.mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Check again' } ) );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 	} );
 
 	it( 'reports a failed activation, and activates again on retry', async () => {
 		const rendered = install();
-		await startTransfer( rendered );
+		await start( rendered );
 
 		mockSite.installedPlugin = PLUGIN;
 		mockSite.activationFailed = true;
@@ -235,7 +265,7 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( '' );
 
 		activatePlugin.mockClear();
-		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Try activating again' } ) );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -6,15 +6,15 @@ import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
 const PLUGIN = { slug: PLUGIN_SLUG, id: 'give/give' };
+const ACTIVE_PLUGIN = { ...PLUGIN, active: true };
 const SITE_ID = 1;
 const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
 
 // The state the component reads, as the mocked selectors below see it. A test moves the flow along
 // by changing this and re-rendering.
 const mockSite = {
-	installedPlugin: null as typeof PLUGIN | null,
-	pluginActive: false,
-	// Redux keys a plugin's status by its id, which is what an activation error comes back under.
+	installedPlugin: null as ( typeof PLUGIN & { active?: boolean } ) | null,
+	// The id an install or activation failure is recorded under.
 	failedPluginId: null as string | null,
 	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
 	// transferred it and started the install.
@@ -52,11 +52,8 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
-		pluginId === mockSite.failedPluginId
-			? { status: 'error', action: 'ACTIVATE_PLUGIN', error: 'Activation failed' }
-			: null,
-	isPluginActive: () => mockSite.pluginActive,
+	isPluginActionStatus: ( _state: unknown, _siteId: number, pluginId: string ) =>
+		pluginId === mockSite.failedPluginId,
 	isRequesting: () => false,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -176,7 +173,6 @@ describe( 'MarketplaceProductInstall', () => {
 		jest.useFakeTimers();
 		jest.clearAllMocks();
 		mockSite.installedPlugin = null;
-		mockSite.pluginActive = false;
 		mockSite.failedPluginId = null;
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
@@ -208,7 +204,7 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 		expect( window.location.href ).toBe( '' );
 
-		mockSite.pluginActive = true;
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe(
 			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
@@ -236,6 +232,20 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( '' );
 	} );
 
+	it( 'shows an install failure keyed by slug even after the plugin exists', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		// An existing but inactive plugin can fail a slow update after activation begins. Its install
+		// status lives under the slug, not the installed id, so it still has to surface.
+		mockSite.installedPlugin = PLUGIN;
+		mockSite.failedPluginId = PLUGIN_SLUG;
+		await settle( rendered );
+
+		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
+	} );
+
 	it( 'keeps polling for a paid plugin, which checkout installs', async () => {
 		mockSite.isAtomic = true;
 		mockSite.isWporgPlugin = false;
@@ -250,7 +260,7 @@ describe( 'MarketplaceProductInstall', () => {
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		mockSite.pluginActive = true;
+		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe(
 			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, act } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -21,8 +21,6 @@ const mockSite = {
 	isWporgPlugin: true,
 	// Whether a site-plugins request is in flight, so a test can hold off the next poll.
 	isFetching: false,
-	// The activation status the store reports for the installed plugin, keyed by its id.
-	activationStatus: null as { action: string; status: string; error?: unknown } | null,
 };
 
 const mockDispatch = jest.fn();
@@ -55,9 +53,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
-		// The installed plugin's id, which activation status is keyed by (PLUGIN.id).
-		pluginId === 'give/give' ? mockSite.activationStatus : null,
+	getStatusForPlugin: () => null,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -181,7 +177,6 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
 		mockSite.isFetching = false;
-		mockSite.activationStatus = null;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -234,50 +229,24 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'keeps polling after an activation_error, which means the plugin was already active', async () => {
+	it( 'reconciles an install on an existing-plan site, redirecting once active', async () => {
+		mockSite.isAtomic = true; // the site already has a plan
+		mockSite.isWporgPlugin = true; // a free wp.org plugin, not a marketplace product
 		const rendered = install();
 		await start( rendered );
+
+		// The flow is under way, so it polls for the active state like the theme flow does, even though
+		// this is neither a transfer nor a paid marketplace install.
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 
 		mockSite.installedPlugin = PLUGIN;
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		// An activation_error is not a failure: it means already-active. The page keeps waiting for the
-		// refreshed active state rather than showing an error.
-		mockSite.activationStatus = {
-			action: 'ACTIVATE_PLUGIN',
-			status: 'error',
-			error: { error: 'activation_error' },
-		};
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-		expect( window.location.href ).toBe( '' );
 
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
-	} );
-
-	it( 'shows an error and stops polling on a genuine activation failure', async () => {
-		const rendered = install();
-		await start( rendered );
-
-		mockSite.installedPlugin = PLUGIN;
-		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		mockSite.activationStatus = {
-			action: 'ACTIVATE_PLUGIN',
-			status: 'error',
-			error: { error: 'some_other_failure' },
-		};
-		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 6000 );
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
-		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
-		expect( window.location.href ).toBe( '' );
 	} );
 
 	it( 'does not start a new plugin fetch while one is already in flight', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -333,8 +333,19 @@ describe( 'MarketplaceProductInstall', () => {
 			'/plugins/give/example.wordpress.com'
 		);
 
+		// The next poll drops the plugin from the installed-plugin selector, but the error must not
+		// flip back to the progress screen — it is read from the captured id, not the live plugin.
+		mockSite.installedPlugin = null;
+		mockSite.isFetching = true;
+		await settle( rendered );
+		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
+		expect( screen.queryByText( /Installing plugin/ ) ).toBeNull();
+		mockSite.isFetching = false;
+
 		// A lost response can follow a server-side success, so polling continues and a later active
 		// refresh still redirects.
+		mockSite.installedPlugin = PLUGIN;
+		await settle( rendered );
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
@@ -364,7 +375,7 @@ describe( 'MarketplaceProductInstall', () => {
 		await expectRedirectsOnceActive( rendered );
 	} );
 
-	it( 'keeps polling on an activation_error, which just means already active', async () => {
+	it( 'surfaces an activation_error, which the API also uses for a missing plugin file', async () => {
 		const rendered = install();
 		await start( rendered );
 
@@ -376,7 +387,9 @@ describe( 'MarketplaceProductInstall', () => {
 		};
 		await settle( rendered );
 
-		// activation_error is not a failure: keep waiting for the refreshed active state.
+		// activation_error is not reliably "already active", so it is surfaced rather than left to poll
+		// forever. Polling still continues, so a genuinely-active plugin redirects on the next refresh.
+		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,39 +1,46 @@
 /**
  * @jest-environment jsdom
  */
-import { render, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
-const PLUGIN = { slug: PLUGIN_SLUG, id: 'give/give' };
-const ACTIVE_PLUGIN = { ...PLUGIN, active: true };
 const SITE_ID = 1;
 const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
 const ACTIVE_LIST_URL = `${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`;
 
-// The state the component reads, as the mocked selectors below see it. A test moves the flow along
-// by changing this and re-rendering; beforeEach restores these defaults.
+// The state the mocked selectors/queries below see. A test moves the flow along by changing this
+// and re-rendering; beforeEach restores the defaults.
 const DEFAULT_SITE = {
-	installedPlugin: null as ( typeof PLUGIN & { active?: boolean } ) | null,
-	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
-	// transferred it and started the install.
-	isAtomic: false,
-	isWporgPlugin: true,
-	// Whether a site-plugins request is in flight, so a test can hold off the next poll.
-	isFetching: false,
-	// Whether the transferred atomic site is ready for its WP Admin URL.
-	isReady: true,
-	// Whether the site's manage-plugins capability has propagated.
+	// What the /plugins/{slug}/active endpoint reports: null (not fetched), 'processing', 'inactive',
+	// or 'complete'.
+	pluginActive: null as null | 'processing' | 'inactive' | 'complete',
+	// A terminal (non-503) read error from that endpoint.
+	pluginActiveError: null as { status: number } | null,
+	// Whether the manage-plugins capability has propagated.
 	canManage: true,
-	// The checkout install status. COMPLETED means checkout finished the install, so this page does
-	// not start one and stays at step 0 — the marketplace poll path.
+	// Whether the site is Atomic (the endpoint only applies to Atomic sites).
+	siteIsAtomic: true,
+	// A self-hosted Jetpack site, which the endpoint does not cover.
+	isJetpack: false,
+	// The plugin the plugin-list selector reports, for the flows the endpoint can't reach.
+	installedPlugin: null as { slug: string; id: string; active?: boolean } | null,
+	// The checkout purchase-flow handoff: which product it installed, and its status.
+	purchaseProduct: 'give' as string | null,
 	purchaseStatus: 'PENDING',
-	// The install status the store reports for the plugin slug, e.g. a terminal install failure.
-	installStatus: null as { status: string; action: string } | null,
+	// The install status the plugin-list selector reports (e.g. a terminal local install failure).
+	installStatus: null as { status: string; action: string; error?: unknown } | null,
+	// A monotonically increasing poll counter; each increment simulates a completed endpoint poll.
+	pollTick: 0,
 };
 const mockSite = { ...DEFAULT_SITE };
 
 const mockDispatch = jest.fn();
+
+// react-query keeps a stable data reference across unchanged polls (structural sharing). Mimic that
+// so activation retries are driven by dataUpdatedAt (pollTick), not by every re-render.
+let mockActiveData: unknown;
+let mockActiveKey: string | undefined;
 
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => mockDispatch,
@@ -43,7 +50,6 @@ jest.mock( 'calypso/state', () => ( {
 jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 	installPlugin: jest.fn( () => ( { type: 'INSTALL_PLUGIN' } ) ),
 	activatePlugin: jest.fn( () => ( { type: 'ACTIVATE_PLUGIN' } ) ),
-	fetchSitePlugins: jest.fn( () => ( { type: 'FETCH_SITE_PLUGINS' } ) ),
 } ) );
 jest.mock( 'calypso/state/themes/actions', () => ( {
 	initiateThemeTransfer: jest.fn( () => ( { type: 'INITIATE_TRANSFER' } ) ),
@@ -58,15 +64,12 @@ jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
 } ) );
 
 jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
-	getPlugin: () => ( { slug: 'give', wporg: mockSite.isWporgPlugin } ),
+	getPlugin: () => ( { slug: 'give', wporg: true } ),
 	isFetched: () => true,
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	// Install status is keyed by the plugin slug.
-	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
-		pluginId === PLUGIN_SLUG ? mockSite.installStatus : null,
-	isRequesting: () => mockSite.isFetching,
+	getStatusForPlugin: () => mockSite.installStatus,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
 	getAutomatedTransferStatus: () => 'complete',
@@ -74,7 +77,7 @@ jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
 jest.mock( 'calypso/state/marketplace/purchase-flow/selectors', () => ( {
 	getPurchaseFlowState: () => ( {
 		pluginInstallationStatus: mockSite.purchaseStatus,
-		productSlugInstalled: 'give',
+		productSlugInstalled: mockSite.purchaseProduct,
 		primaryDomain: 'example.wordpress.com',
 	} ),
 } ) );
@@ -87,12 +90,12 @@ jest.mock( 'calypso/state/themes/selectors', () => ( {
 	isThemeActive: () => false,
 } ) );
 jest.mock( 'calypso/state/sites/selectors', () => ( {
-	isJetpackSite: () => false,
+	isJetpackSite: () => mockSite.isJetpack,
 	getSiteAdminUrl: () => null,
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	__esModule: true,
-	default: () => mockSite.isAtomic,
+	default: () => false,
 } ) );
 jest.mock( 'calypso/state/selectors/site-has-feature', () => ( {
 	__esModule: true,
@@ -124,21 +127,44 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSelectedSiteSlug: () => 'example.wordpress.com',
 } ) );
 
-// The site the transfer hands back: atomic, with an admin URL to redirect to.
+// Two useQuery callers: the fresh site (siteByIdQuery) and the plugin-active endpoint.
 jest.mock( '@tanstack/react-query', () => ( {
-	useQuery: () => ( {
-		data: {
-			ID: 1,
-			is_wpcom_atomic: true,
-			options: { admin_url: 'https://example.wordpress.com/wp-admin/' },
-		},
-	} ),
+	useQuery: ( options: { queryKey?: unknown[]; enabled?: boolean } ) => {
+		if ( ( options?.queryKey ?? [] ).includes( 'plugin-active' ) ) {
+			// A disabled query has no data, like react-query.
+			if ( options?.enabled === false ) {
+				return { data: undefined, error: null, dataUpdatedAt: 0 };
+			}
+			const key = String( mockSite.pluginActive );
+			if ( key !== mockActiveKey ) {
+				mockActiveKey = key;
+				mockActiveData = mockSite.pluginActive
+					? { status: mockSite.pluginActive, plugin: { slug: 'give', id: 'give/give' } }
+					: undefined;
+			}
+			return {
+				data: mockActiveData,
+				error: mockSite.pluginActiveError,
+				dataUpdatedAt: mockSite.pollTick,
+			};
+		}
+		return {
+			data: {
+				ID: 1,
+				is_wpcom_atomic: mockSite.siteIsAtomic,
+				options: { admin_url: 'https://example.wordpress.com/wp-admin/' },
+			},
+		};
+	},
 } ) );
 jest.mock( 'calypso/dashboard/utils/site-atomic-transfers', () => ( {
-	isAtomicTransferredSite: () => mockSite.isReady,
+	isAtomicTransferredSite: ( site: { is_wpcom_atomic?: boolean } ) => !! site?.is_wpcom_atomic,
 } ) );
 jest.mock( '@automattic/api-queries', () => ( {
 	siteByIdQuery: () => ( { queryKey: [ 'site' ] } ),
+	sitePluginActiveQuery: ( _siteId: number, slug: string ) => ( {
+		queryKey: [ 'plugin-active', slug ],
+	} ),
 } ) );
 jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
 	useWPCOMPlugin: () => ( { data: null } ),
@@ -155,178 +181,162 @@ jest.mock( 'calypso/my-sites/marketplace/components/progressbar', () => ( {
 	default: () => <div>Installing plugin</div>,
 } ) );
 
-const { installPlugin, activatePlugin, fetchSitePlugins } = jest.requireMock(
-	'calypso/state/plugins/installed/actions'
-);
+const { activatePlugin } = jest.requireMock( 'calypso/state/plugins/installed/actions' );
 
 const install = () => render( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
 
-// The store the component reads is mocked, so a change to it reaches the page on the next render.
 const settle = async ( rendered: ReturnType< typeof install > ) => {
 	rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
 	await act( async () => {} );
 };
 
-// Getting the install under way takes a render and a resolved promise, so let both settle.
+// The install kicks off, then hands over to the endpoint poll. That takes a render and a resolved
+// promise, so let both settle.
 const start = async ( rendered: ReturnType< typeof install > ) => {
 	await act( async () => {} );
 	await settle( rendered );
-};
-
-const advance = async ( rendered: ReturnType< typeof install >, ms: number ) => {
-	await act( async () => {
-		jest.advanceTimersByTime( ms );
-	} );
-	await settle( rendered );
-};
-
-// The plugin going active is what ends every flow: the store reports it, and the page redirects.
-const expectRedirectsOnceActive = async ( rendered: ReturnType< typeof install > ) => {
-	mockSite.installedPlugin = ACTIVE_PLUGIN;
-	await settle( rendered );
-	expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 };
 
 describe( 'MarketplaceProductInstall', () => {
 	let originalLocation: Location;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
 		jest.clearAllMocks();
 		Object.assign( mockSite, DEFAULT_SITE );
+		mockActiveKey = undefined;
+		mockActiveData = undefined;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
 		Object.defineProperty( window, 'location', { value: originalLocation, writable: true } );
 	} );
 
-	it( 'activates a transferred plugin that appears after a minute, and redirects once active', async () => {
+	it( 'redirects once the active-status endpoint reports the plugin complete', async () => {
+		mockSite.pluginActive = 'processing';
 		const rendered = install();
 		await start( rendered );
 
-		// The transfer is done but the plugin has not been fetched yet, which is the bug this guards
-		// against: the page must not call that an install and leave for a list the plugin is missing
-		// from. It keeps polling however long the install takes, with no cutoff.
-		await advance( rendered, 90 * 1000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-		expect( activatePlugin ).not.toHaveBeenCalled();
+		// Still installing: no redirect yet.
 		expect( window.location.href ).toBe( '' );
 
-		// A later poll finds it, so it is activated.
-		mockSite.installedPlugin = PLUGIN;
+		mockSite.pluginActive = 'complete';
 		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-		expect( window.location.href ).toBe( '' );
-
-		// Only the refreshed active state, not the activation call, ends the wait.
-		await expectRedirectsOnceActive( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'polls a paid plugin that checkout installed, without starting its own install', async () => {
-		mockSite.isAtomic = true;
-		mockSite.isWporgPlugin = false;
-		// Checkout finished the install, so this page starts none and stays at step 0. Polling then
-		// happens only through the marketplace path, which is what this exercises.
+	it( 'activates the plugin when the endpoint reports it installed but inactive', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		// `inactive` means installed-but-not-active: dispatch the targeted activation, using the id the
+		// endpoint returns.
+		activatePlugin.mockClear();
+		mockSite.pluginActive = 'inactive';
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, {
+			id: 'give/give',
+			slug: PLUGIN_SLUG,
+		} );
+
+		// A re-render without a new poll does not re-dispatch.
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+		expect( window.location.href ).toBe( '' );
+	} );
+
+	it( 'retries activation a bounded number of times, then shows an error', async () => {
+		mockSite.pluginActive = 'inactive';
+		const rendered = install();
+		await start( rendered ); // attempt 1
+
+		// Each subsequent poll that still reports inactive retries, up to the cap of 3.
+		mockSite.pollTick = 1;
+		await settle( rendered ); // attempt 2
+		mockSite.pollTick = 2;
+		await settle( rendered ); // attempt 3
+		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
+		expect( screen.queryByText( /could not activate it/ ) ).toBeNull();
+
+		// The next inactive poll exhausts the retries and surfaces the failure.
+		mockSite.pollTick = 3;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
+		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
+	} );
+
+	it( 'redirects when a retried activation eventually succeeds', async () => {
+		mockSite.pluginActive = 'inactive';
+		const rendered = install();
+		await start( rendered ); // attempt 1
+
+		mockSite.pollTick = 1;
+		await settle( rendered ); // attempt 2, still inactive
+		expect( activatePlugin ).toHaveBeenCalledTimes( 2 );
+
+		// A later poll reports it active.
+		mockSite.pluginActive = 'complete';
+		await settle( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'activates and redirects on a non-Atomic site through the plugin list', async () => {
+		// The endpoint is Atomic-only, so a self-hosted Jetpack site keeps the plugin-list path.
+		mockSite.siteIsAtomic = false;
+		mockSite.isJetpack = true;
+		const rendered = install();
+		await start( rendered );
+
+		// The plugin turns up installed-but-inactive and is activated here.
+		activatePlugin.mockClear();
+		mockSite.installedPlugin = { slug: 'give', id: 'give/give' };
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, { id: 'give/give', slug: 'give' } );
+		expect( window.location.href ).toBe( '' );
+
+		// Once the plugin list reports it active, redirect.
+		mockSite.installedPlugin = { slug: 'give', id: 'give/give', active: true };
+		await settle( rendered );
+		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'does not activate a plugin when no install was requested', async () => {
+		// A completed purchase with no handoff for this plugin: opening the URL must not activate it,
+		// even though the endpoint would report it inactive.
+		mockSite.purchaseProduct = null;
 		mockSite.purchaseStatus = 'COMPLETED';
+		mockSite.pluginActive = 'inactive';
 		const rendered = install();
 		await start( rendered );
 
-		expect( installPlugin ).not.toHaveBeenCalled();
-
-		// The plugin is present but inactive. Checkout activates it out of band, so the page must keep
-		// polling rather than leaving as soon as it appears.
-		mockSite.installedPlugin = PLUGIN;
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-		expect( installPlugin ).not.toHaveBeenCalled();
-		expect( window.location.href ).toBe( '' );
-
-		await expectRedirectsOnceActive( rendered );
-	} );
-
-	it( 'reconciles an install on an existing-plan site, redirecting once active', async () => {
-		mockSite.isAtomic = true; // the site already has a plan
-		mockSite.isWporgPlugin = true; // a free wp.org plugin, not a marketplace product
-		const rendered = install();
-		await start( rendered );
-
-		// The flow is under way, so it polls for the active state like the theme flow does, even though
-		// this is neither a transfer nor a paid marketplace install.
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-
-		mockSite.installedPlugin = PLUGIN;
-		await settle( rendered );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		await expectRedirectsOnceActive( rendered );
-	} );
-
-	// A transferred plugin must wait on two readiness signals before this page acts: the atomic site
-	// being ready for its WP Admin URL, and the manage-plugins capability having propagated.
-	it.each( [
-		[ 'the transferred atomic site is ready', 'isReady' as const ],
-		[ 'the manage-plugins capability propagates', 'canManage' as const ],
-	] )( 'does not activate or redirect before %s', async ( _label, gate ) => {
-		mockSite[ gate ] = false;
-		const rendered = install();
-		await start( rendered );
-
-		// The plugin has turned up, but the gate is not open, so it must not activate it, poll, or send
-		// the user to a WP Admin URL that is not there yet.
-		mockSite.installedPlugin = PLUGIN;
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 6000 );
 		expect( activatePlugin ).not.toHaveBeenCalled();
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 		expect( window.location.href ).toBe( '' );
-
-		// Once the gate opens, it activates the plugin and, once active, redirects.
-		mockSite[ gate ] = true;
-		await advance( rendered, 3000 );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
-
-		await expectRedirectsOnceActive( rendered );
 	} );
 
-	it( 'stops polling when a local install fails with no plugin installed', async () => {
-		mockSite.isAtomic = true; // existing-plan site, so this page runs the install itself
-		mockSite.isWporgPlugin = true; // a free wp.org plugin, not a marketplace product
+	it( 'stops polling and shows an error when a local install fails with no plugin', async () => {
+		mockSite.installStatus = {
+			status: 'error',
+			action: 'INSTALL_PLUGIN',
+			error: { error: 'no_package' },
+		};
+		mockSite.pluginActive = 'processing';
 		const rendered = install();
 		await start( rendered );
 
-		// It polls while the install is under way.
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
-
-		// The install fails and leaves no plugin. That is terminal, so polling stops rather than
-		// requesting the list forever behind the error screen.
-		mockSite.installStatus = { status: 'error', action: 'INSTALL_PLUGIN' };
-		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 9000 );
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		// The endpoint is disabled (nothing to reconcile), so it neither activates nor polls; the
+		// install error is shown.
+		expect( activatePlugin ).not.toHaveBeenCalled();
+		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
 	} );
 
-	it( 'does not start a new plugin fetch while one is already in flight', async () => {
+	it( 'shows an error on a terminal read failure and does not redirect', async () => {
+		mockSite.pluginActiveError = { status: 502 };
 		const rendered = install();
 		await start( rendered );
 
-		// A slow request is still running, so a tick must not pile a second one on top of it.
-		mockSite.isFetching = true;
-		await settle( rendered );
-		fetchSitePlugins.mockClear();
-		await advance( rendered, 6000 );
-		expect( fetchSitePlugins ).not.toHaveBeenCalled();
-
-		// Once it settles, polling picks back up.
-		mockSite.isFetching = false;
-		await settle( rendered );
-		await advance( rendered, 3000 );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+		expect( screen.getByText( /could not verify the plugin/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -12,8 +12,8 @@ const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
 const ACTIVE_LIST_URL = `${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`;
 
 // The state the component reads, as the mocked selectors below see it. A test moves the flow along
-// by changing this and re-rendering.
-const mockSite = {
+// by changing this and re-rendering; beforeEach restores these defaults.
+const DEFAULT_SITE = {
 	installedPlugin: null as ( typeof PLUGIN & { active?: boolean } ) | null,
 	// A paid marketplace plugin is not a wp.org one, and its site is already atomic: checkout
 	// transferred it and started the install.
@@ -29,6 +29,7 @@ const mockSite = {
 	// not start one and stays at step 0 — the marketplace poll path.
 	purchaseStatus: 'PENDING',
 };
+const mockSite = { ...DEFAULT_SITE };
 
 const mockDispatch = jest.fn();
 
@@ -175,19 +176,20 @@ const advance = async ( rendered: ReturnType< typeof install >, ms: number ) => 
 	await settle( rendered );
 };
 
+// The plugin going active is what ends every flow: the store reports it, and the page redirects.
+const expectRedirectsOnceActive = async ( rendered: ReturnType< typeof install > ) => {
+	mockSite.installedPlugin = ACTIVE_PLUGIN;
+	await settle( rendered );
+	expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+};
+
 describe( 'MarketplaceProductInstall', () => {
 	let originalLocation: Location;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
 		jest.clearAllMocks();
-		mockSite.installedPlugin = null;
-		mockSite.isAtomic = false;
-		mockSite.isWporgPlugin = true;
-		mockSite.isFetching = false;
-		mockSite.isReady = true;
-		mockSite.canManage = true;
-		mockSite.purchaseStatus = 'PENDING';
+		Object.assign( mockSite, DEFAULT_SITE );
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -216,9 +218,7 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( '' );
 
 		// Only the refreshed active state, not the activation call, ends the wait.
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
-		await settle( rendered );
-		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+		await expectRedirectsOnceActive( rendered );
 	} );
 
 	it( 'polls a paid plugin that checkout installed, without starting its own install', async () => {
@@ -241,9 +241,7 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( installPlugin ).not.toHaveBeenCalled();
 		expect( window.location.href ).toBe( '' );
 
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
-		await settle( rendered );
-		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+		await expectRedirectsOnceActive( rendered );
 	} );
 
 	it( 'reconciles an install on an existing-plan site, redirecting once active', async () => {
@@ -261,9 +259,7 @@ describe( 'MarketplaceProductInstall', () => {
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
-		await settle( rendered );
-		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+		await expectRedirectsOnceActive( rendered );
 	} );
 
 	it( 'does not activate or redirect before the transferred atomic site is ready', async () => {
@@ -285,9 +281,7 @@ describe( 'MarketplaceProductInstall', () => {
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
-		await settle( rendered );
-		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+		await expectRedirectsOnceActive( rendered );
 	} );
 
 	it( 'waits for the manage-plugins capability before activating or redirecting', async () => {
@@ -309,9 +303,7 @@ describe( 'MarketplaceProductInstall', () => {
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
-		mockSite.installedPlugin = ACTIVE_PLUGIN;
-		await settle( rendered );
-		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+		await expectRedirectsOnceActive( rendered );
 	} );
 
 	it( 'does not start a new plugin fetch while one is already in flight', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -23,6 +23,8 @@ const mockSite = {
 	isFetching: false,
 	// Whether the transferred atomic site is ready for its WP Admin URL.
 	isReady: true,
+	// Whether the install status reports a terminal error.
+	installError: false,
 };
 
 const mockDispatch = jest.fn();
@@ -55,7 +57,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => null,
+	getStatusForPlugin: () => ( mockSite.installError ? { error: 'install failed' } : null ),
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -180,6 +182,7 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isWporgPlugin = true;
 		mockSite.isFetching = false;
 		mockSite.isReady = true;
+		mockSite.installError = false;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -299,6 +302,25 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'stops polling when installation fails with nothing installed', async () => {
+		mockSite.isAtomic = true; // existing-plan site, so the install runs through this page
+		mockSite.isWporgPlugin = true;
+		const rendered = install();
+		await start( rendered );
+
+		// It polls while the install is under way.
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+
+		// The install fails and leaves no plugin. That is terminal: the error shows and polling stops.
+		mockSite.installError = true;
+		await settle( rendered );
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 9000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
 	} );
 
 	it( 'does not start a new plugin fetch while one is already in flight', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -21,6 +21,8 @@ const mockSite = {
 	isWporgPlugin: true,
 	// Whether a site-plugins request is in flight, so a test can hold off the next poll.
 	isFetching: false,
+	// The activation status the store reports for the installed plugin, keyed by its id.
+	activationStatus: null as { action: string; status: string; error?: unknown } | null,
 };
 
 const mockDispatch = jest.fn();
@@ -53,7 +55,9 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => null,
+	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
+		// The installed plugin's id, which activation status is keyed by (PLUGIN.id).
+		pluginId === 'give/give' ? mockSite.activationStatus : null,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -177,6 +181,7 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
 		mockSite.isFetching = false;
+		mockSite.activationStatus = null;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -229,16 +234,21 @@ describe( 'MarketplaceProductInstall', () => {
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
 	} );
 
-	it( 'redirects on a later active refresh even if activation looked like it failed', async () => {
+	it( 'keeps polling after an activation_error, which means the plugin was already active', async () => {
 		const rendered = install();
 		await start( rendered );
 
-		// Activation is dispatched, but the store still reports the plugin inactive: an activation
-		// response is not authoritative. The page waits for the refreshed active state, not the action.
 		mockSite.installedPlugin = PLUGIN;
 		await settle( rendered );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
+		// An activation_error is not a failure: it means already-active. The page keeps waiting for the
+		// refreshed active state rather than showing an error.
+		mockSite.activationStatus = {
+			action: 'ACTIVATE_PLUGIN',
+			status: 'error',
+			error: { error: 'activation_error' },
+		};
 		fetchSitePlugins.mockClear();
 		await advance( rendered, 3000 );
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
@@ -247,6 +257,27 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'shows an error and stops polling on a genuine activation failure', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		mockSite.installedPlugin = PLUGIN;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+
+		mockSite.activationStatus = {
+			action: 'ACTIVATE_PLUGIN',
+			status: 'error',
+			error: { error: 'some_other_failure' },
+		};
+		await settle( rendered );
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 6000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
 	} );
 
 	it( 'does not start a new plugin fetch while one is already in flight', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -20,6 +20,8 @@ const mockSite = {
 	// transferred it and started the install.
 	isAtomic: false,
 	isWporgPlugin: true,
+	// Whether a site-plugins request is in flight, so a test can hold off the next poll.
+	isFetching: false,
 };
 
 const mockDispatch = jest.fn();
@@ -53,7 +55,7 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
 	getStatusForPlugin: () => null,
-	isRequesting: () => false,
+	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
 	getAutomatedTransferStatus: () => 'complete',
@@ -177,6 +179,7 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = null;
 		mockSite.isAtomic = false;
 		mockSite.isWporgPlugin = true;
+		mockSite.isFetching = false;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -247,6 +250,24 @@ describe( 'MarketplaceProductInstall', () => {
 		mockSite.installedPlugin = ACTIVE_PLUGIN;
 		await settle( rendered );
 		expect( window.location.href ).toBe( ACTIVE_LIST_URL );
+	} );
+
+	it( 'does not start a new plugin fetch while one is already in flight', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		// A slow request is still running, so a tick must not pile a second one on top of it.
+		mockSite.isFetching = true;
+		await settle( rendered );
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 6000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+
+		// Once it settles, polling picks back up.
+		mockSite.isFetching = false;
+		await settle( rendered );
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 	} );
 
 	it( 'times out installation and activation on their own deadlines, and retry resumes each', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -2,19 +2,20 @@
  * @jest-environment jsdom
  */
 import { render, screen, act } from '@testing-library/react';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import userEvent from '@testing-library/user-event';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
-const SITE = { ID: 1, slug: 'example.wordpress.com' };
+const PLUGIN = { slug: PLUGIN_SLUG, id: 'give/give' };
+const SITE_ID = 1;
 const ADMIN_URL = 'https://example.wordpress.com/wp-admin/';
 
 // The state the component reads, as the mocked selectors below see it. A test moves the flow along
 // by changing this and re-rendering.
 const mockSite = {
-	transferStatus: transferStates.COMPLETE,
-	installedPlugin: null as { slug: string; id: string } | null,
+	installedPlugin: null as typeof PLUGIN | null,
 	pluginActive: false,
+	activationFailed: false,
 };
 
 const mockDispatch = jest.fn();
@@ -48,10 +49,11 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
 	getStatusForPlugin: () => null,
+	isPluginActionStatus: () => mockSite.activationFailed,
 	isPluginActive: () => mockSite.pluginActive,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
-	getAutomatedTransferStatus: () => mockSite.transferStatus,
+	getAutomatedTransferStatus: () => 'complete',
 } ) );
 jest.mock( 'calypso/state/marketplace/purchase-flow/selectors', () => ( {
 	getPurchaseFlowState: () => ( {
@@ -133,34 +135,44 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
 jest.mock( 'calypso/my-sites/marketplace/util', () => ( { waitFor: () => Promise.resolve() } ) );
 jest.mock( 'calypso/my-sites/marketplace/components/progressbar', () => ( {
 	__esModule: true,
-	default: ( { currentStep }: { currentStep: number } ) => (
-		<div data-testid="progress">{ currentStep }</div>
-	),
+	default: () => <div>Installing plugin</div>,
 } ) );
 
 const { activatePlugin, fetchSitePlugins } = jest.requireMock(
 	'calypso/state/plugins/installed/actions'
 );
 
-const renderInstallPage = () => render( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
+const install = () => render( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
 
-// The install page starts the transfer, then hands over to the effects that wait on it. Getting to
-// that point takes a render and a resolved promise, so let both settle.
-const startTransfer = async ( rendered: ReturnType< typeof renderInstallPage > ) => {
-	await act( async () => {} );
+// The store the component reads is mocked, so a change to it reaches the page on the next render.
+const settle = async ( rendered: ReturnType< typeof install > ) => {
 	rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
 	await act( async () => {} );
 };
 
+// Getting the transfer under way takes a render and a resolved promise, so let both settle.
+const startTransfer = async ( rendered: ReturnType< typeof install > ) => {
+	await act( async () => {} );
+	await settle( rendered );
+};
+
+const advance = async ( ms: number ) => {
+	await act( async () => {
+		jest.advanceTimersByTime( ms );
+	} );
+};
+
 describe( 'MarketplaceProductInstall', () => {
 	let originalLocation: Location;
+	let user: ReturnType< typeof userEvent.setup >;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
+		user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		jest.clearAllMocks();
-		mockSite.transferStatus = transferStates.COMPLETE;
 		mockSite.installedPlugin = null;
 		mockSite.pluginActive = false;
+		mockSite.activationFailed = false;
 		originalLocation = window.location;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
@@ -171,50 +183,59 @@ describe( 'MarketplaceProductInstall', () => {
 	} );
 
 	it( 'activates a plugin the transfer installed, and only then leaves the page', async () => {
-		const rendered = renderInstallPage();
+		const rendered = install();
 		await startTransfer( rendered );
 
-		// The transfer is done but the plugin has not been fetched yet, which is the whole bug: the
-		// page must not call this an install and leave for a list the plugin is missing from.
-		expect( window.location.href ).toBe( '' );
+		// The transfer is done but the plugin has not been fetched yet, which is the bug this guards
+		// against: the page must not call that an install and leave for a list the plugin is missing
+		// from. It polls for the plugin instead.
+		await advance( 50 * 1000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		expect( activatePlugin ).not.toHaveBeenCalled();
-
-		// It polls for the plugin instead.
-		await act( async () => {
-			jest.advanceTimersByTime( 3000 );
-		} );
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE.ID );
 		expect( window.location.href ).toBe( '' );
 
-		// A later poll finds it, so it is activated.
-		mockSite.installedPlugin = { slug: PLUGIN_SLUG, id: 'give/give' };
-		await act( async () => {
-			rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
-		} );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE.ID, {
-			slug: PLUGIN_SLUG,
-			id: 'give/give',
-		} );
+		// A late poll finds it, so it is activated.
+		mockSite.installedPlugin = PLUGIN;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 		expect( window.location.href ).toBe( '' );
+
+		// Activating gets its own time to run, rather than what a slow install left over.
+		await advance( 30 * 1000 );
+		expect( screen.getByText( /Installing plugin/ ) ).toBeVisible();
 
 		mockSite.pluginActive = true;
-		await act( async () => {
-			rendered.rerender( <MarketplaceProductInstall pluginSlug={ PLUGIN_SLUG } /> );
-		} );
+		await settle( rendered );
 		expect( window.location.href ).toBe(
 			`${ ADMIN_URL }plugins.php?activate=true&plugin_status=active`
 		);
 	} );
 
-	it( 'stops waiting for an activation that never happens', async () => {
-		const rendered = renderInstallPage();
+	it( 'stops waiting for a plugin that never installs, and looks for it again on retry', async () => {
+		const rendered = install();
 		await startTransfer( rendered );
 
-		await act( async () => {
-			jest.advanceTimersByTime( 60 * 1000 );
-		} );
+		await advance( 60 * 1000 );
+		expect( screen.getByText( /taking longer than expected to install/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
 
+		fetchSitePlugins.mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
+	} );
+
+	it( 'reports a failed activation, and activates again on retry', async () => {
+		const rendered = install();
+		await startTransfer( rendered );
+
+		mockSite.installedPlugin = PLUGIN;
+		mockSite.activationFailed = true;
+		await settle( rendered );
 		expect( screen.getByText( /could not activate it/ ) ).toBeVisible();
 		expect( window.location.href ).toBe( '' );
+
+		activatePlugin.mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -53,7 +53,9 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
 	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
-		pluginId === mockSite.failedPluginId ? { error: { message: 'Activation failed' } } : null,
+		pluginId === mockSite.failedPluginId
+			? { status: 'error', action: 'ACTIVATE_PLUGIN', error: 'Activation failed' }
+			: null,
 	isPluginActive: () => mockSite.pluginActive,
 	isRequesting: () => false,
 } ) );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import MarketplaceProductInstall from '../index';
 
 const PLUGIN_SLUG = 'give';
@@ -28,6 +28,8 @@ const DEFAULT_SITE = {
 	// The checkout install status. COMPLETED means checkout finished the install, so this page does
 	// not start one and stays at step 0 — the marketplace poll path.
 	purchaseStatus: 'PENDING',
+	// The status the store reports for the installed plugin's id, e.g. a failed activation.
+	activationStatus: null as { status: string; action: string; error?: unknown } | null,
 };
 const mockSite = { ...DEFAULT_SITE };
 
@@ -61,7 +63,9 @@ jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	getPluginOnSite: () => mockSite.installedPlugin,
-	getStatusForPlugin: () => null,
+	// Install status is keyed by slug; activation status by the installed plugin's id (PLUGIN.id).
+	getStatusForPlugin: ( _state: unknown, _siteId: number, pluginId: string ) =>
+		pluginId === 'give/give' ? mockSite.activationStatus : null,
 	isRequesting: () => mockSite.isFetching,
 } ) );
 jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
@@ -303,6 +307,47 @@ describe( 'MarketplaceProductInstall', () => {
 		await advance( rendered, 3000 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
 
+		await expectRedirectsOnceActive( rendered );
+	} );
+
+	it( 'shows an error and stops polling on a genuine activation failure', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		mockSite.installedPlugin = PLUGIN;
+		await settle( rendered );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, PLUGIN );
+
+		// Activation comes back with a real failure, so the page stops polling and shows the error.
+		mockSite.activationStatus = {
+			status: 'error',
+			action: 'ACTIVATE_PLUGIN',
+			error: { error: 'some_failure' },
+		};
+		await settle( rendered );
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 9000 );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		expect( screen.getByText( /An error occurred while installing the plugin/ ) ).toBeVisible();
+		expect( window.location.href ).toBe( '' );
+	} );
+
+	it( 'keeps polling on an activation_error, which just means already active', async () => {
+		const rendered = install();
+		await start( rendered );
+
+		mockSite.installedPlugin = PLUGIN;
+		mockSite.activationStatus = {
+			status: 'error',
+			action: 'ACTIVATE_PLUGIN',
+			error: { error: 'activation_error' },
+		};
+		await settle( rendered );
+
+		// activation_error is not a failure: keep waiting for the refreshed active state.
+		fetchSitePlugins.mockClear();
+		await advance( rendered, 3000 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( SITE_ID );
 		await expectRedirectsOnceActive( rendered );
 	} );
 

--- a/packages/api-core/src/site-plugins/fetchers.ts
+++ b/packages/api-core/src/site-plugins/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { SitePluginsResponse, CorePlugin, SitePlugin } from './types';
+import type { SitePluginsResponse, CorePlugin, SitePlugin, SitePluginActive } from './types';
 
 export async function fetchSitePlugin( siteId: number, pluginSlug: string ): Promise< SitePlugin > {
 	return await wpcom.req.get( {
@@ -16,5 +16,17 @@ export async function fetchSiteCorePlugins( siteId: number ): Promise< CorePlugi
 	return await wpcom.req.get( {
 		path: `/sites/${ siteId }/plugins`,
 		apiNamespace: 'wp/v2',
+	} );
+}
+
+// Reports whether a plugin is active on an Atomic site, without mutating anything. Poll this after a
+// marketplace transfer to learn when to redirect the user into the plugin.
+export async function fetchSitePluginActive(
+	siteId: number,
+	pluginSlug: string
+): Promise< SitePluginActive > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/plugins/${ encodeURIComponent( pluginSlug ) }/active`,
+		apiNamespace: 'wpcom/v2',
 	} );
 }

--- a/packages/api-core/src/site-plugins/types.ts
+++ b/packages/api-core/src/site-plugins/types.ts
@@ -50,3 +50,17 @@ export type CorePlugin = {
 	is_managed?: boolean;
 	_links: { self: { [ key: number ]: { href: string } } };
 };
+
+export type SitePluginActiveStatus = 'complete' | 'inactive' | 'processing';
+
+export interface SitePluginActive {
+	// `complete` — active; `inactive` — installed but not active (activate it); `processing` — not
+	// installed yet (keep polling).
+	status: SitePluginActiveStatus;
+	plugin: {
+		slug: string;
+		id?: string;
+		installed?: boolean;
+		active?: boolean;
+	};
+}

--- a/packages/api-queries/src/site-plugins.ts
+++ b/packages/api-queries/src/site-plugins.ts
@@ -12,6 +12,7 @@ import {
 	fetchSitePlugin,
 	installSiteCorePlugin,
 	activateSiteCorePlugin,
+	fetchSitePluginActive,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -137,4 +138,14 @@ export const sitePluginRemoveMutation = ( invalidateQueriesOnSuccess = true ) =>
 				invalidatePluginsForSite( vars.siteId );
 			}
 		},
+	} );
+
+// Whether a plugin is active on a site, keyed by (site, slug). Poll it after a marketplace transfer
+// until the status is `complete`. Ephemeral: a reinstall must never observe a stale `complete`.
+export const sitePluginActiveQuery = ( siteId: number, pluginSlug: string ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'plugins', pluginSlug, 'active' ],
+		queryFn: () => fetchSitePluginActive( siteId, pluginSlug ),
+		gcTime: 0,
+		meta: { persist: false },
 	} );


### PR DESCRIPTION
## Proposed Changes

* Fix a plugin that stays inactive after an Atomic transfer. Buying a plan to install a free plugin transfers the site, and the transfer reports complete before the plugin is actually installed and activated, so this page had no reliable way to know when the plugin was really on — and it landed the user on a plugins list filtered to active plugins, which hid the one they just installed.
* Read the plugin's state from a new authoritative endpoint instead of inferring it client-side. `GET /wpcom/v2/sites/{site}/plugins/{slug}/active` answers one question — is the plugin active yet — returning `complete`, `inactive`, or `processing`. The page polls it until `complete` and then redirects, re-kicks the install once if it reports `inactive`, and surfaces a terminal read error.
* Add the `@automattic/api-core` fetcher and `@automattic/api-queries` query for the endpoint.

This replaces the previous client-side reconciliation, which stitched the outcome together from the plugin list, install status, activation status, and transfer status — several non-authoritative signals that made failure handling fragile.

## Why are these changes being made?

Reported while testing the new plugin upgrade flow: GiveWP installed but wasn't active, and the plugins list it landed on hid it. Whether the user saw a working plugin came down to whether the platform happened to activate it during the transfer.

## Testing Instructions

1. On a Free-plan site, open `/plugins/give/<site>` and click "Upgrade and activate".
2. Buy a plan (test card). The site will transfer, which takes a while.
3. The plugin should be **active** when you land on the plugins page, and visible there without switching to "All".
4. Repeat with a paid plugin (e.g. Sensei Pro) and with a plugin installed on a site that already has a plan, to confirm neither path regressed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
