### PR TITLE
Reader - add new - fix issues with stale search and subscribed state

### DIFF
--- a/client/blocks/reader-feed-item/index.tsx
+++ b/client/blocks/reader-feed-item/index.tsx
@@ -1,10 +1,4 @@
-import {
-	getIsSubscribedFromData,
-	getSiteSubscriptionByBlogIdFromData,
-	getSiteSubscriptionByFeedIdFromData,
-	readFeedQuery,
-	readSiteQuery,
-} from '@automattic/api-queries';
+import { getSiteSubscriptionFromData, readFeedQuery, readSiteQuery } from '@automattic/api-queries';
 import { recordTrainTracksInteract, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import { ExternalLink } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
@@ -97,28 +91,22 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 	const filteredDisplayUrl = filterURLForDisplay( displayUrl ?? '' );
 	const feedUrl = feedId ? getFeedUrl( feedId ) : subscribeUrl;
 	const subscriptionId = feed?.subscription_id;
-	const isSubscribedFromCache = getIsSubscribedFromData( siteSubscriptionsData, {
+	const cachedSubscription = getSiteSubscriptionFromData( siteSubscriptionsData, {
 		feedUrl: subscribeUrl,
 		feedId,
 		blogId: isWpcomFeed ? blogId : null,
 	} );
-	const cachedSubscription =
-		( feedId ? getSiteSubscriptionByFeedIdFromData( siteSubscriptionsData, feedId ) : undefined ) ??
-		( isWpcomFeed && blogId
-			? getSiteSubscriptionByBlogIdFromData( siteSubscriptionsData, blogId )
-			: undefined );
-	const cachedSubscriptionId =
-		cachedSubscription?.is_following && cachedSubscription.ID
-			? Number( cachedSubscription.ID )
-			: undefined;
+	const cachedSubscriptionId = Number( cachedSubscription?.ID );
 	const currentSubscriptionId =
 		localSubscriptionId === null
 			? undefined
-			: localSubscriptionId ?? subscriptionId ?? cachedSubscriptionId;
-	const isSubscribed =
-		localSubscriptionId === null
-			? false
-			: Boolean( currentSubscriptionId ) || isSubscribedFromCache;
+			: localSubscriptionId ??
+			  subscriptionId ??
+			  ( Number.isFinite( cachedSubscriptionId ) && cachedSubscriptionId > 0
+					? cachedSubscriptionId
+					: undefined );
+	// Require an id so Unsubscribe is never shown without a workable unsubscribe target.
+	const isSubscribed = localSubscriptionId === null ? false : Boolean( currentSubscriptionId );
 	const iconUrl = isWpcomFeed ? site?.icon?.img ?? site?.icon?.ico : feed?.image;
 	const shouldTrackRecommendedSearch =
 		source === SOURCE_SUBSCRIPTIONS_SEARCH_RECOMMENDATION_LIST && railcar;
@@ -141,7 +129,7 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 		}
 
 		const noticeOptions: NoticeOptions = { duration: 5000 };
-		if ( isSubscribed && currentSubscriptionId ) {
+		if ( currentSubscriptionId ) {
 			onUnsubscribe( {
 				subscriptionId: currentSubscriptionId,
 				blog_id: blogId || undefined,

--- a/client/blocks/reader-feed-item/index.tsx
+++ b/client/blocks/reader-feed-item/index.tsx
@@ -1,4 +1,10 @@
-import { readFeedQuery, readSiteQuery } from '@automattic/api-queries';
+import {
+	getIsSubscribedFromData,
+	getSiteSubscriptionByBlogIdFromData,
+	getSiteSubscriptionByFeedIdFromData,
+	readFeedQuery,
+	readSiteQuery,
+} from '@automattic/api-queries';
 import { recordTrainTracksInteract, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import { ExternalLink } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
@@ -22,6 +28,7 @@ import {
 	useRecordSiteTitleClicked,
 	useRecordSiteUrlClicked,
 } from 'calypso/landing/subscriptions/tracks';
+import { useSiteSubscriptions } from 'calypso/reader/data/site-subscriptions';
 import { getSiteName, getSiteUrl } from 'calypso/reader/get-helpers';
 import { getFeedUrl } from 'calypso/reader/route';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
@@ -71,6 +78,7 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 	const recordSiteSubscribed = useRecordSiteSubscribed();
 	const recordSiteUnsubscribed = useRecordSiteUnsubscribed();
 	const [ localSubscriptionId, setLocalSubscriptionId ] = useState< number | null | undefined >();
+	const { data: siteSubscriptionsData } = useSiteSubscriptions();
 
 	// Fetch feed and site data.
 	const queryFeed: boolean = ! isWpcomFeed; // No need to query feed data for WPCOM feeds.
@@ -78,7 +86,10 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 		...readFeedQuery( feedId ),
 		enabled: queryFeed,
 	} );
-	const { data: site, isLoading: isSiteLoading } = useQuery( readSiteQuery( Number( blogId ) ) );
+	const { data: site, isLoading: isSiteLoading } = useQuery( {
+		...readSiteQuery( Number( blogId ) ),
+		enabled: isWpcomFeed,
+	} );
 
 	// Reader feed item fields to show in the UI.
 	const description = isWpcomFeed ? site?.description : feed?.description;
@@ -86,8 +97,28 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 	const filteredDisplayUrl = filterURLForDisplay( displayUrl ?? '' );
 	const feedUrl = feedId ? getFeedUrl( feedId ) : subscribeUrl;
 	const subscriptionId = feed?.subscription_id;
+	const isSubscribedFromCache = getIsSubscribedFromData( siteSubscriptionsData, {
+		feedUrl: subscribeUrl,
+		feedId,
+		blogId: isWpcomFeed ? blogId : null,
+	} );
+	const cachedSubscription =
+		( feedId ? getSiteSubscriptionByFeedIdFromData( siteSubscriptionsData, feedId ) : undefined ) ??
+		( isWpcomFeed && blogId
+			? getSiteSubscriptionByBlogIdFromData( siteSubscriptionsData, blogId )
+			: undefined );
+	const cachedSubscriptionId =
+		cachedSubscription?.is_following && cachedSubscription.ID
+			? Number( cachedSubscription.ID )
+			: undefined;
 	const currentSubscriptionId =
-		localSubscriptionId === null ? undefined : localSubscriptionId ?? subscriptionId;
+		localSubscriptionId === null
+			? undefined
+			: localSubscriptionId ?? subscriptionId ?? cachedSubscriptionId;
+	const isSubscribed =
+		localSubscriptionId === null
+			? false
+			: Boolean( currentSubscriptionId ) || isSubscribedFromCache;
 	const iconUrl = isWpcomFeed ? site?.icon?.img ?? site?.icon?.ico : feed?.image;
 	const shouldTrackRecommendedSearch =
 		source === SOURCE_SUBSCRIPTIONS_SEARCH_RECOMMENDATION_LIST && railcar;
@@ -110,10 +141,10 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 		}
 
 		const noticeOptions: NoticeOptions = { duration: 5000 };
-		if ( currentSubscriptionId ) {
+		if ( isSubscribed && currentSubscriptionId ) {
 			onUnsubscribe( {
 				subscriptionId: currentSubscriptionId,
-				blog_id: blogId ?? undefined,
+				blog_id: blogId || undefined,
 				feed_id: feedId,
 				url: subscribeUrl,
 				onSuccess: () => {
@@ -148,10 +179,10 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 					);
 				},
 			} );
-		} else {
+		} else if ( ! isSubscribed ) {
 			onSubscribe(
 				{
-					blog_id: blogId ?? undefined,
+					blog_id: blogId || undefined,
 					doNotInvalidateSiteSubscriptions: shouldHideOnSubscribedState,
 					feed_id: feedId,
 					url: subscribeUrl,
@@ -237,13 +268,13 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 
 	const SubscribeButton = (): JSX.Element => (
 		<Button
-			variant={ currentSubscriptionId ? 'secondary' : 'primary' }
+			variant={ isSubscribed ? 'secondary' : 'primary' }
 			isBusy={ isSubscribing || isUnsubscribing }
 			disabled={ isSubscribing || isUnsubscribing }
 			onClick={ onSubscribeToggle }
 			__next40pxDefaultSize
 		>
-			{ currentSubscriptionId ? translate( 'Unsubscribe' ) : translate( 'Subscribe' ) }
+			{ isSubscribed ? translate( 'Unsubscribe' ) : translate( 'Subscribe' ) }
 		</Button>
 	);
 
@@ -264,7 +295,7 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 		return null;
 	}
 
-	if ( currentSubscriptionId && shouldHideOnSubscribedState ) {
+	if ( isSubscribed && shouldHideOnSubscribedState ) {
 		return null;
 	}
 

--- a/client/blocks/reader-feed-item/index.tsx
+++ b/client/blocks/reader-feed-item/index.tsx
@@ -80,10 +80,7 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 		...readFeedQuery( feedId ),
 		enabled: queryFeed,
 	} );
-	const { data: site, isLoading: isSiteLoading } = useQuery( {
-		...readSiteQuery( Number( blogId ) ),
-		enabled: isWpcomFeed,
-	} );
+	const { data: site, isLoading: isSiteLoading } = useQuery( readSiteQuery( Number( blogId ) ) );
 
 	// Reader feed item fields to show in the UI.
 	const description = isWpcomFeed ? site?.description : feed?.description;

--- a/client/blocks/reader-feed-item/test/index.test.tsx
+++ b/client/blocks/reader-feed-item/test/index.test.tsx
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 
-import { readFeedQuery } from '@automattic/api-queries';
+import {
+	getSiteSubscriptionsQueryKey,
+	readFeedQuery,
+	readSiteQuery,
+} from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -47,6 +51,7 @@ jest.mock( 'calypso/blocks/site-icon', () => ( {
 
 jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	isCurrentUserEmailVerified: jest.fn( () => true ),
+	isUserLoggedIn: jest.fn( () => true ),
 } ) );
 
 const makeFeedItem = ( overrides: Partial< Reader.FeedItem > = {} ): Reader.FeedItem => ( {
@@ -71,13 +76,24 @@ const makeFeedItem = ( overrides: Partial< Reader.FeedItem > = {} ): Reader.Feed
 	...overrides,
 } );
 
-const makeQueryClient = () => {
+const makeQueryClient = ( siteSubscriptions: unknown[] = [] ) => {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 	queryClient.setQueryData( readFeedQuery( 10 ).queryKey, {
 		description: 'Example description',
 		image: '',
 		name: 'Example Feed',
 		subscription_id: undefined,
+	} );
+	queryClient.setQueryData( getSiteSubscriptionsQueryKey(), {
+		pages: [
+			{
+				subscriptions: siteSubscriptions,
+				totalCount: siteSubscriptions.length,
+				page: 1,
+				number: 100,
+			},
+		],
+		pageParams: [ 1 ],
 	} );
 	return queryClient;
 };
@@ -129,5 +145,40 @@ describe( 'ReaderFeedItem', () => {
 			} ),
 			expect.any( Object )
 		);
+	} );
+
+	it( 'shows Unsubscribe when site subscriptions cache already marks the feed as followed', () => {
+		const queryClient = makeQueryClient( [
+			{
+				ID: 55,
+				blog_ID: 99,
+				feed_ID: 10,
+				URL: 'https://example.wordpress.com',
+				feed_URL: 'https://example.wordpress.com',
+				is_following: true,
+				isDeleted: false,
+			},
+		] );
+		queryClient.setQueryData( readSiteQuery( 99 ).queryKey, {
+			ID: 99,
+			name: 'Example Site',
+			description: 'Example description',
+			URL: 'https://example.wordpress.com',
+			icon: {},
+		} );
+
+		renderWithProvider(
+			<ReaderFeedItem
+				feed={ makeFeedItem( {
+					blog_ID: '99',
+					feed_ID: '10',
+					subscribe_URL: 'https://example.wordpress.com',
+				} ) }
+				source="reader-new-subscription"
+			/>,
+			{ queryClient }
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Unsubscribe' } ) ).toBeVisible();
 	} );
 } );

--- a/client/blocks/reader-feed-item/test/index.test.tsx
+++ b/client/blocks/reader-feed-item/test/index.test.tsx
@@ -181,4 +181,42 @@ describe( 'ReaderFeedItem', () => {
 
 		expect( screen.getByRole( 'button', { name: 'Unsubscribe' } ) ).toBeVisible();
 	} );
+
+	it( 'unsubscribes using the cache subscription id when only the feed URL matches', async () => {
+		const user = userEvent.setup();
+		// feed_ID on the result differs from the followed row; URL still matches.
+		const queryClient = makeQueryClient( [
+			{
+				ID: 55,
+				blog_ID: null,
+				feed_ID: 888,
+				URL: 'https://example.com/feed',
+				feed_URL: 'https://example.com/feed',
+				is_following: true,
+				isDeleted: false,
+			},
+		] );
+
+		renderWithProvider(
+			<ReaderFeedItem
+				feed={ makeFeedItem( {
+					blog_ID: '',
+					feed_ID: '10',
+					subscribe_URL: 'https://example.com/feed',
+				} ) }
+				source="reader-new-subscription"
+			/>,
+			{ queryClient }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Unsubscribe' } ) );
+
+		expect( mockUnsubscribeMutate ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				subscriptionId: 55,
+				feed_id: '10',
+				url: 'https://example.com/feed',
+			} )
+		);
+	} );
 } );

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,6 +1,8 @@
 import './styles.scss';
