### PR TITLE
Turn off the split-cancel-remove flag in test environments

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -55,7 +55,7 @@
 		"plans/personal-plan": true,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
-		"purchases/split-cancel-remove": true,
+		"purchases/split-cancel-remove": false,
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,

--- a/config/development.json
+++ b/config/development.json
@@ -190,7 +190,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/split-cancel-remove": true,
+		"purchases/split-cancel-remove": false,
 		"push-notifications": true,
 		"reader/social": true,
 		"reader/spaces": true,

--- a/config/test.json
+++ b/config/test.json
@@ -98,7 +98,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/split-cancel-remove": true,
+		"purchases/split-cancel-remove": false,
 		"reader/social": true,
 		"reader/spaces": true,
 		"reader/full-errors": true,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-509/turn-off-the-split-cancel-remove-flag-in-test-environments

## Proposed Changes

The `split-cancel-remove` feature flag is currently on in development and test environments, but nowhere else.

Since it makes substantial changes to the cancellation and removal flow UI, and since we don't plan to launch it to production imminently (if we did we'd likely do an A/B test first) it may be a good idea to turn it off in all environments, to ensure that people testing pull requests get the same cancel/refund flow that users get in production.


## Testing Instructions

Go through cancelling or refunding a purchase and ensure it works the same in the test environment as in production.