### PR TITLE
Post-checkout: Fix toast message in MSD and Stepper

### DIFF
--- a/client/dashboard/app/checkout-success-flash-message.tsx
+++ b/client/dashboard/app/checkout-success-flash-message.tsx
@@ -1,0 +1,24 @@
+import { __ } from '@wordpress/i18n';
+import FlashMessage from '../components/flash-message';
+
+/**
+ * Flash id used to show a post-checkout success snackbar when the checkout
+ * pending page redirects the user back into the Dashboard. The checkout side
+ * tags the redirect URL with `?flash=<CHECKOUT_SUCCESS_FLASH_ID>` (see
+ * `client/my-sites/checkout/checkout-thank-you/pending/index.tsx`). Keep the two
+ * in sync.
+ *
+ * Rendered in the app shell (`app/root`) so the toast appears regardless of
+ * which Dashboard page checkout redirects to (site overview, sites list,
+ * billing purchases, etc.).
+ */
+export const CHECKOUT_SUCCESS_FLASH_ID = 'checkout-success';
+
+export function CheckoutSuccessFlashMessage() {
+	return (
+		<FlashMessage
+			id={ CHECKOUT_SUCCESS_FLASH_ID }
+			message={ __( 'Your purchase was completed.' ) }
+		/>
+	);
+}

