### PR TITLE
Scope registered security keys to wordpress.com

### DIFF
--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
@@ -14,6 +14,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
 import { ButtonStack } from '../../../../components/button-stack';
+import { getSecurityKeyHostname } from '../../utils';
 import type { Field } from '@wordpress/dataviews';
 
 type SecurityKeyFormData = {
@@ -30,7 +31,7 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const { mutateAsync: registerSecurityKey, isPending: isRegisteringSecurityKey } = useMutation(
-		registerTwoStepAuthSecurityKeyMutation()
+		registerTwoStepAuthSecurityKeyMutation( getSecurityKeyHostname() )
 	);
 
 	const handleSubmit = async ( e: React.FormEvent< HTMLFormElement > ) => {

--- a/client/dashboard/me/security-two-step-auth/utils.ts
+++ b/client/dashboard/me/security-two-step-auth/utils.ts
@@ -14,3 +14,12 @@ function isBrowser() {
 export function isWebAuthnSupported() {
 	return isBrowser() && supported();
 }
+
+// WebAuthn requires the relying party ID to be a registrable suffix of the current origin, so
+// hosts outside wordpress.com must register against their own hostname.
+export function getSecurityKeyHostname() {
+	const { hostname } = window.location;
+	return hostname === 'wordpress.com' || hostname.endsWith( '.wordpress.com' )
+		? undefined
+		: hostname;
+}

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -12,7 +12,6 @@ import {
 	updateUserSettings,
 	sendTwoStepAuthSMSCode,
 } from '@automattic/api-core';
-import config from '@automattic/calypso-config';
 import { create } from '@github/webauthn-json';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { userSettingsQuery } from './me-settings';
@@ -25,12 +24,11 @@ export const twoStepAuthSecurityKeysQuery = () =>
 		queryFn: fetchTwoStepAuthSecurityKeys,
 	} );
 
-export const registerTwoStepAuthSecurityKeyMutation = () =>
+// The hostname is the WebAuthn relying party ID. Keys must be scoped to wordpress.com to be
+// usable at login, not to whichever host the dashboard is served from.
+export const registerTwoStepAuthSecurityKeyMutation = ( hostname = 'wordpress.com' ) =>
 	mutationOptions( {
 		mutationFn: async ( keyName: string ) => {
-			// Get hostname for non-production environments
-			const hostname = 'production' !== config( 'env_id' ) ? window.location.hostname : undefined;
-
 			// First, fetch the registration challenge
 			const options = await fetchTwoStepAuthSecurityKeyRegistrationChallenge( { hostname } );
 


### PR DESCRIPTION
## Proposed Changes

* Register security keys against `wordpress.com` instead of the host the dashboard happens to be served from.
* Hosts that `wordpress.com` is not a registrable suffix of (local development, previews, the Woo variant) keep registering against their own hostname, since WebAuthn would otherwise reject the registration outright.

## Why are these changes being made?

Security keys added from the new dashboard could not be used to log in. The browser simply never offered them.

The hostname we send when requesting a registration challenge becomes the key's WebAuthn relying party ID, which is what scopes the key. Logging in happens on `wordpress.com`, so keys have to be scoped there.

The dashboard inherited a helper from Calypso that only sends a hostname outside production, where "production" is detected by comparing the environment ID against the literal string `production`. That comparison holds in Calypso, but the dashboard builds with an environment ID of `dashboard-production`, so the check never matched: production always sent a hostname, and keys were silently scoped to `my.wordpress.com` — a relying party the login flow never asks for.

The mutation now takes the hostname as a parameter defaulting to `wordpress.com`, so the data layer no longer infers it from build config, and callers that genuinely need a different relying party pass one.

## Considerations

* Hardcoding `wordpress.com` unconditionally was the simpler option and is correct in production, but WebAuthn requires the relying party ID to be a registrable suffix of the current origin. It would fail with a `SecurityError` on `my.localhost` and on `calypso.live` previews, making the flow untestable outside production. Hence the parameter rather than a constant.
* This does not fix the Woo variant, where the two-step screen is also reachable. A key registered there is scoped to that host and is no more usable at login than the old `my.wordpress.com` keys were — but it cannot be scoped to `wordpress.com` from that origin either. Whether security-key registration should be offered off-origin at all is a product question worth raising separately.

## Testing Instructions

Locally, the dashboard is served from a host outside `wordpress.com`, so registration exercises the fallback path rather than the production one.

1. Go to Me → Security → Two-step authentication and add a security key.
2. Confirm the key registers without a `SecurityError` in the console, and appears in the list.

To verify the production path, check the request to the registration challenge endpoint: on `my.wordpress.com` it should send `wordpress.com` as the hostname, rather than `my.wordpress.com` as it does today.

Fully confirming the fix needs a key registered on `my.wordpress.com` and then used to log in on `wordpress.com`, which cannot be reproduced from a local environment.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