+import { prepareComparableUrl } from '@automattic/api-core';
 import { FormInputValidation } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { Button, SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -33,6 +35,62 @@ interface AddSitesFormProps {
 	hideInputError?: boolean;
 }
 
+type CachedFeedSearchItem = {
+	feed_ID?: string | number | null;
+	blog_ID?: string | number | null;
+	subscribe_URL?: string;
+};
+
+const getFeedsFromSearchCacheData = ( data: unknown ): CachedFeedSearchItem[] => {
+	if ( ! data || typeof data !== 'object' ) {
+		return [];
+	}
+
+	if ( 'feeds' in data && Array.isArray( data.feeds ) ) {
+		return data.feeds;
+	}
+
+	if ( 'pages' in data && Array.isArray( data.pages ) ) {
+		return data.pages.flatMap( ( page: unknown ) => {
+			if ( page && typeof page === 'object' && 'feeds' in page && Array.isArray( page.feeds ) ) {
+				return page.feeds;
+			}
+			return [];
+		} );
+	}
+
+	return [];
+};
+
+const findCachedFeedIdsForUrl = (
+	queryClient: QueryClient,
+	url: string
+): { feed_id?: string | number; blog_id?: string | number } => {
+	const comparableUrl = prepareComparableUrl( url );
+	if ( ! comparableUrl ) {
+		return {};
+	}
+
+	const cachedQueries = queryClient.getQueriesData( {
+		queryKey: [ 'read', 'feeds', 'search' ],
+	} );
+
+	for ( const [ , data ] of cachedQueries ) {
+		const matchingFeed = getFeedsFromSearchCacheData( data ).find(
+			( feed ) => prepareComparableUrl( feed.subscribe_URL ) === comparableUrl
+		);
+
+		if ( matchingFeed ) {
+			return {
+				feed_id: matchingFeed.feed_ID ?? undefined,
+				blog_id: matchingFeed.blog_ID || undefined,
+			};
+		}
+	}
+
+	return {};
+};
+
 const AddSitesForm = ( {
 	onChange,
 	placeholder,
@@ -45,6 +103,7 @@ const AddSitesForm = ( {
 	hideInputError = false,
 }: AddSitesFormProps ) => {
 	const translate = useTranslate();
+	const queryClient = useQueryClient();
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ isSubmitting, setIsSubmitting ] = useState< boolean >( false );
 	const [ inputFieldError, setInputFieldError ] = useState< string | null >( null );
@@ -90,9 +149,14 @@ const AddSitesForm = ( {
 		e.preventDefault();
 
 		if ( isValidInput ) {
+			const url = parseUrl( inputValue ).toString();
+			const cachedFeedIds = findCachedFeedIdsForUrl( queryClient, url );
 			setIsSubmitting( true );
 			subscribe(
-				{ url: parseUrl( inputValue ).toString() },
+				{
+					url,
+					...cachedFeedIds,
+				},
 				{
 					onSuccess: ( data ) => {
 						if ( data?.info === 'already_subscribed' ) {
@@ -123,10 +187,8 @@ const AddSitesForm = ( {
 	};
 
 	function onSubscribeToggle( subscribed: boolean ): void {
-		// Reset form.
-		setInputValue( '' );
-		setIsValidInput( false );
-
+		// Fully reset form + shared search term so related-sites results unmount.
+		onTextFieldChange( '' );
 		onChangeSubscribe?.( subscribed );
 	}
 

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -46,16 +46,20 @@ const getFeedsFromSearchCacheData = ( data: unknown ): CachedFeedSearchItem[] =>
 		return [];
 	}
 
-	if ( 'feeds' in data && Array.isArray( data.feeds ) ) {
-		return data.feeds;
+	// Explicit record access for opaque RQ cache blobs (`in` narrowing already satisfies tsc).
+	const record = data as Record< string, unknown >;
+
+	if ( Array.isArray( record.feeds ) ) {
+		return record.feeds;
 	}
 
-	if ( 'pages' in data && Array.isArray( data.pages ) ) {
-		return data.pages.flatMap( ( page: unknown ) => {
-			if ( page && typeof page === 'object' && 'feeds' in page && Array.isArray( page.feeds ) ) {
-				return page.feeds;
+	if ( Array.isArray( record.pages ) ) {
+		return record.pages.flatMap( ( page: unknown ) => {
+			if ( ! page || typeof page !== 'object' ) {
+				return [];
 			}
-			return [];
+			const pageRecord = page as Record< string, unknown >;
+			return Array.isArray( pageRecord.feeds ) ? pageRecord.feeds : [];
 		} );
 	}
 

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { SubscriptionManager } from '@automattic/data-stores';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -13,6 +14,19 @@ import {
 import AddSitesForm from '../add-sites-form';
 
 jest.mock( '@automattic/calypso-router' );
+
+const mockSubscribeMutate = jest.fn();
+
+jest.mock( '@automattic/data-stores', () => {
+	const actual = jest.requireActual( '@automattic/data-stores' );
+	return {
+		...actual,
+		SubscriptionManager: {
+			...actual.SubscriptionManager,
+			useSiteSubscribeMutation: jest.fn(),
+		},
+	};
+} );
 
 type Props = React.ComponentProps< typeof AddSitesForm >;
 
@@ -29,6 +43,14 @@ describe( 'AddSitesForm', () => {
 		onChangeSubscribe: jest.fn(),
 		source: 'test-source',
 	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( SubscriptionManager.useSiteSubscribeMutation as jest.Mock ).mockReturnValue( {
+			mutate: mockSubscribeMutate,
+			isPending: false,
+		} );
+	} );
 
 	it( 'calls onChange when input value changes', async () => {
 		const onChange = jest.fn();
@@ -124,5 +146,32 @@ describe( 'AddSitesForm', () => {
 		await waitFor( () => {
 			expect( addButton ).toBeDisabled();
 		} );
+	} );
+
+	it( 'clears the shared search term after a successful subscribe', async () => {
+		const onChange = jest.fn();
+		const user = userEvent.setup();
+		mockSubscribeMutate.mockImplementation( ( _params, options ) => {
+			options.onSuccess( {
+				subscribed: true,
+				subscription: {
+					ID: '1',
+					blog_ID: '2',
+				},
+			} );
+			options.onSettled();
+		} );
+
+		renderWithContextProvider( <AddSitesForm { ...mockProps } onChange={ onChange } /> );
+
+		const input = screen.getByRole( 'searchbox' );
+		await user.type( input, 'https://example.com' );
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( '' );
+		} );
+		expect( input ).toHaveValue( '' );
+		expect( mockProps.onChangeSubscribe ).toHaveBeenCalledWith( true );
 	} );
 } );

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -19,8 +19,10 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const { searchTerm } = useSiteSubscriptionsQueryProps();
 	const { isPending: isUnsubscribing } = useSiteUnsubscribeMutation();
 	const translate = useTranslate();
+	const hasSearchTerm = Boolean( searchTerm );
 	const { subscriptions, isFetching: isFetchingSubscriptions } = useSiteSubscriptions( {
 		fetchAllPages: true,
+		enabled: hasSearchTerm,
 	} );
 
 	const {
@@ -63,6 +65,12 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 
 		return translate( 'Here are some other sites that match your search:' );
 	};
+
+	// Rendered unconditionally by ReaderSiteSubscriptions, so bail out when there's
+	// no active search — otherwise the empty feed list reads as "no results found".
+	if ( ! hasSearchTerm ) {
+		return null;
+	}
 
 	if ( noFeedsFound ) {
 		return (

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -19,7 +19,7 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const { searchTerm } = useSiteSubscriptionsQueryProps();
 	const { isPending: isUnsubscribing } = useSiteUnsubscribeMutation();
 	const translate = useTranslate();
-	const { subscriptions, isFetching: isFetchingSubscriptions } = useSiteSubscriptions( {
+	const { subscriptions, isLoading: isLoadingSubscriptions } = useSiteSubscriptions( {
 		fetchAllPages: true,
 	} );
 
@@ -38,10 +38,10 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const noFeedsFound =
 		( unsubscribedFeedItems.length === 0 && ! isFetchingUnsubscribedFeeds ) || searchError;
 
+	// Site subscriptions: isLoading only — blanking on isFetching unmounts ReaderFeedItem
+	// observers, which remount and refetch (staleTime 0) in a spinner loop.
 	const shouldShowUnsubcribedFeedsListLoader =
-		isFetchingSubscriptions || // If site subscriptions are still fetching.
-		isFetchingUnsubscribedFeeds || // If unsubscribed feeds are still fetching.
-		isUnsubscribing; // If user is unsubscribing from subscriptions table.
+		isLoadingSubscriptions || isFetchingUnsubscribedFeeds || isUnsubscribing;
 
 	const hasSubscribedTableResults = subscriptions.some(
 		( subscription ) => ! subscription.isDeleted && subscription.is_following

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -19,7 +19,7 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const { searchTerm } = useSiteSubscriptionsQueryProps();
 	const { isPending: isUnsubscribing } = useSiteUnsubscribeMutation();
 	const translate = useTranslate();
-	const { subscriptions, isLoading: isLoadingSubscriptions } = useSiteSubscriptions( {
+	const { subscriptions, isFetching: isFetchingSubscriptions } = useSiteSubscriptions( {
 		fetchAllPages: true,
 	} );
 
@@ -39,7 +39,9 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 		( unsubscribedFeedItems.length === 0 && ! isFetchingUnsubscribedFeeds ) || searchError;
 
 	const shouldShowUnsubcribedFeedsListLoader =
-		isLoadingSubscriptions || isFetchingUnsubscribedFeeds || isUnsubscribing;
+		isFetchingSubscriptions || // If site subscriptions are still fetching.
+		isFetchingUnsubscribedFeeds || // If unsubscribed feeds are still fetching.
+		isUnsubscribing; // If user is unsubscribing from subscriptions table.
 
 	const hasSubscribedTableResults = subscriptions.some(
 		( subscription ) => ! subscription.isDeleted && subscription.is_following

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -38,8 +38,6 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const noFeedsFound =
 		( unsubscribedFeedItems.length === 0 && ! isFetchingUnsubscribedFeeds ) || searchError;
 
-	// Site subscriptions: isLoading only — blanking on isFetching unmounts ReaderFeedItem
-	// observers, which remount and refetch (staleTime 0) in a spinner loop.
 	const shouldShowUnsubcribedFeedsListLoader =
 		isLoadingSubscriptions || isFetchingUnsubscribedFeeds || isUnsubscribing;
 

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -1,6 +1,6 @@
 import './style.scss';
-import { getIsSubscribedFromData, readFeedSearchQuery } from '@automattic/api-queries';
-import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { readFeedSearchQuery } from '@automattic/api-queries';
+import { SubscriptionManager } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -19,11 +19,9 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const { searchTerm } = useSiteSubscriptionsQueryProps();
 	const { isPending: isUnsubscribing } = useSiteUnsubscribeMutation();
 	const translate = useTranslate();
-	const {
-		data: siteSubscriptionsData,
-		subscriptions,
-		isFetching: isFetchingSubscriptions,
-	} = useSiteSubscriptions( { fetchAllPages: true } );
+	const { subscriptions, isFetching: isFetchingSubscriptions } = useSiteSubscriptions( {
+		fetchAllPages: true,
+	} );
 
 	const {
 		data,
@@ -36,19 +34,9 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 		} )
 	);
 
-	const unsubscribedFeedItems = data?.feeds;
+	const unsubscribedFeedItems = data?.feeds ?? [];
 	const noFeedsFound =
-		( unsubscribedFeedItems?.length === 0 && ! isFetchingUnsubscribedFeeds ) || searchError;
-
-	// To avoid showing duplicate feed items between subscribed and unsubscribed feeds.
-	const filteredUnsubscribedFeedItems = ( unsubscribedFeedItems ?? [] ).filter(
-		( feedItem: Reader.FeedItem ): boolean =>
-			! getIsSubscribedFromData( siteSubscriptionsData, {
-				feedUrl: feedItem.subscribe_URL,
-				feedId: feedItem.feed_ID,
-				blogId: feedItem.blog_ID || null,
-			} )
-	);
+		( unsubscribedFeedItems.length === 0 && ! isFetchingUnsubscribedFeeds ) || searchError;
 
 	const shouldShowUnsubcribedFeedsListLoader =
 		isFetchingSubscriptions || // If site subscriptions are still fetching.
@@ -64,12 +52,12 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 			hideTitle ||
 			! hasSubscribedTableResults ||
 			noFeedsFound ||
-			filteredUnsubscribedFeedItems.length === 0
+			unsubscribedFeedItems.length === 0
 		) {
 			return null;
 		}
 
-		if ( filteredUnsubscribedFeedItems.length === 1 ) {
+		if ( unsubscribedFeedItems.length === 1 ) {
 			return translate( 'Here is one result that matches your search:' );
 		}
 
@@ -94,8 +82,8 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 
 	const title = getTitle();
 
-	if ( filteredUnsubscribedFeedItems.length === 1 ) {
-		const feed = filteredUnsubscribedFeedItems[ 0 ];
+	if ( unsubscribedFeedItems.length === 1 ) {
+		const feed = unsubscribedFeedItems[ 0 ];
 		return (
 			<VStack spacing={ 4 }>
 				{ title && <h2 className="reader-unsubscribed-feeds-search-list-title">{ title }</h2> }
@@ -112,7 +100,7 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 		<VStack spacing={ 4 }>
 			{ title && <h2 className="reader-unsubscribed-feeds-search-list-title">{ title }</h2> }
 			<VStack as="ul" className="reader-unsubscribed-feeds-search-list">
-				{ filteredUnsubscribedFeedItems?.map( ( feed, index ) => (
+				{ unsubscribedFeedItems.map( ( feed, index ) => (
 					<ReaderFeedItem
 						key={ `${ feed.blog_ID }-${ feed.feed_ID }` }
 						feed={ feed }

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -1,5 +1,5 @@
 import './style.scss';
-import { readFeedSearchQuery } from '@automattic/api-queries';
+import { getIsSubscribedFromData, readFeedSearchQuery } from '@automattic/api-queries';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Spinner } from '@wordpress/components';
@@ -7,9 +7,9 @@ import { useTranslate } from 'i18n-calypso';
 import ReaderFeedItem from 'calypso/blocks/reader-feed-item';
 import FeedPreview from 'calypso/landing/subscriptions/components/feed-preview';
 import { SOURCE_SUBSCRIPTIONS_SEARCH_RECOMMENDATION_LIST } from 'calypso/landing/subscriptions/tracks';
+import { useSiteSubscriptions } from 'calypso/reader/data/site-subscriptions';
 
-const { useSiteSubscriptionsQuery, useSiteUnsubscribeMutation, useSiteSubscriptionsQueryProps } =
-	SubscriptionManager;
+const { useSiteUnsubscribeMutation, useSiteSubscriptionsQueryProps } = SubscriptionManager;
 
 interface Props {
 	hideTitle?: boolean;
@@ -20,9 +20,10 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 	const { isPending: isUnsubscribing } = useSiteUnsubscribeMutation();
 	const translate = useTranslate();
 	const {
-		data: { subscriptions },
+		data: siteSubscriptionsData,
+		subscriptions,
 		isFetching: isFetchingSubscriptions,
-	} = useSiteSubscriptionsQuery();
+	} = useSiteSubscriptions( { fetchAllPages: true } );
 
 	const {
 		data,
@@ -41,16 +42,12 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 
 	// To avoid showing duplicate feed items between subscribed and unsubscribed feeds.
 	const filteredUnsubscribedFeedItems = ( unsubscribedFeedItems ?? [] ).filter(
-		( feedItem: Reader.FeedItem ): boolean => {
-			const isDuplicate = subscriptions.find(
-				( subscription ): boolean =>
-					! subscription.isDeleted &&
-					// For match either compare feed_ID or URL.
-					( subscription.feed_ID === feedItem.feed_ID ||
-						subscription.URL === feedItem.subscribe_URL )
-			);
-			return ! isDuplicate;
-		}
+		( feedItem: Reader.FeedItem ): boolean =>
+			! getIsSubscribedFromData( siteSubscriptionsData, {
+				feedUrl: feedItem.subscribe_URL,
+				feedId: feedItem.feed_ID,
+				blogId: feedItem.blog_ID || null,
+			} )
 	);
 
 	const shouldShowUnsubcribedFeedsListLoader =
@@ -59,7 +56,7 @@ export const UnsubscribedFeedsSearchList = ( { hideTitle = false }: Props ) => {
 		isUnsubscribing; // If user is unsubscribing from subscriptions table.
 
 	const hasSubscribedTableResults = subscriptions.some(
-		( subscription ) => ! subscription.isDeleted
+		( subscription ) => ! subscription.isDeleted && subscription.is_following
 	);
 
 	const getTitle = (): string | null => {

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/test/index.test.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/test/index.test.tsx
@@ -165,6 +165,15 @@ describe( 'UnsubscribedFeedsSearchList', () => {
 		).toBeVisible();
 	} );
 
+	it( 'renders nothing when there is no active search term', () => {
+		const { container } = render( <UnsubscribedFeedsSearchList />, { searchTerm: '' } );
+
+		expect(
+			screen.queryByText( "Sorry, we couldn't find any sites related to your search." )
+		).not.toBeInTheDocument();
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
 	it( 'renders error message when there is an error with the api', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/read/feed' )

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/test/index.test.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/test/index.test.tsx
@@ -2,16 +2,18 @@
  * @jest-environment jsdom
  */
 
+import { getSiteSubscriptionsQueryKey } from '@automattic/api-queries';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, screen } from '@testing-library/react';
 import nock from 'nock';
 import { ComponentProps } from 'react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 import ReaderFeedItem from 'calypso/blocks/reader-feed-item';
 import FeedPreview from 'calypso/landing/subscriptions/components/feed-preview';
 import { UnsubscribedFeedsSearchList } from '../index';
 
-const mockUseSiteSubscriptionsQuery = SubscriptionManager.useSiteSubscriptionsQuery as jest.Mock;
 const mockUseSiteUnsubscribeMutation = SubscriptionManager.useSiteUnsubscribeMutation as jest.Mock;
 
 jest.mock( '@automattic/data-stores', () => {
@@ -20,7 +22,6 @@ jest.mock( '@automattic/data-stores', () => {
 		...actual,
 		SubscriptionManager: {
 			...actual.SubscriptionManager,
-			useSiteSubscriptionsQuery: jest.fn(),
 			useSiteUnsubscribeMutation: jest.fn(),
 		},
 	};
@@ -68,51 +69,75 @@ const createMockFeedItem = ( overrides = {} ): Partial< Reader.FeedItem > => ( {
 } );
 
 const createMockSubscription = ( overrides = {} ) => ( {
-	ID: '1',
-	feed_ID: '999',
+	ID: 1,
+	feed_ID: 999,
+	blog_ID: 888,
 	URL: 'https://subscribed.example.com',
+	feed_URL: 'https://subscribed.example.com',
+	is_following: true,
 	isDeleted: false,
 	...overrides,
 } );
 
-const Wrapper =
-	( { searchTerm }: { searchTerm: string } ) =>
-	( { children }: { children: React.ReactNode } ) => (
-		<SubscriptionManager.SiteSubscriptionsQueryPropsProvider initialSearchTermState={ searchTerm }>
-			<QueryClientProvider
-				client={
-					new QueryClient( {
-						defaultOptions: {
-							queries: { retry: false },
-						},
-					} )
-				}
-			>
-				{ children }
-			</QueryClientProvider>
-		</SubscriptionManager.SiteSubscriptionsQueryPropsProvider>
-	);
+const makeSiteSubscriptionsData = (
+	subscriptions: ReturnType< typeof createMockSubscription >[]
+) => ( {
+	pages: [
+		{
+			subscriptions,
+			totalCount: subscriptions.length,
+			page: 1,
+			number: 100,
+		},
+	],
+	pageParams: [ 1 ],
+} );
 
 const render = (
 	ui: React.ReactNode,
-	renderOptions: Parameters< typeof Wrapper >[ 0 ] & {
+	renderOptions: {
+		searchTerm?: string;
 		subscriptions?: Array< ReturnType< typeof createMockSubscription > >;
 	} = { searchTerm: 'test' }
 ) => {
-	const { subscriptions = [], searchTerm } = renderOptions;
-	mockUseSiteSubscriptionsQuery.mockReturnValue( {
-		data: { subscriptions },
-		isFetching: false,
-	} );
+	const { subscriptions = [], searchTerm = 'test' } = renderOptions;
 	mockUseSiteUnsubscribeMutation.mockReturnValue( { isPending: false } );
 
-	return rtlRender( ui, { wrapper: Wrapper( { searchTerm } ) } );
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	} );
+	queryClient.setQueryData(
+		getSiteSubscriptionsQueryKey(),
+		makeSiteSubscriptionsData( subscriptions )
+	);
+
+	const store = createStore( () => ( {
+		currentUser: { id: 1 },
+	} ) );
+
+	return rtlRender( ui, {
+		wrapper: ( { children }: { children: React.ReactNode } ) => (
+			<Provider store={ store }>
+				<SubscriptionManager.SiteSubscriptionsQueryPropsProvider
+					initialSearchTermState={ searchTerm }
+				>
+					<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+				</SubscriptionManager.SiteSubscriptionsQueryPropsProvider>
+			</Provider>
+		),
+	} );
 };
 
 describe( 'UnsubscribedFeedsSearchList', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		nock.disableNetConnect();
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
 	} );
 
 	it( 'shows the loading state', () => {
@@ -191,6 +216,88 @@ describe( 'UnsubscribedFeedsSearchList', () => {
 				name: 'Here are some other sites that match your search:',
 			} )
 		).toBeVisible();
+	} );
+
+	it( 'filters out subscribed feeds matched by numeric feed_ID across string/number types', async () => {
+		const feedItems = [
+			createMockFeedItem( {
+				feed_ID: '123',
+				blog_ID: '1',
+				subscribe_URL: 'https://a.example/feed',
+			} ),
+			createMockFeedItem( { feed_ID: '2', blog_ID: '2', subscribe_URL: 'https://b.example/feed' } ),
+			createMockFeedItem( { feed_ID: '3', blog_ID: '3', subscribe_URL: 'https://c.example/feed' } ),
+		];
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/read/feed' )
+			.query( () => true )
+			.once()
+			.reply( 200, {
+				feeds: feedItems,
+			} );
+
+		render( <UnsubscribedFeedsSearchList />, {
+			searchTerm: 'test',
+			subscriptions: [
+				createMockSubscription( {
+					feed_ID: 123,
+					blog_ID: 999,
+					URL: 'https://other.example',
+					feed_URL: 'https://other.example',
+				} ),
+			],
+		} );
+
+		const feedItemElements = await screen.findAllByTestId( 'mock-reader-feed-item' );
+		expect( feedItemElements ).toHaveLength( 2 );
+		expect( feedItemElements[ 0 ] ).toHaveAttribute( 'data-feed-id', '2' );
+		expect( feedItemElements[ 1 ] ).toHaveAttribute( 'data-feed-id', '3' );
+	} );
+
+	it( 'filters out subscribed feeds matched by comparable URL', async () => {
+		const feedItems = [
+			createMockFeedItem( {
+				feed_ID: '1',
+				blog_ID: '1',
+				subscribe_URL: 'https://Example.com/feed/',
+			} ),
+			createMockFeedItem( {
+				feed_ID: '2',
+				blog_ID: '2',
+				subscribe_URL: 'https://other.example/feed',
+			} ),
+			createMockFeedItem( {
+				feed_ID: '3',
+				blog_ID: '3',
+				subscribe_URL: 'https://third.example/feed',
+			} ),
+		];
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/read/feed' )
+			.query( () => true )
+			.once()
+			.reply( 200, {
+				feeds: feedItems,
+			} );
+
+		render( <UnsubscribedFeedsSearchList />, {
+			searchTerm: 'test',
+			subscriptions: [
+				createMockSubscription( {
+					feed_ID: 999,
+					blog_ID: 888,
+					URL: 'http://example.com/feed',
+					feed_URL: 'http://example.com/feed',
+				} ),
+			],
+		} );
+
+		const feedItemElements = await screen.findAllByTestId( 'mock-reader-feed-item' );
+		expect( feedItemElements ).toHaveLength( 2 );
+		expect( feedItemElements[ 0 ] ).toHaveAttribute( 'data-feed-id', '2' );
+		expect( feedItemElements[ 1 ] ).toHaveAttribute( 'data-feed-id', '3' );
 	} );
 
 	it( 'omits the recommendation list heading when hideTitle is set', async () => {

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/test/index.test.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/test/index.test.tsx
@@ -218,86 +218,38 @@ describe( 'UnsubscribedFeedsSearchList', () => {
 		).toBeVisible();
 	} );
 
-	it( 'filters out subscribed feeds matched by numeric feed_ID across string/number types', async () => {
-		const feedItems = [
-			createMockFeedItem( {
-				feed_ID: '123',
-				blog_ID: '1',
-				subscribe_URL: 'https://a.example/feed',
-			} ),
-			createMockFeedItem( { feed_ID: '2', blog_ID: '2', subscribe_URL: 'https://b.example/feed' } ),
-			createMockFeedItem( { feed_ID: '3', blog_ID: '3', subscribe_URL: 'https://c.example/feed' } ),
-		];
+	it( 'still renders a subscribed feed so ReaderFeedItem can show Unsubscribe', async () => {
+		const feedItem = createMockFeedItem( {
+			feed_ID: '123',
+			blog_ID: '456',
+			subscribe_URL: 'https://example.com/feed',
+		} );
 
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/read/feed' )
 			.query( () => true )
 			.once()
 			.reply( 200, {
-				feeds: feedItems,
+				feeds: [ feedItem ],
 			} );
 
 		render( <UnsubscribedFeedsSearchList />, {
-			searchTerm: 'test',
+			searchTerm: 'https://example.com/feed',
 			subscriptions: [
 				createMockSubscription( {
 					feed_ID: 123,
-					blog_ID: 999,
-					URL: 'https://other.example',
-					feed_URL: 'https://other.example',
+					blog_ID: 456,
+					URL: 'https://example.com/feed',
+					feed_URL: 'https://example.com/feed',
 				} ),
 			],
 		} );
 
-		const feedItemElements = await screen.findAllByTestId( 'mock-reader-feed-item' );
-		expect( feedItemElements ).toHaveLength( 2 );
-		expect( feedItemElements[ 0 ] ).toHaveAttribute( 'data-feed-id', '2' );
-		expect( feedItemElements[ 1 ] ).toHaveAttribute( 'data-feed-id', '3' );
-	} );
-
-	it( 'filters out subscribed feeds matched by comparable URL', async () => {
-		const feedItems = [
-			createMockFeedItem( {
-				feed_ID: '1',
-				blog_ID: '1',
-				subscribe_URL: 'https://Example.com/feed/',
-			} ),
-			createMockFeedItem( {
-				feed_ID: '2',
-				blog_ID: '2',
-				subscribe_URL: 'https://other.example/feed',
-			} ),
-			createMockFeedItem( {
-				feed_ID: '3',
-				blog_ID: '3',
-				subscribe_URL: 'https://third.example/feed',
-			} ),
-		];
-
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.1/read/feed' )
-			.query( () => true )
-			.once()
-			.reply( 200, {
-				feeds: feedItems,
-			} );
-
-		render( <UnsubscribedFeedsSearchList />, {
-			searchTerm: 'test',
-			subscriptions: [
-				createMockSubscription( {
-					feed_ID: 999,
-					blog_ID: 888,
-					URL: 'http://example.com/feed',
-					feed_URL: 'http://example.com/feed',
-				} ),
-			],
-		} );
-
-		const feedItemElements = await screen.findAllByTestId( 'mock-reader-feed-item' );
-		expect( feedItemElements ).toHaveLength( 2 );
-		expect( feedItemElements[ 0 ] ).toHaveAttribute( 'data-feed-id', '2' );
-		expect( feedItemElements[ 1 ] ).toHaveAttribute( 'data-feed-id', '3' );
+		expect( await screen.findByTestId( 'mock-feed-preview' ) ).toBeVisible();
+		expect( screen.getByTestId( 'mock-feed-preview' ) ).toHaveAttribute(
+			'data-url',
+			'https://example.com/feed'
+		);
 	} );
 
 	it( 'omits the recommendation list heading when hideTitle is set', async () => {

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -17,6 +17,7 @@ import {
 	getSiteSubscriptionsFromData,
 	getSiteSubscriptionsQueryKey,
 	getIsSubscribedFromData,
+	getSiteSubscriptionFromData,
 	getOrganizationSiteSubscriptionsFromData,
 	markSiteSubscriptionUnfollowed,
 	patchSiteSubscription,
@@ -290,6 +291,10 @@ describe( 'follow selectors and cache helpers', () => {
 		expect( getSiteSubscriptionsCountFromData( data ) ).toBe( 2 );
 		expect( getSiteSubscriptionByBlogIdFromData( data, 22 ) ).toBe( beta );
 		expect( getSiteSubscriptionByFeedIdFromData( data, 101 ) ).toBe( alpha );
+		expect( getSiteSubscriptionFromData( data, { feedUrl: 'https://alpha.example/feed/' } ) ).toBe(
+			alpha
+		);
+		expect( getSiteSubscriptionFromData( data, { feedId: 202 } ) ).toBe( beta );
 		expect( getSubscribedSitesFromData( data, null ) ).toEqual( [ alpha ] );
 		expect( getOrganizationSiteSubscriptionsFromData( data, 7 ) ).toEqual( [ beta ] );
 	} );

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -97,6 +97,7 @@ describe( 'siteSubscriptionsQuery', () => {
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( options.queryKey ).toEqual( [ 'read', 'site-subscriptions' ] );
+		expect( options.staleTime ).toBe( 0 );
 		expect( scope.isDone() ).toBe( true );
 		expect( result.current.data?.pages[ 0 ].subscriptions[ 0 ] ).toMatchObject( {
 			ID: 123,

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -97,7 +97,6 @@ describe( 'siteSubscriptionsQuery', () => {
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( options.queryKey ).toEqual( [ 'read', 'site-subscriptions' ] );
-		expect( options.staleTime ).toBe( 0 );
 		expect( scope.isDone() ).toBe( true );
 		expect( result.current.data?.pages[ 0 ].subscriptions[ 0 ] ).toMatchObject( {
 			ID: 123,

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -163,19 +163,18 @@ export const getAliasedSiteSubscriptionFeedUrl = (
 		subscriptionMatchesFeedUrl( subscription, feedUrl )
 	)?.feed_URL;
 
-export const getIsSubscribedFromData = (
+type SiteSubscriptionLookup = {
+	feedUrl?: string | null;
+	feedId?: number | string | null;
+	blogId?: number | string | null;
+};
+
+/** Followed subscription matching feed URL, feed id, or blog id. */
+export const getSiteSubscriptionFromData = (
 	data: SiteSubscriptionsInfiniteData | undefined,
-	{
-		feedUrl,
-		feedId,
-		blogId,
-	}: {
-		feedUrl?: string | null;
-		feedId?: number | string | null;
-		blogId?: number | string | null;
-	}
-): boolean =>
-	getSiteSubscriptionsFromData( data ).some( ( subscription ) => {
+	{ feedUrl, feedId, blogId }: SiteSubscriptionLookup
+): SiteSubscriptionItem | undefined =>
+	getSiteSubscriptionsFromData( data ).find( ( subscription ) => {
 		if ( ! subscription.is_following ) {
 			return false;
 		}
@@ -199,6 +198,11 @@ export const getIsSubscribedFromData = (
 
 		return false;
 	} );
+
+export const getIsSubscribedFromData = (
+	data: SiteSubscriptionsInfiniteData | undefined,
+	lookup: SiteSubscriptionLookup
+): boolean => Boolean( getSiteSubscriptionFromData( data, lookup ) );
 
 export const getSubscribedSitesFromData = (
 	data: SiteSubscriptionsInfiniteData | undefined,

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -31,11 +31,7 @@ import {
 // offset) will paginate incorrectly.
 const ITEMS_PER_PAGE = 100;
 const MAX_ITEMS = 2000;
-// Fresh enough to heal stale IndexedDB rehydration on mount/focus, without a
-// 1h window of poison. Defaults already refetch when stale on mount and window
-// focus — do not use refetchOnMount: 'always' here; result lists gate on
-// isFetching and remount observers (e.g. ReaderFeedItem) which would loop.
-const STALE_TIME = 0;
+const STALE_TIME = 60 * 60 * 1000;
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
 
 export type SiteSubscriptionsInfiniteData = InfiniteData< SiteSubscriptionsPage, number >;

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -31,7 +31,11 @@ import {
 // offset) will paginate incorrectly.
 const ITEMS_PER_PAGE = 100;
 const MAX_ITEMS = 2000;
-const STALE_TIME = 60 * 60 * 1000;
+// Fresh enough to heal stale IndexedDB rehydration on mount/focus, without a
+// 1h window of poison. Defaults already refetch when stale on mount and window
+// focus — do not use refetchOnMount: 'always' here; result lists gate on
+// isFetching and remount observers (e.g. ReaderFeedItem) which would loop.
+const STALE_TIME = 0;
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
 
 export type SiteSubscriptionsInfiniteData = InfiniteData< SiteSubscriptionsPage, number >;

--- a/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
@@ -264,7 +264,6 @@ describe( 'site subscription mutations', () => {
 		);
 		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
 		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
-		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feed', 'search' ] );
 	} );
 
 	it( 'rolls back site subscription delete when unsubscribe fails', async () => {

--- a/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
@@ -124,7 +124,36 @@ describe( 'site subscription mutations', () => {
 			( [ filters ] ) => filters?.queryKey
 		);
 		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
+		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
 		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 456 ] );
+	} );
+
+	it( 'invalidates blog caches using the subscribe response blog_ID when params omit it', async () => {
+		const queryClient = makeQueryClient();
+		const invalidateQueries = jest.spyOn( queryClient, 'invalidateQueries' );
+		( callApi as jest.Mock ).mockResolvedValue( {
+			subscribed: true,
+			subscription: { ID: '1', blog_ID: '99' },
+		} );
+
+		const { result } = renderHook( () => useSiteSubscribeMutation(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		act( () => {
+			result.current.mutate( {
+				url: 'https://example.com/feed',
+				doNotInvalidateSiteSubscriptions: true,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		const invalidatedKeys = invalidateQueries.mock.calls.map(
+			( [ filters ] ) => filters?.queryKey
+		);
+		expect( invalidatedKeys ).toContainEqual( [ 'read', 'sites', 99 ] );
+		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
 	} );
 
 	it( 'rolls back site subscription restore when subscribe fails', async () => {
@@ -234,6 +263,8 @@ describe( 'site subscription mutations', () => {
 			( [ filters ] ) => filters?.queryKey
 		);
 		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
+		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
+		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feed', 'search' ] );
 	} );
 
 	it( 'rolls back site subscription delete when unsubscribe fails', async () => {

--- a/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
@@ -263,7 +263,7 @@ describe( 'site subscription mutations', () => {
 			( [ filters ] ) => filters?.queryKey
 		);
 		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
-		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 'search' ] );
+		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
 		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feed', 'search' ] );
 	} );
 

--- a/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-subscription-mutations.test.tsx
@@ -124,7 +124,7 @@ describe( 'site subscription mutations', () => {
 			( [ filters ] ) => filters?.queryKey
 		);
 		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
-		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
+		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 'search' ] );
 		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 456 ] );
 	} );
 
@@ -153,7 +153,7 @@ describe( 'site subscription mutations', () => {
 			( [ filters ] ) => filters?.queryKey
 		);
 		expect( invalidatedKeys ).toContainEqual( [ 'read', 'sites', 99 ] );
-		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
+		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 'search' ] );
 	} );
 
 	it( 'rolls back site subscription restore when subscribe fails', async () => {
@@ -263,7 +263,7 @@ describe( 'site subscription mutations', () => {
 			( [ filters ] ) => filters?.queryKey
 		);
 		expect( invalidatedKeys ).toContainEqual( readFeedQueryKey( 456 ) );
-		expect( invalidatedKeys ).toContainEqual( [ 'read', 'feeds', 'search' ] );
+		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feeds', 'search' ] );
 		expect( invalidatedKeys ).not.toContainEqual( [ 'read', 'feed', 'search' ] );
 	} );
 

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -182,7 +182,6 @@ const useSiteSubscribeMutation = () => {
 				} );
 			}
 
-			queryClient.invalidateQueries( { queryKey: [ 'read', 'feeds', 'search' ] } );
 			queryClient.invalidateQueries( { queryKey: subscriptionsCountCacheKey } );
 		},
 		onSuccess: ( data, params ) => {

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -158,20 +158,21 @@ const useSiteSubscribeMutation = () => {
 
 			params.onError?.( _error );
 		},
-		onSettled: ( _data, _error, params: SubscribeParams ) => {
+		onSettled: ( data, _error, params: SubscribeParams ) => {
 			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
 				queryClient.invalidateQueries( { queryKey: siteSubscriptionsCacheKey } );
 			}
 
-			if ( isValidId( params.blog_id ) ) {
+			const blogId = params.blog_id ?? data?.subscription?.blog_ID;
+			if ( isValidId( blogId ) ) {
 				const siteSubscriptionDetailsCacheKey = buildSubscriptionDetailsByBlogIdQueryKey(
-					String( params.blog_id ),
+					String( blogId ),
 					isLoggedIn,
 					userId
 				);
 				queryClient.invalidateQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 				queryClient.invalidateQueries( {
-					queryKey: [ 'read', 'sites', Number( params.blog_id ) ],
+					queryKey: [ 'read', 'sites', Number( blogId ) ],
 				} );
 			}
 
@@ -181,6 +182,7 @@ const useSiteSubscribeMutation = () => {
 				} );
 			}
 
+			queryClient.invalidateQueries( { queryKey: [ 'read', 'feeds', 'search' ] } );
 			queryClient.invalidateQueries( { queryKey: subscriptionsCountCacheKey } );
 		},
 		onSuccess: ( data, params ) => {

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -243,7 +243,7 @@ const useSiteUnsubscribeMutation = () => {
 
 			queryClient.invalidateQueries( { queryKey: subscriptionsCountQueryKey } );
 			queryClient.invalidateQueries( {
-				queryKey: [ 'read', 'feed', 'search' ],
+				queryKey: [ 'read', 'feeds', 'search' ],
 			} );
 			queryClient.invalidateQueries( {
 				queryKey: buildSiteSubscriptionDetailsQueryKey( params.subscriptionId, isLoggedIn, userId ),

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -243,6 +243,9 @@ const useSiteUnsubscribeMutation = () => {
 
 			queryClient.invalidateQueries( { queryKey: subscriptionsCountQueryKey } );
 			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'feeds', 'search' ],
+			} );
+			queryClient.invalidateQueries( {
 				queryKey: buildSiteSubscriptionDetailsQueryKey( params.subscriptionId, isLoggedIn, userId ),
 			} );
 		},

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -243,9 +243,6 @@ const useSiteUnsubscribeMutation = () => {
 
 			queryClient.invalidateQueries( { queryKey: subscriptionsCountQueryKey } );
 			queryClient.invalidateQueries( {
-				queryKey: [ 'read', 'feeds', 'search' ],
-			} );
-			queryClient.invalidateQueries( {
 				queryKey: buildSiteSubscriptionDetailsQueryKey( params.subscriptionId, isLoggedIn, userId ),
 			} );
 		},


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # READ-595 and READ-597

## Proposed Changes

* After a successful Add site (on /reader/new), clear the shared search term (and URL ?s=) so related-sites results unmount and “Your subscriptions” shows again. Previously only the input cleared, but that clear did not propagate to the results list and url.
* Drive ReaderFeedItem follow state from the site-subscriptions cache, and use that same cache on the related-sites search list.
* invalidate site caches using response blog_ID when the request omitted it; fix (wrong-key - 'feeds' vs 'feed') feed-search invalidation on unsubscribe.
* Unify follow-state lookup: getSiteSubscriptionFromData returns the matched subscription (by URL / feed id / blog id) and backs getIsSubscribedFromData, so ReaderFeedItem's Unsubscribe always resolves a real subscription id.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* stale information shown about subscribe states
* clearing the search - previously on "add site" the search input was cleared. This makes sense since "add site" only works off a specific site url. However, this clear did not propagate to the search results list or the query to ensure the regular subscriptions list is shown again.
* regardless of input clearing and whether or not the search is shown, the recently subscribed item (now if searched after, previously was continued shown in the results list) would show the wrong subscribe state.
* clicking to go view the feed page after adding/removing a subscription could result in the feed page noting the wrong subscribe state for the site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* on `*reader/new` type in the full url for a site and click "add site"
* Verify the input clears, and we go back to showing the subscriptions list.
* add the url back into search, verify the result shows the correct subscription state (unsubscribe or subscribe button depending)
* once the new state is shown, click the link in the item to view the feed page. the feed page subscribe button should reflect the appropriate state (or shortly update to if not). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