--- a/client/dashboard/app/checkout-success-flash-message.tsx
+++ b/client/dashboard/app/checkout-success-flash-message.tsx
@@ -4,9 +4,8 @@ import FlashMessage from '../components/flash-message';
 /**
  * Flash id used to show a post-checkout success snackbar when the checkout
  * pending page redirects the user back into the Dashboard. The checkout side
- * tags the redirect URL with `?flash=<CHECKOUT_SUCCESS_FLASH_ID>` (see
- * `client/my-sites/checkout/checkout-thank-you/pending/index.tsx`). Keep the two
- * in sync.
+ * imports this constant and tags the redirect URL with `?flash=<id>` (see
+ * `client/my-sites/checkout/checkout-thank-you/pending/index.tsx`).
  *
  * Rendered in the app shell (`app/root`) so the toast appears regardless of
  * which Dashboard page checkout redirects to (site overview, sites list,

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -17,6 +17,7 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import NotFound from '../404';
 import AccountRecoveryInterstitial from '../account-recovery-interstitial';
 import { bumpStat } from '../analytics';
+import { CheckoutSuccessFlashMessage } from '../checkout-success-flash-message';
 import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import { useTrackVisitedAreas } from '../hooks/use-visit-counter';
@@ -195,6 +196,7 @@ function Root() {
 			{ supports.help && <OmnibarAgentsManager /> }
 			<OmnibarSiteSwitcher />
 			<Snackbars />
+			<CheckoutSuccessFlashMessage />
 			{ isAccountRecoveryInterstitialEnabled && <AccountRecoveryInterstitial /> }
 			{ isOptInWelcomeModalEnabled && <OptInWelcomeModal /> }
 			<PageViewTracker />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
@@ -16,13 +16,19 @@ import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
+import { usePurchasePlanNotification } from '../../hooks/use-purchase-plan-notification';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
 const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
-	const { siteSlug, siteId } = useSiteData();
+	const { site, siteSlug, siteId } = useSiteData();
 	const translate = useTranslate();
 	const ref = useQuery().get( 'ref' );
+
+	// After checkout the `post-checkout-onboarding` step flags the site for a
+	// "plan is now active" toast; consume it here since this is where the user
+	// lands post-purchase.
+	usePurchasePlanNotification( siteId, site?.plan?.product_slug );
 	const showPromptInput = ref === WOO_HOSTING_SOLUTIONS_REF;
 	const [ prompt, setPrompt ] = useState( '' );
 	// Automattician-only "Generate Theme" entry point that provisions a WP Cloud

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/test/index.test.tsx
@@ -55,6 +55,10 @@ jest.mock( '../../../../../hooks/use-site-data', () => ( {
 	useSiteData: jest.fn(),
 } ) );
 
+jest.mock( '../../../hooks/use-purchase-plan-notification', () => ( {
+	usePurchasePlanNotification: jest.fn(),
+} ) );
+
 describe( 'SetupYourSiteAIStep – Generate Theme (Automattician only)', () => {
 	const mockUseReactQuery = useReactQuery as jest.Mock;
 	const mockUseSiteData = useSiteData as jest.Mock;

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -6,10 +6,12 @@ import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
 import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
+import { dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -125,6 +127,28 @@ function CheckoutPending( {
 
 function isValidOrderId( orderId: number | ':orderId' ): orderId is number {
 	return Number.isInteger( orderId );
+}
+
+// Flash id read by the Dashboard's `<CheckoutSuccessFlashMessage>` to show a
+// post-checkout success snackbar on arrival. Must match `CHECKOUT_SUCCESS_FLASH_ID`
+// in `client/dashboard/app/checkout-success-flash-message.tsx`.
+const DASHBOARD_CHECKOUT_SUCCESS_FLASH = 'checkout-success';
+
+// Whether the redirect destination is a page in the multi-site Dashboard (a
+// separate SPA reached via a full page load). The Dashboard doesn't read the
+// classic `notice` query param and Redux's `displayOnNextPage` notice can't
+// survive a cross-app navigation, so these redirects need the Dashboard's own
+// `flash` mechanism to show a post-checkout toast. Only absolute URLs are
+// considered so relative classic-Calypso destinations never match.
+function isDashboardUrl( url: string ): boolean {
+	if ( ! /^https?:\/\//.test( url ) ) {
+		return false;
+	}
+	try {
+		return dashboardOrigins().includes( new URL( url ).origin );
+	} catch {
+		return false;
+	}
 }
 
 function performRedirect( url: string ): void {
@@ -349,15 +373,19 @@ function useRedirectOnTransactionSuccess( {
 		// a `notice` query param so the destination can dispatch a success toast on
 		// arrival - we cannot dispatch from here because the global notice renderer
 		// has no concept of "show only on the next page".
-		const finalRedirectInstructions = isPlanAndDomainPurchase
-			? {
-					...redirectInstructions,
-					url: appendNoticeQueryParam(
-						redirectInstructions.url,
-						PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE
-					),
-			  }
-			: redirectInstructions;
+		let finalUrl = isPlanAndDomainPurchase
+			? appendNoticeQueryParam( redirectInstructions.url, PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE )
+			: redirectInstructions.url;
+
+		// A successful redirect back into the Dashboard (a separate SPA) can't rely on
+		// the classic notice mechanisms, so tag the URL with the Dashboard's `flash`
+		// param and let `<CheckoutSuccessFlashMessage>` show the toast on arrival.
+		const isSuccessRedirect = ! redirectInstructions.isError && ! redirectInstructions.isUnknown;
+		if ( isSuccessRedirect && isDashboardUrl( finalUrl ) ) {
+			finalUrl = addQueryArgs( finalUrl, { flash: DASHBOARD_CHECKOUT_SUCCESS_FLASH } );
+		}
+
+		const finalRedirectInstructions = { ...redirectInstructions, url: finalUrl };
 
 		notifyAndPerformRedirect( siteSlug, finalRedirectInstructions );
 	}, [

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
 import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
+import { CHECKOUT_SUCCESS_FLASH_ID } from 'calypso/dashboard/app/checkout-success-flash-message';
 import { dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -128,11 +129,6 @@ function CheckoutPending( {
 function isValidOrderId( orderId: number | ':orderId' ): orderId is number {
 	return Number.isInteger( orderId );
 }
-
-// Flash id read by the Dashboard's `<CheckoutSuccessFlashMessage>` to show a
-// post-checkout success snackbar on arrival. Must match `CHECKOUT_SUCCESS_FLASH_ID`
-// in `client/dashboard/app/checkout-success-flash-message.tsx`.
-const DASHBOARD_CHECKOUT_SUCCESS_FLASH = 'checkout-success';
 
 // Whether the redirect destination is a page in the multi-site Dashboard (a
 // separate SPA reached via a full page load). The Dashboard doesn't read the
@@ -382,7 +378,7 @@ function useRedirectOnTransactionSuccess( {
 		// param and let `<CheckoutSuccessFlashMessage>` show the toast on arrival.
 		const isSuccessRedirect = ! redirectInstructions.isError && ! redirectInstructions.isUnknown;
 		if ( isSuccessRedirect && isDashboardUrl( finalUrl ) ) {
-			finalUrl = addQueryArgs( finalUrl, { flash: DASHBOARD_CHECKOUT_SUCCESS_FLASH } );
+			finalUrl = addQueryArgs( finalUrl, { flash: CHECKOUT_SUCCESS_FLASH_ID } );
 		}
 
 		const finalRedirectInstructions = { ...redirectInstructions, url: finalUrl };


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-506/

## Proposed changes

After checkout, the pending page redirects the user to a post-checkout destination. When that destination isn't a dedicated thank-you page — the multi-site Dashboard (`/sites/<site>`) or the stepper `setup-your-site-ai` step — no "purchase completed" confirmation was shown. This restores that confirmation for both destinations.

* Tag successful Dashboard-bound redirects from the checkout pending page with the Dashboard's `?flash=checkout-success` param (absolute Dashboard origins only, via `dashboardOrigins()`).
* Add a `CheckoutSuccessFlashMessage` reader that shows a "Your purchase was completed." snackbar on the Dashboard site overview page and strips the param.
* Call `usePurchasePlanNotification()` with the site ID and plan slug on the stepper `setup-your-site-ai` step so the already-set flag is consumed and the "plan is now active" notice fires.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1512" height="909" alt="Screenshot 2026-07-14 at 5 07 54 PM" src="https://github.com/user-attachments/assets/82946969-ec13-4bfe-a9dc-ac86ac3e063e" /> | <img width="1512" height="910" alt="Screenshot 2026-07-14 at 5 09 15 PM" src="https://github.com/user-attachments/assets/7124d2d0-e5fd-4dc8-b21b-e0b97a28e134" />
<img width="1512" height="832" alt="Screenshot 2026-07-14 at 6 24 23 PM" src="https://github.com/user-attachments/assets/8b996f80-5260-4057-97ea-b64471b549da" /> | <img width="1511" height="831" alt="Screenshot 2026-07-14 at 6 24 18 PM" src="https://github.com/user-attachments/assets/79e94308-eccf-410a-aacc-5443f3323901" />



## Why are these changes being made?

When checkout doesn't route to a dedicated thank-you page, the user is sent back to where they came from and is supposed to see a toast confirming the purchase. That confirmation relied on classic-Calypso-only mechanisms: a Redux `successNotice({ displayOnNextPage: true })` that survives a single *client-side* route change, and a `?notice=` query param read only by classic `customer-home`.

Both broken destinations are separate single-page apps reached via a full page load, so neither mechanism reached them:

* **Dashboard (`/sites/<site>`)** is self-contained (`@wordpress/notices` + its own `?flash=` mechanism). It never read the classic `?notice=` param, and the Redux `displayOnNextPage` notice can't survive a cross-app navigation. The Dashboard already had a purpose-built `FlashMessage` component for exactly this case; the checkout side just never tagged the redirect.
* **Stepper `setup-your-site-ai`** already had all the infrastructure — `post-checkout-onboarding` sets a `localStorage` flag and `usePurchasePlanNotification` reads it — but the display side was effectively dead code, because the hook was only ever called *without* arguments. Passing the real `siteId` and plan slug on the step where users land post-checkout makes it fire.

## Testing instructions

* **Dashboard flow:** From the Dashboard purchase list page (https://my.wordpress.com/me/billing/purchases/), select an existing paid plan. Click to Renew that plan. Complete checkout and confirm a "Your purchase was completed." snackbar appears on arrival.
* **Stepper flow:** Go through the onboarding flow (`/setup/onboarding`) with a paid plan, complete checkout, and land on `setup-your-site-ai`. Confirm the "You're in! The <plan> Plan is now active." notice appears.

