### PR TITLE
Domain Search: mobile polish for bundle card and price

### DIFF
--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/breakpoints';
+
 .bundle-card {
 	box-sizing: border-box;
 	// Shares the featured row equally with the exact-match card (matching
@@ -41,5 +43,15 @@
 	&.is-secondary {
 		color: var( --domain-search-secondary-action-color );
 		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
+	}
+}
+
+@media ( max-width: #{ $break-small - 1px } ) {
+	// Stack the badge below the title so the two don't crowd each other when
+	// the translated title and/or badge wrap to multiple lines. Higher
+	// specificity than the HStack's emotion class so the override wins.
+	.bundle-card .bundle-card__header {
+		flex-direction: column;
+		align-items: flex-start;
 	}
 }

--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -66,4 +66,11 @@
 		flex-direction: column;
 		align-items: flex-start;
 	}
+
+	// With the price row stacked, give the CTA the full card width for a larger
+	// tap target and parity with the exact-match card's "Add to cart" button.
+	.bundle-card .bundle-card__cta-wrapper,
+	.bundle-card .bundle-card__cta {
+		width: 100%;
+	}
 }

--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -16,11 +16,15 @@
 }
 
 .bundle-card__members {
-	word-break: break-all;
+	// Break between domains (at the ", " separators) and only break inside a
+	// domain as a last resort for an over-long SLD — never mid-word by default.
+	overflow-wrap: anywhere;
 }
 
 .bundle-card__member-tld {
 	color: #2c3338;
+	// Keep the extension intact so it never splits across lines (".n" / "et").
+	white-space: nowrap;
 }
 
 .bundle-card__cta-wrapper {

--- a/packages/domain-search/src/components/bundle-card/style.scss
+++ b/packages/domain-search/src/components/bundle-card/style.scss
@@ -58,4 +58,12 @@
 		flex-direction: column;
 		align-items: flex-start;
 	}
+
+	// Stack the price above the CTA instead of squeezing them onto one row,
+	// where the (often wider, translated) button crowded the price and floated
+	// mid-height against the multi-line price block.
+	.bundle-card .bundle-card__price-row {
+		flex-direction: column;
+		align-items: flex-start;
+	}
 }

--- a/packages/domain-search/src/ui/bundle-price/index.tsx
+++ b/packages/domain-search/src/ui/bundle-price/index.tsx
@@ -48,7 +48,7 @@ export const BundlePrice = ( {
 
 	return (
 		<VStack spacing={ 0 } className={ clsx( 'bundle-price', className ) }>
-			<HStack spacing={ 2 } justify={ alignment === 'left' ? 'start' : 'end' } expanded={ false }>
+			<HStack spacing={ 3 } justify={ alignment === 'left' ? 'start' : 'end' } expanded={ false }>
 				<Text
 					as="s"
 					size={ size }

--- a/packages/domain-search/src/ui/bundle-price/style.scss
+++ b/packages/domain-search/src/ui/bundle-price/style.scss
@@ -1,7 +1,3 @@
-.bundle-price__original {
-	text-decoration: line-through;
-}
-
 .bundle-price__sub-text {
 	a {
 		color: inherit;


### PR DESCRIPTION
Related to #DOMAINS-2220

Mobile polish for the domain-search bundle card ("Protect your brand") and its price, from the screenshots on the issue. All changes are gated behind the package's existing `$break-small` (600px) breakpoint, so desktop is untouched.

## Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5048a6a4-ef53-4080-9d1a-8577aa75deb0" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ce75bce1-1f16-4519-b2ea-58da4ad4ef01" />

## After
<img width="300" alt="Screenshot 2026-07-14 at 10-19-51 Crear un sitio — WordPress com" src="https://github.com/user-attachments/assets/32e6db18-5fd5-4e2b-ac8d-0abbe160d471" />
<img width="300" alt="Screenshot 2026-07-14 at 10-16-30 Create a site — WordPress com" src="https://github.com/user-attachments/assets/26584965-6d90-4520-9316-3f55edf11f20" />

### Changes (one commit each)
- **Header badge** stacks below the title on mobile so the title and "Bundle and save X%" badge stop crowding each other when either wraps (notably in translated locales).
- **Domain list** no longer breaks mid-TLD (`.n` / `et`). Switched from `word-break: break-all` to `overflow-wrap: anywhere` and marked the TLD span `nowrap`.
- **Price row** stacks the price above the CTA on mobile instead of squeezing them onto one row.
- **CTA** goes full-width on mobile — larger tap target and parity with the exact-match card's "Add to cart".
- **Struck vs. sale price** gap widened (`spacing` 2 → 3) so they no longer collide (e.g. "47 €14,40 €").
- **Removed** a redundant `text-decoration: line-through` — the price already renders as a semantic `<s>`.

### Testing
- `packages/domain-search` bundle-card suite passes (17 tests).
- Manual mobile-viewport check below 600px.

<details>
<summary>Run locally</summary>

```
yarn workspace @automattic/domain-search storybook
```
Narrow the viewport below 600px and view the BundleCard story.
</details>
