### PR TITLE
Revert "Scope registered security keys to wordpress.com"

### DIFF
--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
@@ -14,7 +14,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
 import { ButtonStack } from '../../../../components/button-stack';
-import { getSecurityKeyHostname } from '../../utils';
 import type { Field } from '@wordpress/dataviews';
 
 type SecurityKeyFormData = {
@@ -31,7 +30,7 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const { mutateAsync: registerSecurityKey, isPending: isRegisteringSecurityKey } = useMutation(
-		registerTwoStepAuthSecurityKeyMutation( getSecurityKeyHostname() )
+		registerTwoStepAuthSecurityKeyMutation()
 	);
 
 	const handleSubmit = async ( e: React.FormEvent< HTMLFormElement > ) => {

--- a/client/dashboard/me/security-two-step-auth/utils.ts
+++ b/client/dashboard/me/security-two-step-auth/utils.ts
@@ -14,12 +14,3 @@ function isBrowser() {
 export function isWebAuthnSupported() {
 	return isBrowser() && supported();
 }
-
-// WebAuthn requires the relying party ID to be a registrable suffix of the current origin, so
-// hosts outside wordpress.com must register against their own hostname.
-export function getSecurityKeyHostname() {
-	const { hostname } = window.location;
-	return hostname === 'wordpress.com' || hostname.endsWith( '.wordpress.com' )
-		? undefined
-		: hostname;
-}

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -12,6 +12,7 @@ import {
 	updateUserSettings,
 	sendTwoStepAuthSMSCode,
 } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { create } from '@github/webauthn-json';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { userSettingsQuery } from './me-settings';
@@ -24,11 +25,12 @@ export const twoStepAuthSecurityKeysQuery = () =>
 		queryFn: fetchTwoStepAuthSecurityKeys,
 	} );
 
-// The hostname is the WebAuthn relying party ID. Keys must be scoped to wordpress.com to be
-// usable at login, not to whichever host the dashboard is served from.
-export const registerTwoStepAuthSecurityKeyMutation = ( hostname = 'wordpress.com' ) =>
+export const registerTwoStepAuthSecurityKeyMutation = () =>
 	mutationOptions( {
 		mutationFn: async ( keyName: string ) => {
+			// Get hostname for non-production environments
+			const hostname = 'production' !== config( 'env_id' ) ? window.location.hostname : undefined;
+
 			// First, fetch the registration challenge
 			const options = await fetchTwoStepAuthSecurityKeyRegistrationChallenge( { hostname } );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112611. Just in case if we cannot register wordpress.com Security keys from my.wordpress.com